### PR TITLE
fix(data-imports): stop str+dict column fallback dropping a third mixed type

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -1236,11 +1236,14 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
             if arrow_schema:
                 arrow_schema = arrow_schema.set(field_index, arrow_schema.field(field_index).with_type(pa.string()))
 
-        # If str and dict are shared - then turn everything into a json string
+        # If str and dict are shared - then turn everything into a json string. A column can also
+        # carry a third type alongside them (e.g. an int, as with a free-form field that varies per
+        # row) — JSON-dump anything that isn't already a string rather than only dict/list, so that
+        # third type doesn't reach pa.array() unconverted and raise ArrowTypeError.
         if len(unique_types_in_column) > 1 and str in unique_types_in_column and dict in unique_types_in_column:
             json_array = pa.array(
                 [
-                    None if s is None else _json_dumps(s) if isinstance(s, dict | list) else s
+                    None if s is None else s if isinstance(s, str) else _json_dumps(s)
                     for s in _to_list_array(columnar_table_data[field_name])
                 ]
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -164,10 +164,20 @@ def test_table_from_py_list_inconsistent_types_with_none():
     )
 
 
-def test_table_from_py_list_inconsistent_types_with_str_and_dict():
-    table = table_from_py_list([{"column": "hello"}, {"column": {"field": 1}}])
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        ([{"column": "hello"}, {"column": {"field": 1}}], ["hello", '{"field":1}']),
+        # A third scalar type (e.g. int) alongside str and dict used to reach pa.array()
+        # unconverted and raise "ArrowTypeError: Expected bytes, got a 'int' object" — a free-form
+        # field that's sometimes a plain number is a real shape (e.g. an execution's JSON output).
+        ([{"column": "hello"}, {"column": {"field": 1}}, {"column": 5}], ["hello", '{"field":1}', "5"]),
+    ],
+)
+def test_table_from_py_list_inconsistent_types_with_str_and_dict(rows, expected):
+    table = table_from_py_list(rows)
 
-    assert table.equals(pa.table({"column": ["hello", '{"field":1}']}))
+    assert table.equals(pa.table({"column": expected}))
     assert table.schema.equals(
         pa.schema(
             [


### PR DESCRIPTION
## Problem

A warehouse sync crashes with `ArrowTypeError: Expected bytes, got a 'int' object` when a column mixes strings, dicts, and a plain number across rows (seen on a free-form execution field), stopping the sync instead of landing it as text. See [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a02078-4168-7ec3-a849-2fd93fe47b4d).

The row-to-Arrow conversion already has a fallback for a str+dict mix, but it only serializes dict values to JSON and leaves any other type untouched. A third type sharing the column (an int, in this case) reaches pyarrow's array builder raw, and pyarrow can't build one typed array from a mix of strings and ints.

## Changes

- `pipelines/core/arrow_utils.py`: the str+dict fallback now JSON-dumps anything that isn't already a string, not just dict/list, so a third mixed-in type gets serialized into the same text column instead of crashing the build.
- Added a regression case to the existing str+dict test covering a str/dict/int mix.

## How did you test this code?

Reproduced the crash locally against the fix commit's parent with a `table_from_py_list` call mixing string, dict, and int values in one column, confirmed it raises the same `ArrowTypeError`, then confirmed the fix converts it to a string column instead.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py` — 166 passed, including the new case.

Not run: an end-to-end sync against a live source, since this is a pure-function fix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline behavior, no documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue linked above), which showed the exception's `warehouse_sources_*` properties pointing at an AirOps `executions` full-refresh sync and a stack trace rooted in the shared pipeline's Arrow conversion, not the source connector. Used the `investigating-error-issue` skill to gather the stack trace and event properties, then read `arrow_utils.py` to trace the failing branch and reproduced it locally with a minimal `table_from_py_list` call before writing the fix. Invoked `/writing-tests` and `/writing-pr-descriptions` while preparing this PR. Searched open PRs (excluding the automation bot) for `ArrowTypeError`, the error message, `arrow_utils`, and `airops`, and checked the maintainer's own open PRs — found nothing addressing this.