### PR TITLE
fix(canvas): expose state and comments to agents

### DIFF
--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -28,6 +28,7 @@ export const AGENT_USE_CASE_SCOPES = [
     'cohort:read',
     'cohort:write',
     'comment:read',
+    'comment:write',
     'customer_analytics:read',
     'customer_analytics:write',
     'data_catalog:read',

--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -305,10 +305,9 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             else:
                 actor_canvas_q = Q(created_by_id=user.id) & tasks_facade.visible_channels_q(user.id, relation="channel")
                 task_canvas_q = Q(generation_task_id=sandbox_task_id)
+                can_use_visible_canvas = self.action in [*self.scope_object_read_actions, "set_state"]
                 queryset = queryset.filter(
-                    public_canvas_q | actor_canvas_q
-                    if self.action in self.scope_object_read_actions
-                    else actor_canvas_q | task_canvas_q
+                    public_canvas_q | actor_canvas_q if can_use_visible_canvas else actor_canvas_q | task_canvas_q
                 )
         else:
             # Channels are per-user for the personal kind: the facade's visibility
@@ -1571,14 +1570,7 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return build
 
     def _state_actor(self, request: Request) -> User | None:
-        """The viewer whose state is read or written; None rejects the call.
-
-        Sandboxes are excluded by design: runtime state belongs to viewer
-        sessions, and the authoring agent works with it through the source
-        code it publishes, not by writing rows.
-        """
-        if self._is_sandbox_authenticated(request):
-            return None
+        """The user whose personal state is read or written."""
         return self._request_user()
 
     @extend_schema(
@@ -1676,15 +1668,15 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         ],
         responses={
             200: CanvasStateResponseSerializer,
-            403: OpenApiResponse(description="Canvas state is a viewer surface; sandbox tokens cannot use it."),
+            403: OpenApiResponse(description="Canvas state requires an authenticated user."),
         },
     )
     @action(methods=["GET"], detail=True)
     def state(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Read the canvas's runtime key-value state (the ph.state store).
 
-        Returns the canvas's shared entries plus the caller's own user-scoped
-        entries — never another viewer's.
+        Returns shared entries plus the authenticated user's own user-scoped
+        entries — never another user's.
         """
         canvas = self.get_object()
         user = self._state_actor(request)
@@ -1695,11 +1687,10 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # stops reads of previously written entries.
         version = canvas.current_source_version
         declared = declared_state_scopes(version.capabilities if version else None)
-        entries = (
-            CanvasState.objects.for_team(self.team_id)
-            .filter(canvas=canvas, scope__in=declared)
-            .filter(Q(scope=CanvasState.SCOPE_SHARED, user__isnull=True) | Q(scope=CanvasState.SCOPE_USER, user=user))
+        readable_entries = Q(scope=CanvasState.SCOPE_SHARED, user__isnull=True) | Q(
+            scope=CanvasState.SCOPE_USER, user=user
         )
+        entries = CanvasState.objects.for_team(self.team_id).filter(readable_entries, canvas=canvas, scope__in=declared)
         scope = request.query_params.get("scope")
         if scope:
             if scope not in CanvasState.SCOPES:

--- a/products/canvas/backend/tests/test_canvas_api.py
+++ b/products/canvas/backend/tests/test_canvas_api.py
@@ -1274,8 +1274,15 @@ class TestCanvasState(CanvasAPIBaseTest):
             assert self._set_state(canvas_id, "shared", "one", 11).status_code == status.HTTP_200_OK
             assert self._set_state(canvas_id, "shared", "three", 3).status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_sandbox_tokens_cannot_use_state(self):
+    def test_sandbox_tokens_use_their_users_state_on_visible_canvases(self):
         canvas_id = self._state_canvas()
+        other_user = self._create_user("state-owner@example.com")
+        Canvas.objects.unscoped().filter(id=canvas_id).update(created_by=other_user)
+        self.client.force_login(other_user)
+        assert self._set_state(canvas_id, "user", "draft", "owners-private-state").status_code == status.HTTP_200_OK
+        self.client.force_login(self.user)
+        assert self._set_state(canvas_id, "shared", "progress", {"completed": 12}).status_code == status.HTTP_200_OK
+        assert self._set_state(canvas_id, "user", "draft", "my-private-state").status_code == status.HTTP_200_OK
         task = Task.objects.create(
             team=self.team,
             channel=self.channel,
@@ -1291,15 +1298,26 @@ class TestCanvasState(CanvasAPIBaseTest):
             f"/api/projects/{self.team.id}/canvases/{canvas_id}/state/",
             HTTP_X_POSTHOG_TASK_ID=str(task.id),
         )
-        write = client.post(
+        write_shared = client.post(
             f"/api/projects/{self.team.id}/canvases/{canvas_id}/state/set/",
-            {"scope": "shared", "key": "k", "value": 1},
+            {"scope": "shared", "key": "progress", "value": {"completed": 13}},
+            format="json",
+            HTTP_X_POSTHOG_TASK_ID=str(task.id),
+        )
+        write_user = client.post(
+            f"/api/projects/{self.team.id}/canvases/{canvas_id}/state/set/",
+            {"scope": "user", "key": "draft", "value": "updated-by-agent"},
             format="json",
             HTTP_X_POSTHOG_TASK_ID=str(task.id),
         )
 
-        assert read.status_code == status.HTTP_403_FORBIDDEN
-        assert write.status_code == status.HTTP_403_FORBIDDEN
+        assert read.status_code == status.HTTP_200_OK
+        assert {(entry["scope"], entry["key"]): entry["value"] for entry in read.json()["entries"]} == {
+            ("shared", "progress"): {"completed": 12},
+            ("user", "draft"): "my-private-state",
+        }
+        assert write_shared.status_code == status.HTTP_200_OK
+        assert write_user.status_code == status.HTTP_200_OK
 
 
 class TestCanvasErrorReports(CanvasAPIBaseTest):

--- a/products/canvas/frontend/generated/api.ts
+++ b/products/canvas/frontend/generated/api.ts
@@ -640,8 +640,8 @@ export const getCanvasesStateRetrieveUrl = (projectId: string, id: string, param
 /**
  * Read the canvas's runtime key-value state (the ph.state store).
  *
- * Returns the canvas's shared entries plus the caller's own user-scoped
- * entries — never another viewer's.
+ * Returns shared entries plus the authenticated user's own user-scoped
+ * entries — never another user's.
  */
 export const canvasesStateRetrieve = async (
     projectId: string,

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -345,12 +345,36 @@ tools:
     canvases-revert-create:
         operation: canvases_revert_create
         enabled: false
-    canvases-state-retrieve:
+    canvas-state-retrieve:
         operation: canvases_state_retrieve
-        enabled: false
-    canvases-state-set:
+        enabled: true
+        scopes:
+            - canvas:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Read canvas state
+        description: >
+            Read persisted `ph.state` entries for a visible canvas. Returns shared entries and the authenticated user's
+            own user-scoped entries, never another user's. Use this with canvas-source-retrieve when collaborative
+            progress, checklist selections, filters, or other runtime values live outside the source. Only scopes
+            declared by the live canvas version are readable. Optionally filter to `user` or `shared` with `scope`.
+    canvas-state-set:
         operation: canvases_state_set
-        enabled: false
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set canvas state
+        description: >
+            Set one persisted `ph.state` key on a visible canvas, or delete it by passing a null value. `user` updates
+            only the authenticated user's private state; `shared` updates the state every viewer sees. The scope must
+            be declared by the live canvas version. Read the current entries with canvas-state-retrieve before changing
+            progress or other existing values.
     canvases-versions-retrieve:
         operation: canvases_versions_retrieve
         enabled: false

--- a/products/canvas/mcp/tools.yaml
+++ b/products/canvas/mcp/tools.yaml
@@ -303,6 +303,36 @@ tools:
         param_overrides:
             id:
                 description: ID of the canvas whose source to read.
+    canvas-state-retrieve:
+        operation: canvases_state_retrieve
+        enabled: true
+        scopes:
+            - canvas:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Read canvas state
+        description: >
+            Read persisted `ph.state` entries for a visible canvas. Returns shared entries and the authenticated user's
+            own user-scoped entries, never another user's. Use this with canvas-source-retrieve when collaborative
+            progress, checklist selections, filters, or other runtime values live outside the source. Only scopes
+            declared by the live canvas version are readable. Optionally filter to `user` or `shared` with `scope`.
+    canvas-state-set:
+        operation: canvases_state_set
+        enabled: true
+        scopes:
+            - canvas:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Set canvas state
+        description: >
+            Set one persisted `ph.state` key on a visible canvas, or delete it by passing a null value. `user` updates
+            only the authenticated user's private state; `shared` updates the state every viewer sees. The scope must be
+            declared by the live canvas version. Read the current entries with canvas-state-retrieve before changing
+            progress or other existing values.
     canvas-validate-create:
         operation: canvases_validate_create
         enabled: true
@@ -345,36 +375,6 @@ tools:
     canvases-revert-create:
         operation: canvases_revert_create
         enabled: false
-    canvas-state-retrieve:
-        operation: canvases_state_retrieve
-        enabled: true
-        scopes:
-            - canvas:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Read canvas state
-        description: >
-            Read persisted `ph.state` entries for a visible canvas. Returns shared entries and the authenticated user's
-            own user-scoped entries, never another user's. Use this with canvas-source-retrieve when collaborative
-            progress, checklist selections, filters, or other runtime values live outside the source. Only scopes
-            declared by the live canvas version are readable. Optionally filter to `user` or `shared` with `scope`.
-    canvas-state-set:
-        operation: canvases_state_set
-        enabled: true
-        scopes:
-            - canvas:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: true
-        title: Set canvas state
-        description: >
-            Set one persisted `ph.state` key on a visible canvas, or delete it by passing a null value. `user` updates
-            only the authenticated user's private state; `shared` updates the state every viewer sees. The scope must
-            be declared by the live canvas version. Read the current entries with canvas-state-retrieve before changing
-            progress or other existing values.
     canvases-versions-retrieve:
         operation: canvases_versions_retrieve
         enabled: false

--- a/products/canvas/skills/querying-canvas-data/SKILL.md
+++ b/products/canvas/skills/querying-canvas-data/SKILL.md
@@ -165,6 +165,17 @@ const entries = await ph.state.list({ scope: 'shared' }) // [{ scope, key, value
 - 256 keys per scope. Store big data in PostHog (insights, the warehouse) and reference it.
 - State is team-visible application data — never secrets, never viewer PII.
 
+When a user asks about a canvas's current progress or settings, do not infer them from source alone.
+Call `canvas-state-retrieve` with the canvas id after reading its source. It returns shared state plus
+the authenticated user's own user-scoped state for canvases in public channels or their personal
+channel. Use `canvas-state-set` when the user asks to change those values; read first, preserve
+unrelated keys, and use the scope the canvas source expects.
+
+Canvas discussions use the generic comment tools. Read them with `comments-list` filtered to
+`scope=desktop_canvas`, the canvas id as `item_id`, and its `discussion_task_id` as `task_id`. Create
+a root comment or reply with `comments-create`, using the same scope and ids (put the task id in
+`item_context.taskId`). The same public-channel and personal-channel visibility rules apply.
+
 ## PostHog writes — ph.actions
 
 `ph.actions.invoke(verb, payload)` writes into PostHog as the viewer. Declare every verb in

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -305,7 +305,19 @@ tools:
         enabled: false
     comments-create:
         operation: comments_create
-        enabled: false
+        enabled: true
+        scopes:
+            - comment:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create a comment or reply
+        description: >
+            Create a comment on an accessible resource, or reply by passing `source_comment`. For a canvas use
+            scope `desktop_canvas`, the canvas id as `item_id`, and item_context.taskId from the canvas's
+            `discussion_task_id`. Canvas visibility is enforced: public-channel canvases and the authenticated user's
+            personal-channel canvases are accessible.
     comments-destroy:
         operation: comments_destroy
         enabled: false

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -314,8 +314,8 @@ tools:
             idempotent: false
         title: Create a comment or reply
         description: >
-            Create a comment on an accessible resource, or reply by passing `source_comment`. For a canvas use
-            scope `desktop_canvas`, the canvas id as `item_id`, and item_context.taskId from the canvas's
+            Create a comment on an accessible resource, or reply by passing `source_comment`. For a canvas use scope
+            `desktop_canvas`, the canvas id as `item_id`, and item_context.taskId from the canvas's
             `discussion_task_id`. Canvas visibility is enforced: public-channel canvases and the authenticated user's
             personal-channel canvases are accessible.
     comments-destroy:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1253,6 +1253,34 @@
             "readOnlyHint": true
         }
     },
+    "canvas-state-retrieve": {
+        "description": "Read persisted `ph.state` entries for a visible canvas. Returns shared entries and the authenticated user's own user-scoped entries, never another user's. Use this with canvas-source-retrieve when collaborative progress, checklist selections, filters, or other runtime values live outside the source. Only scopes declared by the live canvas version are readable. Optionally filter to `user` or `shared` with `scope`.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Read canvas state",
+        "title": "Read canvas state",
+        "required_scopes": ["canvas:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "canvas-state-set": {
+        "description": "Set one persisted `ph.state` key on a visible canvas, or delete it by passing a null value. `user` updates only the authenticated user's private state; `shared` updates the state every viewer sees. The scope must be declared by the live canvas version. Read the current entries with canvas-state-retrieve before changing progress or other existing values.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Set canvas state",
+        "title": "Set canvas state",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "canvas-validate-create": {
         "description": "Validate a candidate canvas source project without publishing it. Returns structured diagnostics (severity, code, message, file, line); `valid: false` means a publish would be rejected. Side-effect free — call it as often as needed while iterating, and fix every error-severity diagnostic (including undeclared-capability errors) before publishing.",
         "category": "Canvas",
@@ -1791,6 +1819,20 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "comments-create": {
+        "description": "Create a comment on an accessible resource, or reply by passing `source_comment`. For a canvas use scope `desktop_canvas`, the canvas id as `item_id`, and item_context.taskId from the canvas's `discussion_task_id`. Canvas visibility is enforced: public-channel canvases and the authenticated user's personal-channel canvases are accessible.",
+        "category": "Platform Features",
+        "feature": "platform_features",
+        "summary": "Create a comment or reply",
+        "title": "Create a comment or reply",
+        "required_scopes": ["comment:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "comments-list": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1268,6 +1268,34 @@
             "readOnlyHint": true
         }
     },
+    "canvas-state-retrieve": {
+        "description": "Read persisted `ph.state` entries for a visible canvas. Returns shared entries and the authenticated user's own user-scoped entries, never another user's. Use this with canvas-source-retrieve when collaborative progress, checklist selections, filters, or other runtime values live outside the source. Only scopes declared by the live canvas version are readable. Optionally filter to `user` or `shared` with `scope`.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Read canvas state",
+        "title": "Read canvas state",
+        "required_scopes": ["canvas:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "canvas-state-set": {
+        "description": "Set one persisted `ph.state` key on a visible canvas, or delete it by passing a null value. `user` updates only the authenticated user's private state; `shared` updates the state every viewer sees. The scope must be declared by the live canvas version. Read the current entries with canvas-state-retrieve before changing progress or other existing values.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "Set canvas state",
+        "title": "Set canvas state",
+        "required_scopes": ["canvas:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "canvas-validate-create": {
         "description": "Validate a candidate canvas source project without publishing it. Returns structured diagnostics (severity, code, message, file, line); `valid: false` means a publish would be rejected. Side-effect free — call it as often as needed while iterating, and fix every error-severity diagnostic (including undeclared-capability errors) before publishing.",
         "category": "Canvas",
@@ -1806,6 +1834,20 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "comments-create": {
+        "description": "Create a comment on an accessible resource, or reply by passing `source_comment`. For a canvas use scope `desktop_canvas`, the canvas id as `item_id`, and item_context.taskId from the canvas's `discussion_task_id`. Canvas visibility is enforced: public-channel canvases and the authenticated user's personal-channel canvases are accessible.",
+        "category": "Platform Features",
+        "feature": "platform_features",
+        "summary": "Create a comment or reply",
+        "title": "Create a comment or reply",
+        "required_scopes": ["comment:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "comments-list": {

--- a/services/mcp/src/generated/canvas/api.ts
+++ b/services/mcp/src/generated/canvas/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 14 enabled ops
+ * PostHog API - MCP 16 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1081,6 +1081,52 @@ export const CanvasesSourceRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe('Read this historical source version instead of the head (for version browsing).'),
 })
+
+/**
+ * Read the canvas's runtime key-value state (the ph.state store).
+ *
+ * Returns shared entries plus the authenticated user's own user-scoped
+ * entries — never another user's.
+ */
+export const CanvasesStateRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this canvas.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const CanvasesStateRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    scope: zod.enum(['shared', 'user']).optional().describe('Only return entries in this scope.'),
+})
+
+/**
+ * Write one key of the canvas's runtime state, or delete it with a null value.
+ */
+export const CanvasesStateSetParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this canvas.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const canvasesStateSetBodyKeyMax = 200
+
+export const CanvasesStateSetBody = /* @__PURE__ */ zod
+    .object({
+        scope: zod
+            .enum(['user', 'shared'])
+            .describe('\* `user` - user\n\* `shared` - shared')
+            .describe(
+                'Scope to write into; the canvas must declare it in capabilities.posthog.state.\n\n\* `user` - user\n\* `shared` - shared'
+            ),
+        key: zod.string().max(canvasesStateSetBodyKeyMax).describe('Key to write, unique within its scope.'),
+        value: zod.unknown().describe('JSON value to store (at most 64 KB serialized), or null to delete the key.'),
+    })
+    .describe("Payload for writing (or deleting) one key of a canvas's runtime state.")
 
 /**
  * Validate a candidate source project without publishing it. Side-effect free.

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 22 enabled ops
+ * PostHog API - MCP 23 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -411,6 +411,47 @@ export const CommentsListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe('Owning task for task, task_artifact, and desktop_canvas comment scopes.'),
+})
+
+/**
+ * Create a comment.
+ *
+ * Support messages are deduplicated: an identical message from the same author on the same
+ * ticket within a short window returns the original comment with a 200 instead of creating a
+ * second one, and a 409 while a concurrent request is still creating it.
+ */
+export const CommentsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const commentsCreateBodyScopeMax = 79
+
+export const commentsCreateBodyIsTaskDefault = false
+export const commentsCreateBodyItemIdMax = 72
+
+export const CommentsCreateBody = /* @__PURE__ */ zod.object({
+    scope: zod.string().max(commentsCreateBodyScopeMax).optional(),
+    item_context: zod
+        .unknown()
+        .optional()
+        .describe('Metadata for the comment target, anchor, thread state, and owning task.'),
+    deleted: zod.boolean().nullish(),
+    mentions: zod.array(zod.number()).optional(),
+    slug: zod.string().optional(),
+    is_task: zod
+        .boolean()
+        .default(commentsCreateBodyIsTaskDefault)
+        .describe(
+            'Whether this comment is an actionable task that can be marked complete. Tasks render with a checkbox in the UI and can be filtered as a separate kind. Cannot be set on replies (source_comment) or emoji reactions. Immutable after creation.'
+        ),
+    content: zod.string().nullish(),
+    rich_content: zod.unknown().optional(),
+    item_id: zod.string().max(commentsCreateBodyItemIdMax).nullish(),
+    source_comment: zod.string().nullish(),
 })
 
 export const CommentsRetrieveParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -384,28 +384,6 @@ const canvasSourceRetrieve = (): ToolBase<typeof CanvasSourceRetrieveSchema, Sch
     },
 })
 
-const CanvasValidateCreateSchema = CanvasesValidateCreateParams.omit({ project_id: true })
-    .extend(CanvasesValidateCreateBody.shape)
-    .extend({ id: CanvasesValidateCreateParams.shape['id'].describe('ID of the canvas the project is for.') })
-
-const canvasValidateCreate = (): ToolBase<typeof CanvasValidateCreateSchema, Schemas.CanvasValidateResponse> => ({
-    name: 'canvas-validate-create',
-    schema: CanvasValidateCreateSchema,
-    handler: async (context: Context, params: z.infer<typeof CanvasValidateCreateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.project !== undefined) {
-            body['project'] = params.project
-        }
-        const result = await context.api.request<Schemas.CanvasValidateResponse>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/validate/`,
-            body,
-        })
-        return result
-    },
-})
-
 const CanvasStateRetrieveSchema = CanvasesStateRetrieveParams.omit({ project_id: true }).extend(
     CanvasesStateRetrieveQueryParams.shape
 )
@@ -452,6 +430,28 @@ const canvasStateSet = (): ToolBase<typeof CanvasStateSetSchema, Schemas.CanvasS
     },
 })
 
+const CanvasValidateCreateSchema = CanvasesValidateCreateParams.omit({ project_id: true })
+    .extend(CanvasesValidateCreateBody.shape)
+    .extend({ id: CanvasesValidateCreateParams.shape['id'].describe('ID of the canvas the project is for.') })
+
+const canvasValidateCreate = (): ToolBase<typeof CanvasValidateCreateSchema, Schemas.CanvasValidateResponse> => ({
+    name: 'canvas-validate-create',
+    schema: CanvasValidateCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasValidateCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.project !== undefined) {
+            body['project'] = params.project
+        }
+        const result = await context.api.request<Schemas.CanvasValidateResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/validate/`,
+            body,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-builds-retrieve': canvasBuildsRetrieve,
     'canvas-create': canvasCreate,
@@ -466,7 +466,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-publish-create': canvasPublishCreate,
     'canvas-publish-current-version': canvasPublishCurrentVersion,
     'canvas-source-retrieve': canvasSourceRetrieve,
-    'canvas-validate-create': canvasValidateCreate,
     'canvas-state-retrieve': canvasStateRetrieve,
     'canvas-state-set': canvasStateSet,
+    'canvas-validate-create': canvasValidateCreate,
 }

--- a/services/mcp/src/tools/generated/canvas.ts
+++ b/services/mcp/src/tools/generated/canvas.ts
@@ -26,6 +26,10 @@ import {
     CanvasesPublishCurrentVersionCreateParams,
     CanvasesSourceRetrieveParams,
     CanvasesSourceRetrieveQueryParams,
+    CanvasesStateRetrieveParams,
+    CanvasesStateRetrieveQueryParams,
+    CanvasesStateSetBody,
+    CanvasesStateSetParams,
     CanvasesValidateCreateBody,
     CanvasesValidateCreateParams,
 } from '@/generated/canvas/api'
@@ -402,6 +406,52 @@ const canvasValidateCreate = (): ToolBase<typeof CanvasValidateCreateSchema, Sch
     },
 })
 
+const CanvasStateRetrieveSchema = CanvasesStateRetrieveParams.omit({ project_id: true }).extend(
+    CanvasesStateRetrieveQueryParams.shape
+)
+
+const canvasStateRetrieve = (): ToolBase<typeof CanvasStateRetrieveSchema, Schemas.CanvasStateResponse> => ({
+    name: 'canvas-state-retrieve',
+    schema: CanvasStateRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasStateRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.CanvasStateResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/state/`,
+            query: {
+                scope: params.scope,
+            },
+        })
+        return result
+    },
+})
+
+const CanvasStateSetSchema = CanvasesStateSetParams.omit({ project_id: true }).extend(CanvasesStateSetBody.shape)
+
+const canvasStateSet = (): ToolBase<typeof CanvasStateSetSchema, Schemas.CanvasStateEntry> => ({
+    name: 'canvas-state-set',
+    schema: CanvasStateSetSchema,
+    handler: async (context: Context, params: z.infer<typeof CanvasStateSetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.scope !== undefined) {
+            body['scope'] = params.scope
+        }
+        if (params.key !== undefined) {
+            body['key'] = params.key
+        }
+        if (params.value !== undefined) {
+            body['value'] = params.value
+        }
+        const result = await context.api.request<Schemas.CanvasStateEntry>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/canvases/${encodeURIComponent(String(params.id))}/state/set/`,
+            body,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-builds-retrieve': canvasBuildsRetrieve,
     'canvas-create': canvasCreate,
@@ -417,4 +467,6 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'canvas-publish-current-version': canvasPublishCurrentVersion,
     'canvas-source-retrieve': canvasSourceRetrieve,
     'canvas-validate-create': canvasValidateCreate,
+    'canvas-state-retrieve': canvasStateRetrieve,
+    'canvas-state-set': canvasStateSet,
 }

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -12,6 +12,7 @@ import {
     ChangeRequestsRejectCreateBody,
     ChangeRequestsRejectCreateParams,
     ChangeRequestsRetrieveParams,
+    CommentsCreateBody,
     CommentsListQueryParams,
     CommentsRetrieveParams,
     CommentsThreadRetrieveParams,
@@ -472,6 +473,53 @@ const commentThread = (): ToolBase<typeof CommentThreadSchema, unknown> => ({
     },
 })
 
+const CommentsCreateSchema = CommentsCreateBody
+
+const commentsCreate = (): ToolBase<typeof CommentsCreateSchema, Schemas.Comment> => ({
+    name: 'comments-create',
+    schema: CommentsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof CommentsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.scope !== undefined) {
+            body['scope'] = params.scope
+        }
+        if (params.item_context !== undefined) {
+            body['item_context'] = params.item_context
+        }
+        if (params.deleted !== undefined) {
+            body['deleted'] = params.deleted
+        }
+        if (params.mentions !== undefined) {
+            body['mentions'] = params.mentions
+        }
+        if (params.slug !== undefined) {
+            body['slug'] = params.slug
+        }
+        if (params.is_task !== undefined) {
+            body['is_task'] = params.is_task
+        }
+        if (params.content !== undefined) {
+            body['content'] = params.content
+        }
+        if (params.rich_content !== undefined) {
+            body['rich_content'] = params.rich_content
+        }
+        if (params.item_id !== undefined) {
+            body['item_id'] = params.item_id
+        }
+        if (params.source_comment !== undefined) {
+            body['source_comment'] = params.source_comment
+        }
+        const result = await context.api.request<Schemas.Comment>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/comments/`,
+            body,
+        })
+        return result
+    },
+})
+
 const CommentsListSchema = CommentsListQueryParams
 
 const commentsList = (): ToolBase<typeof CommentsListSchema, Schemas.PaginatedCommentList> => ({
@@ -814,6 +862,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'comment-count': commentCount,
     'comment-get': commentGet,
     'comment-thread': commentThread,
+    'comments-create': commentsCreate,
     'comments-list': commentsList,
     'org-member-get-github-login': orgMemberGetGithubLogin,
     'org-members-list': orgMembersList,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-state-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-state-retrieve.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this canvas.",
+            "type": "string"
+        },
+        "scope": {
+            "description": "Only return entries in this scope.",
+            "enum": ["shared", "user"],
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-state-set.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/canvas-state-set.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this canvas.",
+            "type": "string"
+        },
+        "key": {
+            "description": "Key to write, unique within its scope.",
+            "maxLength": 200,
+            "type": "string"
+        },
+        "scope": {
+            "description": "Scope to write into; the canvas must declare it in capabilities.posthog.state.\n\n* `user` - user\n* `shared` - shared",
+            "enum": ["user", "shared"],
+            "type": "string"
+        },
+        "value": {
+            "description": "JSON value to store (at most 64 KB serialized), or null to delete the key."
+        }
+    },
+    "required": ["id", "scope", "key", "value"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/comments-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/comments-create.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "content": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "deleted": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "is_task": {
+            "default": false,
+            "description": "Whether this comment is an actionable task that can be marked complete. Tasks render with a checkbox in the UI and can be filtered as a separate kind. Cannot be set on replies (source_comment) or emoji reactions. Immutable after creation.",
+            "type": "boolean"
+        },
+        "item_context": {
+            "description": "Metadata for the comment target, anchor, thread state, and owning task."
+        },
+        "item_id": {
+            "anyOf": [
+                {
+                    "maxLength": 72,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "mentions": {
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "rich_content": {},
+        "scope": {
+            "maxLength": 79,
+            "type": "string"
+        },
+        "slug": {
+            "type": "string"
+        },
+        "source_comment": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Agents cannot inspect or update canvas progress stored in `ph.state`, even when the authenticated user can access the canvas.

**Why:** Canvas state and discussions must remain usable when a user asks an agent to check or update their work.

## Changes

- Agents can read and write shared state plus their authenticated user's state on visible canvases.
- Other users' personal state remains private.
- Agents can read and create canvas comments through MCP tools.
- The canvas data skill now directs agents to state and comment tools.

Before:

```mermaid
flowchart LR
    U[User request] --> A{{Agent}}
    A --> S[Canvas source]
    A --> X[State and comment access denied]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class X phRed;
    class U phYellow;
    class S phGray;
```

After:

```mermaid
flowchart LR
    U[User request] --> A{{Agent}}
    A --> P[Visibility check]
    P --> D[(Canvas state and comments)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class P phRed;
    class U phYellow;
    class D phGray;
```

## How did you test this code?

- `ruff format`, `ruff check`, OpenAPI generation, MCP generation, and MCP tool-name validation completed.
- The regression test guards authenticated state access and private-state isolation.
- The backend test did not complete because the local test database rebuild remained CPU-bound in migrations.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The canvas data skill documents the new state and comment workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the change with the querying-canvas-data, writing-tests, improving-drf-endpoints, implementing-mcp-tools, and writing-pr-descriptions skills.

The permission model uses the sandbox token's authenticated user and existing channel visibility rules.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
