### PR TITLE
fix(desktop): show policy refusals in chat

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -2103,7 +2103,7 @@ describe("CodexAppServerAgent", () => {
     stub.emit("turn/completed", { turn: { status: "completed" } });
   });
 
-  it("finalizes the turn on a non-retried error notification", async () => {
+  it("rejects the prompt on a non-retried error notification", async () => {
     const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
     const { client } = makeFakeClient();
     const agent = new CodexAppServerAgent(client, {
@@ -2116,10 +2116,141 @@ describe("CodexAppServerAgent", () => {
       sessionId: "t",
       prompt: [{ type: "text", text: "go" }],
     } as unknown as PromptRequest);
-    // willRetry:false must resolve the turn rather than hang until stream close.
+    // willRetry:false must reject the turn rather than hang until stream close.
     stub.emit("error", { willRetry: false, error: { message: "boom" } });
 
+    await expect(done).rejects.toThrow(
+      "The agent stopped before completing this request. Please try again.",
+    );
+  });
+
+  it("renders a non-retried policy error as agent output", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "turn/start": { turn: { id: "turn_1", status: "inProgress" } },
+    });
+    const sessionUpdates: unknown[] = [];
+    const messageDelivery = new Promise<void>(() => {});
+    const client = {
+      sessionUpdate: async (notification: unknown) => {
+        sessionUpdates.push(notification);
+        await messageDelivery;
+      },
+      requestPermission: async () => ({
+        outcome: "selected" as const,
+        optionId: "allow",
+      }),
+      extNotification: async () => {},
+    } as unknown as AgentSideConnection;
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("error", {
+      willRetry: false,
+      error: {
+        message: "This content was flagged for possible cybersecurity risk.",
+        codexErrorInfo: "cyberPolicy",
+      },
+    });
+    stub.emit("turn/completed", {
+      turn: { id: "turn_1", status: "failed" },
+    });
+
     expect((await done).stopReason).toBe("refusal");
+    expect(sessionUpdates).toContainEqual({
+      sessionId: "t",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "This request was blocked because it may pose a cybersecurity risk. Revise the request and try again.",
+        },
+      },
+    });
+  });
+
+  it("renders a gateway usage policy error as agent output", async () => {
+    const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("error", {
+      willRetry: false,
+      error: {
+        message:
+          "Invalid prompt: your prompt was flagged as potentially violating our usage policy.",
+        codexErrorInfo: "other",
+      },
+    });
+
+    expect((await done).stopReason).toBe("refusal");
+    expect(sessionUpdates).toContainEqual({
+      sessionId: "t",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "This request was blocked by a safety policy. Revise the request and try again.",
+        },
+      },
+    });
+  });
+
+  it("renders a policy error after the turn already completed", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "turn/start": { turn: { id: "turn_1", status: "inProgress" } },
+    });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/completed", {
+      turn: { id: "turn_1", status: "failed" },
+    });
+    stub.emit("error", {
+      willRetry: false,
+      error: {
+        message: "This content was flagged for possible cybersecurity risk.",
+        codexErrorInfo: "cyberPolicy",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(sessionUpdates).toContainEqual({
+        sessionId: "t",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: "This request was blocked because it may pose a cybersecurity risk. Revise the request and try again.",
+          },
+        },
+      });
+    });
+    await expect(done).resolves.toMatchObject({ stopReason: "refusal" });
   });
 
   it("rejects the prompt when the fatal error is a gateway billing denial", async () => {
@@ -2205,7 +2336,7 @@ describe("CodexAppServerAgent", () => {
     expect(stub.requests.some((r) => r.method === "turn/start")).toBe(false);
   });
 
-  it("finalizes a turn once when error and turn/completed both arrive", async () => {
+  it("settles a turn once when error and turn/completed both arrive", async () => {
     const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
     const outputs: Array<Record<string, unknown>> = [];
     const { client, extNotifications } = makeFakeClient();
@@ -2234,12 +2365,14 @@ describe("CodexAppServerAgent", () => {
     stub.emit("item/completed", {
       item: { type: "agentMessage", id: "a1", text: '{"ok":true}' },
     });
-    // error + turn/completed for one turn must not double-fire turn_complete (idempotent).
+    // error + turn/completed for one turn must settle the prompt and idle signal once.
     stub.emit("error", { willRetry: false, error: { message: "boom" } });
     stub.emit("turn/completed", { turn: { status: "failed" } });
-    await done;
+    await expect(done).rejects.toThrow(
+      "The agent stopped before completing this request. Please try again.",
+    );
 
-    // Structured output is gated on a clean end_turn: a refused turn records nothing.
+    // Structured output is gated on a clean end_turn: a failed turn records nothing.
     expect(outputs).toEqual([]);
     expect(
       extNotifications.filter((n) => n.method === "_posthog/turn_complete")
@@ -3315,12 +3448,14 @@ describe("CodexAppServerAgent", () => {
       sessionId: "t",
       prompt: [{ type: "text", text: "go" }],
     } as unknown as PromptRequest);
-    // A fatal error ends the turn before item/completed; the finalize-time recovery still fires the boundary.
+    // A fatal error ends the turn before item/completed; failure recovery still fires the boundary.
     stub.emit("item/started", {
       item: { type: "contextCompaction", id: "c1" },
     });
     stub.emit("error", { willRetry: false, error: { message: "boom" } });
-    await done;
+    await expect(done).rejects.toThrow(
+      "The agent stopped before completing this request. Please try again.",
+    );
 
     expect(
       extNotifications.find((n) => n.method === "_posthog/compact_boundary")

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -2330,6 +2330,41 @@ describe("CodexAppServerAgent", () => {
     vi.useRealTimers();
   });
 
+  it("does not let an ID-less failed completion refuse a later prompt", async () => {
+    vi.useFakeTimers();
+    const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const first = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "first" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/completed", {
+      turn: { status: "failed" },
+    });
+    stub.emit("error", { willRetry: false, error: { message: "boom" } });
+    await expect(first).rejects.toThrow(
+      "The agent stopped before completing this request. Please try again.",
+    );
+
+    const second = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "second" }],
+    } as unknown as PromptRequest);
+    await vi.advanceTimersByTimeAsync(250);
+    stub.emit("turn/completed", {
+      turn: { status: "completed" },
+    });
+
+    await expect(second).resolves.toMatchObject({ stopReason: "end_turn" });
+    vi.useRealTimers();
+  });
+
   it("rejects a malformed fatal error payload", async () => {
     const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
     const { client } = makeFakeClient();

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -2228,7 +2228,7 @@ describe("CodexAppServerAgent", () => {
       prompt: [{ type: "text", text: "go" }],
     } as unknown as PromptRequest);
     stub.emit("turn/completed", {
-      turn: { id: "turn_1", status: "failed" },
+      turn: { status: "failed" },
     });
     stub.emit("error", {
       willRetry: false,
@@ -2251,6 +2251,103 @@ describe("CodexAppServerAgent", () => {
       });
     });
     await expect(done).resolves.toMatchObject({ stopReason: "refusal" });
+  });
+
+  it("ignores a policy error from a failed previous turn", async () => {
+    vi.useFakeTimers();
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "turn/start": { turn: { id: "turn_1", status: "inProgress" } },
+    });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const first = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "first" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/completed", {
+      turn: { id: "turn_1", status: "failed" },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await expect(first).resolves.toMatchObject({ stopReason: "refusal" });
+
+    const second = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "second" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/started", { turn: { id: "turn_2" } });
+    stub.emit("error", {
+      turnId: "turn_1",
+      willRetry: false,
+      error: {
+        message: "This content was flagged for possible cybersecurity risk.",
+        codexErrorInfo: "cyberPolicy",
+      },
+    });
+
+    expect(sessionUpdates).not.toContainEqual({
+      sessionId: "t",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "This request was blocked because it may pose a cybersecurity risk. Revise the request and try again.",
+        },
+      },
+    });
+    stub.emit("turn/completed", {
+      turn: { id: "turn_2", status: "completed" },
+    });
+    await expect(second).resolves.toMatchObject({ stopReason: "end_turn" });
+    vi.useRealTimers();
+  });
+
+  it("settles a failed completion when Codex omits turn/started", async () => {
+    vi.useFakeTimers();
+    const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/completed", {
+      turn: { id: "turn_1", status: "failed" },
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    await expect(done).resolves.toMatchObject({ stopReason: "refusal" });
+    vi.useRealTimers();
+  });
+
+  it("rejects a malformed fatal error payload", async () => {
+    const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("error", { willRetry: false, error: { message: {} } });
+
+    await expect(done).rejects.toThrow(
+      "The agent stopped before completing this request. Please try again.",
+    );
   });
 
   it("rejects the prompt when the fatal error is a gateway billing denial", async () => {

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1623,7 +1623,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       // Drop the late completion of an already-interrupted turn (else it cancels the follow-up).
       if (this.turns.shouldDropCompletion(turn?.id)) return;
       if (turn?.status === "failed") {
-        this.deferFailedTurnFinalization(turn?.id);
+        this.deferFailedTurnFinalization(
+          turn?.id,
+          this.turns.currentGeneration,
+        );
         return;
       }
       void this.finalizeTurn(mapTurnStopReason(turn?.status));
@@ -2028,8 +2031,12 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     void this.emitUsageBreakdown(this.usage.contextTokens());
   }
 
-  private deferFailedTurnFinalization(turnId: string | undefined): void {
+  private deferFailedTurnFinalization(
+    turnId: string | undefined,
+    generation: number,
+  ): void {
     setTimeout(() => {
+      if (generation !== this.turns.currentGeneration) return;
       if (
         turnId &&
         this.turns.activeTurnId &&

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1622,8 +1622,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       }
       // Drop the late completion of an already-interrupted turn (else it cancels the follow-up).
       if (this.turns.shouldDropCompletion(turn?.id)) return;
-      if (turn?.status === "failed" && turn.id) {
-        this.deferFailedTurnFinalization(turn.id);
+      if (turn?.status === "failed") {
+        this.deferFailedTurnFinalization(turn?.id);
         return;
       }
       void this.finalizeTurn(mapTurnStopReason(turn?.status));
@@ -1645,15 +1645,23 @@ export class CodexAppServerAgent extends BaseAcpAgent {
 
     if (method === APP_SERVER_NOTIFICATIONS.ERROR) {
       // A non-retried fatal error: resolve the turn so prompt() returns rather than hangs.
-      const { willRetry, error } = (params ?? {}) as {
+      const { willRetry, turnId, error } = (params ?? {}) as {
         willRetry?: boolean;
-        error?: { message?: string; codexErrorInfo?: string };
+        turnId?: string;
+        error?: { message?: unknown; codexErrorInfo?: unknown };
       };
       if (willRetry === false) {
+        if (turnId && turnId !== this.turns.activeTurnId) {
+          return;
+        }
         this.logger.warn("codex app-server fatal error notification", {
           params,
         });
-        const message = error?.message ?? "";
+        const message = typeof error?.message === "string" ? error.message : "";
+        const codexErrorInfo =
+          typeof error?.codexErrorInfo === "string"
+            ? error.codexErrorInfo
+            : undefined;
         // A gateway billing denial rejects the prompt so the host classifies
         // it and shows the upgrade gate. It must be a RequestError: a plain
         // Error serializes to a bare "Internal error" at the ACP boundary,
@@ -1675,7 +1683,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
           return;
         }
         let policyErrorMessage: string | null = null;
-        if (error?.codexErrorInfo === "cyberPolicy") {
+        if (codexErrorInfo === "cyberPolicy") {
           policyErrorMessage = CYBER_POLICY_ERROR_MESSAGE;
         } else if (message.toLowerCase().includes("usage policy")) {
           policyErrorMessage = POLICY_ERROR_MESSAGE;
@@ -2020,19 +2028,26 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     void this.emitUsageBreakdown(this.usage.contextTokens());
   }
 
-  private deferFailedTurnFinalization(turnId: string): void {
+  private deferFailedTurnFinalization(turnId: string | undefined): void {
     setTimeout(() => {
-      if (this.turns.activeTurnId === turnId) {
-        void this.finalizeTurn("refusal");
+      if (
+        turnId &&
+        this.turns.activeTurnId &&
+        this.turns.activeTurnId !== turnId
+      ) {
+        return;
       }
+      if (!this.turns.isPending) return;
+      this.refuseTurnWithMessage(GENERIC_FATAL_ERROR_MESSAGE);
     }, 250);
   }
 
   private refuseTurnWithMessage(message: string): void {
-    this.broadcastAgentText(message);
+    if (this.session.cancelled) return;
     this.turns.markInterrupted();
     const pending = this.turns.claim();
     if (!pending) return;
+    this.broadcastAgentText(message);
     if (this.compactionActive) {
       this.compactionActive = false;
       this.emitCompactionBoundary();

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -100,6 +100,14 @@ import { parseStructuredOutput } from "./structured-output";
 import { TurnController } from "./turn-controller";
 import { mergeUsage, UsageTracker } from "./usage-tracker";
 
+const ACP_INTERNAL_ERROR_CODE = -32603;
+const CYBER_POLICY_ERROR_MESSAGE =
+  "This request was blocked because it may pose a cybersecurity risk. Revise the request and try again.";
+const POLICY_ERROR_MESSAGE =
+  "This request was blocked by a safety policy. Revise the request and try again.";
+const GENERIC_FATAL_ERROR_MESSAGE =
+  "The agent stopped before completing this request. Please try again.";
+
 type AppServerSessionMeta = {
   // The host sends either a plain string or the Claude-style `{ append }` form.
   systemPrompt?: string | { append?: string };
@@ -1407,15 +1415,14 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   /** Emit a plain agent message (user-facing status the model didn't produce). */
   private broadcastAgentText(text: string): void {
     if (!this.sessionId) return;
-    void this.client
-      .sessionUpdate({
-        sessionId: this.sessionId,
-        update: {
-          sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text },
-        },
-      })
-      .catch(() => undefined);
+    const notification = {
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      },
+    } as unknown as Parameters<AgentSideConnection["sessionUpdate"]>[0];
+    this.emitSessionNotification(notification);
   }
 
   /** The mode's sandbox with the session's extra writable roots folded into workspaceWrite. */
@@ -1615,6 +1622,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       }
       // Drop the late completion of an already-interrupted turn (else it cancels the follow-up).
       if (this.turns.shouldDropCompletion(turn?.id)) return;
+      if (turn?.status === "failed" && turn.id) {
+        this.deferFailedTurnFinalization(turn.id);
+        return;
+      }
       void this.finalizeTurn(mapTurnStopReason(turn?.status));
     }
 
@@ -1636,7 +1647,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       // A non-retried fatal error: resolve the turn so prompt() returns rather than hangs.
       const { willRetry, error } = (params ?? {}) as {
         willRetry?: boolean;
-        error?: { message?: string };
+        error?: { message?: string; codexErrorInfo?: string };
       };
       if (willRetry === false) {
         this.logger.warn("codex app-server fatal error notification", {
@@ -1648,18 +1659,14 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         // Error serializes to a bare "Internal error" at the ACP boundary,
         // which the host reads as fatal and answers with a respawn loop.
         if (classifyGatewayLimitError(message) !== null) {
-          if (this.compactionActive) {
-            this.compactionActive = false;
-            this.emitCompactionBoundary();
-          }
-          this.turns.fail(RequestError.internalError(undefined, message));
+          void this.failTurn(RequestError.internalError(undefined, message));
           return;
         }
         if (
           message.includes("413") ||
           message.toLowerCase().includes("request body too large")
         ) {
-          this.turns.fail(
+          void this.failTurn(
             RequestError.internalError(
               undefined,
               "This conversation is too large to continue. Start a new task and carry over a text summary instead of image or tool output.",
@@ -1667,7 +1674,22 @@ export class CodexAppServerAgent extends BaseAcpAgent {
           );
           return;
         }
-        void this.finalizeTurn("refusal");
+        let policyErrorMessage: string | null = null;
+        if (error?.codexErrorInfo === "cyberPolicy") {
+          policyErrorMessage = CYBER_POLICY_ERROR_MESSAGE;
+        } else if (message.toLowerCase().includes("usage policy")) {
+          policyErrorMessage = POLICY_ERROR_MESSAGE;
+        }
+        if (policyErrorMessage) {
+          void this.refuseTurnWithMessage(policyErrorMessage);
+          return;
+        }
+        void this.failTurn(
+          new RequestError(
+            ACP_INTERNAL_ERROR_CODE,
+            GENERIC_FATAL_ERROR_MESSAGE,
+          ),
+        );
       }
     }
   }
@@ -1980,6 +2002,46 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     }
     pending.resolve({
       stopReason: reason,
+      ...(usage ? { usage } : {}),
+    });
+  }
+
+  private async failTurn(error: Error): Promise<void> {
+    this.turns.markInterrupted();
+    const pending = this.turns.claim();
+    if (!pending) return;
+    if (this.compactionActive) {
+      this.compactionActive = false;
+      this.emitCompactionBoundary();
+    }
+    const usage = this.usage.perTurnUsage();
+    pending.reject(error);
+    void this.emitTurnCompleteSignal("refusal", usage);
+    void this.emitUsageBreakdown(this.usage.contextTokens());
+  }
+
+  private deferFailedTurnFinalization(turnId: string): void {
+    setTimeout(() => {
+      if (this.turns.activeTurnId === turnId) {
+        void this.finalizeTurn("refusal");
+      }
+    }, 250);
+  }
+
+  private refuseTurnWithMessage(message: string): void {
+    this.broadcastAgentText(message);
+    this.turns.markInterrupted();
+    const pending = this.turns.claim();
+    if (!pending) return;
+    if (this.compactionActive) {
+      this.compactionActive = false;
+      this.emitCompactionBoundary();
+    }
+    const usage = this.usage.perTurnUsage();
+    void this.emitTurnCompleteSignal("refusal", usage);
+    void this.emitUsageBreakdown(this.usage.contextTokens());
+    pending.resolve({
+      stopReason: "refusal",
       ...(usage ? { usage } : {}),
     });
   }

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/turn-controller.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/turn-controller.ts
@@ -30,6 +30,10 @@ export class TurnController {
     return this.turnId;
   }
 
+  get currentGeneration(): number {
+    return this.generation;
+  }
+
   get isPending(): boolean {
     return this.pending !== undefined;
   }


### PR DESCRIPTION
## Problem

- Desktop users see an empty completed turn when the Codex gateway blocks a prompt under a safety policy.
- A local desktop reproduction showed a `cyberPolicy` error without visible assistant text.
- The Codex adapter received the error and failed completion in either order.

## Changes

Before:
<img width="2408" height="1676" alt="CleanShot 2026-08-20 at 14 47 24@2x" src="https://github.com/user-attachments/assets/a4dfa3cd-270e-467e-8eac-dae49b4abe53" />


After:
<img width="1824" height="1980" alt="CleanShot 2026-08-20 at 14 46 51@2x" src="https://github.com/user-attachments/assets/b12fc22c-c078-45d4-a373-923c5b5ae181" />


- Codex policy-blocked prompts now show a clear refusal message in the chat.
- The Codex adapter emits a protocol-supported text update before the terminal response.
- Failed turns now handle missing start events, malformed errors, and delayed errors from prior turns.

```mermaid
flowchart LR
    User[User prompt] --> Gateway[Codex gateway policy block]
    Gateway --> Completion[Failed turn completion]
    Completion --> Empty[Empty completed chat turn]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class User phYellow;
    class Gateway phRed;
    class Completion,Empty phBlue;
```

```mermaid
flowchart LR
    User[User prompt] --> Gateway[Codex gateway policy block]
    Gateway --> Message[Policy refusal text]
    Message --> Completion[Completed chat turn]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class User phYellow;
    class Gateway phRed;
    class Message,Completion phBlue;
```

- No screenshot: this Codex adapter change has no standalone visual surface.

## How did you test this code?

- Local desktop testing reproduced the empty turn before the fix.
- Adapter regressions cover policy variants, stalled delivery, completion ordering, stale errors, malformed errors, and missing start events.
- Tested locally


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This change corrects internal Codex error delivery and does not alter a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex created the change with the `posthog-desktop`, `qa-team`, and `writing-pr-descriptions` skills.
- A local reproduction showed the Codex event-order failure before the adapter tests modeled it.
- QA identified stale-turn, malformed-payload, and missing-start edge cases. The final adapter and tests address those cases.
- The committed change contains no session-derived customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*