### PR TITLE
chore(personhog): tighten leader comments

### DIFF
--- a/rust/personhog-leader/src/cache/dirty_index.rs
+++ b/rust/personhog-leader/src/cache/dirty_index.rs
@@ -16,13 +16,13 @@ pub struct DirtyMark {
     /// derive from the same state, so a mismatch means the acked state and
     /// the produced record diverged.
     pub version: i64,
-    /// Changelog offset of that record. Because records are full state and
-    /// the topic is compacted by person key, this single record is always
-    /// sufficient to reconstruct the person — and compaction never removes
-    /// the latest record for a key. Only the topic's `delete` retention
-    /// bounds it, which matters solely if a mark outlives the retention
-    /// window (a writer outage of days); even then recovery fails loudly
-    /// with a retryable error rather than serving stale state.
+    /// Changelog offset of that record. Records are full state and the
+    /// topic is compacted by person key, so this single record always
+    /// reconstructs the person, and compaction never removes the latest
+    /// record for a key. Only the topic's `delete` retention bounds it,
+    /// which matters only if a mark outlives the retention window (a
+    /// writer outage of days); even then recovery fails loudly with a
+    /// retryable error rather than serving stale state.
     pub offset: i64,
     /// The person's routing partition, denormalized so pruning can work
     /// per partition without rehashing keys.
@@ -36,65 +36,66 @@ type ReclaimQueue = Arc<Mutex<VecDeque<(i64, PersonCacheKey)>>>;
 /// Maximum queue pops per prune lock hold (see `prune_partition`).
 const PRUNE_CHUNK: usize = 4_096;
 
-/// Containers below this capacity are never shrunk — the retained memory
+/// Containers below this capacity are never shrunk; the retained memory
 /// is a few hundred KB at most, not worth the churn.
 const SHRINK_CAPACITY_FLOOR: usize = 4 * PRUNE_CHUNK;
 
 /// Index of persons whose latest acked state is (or may be) newer than what
 /// the writer has applied to Postgres.
 ///
-/// The cache evicts freely; this index is what keeps eviction safe. On a
-/// cache miss the leader consults it before trusting the PG fallback: a
-/// marked person is recovered from the changelog record at the marked
-/// offset, an unmarked person's PG row is known current. Entries cost
-/// ~100 bytes with map overhead, so even an hours-long writer outage is
-/// far cheaper to track here than to ride out by pinning person state.
+/// The cache evicts freely; this index keeps eviction safe. On a cache
+/// miss the leader consults it before trusting the PG fallback: a marked
+/// person is recovered from the changelog record at the marked offset;
+/// an unmarked person's PG row is known current. Entries cost ~100 bytes
+/// with map overhead, so even an hours-long writer outage is far cheaper
+/// to track here than to ride out by pinning person state.
 ///
-/// Marks are added under the per-key lock after every acked produce, and
+/// Marks are added under the per-key lock after every acked produce and
 /// removed by a periodic prune once the writer's committed offset passes
-/// them (committed offset semantics: the record at `committed - 1` is the
-/// last one applied, so a mark is prunable when `offset < committed`).
+/// them (the record at `committed - 1` is the last one applied, so a
+/// mark is prunable when `offset < committed`).
 ///
-/// The prune predicate is an offset threshold and marks arrive in roughly
-/// offset order per partition, so reclaim is a queue pop, not a map scan:
-/// alongside the map, each partition keeps an offset-ordered reclaim queue
-/// of `(offset, key)` entries, and a prune pops from the head only while
-/// entries are below the committed offset. A tick therefore costs work
-/// proportional to the marks actually reclaimed — never the index size —
-/// which is what lets the prune loop run every second.
+/// The prune predicate is an offset threshold and marks arrive in
+/// roughly offset order per partition, so reclaim is a queue pop, not a
+/// map scan: each partition keeps an offset-ordered reclaim queue of
+/// `(offset, key)` entries, and a prune pops from the head only while
+/// entries are below the committed offset. A tick costs work
+/// proportional to the marks reclaimed, never the index size, which is
+/// what lets the prune loop run every second.
 ///
-/// The queue is a hint; the map is the truth. Every marked key has exactly
-/// one live queue entry, carrying some offset at or below its map offset:
-/// `mark` enqueues only brand-new keys, so a re-marked key's queue entry
-/// goes stale, and when the prune pops it and finds the map ahead of the
-/// committed offset it re-enqueues the entry at the map's offset instead
-/// of removing the mark. Task scheduling can also interleave near-
-/// simultaneous marks slightly out of offset order; the prune stops at the
-/// first unapplied head, so an inversion only delays the entries behind it
-/// until a later tick.
+/// The queue is a hint; the map is the truth. Every marked key has
+/// exactly one live queue entry, at some offset at or below its map
+/// offset: `mark` enqueues only brand-new keys, so a re-marked key's
+/// queue entry goes stale, and when the prune pops it and finds the map
+/// ahead of the committed offset it re-enqueues at the map's offset
+/// instead of removing the mark. Task scheduling can interleave
+/// near-simultaneous marks slightly out of offset order; the prune stops
+/// at the first unapplied head, so an inversion only delays the entries
+/// behind it until a later tick.
 ///
 /// The index is soft-bounded by `max_entries`: under a sustained writer
-/// outage it would otherwise grow one mark per unique person written —
-/// gigabytes over hours at production churn, and an OOM restart replays
-/// the same backlog through warming. Write admission (`can_admit`) is
-/// checked before producing, so the bound sheds new write volume instead
-/// of ever refusing to record a fact: `mark` itself never fails, because
-/// warming must be able to record marks for records that are already
-/// durable regardless of the bound.
+/// outage it would otherwise grow one mark per unique person written
+/// (gigabytes over hours at production churn), and an OOM restart
+/// replays the same backlog through warming. Write admission
+/// (`can_admit`) is checked before producing, so the bound sheds new
+/// write volume instead of refusing to record a fact: `mark` itself
+/// never fails, because warming must record marks for already-durable
+/// records regardless of the bound.
 pub struct DirtyIndex {
     map: DashMap<PersonCacheKey, DirtyMark>,
     /// Per-partition reclaim queues (see the struct docs). A prune pass
-    /// holds a queue's lock for at most `PRUNE_CHUNK` pops and re-fetches
-    /// the queue from this map between chunks, so `clear_partition` —
-    /// which detaches the queue and then takes the same lock — waits out
-    /// at most one chunk before draining, and a paused pass finds the
-    /// queue gone instead of racing the drain. Entries popped before the
-    /// detach have already had their map marks removed; everything else
-    /// is still in the queue for the drain — no entry escapes a release.
+    /// holds a queue's lock for at most `PRUNE_CHUNK` pops and
+    /// re-fetches the queue from this map between chunks, so
+    /// `clear_partition` (which detaches the queue, then takes the same
+    /// lock) waits out at most one chunk before draining, and a paused
+    /// pass finds the queue gone instead of racing the drain. Entries
+    /// popped before the detach already had their map marks removed;
+    /// everything else is still in the queue for the drain, so no entry
+    /// escapes a release.
     queues: DashMap<u32, ReclaimQueue>,
     /// Highest offset ever marked per partition since its last clear.
     /// Map offsets only grow and pruning removes low offsets first, so
-    /// while any mark lives this equals the largest live mark — an O(1)
+    /// while any mark lives this equals the largest live mark: an O(1)
     /// read for the writer-lag gauge.
     max_marked: DashMap<u32, i64>,
     /// Entry count maintained alongside the map: `DashMap::len()` takes a
@@ -119,10 +120,11 @@ impl DirtyIndex {
 
     /// Whether a write for `key` may be admitted: either the index has
     /// room to grow, or the key is already marked (updating a mark does
-    /// not grow the index). Checked before the produce — a durable but
-    /// unmarked write would silently reopen the stale-fallback hole.
-    /// Concurrent in-flight writes can overshoot the bound by the request
-    /// concurrency; it is a memory bound, not an exact count.
+    /// not grow the index). Checked before the produce, because a
+    /// durable but unmarked write would silently reopen the
+    /// stale-fallback hole. Concurrent in-flight writes can overshoot
+    /// the bound by the request concurrency; it is a memory bound, not
+    /// an exact count.
     pub fn can_admit(&self, key: &PersonCacheKey) -> bool {
         self.size.load(Ordering::Relaxed) < self.max_entries || self.map.contains_key(key)
     }
@@ -200,16 +202,16 @@ impl DirtyIndex {
         }
     }
 
-    /// Drop marks on `partition` that the writer has applied (offset below
-    /// its committed offset). Pops the reclaim queue only while its head
-    /// is applied, so the cost is proportional to the marks reclaimed.
-    /// The pass releases the queue lock every `PRUNE_CHUNK` pops: a
-    /// catch-up after a long writer outage reclaims millions of marks in
-    /// one call, and an unbroken hold would stall every new-key `mark` —
-    /// the write hot path — for the whole pass. Between chunks the queue
-    /// is re-fetched, so a concurrent `clear_partition` (which detaches
-    /// it) ends the pass instead of racing the drain. Returns how many
-    /// were pruned.
+    /// Drop marks on `partition` that the writer has applied (offset
+    /// below its committed offset). Pops the reclaim queue only while
+    /// its head is applied, so the cost is proportional to the marks
+    /// reclaimed. The pass releases the queue lock every `PRUNE_CHUNK`
+    /// pops: a catch-up after a long writer outage reclaims millions of
+    /// marks in one call, and an unbroken hold would stall every
+    /// new-key `mark` (the write hot path) for the whole pass. Between
+    /// chunks the queue is re-fetched, so a concurrent
+    /// `clear_partition` (which detaches it) ends the pass instead of
+    /// racing the drain. Returns how many were pruned.
     pub fn prune_partition(&self, partition: u32, committed: i64) -> usize {
         let mut removed = 0;
         loop {
@@ -239,9 +241,9 @@ impl DirtyIndex {
     /// One bounded slice of a prune pass: re-fetch the queue, hold its
     /// lock for at most `PRUNE_CHUNK` pops, and report how many marks
     /// were removed plus whether the pass is exhausted. Exhaustion means
-    /// the head is unapplied, the queue is empty, or the queue was
-    /// detached by a concurrent `clear_partition` — the re-fetch is what
-    /// lets a release end an in-flight pass instead of racing its drain.
+    /// the head is unapplied, the queue is empty, or a concurrent
+    /// `clear_partition` detached the queue; the re-fetch is what lets a
+    /// release end an in-flight pass instead of racing its drain.
     fn prune_chunk(&self, partition: u32, committed: i64) -> (usize, bool) {
         let Some(queue) = self
             .queues
@@ -276,15 +278,14 @@ impl DirtyIndex {
                 removed += 1;
             } else if let Some(mark) = self.map.get(&key) {
                 // Superseded: the live mark is ahead of the committed
-                // offset, and the entry just popped was this key's only
-                // queue presence (`mark` enqueues keys once). Dropping
-                // it would leave the mark unreclaimable — pops are the
-                // only reclaim path — so re-enqueue at the map's
-                // offset. The tail lands past the committed threshold,
-                // so the head check terminates the pass before
-                // re-processing it; the resulting disorder only delays
-                // that key's reclaim, since removal is always re-proved
-                // against the map.
+                // offset, and the popped entry was this key's only
+                // queue presence (`mark` enqueues keys once). Pops are
+                // the only reclaim path, so dropping it would leave the
+                // mark unreclaimable; re-enqueue at the map's offset
+                // instead. The tail lands past the committed threshold,
+                // so the head check ends the pass before re-processing
+                // it; the disorder only delays that key's reclaim,
+                // since removal is always re-proved against the map.
                 queue.push_back((mark.offset, key.clone()));
             }
         }
@@ -292,8 +293,8 @@ impl DirtyIndex {
         (removed, false)
     }
 
-    /// Drop every mark on `partition` — used when the partition is released
-    /// to another owner, whose warming rebuilds its own marks.
+    /// Drop every mark on `partition`, used when the partition is
+    /// released to another owner, whose warming rebuilds its own marks.
     pub fn clear_partition(&self, partition: u32) -> usize {
         let Some((_, queue)) = self.queues.remove(&partition) else {
             return 0;
@@ -315,8 +316,8 @@ impl DirtyIndex {
         removed
     }
 
-    /// Partitions that currently hold marks — the prune loop's targeting
-    /// set for the writer committed-offset fetch.
+    /// Partitions that hold marks: the prune loop's targeting set for
+    /// the writer committed-offset fetch.
     pub fn partitions_with_marks(&self) -> Vec<u32> {
         self.queues
             .iter()
@@ -331,7 +332,7 @@ impl DirtyIndex {
             .collect()
     }
 
-    /// Highest live marked offset for a partition, if any — feeds the
+    /// Highest live marked offset for a partition, if any. Feeds the
     /// writer-lag gauge.
     pub fn max_offset(&self, partition: u32) -> Option<i64> {
         let has_marks = self.queues.get(&partition).is_some_and(|queue| {
@@ -351,7 +352,7 @@ impl DirtyIndex {
         self.size.load(Ordering::Relaxed)
     }
 
-    /// The soft entry bound — exported as a gauge so fullness
+    /// The soft entry bound, exported as a gauge so fullness
     /// (`len / max_entries`) is alertable before writes start shedding.
     pub fn max_entries(&self) -> usize {
         self.max_entries
@@ -439,8 +440,9 @@ mod tests {
         assert_eq!(index.prune_partition(0, 3), 0);
         assert_eq!(index.get(&key(1)).unwrap().offset, 5);
 
-        // The re-enqueued entry keeps the key reclaimable once the writer
-        // catches up — a dropped entry would leak the mark forever.
+        // The re-enqueued entry keeps the key reclaimable once the
+        // writer catches up; a dropped entry would leak the mark
+        // forever.
         assert_eq!(index.prune_partition(0, 6), 1);
         assert!(index.get(&key(1)).is_none());
         assert_eq!(index.len(), 0);
@@ -488,7 +490,7 @@ mod tests {
         assert!(!exhausted);
 
         // A release lands between chunks: it detaches the queue and
-        // drains every remaining mark — nothing escapes.
+        // drains every remaining mark; nothing escapes.
         assert_eq!(index.clear_partition(0), 500);
         assert_eq!(index.len(), 0);
 

--- a/rust/personhog-leader/src/cache/partitioned.rs
+++ b/rust/personhog-leader/src/cache/partitioned.rs
@@ -18,12 +18,12 @@ pub enum CacheLookup {
 /// Foyer cache so that releasing a partition drops all its entries cleanly.
 pub struct PartitionedCache {
     partitions: DashMap<u32, PersonCache>,
-    /// Partitions mid-warm: built here record by record — evicting under
-    /// the same per-partition byte budget as a serving cache — and moved
+    /// Partitions mid-warm: built here record by record (evicting under
+    /// the same per-partition byte budget as a serving cache) and moved
     /// to `partitions` in a single insert when the warm's range
-    /// completes. Entirely invisible to readers: `get`/`has_partition`
-    /// consult `partitions` only, so a partition under construction
-    /// answers `PartitionNotOwned` on every path.
+    /// completes. Invisible to readers: `get`/`has_partition` consult
+    /// `partitions` only, so a partition under construction answers
+    /// `PartitionNotOwned` on every path.
     warming: DashMap<u32, PersonCache>,
     per_partition_capacity: usize,
 }
@@ -37,21 +37,19 @@ impl PartitionedCache {
         }
     }
 
-    /// Create a new cache for the given partition. Called during warm-up.
     pub fn create_partition(&self, partition: u32) {
         self.partitions
             .insert(partition, PersonCache::new(self.per_partition_capacity));
     }
 
     /// Atomically install a fully-populated partition cache. The records
-    /// are inserted into a fresh `PersonCache` *before* the partition is
-    /// added to the shared `DashMap`, so any thread that observes
-    /// `has_partition(partition) == true` will also see every record —
-    /// no observer can land in the window where the partition exists
-    /// but its keys haven't been put yet. Used by warming so reads that
-    /// arrive immediately after a handoff Complete don't fall through
-    /// to PG and return stale values for records that the writer hasn't
-    /// yet persisted.
+    /// go into a fresh `PersonCache` before the partition is added to
+    /// the shared `DashMap`, so any thread that observes
+    /// `has_partition(partition) == true` also sees every record; no
+    /// observer can land in a window where the partition exists but its
+    /// keys are missing. Used by warming so reads that arrive right
+    /// after a handoff Complete do not fall through to PG and return
+    /// stale values for records the writer has not yet persisted.
     pub fn install_warmed_partition(
         &self,
         partition: u32,
@@ -65,8 +63,8 @@ impl PartitionedCache {
     }
 
     /// Start building a partition's cache without publishing it. The
-    /// warm inserts record by record with `warm_put` — bounded by the
-    /// per-partition budget, evicting as it goes — and publishes the
+    /// warm inserts record by record with `warm_put` (bounded by the
+    /// per-partition budget, evicting as it goes) and publishes the
     /// finished cache with `publish_warmed_partition`. Re-entrant: a
     /// retried warm begins fresh, replacing any half-built predecessor.
     pub fn begin_warm_partition(&self, partition: u32) {
@@ -99,7 +97,7 @@ impl PartitionedCache {
         self.warming.remove(&partition);
     }
 
-    /// Resident weight of a build in flight — what the warm retained of
+    /// Resident weight of a build in flight: what the warm retained of
     /// its range under the budget.
     pub fn warm_usage_bytes(&self, partition: u32) -> usize {
         self.warming
@@ -108,7 +106,7 @@ impl PartitionedCache {
             .unwrap_or(0)
     }
 
-    /// Drop the cache for the given partition, evicting all entries —
+    /// Drop the cache for the given partition, evicting all entries,
     /// including a build in flight, so a release racing a warm leaves
     /// nothing behind.
     pub fn drop_partition(&self, partition: u32) {
@@ -117,8 +115,8 @@ impl PartitionedCache {
     }
 
     /// Total resident weight in bytes across all owned partitions,
-    /// builds in flight included — the gauge tells the truth during
-    /// warms rather than hiding the construction cost.
+    /// builds in flight included, so the gauge tells the truth during
+    /// warms instead of hiding the construction cost.
     pub fn usage_bytes(&self) -> usize {
         self.partitions
             .iter()
@@ -127,7 +125,7 @@ impl PartitionedCache {
             + self.warming.iter().map(|c| c.usage_bytes()).sum::<usize>()
     }
 
-    /// Check if a partition cache exists (i.e., the partition is owned).
+    /// Whether the partition is owned (its cache exists).
     pub fn has_partition(&self, partition: u32) -> bool {
         self.partitions.contains_key(&partition)
     }
@@ -146,17 +144,17 @@ impl PartitionedCache {
         }
     }
 
-    /// Insert or update a person in the partition's cache.
     pub fn put(&self, partition: u32, key: PersonCacheKey, person: CachedPerson) {
         if let Some(cache) = self.partitions.get(&partition) {
             cache.put(key, person);
         }
     }
 
-    /// Remove a single person from the partition's cache. Only tests call
-    /// this, to force a deterministic eviction — production evictions come
-    /// from Foyer's capacity policy. Safe regardless: the miss path
-    /// recovers the person from the changelog or PG on next access.
+    /// Remove a single person from the partition's cache. Only tests
+    /// call this, to force a deterministic eviction; production
+    /// evictions come from Foyer's capacity policy. Safe regardless: the
+    /// miss path recovers the person from the changelog or PG on next
+    /// access.
     pub fn remove(&self, partition: u32, key: &PersonCacheKey) {
         if let Some(cache) = self.partitions.get(&partition) {
             cache.remove(key);

--- a/rust/personhog-leader/src/cache/persons.rs
+++ b/rust/personhog-leader/src/cache/persons.rs
@@ -50,8 +50,8 @@ pub struct CachedPerson {
     /// falling back to a PG row the writer may not have tombstoned yet.
     pub is_deleted: bool,
     /// Epoch milliseconds of the person's last observed activity, when
-    /// known (matching `created_at`'s unit). Max-merged on update — the
-    /// value only ever advances — and deliberately not a change by itself.
+    /// known (matching `created_at`'s unit). Max-merged on update, so
+    /// the value only advances, and deliberately not a change by itself.
     pub last_seen_at: Option<i64>,
     /// Byte weight charged against the cache capacity; see
     /// [`approx_person_bytes`].
@@ -71,9 +71,9 @@ impl CachedPerson {
     }
 }
 
-/// Decodes a changelog `Person` record into cache form. The only fallible
-/// step is validating the properties JSON — validated without building
-/// the tree, and stored as the record's own bytes.
+/// Decodes a changelog `Person` record into cache form. The only
+/// fallible step validates the properties JSON, without building the
+/// tree; the record's own bytes are stored.
 impl TryFrom<Person> for CachedPerson {
     type Error = serde_json::Error;
 
@@ -114,8 +114,8 @@ impl EventListener for CacheEventMetrics {
             Event::Remove => "remove",
             Event::Clear => "clear",
             // Every successful update overwrites its cache entry, so
-            // Replace fires once per write — pure hot-path noise that
-            // would drown the signal this metric exists for.
+            // Replace fires once per write: hot-path noise that would
+            // drown the signal this metric exists for.
             Event::Replace => return,
         };
         counter!("personhog_leader_cache_entries_left_total", "reason" => reason).increment(1);
@@ -136,7 +136,7 @@ pub struct PersonCache {
 
 impl PersonCache {
     /// `capacity_bytes` bounds the cache by the entries' byte weights
-    /// (see [`approx_person_bytes`]), not their count — person documents
+    /// (see [`approx_person_bytes`]), not their count: person documents
     /// vary by orders of magnitude and grow in place across writes, so
     /// an entry-count bound cannot bound memory.
     pub fn new(capacity_bytes: usize) -> Self {
@@ -168,7 +168,7 @@ impl PersonCache {
         self.inner.remove(key);
     }
 
-    /// Resident weight in bytes — the sum of entries' `approx_bytes` as
+    /// Resident weight in bytes: the sum of entries' `approx_bytes` as
     /// foyer accounts it against the capacity.
     pub fn usage_bytes(&self) -> usize {
         self.inner.usage()
@@ -180,11 +180,11 @@ mod tests {
     use super::*;
 
     /// Proto3 encodes an absent bytes field as empty, and every leader
-    /// write path serializes at least `{}` — so empty properties can
-    /// only arrive from records that predate this store, and rejecting
-    /// them would fail the warm over a document that is simply
-    /// property-less. This pins the lenient reading in both directions:
-    /// decode accepts, and parse yields the empty map.
+    /// write path serializes at least `{}`, so empty properties can only
+    /// arrive from records that predate this store. Rejecting them would
+    /// fail the warm over a document that is simply property-less. This
+    /// pins the lenient reading in both directions: decode accepts, and
+    /// parse yields the empty map.
     #[test]
     fn empty_properties_bytes_read_as_the_empty_map() {
         let record = Person {
@@ -218,13 +218,12 @@ mod tests {
 
     /// An entry-count capacity cannot bound memory: documents grow in
     /// place and vary by orders of magnitude. This pins the byte
-    /// denomination — sustained inserts whose combined weight far
-    /// exceeds the byte capacity must evict most, but not all, of them.
-    /// Foyer splits capacity across eight shards and evicts lazily on
-    /// later inserts to the same shard, so entries are sized well under
-    /// the per-shard budget (admission must succeed for eviction to be
-    /// what's under test) and the bound is asserted with per-shard
-    /// slack rather than exactly.
+    /// denomination: sustained inserts whose combined weight far exceeds
+    /// the byte capacity must evict most, but not all, of them. Foyer
+    /// splits capacity across eight shards and evicts lazily on later
+    /// inserts to the same shard, so entries are sized well under the
+    /// per-shard budget (admission must succeed for eviction to be under
+    /// test) and the bound is asserted with per-shard slack.
     #[test]
     fn byte_weights_evict_under_capacity_pressure() {
         // 64 KiB capacity → ~8 KiB per shard; ~2 KiB entries fit a

--- a/rust/personhog-leader/src/config.rs
+++ b/rust/personhog-leader/src/config.rs
@@ -18,9 +18,9 @@ pub struct Config {
     /// by their approximate serialized size, so this bounds memory, not
     /// entry count. Sized against full ownership: a lone survivor owns
     /// every partition, so the worst-case cache footprint is this value
-    /// times the partition count — 16 MiB × 16 partitions = 256 MiB —
-    /// and in-memory size can run a small multiple of serialized weight
-    /// for key-dense documents.
+    /// times the partition count (16 MiB × 16 partitions = 256 MiB), and
+    /// in-memory size can run a small multiple of serialized weight for
+    /// key-dense documents.
     #[envconfig(default = "16777216")]
     pub cache_memory_capacity_bytes: usize,
 
@@ -53,9 +53,9 @@ pub struct Config {
     #[envconfig(default = "0")]
     pub fencing_txn_timeout_ms: u64,
 
-    /// `message.timeout.ms` for the fenced changelog producer only. It is
-    /// separate from the shared producer's because a fenced write's total
-    /// must fit inside the lease self-fence runway — see
+    /// `message.timeout.ms` for the fenced changelog producer only. It
+    /// is separate from the shared producer's because a fenced write's
+    /// total must fit inside the lease self-fence runway; see
     /// [`Config::validate_fencing_timescales`].
     #[envconfig(default = "0")]
     pub fencing_message_timeout_ms: u32,
@@ -64,7 +64,7 @@ pub struct Config {
     pub metrics_port: u16,
 
     /// Maximum concurrent partition warms. Warms are broker-bound reads
-    /// on MSK, so this can sit well above the S3-era default of 4.
+    /// on MSK, so moderate concurrency is safe.
     #[envconfig(default = "8")]
     pub warm_concurrency: usize,
 
@@ -91,10 +91,10 @@ pub struct Config {
     #[envconfig(default = "300")]
     pub grpc_max_connection_age_secs: u64,
 
-    /// Maximum concurrent in-flight gRPC requests before the server sheds
-    /// load with RESOURCE_EXHAUSTED. That code is terminal end to end —
-    /// the router treats a delivered response as an outcome and the
-    /// client does not retry it — so this is backpressure to the caller,
+    /// Maximum concurrent in-flight gRPC requests before the server
+    /// sheds load with RESOURCE_EXHAUSTED. That code is terminal end to
+    /// end (the router treats a delivered response as an outcome and the
+    /// client does not retry it), so this is backpressure to the caller,
     /// not a redirect. 0 = disabled.
     #[envconfig(default = "0")]
     pub max_concurrent_requests: usize,
@@ -142,11 +142,11 @@ pub struct Config {
     #[envconfig(default = "personhog-writer")]
     pub writer_consumer_group: String,
 
-    /// How many offsets to rewind past the writer's committed offset when
-    /// warming. Pure safety margin — any non-negative value is correct, but
-    /// a larger value is more forgiving of momentary races between the
-    /// writer's commit and our observation of it. Bounded above by Kafka's
-    /// earliest available offset.
+    /// How many offsets to rewind past the writer's committed offset
+    /// when warming. Pure safety margin: any non-negative value is
+    /// correct, and a larger value is more forgiving of momentary races
+    /// between the writer's commit and our observation of it. Bounded
+    /// above by Kafka's earliest available offset.
     #[envconfig(default = "1000")]
     pub warm_lookback_offsets: i64,
 
@@ -186,7 +186,7 @@ pub struct Config {
     /// that would newly push a within-limit row over this is rejected; a
     /// row already over it (predating the constraint, or from another
     /// writer) is remediated by trimming to the target below, discarding
-    /// the triggering update — mirroring the Node pipeline's policy. So
+    /// the triggering update (mirroring the Node pipeline's policy). So
     /// every acked record is applyable by the writer verbatim: the cache,
     /// the changelog, and Postgres can never disagree about an acked row.
     #[envconfig(default = "655360")]
@@ -205,30 +205,29 @@ pub struct Config {
 
     // ── Dirty index / changelog recovery ─────────────────────────
     /// How often to poll the writer's committed offsets and prune dirty
-    /// index marks the writer has applied to PG. A tick costs one batched
-    /// OffsetFetch plus work proportional to the marks actually reclaimed
-    /// (the index is never scanned), so a short interval is cheap — and it
-    /// bounds how long an applied-but-unpruned mark keeps sending reads to
-    /// the changelog for state PG already has.
+    /// index marks the writer has applied to PG. A tick costs one
+    /// batched OffsetFetch plus work proportional to the marks actually
+    /// reclaimed (the index is never scanned), so a short interval is
+    /// cheap, and it bounds how long an applied-but-unpruned mark keeps
+    /// sending reads to the changelog for state PG already has.
     #[envconfig(default = "1")]
     pub dirty_index_prune_interval_secs: u64,
 
-    /// Overall deadline for recovering one evicted dirty person from the
-    /// changelog, including transient-failure retries. A point read that
-    /// hasn't returned in a few seconds isn't going to, and each recovery
-    /// occupies a pooled consumer for its whole duration — a long deadline
-    /// amplifies a broker blip into pool exhaustion.
+    /// Overall deadline for recovering one evicted dirty person from
+    /// the changelog, including transient-failure retries. A point read
+    /// that has not returned in a few seconds is not going to, and each
+    /// recovery occupies a pooled consumer for its whole duration; a
+    /// long deadline amplifies a broker blip into pool exhaustion.
     #[envconfig(default = "5")]
     pub recovery_recv_timeout_secs: u64,
 
-    /// Number of pooled changelog-recovery consumers, bounding concurrent
-    /// recoveries the way a DB connection pool bounds queries. Each is a
-    /// full Kafka client (its own connections and background threads), but
-    /// even 16 is fewer than the per-partition consumers this pool
-    /// replaced. Under a benchmarked writer outage a pool of 4 queued
-    /// recoveries for ~10ms on average and tripled write p99; 16 zeroed
-    /// the queueing. The `personhog_leader_recovery_pool_wait_ms`
-    /// histogram shows when this is undersized.
+    /// Number of pooled changelog-recovery consumers, bounding
+    /// concurrent recoveries the way a DB connection pool bounds
+    /// queries. Each is a full Kafka client (its own connections and
+    /// background threads). Under a benchmarked writer outage a pool of
+    /// 4 queued recoveries and tripled write p99; 16 zeroed the
+    /// queueing. The `personhog_leader_recovery_pool_wait_ms` histogram
+    /// shows when this is undersized.
     #[envconfig(default = "16")]
     pub recovery_pool_size: usize,
 
@@ -242,20 +241,20 @@ pub struct Config {
 
     /// Bound on the unresolved-version floors, its own knob rather than
     /// borrowing the dirty index's. The two grow under different
-    /// failures: dirty marks accumulate whenever the writer lags, floors
-    /// only when writes end without an answer — cancellations and
-    /// ambiguous commits — which is orders of magnitude rarer. Past the
+    /// failures: dirty marks accumulate whenever the writer lags; floors
+    /// only when writes end without an answer (cancellations and
+    /// ambiguous commits), which is orders of magnitude rarer. Past the
     /// bound, floors spill to one coarse per-partition value (safety
     /// survives; precision degrades), so this sizes memory, not
     /// correctness. The default is a fraction of the dirty index's.
     #[envconfig(default = "1000000")]
     pub emitted_versions_max_entries: usize,
 
-    /// Hard cap on live lifecycle fences (~100 bytes each). The fence map
-    /// grows one entry per person frozen by a lifecycle op and has no
-    /// eviction, so this is the memory fuse against a surge of ops from a
-    /// huge customer: at the cap, new FencePerson calls shed with
-    /// RESOURCE_EXHAUSTED — backpressure the saga's retries absorb —
+    /// Hard cap on live lifecycle fences (~100 bytes each). The fence
+    /// map grows one entry per person frozen by a lifecycle op and has
+    /// no eviction, so this is the memory fuse against a surge of ops
+    /// from a huge customer: at the cap, new FencePerson calls shed with
+    /// RESOURCE_EXHAUSTED (backpressure the saga's retries absorb),
     /// while re-seals of already-fenced persons and the takeover scan
     /// (marks already live; the freeze must hold) are exempt.
     #[envconfig(default = "250000")]
@@ -275,7 +274,8 @@ pub struct Config {
     /// (its PG_TARGET_TABLE): the dirty index treats an unmarked person's
     /// PG row as current, which is only true of the writer's own target.
     /// Prod pairs posthog_person on both sides; the dev validation stack
-    /// pairs personhog_person_tmp on both — flip them together at cutover.
+    /// pairs personhog_person_tmp on both. Flip them together at
+    /// cutover.
     #[envconfig(default = "posthog_person")]
     pub fallback_table: String,
 
@@ -333,13 +333,13 @@ pub struct Config {
 
     // ── Shutdown budgets ─────────────────────────────────────────
     // The lifecycle manager's per-phase windows. Configurable because
-    // the terms validated against them — the drain timeout, the
-    // heartbeat interval — are, and a fixed ceiling under adjustable
+    // the terms validated against them (the drain timeout, the
+    // heartbeat interval) are, and a fixed ceiling under adjustable
     // terms is a configuration an operator cannot resolve. Their
     // relations are checked by `validate_shutdown_budgets` at startup.
     /// How long the lifecycle manager lets the coordination component
-    /// exit gracefully. The pod's whole teardown — drain setup, drain,
-    /// fence, keepalive join, revoke — must fit inside it, which
+    /// exit gracefully. The pod's whole teardown (drain setup, drain,
+    /// fence, keepalive join, revoke) must fit inside it, which
     /// `validate_lease_timescales` enforces.
     #[envconfig(default = "55")]
     pub coordination_graceful_shutdown_secs: u64,
@@ -360,15 +360,14 @@ pub struct Config {
 /// reserves for self-fencing (a third of the TTL). The bound is on the
 /// *queued* write, not the lucky one: an arrival can park behind a
 /// window that is already committing, so it pays that window's send and
-/// commit before its own — hence the factor of two below.
+/// commit before its own, hence the factor of two below.
 ///
 /// A commit may also be re-attempted, and the shares are sized so that
-/// every attempt the code will make still fits. The alternative was a
-/// bound that quietly assumed a single attempt while the retry loop
-/// spent three times it: an assertion the runway could not honour is
-/// worse than a tighter timeout, because the whole point of deriving
-/// these from the lease is that a write cannot outlive the fence that
-/// ends its session.
+/// every attempt the code will make still fits. A bound that quietly
+/// assumed a single attempt while the retry loop spent three times it
+/// would be an assertion the runway cannot honor, worse than a tighter
+/// timeout: the whole point of deriving these from the lease is that a
+/// write cannot outlive the fence that ends its session.
 ///
 /// librdkafka additionally requires `message.timeout.ms <= transaction
 /// .timeout.ms`, and rejects a `transaction.timeout.ms` under a second.
@@ -386,14 +385,14 @@ pub const FENCING_COMMIT_ATTEMPTS: u32 = 2;
 
 /// How many times a window's abort is attempted in total.
 ///
-/// One, deliberately. An abort that does not land leaves the producer in
-/// a state it cannot begin another transaction from — which is now a
-/// condemned fence, given up on the next write and re-taken by the
-/// healing pass, whose `init_transactions` aborts the pending
-/// transaction at the broker as a side effect. Retrying the abort is
-/// therefore a slower, less reliable version of a recovery that already
-/// exists, and it is not free: every attempt is bounded by the
-/// transaction timeout and has to fit the same runway.
+/// One, deliberately. An abort that does not land leaves the producer
+/// in a state it cannot begin another transaction from: a condemned
+/// fence, given up on the next write and re-taken by the healing pass,
+/// whose `init_transactions` aborts the pending transaction at the
+/// broker as a side effect. Retrying the abort is a slower, less
+/// reliable version of a recovery that already exists, and it is not
+/// free: every attempt is bounded by the transaction timeout and has to
+/// fit the same runway.
 pub const FENCING_ABORT_ATTEMPTS: u32 = 1;
 
 /// Every call bounded by the transaction timeout that one window can
@@ -423,16 +422,17 @@ impl Config {
     /// Slack the drain spends outside the writes themselves: the settle
     /// wait that follows `wait_until_empty`, plus one poll interval of
     /// granularity on the wait (the coordination drain polls at 50ms).
-    /// Subtracted from the runway before sizing the write budget — sizing
-    /// against the full runway left the lease-loss drain oversubscribed
-    /// by construction, so worst-case queueing failed the drain and cost
-    /// a restart to load rather than to failure.
+    /// Subtracted from the runway before sizing the write budget:
+    /// sizing against the full runway would oversubscribe the
+    /// lease-loss drain by construction, so worst-case queueing would
+    /// fail the drain and cost a restart to load rather than to
+    /// failure.
     fn fencing_drain_slack(&self) -> Duration {
         self.fencing_settle_budget() + Duration::from_millis(50)
     }
 
     /// The budget one write may spend, derived so that a write queued
-    /// behind another — and the settle that follows the queue draining —
+    /// behind another, and the settle that follows the queue draining,
     /// still finishes inside the runway.
     fn fencing_budget(&self) -> Duration {
         self.lease_fence_runway()
@@ -461,34 +461,22 @@ impl Config {
     /// The producer queue each fenced producer gets, in MiB.
     ///
     /// The shared producer's queue is sized for one client; the fenced
-    /// path creates one producer *per owned partition*, so inheriting
-    /// that figure multiplies it by the partition count. A lone survivor
-    /// owning every partition would be entitled to the whole product,
-    /// which for the deployed shape is several gigabytes against a pod
-    /// sized for one — a client spreading large property updates across
-    /// partitions while Kafka is slow could fill the independent queues
-    /// and exhaust the leader.
-    ///
-    /// So the budget is the aggregate, divided. The floor keeps a
-    /// high-partition-count deployment from starving any single producer
-    /// below a workable depth; it trades the guarantee for a bound that
-    /// is still far under the un-divided figure.
+    /// path creates one producer per owned partition, so inheriting
+    /// that figure multiplies it by the partition count. A lone
+    /// survivor owning every partition would be entitled to the whole
+    /// product, several gigabytes against a pod sized for one, and a
+    /// client spreading large property updates across partitions while
+    /// Kafka is slow could fill the independent queues and exhaust the
+    /// leader. So the budget is the aggregate, divided.
     pub fn fencing_queue_mib(&self, partitions: u32) -> u32 {
-        // The floor cannot be unconditional: above roughly fifty
-        // partitions it would start multiplying again, and the aggregate
-        // this exists to bound would scale with partition count exactly
-        // as it did before. So it applies only while it stays inside the
-        // aggregate, and past that point the division wins and each
-        // producer gets a shallow queue — which is the honest answer for
-        // a deployment with more partitions than a producer's worth of
-        // memory to give them.
-        // No floor. One was tried and was dead code: inside a guard that
-        // only admits it when `MIN * partitions <= aggregate`, the
-        // division already yields at least `MIN`, so the `max` never
-        // fired. Applying it *outside* such a guard is worse — it
-        // multiplies back up, which is the defect this division exists to
-        // remove. The honest bound is the aggregate, and one MiB is the
-        // smallest queue librdkafka will take.
+        // No floor beyond one MiB, the smallest queue librdkafka will
+        // take. A larger floor guarded to fit the aggregate is dead
+        // code (the division already yields at least it), and one
+        // applied without the guard multiplies back up with partition
+        // count, the defect this division exists to remove. Past
+        // roughly fifty partitions each producer simply gets a shallow
+        // queue: the honest answer for a deployment with more
+        // partitions than memory to give them.
         (self.kafka.kafka_producer_queue_mib / partitions.max(1)).max(1)
     }
 
@@ -501,13 +489,13 @@ impl Config {
     /// How long fence acquisition may take.
     ///
     /// Deliberately not the transaction timeout. That one is sized so
-    /// that a *queued write* still resolves inside the lease runway, and
-    /// acquisition is neither queued nor a write — it is two broker round
+    /// that a queued write still resolves inside the lease runway, and
+    /// acquisition is neither queued nor a write: it is two broker round
     /// trips, one of which makes the coordinator abort a predecessor's
-    /// open transaction. Tying it to the runway meant re-budgeting the
-    /// write path silently tightened acquisition, and acquisition happens
-    /// fleet-wide during a deploy, which is the worst moment to have
-    /// shortened it.
+    /// open transaction. Deriving it from the write budget would let a
+    /// write-path re-budget silently tighten acquisition, and
+    /// acquisition happens fleet-wide during a deploy, the worst moment
+    /// to shorten it.
     ///
     /// It still has to fit inside the runway as a whole: a warm that
     /// outlives the lease it is warming for has nothing to serve.
@@ -520,26 +508,23 @@ impl Config {
 
     /// Ceiling on the drain's wait for an open window to commit.
     ///
-    /// The wait exists to catch a committer about to fire anyway — it
-    /// sleeps for the window, then commits — so a longer budget only
+    /// The wait exists to catch a committer about to fire anyway (it
+    /// sleeps for the window, then commits), so a longer budget only
     /// helps when the commit is retrying, which is the case where the
     /// successor's abort is the right answer regardless.
     ///
     /// Absolute rather than derived from the lease, because what it has
     /// to fit inside is absolute: the pre-revoke self-fence allows three
     /// seconds for a whole drain. Bounding it by the broker's own
-    /// patience instead would be inert — `fencing_txn_timeout` floors at
+    /// patience instead would be inert: `fencing_txn_timeout` floors at
     /// a second and the window can make three such calls, so that bound
-    /// never falls below four and a half, and every accepted lease would
-    /// leave the cap doing all the work. Before the drain slack was paid
-    /// out of the write budget it sat at 7.5s at the production lease
-    /// (about 6s now), truncating on every shutdown with an open window
-    /// and reporting the drain as failed.
+    /// never falls below four and a half seconds, past the whole
+    /// allowance.
     ///
     /// Residual: a `drain_timeout` configured under two seconds shrinks
     /// that allowance below this budget, and the leader cannot see the
-    /// coordination-side value to derive against. Truncating is safe —
-    /// the wait is best-effort — so the cost is a spurious drain
+    /// coordination-side value to derive against. Truncating is safe
+    /// (the wait is best-effort), so the cost is a spurious drain
     /// failure, not a correctness one.
     pub fn fencing_settle_budget(&self) -> Duration {
         Duration::from_secs(2)
@@ -550,19 +535,19 @@ impl Config {
     ///
     /// A window lives from `begin_transaction` through its admission
     /// interval, its sends, and its commit, so the broker's patience has
-    /// to cover all three — bounding it by the commit alone would let the
+    /// to cover all three. Bounding it by the commit alone would let the
     /// broker abort a window this pod is still legitimately filling, and
     /// the resulting epoch bump reads exactly like a fence from a real
     /// successor.
     pub fn fencing_broker_txn_timeout(&self) -> Duration {
-        // Every transaction-timeout-bounded call the window can make, not
-        // just the first: a commit that retries, or a commit followed by
-        // an abort, keeps the transaction open for all of them. A bound
-        // that covers only one call lets the broker abandon a window this
-        // pod is still legitimately working, and that epoch bump is
-        // indistinguishable from a real successor's fence — so a
-        // retriable blip would read as "this pod's claim is stale" and
-        // cost the partition its fence.
+        // Every transaction-timeout-bounded call the window can make,
+        // not just the first: a commit that retries, or a commit
+        // followed by an abort, keeps the transaction open for all of
+        // them. A bound that covers only one call lets the broker
+        // abandon a window this pod is still legitimately working, and
+        // that epoch bump is indistinguishable from a real successor's
+        // fence, so a retriable blip would read as "this pod's claim is
+        // stale" and cost the partition its fence.
         //
         // Half again on top, because the arithmetic is a floor: the
         // window sleep can overshoot and each blocking call waits its
@@ -576,20 +561,21 @@ impl Config {
     /// The lease relations that hold whether or not fencing is on.
     ///
     /// `PodHandle::new` asserts that the heartbeat fits inside the
-    /// keepalive's renewal margin, but it does so several hundred lines
-    /// into startup — after etcd, Kafka and the Postgres pool are
-    /// established — and its message names the heartbeat rather than the
-    /// TTL that decides the margin. Checking it here turns a late panic
-    /// into an early refusal that names both.
+    /// keepalive's renewal margin, but it does so deep into startup
+    /// (after etcd, Kafka, and the Postgres pool are established), and
+    /// its message names the heartbeat rather than the TTL that decides
+    /// the margin. Checking it here turns a late panic into an early
+    /// refusal that names both.
     pub fn validate_lease_timescales(&self) -> Result<(), String> {
         let margin = AuthorityClock::renewal_margin(self.lease_ttl);
         let heartbeat = self.heartbeat_interval();
         // Zero is under every margin, so the comparison below waves it
-        // through — but the keepalive uses this interval as the *timeout*
+        // through, but the keepalive uses this interval as the timeout
         // for each renewal round, so a zero one times out instantly,
         // exhausts the margin through its retry pace, and ends the
-        // session. The pod then releases every partition and starts over,
-        // for as long as it runs, without ever serving or crashing.
+        // session. The pod then releases every partition and starts
+        // over, for as long as it runs, without ever serving or
+        // crashing.
         if heartbeat.is_zero() {
             return Err(
                 "HEARTBEAT_INTERVAL_SECS must be greater than zero: the keepalive uses it as \
@@ -607,13 +593,13 @@ impl Config {
                 self.lease_ttl,
             ));
         }
-        // The pod's graceful exit — drain setup, drain, shutdown-path
-        // fence, one keepalive round's join, bounded revoke — has to
-        // fit the coordination budget, or the lifecycle manager
-        // abandons it mid-teardown while this pod is still the
-        // registered owner. The drain term reads the same
-        // `base_pod_config` the running pod is built from, so a future
-        // knob cannot decouple the validated sum from the deployed one.
+        // The pod's graceful exit (drain setup, drain, shutdown-path
+        // fence, one keepalive round's join, bounded revoke) has to fit
+        // the coordination budget, or the lifecycle manager abandons it
+        // mid-teardown while this pod is still the registered owner.
+        // The drain term reads the same `base_pod_config` the running
+        // pod is built from, so a future knob cannot decouple the
+        // validated sum from the deployed one.
         let drain = self.base_pod_config().drain_timeout;
         let teardown =
             DRAIN_SETUP_BOUND + drain + SHUTDOWN_FENCE_BOUND + heartbeat + REVOKE_TIMEOUT;
@@ -745,8 +731,8 @@ impl Config {
                  ({txn:?}); librdkafka rejects the producer outright"
             ));
         }
-        // Acquisition spends its timeout twice — once on the metadata
-        // ping, once on init_transactions — and both have to land inside
+        // Acquisition spends its timeout twice (once on the metadata
+        // ping, once on init_transactions), and both have to land inside
         // the runway the keepalive reserves. The queued-write bound below
         // caps the derived value transitively at the defaults, but an
         // override can move the inputs, so the two-call bound is checked
@@ -761,7 +747,7 @@ impl Config {
         }
         // A write parked behind a committing window pays that window's
         // send and commit before its own, so the runway has to cover
-        // two — each of them including every commit attempt the code
+        // two, each of them including every commit attempt the code
         // will make, not just the first.
         let queued_worst_case = window + (message + txn * FENCING_TXN_CALLS) * 2;
         let drain_room = runway.saturating_sub(self.fencing_drain_slack());
@@ -902,19 +888,19 @@ mod lease_timescale_tests {
 
     /// The pod's teardown must fit the coordination component's budget,
     /// and the keepalive join is the one term an operator can move. A
-    /// heartbeat the renewal margin accepts can still blow the budget —
+    /// heartbeat the renewal margin accepts can still blow the budget:
     /// that band is exactly what a check on the margin alone missed.
     #[test]
     fn a_teardown_the_shutdown_budget_cannot_fit_is_refused() {
         let mut config =
             Config::init_from_hashmap(&std::collections::HashMap::new()).expect("defaults");
         config.lease_ttl = 30;
-        // Inside the 20s renewal margin, so the pair check passes — but
+        // Inside the 20s renewal margin, so the pair check passes, but
         // setup (5s) + drain (30s) + fence (3s) + a 16s join + revoke
         // (5s) = 59s overruns the 55s budget. Sixteen, not a rounder
         // number, because it discriminates on every term: without the
         // setup bound the sum is 54s, which a broken validation would
-        // accept — a 17s join sums to exactly 55s either way and pins
+        // accept; a 17s join sums to exactly 55s either way and pins
         // nothing about the setup term.
         config.heartbeat_interval_secs = 16;
         assert!(config.validate_lease_timescales().is_err());
@@ -946,12 +932,12 @@ mod fencing_timescale_tests {
     }
 
     /// At any lease TTL the derivation must either satisfy every
-    /// relation or be rejected — never produce a config that starts and
+    /// relation or be rejected: never produce a config that starts and
     /// then violates the runway, and never one librdkafka refuses.
     #[test]
     fn derived_timeouts_are_either_valid_or_rejected() {
         // 16 and 20 are the band where the bound's attempt count is the
-        // only thing that decides acceptance — without them the sweep
+        // only thing that decides acceptance; without them the sweep
         // cannot tell a two-call model from a three-call one.
         for lease_ttl in [0, 1, 5, 10, 16, 20, 21, 30, 60, 300] {
             let config = fenced(lease_ttl);
@@ -979,7 +965,7 @@ mod fencing_timescale_tests {
     /// The retry budget and the timeout shares are one decision split
     /// across two constants. Raising the attempt count without shrinking
     /// the shares puts the code back outside the runway it validates
-    /// against — silently, because every existing test would still pass.
+    /// against, silently, because every existing test would still pass.
     #[test]
     fn the_production_ttl_affords_every_transaction_call() {
         let config = fenced(30);
@@ -1012,8 +998,8 @@ mod fencing_timescale_tests {
     /// mentioned the TTL that actually decides the margin.
     ///
     /// The fencing floor and the heartbeat happen not to overlap at the
-    /// default heartbeat today, so the pairs below raise it — which is
-    /// the point: the two checks constrain different things, and nothing
+    /// default heartbeat, so the pairs below raise it, which is the
+    /// point: the two checks constrain different things, and nothing
     /// keeps a future change to the timeout shares from moving the
     /// fencing floor back under the heartbeat.
     #[test]
@@ -1035,7 +1021,7 @@ mod fencing_timescale_tests {
         }
     }
 
-    /// Zero passes the margin comparison — it is under every margin — but
+    /// Zero passes the margin comparison (it is under every margin), but
     /// the keepalive uses the interval as each round's timeout, so it
     /// fences the pod against healthy etcd forever.
     #[test]
@@ -1062,10 +1048,10 @@ mod fencing_timescale_tests {
             .expect("LEASE_TTL=30 with a 10s heartbeat must start");
     }
 
-    /// The broker's patience has to cover the whole window, not the first
-    /// call into it. A bound shorter than the lifetime lets the broker
-    /// abandon a window this pod is still working, and that epoch bump
-    /// is indistinguishable from a real successor's fence — so a
+    /// The broker's patience has to cover the whole window, not the
+    /// first call into it. A bound shorter than the lifetime lets the
+    /// broker abandon a window this pod is still working, and that epoch
+    /// bump is indistinguishable from a real successor's fence, so a
     /// retriable blip would cost the partition its fence and read as a
     /// stale claim.
     #[test]
@@ -1090,9 +1076,9 @@ mod fencing_timescale_tests {
 
     /// The fenced path creates one producer per owned partition, so the
     /// shared producer's queue limits are an aggregate to divide rather
-    /// than a per-producer figure to copy. Inheriting them let a lone
-    /// survivor owning every partition claim the whole product — several
-    /// gigabytes on a pod sized for one — which a client can reach by
+    /// than a per-producer figure to copy. Inheriting them lets a lone
+    /// survivor owning every partition claim the whole product (several
+    /// gigabytes on a pod sized for one), which a client can reach by
     /// spreading large property updates across partitions while Kafka is
     /// slow.
     #[test]
@@ -1109,14 +1095,13 @@ mod fencing_timescale_tests {
                 "partitions={partitions}: a single fenced producer must never be entitled \
                  to more than the shared producer's whole queue"
             );
-            // The aggregate is the invariant: every individual value
-            // looked reasonable while the total scaled with the partition
-            // count, which is how the original defect hid.
-            // Either the whole fleet of producers fits the aggregate, or
-            // every one of them is already at the smallest queue
-            // librdkafka will take — past that point the budget cannot be
-            // honoured at all, and the honest answer is the floor rather
-            // than a number that quietly multiplies.
+            // The aggregate is the invariant: every individual value can
+            // look reasonable while the total scales with the partition
+            // count. Either the whole fleet of producers fits the
+            // aggregate, or every one of them is already at the smallest
+            // queue librdkafka will take; past that point the budget
+            // cannot be honored at all, and the honest answer is the
+            // floor rather than a number that quietly multiplies.
             let aggregate_mib = per_partition_mib * partitions;
             assert!(
                 aggregate_mib <= shared_mib || per_partition_mib == 1,
@@ -1136,7 +1121,7 @@ mod fencing_timescale_tests {
     /// hold a window's worth of writes.
     /// Overrides are the only way to reach the librdkafka limits the
     /// derivation floors away from, so they are the only way these two
-    /// checks ever fire — and without them a pod starts with a producer
+    /// checks ever fire; without them a pod starts with a producer
     /// librdkafka refuses to create, or with no send timeout at all.
     #[test]
     fn overrides_outside_librdkafkas_limits_are_refused() {
@@ -1158,11 +1143,10 @@ mod fencing_timescale_tests {
     }
 
     /// The pre-revoke self-fence allows three seconds for a whole drain,
-    /// and the drain is `wait_until_empty` *then* this wait. A budget
-    /// that ate the whole allowance would turn every shutdown with an
-    /// open window into a reported drain failure — while a budget under
-    /// the admission window cannot outwait the window it exists to
-    /// settle.
+    /// and the drain is `wait_until_empty` then this wait. A budget that
+    /// ate the whole allowance would turn every shutdown with an open
+    /// window into a reported drain failure, while a budget under the
+    /// admission window cannot outwait the window it exists to settle.
     #[test]
     fn settling_fits_inside_the_shutdown_fence_bound() {
         for lease_ttl in [21, 30, 60, 300, 3599] {
@@ -1191,9 +1175,8 @@ mod fencing_timescale_tests {
     }
 
     /// Acquisition is two broker round trips and happens fleet-wide
-    /// during a deploy. Nothing asserted on its budget, and tying it to
-    /// the write path's once already shortened it by a quarter as a side
-    /// effect of re-budgeting writes.
+    /// during a deploy. Deriving its budget from the write path's would
+    /// let a write re-budget silently shorten it.
     #[test]
     fn acquisition_keeps_its_own_budget() {
         for lease_ttl in [21, 30, 60, 300] {
@@ -1205,9 +1188,9 @@ mod fencing_timescale_tests {
                 config.fencing_init_timeout() >= Duration::from_secs(2),
                 "LEASE_TTL={lease_ttl}: acquisition needs room for a broker round trip"
             );
-            // The timeout bounds each of the two calls acquisition makes
-            // — `fetch_metadata` then `init_transactions` — so the budget
-            // the lease has to cover is twice what it names.
+            // The timeout bounds each of the two calls acquisition
+            // makes (`fetch_metadata` then `init_transactions`), so the
+            // budget the lease has to cover is twice what it names.
             assert!(
                 config.fencing_init_timeout() * 2 <= config.lease_fence_runway(),
                 "LEASE_TTL={lease_ttl}: a warm cannot outlive the lease it warms for"

--- a/rust/personhog-leader/src/coordination/mod.rs
+++ b/rust/personhog-leader/src/coordination/mod.rs
@@ -53,9 +53,9 @@ pub struct LeaderHandoffHandler {
     /// The in-process fence copies, rebuilt from the live marks at every
     /// ownership boundary (see the fence module for the durability model).
     fences: FenceMap,
-    /// Pool for the takeover scan — the cache-miss fallback pool. Without
-    /// it (dev fixtures) fences are not rebuilt on takeover and only
-    /// FencePerson calls fill the map.
+    /// Pool for the takeover scan (the cache-miss fallback pool).
+    /// Without it (dev fixtures) fences are not rebuilt on takeover and
+    /// only FencePerson calls fill the map.
     fence_scan_pool: Option<sqlx::PgPool>,
     num_partitions: u32,
     pools: Arc<WarmClientPools>,
@@ -77,10 +77,10 @@ pub struct LeaderHandoffHandler {
     /// is still running.
     ///
     /// A convergence to `Serving` can both warm and resume, in that
-    /// order, and warming re-admits writes as its last act. Without this,
-    /// the resume that follows re-acquires and bumps the epoch out from
-    /// under every write admitted in between — the pod fencing its own
-    /// live window.
+    /// order, and warming re-admits writes as its last act. Without
+    /// this, the resume that follows re-acquires and bumps the epoch out
+    /// from under every write admitted in between: the pod fencing its
+    /// own live window.
     freshly_fenced: Arc<dashmap::DashSet<u32>>,
 }
 
@@ -134,13 +134,13 @@ impl LeaderHandoffHandler {
     ///
     /// `check_authority` before `acquire` is a pre-check across an
     /// operation that talks to the broker, so the claim can lapse while
-    /// it runs. The epoch bump cannot be undone — `init_transactions`
-    /// has already taken it from whoever held it — but this pod can
-    /// decline to build on a claim it no longer has: it drops the fence
-    /// and fails the convergence rather than serving. The partition's
-    /// real owner re-takes the epoch through its own healing
-    /// re-acquisition, so a fence stolen this way corrects itself
-    /// instead of persisting until the next handoff.
+    /// it runs. The epoch bump cannot be undone (`init_transactions`
+    /// already took it from whoever held it), but this pod can decline
+    /// to build on a claim it no longer has: it drops the fence and
+    /// fails the convergence rather than serving. The partition's real
+    /// owner re-takes the epoch through its own healing re-acquisition,
+    /// so a fence stolen this way corrects itself instead of persisting
+    /// until the next handoff.
     fn check_authority_after_acquire(&self, partition: u32, phase: &'static str) -> Result<()> {
         let Err(e) = self.check_authority(partition, phase) else {
             return Ok(());
@@ -188,8 +188,8 @@ impl LeaderHandoffHandler {
         self.freshly_fenced.insert(partition);
     }
 
-    /// Whether a resume would take the fence rather than trust an earlier
-    /// acquisition — the decision the mark exists to make.
+    /// Whether a resume would take the fence rather than trust an
+    /// earlier acquisition: the decision the mark exists to make.
     #[cfg(test)]
     fn would_reacquire_on_resume(&self, partition: u32) -> bool {
         !self.freshly_fenced.contains(&partition)
@@ -203,9 +203,9 @@ impl HandoffHandler for LeaderHandoffHandler {
         // and `preconnect` is single-flight per partition, so repeated
         // convergences through the drain window cost one spawn each and
         // one client total. A parked connection the acquire never
-        // consumes is discarded on release or by the periodic sweep —
-        // a cancelled inbound handoff leaves no convergence behind, so
-        // the sweep is the only path that reaches its leftovers.
+        // consumes is discarded on release or by the periodic sweep; a
+        // cancelled inbound handoff leaves no convergence behind, so the
+        // sweep is the only path that reaches its leftovers.
         if let Some(fenced) = &self.fenced {
             let fenced = Arc::clone(fenced);
             tokio::spawn(async move { fenced.preconnect(partition).await });
@@ -229,16 +229,16 @@ impl HandoffHandler for LeaderHandoffHandler {
         self.inflight
             .wait_until_empty(partition, DRAIN_POLL_INTERVAL)
             .await;
-        // A request cancelled mid-produce takes its handler — and the
-        // count above — with it, leaving the record it enqueued in a
+        // A request cancelled mid-produce takes its handler (and the
+        // count above) with it, leaving the record it enqueued in a
         // window nobody is waiting on. Committing that window here lands
         // the cancelled write below the cutoff the successor is about to
         // read, rather than leaving it to be aborted by whichever side
         // acts first.
         //
-        // Best-effort by construction, and the drain proceeds either way:
-        // the successor's `init_transactions` aborts whatever is left,
-        // exactly as it did before this wait existed — pinned by
+        // Best-effort by construction, and the drain proceeds either
+        // way: the successor's `init_transactions` aborts whatever is
+        // left, pinned by
         // `a_successors_init_aborts_the_predecessors_open_window`.
         if let Some(fenced) = &self.fenced {
             fenced.settle(partition).await;
@@ -248,10 +248,11 @@ impl HandoffHandler for LeaderHandoffHandler {
     }
 
     async fn warm_partition(&self, partition: u32) -> Result<()> {
-        // The takeover scan: rebuild the partition's lifecycle fences from
-        // the live marks BEFORE warming — the partition becomes servable
-        // the moment `warm_from_kafka` installs it in the cache, and a
-        // fenced person must never be writable in that gap. A mark
+        // The takeover scan: rebuild the partition's lifecycle fences
+        // from the live marks BEFORE warming. The partition becomes
+        // servable the moment `warm_from_kafka` installs it in the
+        // cache, and a fenced person must never be writable in that
+        // gap. A mark
         // committed after this read arrives as a FencePerson call to this
         // (now current) owner, so the two sources cover every mark; a
         // fence installed for a partition that is not yet serving is
@@ -295,10 +296,10 @@ impl HandoffHandler for LeaderHandoffHandler {
             self.check_authority_after_acquire(partition, "warm")?;
             info!(partition, "changelog fence acquired");
             // From here the fence is held for a warm that has not
-            // happened yet. If the warm fails — or never returns,
-            // because the attempt was torn down by a lost lease — the
-            // guard gives the epoch back rather than leaving this
-            // process holding a partition it does not own.
+            // happened yet. If the warm fails, or never returns because
+            // a lost lease tore the attempt down, the guard gives the
+            // epoch back rather than leaving this process holding a
+            // partition it does not own.
             Some(FenceGuard::new(Arc::clone(fenced), partition, "warm"))
         } else {
             None
@@ -325,14 +326,14 @@ impl HandoffHandler for LeaderHandoffHandler {
 
     /// The partition is meant to be served, so make sure this pod can
     /// actually write to it. A fence lost to a broker rejection or a
-    /// failed abort has no other way back — convergence sees the
+    /// failed abort has no other way back: convergence sees the
     /// partition warmed and unfenced and would otherwise do nothing.
     ///
     /// A heal that cannot acquire is reported through the
     /// partition-labeled failure counter and the error log, not by
     /// failing the run. Failing the run would escalate through the
-    /// convergence budgets to process death — trading one partition's
-    /// writes for every partition's reads — while the reconcile tick
+    /// convergence budgets to process death (trading one partition's
+    /// writes for every partition's reads) while the reconcile tick
     /// already retries this every pass. A heal that succeeds counts as
     /// applied work, so a repairing pod's budgets reset like any other
     /// progress.
@@ -383,17 +384,18 @@ impl HandoffHandler for LeaderHandoffHandler {
         info!(partition, "handoff cancelled; re-admitting writes");
         self.check_authority(partition, "resume")?;
         // The cancelled handoff's target may have gotten as far as
-        // acquiring the changelog fence, which leaves this pod's producer
-        // epoch-stale — every write would fail as fenced until the next
-        // handoff. Re-acquiring bumps the epoch back to this pod before
-        // writes are re-admitted. (No acked write can predate this: the
-        // target never serves before the assignment flips.)
+        // acquiring the changelog fence, which leaves this pod's
+        // producer epoch-stale: every write would fail as fenced until
+        // the next handoff. Re-acquiring bumps the epoch back to this
+        // pod before writes are re-admitted. (No acked write can predate
+        // this: the target never serves before the assignment flips.)
         //
-        // Unless this convergence already took the fence on its way here.
-        // Warming re-admits writes as its last act, so acquiring again
-        // would bump the epoch out from under everything admitted since —
-        // the pod fencing its own live window, and handing the successor
-        // of a genuinely moved partition an epoch nobody asked for.
+        // Unless this convergence already took the fence on its way
+        // here. Warming re-admits writes as its last act, so acquiring
+        // again would bump the epoch out from under everything admitted
+        // since: the pod fencing its own live window, and handing the
+        // successor of a genuinely moved partition an epoch nobody asked
+        // for.
         if self.freshly_fenced.contains(&partition) {
             info!(
                 partition,
@@ -408,12 +410,12 @@ impl HandoffHandler for LeaderHandoffHandler {
                 .await
                 .map_err(Error::invalid_state)?;
             self.check_authority_after_acquire(partition, "resume")?;
-            // Mark it the same way warming does. A convergence torn down
-            // between here and the point `apply` records the resume
-            // retries with the partition still listed as fenced, and
-            // without this mark that retry would acquire again — this
-            // time bumping the epoch out from under the writes the line
-            // below is about to admit.
+            // Mark it the same way warming does. A convergence torn
+            // down between here and the point `apply` records the
+            // resume retries with the partition still listed as fenced,
+            // and without this mark that retry would acquire again,
+            // this time bumping the epoch out from under the writes the
+            // line below is about to admit.
             self.freshly_fenced.insert(partition);
             info!(partition, "changelog fence re-acquired on resume");
         }
@@ -560,9 +562,9 @@ mod tests {
     /// A fence taken while warming only licenses skipping the re-acquire
     /// for the convergence that took it. Once a handoff drains the
     /// partition it is moving, and the incoming owner can take the epoch
-    /// before the handoff is cancelled — so a resume that still trusted
+    /// before the handoff is cancelled, so a resume that still trusted
     /// that mark would re-admit writes onto a producer the broker has
-    /// moved past, which is exactly what the re-acquire exists to stop.
+    /// moved past: exactly what the re-acquire exists to stop.
     #[tokio::test]
     async fn a_handoff_drain_retires_an_earlier_convergences_fence() {
         let handler = handler();

--- a/rust/personhog-leader/src/emitted.rs
+++ b/rust/personhog-leader/src/emitted.rs
@@ -1,22 +1,17 @@
-//! Versions this pod put on the wire but never heard the outcome of.
+//! Versions this pod emitted without learning the outcome.
 //!
-//! A changelog record can become durable without the write that produced
-//! it learning so. A request cancelled while its send is in flight leaves
-//! the record to ride its window's commit; a request cancelled while
-//! waiting on that commit has already been counted, and the commit lands
-//! with nobody to tell; and a commit whose outcome stays unknown is, by
-//! construction, a record that may or may not exist.
+//! A changelog record can become durable while its write never learns so:
+//! a cancel during the send leaves the record to commit with its window;
+//! a cancel while waiting on the commit leaves the commit with no
+//! listener; an ambiguous commit may or may not have written the record.
 //!
-//! In each case the version is spent. The cache still holds the version
-//! before the write, so the next write for that person derives the same
-//! number again and produces a second record carrying it. The writer
-//! keeps whichever of the two arrived first and discards the other — and
-//! when the discarded one is the acked write, the acknowledgement was a
-//! lie.
+//! In each case the version is spent. The cache still holds the pre-write
+//! version, so the next write for the person derives the same number and
+//! emits a second record with it. The writer keeps whichever record
+//! arrives first. If it discards the acked one, the ack was false.
 //!
-//! Recording a floor costs nothing on the path that succeeds: the guard
-//! is a stack value that only writes to the map when it is dropped
-//! without an answer.
+//! The success path pays nothing: the guard is a stack value and writes
+//! to the map only when it drops unanswered.
 
 use std::sync::Arc;
 
@@ -30,25 +25,23 @@ use crate::cache::PersonCacheKey;
 #[derive(Default)]
 pub struct EmittedVersions {
     floors: DashMap<(u32, PersonCacheKey), i64>,
-    /// The coarse fallback once `floors` is full: one spent version per
-    /// partition rather than per person.
+    /// Coarse fallback once `floors` is full: one spent version per
+    /// partition instead of per person.
     ///
-    /// A floor is only ever cleared by a later successful write for the
-    /// same person, so persons written once and abandoned leave entries
-    /// nothing collects — and a client can manufacture exactly that by
-    /// updating unique persons while produce latency sits above its own
-    /// deadline. Refusing writes at the bound would answer a memory
-    /// exhaustion with an availability one, and these entries do not
-    /// drain, so the refusal would never lift.
+    /// Only a later successful write for the same person clears a floor,
+    /// so a person written once and abandoned leaves an entry forever. A
+    /// client can create such entries without bound by updating unique
+    /// persons while produce latency exceeds its deadline. Refusing
+    /// writes at the bound would never recover, because the entries never
+    /// drain.
     ///
-    /// Spilling keeps the safety property and gives up only precision:
-    /// every person in the partition derives past the spilled version, so
-    /// versions jump once and stay monotonic. A spilled floor is also
-    /// never lowered — only `clear_partition` drops it, on release —
-    /// which is safe for the same reason the jump is: nothing downstream
-    /// reads a version as a count. The writer's guard is a strict
-    /// greater-than, and ClickHouse collapses person rows by the highest
-    /// version; both are indifferent to gaps of any size.
+    /// Spilling keeps safety and loses only precision: every person in
+    /// the partition derives past the spilled version, so versions jump
+    /// once and stay monotonic. A spilled floor is never lowered; only
+    /// `clear_partition` removes it, on release. Gaps of any size are
+    /// safe because nothing reads a version as a count: the writer's
+    /// guard is a strict greater-than, and ClickHouse keeps the
+    /// highest-version row.
     partition_floors: DashMap<u32, i64>,
     capacity: usize,
 }
@@ -79,10 +72,10 @@ impl EmittedVersions {
     }
 
     fn raise(&self, partition: u32, key: PersonCacheKey, version: i64) {
-        // At the bound, spill to the partition rather than admit an entry
-        // nothing will collect. Keys already tracked keep their precise
-        // floor, so the degradation only reaches persons arriving after
-        // the map is full.
+        // At capacity, spill to the partition floor instead of adding an
+        // entry nothing will collect. Keys already tracked keep their
+        // precise floor, so only persons that arrive after the map fills
+        // degrade.
         if self.floors.len() >= self.capacity
             && !self.floors.contains_key(&(partition, key.clone()))
         {
@@ -95,9 +88,8 @@ impl EmittedVersions {
             counter!("personhog_leader_unresolved_versions_spilled_total").increment(1);
             return;
         }
-        // The entry guard holds a write lock on its shard, and `len`
-        // walks every shard — including that one. Anything that reads the
-        // map as a whole has to wait until the guard is gone.
+        // The entry guard write-locks its shard, and `len` walks every
+        // shard, so drop the guard before reading the map as a whole.
         {
             let mut entry = self.floors.entry((partition, key)).or_insert(version);
             if *entry < version {
@@ -108,8 +100,8 @@ impl EmittedVersions {
         gauge!("personhog_leader_unresolved_versions").set(self.floors.len() as f64);
     }
 
-    /// Forget a person's floor: the cache now holds a version at least
-    /// this high, so it already carries the constraint.
+    /// Forget a person's floor. The cache now holds a version at least
+    /// this high, so it carries the constraint.
     fn resolve(&self, partition: u32, key: &PersonCacheKey, version: i64) {
         // Same discipline as `raise`: settle the map first, then read it.
         let removed = self
@@ -121,9 +113,9 @@ impl EmittedVersions {
         }
     }
 
-    /// Drop every floor for a partition's persons. Ownership is leaving,
-    /// and the incoming owner derives versions from the changelog, which
-    /// is the authority these floors stand in for.
+    /// Drop every floor for a partition. Ownership is leaving, and the
+    /// next owner derives versions from the changelog, the authority
+    /// these floors stand in for.
     pub fn clear_partition(&self, partition: u32) {
         self.floors.retain(|(owner, _), _| *owner != partition);
         self.partition_floors.remove(&partition);
@@ -132,10 +124,9 @@ impl EmittedVersions {
 
     /// Stage the state a cancelled or indeterminate write leaves behind.
     ///
-    /// The real path needs a request to vanish mid-produce or a broker to
-    /// fail a commit ambiguously; neither is stageable against a healthy
-    /// cluster, and what matters is that the *derivation* consults the
-    /// floor afterwards.
+    /// The real path needs a cancel mid-produce or an ambiguous broker
+    /// commit; neither is stageable against a healthy cluster. Tests only
+    /// need the derivation to consult the floor afterwards.
     #[cfg(any(test, feature = "test-support"))]
     pub fn raise_for_test(&self, partition: u32, key: PersonCacheKey, version: i64) {
         self.raise(partition, key, version);
@@ -149,9 +140,9 @@ impl EmittedVersions {
 
 /// Holds a version open until the write that emitted it is answered for.
 ///
-/// Dropped without a call to [`EmittedVersionGuard::resolved`] — a
-/// cancelled request, or a commit whose fate is unknown — the version is
-/// recorded as spent so no later write can reuse it.
+/// A drop without [`EmittedVersionGuard::resolved`] (a cancelled request,
+/// or a commit with unknown fate) records the version as spent so no
+/// later write can reuse it.
 pub struct EmittedVersionGuard {
     versions: Arc<EmittedVersions>,
     partition: u32,
@@ -189,8 +180,8 @@ impl EmittedVersionGuard {
             .resolve(self.partition, &self.key, self.version);
     }
 
-    /// The record is known not to exist — the window aborted, or the send
-    /// never reached the broker. The version is free again.
+    /// The record is known not to exist (the window aborted, or the send
+    /// never reached the broker), so the version is free again.
     pub fn discarded(mut self) {
         self.settled = true;
     }
@@ -216,8 +207,8 @@ mod tests {
         }
     }
 
-    /// The whole point: a write that is never answered for spends its
-    /// version, so the next write derives past it instead of colliding.
+    /// A write never answered for spends its version, so the next write
+    /// derives past it instead of colliding.
     #[test]
     fn an_unanswered_emission_raises_the_floor() {
         let versions = Arc::new(EmittedVersions::new(8));
@@ -268,11 +259,11 @@ mod tests {
         assert_eq!(versions.floor_for(0, &key(1), 4), 4);
     }
 
-    /// A floor only ever moves up. A later unresolved emission at a
-    /// *lower* version must not lower it, because the higher one is the
-    /// constraint — losing it lets a subsequent write reuse a version
-    /// already on the wire. `only_a_version_that_covers_the_floor_clears_it`
-    /// pins the same asymmetry on the resolve side.
+    /// A floor only moves up. A later unresolved emission at a lower
+    /// version must not lower it; losing the higher floor lets a later
+    /// write reuse a version already on the wire.
+    /// `only_a_version_that_covers_the_floor_clears_it` pins the same
+    /// asymmetry on the resolve side.
     #[test]
     fn a_lower_emission_does_not_lower_the_floor() {
         let versions = Arc::new(EmittedVersions::new(8));
@@ -285,11 +276,9 @@ mod tests {
         );
     }
 
-    /// The complement: a second unresolved emission has to move the floor
-    /// forward. Leaving it where the first one put it hands the second
-    /// write's version back for reuse, and the writer's first-wins guard
-    /// then keeps whichever record arrived first — discarding the acked
-    /// one.
+    /// The complement: a second unresolved emission must raise the floor.
+    /// Leaving the first floor hands the second version back for reuse,
+    /// and the writer's first-wins guard then discards the acked record.
     #[test]
     fn a_later_emission_raises_the_floor_it_finds() {
         let versions = Arc::new(EmittedVersions::new(8));
@@ -302,15 +291,11 @@ mod tests {
         );
     }
 
-    /// A floor is only cleared by a later successful write for the same
-    /// person, so persons written once and abandoned leave entries
-    /// nothing collects — and a client can manufacture exactly that by
-    /// updating unique persons while produce latency sits above its own
-    /// deadline, one entry per person, indefinitely.
-    ///
-    /// At the bound the state stops growing, and the safety property
-    /// survives the degradation: a version spilled to the partition is
-    /// still a version no later write can reuse.
+    /// Only a later successful write clears a floor, so abandoned persons
+    /// leave entries forever; a client can add one entry per person while
+    /// produce latency exceeds its deadline. At the bound the state stops
+    /// growing, and a version spilled to the partition still cannot be
+    /// reused.
     #[test]
     fn unresolved_versions_stop_growing_at_the_bound() {
         let versions = Arc::new(EmittedVersions::new(4));
@@ -325,9 +310,8 @@ mod tests {
             versions.len()
         );
 
-        // Every spilled version is still refused to a later write, for
-        // every person in the partition — that is what makes shedding
-        // safe rather than a silent reopening of the collision.
+        // Every spilled version stays refused to every person in the
+        // partition; that is what makes shedding safe.
         let highest = 100 + 63;
         for person_id in 0..64 {
             assert!(
@@ -337,8 +321,8 @@ mod tests {
         }
     }
 
-    /// The spill is scoped to its partition: an unrelated one must not
-    /// inherit a floor, or one attacked partition would inflate versions
+    /// The spill is scoped to its partition. An unrelated partition must
+    /// not inherit the floor, or one hot partition would inflate versions
     /// across the whole pod.
     #[test]
     fn a_spilled_floor_does_not_cross_partitions() {
@@ -350,9 +334,9 @@ mod tests {
         assert_eq!(versions.floor_for(1, &key(0), 3), 3);
     }
 
-    /// Releasing a partition drops its coarse floor as well as its
+    /// Releasing a partition drops the coarse floor as well as the
     /// precise ones, or a re-acquisition would derive past a version the
-    /// changelog has already settled.
+    /// changelog already settled.
     #[test]
     fn releasing_a_partition_drops_its_spilled_floor() {
         let versions = Arc::new(EmittedVersions::new(1));

--- a/rust/personhog-leader/src/fence.rs
+++ b/rust/personhog-leader/src/fence.rs
@@ -1,44 +1,43 @@
-//! Lifecycle fence state: which persons are frozen by a live lifecycle
-//! operation, and how a leader rebuilds that knowledge across ownership
+//! Lifecycle fence state: which persons a live lifecycle operation
+//! freezes, and how a leader rebuilds that knowledge across ownership
 //! changes.
 //!
-//! The fence's source of truth is not this map — it is the saga's mark row
-//! (`lifecycle_op_person` in `marked`/`sealed`), committed on the persons
-//! primary before `FencePerson` is ever called. The map is the leader's
-//! in-process copy, and on the write path it is authoritative: a fenced
-//! write is rejected from memory alone, never a database read.
+//! The saga's mark row (`lifecycle_op_person` in `marked`/`sealed`,
+//! committed on the persons primary before `FencePerson` is called) is
+//! the source of truth. This map is the leader's in-process copy. On the
+//! write path the map is authoritative: a fenced write is rejected from
+//! memory alone, never from a database read.
 //!
-//! Postgres is read in exactly one place — the takeover scan, once per
-//! partition acquisition, before the partition accepts writes. That plus
-//! the `FencePerson` RPC are the only two ways an entry gets in, and
-//! together they cover every mark. Entries leave in exactly two ways: a
-//! `ReleaseFence`, or dropping the whole partition.
+//! Entries enter in exactly two ways: the takeover scan (the one
+//! Postgres read, once per partition acquisition, before the partition
+//! accepts writes) and the `FencePerson` RPC. Together they cover every
+//! mark. Entries leave in exactly two ways: `ReleaseFence`, or dropping
+//! the whole partition.
 //!
-//! The leader never reclaims a fence on its own, and deliberately so.
-//! personhog-identity owns lifecycle correctness: every op is driven to a
-//! terminal state (lease steal, sweeper resumption), so a `ReleaseFence`
-//! always eventually arrives, with one exception: an op whose committed
-//! release this leader definitively refused (a semantic refusal) is
-//! parked by the saga engine and stops retrying, so its fences hold
-//! until an operator re-drives it. The person stays frozen rather than
-//! half-destroyed. An entry that outlives a crashed saga is not stale —
-//! the mark is still live, the op really is unfinished, and the person
-//! really should stay frozen. For that guarantee to hold, a
-//! release must never *vacuously* succeed: both fence RPCs verify this
-//! pod serves the partition, so a misrouted call fails and identity's
-//! retry reaches the pod whose map actually gates the writes.
+//! The leader never reclaims a fence on its own, deliberately.
+//! personhog-identity owns lifecycle correctness and drives every op to
+//! a terminal state (lease steal, sweeper resumption), so a
+//! `ReleaseFence` always eventually arrives. One exception: when this
+//! leader definitively refuses an op's committed release (a semantic
+//! refusal), the saga engine parks the op, and its fences hold until an
+//! operator re-drives it. The person stays frozen rather than
+//! half-destroyed. An entry that outlives a crashed saga is not stale:
+//! the mark is still live, the op is unfinished, and the person must
+//! stay frozen. For that guarantee, a release must never vacuously
+//! succeed: both fence RPCs verify this pod serves the partition, so a
+//! misrouted call fails and identity's retry reaches the pod whose map
+//! gates the writes.
 //!
-//! The map is NOT a cache: it has no capacity limit and no eviction path
-//! — losing an entry while continuing to serve would violate consistency,
-//! not degrade it.
+//! The map is NOT a cache: no capacity limit, no eviction. Losing an
+//! entry while continuing to serve would violate consistency, not
+//! degrade it.
 //!
-//! One known window: a takeover that runs between a release being acked
-//! and the saga settling its mark row installs a fence for an op that is
-//! already done — a ghost no `ReleaseFence` will ever clear. The
-//! [`FenceHealer`] closes it lazily: a write rejected by a fence triggers
-//! a non-blocking mark-row read, and a fence whose op has settled is
-//! dropped, so the next write goes through instead of waiting for the
-//! partition to change hands.
+//! One known window: a takeover between a release ack and the saga
+//! settling its mark row installs a fence for a finished op, a ghost no
+//! `ReleaseFence` will ever clear. The [`FenceHealer`] closes it lazily:
+//! a write rejected by a fence triggers a non-blocking mark-row read,
+//! and a fence whose op has settled is dropped, so the next write goes
+//! through instead of waiting for the partition to change hands.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -71,12 +70,11 @@ pub const FENCED_METADATA_KEY: &str = "x-person-fenced";
 /// Metadata key carrying the fencing operation's id on rejections.
 pub const FENCED_OP_ID_METADATA_KEY: &str = "x-person-fenced-op-id";
 
-/// A definitive FAILED_PRECONDITION the router passes through to the
-/// caller instead of bouncing. Bare FAILED_PRECONDITION classifies as a
-/// routing-race bounce and exhausts into retriable UNAVAILABLE, which
-/// would turn a fail-closed verification refusal into an infinite saga
-/// retry loop; the marker (see
-/// `personhog_common::grpc::SEMANTIC_REFUSAL_METADATA_KEY`) makes the
+/// A definitive FAILED_PRECONDITION the router passes through instead of
+/// bouncing. Bare FAILED_PRECONDITION classifies as a routing-race
+/// bounce and exhausts into retriable UNAVAILABLE, which turns a
+/// fail-closed refusal into an infinite saga retry loop. The marker
+/// (`personhog_common::grpc::SEMANTIC_REFUSAL_METADATA_KEY`) makes the
 /// refusal survive the trip.
 pub use personhog_common::grpc::semantic_refusal;
 
@@ -105,29 +103,27 @@ pub fn fenced_status(state: &FenceState) -> Status {
     status
 }
 
-/// How long the takeover scan may run before the handoff gives up. The
-/// scan gates a partition's return to service, and it reads a set whose
-/// size depends on another service's liveness (marks stay live while
-/// their op does), so it is bounded here rather than trusted to be
-/// small. Expiry fails the handoff — a partition whose fences cannot be
-/// known must not serve writes.
+/// Bound on the takeover scan. The scan gates a partition's return to
+/// service and reads a set whose size depends on another service's
+/// liveness (marks stay live while their op does), so it is bounded
+/// rather than trusted to be small. Expiry fails the handoff: a
+/// partition whose fences cannot be known must not serve writes.
 const SCAN_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// The takeover scan: load every live mark belonging to `partition` and
-/// install it in the fence map, before the partition accepts writes.
+/// The takeover scan: load every live mark for `partition` into the
+/// fence map before the partition accepts writes.
 ///
-/// The scan cannot target a partition (the partition is a murmur2 hash
-/// Postgres cannot compute), so it reads the whole live-mark set — the
-/// partial mark index contains nothing but live marks — and filters
-/// in-process with the same partition function request validation uses.
-/// The join to `lifecycle_op` for the op type costs a lookup per row, so
-/// this is not an index-only read; it stays cheap because the live-mark
-/// set is small while ops complete. Merge targets are claimed but never
-/// fenced, so they are excluded.
+/// The partition is a murmur2 hash Postgres cannot compute, so the scan
+/// reads the whole live-mark set (the partial mark index holds only live
+/// marks) and filters in-process with the partition function request
+/// validation uses. The join to `lifecycle_op` for the op type costs a
+/// lookup per row, so this is not an index-only read; it stays cheap
+/// because the live-mark set stays small while ops complete. Merge
+/// targets are claimed but never fenced, so they are excluded.
 ///
-/// The partition's existing entries are dropped first, so a re-warm
-/// (a handoff cancelled after warming, then re-acquired) converges
-/// instead of accumulating. Returns how many fences were installed.
+/// The partition's existing entries are dropped first, so a re-warm (a
+/// handoff cancelled after warming, then re-acquired) converges instead
+/// of accumulating. Returns how many fences were installed.
 pub async fn rebuild_partition_fences(
     pool: &PgPool,
     fences: &FenceMap,
@@ -155,15 +151,14 @@ pub async fn rebuild_partition_fences(
     };
     histogram!("personhog_leader_fence_scan_duration_seconds")
         .record(start.elapsed().as_secs_f64());
-    // Read next to installed is the scan's amplification: it reads the
-    // whole live-mark set (the partition is a hash Postgres cannot
-    // compute) and keeps ~1/num_partitions of it. This ratio growing is
-    // the signal that the scan-the-world design needs revisiting.
+    // Rows read versus installed is the scan's amplification: it reads
+    // the whole live-mark set and keeps ~1/num_partitions of it. Growth
+    // in this ratio is the signal to revisit the scan-the-world design.
     counter!("personhog_leader_fence_scan_rows_read_total").increment(rows.len() as u64);
 
-    // Converge rather than accumulate: this partition's fences are
-    // exactly what the marks say, not that plus whatever a previous warm
-    // left behind.
+    // Converge rather than accumulate: the partition's fences are
+    // exactly what the marks say, not that plus a previous warm's
+    // leftovers.
     drop_partition_fences(fences, partition, num_partitions);
 
     let mut installed = 0usize;
@@ -192,11 +187,10 @@ pub async fn rebuild_partition_fences(
     Ok(installed)
 }
 
-/// Drop every fence belonging to `partition` — the counterpart of
-/// [`rebuild_partition_fences`] for partition release. The new owner
-/// rebuilds its own; stale entries here would only pin memory for persons
-/// this pod no longer serves (misrouted requests are already rejected by
-/// partition validation).
+/// Drop every fence for `partition` on release, the counterpart of
+/// [`rebuild_partition_fences`]. The new owner rebuilds its own; stale
+/// entries here would only pin memory for persons this pod no longer
+/// serves (partition validation already rejects misrouted requests).
 pub fn drop_partition_fences(fences: &FenceMap, partition: u32, num_partitions: u32) -> usize {
     let before = fences.len();
     fences.retain(|key, _| {
@@ -206,27 +200,26 @@ pub fn drop_partition_fences(fences: &FenceMap, partition: u32, num_partitions: 
     before - fences.len()
 }
 
-/// How long a person's heal verdict stands before a rejected write may
-/// trigger another mark-row read. Bounds the PG read rate for a person
-/// that is legitimately fenced and still receiving writes: at most one
-/// point read per person per cooldown, however hot the write storm.
+/// How long a heal verdict stands before a rejected write may trigger
+/// another mark-row read. Caps the PG read rate for a legitimately
+/// fenced person at one point read per cooldown, however hot the write
+/// storm.
 const HEAL_COOLDOWN: Duration = Duration::from_secs(5);
 
 /// Above this many tracked persons, expired cooldown stamps are pruned on
 /// the next trigger. Keeps the tracker bounded without a sweeper task.
 const HEAL_TRACKER_PRUNE_THRESHOLD: usize = 10_000;
 
-/// Lazily removes ghost fences — entries whose op has already settled its
-/// mark row, so no `ReleaseFence` will ever arrive for them (see the
-/// module docs for how the takeover scan creates these).
+/// Lazily removes ghost fences: entries whose op already settled its
+/// mark row, so no `ReleaseFence` will ever arrive for them (the module
+/// docs cover how the takeover scan creates these).
 ///
 /// Triggered from the write path when a fence rejects a write, but never
 /// on it: the check runs on a spawned task, the write fails as fenced
-/// either way, and the caller's retry finds the fence gone. Fail-closed
-/// by construction — the fence is only dropped when Postgres, the source
-/// of truth, says the mark is no longer live, and only if the entry still
-/// belongs to the op that was checked (a newer op's fence is never
-/// touched).
+/// either way, and the caller's retry finds the fence gone. Fail-closed:
+/// the fence is dropped only when Postgres says the mark is no longer
+/// live, and only if the entry still belongs to the checked op (a newer
+/// op's fence is never touched).
 pub struct FenceHealer {
     pool: PgPool,
     fences: FenceMap,
@@ -285,9 +278,9 @@ impl FenceHealer {
                 return;
             }
         };
-        // Live is what the takeover scan installs from; anything else —
-        // a terminal status or no row at all — means the op has settled
-        // and its release already happened somewhere.
+        // Live is what the takeover scan installs from. Anything else (a
+        // terminal status or no row) means the op settled and its
+        // release already happened somewhere.
         if matches!(status.as_deref(), Some("marked") | Some("sealed")) {
             counter!("personhog_leader_fence_heals_total", "outcome" => "still_live").increment(1);
             return;
@@ -312,11 +305,11 @@ impl FenceHealer {
     }
 }
 
-/// The committed-release check: the status of the op's mark row for this
-/// person, straight from the source of truth. `None` when the op never
-/// claimed the person (or claimed it only as a merge target — targets are
-/// never destroyed). A committed release must find a live mark here before
-/// it may produce a death document: the request alone must never be enough
+/// The committed-release check: the op's mark-row status for this
+/// person, from the source of truth. `None` when the op never claimed
+/// the person, or claimed it only as a merge target (targets are never
+/// destroyed). A committed release must find a live mark here before it
+/// may produce a death document: the request alone must never be enough
 /// to destroy a person.
 pub async fn mark_status(
     pool: &PgPool,
@@ -335,15 +328,15 @@ pub async fn mark_status(
     .await
 }
 
-/// The fold's check: the status of the op's mark row claiming this person
-/// as its merge target. `None` when the op never claimed the person as
-/// target — including when it holds the person under another role, which
-/// would make a fold into it a saga bug. A fold must find a live mark here
-/// before it may write. The check is read-time only: a fold already past
-/// it when the op settles can still land (the window spans the fold
-/// computation and the produce), so it closes late re-drives, not the
-/// full race — the same at-least-once residual the op_id proto comment
-/// states.
+/// The fold's check: the status of the op's mark row claiming this
+/// person as its merge target. `None` when the op never claimed the
+/// person as target, including when it holds the person under another
+/// role (a fold into that would be a saga bug). A fold must find a live
+/// mark here before it may write. The check is read-time only: a fold
+/// already past it when the op settles can still land, because the
+/// window spans the fold computation and the produce. It closes late
+/// re-drives, not the full race; the op_id proto comment states the same
+/// at-least-once residual.
 pub async fn target_mark_status(
     pool: &PgPool,
     op_id: Uuid,

--- a/rust/personhog-leader/src/fencing.rs
+++ b/rust/personhog-leader/src/fencing.rs
@@ -5,7 +5,7 @@
 //! derived from the partition alone. Taking ownership initializes
 //! transactions for that id, which bumps the broker-side producer epoch
 //! and fences every predecessor: a zombie old owner that missed its own
-//! drain can no longer append to the changelog — its next produce or
+//! drain can no longer append to the changelog. Its next produce or
 //! commit fails with a fenced error at the broker, loudly, instead of
 //! silently corrupting the partition's history.
 //!
@@ -64,21 +64,21 @@ fn transactional_id(topic: &str, partition: u32) -> String {
 
 #[derive(Debug)]
 pub enum FencedProduceError {
-    /// This pod holds no fenced producer for the partition — ownership
+    /// This pod holds no fenced producer for the partition: ownership
     /// was never taken or was released.
     NotAcquired,
     /// The broker fenced this producer: a newer owner has initialized
     /// the partition's transactional id. This pod's claim is stale, and
     /// the records demonstrably never became visible.
     Fenced,
-    /// Fenced, but the window's own outcome was never settled — so the
-    /// partition has moved *and* whether these records landed is unknown.
+    /// Fenced, but the window's own outcome was never settled, so the
+    /// partition has moved AND whether these records landed is unknown.
     ///
     /// The two are independent facts and the caller needs both: the
     /// router still wants the ownership answer, while the version must
     /// stay spent because a commit that was re-issued may have succeeded
-    /// on an earlier attempt. Collapsing this into `Fenced` is what let a
-    /// committed record's version be handed back for reuse.
+    /// on an earlier attempt. Collapsing this into `Fenced` would hand a
+    /// committed record's version back for reuse.
     FencedUncertain(String),
     /// Send or commit failed for an ordinary, retryable reason; the
     /// window was aborted and no record became visible.
@@ -89,9 +89,9 @@ pub enum FencedProduceError {
     /// This is not the same as failure and must not be reported as one.
     /// A caller told "aborted" retries against a cache still holding the
     /// pre-write version, and produces a second record carrying the same
-    /// version as the one that may already have committed — which the
-    /// writer's strict version guard resolves in favour of whichever
-    /// arrived first, discarding the acked one.
+    /// version as the one that may already have committed. The writer's
+    /// strict version guard then keeps whichever arrived first,
+    /// discarding the acked one.
     Indeterminate(String),
 }
 
@@ -127,7 +127,7 @@ struct Gate {
     /// The committer is between closing the window and finishing the
     /// commit. Once it drains `in_flight` and takes `waiters`, the other
     /// fields read as idle even though `commit_transaction` is still
-    /// running — this flag keeps the next window from beginning until
+    /// running; this flag keeps the next window from beginning until
     /// the producer is actually free.
     committing: bool,
     /// Commit-outcome subscribers for the open window.
@@ -158,7 +158,7 @@ impl Gate {
 
 /// Initialize a connected producer on the blocking pool, claiming the
 /// partition's transactional id. On failure the connection is discarded
-/// there too — librdkafka teardown blocks — and only the error comes
+/// there too (librdkafka teardown blocks) and only the error comes
 /// back.
 async fn init_producer(
     connected: ConnectedTransactionalProducer,
@@ -176,10 +176,10 @@ async fn init_producer(
 
 /// Send a fence to the blocking pool to die. Dropping the last
 /// reference runs librdkafka's destroy, which blocks while the client
-/// tears down — up to hundreds of milliseconds — and both removal sites
+/// tears down (up to hundreds of milliseconds), and both removal sites
 /// run on async workers. Best-effort: a caller (an in-flight write, the
-/// settle wait) still holding the Arc pays the destroy wherever it drops
-/// last, which is rarer than the common case this moves.
+/// settle wait) still holding the Arc pays the destroy wherever it
+/// drops last, which is rarer than the common case this moves.
 fn drop_fence_off_worker(fence: Arc<PartitionFence>) {
     tokio::task::spawn_blocking(move || drop(fence));
 }
@@ -201,14 +201,14 @@ struct PartitionFence {
     /// writers open the next one.
     window_closed: Notify,
     /// Set when the producer is left in a transaction state no later
-    /// `begin_transaction` can recover from — an abort that did not land,
+    /// `begin_transaction` can recover from: an abort that did not land,
     /// or a commit whose outcome stayed unknown.
     ///
     /// Such a producer is still installed, so presence alone cannot tell
     /// a working fence from a dead one. This flag is what makes the
     /// distinction visible: a condemned partition answers as unowned, so
     /// the router bounces instead of retrying a dead producer, and
-    /// `holds()` reports the fence missing — which is what lets
+    /// `holds()` reports the fence missing, which is what lets
     /// `heal_fence`, on the next convergence to Serving, re-take the
     /// epoch once the pod's claim is confirmed.
     unusable: AtomicBool,
@@ -232,12 +232,12 @@ impl PartitionFence {
                 partition,
                 reason, "changelog producer left unusable; awaiting re-acquisition"
             );
-            // The only way back is a heal on a convergence to Serving, and
-            // the reconcile tick that would otherwise carry it is seconds
-            // away — writes bounce for that whole gap. The nudge lets the
-            // coordination loop run its repair pass now; Notify stores
-            // the permit, so a nudge landing before the loop listens is
-            // not lost.
+            // The only way back is a heal on a convergence to Serving,
+            // and the reconcile tick that would otherwise carry it is
+            // seconds away; writes bounce for that whole gap. The nudge
+            // lets the coordination loop run its repair pass now; Notify
+            // stores the permit, so a nudge landing before the loop
+            // listens is not lost.
             if let Some(nudge) = &self.repair_nudge {
                 nudge.notify_one();
             }
@@ -251,8 +251,8 @@ impl PartitionFence {
 
 /// One seat in the open window, released on drop.
 ///
-/// A request can vanish at any await — tonic drops the handler future
-/// when the client's deadline expires or its stream resets — and the
+/// A request can vanish at any await (tonic drops the handler future
+/// when the client's deadline expires or its stream resets), and the
 /// seat has to come back even then, or the committer waits on an
 /// in-flight count that never reaches zero and every later write on the
 /// partition parks forever behind it.
@@ -336,7 +336,7 @@ impl Drop for WindowSlot {
 /// Marks a window as committing, and clears the mark on drop.
 ///
 /// Between closing a window and finishing its commit the gate reads as
-/// idle — `in_flight` is zero and the waiters have been taken — so only
+/// idle (`in_flight` is zero and the waiters have been taken), so only
 /// this mark keeps the next writer from beginning a transaction the
 /// producer is not free for. If the committer unwinds while it is set,
 /// nothing else ever clears it: every later write parks on
@@ -377,12 +377,13 @@ impl Drop for CommittingMark {
                 mem::take(&mut gate.waiters)
             }
         };
-        // On the ordinary path the committer took the waiters before this
-        // drops, so the list is empty. Waiters still here mean the
-        // committer unwound between taking the mark and answering anyone
-        // — their outcomes are unobservable, and leaving them queued
-        // would park every later write forever: nothing can open a window
-        // while waiters remain, and nothing would notify again. Dropping
+        // On the ordinary path the committer took the waiters before
+        // this drops, so the list is empty. Waiters still here mean the
+        // committer unwound between taking the mark and answering
+        // anyone; their outcomes are unobservable, and leaving them
+        // queued would park every later write forever: nothing can open
+        // a window while waiters remain, and nothing would notify
+        // again. Dropping
         // their senders answers each with the doubt it earned (a closed
         // channel reads as an unobserved commit), and condemning routes
         // the partition into the same bounce-and-recover story as every
@@ -398,7 +399,7 @@ impl Drop for CommittingMark {
 /// Holds a freshly acquired fence until the work that justified taking
 /// it succeeds, and gives it back otherwise.
 ///
-/// A warm can end without returning — its future is dropped when the
+/// A warm can end without returning: its future is dropped when the
 /// pod's coordination attempt is torn down, which is exactly what a lost
 /// lease does. The pod records a partition as held only once the warm
 /// returns, so a fence taken by a warm that never finishes belongs to no
@@ -411,7 +412,7 @@ pub struct FenceGuard {
     /// The fence this guard is answerable for. Releasing by partition
     /// alone would drop whatever happens to be installed at drop time,
     /// which after a release and a re-acquire is somebody else's
-    /// producer — the same hazard `forget_fence` checks for.
+    /// producer: the same hazard `forget_fence` checks for.
     taken: Option<Arc<PartitionFence>>,
     /// Names the work the fence was taken for, so an abandon names the
     /// path that dropped mid-flight.
@@ -471,7 +472,7 @@ enum Prepared {
     /// The token identifies the owning dial. A dial resolves only its
     /// own claim: a stale dial whose claim was removed mid-flight (by
     /// an acquire, a release, or the sweep) must neither usurp a
-    /// replacement dial's claim on success nor release it on failure —
+    /// replacement dial's claim on success nor release it on failure;
     /// either would let convergence start extra dials, which is the
     /// churn the claim exists to prevent.
     Connecting { token: u64, since: Instant },
@@ -513,7 +514,7 @@ pub struct FencedChangelogProducers {
     /// parked by `preconnect` for a later `acquire` to claim. Connection
     /// setup is the slow half of acquisition and touches no broker
     /// transactional state, so it can run ahead of the authority
-    /// transition; `init_transactions` — the fencing action — still
+    /// transition; `init_transactions`, the fencing action, still
     /// happens only inside `acquire`.
     prepared: DashMap<u32, Prepared>,
     /// Distinguishes dials, so each resolves only its own claim.
@@ -528,8 +529,8 @@ pub struct FencedChangelogProducers {
     /// Outcomes a test stages for the next produce on a partition.
     ///
     /// The uncertain outcomes need a broker fault landing inside a
-    /// transaction, which no test can stage against a healthy cluster —
-    /// but what the caller *does* with them is the reason they are
+    /// transaction, which no test can stage against a healthy cluster,
+    /// but what the caller does with them is the reason they are
     /// distinguished at all, so the answers have to be reachable.
     #[cfg(any(test, feature = "test-support"))]
     staged_failures: DashMap<u32, FencedProduceError>,
@@ -537,9 +538,9 @@ pub struct FencedChangelogProducers {
 
 /// Construction parameters for [`FencedChangelogProducers`], named
 /// because five of them are `Duration`s: a transposed pair at a call
-/// site compiles, and `main`'s wiring is executed by no test — a swapped
-/// window and settle budget would ship as a 2s admission window on
-/// every fenced write.
+/// site compiles, and `main`'s wiring is executed by no test, so a
+/// swapped window and settle budget would ship as a 2s admission window
+/// on every fenced write.
 pub struct FencedProducerConfig {
     pub kafka: KafkaConfig,
     pub topic: String,
@@ -594,8 +595,8 @@ impl FencedChangelogProducers {
 
     /// Take the partition's fence: create the transactional producer and
     /// initialize transactions, which fences every previous owner of the
-    /// partition's transactional id. Runs on the blocking pool — init is
-    /// a synchronous broker round trip.
+    /// partition's transactional id. Runs on the blocking pool, because
+    /// init is a synchronous broker round trip.
     async fn acquire_installed(&self, partition: u32) -> Result<Arc<PartitionFence>, String> {
         let timeout = self.init_timeout;
         let mut start = Instant::now();
@@ -672,7 +673,7 @@ impl FencedChangelogProducers {
         if let Some(replaced) = self.partitions.insert(partition, Arc::clone(&installed)) {
             // The heal path installs over a still-present condemned
             // fence, and by then the commit task has usually dropped its
-            // clones — making this insert the last reference and its
+            // clones, making this insert the last reference and its
             // drop a blocking librdkafka destroy. Send it to the
             // blocking pool like every other eviction site.
             drop_fence_off_worker(replaced);
@@ -738,7 +739,7 @@ impl FencedChangelogProducers {
                 counter!("personhog_leader_fence_preconnect_total", "outcome" => "error")
                     .increment(1);
                 warn!(partition, error = %e, "fence preconnect failed; acquisition will connect cold");
-                // Release the claim so a later preconnect can retry —
+                // Release the claim so a later preconnect can retry,
                 // but only this dial's own claim. A replacement dial's
                 // claim, or a parked connection, stays.
                 self.prepared.remove_if(
@@ -752,7 +753,7 @@ impl FencedChangelogProducers {
     /// Park a finished dial, unless its claim is gone (a release, a
     /// sweep, or an acquire that went cold discarded it): a discarded
     /// partition must not resurrect, so the late connection is dropped
-    /// instead. The token check makes ownership exact — a stale dial
+    /// instead. The token check makes ownership exact: a stale dial
     /// finding a replacement dial's claim here must not usurp it, or
     /// the replacement's own park would discard the newer connection
     /// while later convergence passes see whatever raced in.
@@ -795,7 +796,7 @@ impl FencedChangelogProducers {
         .map_err(|e| format!("fence connect: {e}"))
     }
 
-    /// Drop a parked connection on the blocking pool — librdkafka's
+    /// Drop a parked connection on the blocking pool; librdkafka's
     /// client teardown blocks, same as a full fence's. A Connecting
     /// claim is removed without a drop: its dial discards on
     /// completion once the claim is gone.
@@ -808,7 +809,7 @@ impl FencedChangelogProducers {
     /// Discard every parked connection. A connection is normally
     /// consumed within its drain window, seconds after parking; one
     /// still here at the periodic sweep belongs to an acquire that went
-    /// cold first or to a cancelled inbound handoff — and a cancelled
+    /// cold first or to a cancelled inbound handoff, and a cancelled
     /// inbound handoff leaves no convergence behind to notice it, so
     /// the sweep is the only owner its lifetime has. A drain window
     /// that happens to straddle the sweep tick loses its head start and
@@ -892,9 +893,8 @@ impl FencedChangelogProducers {
     ///
     /// Deliberately not mere presence. A condemned producer is still
     /// installed, and answering "yes" for one would tell the repair pass
-    /// that a partition it must re-acquire needs nothing — which is
-    /// exactly how such a partition stayed unwritable until a handoff
-    /// moved it.
+    /// that a partition it must re-acquire needs nothing, leaving the
+    /// partition unwritable until a handoff moved it.
     pub fn holds(&self, partition: u32) -> bool {
         self.partitions
             .get(&partition)
@@ -903,41 +903,39 @@ impl FencedChangelogProducers {
 
     /// Commit the partition's open window before its owner gives it up.
     ///
-    /// A request cancelled mid-produce takes its handler — and the
-    /// drain's in-flight count — with it, leaving the record it enqueued
+    /// A request cancelled mid-produce takes its handler (and the
+    /// drain's in-flight count) with it, leaving the record it enqueued
     /// in a window nobody is waiting on. Left alone, that window's fate
     /// falls to whichever acts first: this pod's own committer, or the
-    /// successor's `init_transactions` aborting it at the broker. Waiting
-    /// here settles it in the successor's favour, so a cancelled client's
-    /// changes land instead of being discarded by a race.
+    /// successor's `init_transactions` aborting it at the broker.
+    /// Waiting here lets this pod's committer settle it, so a cancelled
+    /// client's changes land instead of being discarded by a race.
     ///
     /// Deliberately best-effort. Refusing to hand over a partition whose
     /// window did not settle would buy nothing: a producer that cannot
     /// report its outcome is a producer the broker will not accept
-    /// another record from, so the records cannot grow after this point
-    /// whatever we do — and the successor's init aborts what is left,
-    /// exactly as it did before this wait existed. What refusing *does*
+    /// another record from, so the records cannot grow after this point,
+    /// and the successor's init aborts what is left. What refusing does
     /// cost is the partition: the drain has already fenced writes, and
     /// there is no branch that un-fences one whose handoff never
     /// completed.
     pub async fn settle(&self, partition: u32) {
         let Some(fence) = self.installed(partition) else {
             // A write that met a condemned producer already gave the
-            // fence up, which is the ordinary shape after a condemnation
-            // — recorded rather than silent, or the series has no
+            // fence up, the ordinary shape after a condemnation.
+            // Recorded rather than silent, or the series has no
             // denominator.
             counter!("personhog_leader_fence_settle_total", "outcome" => "absent").increment(1);
             return;
         };
         // Bounded well under the broker's own patience for the window.
         // The wait exists to catch a committer that is about to fire
-        // anyway — it sleeps for the window, five milliseconds by
-        // default, then commits — so seconds of budget only help when
-        // the commit is retrying, which is the case where the
-        // successor's abort is the right answer regardless. The cap
-        // matters because the pre-revoke self-fence allows three seconds
-        // for a whole drain: a budget derived from the lease alone
-        // reaches about 6s at the production TTL, so every shutdown with an
+        // anyway (it sleeps for the window, then commits), so seconds
+        // of budget only help when the commit is retrying, which is the
+        // case where the successor's abort is the right answer
+        // regardless. The cap matters because the pre-revoke self-fence
+        // allows three seconds for a whole drain: a budget derived from
+        // the lease alone would overrun it, so every shutdown with an
         // open window would truncate here and report a failed drain.
         let budget = self.settle_budget;
         let waited = timeout(budget, async {
@@ -979,20 +977,13 @@ impl FencedChangelogProducers {
         }
     }
 
-    /// Put the partition's producer into the state a failed abort or an
-    /// unknown commit leaves it in.
-    ///
-    /// Reaching that state for real takes a broker fault landing inside a
-    /// transaction, which no test can stage against a healthy cluster —
-    /// but what happens *afterwards* is the entire reason the state is
-    /// tracked, so the aftermath has to be reachable.
     /// Hold the partition's gate in the state a commit in flight leaves
     /// it, so a writer arriving now parks instead of opening a window.
     ///
     /// The wake path is otherwise unreachable from a test: parking
     /// requires arriving inside the commit's own round trip, which is
-    /// milliseconds wide and not something a test can aim at. Staging the
-    /// gate directly is what makes the interleaving deterministic rather
+    /// milliseconds wide and not something a test can aim at. Staging
+    /// the gate directly makes the interleaving deterministic rather
     /// than statistical.
     #[cfg(any(test, feature = "test-support"))]
     pub fn begin_committing_for_test(&self, partition: u32) {
@@ -1018,7 +1009,7 @@ impl FencedChangelogProducers {
     ///
     /// A real poisoning needs a produce to fail mid-window against a
     /// broker that is otherwise healthy enough to have opened one, which
-    /// is not stageable — but what the commit path does with a poisoned
+    /// is not stageable, but what the commit path does with a poisoned
     /// window is the whole reason the flag exists.
     #[cfg(any(test, feature = "test-support"))]
     pub fn poison_window_for_test(&self, partition: u32) {
@@ -1028,7 +1019,7 @@ impl FencedChangelogProducers {
     }
 
     /// Stage a committer that unwound between taking the mark and
-    /// answering its subscribers — the shape a runtime teardown or a
+    /// answering its subscribers: the shape a runtime teardown or a
     /// panic in the settle wait leaves behind. Real unwinds are not
     /// stageable deterministically; what matters is the mark's cleanup.
     #[cfg(any(test, feature = "test-support"))]
@@ -1069,6 +1060,12 @@ impl FencedChangelogProducers {
         self.staged_failures.insert(partition, outcome);
     }
 
+    /// Put the partition's producer into the state a failed abort or an
+    /// unknown commit leaves it in. Reaching that state for real takes a
+    /// broker fault landing inside a transaction, which no test can
+    /// stage against a healthy cluster, but what happens afterwards is
+    /// the entire reason the state is tracked, so the aftermath has to
+    /// be reachable.
     #[cfg(any(test, feature = "test-support"))]
     pub fn condemn_for_test(&self, partition: u32) {
         if let Some(fence) = self.partitions.get(&partition) {
@@ -1103,12 +1100,12 @@ impl FencedChangelogProducers {
         let opened = loop {
             // Checked every iteration, not only on the way in. A
             // condemned producer cannot begin another transaction, and
-            // the commit that condemns it is the same one whose end wakes
-            // whoever is parked below — so a check placed after the park
-            // is skipped by exactly the writer it exists for, which then
-            // opens a window on a dead producer and answers with a
-            // retryable failure instead of the ownership bounce that gets
-            // the partition re-acquired.
+            // the commit that condemns it is the same one whose end
+            // wakes whoever is parked below, so a check placed after
+            // the park is skipped by exactly the writer it exists for,
+            // which then opens a window on a dead producer and answers
+            // with a retryable failure instead of the ownership bounce
+            // that gets the partition re-acquired.
             if !fence.is_usable() {
                 self.forget_fence(partition, &fence);
                 counter!("personhog_leader_kafka_produce_errors_total").increment(1);
@@ -1157,10 +1154,10 @@ impl FencedChangelogProducers {
             }
             closed.await;
         };
-        // Near-zero when a window was open or the producer idle; the tail
-        // is time parked behind a draining or committing window — the
-        // queueing term of the fencing tax, and the first thing to grow
-        // if commits slow down.
+        // Near-zero when a window was open or the producer idle; the
+        // tail is time parked behind a draining or committing window,
+        // the queueing term of the fencing tax and the first thing to
+        // grow if commits slow down.
         // From here the window counts this write as in flight; the slot
         // returns the seat on every exit, including cancellation.
         let slot = WindowSlot::held(Arc::clone(&fence));
@@ -1221,7 +1218,7 @@ impl FencedChangelogProducers {
         };
 
         // A failed send poisons the window (the committer aborts it) and
-        // returns immediately with its own classified error — a fenced
+        // returns immediately with its own classified error: a fenced
         // rejection must surface as `Fenced`, not as the window's
         // generic abort.
         if let Err(send_err) = offset {
@@ -1271,7 +1268,7 @@ impl FencedChangelogProducers {
                 Err(e)
             }
             // The committer dropped its senders without answering, so
-            // nobody observed whether the commit landed — and
+            // nobody observed whether the commit landed, and
             // `spawn_blocking` work is not cancelled when its handle is
             // dropped, so it may well have. Reporting a definite abort
             // here frees a version whose record may exist.
@@ -1286,8 +1283,8 @@ impl FencedChangelogProducers {
 
     /// Classify a transaction error, removing the fence on a broker
     /// fence rejection so subsequent writes fail fast as stale. The
-    /// fenced signal often hides behind a local symptom — librdkafka
-    /// purges queued messages once the producer turns fatal — so the
+    /// fenced signal often hides behind a local symptom (librdkafka
+    /// purges queued messages once the producer turns fatal), so the
     /// producer's fatal error is consulted alongside the surface error.
     fn classify(
         &self,
@@ -1324,7 +1321,7 @@ impl FencedChangelogProducers {
         if let Some((_, evicted)) = removed {
             drop_fence_off_worker(evicted);
             // The escalation signal for a partition giving up its fence
-            // outside the orderly release path — the series exists so a
+            // outside the orderly release path; the series exists so a
             // deploy-window burst of these is visible.
             counter!(
                 "personhog_leader_fenced_partition_drops_total",
@@ -1368,7 +1365,7 @@ enum WindowVerdict {
     /// A newer owner holds the partition; the records never landed.
     Fenced,
     /// A newer owner holds the partition and the records' fate is
-    /// unknown — both facts, because they answer different questions.
+    /// unknown: both facts, because they answer different questions.
     FencedUncertain,
     /// The window aborted for an ordinary reason; safe to retry.
     Aborted,
@@ -1376,16 +1373,6 @@ enum WindowVerdict {
     Indeterminate,
 }
 
-/// Whether the partition moved and whether the records landed are
-/// independent, so the verdict carries both.
-///
-/// A commit can time out, be re-issued by librdkafka itself, and only
-/// then report the fence — by which point an earlier attempt may already
-/// have succeeded. Reporting that as a plain fence tells the caller the
-/// record does not exist, which frees its version and puts a second
-/// record at the same number behind one that may be committed. Reporting
-/// it as merely indeterminate throws away the ownership answer the router
-/// bounces on. `FencedUncertain` is both.
 /// Every reason production code passes to `condemn`, in one place so the
 /// preregistration below cannot drift from the call sites: a reason
 /// missing here first appears as a brand-new series mid-incident instead
@@ -1407,18 +1394,19 @@ const CONDEMN_REASONS: [&str; 6] = [
 /// and it is the only path in production that ever sets the flag.
 ///
 /// A dead producer carries two very different stories, split by
-/// `fenced`: a producer fenced by a newer owner's init lost the epoch (a
-/// handoff, a heal, a zombie being cut off — coordination working), while
-/// an abort that failed on a producer nobody fenced means the broker
-/// could not be reached in time (an infrastructure excursion). The panel
-/// reading this label has to tell those apart without the logs.
+/// `fenced`: a producer fenced by a newer owner's init lost the epoch,
+/// which is coordination working (a handoff, a heal, a zombie being cut
+/// off), while an abort that failed on a producer nobody fenced means
+/// the broker could not be reached in time (an infrastructure
+/// excursion). The panel reading this label has to tell those apart
+/// without the logs.
 fn condemn_reason(outcome: CommitOutcome, fenced: bool) -> Option<&'static str> {
     match outcome {
         CommitOutcome::Aborted => None,
         CommitOutcome::AbortedProducerDead if fenced => Some("abort_fenced"),
         CommitOutcome::AbortedProducerDead => Some("abort_failed"),
         // A commit killed by a newer owner's init reports librdkafka's
-        // fatal class and lands here, not in AbortedProducerDead — the
+        // fatal class and lands here, not in AbortedProducerDead; the
         // fenced split must cover this arm or every deploy-shaped
         // condemnation reads as a broker excursion.
         CommitOutcome::Unknown if fenced => Some("commit_fenced"),
@@ -1426,6 +1414,16 @@ fn condemn_reason(outcome: CommitOutcome, fenced: bool) -> Option<&'static str> 
     }
 }
 
+/// Whether the partition moved and whether the records landed are
+/// independent, so the verdict carries both.
+///
+/// A commit can time out, be re-issued by librdkafka itself, and only
+/// then report the fence, by which point an earlier attempt may already
+/// have succeeded. Reporting that as a plain fence tells the caller the
+/// record does not exist, which frees its version and puts a second
+/// record at the same number behind one that may be committed.
+/// Reporting it as merely indeterminate throws away the ownership
+/// answer the router bounces on. `FencedUncertain` is both.
 fn window_verdict(outcome: CommitOutcome, fenced: bool) -> WindowVerdict {
     match (outcome.is_aborted(), fenced) {
         (true, true) => WindowVerdict::Fenced,
@@ -1469,10 +1467,9 @@ fn producer_fenced<C: ClientContext>(producer: &FutureProducer<C>) -> bool {
 /// Abort the window, up to the number of attempts the lease runway was
 /// sized for.
 ///
-/// Derived from the constant rather than written out, so that raising the
-/// budget raises the attempts and vice versa. The two drifted apart once
-/// already: the loop spent four transaction timeouts while the bound that
-/// had to contain them counted one.
+/// Derived from the constant rather than written out, so that raising
+/// the budget raises the attempts and vice versa; a hand-written count
+/// can silently drift from the bound that must contain it.
 fn abort_window<C: ClientContext>(
     producer: &FutureProducer<C>,
     timeout: Duration,
@@ -1512,7 +1509,7 @@ async fn commit_window_after(
     }
 
     // Stop admitting joiners, then wait for outstanding sends. The mark
-    // holds until this function returns — by any path — so no writer can
+    // holds until this function returns, by any path, so no writer can
     // begin the next transaction while this one is still resolving, and
     // none is stranded if it unwinds.
     let _committing = CommittingMark::take(Arc::clone(&fence), partition);
@@ -1553,16 +1550,16 @@ async fn commit_window_after(
         if poisoned {
             // One attempt. A producer left in its abortable state fails
             // every later `begin_transaction`, so a failed abort costs
-            // the producer itself rather than just this window — and the
+            // the producer itself rather than just this window, and the
             // recovery for that is re-acquisition, whose init aborts the
             // pending transaction at the broker anyway.
             match abort_window(&producer, timeout) {
                 Ok(()) => Err((KafkaError::Canceled, CommitOutcome::Aborted)),
-                // The records are still definitely not visible — an abort
-                // that did not land leaves the transaction open, and open
-                // is not committed. What is lost is the producer: it stays
-                // in its abortable state, where every later
-                // `begin_transaction` fails.
+                // The records are still definitely not visible: an
+                // abort that did not land leaves the transaction open,
+                // and open is not committed. What is lost is the
+                // producer: it stays in its abortable state, where
+                // every later `begin_transaction` fails.
                 Err(e) => {
                     counter!("personhog_leader_fence_abort_failed_total").increment(1);
                     Err((e, CommitOutcome::AbortedProducerDead))
@@ -1571,7 +1568,7 @@ async fn commit_window_after(
         } else {
             // A commit that fails is not the same as a commit that did
             // not happen. librdkafka distinguishes three cases and the
-            // caller's correct behaviour differs for each: a retriable
+            // caller's correct behavior differs for each: a retriable
             // failure leaves the outcome unknown and must be re-attempted
             // (commit is idempotent within the transaction); an
             // abort-requiring failure is a definite abort once the abort
@@ -1689,7 +1686,7 @@ async fn commit_window_after(
             }
         }
         // The commit task itself vanished, so nothing observed the
-        // transaction's fate — which leaves the transaction open and this
+        // transaction's fate, which leaves the transaction open and this
         // producer unable to begin another. Condemning it is what stops
         // the partition counting as fenced; without it every later write
         // retries a producer that cannot serve one, for the life of the
@@ -1711,7 +1708,7 @@ async fn commit_window_after(
 
 /// Materialize every fencing series at startup so deploy-window bursts
 /// land in an already-scraped series instead of being swallowed by
-/// first-increment lazy registration — fence acquisition in particular
+/// first-increment lazy registration; fence acquisition in particular
 /// fires exactly during deploys. A touched histogram renders with zero
 /// count until its first sample.
 pub fn preregister_fencing_metrics(partitions: u32) {
@@ -1719,7 +1716,7 @@ pub fn preregister_fencing_metrics(partitions: u32) {
         counter!("personhog_leader_fence_init_total", "outcome" => outcome).increment(0);
     }
     // Settling fires only during handoffs, so every one of its samples
-    // lands in a deploy window — the case this preregistration exists
+    // lands in a deploy window, the case this preregistration exists
     // for.
     for outcome in ["settled", "timeout", "unusable", "absent"] {
         counter!("personhog_leader_fence_settle_total", "outcome" => outcome).increment(0);
@@ -1800,26 +1797,9 @@ fn clone_outcome(outcome: &Result<(), FencedProduceError>) -> Result<(), FencedP
     }
 }
 
-/// Re-take the partition's fence if this pod is serving it without one.
-///
-/// A fence can go missing under a pod that legitimately owns its
-/// partition: a broker rejection evicted it, an abort exhausted its
-/// retries and left the producer unusable, or a stale pod took the epoch
-/// and stepped back. Nothing in the handoff protocol repairs that —
-/// convergence sees the partition warmed and unfenced and does nothing —
-/// so without this the partition stays unwritable until a handoff moves
-/// it.
-///
-/// Re-acquisition is safe only because of where this is called from and
-/// what it checks. The caller is the convergence to `Serving`, so the
-/// durable assignment says this pod owns the partition; the claim must
-/// still be valid, because taking a fence moves the broker's epoch away
-/// from whoever holds it; and a partition being locally fenced is
-/// disqualifying, since that means a handoff is moving it and the
-/// incoming owner's fence is the one that should stand.
 /// What the healing pass did, for the caller to act on: a healed
-/// partition is freshly fenced — the epoch just moved, and the same
-/// convergence must not move it again — and a failure is the caller's
+/// partition is freshly fenced (the epoch just moved, and the same
+/// convergence must not move it again), and a failure is the caller's
 /// to surface, because a partition that cannot regain its fence has no
 /// other repair path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1829,11 +1809,28 @@ pub enum HealOutcome {
     Intact,
     /// A fence was re-taken and is serving.
     Healed,
-    /// A fence was taken but given back — standing lapsed or a handoff
+    /// A fence was taken but given back: standing lapsed or a handoff
     /// began during the broker round trip.
     Abandoned,
 }
 
+/// Re-take the partition's fence if this pod is serving it without one.
+///
+/// A fence can go missing under a pod that legitimately owns its
+/// partition: a broker rejection evicted it, an abort exhausted its
+/// retries and left the producer unusable, or a stale pod took the
+/// epoch and stepped back. Nothing in the handoff protocol repairs that
+/// (convergence sees the partition warmed and unfenced and does
+/// nothing), so without this the partition stays unwritable until a
+/// handoff moves it.
+///
+/// Re-acquisition is safe only because of where this is called from and
+/// what it checks. The caller is the convergence to `Serving`, so the
+/// durable assignment says this pod owns the partition; the claim must
+/// still be valid, because taking a fence moves the broker's epoch away
+/// from whoever holds it; and a partition being locally fenced is
+/// disqualifying, since that means a handoff is moving it and the
+/// incoming owner's fence is the one that should stand.
 pub async fn heal_fence(
     fenced: &Arc<FencedChangelogProducers>,
     inflight: &InflightTracker,
@@ -1861,19 +1858,19 @@ pub async fn heal_fence(
         }
     };
     // Answerable for the installed fence from here until a deliberate
-    // branch takes over. A drop *during* the acquire needs no guard —
-    // the producer is discarded before it is installed, `holds()` stays
-    // false, and the next convergence heals again. What the guard covers
-    // is the stretch after installation: the checks below await nothing
-    // today, so its teeth are a panic between them and any await a
+    // branch takes over. A drop during the acquire needs no guard: the
+    // producer is discarded before it is installed, `holds()` stays
+    // false, and the next convergence heals again. What the guard
+    // covers is the stretch after installation: the checks below await
+    // nothing, so its teeth are a panic between them and any await a
     // future change adds. Same shape as the warm path.
     let guard = FenceGuard::new(Arc::clone(fenced), partition, "heal");
-    // The round trip is long enough for the ground to move: the claim can
-    // lapse, or a handoff can start draining the partition. Holding a
-    // fence taken without standing is not passive — the write path trusts
-    // the broker epoch rather than re-checking the claim, so a request
-    // landing here would ack a mutation with an epoch taken from the
-    // partition's real owner.
+    // The round trip is long enough for the ground to move: the claim
+    // can lapse, or a handoff can start draining the partition. Holding
+    // a fence taken without standing is not passive: the write path
+    // trusts the broker epoch rather than re-checking the claim, so a
+    // request landing here would ack a mutation with an epoch taken
+    // from the partition's real owner.
     let lost_standing = authority.is_some_and(|a| !a.is_valid());
     if lost_standing || inflight.is_fenced(partition) {
         guard.keep();
@@ -1901,17 +1898,7 @@ pub async fn heal_fence(
 mod tests {
     use super::*;
 
-    /// The verdict the caller acts on, as a truth table over the two
-    /// independent facts it combines.
-    ///
-    /// The cell that matters is (unknown, fenced). A commit that timed
-    /// out, was re-issued — by librdkafka itself, not just by this loop —
-    /// and only then discovered the fence may already have landed. Its
-    /// own verdict keeps both facts: the router still gets the ownership
-    /// answer it bounces on, and the version stays spent. Collapsing it
-    /// into `Fenced` frees a version whose record may be committed, and
-    /// collapsing it into `Indeterminate` throws away the bounce.
-    /// The arrow *into* the condemned state. A producer left in a
+    /// The arrow into the condemned state. A producer left in a
     /// transaction it cannot leave must be given up, or the partition
     /// keeps counting as fenced and every later write retries a producer
     /// that cannot serve one, for the life of the process.
@@ -1928,10 +1915,10 @@ mod tests {
             condemn_reason(CommitOutcome::Unknown, false),
             Some("commit_indeterminate")
         );
-        // The same dead producer, split by what killed it: an epoch lost
-        // to a newer owner is coordination working, an abort nobody
-        // fenced failing is the broker unreachable — the operator's first
-        // question, answered from the series alone.
+        // The same dead producer, split by what killed it: an epoch
+        // lost to a newer owner is coordination working, an abort
+        // nobody fenced failing is the broker unreachable; the
+        // operator's first question, answered from the series alone.
         assert_eq!(
             condemn_reason(CommitOutcome::AbortedProducerDead, true),
             Some("abort_fenced")
@@ -1968,6 +1955,13 @@ mod tests {
         }
     }
 
+    /// The verdict the caller acts on, as a truth table over the two
+    /// independent facts it combines. The cell that matters is
+    /// (unknown, fenced): a commit that timed out, was re-issued (by
+    /// librdkafka itself, not just this loop), and only then discovered
+    /// the fence may already have landed. Its verdict keeps both facts:
+    /// the router still gets the ownership answer it bounces on, and
+    /// the version stays spent.
     #[test]
     fn a_fence_only_settles_the_records_when_the_window_also_aborted() {
         for (outcome, fenced, expected) in [

--- a/rust/personhog-leader/src/inflight.rs
+++ b/rust/personhog-leader/src/inflight.rs
@@ -4,25 +4,25 @@ use std::time::Duration;
 
 use dashmap::{DashMap, DashSet};
 
-/// Per-partition write-admission state used by the handoff protocol to
-/// prove that all writes this pod ever acked are durably in Kafka.
+/// Per-partition write-admission state. The handoff protocol uses it to
+/// prove that every write this pod acked is durably in Kafka.
 ///
 /// Two pieces work together:
 ///
-/// * An inflight counter. Because `produce_person_changelog` awaits the
-///   Kafka delivery future before the handler returns success, "no
-///   inflight handlers for partition p" implies "every write for p that
-///   this pod ever acknowledged is in Kafka."
-/// * A write fence. Once a partition drains for handoff, no further write
-///   may be admitted: every router acked the freeze before the drain
-///   began, so a late write can only come from a router serving with a
-///   stale view — accepting it would advance the Kafka HWM past the point
+/// * An inflight counter. `produce_person_changelog` awaits the Kafka
+///   delivery future before the handler returns success, so "no inflight
+///   handlers for partition p" implies "every acked write for p is in
+///   Kafka."
+/// * A write fence. Once a partition drains for handoff, no further
+///   write may be admitted: every router acked the freeze before the
+///   drain began, so a late write can only come from a router with a
+///   stale view. Accepting it would advance the Kafka HWM past the point
 ///   warming snapshots, silently losing the write from the new owner.
 ///
 /// Callers obtain a guard via `begin(partition)` and drop it when the
-/// handler completes; the handoff protocol fences the partition, then
-/// calls `wait_until_empty(partition)` to block until all inflight
-/// handlers have returned.
+/// handler completes. The handoff fences the partition, then calls
+/// `wait_until_empty(partition)` to block until all inflight handlers
+/// return.
 #[derive(Default)]
 pub struct InflightTracker {
     partitions: DashMap<u32, Arc<AtomicUsize>>,
@@ -44,15 +44,14 @@ impl InflightTracker {
         InflightGuard { counter }
     }
 
-    /// Admit a write for the partition unless it is fenced. The increment
-    /// happens *before* the fence check: at every interleaving with the
-    /// drain path (which fences, then waits for the count to reach zero),
-    /// either this write's increment is visible to the drain's wait, or
-    /// this write observes the fence and is refused. Checking the fence
-    /// before incrementing would leave a window where a write passes the
-    /// check, the drain fences and observes a zero count, and the write
-    /// then increments — producing past the HWM the new owner's warming
-    /// snapshots.
+    /// Admit a write for the partition unless it is fenced. The
+    /// increment happens before the fence check: at every interleaving
+    /// with the drain (which fences, then waits for a zero count),
+    /// either the drain's wait sees this increment, or this write sees
+    /// the fence and is refused. Checking the fence first would leave a
+    /// window where the write passes the check, the drain fences and
+    /// sees zero, and the write then increments, producing past the HWM
+    /// the new owner's warming snapshots.
     pub fn try_begin(self: &Arc<Self>, partition: u32) -> Option<InflightGuard> {
         let guard = self.begin(partition);
         if self.is_fenced(partition) {
@@ -94,7 +93,6 @@ impl InflightTracker {
         self.fenced.remove(&partition);
     }
 
-    /// Whether writes for the partition are currently rejected.
     pub fn is_fenced(&self, partition: u32) -> bool {
         self.fenced.contains(&partition)
     }
@@ -208,7 +206,7 @@ mod tests {
         wait.await.unwrap();
     }
 
-    /// Fences are per-partition, idempotent, and reversible — the exact
+    /// Fences are per-partition, idempotent, and reversible: the
     /// lifecycle the handoff handler drives (fence on drain, unfence on
     /// release/cancel/re-warm).
     #[test]

--- a/rust/personhog-leader/src/kafka.rs
+++ b/rust/personhog-leader/src/kafka.rs
@@ -12,34 +12,36 @@ use personhog_proto::personhog::types::v1::Person;
 /// Formats the Kafka message key for person state changelog messages.
 /// The topic must include `compact` in its `cleanup.policy` so Kafka
 /// retains the latest state per person. Deployed config is
-/// `compact,delete`, where retention bounds even the latest record —
+/// `compact,delete`, so retention bounds even the latest record. That is
 /// acceptable because nothing reads records older than the writer's
-/// committed offset, which retention outruns by design.
+/// committed offset, and retention outruns that offset by design.
 pub fn changelog_message_key(team_id: i64, person_id: i64) -> String {
     format!("{team_id}:{person_id}")
 }
 
 /// Produce a person state changelog message to Kafka.
 ///
-/// Encodes the `Person` proto as the message payload and uses
-/// `{team_id}:{person_id}` as the key for compaction. The message is
-/// produced to an explicit partition — the person's routing partition —
-/// rather than relying on the producer's key partitioner. Warming rebuilds
-/// one routing partition's cache by consuming the same-numbered Kafka
-/// partition, so the two numbering schemes must agree; producing explicitly
-/// makes that alignment structural instead of depending on the partitioner
-/// config matching the router's murmur2 (librdkafka's default partitioner
-/// is CRC32-based and routes keys differently). A partition-count mismatch
-/// fails loudly at produce time instead of silently mis-sharding.
-/// Returns the record's changelog offset on successful delivery — the
-/// dirty index records it so an evicted entry can be recovered from the
-/// changelog later — or an error string on failure.
+/// Encodes the `Person` proto as the payload and keys it
+/// `{team_id}:{person_id}` for compaction. The message goes to an
+/// explicit partition, the person's routing partition, not through the
+/// producer's key partitioner. Warming rebuilds one routing partition's
+/// cache from the same-numbered Kafka partition, so the two numbering
+/// schemes must agree; producing explicitly makes that alignment
+/// structural (librdkafka's default partitioner is CRC32-based and
+/// routes keys differently from the router's murmur2). A partition-count
+/// mismatch fails loudly at produce time instead of silently
+/// mis-sharding.
 ///
-/// The handoff protocol relies on "handler returned Ok == message durable in Kafka."
-/// That requires the delivery future to be awaited before returning (done here) and
-/// `acks=all` on the producer. We rely on librdkafka's default (`acks=-1`) for the
-/// latter; if that default ever changes, the drain-inflight step in
-/// `coordination::LeaderHandoffHandler::drain_partition_inflight` becomes unsafe.
+/// Returns the record's changelog offset on delivery; the dirty index
+/// records it so an evicted entry can be recovered from the changelog.
+///
+/// The handoff protocol relies on "handler returned Ok == message
+/// durable in Kafka." That requires awaiting the delivery future before
+/// returning (done here) and `acks=all` on the producer. We rely on
+/// librdkafka's default (`acks=-1`) for the latter; if that default ever
+/// changes, the drain-inflight step in
+/// `coordination::LeaderHandoffHandler::drain_partition_inflight`
+/// becomes unsafe.
 pub async fn produce_person_changelog(
     producer: &FutureProducer<KafkaContext>,
     topic: &str,
@@ -91,17 +93,17 @@ pub async fn produce_person_changelog(
 /// flush instead of waiting for the last producer reference to drop.
 ///
 /// The component's handle rides inside the producer context, which
-/// every clone of the producer shares — so without explicit shutdown
-/// work, the component completed only when everything holding the
-/// producer let go, and a queue wedged against a stalled broker held
-/// its shutdown phase to the global timeout. This task flushes what
-/// the queue holds within `bound` once the component's phase shuts
-/// down, then reports completion either way.
+/// every producer clone shares. Without explicit shutdown work the
+/// component completed only when everything holding the producer let
+/// go, and a queue wedged against a stalled broker held its shutdown
+/// phase to the global timeout. This task flushes the queue within
+/// `bound` once the component's phase shuts down, then reports
+/// completion either way.
 ///
 /// A timed-out flush drops only records nobody acked: the changelog
-/// path awaits each record's delivery before acking (so anything acked
-/// is already off the queue, and unacked writes retry via redelivery),
-/// and the rest of this producer's traffic is best-effort warnings.
+/// path awaits each record's delivery before acking (anything acked is
+/// off the queue; unacked writes retry via redelivery), and the rest of
+/// this producer's traffic is best-effort warnings.
 pub fn spawn_bounded_flush_on_shutdown(
     producer: FutureProducer<KafkaContext>,
     handle: Handle,

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -48,10 +48,11 @@ common_alloc::used!();
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Install a process-wide rustls CryptoProvider before any TLS use. kube's
-    // HTTPS client (controller discovery) uses rustls 0.23, which can't
-    // auto-pick a provider with both aws-lc-rs and ring compiled in — it
-    // panics. Matches personhog-router / cymbal / ingestion-consumer.
+    // Install a process-wide rustls CryptoProvider before any TLS use.
+    // kube's HTTPS client (controller discovery) uses rustls 0.23, which
+    // cannot auto-pick a provider with both aws-lc-rs and ring compiled
+    // in; it panics. Matches personhog-router / cymbal /
+    // ingestion-consumer.
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install rustls ring CryptoProvider");
@@ -68,7 +69,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Invalid shutdown configuration");
     validate_table_name(&config.fallback_table).expect("Invalid FALLBACK_TABLE");
 
-    // Initialize tracing
     let log_layer = fmt::layer()
         .with_target(true)
         .with_thread_ids(true)
@@ -95,17 +95,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Pod name: {}", config.pod_name);
     tracing::info!("Kafka changelog topic: {}", config.kafka_person_state_topic);
 
-    // Shutdown order matters: the coordination drain (phase 0) hands this
-    // pod's partitions off, which requires the gRPC server to keep serving
-    // reads and completing in-flight writes and the producer to keep
-    // delivering their changelog records. Server and producer therefore
-    // stop in phase 1, only after the drain finishes — signalling them
-    // together with coordination black-holed every partition for the whole
-    // drain (dead server, still the registered owner). The coordination
-    // window must fit the pod's whole teardown — drain, fence, keepalive
-    // join, revoke — and the global timeout both phases;
-    // `validate_lease_timescales` refuses a configuration that breaks
-    // the first relation at startup.
+    // Shutdown order matters: the coordination drain (phase 0) hands
+    // this pod's partitions off, which requires the gRPC server to keep
+    // serving reads and completing in-flight writes and the producer to
+    // keep delivering their changelog records. Server and producer
+    // therefore stop in phase 1, only after the drain finishes;
+    // signalling them together with coordination black-holed every
+    // partition for the whole drain (dead server, still the registered
+    // owner). The coordination window must fit the pod's whole teardown
+    // (drain, fence, keepalive join, revoke) and the global timeout both
+    // phases; `validate_lease_timescales` refuses a configuration that
+    // breaks the first relation at startup.
     let mut manager = Manager::builder("personhog-leader")
         .with_global_shutdown_timeout(config.global_shutdown_timeout())
         .build();
@@ -266,7 +266,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Metrics server error");
     });
 
-    // Initialize partitioned cache and Kafka producer
     let cache = Arc::new(PartitionedCache::new(config.cache_memory_capacity_bytes));
 
     let kafka_producer = match create_kafka_producer(&config.kafka, kafka_handle.clone()).await {
@@ -284,7 +283,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Duration::from_secs(10),
     );
 
-    // PG fallback pool for cache misses (optional, disabled if URL is empty)
     let fallback = if config.fallback_database_url.is_empty() {
         tracing::info!("PG fallback disabled (no FALLBACK_DATABASE_URL)");
         None
@@ -306,7 +304,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
     };
 
-    // Connect to etcd for coordination and the partition count
     let etcd_config = StoreConfig {
         endpoints: config.etcd_endpoint_list(),
         prefix: config.etcd_prefix.clone(),
@@ -316,9 +313,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to connect to etcd");
     let store = Arc::new(PersonhogStore::new(etcd_store));
 
-    // Read total_partitions from etcd (set by kafka-assigner) — the same
-    // source the router hashes against, so partition validation can never
-    // drift between the two.
+    // Read total_partitions from etcd (set by kafka-assigner): the same
+    // source the router hashes against, so partition validation can
+    // never drift between the two.
     let num_partitions = store
         .get_total_partitions()
         .await
@@ -407,7 +404,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // to the margin, and that has to be answerable from a deployment
     // that is not yet enforcing anything.
     //
-    // This says nothing about a process-wide stall — a task that cannot
+    // This says nothing about a process-wide stall: a task that cannot
     // run cannot report that it cannot run, which is the same limitation
     // the clock exists to route around, and why enforcement reads the
     // stamp inline on the request path instead of trusting a publisher.
@@ -523,7 +520,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // coordinator can steer placement away from old-generation pods
     // during rollouts. Fail-open, and bounded: this runs before the pod
     // handle and gRPC server exist, so an unresponsive API server must
-    // cost a few seconds of startup at worst — never availability.
+    // cost a few seconds of startup at worst, never availability.
     let (controller, generation, k8s_awareness) = if config.k8s_awareness_enabled {
         let discovery = discover_own_controller(&config, coordination_handle.shutdown_token());
         match timeout(K8S_DISCOVERY_TIMEOUT, discovery).await {
@@ -569,16 +566,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Open connections up front: warms cluster in deploy bursts, and a
     // cold pool would make every burst's first operations pay the client
-    // setup the pool exists to amortize. Sized from the pod's actual
-    // configured warm concurrency — the bound the semaphore enforces —
-    // so the pool and the concurrency limit cannot drift apart.
-    // Committed-offset queries run one per concurrent warm, so the
-    // offsets pool needs the same depth; it also serves the dirty-index
-    // prune tick.
+    // setup the pool exists to amortize. Sized from the pod's configured
+    // warm concurrency (the bound the semaphore enforces) so the pool
+    // and the concurrency limit cannot drift apart. Committed-offset
+    // queries run one per concurrent warm, so the offsets pool needs the
+    // same depth; it also serves the dirty-index prune tick.
     //
     // Awaited before the pod registers for partitions: a deploy burst
     // hands this pod partitions immediately, and a warm that finds the
-    // pool empty builds its clients cold inside the handoff — seconds of
+    // pool empty builds its clients cold inside the handoff, seconds of
     // connection setup on the path the pool exists to keep off. The
     // deadline keeps a broker outage from wedging boot; past it,
     // registration proceeds and the remaining slots are built cold, so
@@ -644,13 +640,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Duration::from_secs(config.dirty_index_prune_interval_secs.max(1)),
     ));
 
-    // gRPC server. Mirrors the replica's middleware stack so the router's
-    // per-backend metrics (processing time, transport/network overhead) and
-    // response compression behave identically on both backends. No tonic
-    // codec compression: requests always arrive uncompressed (the router
-    // rejects compressed leader requests before forwarding — it scans the
-    // request bytes for the routing key), and response compression is
-    // exclusively the gzip layer.
+    // gRPC server. Mirrors the replica's middleware stack so the
+    // router's per-backend metrics (processing time, transport/network
+    // overhead) and response compression behave identically on both
+    // backends. No tonic codec compression: requests always arrive
+    // uncompressed (the router rejects compressed leader requests
+    // before forwarding, because it scans the request bytes for the
+    // routing key), and response compression is exclusively the gzip
+    // layer.
     let grpc_addr = config.grpc_address;
     let keepalive_interval = config.grpc_keepalive_interval();
     let keepalive_timeout = config.grpc_keepalive_timeout();
@@ -708,7 +705,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .add_service(
                 // accept_compressed only decodes gzip request frames from
                 // opted-in clients; responses stay with the AsyncGzipLayer
-                // (never send_compressed — see the tonic entry in Cargo.toml).
+                // (never send_compressed; see the tonic entry in
+                // Cargo.toml).
                 PersonHogLeaderServer::new(service)
                     .accept_compressed(CompressionEncoding::Gzip)
                     .max_encoding_message_size(max_send)
@@ -728,7 +726,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Periodically drop dirty-index marks the writer has applied to PG, and
 /// export the dirty-count and writer-lag gauges as a side effect. One
 /// batched OffsetFetch covers every partition with marks, on a pooled
-/// client — each tick reuses the connection instead of rebuilding one.
+/// client, so each tick reuses the connection instead of rebuilding one.
 async fn run_dirty_index_prune_loop(
     dirty_index: Arc<DirtyIndex>,
     cache: Arc<PartitionedCache>,
@@ -741,7 +739,7 @@ async fn run_dirty_index_prune_loop(
     loop {
         interval.tick().await;
         // One batched OffsetFetch, then queue pops proportional to the
-        // marks actually reclaimed — a tick never scans the index, which
+        // marks actually reclaimed; a tick never scans the index, which
         // is what makes the 1s interval affordable even when a lagging
         // writer has made the index large.
         let partitions = dirty_index.partitions_with_marks();
@@ -773,8 +771,8 @@ async fn run_dirty_index_prune_loop(
         // A partition absent from the committed offsets has no writer
         // commit yet: nothing is applied, every mark stays, and its lag
         // is the entire marked backlog. A partition the prune fully
-        // reclaimed has no live marks left — the writer caught up, so its
-        // lag reads zero.
+        // reclaimed has no live marks left: the writer caught up, so
+        // its lag reads zero.
         for partition in &partitions {
             let lag = match dirty_index.max_offset(*partition) {
                 Some(max_offset) => {

--- a/rust/personhog-leader/src/person_update.rs
+++ b/rust/personhog-leader/src/person_update.rs
@@ -16,11 +16,12 @@ pub struct PropertyUpdates {
     pub has_changes: bool,
 }
 
-/// Compute property changes from event data without modifying the existing person properties.
+/// Compute property changes from event data without modifying the
+/// existing person properties.
 ///
-/// This mirrors the TypeScript `computeEventPropertyUpdates` in `person-update.ts`,
-/// but simplified for the PoC by omitting the property filtering logic
-/// (FILTERED_PERSON_UPDATE_PROPERTIES).
+/// Mirrors the TypeScript `computeEventPropertyUpdates` in
+/// `person-update.ts`, minus the `FILTERED_PERSON_UPDATE_PROPERTIES`
+/// filtering.
 pub fn compute_event_property_updates(
     event_name: &str,
     set_properties: &Value,
@@ -42,7 +43,7 @@ pub fn compute_event_property_updates(
     let mut to_set = HashMap::new();
     let mut to_unset = Vec::new();
 
-    // Process $set_once: only set if the property doesn't already exist
+    // $set_once applies only when the property does not already exist.
     if let Some(set_once_map) = set_once_properties.as_object() {
         for (key, value) in set_once_map {
             let existing = person_props.and_then(|p| p.get(key));
@@ -53,7 +54,6 @@ pub fn compute_event_property_updates(
         }
     }
 
-    // Process $set: apply all changed properties
     if let Some(set_map) = set_properties.as_object() {
         for (key, value) in set_map {
             let existing = person_props.and_then(|p| p.get(key));
@@ -64,7 +64,6 @@ pub fn compute_event_property_updates(
         }
     }
 
-    // Process $unset: remove properties that exist
     for key in unset_properties {
         let exists = person_props.is_some_and(|p| p.contains_key(key));
         if exists {
@@ -81,7 +80,7 @@ pub fn compute_event_property_updates(
 }
 
 /// Apply computed property updates to a person's properties map.
-/// Returns the new properties value and whether any changes were actually made.
+/// Returns the new properties value and whether any changes were made.
 pub fn apply_property_updates(
     updates: &PropertyUpdates,
     person_properties: &Value,
@@ -92,7 +91,6 @@ pub fn apply_property_updates(
     };
     let mut updated = false;
 
-    // Apply $set and $set_once
     for (key, value) in &updates.to_set {
         if props.get(key) != Some(value) {
             updated = true;
@@ -100,7 +98,6 @@ pub fn apply_property_updates(
         props.insert(key.clone(), value.clone());
     }
 
-    // Apply $unset
     for key in &updates.to_unset {
         if props.remove(key).is_some() {
             updated = true;
@@ -170,7 +167,6 @@ mod tests {
         assert!(result.has_changes);
         assert_eq!(result.to_set.len(), 1);
         assert_eq!(result.to_set["initial_referrer"], json!("google.com"));
-        // Should NOT overwrite existing email
         assert!(!result.to_set.contains_key("email"));
     }
 

--- a/rust/personhog-leader/src/pg.rs
+++ b/rust/personhog-leader/src/pg.rs
@@ -24,9 +24,8 @@ pub fn validate_table_name(table: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Reads a person from the configured fallback table — the table the
-/// writer maintains. Used as a fallback when the leader's cache doesn't
-/// have the person.
+/// Reads a person from the configured fallback table (the table the
+/// writer maintains) when the leader's cache does not have the person.
 pub async fn load_person_from_pg(
     pool: &PgPool,
     table: &str,
@@ -37,13 +36,13 @@ pub async fn load_person_from_pg(
     let team_id_i32 = i32::try_from(key.team_id)
         .map_err(|_| sqlx::Error::Protocol(format!("team_id {} exceeds i32 range", key.team_id)))?;
 
-    // properties comes back as text and is parsed here rather than through
-    // sqlx's jsonb decode: rows written by other services can hold numerics
-    // whose PG-expanded rendering serde_json rejects, and the leniency
-    // lives in our parse step (see below). The cost is identical — sqlx's
-    // jsonb decode parses the same text under the hood.
-    // A tombstoned person must not be re-served on a cache miss; not-found
-    // is the truthful answer for a deleted person.
+    // properties comes back as text and is parsed here rather than
+    // through sqlx's jsonb decode: rows written by other services can
+    // hold numerics whose PG-expanded rendering serde_json rejects, and
+    // the leniency lives in our parse step (see below). The cost is
+    // identical; sqlx's jsonb decode parses the same text.
+    // A tombstoned person must not be re-served on a cache miss;
+    // not-found is the truthful answer for a deleted person.
     let row = sqlx::query(&format!(
         "SELECT id, team_id, uuid::text, properties::text AS properties, created_at, version, \
          is_identified, last_seen_at
@@ -66,8 +65,7 @@ pub async fn load_person_from_pg(
     let id: i64 = row.get("id");
     let team_id: i32 = row.get("team_id");
     let uuid: String = row.get("uuid");
-    // Borrowed from the row buffer — no copy; parse cost matches what
-    // sqlx's own jsonb decode would spend on the same bytes.
+    // Borrowed from the row buffer, no copy.
     let properties_text: &str = row.get("properties");
     let created_at: chrono::DateTime<chrono::Utc> = row.get("created_at");
     let version: Option<i64> = row.get("version");

--- a/rust/personhog-leader/src/recovery.rs
+++ b/rust/personhog-leader/src/recovery.rs
@@ -41,37 +41,37 @@ enum FetchError {
     Permanent(String),
 }
 
-/// Fetches single persons from the changelog — the recovery path for cache
-/// entries evicted while the writer still lags. It reads Kafka, never
-/// Postgres, so the leader's availability stays decoupled from writer
-/// progress.
+/// Fetches single persons from the changelog: the recovery path for
+/// cache entries evicted while the writer still lags. It reads Kafka,
+/// never Postgres, so the leader's availability stays decoupled from
+/// writer progress.
 ///
 /// Every changelog record carries the person's full state, so the one
 /// record at the dirty index's marked offset supersedes anything before
-/// it; no replay is needed. And because the topic compacts by person key,
-/// compaction never removes the latest record for a key — the only offset
-/// the index ever holds — so the fetch lands on it for as long as the
+/// it; no replay is needed. The topic compacts by person key, and
+/// compaction never removes the latest record for a key (the only offset
+/// the index ever holds), so the fetch lands on it for as long as the
 /// topic's `delete` retention keeps it, far longer than any mark should
 /// live.
 ///
-/// A fresh `assign` positions any consumer at any (partition, offset), so
-/// the consumers are fungible and pooled globally: a fixed set is built at
-/// startup — where construction failure is loud and nothing is in flight —
-/// and checked out per fetch, bounding concurrent recoveries at the pool
-/// size the way a DB connection pool bounds queries. Checkout transfers
-/// exclusive ownership through the idle deque (the semaphore only counts;
-/// a permit holder always finds a consumer), so no lock is held while a
-/// fetch waits on Kafka or backs off between retries. The pool-wait
-/// histogram is the tuning signal for the pool size. Errors never manage
-/// the pool — librdkafka clients self-heal their connections — so
-/// transient fetch failures retry on the same consumer within the
-/// recovery deadline. Checkout is an RAII guard (`PooledConsumer`) that
-/// returns the consumer and only then releases its permit on Drop, so
-/// the consumer comes home on every path including future cancellation —
-/// a client disconnecting mid-recovery drops the request future at an
-/// await point, and anything less than Drop-based return would leak the
-/// consumer while freeing its permit, eventually leaving permits with an
-/// empty pool.
+/// A fresh `assign` positions any consumer at any (partition, offset),
+/// so the consumers are fungible and pooled globally: a fixed set is
+/// built at startup (where construction failure is loud and nothing is
+/// in flight) and checked out per fetch, bounding concurrent recoveries
+/// at the pool size the way a DB connection pool bounds queries.
+/// Checkout transfers exclusive ownership through the idle deque (the
+/// semaphore only counts; a permit holder always finds a consumer), so
+/// no lock is held while a fetch waits on Kafka or backs off between
+/// retries. The pool-wait histogram is the tuning signal for the pool
+/// size. Errors never manage the pool, because librdkafka clients
+/// self-heal their connections; transient fetch failures retry on the
+/// same consumer within the recovery deadline. Checkout is an RAII guard
+/// (`PooledConsumer`) that returns the consumer and only then releases
+/// its permit on Drop, so the consumer comes home on every path,
+/// including cancellation: a client disconnecting mid-recovery drops the
+/// request future at an await point, and anything less than Drop-based
+/// return would leak the consumer while freeing its permit, eventually
+/// leaving permits with an empty pool.
 pub struct ChangelogRecovery {
     topic: String,
     recv_timeout: Duration,
@@ -100,12 +100,13 @@ impl ChangelogRecovery {
         })
     }
 
-    /// Check a consumer out of the pool. The returned guard owns both the
-    /// consumer and its semaphore permit; its Drop parks the consumer
-    /// (best-effort unassign so it does not keep fetching a partition
-    /// tail), returns it to the idle deque, and only then releases the
-    /// permit — so a slot never opens before its consumer is home, on
-    /// every path including cancellation of the awaiting future.
+    /// Check a consumer out of the pool. The returned guard owns both
+    /// the consumer and its semaphore permit; its Drop parks the
+    /// consumer (best-effort unassign so it does not keep fetching a
+    /// partition tail), returns it to the idle deque, and only then
+    /// releases the permit, so a slot never opens before its consumer is
+    /// home, on every path including cancellation of the awaiting
+    /// future.
     async fn checkout(&self) -> Result<PooledConsumer<'_>, String> {
         let wait_start = Instant::now();
         let permit = self
@@ -129,11 +130,11 @@ impl ChangelogRecovery {
     }
 
     /// Fetch a person's latest state from the changelog record the dirty
-    /// index marked for its most recent acked produce. The decoded record
-    /// must carry the mark's key and version exactly: the mark was written
-    /// from the same state the record was encoded from, so any mismatch
-    /// means acked state and produced state diverged — a bug worth failing
-    /// loudly over, never worth serving.
+    /// index marked for its most recent acked produce. The decoded
+    /// record must carry the mark's key and version exactly: the mark
+    /// was written from the same state the record was encoded from, so
+    /// any mismatch means acked state and produced state diverged, a bug
+    /// worth failing loudly over, never worth serving.
     pub async fn fetch_person_at(
         &self,
         mark: &DirtyMark,

--- a/rust/personhog-leader/src/service.rs
+++ b/rust/personhog-leader/src/service.rs
@@ -46,7 +46,7 @@ use personhog_common::properties::{
 const DEFAULT_FENCE_MAP_MAX_ENTRIES: usize = 250_000;
 
 /// Admission-time property size limits, in `pg_column_size` (JSONB
-/// binary) terms — the same units as the `check_properties_size`
+/// binary) terms: the same units as the `check_properties_size`
 /// constraint they exist to enforce.
 #[derive(Clone, Copy)]
 pub struct PropertySizeLimits {
@@ -103,8 +103,8 @@ pub struct PersonHogLeaderService {
     /// Mutated only under the per-key lock.
     fences: FenceMap,
     /// Ghost-fence recovery, derived from the fallback pool at
-    /// construction. Absent without one (dev fixtures) — ghost fences
-    /// then last until the partition changes hands, as before.
+    /// construction. Absent without one (dev fixtures); ghost fences
+    /// then last until the partition changes hands.
     fence_healer: Option<Arc<FenceHealer>>,
     /// Memory fuse for the fence map (see `fence_map_max_entries` in the
     /// config for the full policy): at this many live fences, FencePerson
@@ -130,7 +130,7 @@ impl PersonHogLeaderService {
     /// process that is stopped, starved, or wedged stops renewing and
     /// stops noticing together, then keeps serving state the new owner
     /// is already changing. Reading the published stamp here makes the
-    /// lapse self-enforcing — nothing has to be alive to apply it.
+    /// lapse self-enforcing; nothing has to be alive to apply it.
     ///
     /// Refusal starts at the keepalive's renewal margin, strictly before
     /// the coordinator could treat the lease as expired, so requests are
@@ -248,7 +248,7 @@ impl PersonHogLeaderService {
     /// The fence RPCs must never succeed on a pod that does not serve the
     /// partition. A misrouted release that removed nothing and returned
     /// OK would leave the real owner's fence in place while the saga
-    /// believes it released — a person frozen with no retry coming. The
+    /// believes it released: a person frozen with no retry coming. The
     /// handoff guard is not enough on its own: `release_partition`
     /// unfences, so a pod that has already handed the partition off looks
     /// unfenced. Rejecting sends the saga's retry to the current owner.
@@ -271,22 +271,23 @@ impl PersonHogLeaderService {
     }
 
     /// Recover a cache miss from the right source. A person in the dirty
-    /// index has acked state the writer may not have applied to PG yet, so
-    /// the PG row cannot be trusted — recover the full latest state from
-    /// the changelog record at the marked offset instead. If that fetch
-    /// fails, the only honest answer is a retryable error: falling back to
-    /// PG would serve exactly the staleness this index exists to prevent.
-    /// Unmarked persons' PG rows are known current — but only while this
-    /// pod owns the partition, so the no-mark path re-checks ownership
-    /// before trusting PG. Assumes the caller holds the per-key lock.
+    /// index has acked state the writer may not have applied to PG yet,
+    /// so the PG row cannot be trusted; recover the full latest state
+    /// from the changelog record at the marked offset instead. If that
+    /// fetch fails, the only honest answer is a retryable error: falling
+    /// back to PG would serve exactly the staleness this index exists to
+    /// prevent. Unmarked persons' PG rows are known current, but only
+    /// while this pod owns the partition, so the no-mark path re-checks
+    /// ownership before trusting PG. Assumes the caller holds the
+    /// per-key lock.
     async fn recover_or_load(
         &self,
         partition: u32,
         key: &PersonCacheKey,
     ) -> Result<Arc<CachedPerson>, Status> {
         let Some(mark) = self.dirty_index.get(key) else {
-            // "No mark" means PG is current — but only while this pod owns
-            // the partition. Handoffs drain writes, not reads, so a read
+            // "No mark" means PG is current, but only while this pod
+            // owns the partition. Handoffs drain writes, not reads, so a read
             // admitted before the freeze can still be executing here when
             // `release_partition` clears the partition's marks (the new
             // owner rebuilds its own), and to that reader a still-dirty
@@ -457,7 +458,7 @@ impl PersonHogLeaderService {
     }
 
     /// The shared tail of every document write: refuse unapplyable records,
-    /// produce to Kafka first, then dirty-mark and update the cache — so
+    /// produce to Kafka first, then dirty-mark and update the cache, so
     /// readers only ever see durably committed state. The mark precedes the
     /// cache insert: a reader that misses the cache in the gap sees the
     /// mark and recovers this exact record from the changelog. Assumes the
@@ -468,8 +469,8 @@ impl PersonHogLeaderService {
         cache_key: &PersonCacheKey,
         person: CachedPerson,
     ) -> Result<Person, Status> {
-        // A record the writer cannot bind must never reach the changelog —
-        // no consumer downstream can apply or repair it.
+        // A record the writer cannot bind must never reach the
+        // changelog; no consumer downstream can apply or repair it.
         if let Err(reason) = assert_writeable(&person) {
             counter!("personhog_leader_unwriteable_state_total").increment(1);
             tracing::error!(
@@ -489,16 +490,16 @@ impl PersonHogLeaderService {
         // re-checks before answering: admission proves nothing about the
         // moment the record lands. Between the check at entry and here a
         // write can wait on the per-key lock behind another produce, and
-        // on a changelog recovery — long enough for a starved keepalive's
+        // on a changelog recovery: long enough for a starved keepalive's
         // stamp to age out, for the lease to expire at etcd, and for the
         // coordinator to warm a successor past the point this record
         // would land.
         self.check_authority(partition)?;
 
         // From here the record may reach the changelog whatever happens
-        // to this request — including the request simply ceasing to exist
-        // when the client's deadline expires. The guard is what makes the
-        // version un-reusable in that case.
+        // to this request, including the request simply ceasing to exist
+        // when the client's deadline expires. The guard is what makes
+        // the version un-reusable in that case.
         let mut emitted = EmittedVersionGuard::new(
             Arc::clone(&self.emitted_versions),
             partition,
@@ -514,7 +515,7 @@ impl PersonHogLeaderService {
                 Ok(offset) => offset,
                 // The broker fenced this pod: a newer owner holds the
                 // partition, so this claim is stale. FailedPrecondition
-                // is the admission fence's own vocabulary — the router
+                // is the admission fence's own vocabulary; the router
                 // classifies it as a bounce and re-resolves toward the
                 // real owner.
                 Err(e @ FencedProduceError::Fenced) => {
@@ -537,7 +538,7 @@ impl PersonHogLeaderService {
                     // more; `heal_fence`, on the next convergence to
                     // Serving, re-takes the epoch once the authority
                     // stamp confirms this pod's standing. Reads stay
-                    // served meanwhile under the same stamp — the
+                    // served meanwhile under the same stamp; the
                     // `check_authority` calls at admission and before
                     // answering are what refuse them once the claim
                     // lapses.
@@ -545,11 +546,7 @@ impl PersonHogLeaderService {
                         "partition ownership fenced: {e}"
                     )));
                 }
-                // This pod holds no producer for the partition — an
-                // ownership statement, in the same vocabulary the
-                // admission fence uses, so the router bounces and
-                // re-resolves instead of surfacing a hard error.
-                // The partition moved *and* this window's outcome was
+                // The partition moved AND this window's outcome was
                 // never settled. The router still needs the ownership
                 // answer, but the version cannot be handed back: the
                 // commit may have succeeded on an attempt librdkafka
@@ -575,6 +572,10 @@ impl PersonHogLeaderService {
                         "partition ownership fenced: {e}"
                     )));
                 }
+                // This pod holds no producer for the partition: an
+                // ownership statement, in the same vocabulary the
+                // admission fence uses, so the router bounces and
+                // re-resolves instead of surfacing a hard error.
                 Err(e @ FencedProduceError::NotAcquired) => {
                     emitted.discarded();
                     tracing::warn!(
@@ -593,8 +594,8 @@ impl PersonHogLeaderService {
                 // version would produce a second record at the same
                 // version as the one that may already have committed,
                 // and the writer's strict guard keeps whichever arrived
-                // first — which the floor prevents by holding the
-                // version spent.
+                // first. The floor prevents that by holding the version
+                // spent.
                 Err(e @ FencedProduceError::Indeterminate(_)) => {
                     // Deliberately not settled: whether the record exists
                     // is exactly what is unknown, so the version stays
@@ -643,11 +644,12 @@ impl PersonHogLeaderService {
                     // enqueue that never left the client with a delivery
                     // that timed out after the broker may already have
                     // appended it, and idempotence is off by default, so
-                    // the record's fate is genuinely unknown. Freeing the
-                    // version here let a retry derive the same number and
-                    // put a second record behind one that may be in the
-                    // log — the writer's strict guard then keeps whichever
-                    // arrived first and discards the acked one.
+                    // the record's fate is genuinely unknown. Freeing
+                    // the version here would let a retry derive the same
+                    // number and put a second record behind one that may
+                    // be in the log; the writer's strict guard then
+                    // keeps whichever arrived first and discards the
+                    // acked one.
                     //
                     // The floor alone carries that: the next write
                     // derives past it whether or not the cache still
@@ -655,9 +657,9 @@ impl PersonHogLeaderService {
                     // reads may answer with a version older than the
                     // changelog until a later write for this person
                     // settles one. Evicting instead would resolve
-                    // nothing — recovery reads the last *marked* offset,
-                    // which is the previous write that did succeed — and
-                    // would answer NOT_FOUND outright once that mark is
+                    // nothing (recovery reads the last marked offset,
+                    // the previous write that did succeed) and would
+                    // answer NOT_FOUND outright once that mark is
                     // pruned and no fallback pool is configured.
                     tracing::error!(
                         team_id = cache_key.team_id,
@@ -691,12 +693,13 @@ impl PersonHogLeaderService {
         Ok(proto)
     }
 
-    /// The write path's fence conditional: an in-memory lookup and nothing
-    /// else. The map is authoritative here — a fence that outlives its op
-    /// is not the leader's to detect, because the op being unfinished is
-    /// exactly what a live mark means (see the fence module's ownership
-    /// model). Returns the fence to reject with, or None when the person
-    /// is writable. Assumes the caller holds the per-key lock.
+    /// The write path's fence conditional: an in-memory lookup and
+    /// nothing else. The map is authoritative here: a fence that
+    /// outlives its op is not the leader's to detect, because the op
+    /// being unfinished is exactly what a live mark means (see the fence
+    /// module's ownership model). Returns the fence to reject with, or
+    /// None when the person is writable. Assumes the caller holds the
+    /// per-key lock.
     fn check_fence(&self, cache_key: &PersonCacheKey) -> Option<FenceState> {
         self.fences.get(cache_key).map(|entry| *entry.value())
     }
@@ -712,10 +715,10 @@ const MAX_EPOCH_MS_YEAR_9999: i64 = 253_402_300_799_999;
 /// hourly truncation so both write paths produce identical stored values.
 const MS_PER_HOUR: i64 = 3_600_000;
 
-/// The changelog contract: every produced record must be applyable by the
-/// writer's upsert verbatim. Properties are guaranteed by admission
+/// The changelog contract: every produced record must be applyable by
+/// the writer's upsert verbatim. Properties are guaranteed by admission
 /// (NUL sanitization plus the exact size measure); this checks the
-/// remaining writer-bound fields against the writer's bind conversions —
+/// remaining writer-bound fields against the writer's bind conversions:
 /// uuid must parse, team_id must fit the column's `integer`, and the
 /// timestamps must sit inside a sanity range ([1970, 9999]) any
 /// legitimate value satisfies. The legacy jsonb columns have no cache
@@ -795,8 +798,8 @@ struct SealedSnapshot {
 /// Admit the fold request's sealed snapshots: validate, parse, and
 /// sanitize each, returning them in ordinal order plus what sanitization
 /// rewrote. Every refusal is a deterministic `InvalidArgument`: each
-/// snapshot must be a plausible living source of the target — same team,
-/// a different person, not a death document — and ordinals must be
+/// snapshot must be a plausible living source of the target (same team,
+/// a different person, not a death document), and ordinals must be
 /// unique, or precedence would be ambiguous. A mismatch can only be a
 /// saga bug, and folding it silently would launder it into the target.
 // See `partition_from_metadata` for why `result_large_err` is allowed.
@@ -890,9 +893,9 @@ impl PersonHogLeader for PersonHogLeaderService {
         };
 
         let person = self.lookup_or_load(partition, &cache_key).await?;
-        // Re-check before answering. The load can wait — on the per-key
+        // Re-check before answering. The load can wait (on the per-key
         // lock behind another request's produce, or on a changelog
-        // recovery — for long enough that a claim valid at admission has
+        // recovery) for long enough that a claim valid at admission has
         // lapsed by the time there is something to return, and it is the
         // answer, not the arrival, that has to be backed by ownership.
         self.check_authority(partition)?;
@@ -916,30 +919,31 @@ impl PersonHogLeader for PersonHogLeaderService {
         let req = request.into_inner();
         self.validate_partition(partition, req.team_id, req.person_id)?;
         // A write is serving too. Broker-enforced fencing covers this
-        // path when it is on, but it cannot be turned on first — startup
-        // refuses fencing without the gate — so every fleet passes
+        // path when it is on, but it cannot be turned on first (startup
+        // refuses fencing without the gate), so every fleet passes
         // through a window where the gate is the only thing standing
         // between a pod that stopped renewing and a write the successor
         // will never see. The lease-loss path surrenders before it
-        // drains, deliberately, and until this check existed only reads
-        // honoured that: writes stayed admitted until the local fence
-        // landed, behind a watch teardown and a task join.
+        // drains, deliberately; without this check writes would stay
+        // admitted until the local fence lands, behind a watch teardown
+        // and a task join.
         self.check_authority(partition)?;
 
         // Admit the write as inflight, unless the partition is fenced. A
-        // fenced partition has drained for handoff: every router acked the
-        // freeze, so this write can only come from a router with a stale
-        // view — accepting it would produce past the Kafka HWM that the new
-        // owner's warming snapshots, silently losing the write. Admission
-        // and the fence check are one atomic operation (`try_begin`): the
-        // inflight increment precedes the check, so the drain either waits
-        // for this write or this write sees the fence. Reads are unaffected
-        // — the frozen state stays the latest until cutover. The handoff
-        // protocol waits for the per-partition inflight count to drop to
-        // zero before advancing; combined with sync-acked produces, a zero
-        // count implies every acked write is durable in Kafka. Using a
-        // non-`_` prefixed binding so the RAII guard is held for the full
-        // handler lifetime (see the `let_underscore_drop` lint).
+        // fenced partition has drained for handoff: every router acked
+        // the freeze, so this write can only come from a router with a
+        // stale view, and accepting it would produce past the Kafka HWM
+        // that the new owner's warming snapshots, silently losing the
+        // write. Admission and the fence check are one atomic operation
+        // (`try_begin`): the inflight increment precedes the check, so
+        // the drain either waits for this write or this write sees the
+        // fence. Reads are unaffected; the frozen state stays the latest
+        // until cutover. The handoff protocol waits for the
+        // per-partition inflight count to drop to zero before advancing;
+        // combined with sync-acked produces, a zero count implies every
+        // acked write is durable in Kafka. Using a non-`_` prefixed
+        // binding so the RAII guard is held for the full handler
+        // lifetime (see the `let_underscore_drop` lint).
         let Some(_inflight_guard) = self.inflight.try_begin(partition) else {
             return Err(Status::failed_precondition(format!(
                 "partition {partition} is fenced for handoff; writes are rejected"
@@ -998,12 +1002,12 @@ impl PersonHogLeader for PersonHogLeaderService {
             .map(|k| k.replace('\u{0000}', "\u{FFFD}"))
             .collect();
 
-        // Per-key lock serializes concurrent updates for the same person.
-        // The wait is measured because it is the queueing component of
-        // handler latency: with every acked write holding the lock
-        // through its acks=all produce, per-person throughput is capped
-        // near 1/produce-latency, and contending updates spend their
-        // time here — invisible in the produce histogram.
+        // Per-key lock serializes concurrent updates for the same
+        // person. The wait is measured because it is the queueing
+        // component of handler latency: with every acked write holding
+        // the lock through its acks=all produce, per-person throughput
+        // is capped near 1/produce-latency, and contending updates spend
+        // their time here, invisible in the produce histogram.
         let mutex = self
             .locks
             .entry(cache_key.clone())
@@ -1016,10 +1020,10 @@ impl PersonHogLeader for PersonHogLeaderService {
             .record(lock_wait.elapsed().as_secs_f64() * 1000.0);
 
         // Admission check before any work: if the dirty index is at
-        // capacity and this person is not already marked, acking the write
-        // would leave it durable but unmarked — reopening the
-        // stale-fallback hole on eviction. Shed instead; the index drains
-        // (and admission resumes) as the writer catches up.
+        // capacity and this person is not already marked, acking the
+        // write would leave it durable but unmarked, reopening the
+        // stale-fallback hole on eviction. Shed instead; the index
+        // drains (and admission resumes) as the writer catches up.
         if !self.dirty_index.can_admit(&cache_key) {
             counter!("personhog_leader_writes_shed_total", "reason" => "dirty_index_full")
                 .increment(1);
@@ -1045,8 +1049,9 @@ impl PersonHogLeader for PersonHogLeaderService {
 
         let person = self.lookup_or_load_locked(partition, &cache_key).await?;
 
-        // A destroyed person answers not-found — the caller re-resolves;
-        // post-death the distinct id may have been reborn as a new person.
+        // A destroyed person answers not-found and the caller
+        // re-resolves; post-death the distinct id may have been reborn
+        // as a new person.
         if person.is_deleted {
             return Err(Status::not_found("person is destroyed"));
         }
@@ -1057,7 +1062,6 @@ impl PersonHogLeader for PersonHogLeaderService {
             .parse_properties()
             .map_err(|e| Status::internal(format!("cached properties unparseable: {e}")))?;
 
-        // Compute property updates
         let updates = compute_event_property_updates(
             &req.event_name,
             &set_properties,
@@ -1068,18 +1072,18 @@ impl PersonHogLeader for PersonHogLeaderService {
 
         // OR-merge: identification never reverts through this RPC, so
         // only a true that finds false is a change. It counts as one on
-        // its own — an $identify with no property diffs must still
+        // its own: an $identify with no property diffs must still
         // produce a record.
         let identified_now = person.is_identified || req.is_identified == Some(true);
         let identity_changed = identified_now != person.is_identified;
 
         // last_seen_at is request-borne and best-effort: an out-of-range
         // value is discarded rather than failing the update, so the
-        // acked ⇒ writeable invariant never hinges on it. In-range values
-        // are floored to the hour — Node's startOf('hour') on its
-        // UTC-normalized timestamps, expressed in epoch terms — so record
-        // volume is bounded at one per person-hour by construction, not
-        // by trusting callers to coarsen.
+        // acked ⇒ writeable invariant never hinges on it. In-range
+        // values are floored to the hour (Node's startOf('hour') on its
+        // UTC-normalized timestamps, expressed in epoch terms), so
+        // record volume is bounded at one per person-hour by
+        // construction, not by trusting callers to coarsen.
         let requested_last_seen = req
             .last_seen_at
             .filter(|t| (0..=MAX_EPOCH_MS_YEAR_9999).contains(t));
@@ -1088,7 +1092,7 @@ impl PersonHogLeader for PersonHogLeaderService {
         }
         let requested_last_seen = requested_last_seen.map(|t| t - t % MS_PER_HOUR);
         // Max-merge: the stored value only ever advances, and an advance
-        // is a change in its own right — ingestion's direct write path
+        // is a change in its own right; ingestion's direct write path
         // persists a last-seen-only advance, so this path must too.
         let merged_last_seen = person.last_seen_at.max(requested_last_seen);
         let last_seen_changed = merged_last_seen != person.last_seen_at;
@@ -1115,19 +1119,20 @@ impl PersonHogLeader for PersonHogLeaderService {
             }));
         }
 
-        // Admission-time size enforcement, hoisted from the writer: every
-        // acked record must be applyable by the writer verbatim, or the
-        // cache and changelog would carry state Postgres never gets (the
-        // stale-serve hole the dirty index exists to close). The measure
-        // is the constraint's own — pg_column_size of the JSONB encoding
-        // — so admitted rows cannot violate it at apply time.
+        // Admission-time size enforcement, hoisted from the writer:
+        // every acked record must be applyable by the writer verbatim,
+        // or the cache and changelog would carry state Postgres never
+        // gets (the stale-serve hole the dirty index exists to close).
+        // The measure is the constraint's own, pg_column_size of the
+        // JSONB encoding, so admitted rows cannot violate it at apply
+        // time.
         let mut new_properties = new_properties;
 
-        // Rewrite the merged state into jsonb-safe form before measuring:
-        // NUL sanitization (Node-pipeline parity — Postgres refuses it)
-        // and extreme-float clamping (Postgres's expanded numeric
-        // rendering would otherwise be unparseable on the way back). The
-        // measured size is then the stored size.
+        // Rewrite the merged state into jsonb-safe form before
+        // measuring: NUL sanitization (Node-pipeline parity; Postgres
+        // refuses it) and extreme-float clamping (Postgres's expanded
+        // numeric rendering would otherwise be unparseable on the way
+        // back). The measured size is then the stored size.
         let sanitize_stats = sanitize_for_jsonb(&mut new_properties);
         if sanitize_stats.nul_strings > 0 {
             counter!("personhog_leader_properties_nul_sanitized_total")
@@ -1143,7 +1148,7 @@ impl PersonHogLeader for PersonHogLeaderService {
             // Policy mirror of the Node pipeline's
             // `handleOversizedPersonProperties`: trimming is remediation
             // for rows already oversized in storage (they predate the
-            // constraint, or another writer produced them) — the stored
+            // constraint, or another writer produced them). The stored
             // properties are trimmed to the target and the triggering
             // update's property changes are discarded, exactly as Node
             // retries with trimmed existing state. An update that would
@@ -1167,10 +1172,11 @@ impl PersonHogLeader for PersonHogLeaderService {
                         });
                         new_properties = trimmed;
                     }
-                    // Reachable only when trim_target == threshold and the
-                    // stored size sits exactly on it: nothing to trim, but
-                    // the update still cannot apply — keep the stored
-                    // state, discarding the update like the arm above.
+                    // Reachable only when trim_target == threshold and
+                    // the stored size sits exactly on it: nothing to
+                    // trim, but the update still cannot apply, so keep
+                    // the stored state, discarding the update like the
+                    // arm above.
                     TrimResult::Fits => {
                         new_properties = person_properties.clone();
                     }
@@ -1331,12 +1337,12 @@ impl PersonHogLeader for PersonHogLeaderService {
             return Err(Status::not_found("person is destroyed"));
         }
 
-        // The mark row — the fence's source of truth — must vouch for the
-        // op holding this person as its live merge target before the fold
-        // may write. The fence check above proves nothing here (the target
-        // is marked, never fenced), and without this a superseded or
-        // settled saga runner's late fold would still land. Mirrors
-        // ReleaseFence: unverifiable requests are refused — fail closed.
+        // The mark row (the fence's source of truth) must vouch for the
+        // op holding this person as its live merge target before the
+        // fold may write. The fence check above proves nothing here (the
+        // target is marked, never fenced), and without this a superseded
+        // or settled saga runner's late fold would still land. Mirrors
+        // ReleaseFence: unverifiable requests are refused, fail closed.
         let Some(fallback) = &self.fallback else {
             return Err(semantic_refusal(
                 "no lifecycle database configured; refusing to fold",
@@ -1418,7 +1424,7 @@ impl PersonHogLeader for PersonHogLeaderService {
         // Unlike a property update, a fold cannot be rejected for size:
         // the saga would re-drive it forever, so trimming is the only
         // completing behavior. Trim candidates are the fold's own
-        // contribution — keys the target did not already hold — so a
+        // contribution (keys the target did not already hold), so a
         // within-limit target never loses a key it had to a fold. The
         // target's own keys join the candidates only when its stored
         // document already exceeded the limit (the remediation the update
@@ -1483,16 +1489,17 @@ impl PersonHogLeader for PersonHogLeaderService {
                     });
                     if target_oversized {
                         // No applyable document exists: the stored one
-                        // itself violates the size constraint (protected
-                        // keys alone exceed the ceiling). Producing it
-                        // anyway would halt the writer — admission
-                        // promises every acked record applies verbatim,
-                        // and the writer fail-stops on a violation rather
-                        // than skip — and rejecting would wedge the
-                        // saga's re-drive loop. The fold completes
-                        // without producing: this person's fold effects
-                        // (properties and scalars) are skipped. Accepted
-                        // residual — README, "Admission".
+                        // itself violates the size constraint
+                        // (protected keys alone exceed the ceiling).
+                        // Producing it anyway would halt the writer
+                        // (admission promises every acked record
+                        // applies verbatim, and the writer fail-stops
+                        // on a violation rather than skip), and
+                        // rejecting would wedge the saga's re-drive
+                        // loop. The fold completes without producing:
+                        // this person's fold effects (properties and
+                        // scalars) are skipped. Accepted residual; see
+                        // README, "Admission".
                         counter!("personhog_leader_folds_total", "outcome" => "unapplyable")
                             .increment(1);
                         tracing::error!(
@@ -1515,10 +1522,11 @@ impl PersonHogLeader for PersonHogLeaderService {
 
         // Scalars: created_at is the min over the target and every
         // snapshot (ignoring non-positive values a malformed snapshot
-        // could carry); is_identified is unconditionally true — a merge
-        // is an identify; last_seen_at max-merges like the update path —
-        // the merged person was last seen whenever any constituent was
-        // (snapshot values were already hour-floored when stored).
+        // could carry); is_identified is unconditionally true (a merge
+        // is an identify); last_seen_at max-merges like the update
+        // path, because the merged person was last seen whenever any
+        // constituent was (snapshot values were already hour-floored
+        // when stored).
         let created_at = snapshots
             .iter()
             .map(|snapshot| snapshot.created_at)
@@ -1535,9 +1543,10 @@ impl PersonHogLeader for PersonHogLeaderService {
         // The version is a max-merge over the target's floor and every
         // sealed version, plus one: at or above every source's death
         // document, which derives from the same sealed + 1 (equal when
-        // the highest sealed version dominates — harmless, the streams
-        // are per-person), and re-applying the fold only bumps it again
-        // — convergent under at-least-once delivery.
+        // the highest sealed version dominates, which is harmless
+        // because the streams are per-person). Re-applying the fold
+        // only bumps it again, so it converges under at-least-once
+        // delivery.
         let base_version = self
             .emitted_versions
             .floor_for(partition, &cache_key, person.version);
@@ -1592,7 +1601,7 @@ impl PersonHogLeader for PersonHogLeaderService {
 
         // A fence installed anywhere but the current owner protects
         // nothing: the map that gates writes is the owner's. Both guards
-        // are needed — ownership covers a pod that already handed the
+        // are needed: ownership covers a pod that already handed the
         // partition off (release unfences), the handoff guard covers the
         // drain window before that. Refusing is what makes "a mark
         // committed after the takeover scan arrives as a FencePerson call
@@ -1637,9 +1646,9 @@ impl PersonHogLeader for PersonHogLeaderService {
         };
 
         // The memory fuse: the map has no eviction, so a surge of ops is
-        // bounded here, by shedding new fences. Re-seals are exempt — the
-        // person is already fenced, refusing frees nothing — and so is
-        // the takeover scan, whose marks are already live. The saga's
+        // bounded here, by shedding new fences. Re-seals are exempt (the
+        // person is already fenced, so refusing frees nothing), and so
+        // is the takeover scan, whose marks are already live. The saga's
         // retry absorbs the backpressure.
         if !refence && self.fences.len() >= self.fence_map_max_entries {
             counter!("personhog_leader_fences_total", "action" => "shed_capacity").increment(1);
@@ -1649,16 +1658,17 @@ impl PersonHogLeader for PersonHogLeaderService {
             )));
         }
 
-        // The seal: the newest cached state, captured under the same lock
-        // that admits writes — no gap for a write to sneak into. Fencing
-        // produces nothing and does not advance the version; the sealed
-        // version is the person's current one raised to the emitted
-        // floor, made final by the fence. The floor matters because a
-        // pre-fence write with an indeterminate outcome leaves a version
-        // spent above the cache's — sealing below it would derive the
-        // death document at a version that may already be live. A
-        // same-op re-fence takes this path too, re-sealing with fresh
-        // state (the saga's seal step is safe to repeat).
+        // The seal: the newest cached state, captured under the same
+        // lock that admits writes, so no gap exists for a write to
+        // sneak into. Fencing produces nothing and does not advance the
+        // version; the sealed version is the person's current one
+        // raised to the emitted floor, made final by the fence. The
+        // floor matters because a pre-fence write with an indeterminate
+        // outcome leaves a version spent above the cache's; sealing
+        // below it would derive the death document at a version that
+        // may already be live. A same-op re-fence takes this path too,
+        // re-sealing with fresh state (the saga's seal step is safe to
+        // repeat).
         let person = self.lookup_or_load_locked(partition, &cache_key).await?;
         if person.is_deleted {
             return Err(Status::not_found("person is destroyed"));
@@ -1690,7 +1700,7 @@ impl PersonHogLeader for PersonHogLeaderService {
 
         // Both outcomes: a release that removed nothing and returned OK
         // would leave the real owner's fence standing while the saga
-        // believes it released — a person frozen with no retry coming.
+        // believes it released: a person frozen with no retry coming.
         self.validate_ownership(partition)?;
 
         let cache_key = PersonCacheKey {
@@ -1760,11 +1770,12 @@ impl PersonHogLeader for PersonHogLeaderService {
                     return Ok(Response::new(ReleaseFenceResponse {}));
                 }
 
-                // The death document's identity comes from the request (a
-                // cold leader has nothing else), so when the leader DOES
-                // hold the person, the request must agree with it — the
-                // writer upserts uuid verbatim, and a mismatched request
-                // would rewrite the row's identity on its way out.
+                // The death document's identity comes from the request
+                // (a cold leader has nothing else), so when the leader
+                // DOES hold the person, the request must agree with it:
+                // the writer upserts uuid verbatim, and a mismatched
+                // request would rewrite the row's identity on its way
+                // out.
                 if let Some(person) = &current {
                     if person.uuid != req.person_uuid {
                         return Err(semantic_refusal(
@@ -1774,13 +1785,13 @@ impl PersonHogLeader for PersonHogLeaderService {
                     }
                 }
 
-                // The mark row — the fence's source of truth — must vouch
-                // for the op before anything is destroyed. The in-memory
-                // fence is not enough: FencePerson never verified the op
-                // either, so the request (plus a fence it installed
-                // itself) must never be sufficient to produce a death
-                // document. Unverifiable requests are refused — fail
-                // closed.
+                // The mark row (the fence's source of truth) must vouch
+                // for the op before anything is destroyed. The
+                // in-memory fence is not enough: FencePerson never
+                // verified the op either, so the request (plus a fence
+                // it installed itself) must never be sufficient to
+                // produce a death document. Unverifiable requests are
+                // refused, fail closed.
                 let Some(fallback) = &self.fallback else {
                     return Err(semantic_refusal(
                         "no lifecycle database configured; refusing to produce a death document",
@@ -1822,16 +1833,16 @@ impl PersonHogLeader for PersonHogLeaderService {
                          cannot be tracked; retry later",
                     ));
                 }
-                // The death version: sealed + 1 per the RFC — the fence
-                // makes the sealed version final. The max over the current
-                // version and the emitted floor is defense in depth until
-                // broker producer fencing lands (a deposed leader's
-                // produce could otherwise still advance the version, and
-                // an indeterminate one leaves a version spent that the
-                // cache never learned of); a cold leader with no state
-                // falls back to the sealed version carried by the
-                // request, reproducing the death document
-                // deterministically.
+                // The death version: sealed + 1 per the RFC, because
+                // the fence makes the sealed version final. The max
+                // over the current version and the emitted floor is
+                // defense in depth until broker producer fencing lands
+                // (a deposed leader's produce could otherwise still
+                // advance the version, and an indeterminate one leaves
+                // a version spent that the cache never learned of); a
+                // cold leader with no state falls back to the sealed
+                // version carried by the request, reproducing the death
+                // document deterministically.
                 let base_version = self.emitted_versions.floor_for(
                     partition,
                     &cache_key,
@@ -1859,14 +1870,15 @@ impl PersonHogLeader for PersonHogLeaderService {
                     approx_bytes: approx_person_bytes(2),
                 };
                 self.commit_document(partition, &cache_key, death).await?;
-                // The death document stays in the cache (commit_document
-                // put it there): an is_deleted entry answers reads and
-                // writes with an authoritative not-found from memory, the
-                // same way a recovered death document does. Removing it
-                // would only re-derive it — the next attempt recovers the
-                // death record via the dirty mark and re-installs it — and
-                // once the mark is pruned every attempt would fall through
-                // to a PG read instead.
+                // The death document stays in the cache
+                // (commit_document put it there): an is_deleted entry
+                // answers reads and writes with an authoritative
+                // not-found from memory, the same way a recovered death
+                // document does. Removing it would only re-derive it
+                // (the next attempt recovers the death record via the
+                // dirty mark and re-installs it), and once the mark is
+                // pruned every attempt would fall through to a PG read
+                // instead.
                 self.fences.remove(&cache_key);
                 counter!("personhog_leader_fences_total", "action" => "released_committed")
                     .increment(1);
@@ -2030,8 +2042,9 @@ mod tests {
         assert_eq!(stats.clamped_numbers, 1);
     }
 
-    /// A service with no PG pool and a producer that never connects —
-    /// enough to exercise the miss path, where no test reaches Kafka or PG.
+    /// A service with no PG pool and a producer that never connects:
+    /// enough to exercise the miss path, where no test reaches Kafka or
+    /// PG.
     async fn make_test_service() -> PersonHogLeaderService {
         let kafka = KafkaConfig::init_from_hashmap(&HashMap::new()).unwrap();
         let liveness = HealthRegistry::new("test")
@@ -2075,7 +2088,7 @@ mod tests {
     /// wedged is exactly the case the lease machinery cannot cover.
     #[tokio::test]
     async fn a_pod_whose_renewals_stopped_refuses_to_serve() {
-        // A clock whose renewals stopped longer ago than the margin —
+        // A clock whose renewals stopped longer ago than the margin,
         // constructed stale rather than aged by sleeping, so no runner
         // pace can blur which side of the margin the test is on.
         let margin = Duration::from_secs(20);
@@ -2122,7 +2135,7 @@ mod tests {
     /// this drives `get_person` itself rather than the check in
     /// isolation.
     ///
-    /// It does not distinguish the two checks — a read that finds its
+    /// It does not distinguish the two checks: a read that finds its
     /// person in cache never waits, so either one refuses it, and both
     /// return the same status. `a_read_admitted_before_the_lapse_still_
     /// refuses_to_answer` is what pins the second.
@@ -2183,7 +2196,7 @@ mod tests {
     }
 
     /// A write is serving too, and the lease-loss path surrenders before
-    /// it drains — so between the surrender and the local fence landing,
+    /// it drains, so between the surrender and the local fence landing,
     /// this check is what stops a pod that no longer holds its lease from
     /// acking a mutation the successor will never see. Fencing covers the
     /// same ground when it is on, but it cannot be enabled first, so this
@@ -2264,8 +2277,8 @@ mod tests {
     ///
     /// The load is what makes it distinct. A read that finds the person
     /// in cache never waits, so the admission check is the only one it
-    /// can trip; a read that has to wait — on the per-key lock, or on a
-    /// changelog recovery — can be admitted under a claim that is gone by
+    /// can trip; a read that has to wait (on the per-key lock, or on a
+    /// changelog recovery) can be admitted under a claim that is gone by
     /// the time there is an answer, and it is the answer, not the
     /// arrival, that has to be backed by ownership.
     #[tokio::test]
@@ -2281,7 +2294,7 @@ mod tests {
         service.cache.create_partition(0);
 
         // Hold the per-key lock. The read misses the cache, reaches for
-        // this lock, and parks there — which is where a changelog
+        // this lock, and parks there, which is where a changelog
         // recovery would leave it.
         let mutex = service
             .locks
@@ -2338,11 +2351,11 @@ mod tests {
     /// apart. This one pins the second.
     ///
     /// A write admitted under a valid claim can wait on the per-key lock
-    /// behind another produce, and on a changelog recovery — long enough
+    /// behind another produce, and on a changelog recovery: long enough
     /// for a starved keepalive's stamp to age out, for the lease to
     /// expire, and for a successor to warm past the point this record
-    /// would land. Acking it then is acked-write loss that needs only one
-    /// wedged pod, not a double zombie.
+    /// would land. Acking it then is acked-write loss that needs only
+    /// one wedged pod, not a double zombie.
     #[tokio::test]
     async fn a_write_admitted_before_the_lapse_is_not_produced() {
         let clock = Arc::new(AuthorityClock::unclaimed());
@@ -2513,9 +2526,10 @@ mod tests {
         let err = service.recover_or_load(0, &key).await.unwrap_err();
         assert_eq!(err.code(), Code::NotFound);
 
-        // Released mid-miss (cache dropped, then marks cleared — release
-        // order): the same lookup must fail closed rather than trust a
-        // possibly-stale PG row the cleared mark no longer guards.
+        // Released mid-miss (cache dropped, then marks cleared, the
+        // release order): the same lookup must fail closed rather than
+        // trust a possibly-stale PG row the cleared mark no longer
+        // guards.
         service.cache.drop_partition(0);
         service.dirty_index.clear_partition(0);
         let err = service.recover_or_load(0, &key).await.unwrap_err();

--- a/rust/personhog-leader/src/warming.rs
+++ b/rust/personhog-leader/src/warming.rs
@@ -31,8 +31,8 @@ pub struct WarmingRetryPolicy {
 ///
 /// The consume loop is not retried and does not need to be: it rides
 /// out non-fatal consumer errors in place while librdkafka handles them,
-/// bounded by `recv_timeout`. A fatal client state — and a genuine
-/// stall — ends it.
+/// bounded by `recv_timeout`. A fatal client state or a genuine stall
+/// ends it.
 async fn with_warm_retry<T, F, Fut>(
     stage: &str,
     partition: u32,
@@ -112,12 +112,13 @@ pub struct WarmingConfig {
     pub retry: WarmingRetryPolicy,
 }
 
-/// Build a consumer used by warming. Auto-commit and auto-offset-store are
-/// disabled so this is safe to instantiate with any group id — including
-/// the writer's, where mutating stored offsets would corrupt the writer's
-/// durable-progress marker. Two callers reuse it: the warming consume loop
-/// (which seeks explicitly per partition) and a short-lived OffsetFetch
-/// query against the writer's group (which never subscribes or consumes).
+/// Build a consumer used by warming. Auto-commit and auto-offset-store
+/// are disabled, so this is safe to instantiate with any group id,
+/// including the writer's, where mutating stored offsets would corrupt
+/// the writer's durable-progress marker. Two callers reuse it: the
+/// warming consume loop (which seeks explicitly per partition) and a
+/// short-lived OffsetFetch query against the writer's group (which never
+/// subscribes or consumes).
 pub(crate) fn make_consumer(
     kafka: &KafkaConfig,
     group_id: &str,
@@ -143,9 +144,10 @@ pub(crate) fn make_consumer(
 }
 
 /// A checkout stack of assign-only Kafka clients sharing one group id.
-/// Clients are checked out for the duration of one operation, returned on
-/// success, and dropped when the operation fails — a client whose
-/// operation just failed is never reused, so error hygiene is structural.
+/// Clients are checked out for the duration of one operation, returned
+/// on success, and dropped when the operation fails: a client whose
+/// operation just failed is never reused, so error hygiene is
+/// structural.
 /// A non-fatal error the operation rode out does not count as failure:
 /// the client handled it and completed, and both the consume loop and
 /// the give-back verify the client-level fatal state. None of these
@@ -196,15 +198,15 @@ impl ConsumerPool {
     /// Return a client after a successful operation. The assignment is
     /// cleared so the next checkout starts from a clean slate; clearing
     /// an unassigned client is a harmless no-op. A client whose
-    /// assignment cannot be cleared is dropped instead of pooled — the
-    /// pool's contract is that doubtful clients are never reused — with
+    /// assignment cannot be cleared is dropped instead of pooled (the
+    /// pool's contract is that doubtful clients are never reused), with
     /// the failure logged so a systematic cleanup problem surfaces as a
     /// visible signal rather than silent churn.
     pub fn give_back(&self, consumer: StreamConsumer) {
-        // The unassign gate below cannot catch a fatal client —
-        // librdkafka treats ops on one as successful unassigns — so the
-        // contract that a dead client is never pooled is enforced here
-        // by construction rather than left to the accident that
+        // The unassign gate below cannot catch a fatal client
+        // (librdkafka treats ops on one as successful unassigns), so
+        // the contract that a dead client is never pooled is enforced
+        // here by construction rather than left to the accident that
         // consumer fatals only arise from group paths these clients
         // never join.
         if let Some((code, reason)) = consumer.client().fatal_error() {
@@ -227,7 +229,7 @@ impl ConsumerPool {
         self.stack.lock().unwrap().push(consumer);
     }
 
-    /// Total clients ever created — flat across operations when reuse
+    /// Total clients ever created: flat across operations when reuse
     /// works; grows per operation when it does not.
     pub fn created_count(&self) -> u64 {
         self.created.load(Ordering::Relaxed)
@@ -239,12 +241,12 @@ impl ConsumerPool {
     /// only means the first operations pay the setup they would have
     /// paid anyway.
     pub async fn warm_up(&self, n: usize) {
-        // Create every client before connecting any: returning them as we
-        // go would make the next checkout pop the client we just returned,
-        // connecting one client n times and leaving the other n-1 slots to
-        // be built cold on the hot path. The connects then run
-        // concurrently — a deploy burst needs the pool populated in one
-        // connect's time, not n of them in sequence.
+        // Create every client before connecting any: returning them as
+        // we go would make the next checkout pop the client we just
+        // returned, connecting one client n times and leaving the other
+        // n-1 slots to be built cold on the hot path. The connects then
+        // run concurrently: a deploy burst needs the pool populated in
+        // one connect's time, not n of them in sequence.
         let mut clients = Vec::with_capacity(n);
         for _ in 0..n {
             let Ok(consumer) = self.checkout() else {
@@ -310,7 +312,7 @@ async fn fetch_writer_committed_offset(
 /// in one OffsetFetch round-trip, with one short-lived consumer for the
 /// whole batch. Partitions without a commit are absent from the result.
 /// The batch shape suits the dirty-index prune loop, which polls every
-/// owned partition on a cadence — per-partition consumers would be
+/// owned partition on a cadence; per-partition consumers would be
 /// constant churn.
 ///
 /// The OffsetFetch RPC inside `committed_offsets` is synchronous in rdkafka
@@ -361,10 +363,10 @@ pub async fn fetch_writer_committed_offsets(
 /// Decide where to start consuming for a partition.
 ///
 /// The writer's committed offset is the authoritative "everything up to
-/// here is durable in PG" marker. Messages at or after it need to be warmed
-/// into the leader's cache — otherwise a cache miss for a key in that
-/// range would fall through to PG and return a stale value (PG hasn't seen
-/// the update yet).
+/// here is durable in PG" marker. Messages at or after it need to be
+/// warmed into the leader's cache; otherwise a cache miss for a key in
+/// that range would fall through to PG and return a stale value (PG has
+/// not seen the update yet).
 ///
 /// We rewind an extra `lookback` offsets as a safety margin against races
 /// between the writer's commit and our read of it, and clamp to the
@@ -387,7 +389,7 @@ fn record_warm_span(span: &'static str, start: Instant) {
 
 /// Cancellation-safe cleanup for a warm in flight. The coordination loop
 /// drops warms on lease loss and shutdown, and a dropped future never
-/// reaches code after its await points — so the abort of the unpublished
+/// reaches code after its await points, so the abort of the unpublished
 /// build and the clearing of this partition's seeded dirty marks live in
 /// `Drop`, which runs on every exit: error, panic, and cancellation.
 /// Disarmed immediately before the publish, when the state stops being
@@ -446,9 +448,9 @@ pub async fn warm_from_kafka(
     let consumer = Arc::new(pools.warming.checkout()?);
     record_warm_span("checkout", span_start);
 
-    // The two offset queries are independent — the writer's committed
+    // The two offset queries are independent (the writer's committed
     // position comes from the offsets pool, the watermarks from this
-    // consumer — so they run concurrently; each keeps its own retry
+    // consumer), so they run concurrently; each keeps its own retry
     // policy. The committed query uses a separate, short-lived client to
     // keep the long-lived warming consumer isolated from the writer's
     // consumer group. `fetch_watermarks` is synchronous in rdkafka and
@@ -514,7 +516,7 @@ pub async fn warm_from_kafka(
     );
 
     if hwm <= start_offset {
-        // Empty range — install an empty partition cache. Use the
+        // Empty range: install an empty partition cache. Use the
         // atomic install path so this matches the populated path's
         // publication semantics (the partition becomes observable in
         // a single dashmap insert). The consumer never got assigned, so
@@ -541,13 +543,13 @@ pub async fn warm_from_kafka(
     // cache, so the warm's peak memory is bounded no matter how large
     // the range is. Each record writes its dirty mark BEFORE its insert,
     // so at every instant an evicted unapplied person is already
-    // recoverable from the changelog — the same miss path a serving
+    // recoverable from the changelog, the same miss path a serving
     // partition relies on. Nothing is observable until the publish at
     // the end.
     cache.begin_warm_partition(partition);
-    // Every non-published exit — an error, a panic, or the coordination
-    // loop dropping this future on lease loss or shutdown (the
-    // cancellation `HandoffHandler::warm_partition`'s contract names) —
+    // Every non-published exit (an error, a panic, or the coordination
+    // loop dropping this future on lease loss or shutdown, the
+    // cancellation `HandoffHandler::warm_partition`'s contract names)
     // must leave no trace: the guard aborts the build and clears the
     // partition's seeded marks on drop. A stale mark surviving into a
     // later acquisition would redirect a miss to a superseded changelog
@@ -578,28 +580,28 @@ pub async fn warm_from_kafka(
         loop {
         let msg = match timeout(poll_slice, consumer.recv()).await {
             Ok(Ok(m)) => m,
-            // A non-fatal consumer error means librdkafka is handling it:
-            // a connection blip resolves by reconnecting with the fetch
-            // position intact, and the stream never terminates, so the
-            // answer is to keep polling — as the fleet's streaming
-            // consumers do. The per-event fatal split is not the whole
-            // fatality story, so the client-level fatal state (an
-            // unrecoverable idempotence or authentication failure) is
-            // checked first: it survives even when the event that set it
-            // was consumed, and a dead client must not be re-polled while
-            // reporting progress.
+            // A non-fatal consumer error means librdkafka is handling
+            // it: a connection blip resolves by reconnecting with the
+            // fetch position intact, and the stream never terminates,
+            // so the answer is to keep polling, as the fleet's
+            // streaming consumers do. The per-event fatal split is not
+            // the whole fatality story, so the client-level fatal state
+            // (an unrecoverable idempotence or authentication failure)
+            // is checked first: it survives even when the event that
+            // set it was consumed, and a dead client must not be
+            // re-polled while reporting progress.
             //
-            // The accepted trade, stated for the record: librdkafka also
-            // reports record-skipping through this same non-fatal channel
-            // — an unreadable message set is discarded and the fetch
-            // position advances past it — and riding one out publishes a
-            // cache missing the skipped records. Today that requires
+            // The accepted trade: librdkafka also reports
+            // record-skipping through this same non-fatal channel (an
+            // unreadable message set is discarded and the fetch
+            // position advances past it), and riding one out publishes
+            // a cache missing the skipped records. That requires
             // broker-side corruption of bytes no consumer could read
-            // anyway, or a record format newer than this client, which
-            // does not exist. Stop-class errors (an ACL revocation, a
-            // deleted topic) also ride, costing the stall budget and a
-            // generic stall error instead of an immediate named one; the
-            // code survives in the counter label and the warn line.
+            // anyway, or a record format newer than this client.
+            // Stop-class errors (an ACL revocation, a deleted topic)
+            // also ride, costing the stall budget and a generic stall
+            // error instead of an immediate named one; the code
+            // survives in the counter label and the warn line.
             Ok(Err(KafkaError::MessageConsumption(code))) => {
                 if let Some((fatal_code, reason)) = consumer.client().fatal_error() {
                     return Err(CoordError::invalid_state(format!(
@@ -689,12 +691,12 @@ pub async fn warm_from_kafka(
             }
             cache.warm_put(partition, key, cached);
         } else {
-            // The writer never produces null-payload (tombstone) records
-            // to `personhog_updates` today. If one ever appears it would
-            // semantically represent a deletion, but the warming pipeline
-            // has no concept of evictions — so we silently skip and
-            // surface the occurrence via metrics + logs so an operator
-            // notices if this assumption ever stops holding.
+            // The writer never produces null-payload (tombstone)
+            // records to `personhog_updates`. One would semantically
+            // mean a deletion, but the warming pipeline has no concept
+            // of evictions, so skip it and surface the occurrence via
+            // metrics and logs so an operator notices if the assumption
+            // stops holding.
             counter!("personhog_leader_warm_tombstones_skipped_total").increment(1);
             tracing::warn!(
                 partition,
@@ -703,7 +705,7 @@ pub async fn warm_from_kafka(
             );
         }
 
-        // HWM is exclusive — it's one past the last offset present.
+        // HWM is exclusive: one past the last offset present.
         if offset + 1 >= hwm {
             break;
         }
@@ -716,13 +718,12 @@ pub async fn warm_from_kafka(
     record_warm_span("consume", span_start);
 
     // Atomic publish: one `DashMap` insert flips the fully-built cache
-    // from invisible to observable. The previous pattern
-    // (`create_partition` + per-record `put` loop) created a window
-    // where readers could observe `has_partition == true` while the
-    // cache was still being populated, and then fall through to PG —
-    // potentially returning stale values for records the writer hasn't
-    // yet persisted. Publishing at the end removes the dependency on the
-    // protocol invariant ("no reads during Warming") for correctness.
+    // from invisible to observable. Publishing per record would let
+    // readers observe `has_partition == true` while the cache is still
+    // filling, then fall through to PG and return stale values for
+    // records the writer has not yet persisted. Publishing at the end
+    // keeps correctness independent of the protocol invariant that no
+    // reads arrive during Warming.
     let resident_bytes = cache.warm_usage_bytes(partition) as u64;
     // Disarm before the publish: from here the marks and the cache are
     // the partition's serving state, not warm residue. No await sits
@@ -747,7 +748,7 @@ pub async fn warm_from_kafka(
     counter!("personhog_leader_warmed_messages_total").increment(consumed);
 
     // Every error path above dropped the consumer instead of returning
-    // it — a client that just failed is not pool material. Failing to
+    // it; a client that just failed is not pool material. Failing to
     // unwrap the Arc would only mean the same disposition.
     if let Ok(consumer) = Arc::try_unwrap(consumer) {
         pools.warming.give_back(consumer);
@@ -784,7 +785,7 @@ mod tests {
     }
 
     /// The coordination loop cancels a warm by dropping its future, which
-    /// never reaches code after an await point — so the cleanup lives in
+    /// never reaches code after an await point, so the cleanup lives in
     /// `WarmCleanup::drop`, and this pins that it runs. A surviving build
     /// pins memory for a partition this pod never serves; a surviving mark
     /// outlives re-acquisition, because the next warm only overwrites

--- a/rust/personhog-leader/src/warnings.rs
+++ b/rust/personhog-leader/src/warnings.rs
@@ -19,31 +19,31 @@ const LEADER_ADMISSION: WarningSource = WarningSource {
     pipeline_step: "personhog_admission",
 };
 
-/// An in-product ingestion warning about a person's property size —
+/// An in-product ingestion warning about a person's property size,
 /// emitted when admission trims an update to fit the Postgres constraint
 /// or rejects one that cannot fit. Carries no property values, only
 /// identifiers and sizes.
 pub struct SizeViolationWarning {
     pub team_id: i64,
-    /// The person's UUID — the pipeline convention for `personId` in
+    /// The person's UUID: the pipeline convention for `personId` in
     /// warning details (row ids stay internal).
     pub person_uuid: String,
     pub message: String,
 }
 
 /// Produces ingestion warnings to Kafka so users see property size
-/// violations in-product, with the payload built by the shared
-/// ingestion-warnings crate so type and classification come from the
-/// pipeline registry. Shares the leader's changelog producer (rdkafka
-/// producers are topic-agnostic), so buffered warnings flush with it on
-/// shutdown; emission is fire-and-forget and never blocks or fails the
-/// update that triggered it.
+/// violations in-product. The shared ingestion-warnings crate builds the
+/// payload, so type and classification come from the pipeline registry.
+/// Shares the leader's changelog producer (rdkafka producers are
+/// topic-agnostic), so buffered warnings flush with it on shutdown.
+/// Emission is fire-and-forget and never blocks or fails the update that
+/// triggered it.
 ///
 /// Emission is throttled per `(team, type)` with the pipeline's default
-/// budget (one per hour), matching the Node consumers' warning limiter:
-/// one oversized person being hammered with updates yields one warning an
-/// hour, not one per update. Cloning shares the throttle, so every handle
-/// draws from the same budget.
+/// budget (one per hour), matching the Node consumers' limiter: one
+/// oversized person hammered with updates yields one warning an hour,
+/// not one per update. Clones share the throttle, so every handle draws
+/// from the same budget.
 #[derive(Clone)]
 pub struct WarningsProducer {
     producer: FutureProducer<KafkaContext>,
@@ -56,7 +56,7 @@ impl WarningsProducer {
         Self::with_throttle(producer, topic, WarningThrottle::default())
     }
 
-    /// Construct with an explicit throttle — tests use a larger burst so
+    /// Construct with an explicit throttle. Tests use a larger burst so
     /// consecutive enforcement actions for one team all surface.
     pub fn with_throttle(
         producer: FutureProducer<KafkaContext>,

--- a/rust/personhog-leader/tests/common/mod.rs
+++ b/rust/personhog-leader/tests/common/mod.rs
@@ -228,8 +228,8 @@ pub fn test_kafka_config() -> KafkaConfig {
     }
 }
 
-/// Default warming knobs for e2e tests — production-equivalent timeouts and
-/// retry policy. `kafka_bootstrap` must match the broker the test's
+/// Default warming knobs for e2e tests: production-equivalent timeouts
+/// and retry policy. `kafka_bootstrap` must match the broker the test's
 /// producer is publishing to, so the warming consumer reads from the same
 /// place. With a mock cluster, that's `mock_cluster.bootstrap_servers()`;
 /// with real local Kafka, `KAFKA_BOOTSTRAP`.
@@ -319,7 +319,7 @@ pub async fn create_test_kafka() -> (
 
 /// Variant of `create_test_kafka` that lets a test pin the topic to a
 /// specific partition count. Use this for tests that exercise the
-/// producer's partition-routing behavior — they need a topology they
+/// producer's partition-routing behavior: they need a topology they
 /// control, not the default warming-friendly multi-partition setup.
 pub async fn create_test_kafka_with_partitions(
     partitions: i32,
@@ -647,10 +647,10 @@ pub const BROKER_TXN_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Fenced producers pointed at the local broker.
 ///
-/// Lives here rather than beside the fencing tests because the *service*
+/// Lives here rather than beside the fencing tests because the service
 /// needs it too: without a way to build `PersonHogLeaderService` with
-/// fencing on, its entire fenced write arm — the version settlement, the
-/// cache eviction, the four-way error mapping — is unreachable from any
+/// fencing on, its entire fenced write arm (the version settlement, the
+/// cache eviction, the four-way error mapping) is unreachable from any
 /// test.
 pub fn fenced_producers_for(topic: &str) -> personhog_leader::fencing::FencedChangelogProducers {
     let mut kafka = test_kafka_config();
@@ -674,9 +674,9 @@ pub fn fenced_producers_for(topic: &str) -> personhog_leader::fencing::FencedCha
 ///
 /// Deliberately not `None` for the authority. A fixture that leaves a
 /// mechanism out makes every test written against it exercise the
-/// degenerate path, and the gate stops being covered by anything —
-/// which is exactly how all four of its call sites became deletable
-/// with the suite green. Tests that need a lapsed claim pass their own.
+/// degenerate path, and the gate stops being covered by anything, which
+/// leaves its call sites deletable with the suite green. Tests that
+/// need a lapsed claim pass their own.
 #[allow(dead_code)]
 pub fn test_handoff_handler(
     topic: &str,
@@ -709,9 +709,9 @@ pub fn test_handoff_handler_with_authority(
     )
 }
 
-/// The same handler, sharing its inflight tracker with the caller — the
-/// only way to observe when the drain closes admissions relative to when
-/// it waits.
+/// The same handler, sharing its inflight tracker with the caller: the
+/// only way to observe when the drain closes admissions relative to
+/// when it waits.
 #[allow(dead_code)]
 pub fn test_handoff_handler_with_inflight(
     topic: &str,
@@ -725,9 +725,9 @@ pub fn test_handoff_handler_with_inflight(
 ///
 /// A fixture that can be built without one produces tests that exercise
 /// the ungated path by default, and the gate stops being covered by
-/// anything — which is how all four of its call sites became deletable
-/// with the suite green. Requiring it makes that configuration
-/// unbuildable rather than merely discouraged.
+/// anything, which leaves its call sites deletable with the suite
+/// green. Requiring it makes that configuration unbuildable rather than
+/// merely discouraged.
 fn handoff_handler_with(
     topic: &str,
     fenced: Arc<personhog_leader::fencing::FencedChangelogProducers>,
@@ -755,16 +755,15 @@ fn handoff_handler_with(
     )
 }
 
-/// A clock holding a claim its keepalive is still confirming.
-#[allow(dead_code)]
 /// A claim that stays valid for the whole of any test.
 ///
 /// The TTL is deliberately far longer than production's. Validity lapses
 /// once no renewal has been confirmed for two thirds of the TTL, and
-/// nothing renews this one — so a production-shaped 30s TTL gives a 20s
+/// nothing renews this one, so a production-shaped 30s TTL gives a 20s
 /// margin, which the fencing suite's longest tests already reach. Tests
 /// that want a lapsed claim surrender explicitly rather than waiting one
 /// out.
+#[allow(dead_code)]
 pub fn live_authority() -> Arc<AuthorityClock> {
     let clock = Arc::new(AuthorityClock::unclaimed());
     clock.begin_session(Duration::from_secs(3600), std::time::Instant::now());

--- a/rust/personhog-leader/tests/fence_integration.rs
+++ b/rust/personhog-leader/tests/fence_integration.rs
@@ -88,8 +88,9 @@ async fn start_fence_harness(mut seed: CachedPerson, fallback: Option<PgFallback
     let (mock_cluster, kafka_producer) = create_test_kafka().await;
     let bootstrap = mock_cluster.bootstrap_servers();
 
-    // Every harness gets its own team, so concurrent tests — and leftover
-    // rows from a failed earlier run — can never stomp on each other's
+    // Every harness gets its own team, so concurrent tests (and
+    // leftover rows from a failed earlier run) can never stomp on each
+    // other's
     // lifecycle marks.
     let team_id = unique_team_id();
     seed.team_id = team_id;
@@ -196,7 +197,7 @@ async fn fencing_seals_and_blocks_writes_until_an_aborted_release() {
     let op = Uuid::now_v7();
 
     // Fence + seal in one call: the sealed state is the person's current
-    // state — fencing produces nothing and does not advance the version.
+    // state; fencing produces nothing and does not advance the version.
     let sealed = harness
         .client
         .fence_person(with_partition(
@@ -329,7 +330,7 @@ async fn a_committed_release_produces_the_death_document_above_every_version() {
     let person_uuid = test_cached_person().uuid;
     let op = Uuid::now_v7();
 
-    // The mark rows the committed release verifies against — committed by
+    // The mark rows the committed release verifies against, committed by
     // the saga before the fence in the real flow.
     sqlx::query(
         "INSERT INTO lifecycle_op (op_id, op_type, team_id, step, request) \
@@ -414,7 +415,7 @@ async fn a_committed_release_produces_the_death_document_above_every_version() {
     );
 
     // The death document stays cached, so reads answer an authoritative
-    // not-found from memory — no changelog recovery, no PG fallback.
+    // not-found from memory: no changelog recovery, no PG fallback.
     match harness.cache.get(
         partition,
         &personhog_leader::cache::PersonCacheKey { team_id, person_id },
@@ -596,7 +597,7 @@ async fn a_committed_release_derives_the_death_version_above_the_emitted_floor()
 }
 
 /// A fresh person stub is created at version 0, so 0 is a sealed version
-/// the committed release must accept — a presence check that treats 0 as
+/// the committed release must accept; a presence check that treats 0 as
 /// "unset" fences the stub forever.
 #[tokio::test]
 async fn a_stub_sealed_at_version_zero_can_be_released() {
@@ -730,7 +731,7 @@ async fn a_ghost_fence_heals_after_a_rejected_write() {
         .expect("fence succeeds");
 
     // The op settles (release acked to the saga, mark rows cleaned up)
-    // without this leader hearing about it — the ghost scenario.
+    // without this leader hearing about it: the ghost scenario.
     sqlx::query("DELETE FROM lifecycle_op WHERE op_id = $1")
         .bind(op)
         .execute(&pool)
@@ -823,7 +824,7 @@ async fn a_ghost_fence_heals_after_a_rejected_fence_attempt() {
         .expect("fence succeeds");
 
     // The op settles (release acked to the saga, mark rows cleaned up)
-    // without this leader hearing about it — the ghost scenario.
+    // without this leader hearing about it: the ghost scenario.
     sqlx::query("DELETE FROM lifecycle_op WHERE op_id = $1")
         .bind(ghost_op)
         .execute(&pool)
@@ -928,8 +929,9 @@ async fn a_live_marked_fence_survives_heal_attempts() {
     }
 }
 
-/// The fail-closed half of the committed release: the request — even with
-/// a fence the caller installed itself — is never enough to destroy a
+/// The fail-closed half of the committed release: the request, even
+/// with a fence the caller installed itself, is never enough to destroy
+/// a
 /// person. Without a live mark row vouching for the op, the release is
 /// refused and the person is untouched.
 #[tokio::test]
@@ -948,7 +950,7 @@ async fn a_committed_release_without_a_live_mark_is_refused() {
     let person_id = harness.person_id;
     let op = Uuid::now_v7();
 
-    // Fencing succeeds — the fence RPC does not verify the op…
+    // Fencing succeeds; the fence RPC does not verify the op.
     let sealed = harness
         .client
         .fence_person(with_partition(
@@ -1007,7 +1009,7 @@ async fn a_committed_release_without_a_live_mark_is_refused() {
 
 /// Neither fence RPC may succeed on a pod that does not serve the
 /// partition. A release that removed nothing and returned OK would leave
-/// the real owner's fence standing while the saga believes it released —
+/// the real owner's fence standing while the saga believes it released:
 /// a person frozen with no retry coming.
 #[tokio::test]
 async fn the_fence_rpcs_refuse_a_partition_this_pod_does_not_serve() {
@@ -1218,7 +1220,7 @@ async fn the_takeover_scan_rebuilds_exactly_the_partitions_live_fences() {
     // A re-warm converges on the marks rather than accumulating: an entry
     // a previous warm left behind for a person no longer marked is gone.
     // (A handoff cancelled after warming, then re-acquired, takes this
-    // path — nothing else would ever clear that entry.)
+    // path; nothing else would ever clear that entry.)
     let ghost = fenced_a + 1_000_000;
     let ghost_partition = partition_for_person(team_id, ghost, NUM_PARTITIONS);
     fences.insert(
@@ -1258,7 +1260,7 @@ async fn the_takeover_scan_rebuilds_exactly_the_partitions_live_fences() {
 
 /// The fence map's memory fuse: at capacity, a new fence sheds with
 /// RESOURCE_EXHAUSTED (backpressure the saga retries), while a re-seal of
-/// an already-fenced person still succeeds — refusing it would free
+/// an already-fenced person still succeeds; refusing it would free
 /// nothing.
 #[tokio::test]
 async fn at_capacity_new_fences_shed_but_reseals_succeed() {
@@ -1406,7 +1408,7 @@ fn person_properties(person: &Person) -> serde_json::Value {
     serde_json::from_slice(&person.properties).expect("changelog properties parse")
 }
 
-/// The mark rows the fold verifies against — committed by the merge saga
+/// The mark rows the fold verifies against, committed by the merge saga
 /// before it fences the sources in the real flow.
 async fn seed_target_mark(
     pool: &sqlx::PgPool,
@@ -1442,7 +1444,7 @@ async fn seed_target_mark(
 }
 
 /// A fold-ready harness: lifecycle database attached and a live 'marked'
-/// target row for `op` — the state the merge saga guarantees before it
+/// target row for `op`: the state the merge saga guarantees before it
 /// calls the fold.
 async fn start_marked_fold_harness(seed: CachedPerson, op: &Uuid) -> FenceHarness {
     let pool = common::create_persons_pool().await;
@@ -1912,8 +1914,9 @@ async fn invalid_fold_requests_are_rejected_before_any_work() {
     }
 }
 
-/// The fail-closed half of the fold: the request — even with a well-formed
-/// op id — is never enough to write to the target. Without a live 'marked'
+/// The fail-closed half of the fold: the request, even with a
+/// well-formed op id, is never enough to write to the target. Without a
+/// live 'marked'
 /// target row vouching for the op, the fold is refused and the target is
 /// untouched: a superseded or settled saga runner's late fold must land
 /// nowhere.
@@ -1964,7 +1967,7 @@ async fn a_fold_whose_op_holds_no_live_target_mark_is_refused() {
         .expect_err("a settled op's re-driven fold is refused");
     assert_eq!(status.code(), Code::FailedPrecondition);
 
-    // The wrong role: the op holds the person, but not as its target —
+    // The wrong role: the op holds the person, but not as its target;
     // folding into it would be a saga bug.
     sqlx::query(
         "UPDATE lifecycle_op_person SET role = 'victim', status = 'marked' WHERE op_id = $1",
@@ -1995,7 +1998,7 @@ async fn a_fold_whose_op_holds_no_live_target_mark_is_refused() {
         .expect("the person is still readable");
     assert_eq!(read.into_inner().person.unwrap().version, 1);
 
-    // With the live target mark restored, the same request folds — the
+    // With the live target mark restored, the same request folds; the
     // mark was the only thing missing.
     sqlx::query("UPDATE lifecycle_op_person SET role = 'target' WHERE op_id = $1")
         .bind(op)
@@ -2010,7 +2013,7 @@ async fn a_fold_whose_op_holds_no_live_target_mark_is_refused() {
 }
 
 /// An oversized fold trims only what the fold contributed: the target's
-/// own keys — state admission already accepted — survive even when they
+/// own keys (state admission already accepted) survive even when they
 /// sort first alphabetically, and the contributed keys absorb the trim.
 #[tokio::test]
 async fn an_oversized_fold_trims_the_contribution_not_the_targets_keys() {
@@ -2059,7 +2062,7 @@ async fn an_oversized_fold_trims_the_contribution_not_the_targets_keys() {
 
 /// When trimming the fold's contribution cannot get the document under the
 /// limit, the fold discards the contribution entirely and keeps the
-/// target's document byte for byte — it never dips into keys a
+/// target's document byte for byte; it never dips into keys a
 /// within-limit target already owned. The scalar fold still applies.
 #[tokio::test]
 async fn an_unremediable_fold_keeps_the_targets_document_untouched() {
@@ -2117,7 +2120,7 @@ async fn an_unremediable_fold_keeps_the_targets_document_untouched() {
 /// against the hard ceiling: a document in the band between them is
 /// still applyable by the writer, so an already-oversized target folds
 /// to an applyable document instead of discarding to its oversized
-/// stored state — which the writer would refuse to commit past.
+/// stored state, which the writer would refuse to commit past.
 #[tokio::test]
 async fn an_oversized_targets_fold_trims_to_the_hard_ceiling() {
     let op = Uuid::now_v7();
@@ -2165,8 +2168,8 @@ async fn an_oversized_targets_fold_trims_to_the_hard_ceiling() {
     assert_eq!(folded.version, 8, "max(target 3, sealed 7) + 1");
 }
 
-/// When no applyable document exists at all — the target's stored
-/// protected keys alone exceed the hard ceiling — the fold completes
+/// When no applyable document exists at all (the target's stored
+/// protected keys alone exceed the hard ceiling), the fold completes
 /// without producing: committing the oversized document would halt the
 /// writer, and rejecting would wedge the saga's re-drive loop. The
 /// person comes back unchanged, fold effects skipped.
@@ -2263,7 +2266,7 @@ async fn a_non_object_target_stays_an_object_through_the_unremediable_path() {
 }
 
 /// Precedence follows the recorded ordinals, not the request order: the
-/// same sources listed differently fold to the same document — the
+/// same sources listed differently fold to the same document: the
 /// convergence a re-driven saga step depends on.
 #[tokio::test]
 async fn precedence_follows_ordinals_not_request_order() {
@@ -2320,8 +2323,8 @@ async fn precedence_follows_ordinals_not_request_order() {
     );
 }
 
-/// Cache dirt on the target — state loaded from Postgres or warmed from
-/// records that predate sanitization — is rewritten like every other
+/// Cache dirt on the target (state loaded from Postgres or warmed from
+/// records that predate sanitization) is rewritten like every other
 /// fold input, so the committed document is measured in stored form.
 #[tokio::test]
 async fn a_folds_target_cache_dirt_is_sanitized() {
@@ -2366,7 +2369,7 @@ async fn a_folds_target_cache_dirt_is_sanitized() {
 /// mistake that direct tombstone for an already-emitted death document.
 /// Today this holds because the PG fallback load filters `is_deleted =
 /// false`, so the release sees no person and takes the cold-leader path,
-/// re-deriving the document from the sealed version — this test pins that
+/// re-deriving the document from the sealed version; this test pins that
 /// composed behavior against either side changing (the load filter, or the
 /// duplicate-release absorb).
 #[tokio::test]

--- a/rust/personhog-leader/tests/fencing_integration.rs
+++ b/rust/personhog-leader/tests/fencing_integration.rs
@@ -1,7 +1,7 @@
 //! Broker-enforced fencing, proven against a real broker: a partition's
 //! new owner initializing its transactional id must make the previous
 //! owner's producer unusable. Without the fence, a stale owner's writes
-//! land in the changelog silently — the exact zombie hazard this
+//! land in the changelog silently: the exact zombie hazard this
 //! mechanism exists to close.
 
 mod common;
@@ -34,8 +34,8 @@ fn test_person(version: i64) -> Person {
     }
 }
 
-/// Count the records a `read_committed` consumer can see on partition 0
-/// — the same isolation the warming path uses.
+/// Count the records a `read_committed` consumer can see on partition
+/// 0, the same isolation the warming path uses.
 async fn read_committed_count(topic: &str) -> usize {
     use rdkafka::consumer::{Consumer, StreamConsumer};
     use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
@@ -113,7 +113,7 @@ fn fenced_producers(topic: &str) -> FencedChangelogProducers {
 
 /// The prepared path must fence exactly as the cold path does: a
 /// connection built ahead of acquisition carries no broker transactional
-/// state, so the epoch bump happens at `acquire` — and the previous
+/// state, so the epoch bump happens at `acquire`, and the previous
 /// owner must find itself fenced by it.
 #[tokio::test]
 async fn a_prepared_connection_still_fences_the_previous_owner() {
@@ -346,7 +346,7 @@ async fn second_acquisition_fences_the_first_producer() {
         }
     })
     .await
-    .expect("writes parked forever — a window_closed wakeup was lost");
+    .expect("writes parked forever: a window_closed wakeup was lost");
 }
 
 /// Concurrent same-partition writes share a transaction window: both
@@ -396,7 +396,7 @@ async fn a_filled_window_commits_before_its_timer() {
         }
     })
     .await
-    .expect("acks waited on the 60s timer — the fill close never fired");
+    .expect("acks waited on the 60s timer: the fill close never fired");
     assert_eq!(read_committed_count(&topic).await, 3);
 }
 
@@ -432,13 +432,14 @@ async fn sustained_writes_across_window_boundaries() {
         }
     })
     .await
-    .expect("writes parked forever — a window_closed wakeup was lost");
+    .expect("writes parked forever: a window_closed wakeup was lost");
 }
 
 /// A commit nobody observed is not a commit that did not happen.
 ///
-/// The committer can stop without answering — its task dropped at runtime
-/// teardown, or unwound — and `spawn_blocking` work is not cancelled when
+/// The committer can stop without answering (its task dropped at
+/// runtime teardown, or unwound), and `spawn_blocking` work is not
+/// cancelled when
 /// its handle is dropped, so the commit it was running may well have
 /// landed. Reporting that as a definite abort frees a version whose record
 /// may exist: the retry derives the same number, and the writer's
@@ -471,8 +472,8 @@ async fn a_committer_that_vanishes_leaves_the_outcome_in_doubt() {
     }
 }
 
-/// A request that vanishes mid-produce — tonic drops the handler future
-/// when the client's deadline expires — must return its seat in the
+/// A request that vanishes mid-produce (tonic drops the handler future
+/// when the client's deadline expires) must return its seat in the
 /// window. Without that, the committer waits on an in-flight count that
 /// never reaches zero and every later write on the partition parks
 /// forever behind it.
@@ -505,8 +506,8 @@ async fn a_cancelled_produce_does_not_wedge_the_partition() {
 ///
 /// The drain does not wait for open transaction windows, which is only
 /// safe if a record abandoned in one cannot become visible after the
-/// partition moves. This pins that: the successor's acquire — which
-/// precedes its warm read — leaves the predecessor unable to commit.
+/// partition moves. This pins that: the successor's acquire, which
+/// precedes its warm read, leaves the predecessor unable to commit.
 ///
 /// Without this guarantee the drain would have to wait out every open
 /// window before acking, so the assertion is load-bearing rather than
@@ -517,7 +518,7 @@ async fn a_successors_init_aborts_the_predecessors_open_window() {
 
     // Predecessor: open a window and get a record enqueued into it, then
     // abandon it exactly as a cancelled request would. The window is
-    // short on purpose — its committer must fire *after* the successor
+    // short on purpose: its committer must fire after the successor
     // has taken the epoch, because "invisible while uncommitted" proves
     // nothing. What has to be shown is that the record can never become
     // visible once the successor owns the partition.
@@ -547,7 +548,7 @@ async fn a_successors_init_aborts_the_predecessors_open_window() {
     let visible = read_committed_count(&topic).await;
     assert_eq!(
         visible, 0,
-        "an abandoned record must not become readable after the successor's init — \
+        "an abandoned record must not become readable after the successor's init; \
          if this fails, the drain must wait for open windows before acking"
     );
 
@@ -572,7 +573,7 @@ async fn a_successors_init_aborts_the_predecessors_open_window() {
     assert_eq!(
         read_committed_count(&control_topic).await,
         1,
-        "with no successor the abandoned record commits — without this the assertion \
+        "with no successor the abandoned record commits; without this the assertion \
          above cannot tell an aborted window from a send that never happened"
     );
 }
@@ -581,8 +582,8 @@ async fn a_successors_init_aborts_the_predecessors_open_window() {
 /// partition's broker epoch.
 ///
 /// The pod records a partition as held only once the warm returns, so a
-/// fence taken by a warm whose future is dropped — what a lost lease
-/// does to an in-flight attempt — belongs to no partition the local
+/// fence taken by a warm whose future is dropped (what a lost lease
+/// does to an in-flight attempt) belongs to no partition the local
 /// self-fence knows to release. The process would keep the epoch while
 /// owning nothing, and the real owner's writes would fail as fenced.
 #[tokio::test]
@@ -686,8 +687,8 @@ async fn a_condemned_producer_stops_claiming_the_partition() {
 
 /// A guard outlives the fence it was taken for when a warm is abandoned
 /// and the partition is re-acquired before the guard drops. Releasing by
-/// partition alone would then evict the *replacement* — a live fence, on
-/// a partition this pod legitimately owns — and every write would fail as
+/// partition alone would then evict the replacement (a live fence, on a
+/// partition this pod legitimately owns), and every write would fail as
 /// unowned until something re-acquired again.
 #[tokio::test]
 async fn an_abandoned_guard_does_not_evict_its_replacement() {
@@ -711,7 +712,7 @@ async fn an_abandoned_guard_does_not_evict_its_replacement() {
         .expect("the replacement fence must survive the stale guard");
 }
 
-/// A partition can end up served without a fence — a broker rejection
+/// A partition can end up served without a fence: a broker rejection
 /// evicted it, an abort exhausted its retries, a stale pod took the
 /// epoch and stepped back. Convergence sees such a partition warmed and
 /// unfenced and does nothing, so this is what gets it writable again
@@ -739,7 +740,7 @@ async fn healing_retakes_a_fence_for_a_served_partition() {
 
 /// Healing takes the partition's epoch from whoever holds it, so a pod
 /// that cannot vouch for its own claim must not start the round trip at
-/// all — `init_transactions` cannot be undone once it returns, and the
+/// all; `init_transactions` cannot be undone once it returns, and the
 /// post-acquire check can only stop *this* pod from building on a fence
 /// it already stole.
 ///
@@ -833,7 +834,7 @@ async fn healing_gives_back_a_fence_it_lost_standing_for() {
 /// A writer parked behind a committing window is woken by the very commit
 /// that condemns the producer. Checking usability only before the park
 /// skips exactly that writer: it wakes, finds the gate idle, and opens a
-/// window on a producer that cannot begin one — answering with a
+/// window on a producer that cannot begin one, answering with a
 /// retryable failure the client retries against a pod that cannot write
 /// the partition, instead of the ownership bounce that moves it.
 #[tokio::test]
@@ -852,7 +853,7 @@ async fn a_writer_woken_onto_a_condemned_producer_is_bounced() {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // The commit resolves badly and condemns the producer, then releases
-    // the gate and wakes the parked writer — production's exact order.
+    // the gate and wakes the parked writer: production's exact order.
     producers.condemn_for_test(0);
     producers.finish_committing_for_test(0);
 
@@ -865,7 +866,7 @@ async fn a_writer_woken_onto_a_condemned_producer_is_bounced() {
 }
 
 /// Healing must leave a partition it already holds alone. Re-acquiring
-/// runs `init_transactions`, which bumps the broker epoch — so a healing
+/// runs `init_transactions`, which bumps the broker epoch, so a healing
 /// pass that ignored the fence it is already holding would fence this
 /// pod's own producer on every reconcile tick.
 ///
@@ -907,7 +908,7 @@ async fn healing_leaves_a_fence_it_already_holds_alone() {
 /// A commit task that never reports its outcome must condemn the producer.
 ///
 /// `spawn_blocking` work is not cancelled when its handle drops, so the
-/// commit may well have landed — the caller therefore learns nothing, and
+/// commit may well have landed; the caller therefore learns nothing, and
 /// the version stays spent. What matters here is the producer: its
 /// transaction is left open, and without the condemn `holds()` keeps
 /// answering yes, the repair pass sees nothing to do, and every later
@@ -941,7 +942,7 @@ async fn a_committer_that_never_reports_condemns_its_producer() {
 /// `a_successors_init_aborts_the_predecessors_open_window` shows the
 /// safety net: an abandoned record can never become visible once the
 /// successor owns the partition. This shows the boundary the drain is
-/// supposed to be — the record is committed *before* the handoff
+/// supposed to be: the record is committed before the handoff
 /// advances, so the successor reads it as ordinary history rather than
 /// racing the predecessor's committer for it.
 ///
@@ -1005,19 +1006,19 @@ async fn settling_commits_an_abandoned_record_before_the_handoff_advances() {
 /// Warming acquires the partition's transactional id and then re-admits
 /// writes as its last act. The resume that can follow in the same
 /// convergence exists for a cancelled handoff whose target got as far as
-/// taking the epoch — but if it runs after this pod's own warm, its
+/// taking the epoch, but if it runs after this pod's own warm, its
 /// `init_transactions` bumps the epoch out from under every write the
 /// warm just admitted, and the pod fences its own live window.
 ///
 /// The mark that prevents this has two halves, and either one alone is
 /// useless: warming records the fence it took, and the resume honours
-/// that record. This covers both — delete either and the in-flight write
+/// that record. This covers both: delete either and the in-flight write
 /// below is fenced by its own pod.
 #[tokio::test]
 async fn a_resume_does_not_fence_the_window_its_own_warm_admitted() {
     let topic = format!("fence_resume_{}", uuid::Uuid::new_v4().simple());
     // Long enough that the write is still sitting in an open window when
-    // the resume runs — a window that closed first would be committed
+    // the resume runs; a window that closed first would be committed
     // already and could not be fenced.
     let producers = Arc::new(fenced_producers_with_window(
         &topic,
@@ -1026,7 +1027,7 @@ async fn a_resume_does_not_fence_the_window_its_own_warm_admitted() {
     let handler = common::test_handoff_handler(&topic, Arc::clone(&producers));
 
     // A record for the warm to read, which also brings the topic into
-    // existence — `fetch_watermarks` has nothing to answer for a topic
+    // existence; `fetch_watermarks` has nothing to answer for a topic
     // no one has produced to.
     producers.acquire(0).await.expect("seed the topic");
     producers
@@ -1059,8 +1060,8 @@ async fn a_resume_does_not_fence_the_window_its_own_warm_admitted() {
 ///
 /// A send that fails inside a window leaves records the transaction can
 /// never be allowed to commit, so the commit path aborts instead. Skip
-/// the abort and the producer is left in its abortable state — where
-/// every later `begin_transaction` fails — while the code reports a
+/// the abort and the producer is left in its abortable state (where
+/// every later `begin_transaction` fails) while the code reports a
 /// clean abort, so nothing condemns it and nothing re-acquires. The
 /// partition then refuses every write for the life of the process.
 #[tokio::test]
@@ -1097,7 +1098,7 @@ async fn a_poisoned_window_is_aborted_rather_than_committed() {
 /// A window that cannot be settled must not hold the partition hostage.
 ///
 /// The drain fences writes as its first act, and the only branch that
-/// lifts that fence runs after the handoff completes — which needs the
+/// lifts that fence runs after the handoff completes, which needs the
 /// ack this drain is about to write. So a drain that refuses to ack over
 /// an unsettled window strands the partition rejecting every write for
 /// the life of the process, while reads carry on and the convergence
@@ -1131,7 +1132,7 @@ async fn a_window_that_cannot_settle_still_lets_the_handoff_proceed() {
 /// A resume that skipped its acquire must leave the mark for the retry.
 ///
 /// The skip branch consumed the mark, so a convergence torn down after
-/// the resume returned — but before `apply` recorded it — retried with
+/// the resume returned, but before `apply` recorded it, retried with
 /// the partition still listed as fenced and nothing to say the fence was
 /// already held. That retry re-acquires and bumps the epoch out from
 /// under the writes the first resume admitted.
@@ -1177,7 +1178,7 @@ async fn a_repeated_resume_does_not_fence_the_window_the_first_one_admitted() {
 /// `commit_transaction` is still mid round trip. A settle that asked only
 /// whether the window was open would return there and let the drain ack,
 /// handing the successor a partition whose last records are still racing
-/// its `init_transactions` — the race settling exists to end.
+/// its `init_transactions`: the race settling exists to end.
 #[tokio::test]
 async fn a_drain_waits_for_a_commit_that_is_already_running() {
     let topic = format!("fence_settle_mid_{}", uuid::Uuid::new_v4().simple());
@@ -1207,7 +1208,7 @@ async fn a_drain_waits_for_a_commit_that_is_already_running() {
 /// left behind.
 ///
 /// A handoff cancelled after the drain reaches `resume_partition` with no
-/// mark — the drain retires it — so this resume acquires. A convergence
+/// mark (the drain retires it), so this resume acquires. A convergence
 /// torn down before `apply` files the resume runs the same one again, and
 /// without a mark of its own that retry re-acquires, bumping the epoch out
 /// from under everything the first resume just admitted.
@@ -1222,7 +1223,7 @@ async fn a_resume_that_took_the_fence_itself_does_not_take_it_again() {
 
     producers.acquire(0).await.expect("seed the topic");
     // Handed away, then cancelled: the drain retires the mark and the
-    // resume has to take the fence — and record it — on its own.
+    // resume has to take the fence, and record it, on its own.
     handler
         .drain_partition_inflight(0)
         .await
@@ -1248,7 +1249,7 @@ async fn a_resume_that_took_the_fence_itself_does_not_take_it_again() {
 /// Warming without a confirmed renewal must not take the epoch.
 ///
 /// `init_transactions` grants the epoch to whoever initializes last, not
-/// to whoever the protocol says owns the partition — so a zombie warming
+/// to whoever the protocol says owns the partition, so a zombie warming
 /// on its way to noticing it is dead would fence the legitimate owner.
 #[tokio::test]
 async fn warming_without_a_confirmed_lease_does_not_take_the_epoch() {
@@ -1275,7 +1276,7 @@ async fn warming_without_a_confirmed_lease_does_not_take_the_epoch() {
         .expect("a warm with no standing must not take the epoch from the real owner");
 }
 
-/// A resume without a confirmed renewal must not take the epoch either —
+/// A resume without a confirmed renewal must not take the epoch either:
 /// the same act, reached through the branch that cancels a handoff.
 #[tokio::test]
 async fn a_resume_without_a_confirmed_lease_does_not_take_the_epoch() {
@@ -1343,7 +1344,7 @@ async fn a_warm_that_loses_its_claim_mid_acquire_gives_the_fence_back() {
                 panic!("a fence taken across a lapsed claim must be given back, got {other:?}")
             }
         },
-        // The surrender lost the race outright — the claim was valid at
+        // The surrender lost the race outright: the claim was valid at
         // both checks, so the warm keeps its fence legitimately. A fast
         // broker reaches this branch; asserting the fence works keeps
         // the test meaningful there instead of panicking on good
@@ -1386,7 +1387,7 @@ async fn a_resume_that_loses_its_claim_mid_acquire_gives_the_fence_back() {
                 panic!("a fence taken across a lapsed claim must be given back, got {other:?}")
             }
         },
-        // The surrender lost the race outright — the claim held at both
+        // The surrender lost the race outright: the claim held at both
         // checks and the resume keeps a working fence.
         Ok(()) => {
             producers
@@ -1400,7 +1401,8 @@ async fn a_resume_that_loses_its_claim_mid_acquire_gives_the_fence_back() {
 /// The drain closes admissions before it waits, not after.
 ///
 /// Waiting first leaves a window where a request admitted during the wait
-/// acks after the count reached zero — a write landing above the watermark
+/// acks after the count reached zero: a write landing above the
+/// watermark
 /// the successor's warm is about to read, which is the loss the drain
 /// exists to prevent.
 #[tokio::test]
@@ -1436,7 +1438,8 @@ async fn the_drain_refuses_new_writes_while_it_is_still_waiting() {
 /// Releasing a partition retires its fresh-fence mark.
 ///
 /// The mark says "this convergence already holds the epoch". Left behind
-/// across a release — which drops the producer — a later resume trusts it,
+/// across a release (which drops the producer), a later resume trusts
+/// it,
 /// skips the acquire, and re-admits writes to a partition with no fence
 /// installed at all.
 #[tokio::test]
@@ -1502,7 +1505,7 @@ async fn verifying_a_served_partition_retakes_a_condemned_fence() {
 /// run's failure budgets escalate to process death, which would trade
 /// one partition's writes for every partition's reads. The wedge stays
 /// visible through the partition-labeled failure counter and stays
-/// retried by the reconcile tick — and the partition must still answer
+/// retried by the reconcile tick, and the partition must still answer
 /// as unfenced, never as quietly repaired.
 #[tokio::test]
 async fn a_heal_that_cannot_acquire_does_not_fail_the_run() {
@@ -1536,7 +1539,7 @@ async fn a_heal_that_cannot_acquire_does_not_fail_the_run() {
 /// A heal is an acquisition like any other: the same convergence's
 /// resume step must trust its fence rather than bump the epoch again.
 /// Re-acquiring on resume would fence the very window the heal just made
-/// writable — the double-acquire the fresh-fence mark exists to prevent.
+/// writable: the double-acquire the fresh-fence mark exists to prevent.
 #[tokio::test]
 async fn a_healed_fence_is_not_reacquired_by_the_same_convergences_resume() {
     let topic = format!("fence_heal_mark_{}", uuid::Uuid::new_v4().simple());
@@ -1546,7 +1549,7 @@ async fn a_healed_fence_is_not_reacquired_by_the_same_convergences_resume() {
     ));
     let handler = common::test_handoff_handler(&topic, Arc::clone(&producers));
 
-    // A served partition with no usable fence — the state heal repairs.
+    // A served partition with no usable fence: the state heal repairs.
     handler
         .verify_serving(0)
         .await
@@ -1575,12 +1578,13 @@ async fn a_healed_fence_is_not_reacquired_by_the_same_convergences_resume() {
 /// A committer that unwinds with subscribers still queued must condemn
 /// the producer, not strand them.
 ///
-/// The mark's drop used to clear `committing` and nothing else: the
-/// orphaned waiter list blocked every later window (nothing opens while
-/// waiters remain) while `is_usable` kept reporting the fence healthy —
-/// every write on the partition parked until its own deadline, silently,
-/// forever. Condemning routes it into the same bounce-and-recover story
-/// as every other producer no window can be begun from.
+/// If the mark's drop cleared `committing` and nothing else, the
+/// orphaned waiter list would block every later window (nothing opens
+/// while waiters remain) while `is_usable` kept reporting the fence
+/// healthy; every write on the partition would park until its own
+/// deadline, silently, forever. Condemning routes it into the same
+/// bounce-and-recover story as every other producer no window can be
+/// begun from.
 #[tokio::test]
 async fn an_unwound_committer_condemns_rather_than_stranding_its_waiters() {
     let topic = format!("fence_orphan_{}", uuid::Uuid::new_v4().simple());
@@ -1611,7 +1615,7 @@ async fn an_unwound_committer_condemns_rather_than_stranding_its_waiters() {
 /// not the test constants: window 5ms, txn ~1.2s, settle 2s, broker
 /// patience ~6s at the production lease. The per-arm tests pin each
 /// mechanism with generous constants; this pins that the *derived*
-/// numbers compose against a real broker — windows turn over, commits
+/// numbers compose against a real broker: windows turn over, commits
 /// land inside their budgets, and a drain (with its settle) finishes
 /// inside the lease runway the arithmetic promises.
 #[tokio::test]
@@ -1666,7 +1670,7 @@ async fn the_derived_production_timescales_compose_against_a_real_broker() {
     }
     assert_eq!(acked, 100);
 
-    // The drain — wait plus settle — must fit the runway the validator
+    // The drain (wait plus settle) must fit the runway the validator
     // sized it against.
     let handler = common::test_handoff_handler(&topic, Arc::clone(&producers));
     let drain_started = std::time::Instant::now();

--- a/rust/personhog-leader/tests/integration.rs
+++ b/rust/personhog-leader/tests/integration.rs
@@ -112,7 +112,6 @@ async fn service_accepts_requests_after_coordination_warmup() {
     })
     .await;
 
-    // Seed a person into partition 0
     let person = test_cached_person();
     seed_person(&pod.cache, 0, person.clone());
 
@@ -150,7 +149,6 @@ async fn service_accepts_requests_after_coordination_warmup() {
     assert!(result.updated);
     assert_eq!(result.person.unwrap().version, 2);
 
-    // Read back should reflect the update
     let response = client
         .get_person(leader_get_request(1, 42, 0))
         .await
@@ -255,7 +253,7 @@ async fn unowned_partition_returns_failed_precondition() {
 /// The partition arrives only via `x-partition` metadata, stamped by the
 /// router. A request without it is misrouted or malformed and must be
 /// rejected with INVALID_ARGUMENT rather than served against a guessed
-/// partition — even when the person exists and its partition is warm.
+/// partition, even when the person exists and its partition is warm.
 #[tokio::test]
 async fn missing_partition_metadata_returns_invalid_argument() {
     let cache = Arc::new(PartitionedCache::new(1 << 20));
@@ -340,7 +338,7 @@ async fn missing_partition_metadata_returns_invalid_argument() {
 /// The leader validates the router's routing decision against the decoded
 /// body: `x-partition` must equal `partition_for_person(team_id,
 /// person_id)`. A mismatch means a client stamped wrong routing-key
-/// headers or the hash implementations diverged — serving it would read or
+/// headers or the hash implementations diverged; serving it would read or
 /// write through the wrong partition's cache, so it must be rejected even
 /// when the named partition is warm and the person exists there.
 #[tokio::test]
@@ -426,7 +424,7 @@ async fn mismatched_partition_metadata_returns_invalid_argument() {
 // ============================================================
 
 /// Once the old owner has drained a partition, every router has acked the
-/// freeze — so a later write can only come from a router serving with a
+/// freeze, so a later write can only come from a router serving with a
 /// stale table (an expired lease it hasn't noticed, a missed freeze).
 /// Accepting it would produce to Kafka past the HWM that warming
 /// snapshots, silently losing the write from the new owner's cache. After
@@ -558,7 +556,7 @@ async fn writes_fenced_after_drain_reads_still_served() {
 }
 
 /// The fence must go up before the drain starts waiting on inflight
-/// handlers — fencing only after `wait_until_empty` returns would leave a
+/// handlers; fencing only after `wait_until_empty` returns would leave a
 /// window where a write lands between the inflight count hitting zero and
 /// the DrainedAck being written, advancing the Kafka HWM past what
 /// warming will read. With an inflight write held open, new writes must
@@ -694,7 +692,7 @@ async fn release_partition_stops_serving() {
     );
     let _router = start_router(Arc::clone(&store), "router-0", cancel.clone());
 
-    // Start pod 1 — gets all partitions
+    // Start pod 1; it gets all partitions.
     let pod1 = start_leader_pod(Arc::clone(&store), "leader-0", 1 << 20, cancel.clone()).await;
 
     let check_store = Arc::clone(&store);
@@ -718,10 +716,8 @@ async fn release_partition_stops_serving() {
     })
     .await;
 
-    // Seed a person into partition 0
     seed_person(&pod1.cache, 0, test_cached_person());
 
-    // Verify get_person works on pod 1
     let mut client1 = create_leader_client(pod1.leader_addr).await;
     let response = client1
         .get_person(leader_get_request(1, 42, 0))
@@ -729,7 +725,7 @@ async fn release_partition_stops_serving() {
         .unwrap();
     assert_eq!(response.into_inner().person.unwrap().id, 42);
 
-    // Start pod 2 — triggers rebalance
+    // Start pod 2; it triggers a rebalance.
     let pod2 = start_leader_pod(Arc::clone(&store), "leader-1", 1 << 20, cancel.clone()).await;
 
     // Wait for balanced assignment and handoffs to settle
@@ -884,7 +880,7 @@ async fn rewarm_after_pod_crash() {
 #[tokio::test]
 async fn update_produces_person_state_to_kafka() {
     // The changelog must land on the exact Kafka partition the request's
-    // `x-partition` named — warming rebuilds a routing partition's cache by
+    // `x-partition` named: warming rebuilds a routing partition's cache by
     // consuming the same-numbered Kafka partition, so key-hash placement
     // (whose partitioner config could diverge from the router's murmur2)
     // is not acceptable. The key (team 1, person 2) murmur2-hashes to
@@ -965,7 +961,7 @@ async fn update_produces_person_state_to_kafka() {
     assert!(result.updated);
     assert_eq!(result.person.unwrap().version, 2);
 
-    // Consume only the routing partition — finding the message here proves
+    // Consume only the routing partition; finding the message here proves
     // the explicit-partition produce, not just delivery.
     let consumer: BaseConsumer = ClientConfig::new()
         .set("bootstrap.servers", mock_cluster.bootstrap_servers())
@@ -987,11 +983,9 @@ async fn update_produces_person_state_to_kafka() {
         .expect("no message received on the routing partition")
         .expect("kafka error");
 
-    // Verify message key
     let key = std::str::from_utf8(msg.key().unwrap()).unwrap();
     assert_eq!(key, "1:2");
 
-    // Verify payload is a valid Person proto with updated state
     let person = Person::decode(msg.payload().unwrap()).unwrap();
     assert_eq!(person.id, PERSON_ID);
     assert_eq!(person.team_id, 1);
@@ -1121,7 +1115,7 @@ async fn kafka_produce_failure_leaves_cache_unchanged() {
     // Three, not two: the failed write's version is spent. The produce
     // path cannot tell an enqueue that never left the client from a
     // delivery that timed out after the broker appended it, and
-    // idempotence is off by default — so reusing that number would put a
+    // idempotence is off by default, so reusing that number would put a
     // second record behind one that may be in the log, and the writer's
     // strict guard keeps whichever arrived first. Burning a version on a
     // write that genuinely never landed is the cheap side of that trade:
@@ -1284,7 +1278,7 @@ async fn pg_fallback_loads_person_on_cache_miss() {
     .await
     .unwrap();
 
-    // Warm the key's own partition (the cache is empty — no persons seeded)
+    // Warm the key's own partition (the cache is empty, no persons seeded).
     let partition = partition_for_person(team_id as i64, person_id, NUM_PARTITIONS);
     cache.create_partition(partition);
 
@@ -1300,7 +1294,6 @@ async fn pg_fallback_loads_person_on_cache_miss() {
     assert_eq!(person.id, person_id);
     assert_eq!(person.team_id, team_id as i64);
 
-    // Verify person is now cached
     let key = PersonCacheKey {
         team_id: team_id as i64,
         person_id,
@@ -1320,9 +1313,10 @@ async fn pg_fallback_loads_person_on_cache_miss() {
 
 /// Rows written by other services can hold numerics whose PG-expanded
 /// rendering serde_json rejects even though JSON.parse reads them fine
-/// (JS `Number.MAX_VALUE` is the canonical case — a common "unlimited"
-/// sentinel). The fallback must load such rows the way JS would — rounding
-/// representable values, clamping beyond-f64 garbage — never panic or
+/// (JS `Number.MAX_VALUE` is the canonical case, a common "unlimited"
+/// sentinel). The fallback must load such rows the way JS would
+/// (rounding representable values, clamping beyond-f64 garbage), never
+/// panic or
 /// leave the person permanently unloadable.
 #[tokio::test]
 async fn pg_fallback_reads_numerics_the_leaders_parser_rejects() {
@@ -1439,7 +1433,7 @@ async fn update_triggers_pg_fallback_then_applies_changes() {
 
     let mut client = create_leader_client(addr).await;
 
-    // Update a person not in cache — should load from PG then apply
+    // Update a person not in cache: it loads from PG, then applies.
     let response = client
         .update_person_properties(with_partition(
             UpdatePersonPropertiesRequest {
@@ -1585,7 +1579,7 @@ async fn evicted_dirty_person_recovers_from_changelog() {
 
 // ============================================================
 // Dirty-index recovery failure: when the changelog fetch cannot
-// complete, the person is unavailable — not silently stale
+// complete, the person is unavailable, not silently stale
 // ============================================================
 
 #[tokio::test]
@@ -1777,7 +1771,7 @@ async fn writes_shed_when_dirty_index_is_full() {
         .await
         .expect("first person's write is admitted");
 
-    // The same person stays admitted at capacity — updating its mark does
+    // The same person stays admitted at capacity; updating its mark does
     // not grow the index.
     client
         .update_person_properties(with_partition(update_for(person_a, "v2"), partition))
@@ -1872,7 +1866,7 @@ async fn recovery_fails_when_record_version_disagrees_with_the_mark() {
         team_id: 1,
         person_id: PERSON_ID,
     };
-    // Corrupt the mark's version while keeping the true offset — `mark`
+    // Corrupt the mark's version while keeping the true offset; `mark`
     // only replaces newer offsets, so clear the partition and re-insert.
     // The seek now lands on the right record, but its version disagrees.
     let mark = dirty_index.get(&key).unwrap();
@@ -2018,7 +2012,7 @@ async fn recovery_reuses_the_partition_consumer_across_fetches() {
     // first fetches at offset 0, the second repositions forward, and the
     // third repositions backward past a record the consumer already read.
     // A consumer that fails to reposition serves the wrong record (key
-    // mismatch) or times out — either fails the unwraps above.
+    // mismatch) or times out; either fails the unwraps above.
     evict(person_a);
     assert_eq!(recover(person_a).await, "a");
     evict(person_b);
@@ -2033,7 +2027,7 @@ async fn recovery_reuses_the_partition_consumer_across_fetches() {
 /// point. Checkout is an RAII guard, so the cancelled fetch's consumer
 /// must come home: without Drop-based return, every cancellation leaked
 /// the consumer while freeing its permit, and pool_size cancellations
-/// left permits pointing at an empty pool — a panic under the pool mutex
+/// left permits pointing at an empty pool: a panic under the pool mutex
 /// that poisoned it and disabled recovery until restart.
 #[tokio::test]
 async fn cancelled_recovery_returns_its_consumer_to_the_pool() {
@@ -2079,7 +2073,7 @@ async fn cancelled_recovery_returns_its_consumer_to_the_pool() {
     }
 
     // The pool must still function end to end: produce the sought record
-    // and the next fetch — checkout included — succeeds.
+    // and the next fetch, checkout included, succeeds.
     let person = Person {
         id: 7,
         uuid: "00000000-0000-0000-0000-000000000007".to_string(),
@@ -2117,8 +2111,8 @@ async fn cancelled_recovery_returns_its_consumer_to_the_pool() {
 // Admission-time property size enforcement, mirroring the Node
 // pipeline's policy: an update that would newly push a within-limit
 // row over the ceiling is rejected; a row already over it is
-// remediated (existing properties trimmed, the update discarded) —
-// so every acked record is applyable by the writer verbatim.
+// remediated (existing properties trimmed, the update discarded), so
+// every acked record is applyable by the writer verbatim.
 // ============================================================
 
 #[tokio::test]
@@ -2146,7 +2140,7 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
         Arc::clone(&dirty_index),
         recovery,
         PropertySizeLimits::new(655360, 524288),
-        // Burst 2 so the trim and reject below — same team, same type —
+        // Burst 2 so the trim and reject below (same team, same type)
         // both clear the throttle; the third enforcement action then
         // exercises suppression.
         WarningsProducer::with_throttle(
@@ -2185,7 +2179,7 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
     let mut client = create_leader_client(addr).await;
 
     // New violation: the seeded person is within limits and this update
-    // would push the merged state over the ceiling — rejected outright,
+    // would push the merged state over the ceiling: rejected outright,
     // nothing stored, matching the Node pipeline's
     // attempt_to_violate_limit path.
     let big = "x".repeat(400_000);
@@ -2253,7 +2247,7 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
 
     // Remediation: a row already over the ceiling (legacy rows, and rows
     // from the Node writer during dual-write) is healed on its next
-    // update — existing properties trimmed alphabetically to the target
+    // update: existing properties are trimmed alphabetically to the target
     // and the triggering update's changes discarded, matching the Node
     // pipeline's existing_record_violates_limit path. custom_a goes
     // (alphabetically first) and custom_b, which alone fits the target,
@@ -2327,8 +2321,8 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
     assert!(!read_props.as_object().unwrap().contains_key("custom_a"));
 
     // Unremediable: the stored row is over the ceiling and its protected
-    // property alone exceeds the trim target — nothing can be trimmed,
-    // so the update is rejected. (Its warning lands after the throttle
+    // property alone exceeds the trim target, so nothing can be trimmed
+    // and the update is rejected. (Its warning lands after the throttle
     // burst of 2 and is suppressed; the error is asserted directly.)
     const UNREMEDIABLE_PERSON_ID: i64 = 12;
     let unremediable_partition = partition_for_person(1, UNREMEDIABLE_PERSON_ID, NUM_PARTITIONS);
@@ -2422,8 +2416,8 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
 
     // Team 1's (team, type) budget is exhausted: another enforcement
     // action still rejects, but its warning is suppressed. A fresh
-    // team's warning still emits, and — the warnings topic being a
-    // single partition — arriving as the very next message proves the
+    // team's warning still emits, and (the warnings topic being a
+    // single partition) arriving as the very next message proves the
     // suppressed one was never produced.
     const TEAM_2_PERSON_ID: i64 = 11;
     let team2_partition = partition_for_person(2, TEAM_2_PERSON_ID, NUM_PARTITIONS);
@@ -2494,7 +2488,7 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
     // NUL bytes are sanitized at admission (`\u{0000}` → `\u{FFFD}`,
     // matching the Node pipeline): Postgres jsonb refuses NUL, so an
     // unsanitized record would be unapplyable by the writer. The stored
-    // state — response and strong read alike — carries the sanitized form.
+    // state, response and strong read alike, carries the sanitized form.
     let response = client
         .update_person_properties(with_partition(
             UpdatePersonPropertiesRequest {
@@ -2583,7 +2577,7 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
 /// A cancelled request, or a commit whose fate stayed unknown, can leave a
 /// record on the changelog that this pod never learned about. The cache
 /// still holds the version from before that write, so the next update for
-/// the same person would derive the same number again — and the writer's
+/// the same person would derive the same number again, and the writer's
 /// strict version guard keeps whichever of the two records arrived first,
 /// discarding the other. When the discarded one is the acked write, the
 /// acknowledgement was a lie.
@@ -2663,7 +2657,7 @@ async fn an_unresolved_version_is_never_reused() {
 /// Nothing constructed the service with fencing on, so its entire fenced
 /// arm was unreachable: a `panic!` at the top of it left the whole suite
 /// green. That arm decides, for every failure mode, whether the write's
-/// version is handed back for reuse — and handing back a version whose
+/// version is handed back for reuse, and handing back a version whose
 /// record may be on the changelog is the acked-write loss the floors
 /// exist to prevent.
 ///
@@ -2741,7 +2735,7 @@ async fn a_fenced_write_that_bounces_does_not_hand_its_version_back() {
     );
 
     // The bounced write never reached the broker, so its version is free
-    // to derive again — the next successful write must land exactly one
+    // to derive again: the next successful write must land exactly one
     // past the first, not two.
     fenced.acquire(0).await.expect("re-take the fence");
     let third = service
@@ -2761,10 +2755,10 @@ async fn a_fenced_write_that_bounces_does_not_hand_its_version_back() {
 /// have landed on an attempt librdkafka re-issued internally. Handing the
 /// version back would put a second record at the same number behind one
 /// that may be committed, and the writer's first-wins guard then discards
-/// whichever arrived second — which is the acked one.
+/// whichever arrived second, which is the acked one.
 ///
 /// The cached entry stays. Evicting it resolves nothing, since recovery
-/// reads the last *marked* offset — the previous write that did succeed —
+/// reads the last marked offset (the previous write that did succeed)
 /// and it would answer NOT_FOUND outright once that mark is pruned on a
 /// pod with no fallback pool configured.
 #[tokio::test]
@@ -2785,7 +2779,7 @@ async fn a_fence_with_an_unknown_outcome_keeps_both_its_version_and_its_cache_en
 
 /// Both doubt arms carry the same obligation: the record may be in the
 /// log, so the version stays spent and the cached entry stays put. They
-/// differ only in what the caller is told — an ownership bounce when the
+/// differ only in what the caller is told: an ownership bounce when the
 /// partition also moved, plain doubt when it did not.
 async fn an_unknown_outcome_keeps_its_version(
     staged: personhog_leader::fencing::FencedProduceError,
@@ -2875,7 +2869,7 @@ async fn an_unknown_outcome_keeps_its_version(
 }
 
 /// The scalar fields carry merge semantics, not assignment: identification
-/// only ever ORs true (and counts as a change on its own — an $identify
+/// only ever ORs true (and counts as a change on its own: an $identify
 /// with no property diffs must still produce a record), while last-seen
 /// only ever advances and never earns a record by itself.
 #[tokio::test]

--- a/rust/personhog-leader/tests/producer_flush.rs
+++ b/rust/personhog-leader/tests/producer_flush.rs
@@ -1,7 +1,7 @@
 //! The kafka-producer lifecycle component must complete its shutdown
-//! within its flush bound even when the broker is unreachable — a
-//! wedged queue previously held the shutdown phase until the global
-//! timeout, reporting every later phase as stuck along with it.
+//! within its flush bound even when the broker is unreachable;
+//! otherwise a wedged queue holds the shutdown phase until the global
+//! timeout and reports every later phase as stuck along with it.
 
 use std::time::{Duration, Instant};
 
@@ -51,11 +51,11 @@ async fn shutdown_flush_is_bounded_against_an_unreachable_broker() {
     );
 }
 
-/// The incident's failure mode was a stalled broker, not an absent one:
-/// the connection succeeds and requests hang. The flush must give up on
-/// its own bound there too — librdkafka's broker state differs from the
-/// unroutable case (a live socket it waits on, not a connect it
-/// retries), so the unroutable test alone does not cover it.
+/// A stalled broker, not an absent one: the connection succeeds and
+/// requests hang. The flush must give up on its own bound there too,
+/// because librdkafka's broker state differs from the unroutable case
+/// (a live socket it waits on, not a connect it retries), so the
+/// unroutable test alone does not cover it.
 #[tokio::test]
 async fn shutdown_flush_is_bounded_against_a_stalled_broker() {
     // Accept connections and never respond, holding each socket open:

--- a/rust/personhog-leader/tests/warming_integration.rs
+++ b/rust/personhog-leader/tests/warming_integration.rs
@@ -19,7 +19,7 @@ use rdkafka::producer::{DefaultProducerContext, FutureProducer, FutureRecord};
 use rdkafka::types::{RDKafkaApiKey, RDKafkaRespErr};
 use rdkafka::{Offset, TopicPartitionList};
 
-/// Build a Person proto with deterministic fields — enough that the
+/// Build a Person proto with deterministic fields: enough that the
 /// warming pipeline's decode + JSON-parse + cache-write round-trip
 /// covers every code path.
 fn make_person(team_id: i64, person_id: i64) -> Person {
@@ -68,8 +68,8 @@ async fn produce_garbage_to_partition(
     partition: i32,
 ) {
     let key = "garbage";
-    // Payload that isn't valid Person proto: a long byte string of 0xFFs
-    // — prost's varint decoder rejects these immediately.
+    // Payload that is not a valid Person proto: a long byte string of
+    // 0xFFs, which prost's varint decoder rejects immediately.
     let payload = vec![0xFFu8; 32];
     let record = FutureRecord::to(CHANGELOG_TOPIC)
         .key(key)
@@ -92,13 +92,12 @@ fn warming_config_for(
 
 /// Happy path: produce N messages to a partition, warm, assert every
 /// record landed in the cache. Also asserts FIFO ordering by relying on
-/// the cache's `put` semantics — later puts overwrite earlier ones, so
+/// the cache's `put` semantics: later puts overwrite earlier ones, so
 /// distinct `person_id`s produce distinct entries that we can count.
 #[tokio::test]
 async fn warming_populates_cache_from_kafka() {
     let (cluster, producer) = create_test_kafka().await;
 
-    // Produce 5 records to partition 0.
     for person_id in 1..=5 {
         let person = make_person(1, person_id);
         produce_person_to_partition(&producer, 0, &person).await;
@@ -156,8 +155,9 @@ async fn warming_handles_empty_partition() {
         "no records were produced, so cache must be empty"
     );
 
-    // The empty path must return its consumer to the pool, not drop it —
-    // a second empty warm reuses the same client instead of creating one.
+    // The empty path must return its consumer to the pool, not drop it:
+    // a second empty warm reuses the same client instead of creating
+    // one.
     let created_after_first = pools.warming.created_count();
     warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0)
         .await
@@ -176,7 +176,6 @@ async fn warming_handles_empty_partition() {
 async fn warming_only_populates_target_partition() {
     let (cluster, producer) = create_test_kafka().await;
 
-    // Produce one record to partition 0 and one to partition 1.
     produce_person_to_partition(&producer, 0, &make_person(1, 100)).await;
     produce_person_to_partition(&producer, 1, &make_person(1, 200)).await;
 
@@ -308,9 +307,9 @@ async fn warming_starts_from_writer_committed_offset() {
         produce_person_to_partition(&producer, 0, &person).await;
     }
 
-    // Writer "committed" through offset 5 — meaning records at offsets
-    // 0..4 are durable in PG, the records at 5..7 are still in flight
-    // and must be warmed.
+    // Writer "committed" through offset 5, meaning records at offsets
+    // 0..4 are durable in PG and the records at 5..7 are still in
+    // flight and must be warmed.
     commit_writer_offset_at(&cluster, "personhog-writer", 0, 5);
 
     let cache = PartitionedCache::new(1 << 20);
@@ -336,7 +335,7 @@ async fn warming_starts_from_writer_committed_offset() {
         );
     }
 
-    // Records 0..4 (person_ids 1..5) must NOT be in cache — they're
+    // Records 0..4 (person_ids 1..5) must NOT be in cache; they are
     // durable in PG and warming correctly skipped them.
     for person_id in 1..=5 {
         let key = PersonCacheKey {
@@ -363,7 +362,7 @@ async fn warming_fails_loudly_on_properties_json_error() {
     // and buffers something before hitting the failure.
     produce_person_to_partition(&producer, 0, &make_person(1, 1)).await;
 
-    // Person with invalid JSON in properties — proto decodes, but
+    // Person with invalid JSON in properties: proto decodes, but
     // `serde_json::from_slice` on `properties` fails.
     let bad = Person {
         id: 2,
@@ -400,8 +399,9 @@ async fn warming_fails_loudly_on_properties_json_error() {
         "atomic commit: cache must not have been touched on JSON failure"
     );
     // Marks are written per record as the range streams; a failed warm
-    // must clear them — orphaned marks for a partition this pod never
-    // serves would pin memory and mislead a later owner's bookkeeping.
+    // must clear them, because orphaned marks for a partition this pod
+    // never serves would pin memory and mislead a later owner's
+    // bookkeeping.
     assert_eq!(
         dirty_index.get(&PersonCacheKey {
             team_id: 1,
@@ -414,7 +414,7 @@ async fn warming_fails_loudly_on_properties_json_error() {
 
 /// Last-write-wins: the changelog can contain multiple updates for the
 /// same `person_id` (each update produces a new record). After warming,
-/// the cache must reflect the *latest* update — proven by checking the
+/// the cache must reflect the latest update, proven by checking the
 /// version field, which the writer increments per update.
 #[tokio::test]
 async fn warming_preserves_last_write_for_same_key() {
@@ -519,9 +519,9 @@ async fn warming_seeds_dirty_index_only_at_or_past_the_committed_offset() {
     }
 }
 
-/// Warming must seed the dirty index for every record the writer has not
-/// applied — with no committed offset at all, that is every record — so a
-/// post-warm eviction still recovers from the changelog instead of
+/// Warming must seed the dirty index for every record the writer has
+/// not applied (with no committed offset at all, that is every record),
+/// so a post-warm eviction still recovers from the changelog instead of
 /// trusting a PG row the writer never wrote.
 #[tokio::test]
 async fn warming_seeds_dirty_index_when_writer_has_no_commits() {
@@ -584,7 +584,7 @@ async fn sequential_warms_reuse_pooled_clients() {
     );
 }
 
-/// Prewarming must fill every slot with a distinct connected client —
+/// Prewarming must fill every slot with a distinct connected client;
 /// returning clients to the pool mid-loop would hand the same one back
 /// to each iteration, leaving all but one slot to be built cold on the
 /// handoff path.
@@ -688,8 +688,8 @@ async fn warming_still_fails_on_a_persistent_stop_class_error() {
 }
 
 /// The warm's memory contract: the build evicts under the partition's
-/// byte budget, so a range larger than the budget still warms — with a
-/// partial cache — while EVERY unapplied person gets a dirty mark. The
+/// byte budget, so a range larger than the budget still warms, with a
+/// partial cache, while EVERY unapplied person gets a dirty mark. The
 /// marks are what make the evictions safe: a miss on a marked person
 /// recovers from the changelog instead of trusting a stale PG row, so
 /// full mark coverage under eviction is the invariant that lets the
@@ -698,8 +698,8 @@ async fn warming_still_fails_on_a_persistent_stop_class_error() {
 async fn warming_a_range_larger_than_the_budget_marks_every_person() {
     let (cluster, producer) = create_test_kafka().await;
 
-    // Forty persons with ~4KB of properties each — far past the tiny
-    // budget below — with no writer committed offset, so every record
+    // Forty persons with ~4KB of properties each, far past the tiny
+    // budget below, with no writer committed offset, so every record
     // counts as unapplied.
     let persons = 40i64;
     for person_id in 1..=persons {


### PR DESCRIPTION
## Problem

Reading personhog-leader means reading its comments: they carry the coordination invariants (fencing, leases, drains, version floors) that the code alone cannot show. The prose had grown long and literary, so the invariants were slow to extract and easy to skip, and some comments had drifted into change history or contradicted the code beside them.

## Changes

Comment-only. No code, string, or behavior changes; every edit is inside `//`, `///`, or `//!` text in `rust/personhog-leader`.

- Rewrites the invariant-bearing comments into shorter active-voice sentences, keeping every condition and qualifier.
- Replaces every em-dash construction with a real connective, per `/writing-code-comments`.
- Deletes comments that narrated the adjacent code, restated a function name, or recorded change history ("one was tried", "the S3-era default", stale timing numbers).
- Reattaches four `fencing.rs` doc comments that carried two merged paragraphs, one of them describing a different item.
- Mechanical alongside: American spellings (favour, honoured, behaviour) and `cargo fmt` re-wraps.

## How did you test this code?

- Ran locally: `cargo fmt`, `cargo clippy -p personhog-leader --all-targets` (clean), and `cargo test -p personhog-leader --lib` (102 tests pass).
- Not run: the integration suites, because they need the local etcd/Kafka stack; their edits are comment-only and they compile under `clippy --all-targets`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session directed by the assignee: a full pass over every comment in the crate, deleting superfluous ones and compressing the rest. Skills invoked: `/writing-code-comments`, a personal ASD-STE100 (Simplified Technical English) rewrite skill, and `/writing-pr-descriptions`. Safety-invariant docs were deliberately shortened less than the rest so no condition or qualifier was lost.
