### PR TITLE
fix(warehouse): make connecting Instagram work again

### DIFF
--- a/posthog/models/integration/oauth.py
+++ b/posthog/models/integration/oauth.py
@@ -79,13 +79,12 @@ def _raise_oauth_validation_error(kind: str, res: requests.Response) -> NoReturn
 
 
 # Instagram API with Facebook Login: the professional account is reached through the Facebook Page
-# it is linked to, so the grant needs the page permissions as well as the Instagram ones. Meta
-# replaced the legacy `instagram_*` permission names with `instagram_business_*`; the old names are
-# rejected at the OAuth dialog ("This app needs at least one supported permission").
+# it is linked to, so the grant needs the page permissions as well as the Instagram ones. These are
+# the Facebook Login permission names. The `instagram_business_*` names belong to Instagram Login, a
+# separate flow with its own authorize host, so the dialog rejects them as invalid scopes here.
 # https://developers.facebook.com/docs/instagram-platform/instagram-api-with-facebook-login
 INSTAGRAM_OAUTH_SCOPE = (
-    "instagram_business_basic instagram_business_manage_insights instagram_business_manage_comments"
-    " pages_show_list pages_read_engagement"
+    "instagram_basic instagram_manage_insights instagram_manage_comments pages_show_list pages_read_engagement"
 )
 
 

--- a/posthog/models/test/integration/test_meta.py
+++ b/posthog/models/test/integration/test_meta.py
@@ -28,9 +28,9 @@ class TestInstagramIntegrationModel(BaseTest):
         # Instagram is reached through the Facebook page it is linked to, so the page scopes
         # are as load-bearing as the Instagram ones.
         assert set(config.scope.split(" ")) == {
-            "instagram_business_basic",
-            "instagram_business_manage_insights",
-            "instagram_business_manage_comments",
+            "instagram_basic",
+            "instagram_manage_insights",
+            "instagram_manage_comments",
             "pages_show_list",
             "pages_read_engagement",
         }

--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
@@ -426,7 +426,7 @@ function IntegrationAccountFieldWithDropdown({
                         )}
                         {accountsLoaded && !accountsLoading && !accountsError && accounts.length === 0 && (
                             <p className="m-0 text-xs text-warning">
-                                No accounts to show. If you know the account ID, enter it above and save. You can also{' '}
+                                No accounts to show. If you know the {fieldLabel}, enter it above and save. You can also{' '}
                                 <ReconnectLink integrationKind={integrationKind} /> to grant access to more accounts.
                             </p>
                         )}

--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
@@ -426,8 +426,8 @@ function IntegrationAccountFieldWithDropdown({
                         )}
                         {accountsLoaded && !accountsLoading && !accountsError && accounts.length === 0 && (
                             <p className="m-0 text-xs text-warning">
-                                No accounts are accessible for this connection. Check that the connected account has the
-                                right permissions, then <ReconnectLink integrationKind={integrationKind} />.
+                                No accounts to show. If you know the account ID, enter it above and save. You can also{' '}
+                                <ReconnectLink integrationKind={integrationKind} /> to grant access to more accounts.
                             </p>
                         )}
                         {savedValueMissing && (

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/instagram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/instagram.py
@@ -626,6 +626,11 @@ def list_professional_accounts(
 
     A page with no linked professional account is skipped rather than offered as a choice that
     can never sync.
+
+    Accounts owned by a Business portfolio stay invisible here even when the page really is linked:
+    Meta omits `instagram_business_account` rather than erroring unless the token carries
+    `business_management`, which this integration deliberately does not request. Syncing such an
+    account works once its ID is known, so the account field also accepts an ID typed by hand.
     """
     client = InstagramClient(access_token=access_token, api_version=api_version, logger=logger)
     url = client.build_url("me/accounts", {"fields": PAGE_FIELDS, "limit": str(PAGE_SIZE)})

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram_source.py
@@ -96,9 +96,9 @@ class TestInstagramSource:
         # be able to tell the user which grant is missing.
         assert integration.requiredScopes is not None
         assert set(integration.requiredScopes.split(" ")) == {
-            "instagram_business_basic",
-            "instagram_business_manage_insights",
-            "instagram_business_manage_comments",
+            "instagram_basic",
+            "instagram_manage_insights",
+            "instagram_manage_comments",
             "pages_show_list",
             "pages_read_engagement",
         }


### PR DESCRIPTION
## Problem

Nobody can connect an Instagram source. Meta rejects the authorization with "Invalid Scopes" before the consent screen renders.

- The requested scope named `instagram_business_basic`, `instagram_business_manage_insights` and `instagram_business_manage_comments`.
- Those names belong to the Instagram Login flow. This integration authorizes through Facebook Login, whose permission names carry no `business_` prefix.
- The source is in alpha behind the `dwh-instagram` flag, so the break reached testers rather than customers.

A second problem sits behind the first. When the account list comes back empty, the message tells the user to check permissions and reconnect. Reconnecting cannot change the result.

## Changes

- Connecting Instagram works again. Meta grants all five permissions and the flow reaches table selection.
- The scope holds the Facebook Login names: `instagram_basic`, `instagram_manage_insights`, `instagram_manage_comments`, plus the two page scopes.
- An empty account selector now points at the input, which already accepts an account ID typed by hand.

```diff
-No accounts are accessible for this connection. Check that the connected account has the right permissions, then Reconnect.
+No accounts to show. If you know the account ID, enter it above and save. You can also Reconnect to grant access to more accounts.
```

- The comment above the scope, and a docstring on `list_professional_accounts`, record which flow owns which names. Mechanical.
- This reverts the three permission names from #84435. The Graph API version pin that PR raised in the same commit stays at v25.0.

> [!NOTE]
> An account owned by a Business portfolio stays out of the list even after this fix. Meta omits `instagram_business_account` unless the token carries `business_management`, which this integration does not request, and it omits the field rather than returning an error. The ID has to be entered by hand. `meta_ads` documents the same trade-off at `products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py`.

## How did you test this code?

- The OAuth flow ran end to end against a real Instagram professional account. `/me/permissions` returned the five permissions as `granted`, the consent screen listed exactly those five, and the source reached table selection.
- The same account then synced after its ID was entered by hand, with `business_management` revoked, which is the state a new customer starts from.
- `test_instagram_source.py`: 31 passed.
- `test_meta.py`: not completed. Its four Instagram cases error during ClickHouse setup on this machine. The same four error on `master` with this branch stashed, so the cause is local state, not this change.
- No screenshot. Reproducing the empty selector needs an account Meta hides from discovery, and the copy change is quoted above in full.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The Business portfolio case is worth a note on the Instagram source docs page. That page lives in the `posthog.com` repo, so it needs a separate PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code drove the diagnosis from a report that Instagram would not connect locally. The first hypothesis was a misconfigured Meta app. Querying Meta's permission reference ruled that out and identified the flow mismatch instead.

The empty-selector copy was the second finding, reached after the Business portfolio case cost a long detour through Business Suite settings chasing a permission problem that did not exist. Adding `business_management` was considered and rejected: it needs its own App Review, it widens consent for every customer, and `meta_ads` already declined it for the same reason. Manual entry already works, so the copy carries the fix.

Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

Graph API calls during diagnosis used a local integration token against the author's own Instagram account. No account names, IDs, or customer data appear in this diff or description.

<img width="1259" height="358" alt="image" src="https://github.com/user-attachments/assets/01adaddd-0161-468f-9516-4f7847c79867" />
