### PR TITLE
feat(stamphog): hand off to ReviewHog only on self-driving runs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,10 +48,6 @@ tools/owners/** @PostHog/team-security
 # assignment and are much safer to change.
 CODEOWNERS @PostHog/team-security
 
-# PR approval agent — can auto-approve PRs, so changes need review
-products/stamphog/packages/pr-approval-agent/** @PostHog/team-security
-tools/pr-approval-agent/** @PostHog/team-security
-
 # Ingestion team owns persons migrations
 rust/persons_migrations/** @PostHog/team-ingestion
 

--- a/products/stamphog/AGENTS.md
+++ b/products/stamphog/AGENTS.md
@@ -151,6 +151,12 @@ narrow:
 - These runs bypass the review-mode and author-write-permission gates: the reviewers' toggle is
   the gate, and the App's machine user is not a collaborator (the permission lookup would always
   deny). `review_mode` keeps governing human PRs only.
+- A refused or escalated verdict hands the PR to ReviewHog (`post_verdict` adds the `reviewhog`
+  label) **only** for these runs. A human author reads their own refusal and decides what comes next.
+  A self-driving PR has no such author, and its refusal otherwise sits unread until Inbox triage.
+  In ALL mode an unconditional handoff also fires a second bot review on every PR the repo opens.
+  The condition is the derived `ReviewTrigger`, not the raw provenance flag, so it stays aligned with
+  what the reviewer prompt was told about its own invocation.
 
 ## Trust boundaries
 
@@ -195,10 +201,10 @@ tells the reviewer that every author owns the code they touched. `pr_provenance`
 is computed in the sandbox from the checkout.
 
 A pending `Migration risk` check returns WAIT rather than falling through to a refusal, because a
-refusal costs a ReviewHog handoff and a trigger-label strip over what is a race with CI. It can't
-reuse `Pipeline._only_pending_migration_check`: that method disqualifies on any failing gate other
-than the deny-list, and a migrations deny always drags the tier gate to T2-never with it, so it
-answers False for every PR it exists to catch.
+refusal costs a trigger-label strip, and a ReviewHog handoff on a self-driving PR, over what is a
+race with CI. It can't reuse `Pipeline._only_pending_migration_check`: that method disqualifies on
+any failing gate other than the deny-list, and a migrations deny always drags the tier gate to
+T2-never with it, so it answers False for every PR it exists to catch.
 
 ## Temporal specifics
 

--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -39,7 +39,13 @@ from posthog.ph_client import ph_scoped_capture
 from posthog.temporal.common.utils import asyncify
 from posthog.temporal.oauth import create_oauth_access_token_for_user
 
-from products.stamphog.backend.facade.enums import TERMINAL_STATUSES, ReviewMode, ReviewRunStatus, ReviewVerdict
+from products.stamphog.backend.facade.enums import (
+    TERMINAL_STATUSES,
+    ReviewMode,
+    ReviewRunStatus,
+    ReviewTrigger,
+    ReviewVerdict,
+)
 from products.stamphog.backend.logic.approvals import dismiss_stale_approvals_for_head
 from products.stamphog.backend.logic.audiences import resolve_audiences
 from products.stamphog.backend.logic.github_client import StamphogGitHubClient, expected_app_bot_login
@@ -812,6 +818,9 @@ def post_verdict(input: StamphogReviewInput) -> dict:
     # but both the label-strip and the ReviewHog handoff below treat a gate-blocked refusal the same
     # as an engine-refused one.
     is_refusal = parsed.verdict in (ReviewVerdict.REFUSED, ReviewVerdict.ESCALATE)
+    # Same reading the reviewer got, from the same stamp, so the handoff can't disagree with what
+    # the run was told it was.
+    trigger = trigger_for_run(output=output, review_mode=repo_config.review_mode)
 
     # Action parity: in label-triggered mode a refused/escalated verdict strips the trigger label, so
     # the author re-requests the next review by re-adding it.
@@ -842,17 +851,22 @@ def post_verdict(input: StamphogReviewInput) -> dict:
 
     # Hand a refused/escalated PR to ReviewHog only AFTER the refusal verdict wins the terminal save
     # above — running it before would trigger ReviewHog for a stale refusal that a superseding delivery
-    # then overrode (a newer run might approve the same head). Same is_refusal condition as the
-    # trigger-label strip above, in both review modes: stamphog couldn't sign off, so a deeper
-    # second-opinion review is wanted. Adding the ReviewHog trigger label fires its workflow
-    # (review-hog.yml exempts stamphog[bot] from the bot-labeler-skip that would otherwise strip it).
+    # then overrode (a newer run might approve the same head). Adding the ReviewHog trigger label fires
+    # its workflow (review-hog.yml exempts stamphog[bot] from the bot-labeler-skip that would otherwise
+    # strip it).
+    #
+    # Only self-driving runs hand off. A human PR has an author who reads the refusal and decides what
+    # to do about it, and in ALL mode the handoff would fire on PRs nobody asked stamphog to look at.
+    # A self-driving PR has no such author — the refusal sits unread until Inbox triage — so ReviewHog's
+    # deeper review is the next step rather than a second unrequested opinion.
+    #
     # This is a secondary, cross-product notification that must never jeopardize the verdict — the
     # refusal is already durably saved, so it is single-shot best-effort: catching every exception (not
     # just StamphogGitHubError) contains the client's own errors plus the GitHubRateLimitError /
     # requests.RequestException the egress layer raises on rate limits and network blips, neither a
     # subclass of StamphogGitHubError. The sticky upsert above is idempotent, so a missed handoff is a
     # missed handoff, not corruption.
-    if is_refusal:
+    if is_refusal and trigger == ReviewTrigger.SELF_DRIVING.value:
         try:
             client.add_pr_label(repo, pull_request.pr_number, STAMPHOG_REVIEWHOG_LABEL)
         except Exception:

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -1118,11 +1118,65 @@ def test_refused_verdict_strips_trigger_label_only_in_label_mode(
     else:
         assert label_removals == []
 
-    # A refused PR hands off to ReviewHog by adding its trigger label, in both review modes —
-    # stamphog couldn't sign off, so a deeper second-opinion review is wanted regardless of how the
-    # review was triggered.
+    # Neither mode hands off to ReviewHog: this PR has a human author who reads the refusal, so a
+    # second unrequested bot review is not stamphog's call to make. Only self-driving runs hand off
+    # (test_refused_verdict_hands_off_to_reviewhog_only_when_self_driving).
+    assert [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "add_label"] == []
+
+
+@pytest.mark.parametrize(
+    "review_mode,inbox_review,expect_handoff",
+    [
+        (ReviewMode.ALL, {"trigger": "inbox"}, True),
+        (ReviewMode.LABEL, {"trigger": "inbox"}, True),
+        (ReviewMode.ALL, None, False),
+        (ReviewMode.LABEL, None, False),
+    ],
+    ids=[
+        "self_driving_in_all_mode_hands_off",
+        "self_driving_in_label_mode_hands_off",
+        "human_pr_in_all_mode_does_not",
+        "human_pr_in_label_mode_does_not",
+    ],
+)
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+def test_refused_verdict_hands_off_to_reviewhog_only_when_self_driving(
+    team,
+    stamphog_chain: StamphogChain,
+    review_mode: ReviewMode,
+    inbox_review: dict | None,
+    expect_handoff: bool,
+) -> None:
+    # A self-driving PR has no author to read the refusal, so ReviewHog's deeper review is the next
+    # step; a human PR's author decides that for themselves. Inbox provenance outranks the repo's
+    # review mode both ways, which is why the mode is crossed with it here: an ALL-mode repo must
+    # still hand off its self-driving PRs, and must not hand off the human ones it reviews by default.
+    repo_config = _repo_config(team.id)
+    repo_config.review_mode = review_mode
+    repo_config.save()
+    head_sha = "sha-refused-handoff-trigger"
+    stamphog_chain.recorder.register_pr(REPO, 101, _pr_object(101, "devex-dev", head_sha))
+    pull_request = PullRequest.objects.for_team(team.id).create(
+        team_id=team.id, repo_config=repo_config, pr_number=101, author_login="devex-dev"
+    )
+    output: dict = {"reviewer_raw": _refused_engine_output()}
+    if inbox_review is not None:
+        output["inbox_review"] = inbox_review
+    run = ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id,
+        pull_request=pull_request,
+        head_sha=head_sha,
+        status=ReviewRunStatus.REVIEWING,
+        output=output,
+    )
+
+    _run_activity(post_verdict, StamphogReviewInput(review_run_id=str(run.id), team_id=team.id))
+
+    run.refresh_from_db()
+    assert run.verdict == ReviewVerdict.REFUSED
     label_adds = [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "add_label"]
-    assert label_adds == [{"kind": "add_label", "repo": REPO, "number": 101, "labels": ["reviewhog"]}]
+    expected = [{"kind": "add_label", "repo": REPO, "number": 101, "labels": ["reviewhog"]}]
+    assert label_adds == (expected if expect_handoff else [])
 
 
 @pytest.mark.parametrize(
@@ -1152,7 +1206,7 @@ def test_refused_verdict_lands_even_when_reviewhog_handoff_fails(
     # GitHubRateLimitError and a network blip raises requests.RequestException from the egress layer.
     # All four must leave the run COMPLETED + REFUSED, not FAILED. The latter two are the regression:
     # they are not subclasses of StamphogGitHubError, so only a broad catch at the call site contains
-    # them.
+    # them. The run carries inbox provenance because only a self-driving refusal reaches the handoff.
     repo_config = _repo_config(team.id)
     head_sha = "sha-refused-handoff"
     stamphog_chain.recorder.register_pr(REPO, 101, _pr_object(101, "devex-dev", head_sha))
@@ -1168,7 +1222,7 @@ def test_refused_verdict_lands_even_when_reviewhog_handoff_fails(
         pull_request=pull_request,
         head_sha=head_sha,
         status=ReviewRunStatus.REVIEWING,
-        output={"reviewer_raw": _refused_engine_output()},
+        output={"reviewer_raw": _refused_engine_output(), "inbox_review": {"trigger": "inbox"}},
     )
 
     _run_activity(post_verdict, StamphogReviewInput(review_run_id=str(run.id), team_id=team.id))
@@ -1183,7 +1237,8 @@ def test_superseded_refusal_does_not_hand_off_to_reviewhog(team, stamphog_chain:
     # The ReviewHog handoff runs AFTER the conditional terminal save, so a refusal that loses the save
     # to a supersession (a synchronize/re-review delivery landing between the head guard and the save)
     # must not trigger ReviewHog for the stale refusal — a newer run may approve the same head. The run
-    # returns skipped_superseded and the reviewhog label is never added.
+    # returns skipped_superseded and the reviewhog label is never added. The run carries inbox
+    # provenance so the supersession is what blocks the handoff, not the self-driving-only condition.
     repo_config = _repo_config(team.id)
     head_sha = "sha-refused-superseded"
     stamphog_chain.recorder.register_pr(REPO, 101, _pr_object(101, "devex-dev", head_sha))
@@ -1195,7 +1250,7 @@ def test_superseded_refusal_does_not_hand_off_to_reviewhog(team, stamphog_chain:
         pull_request=pull_request,
         head_sha=head_sha,
         status=ReviewRunStatus.REVIEWING,
-        output={"reviewer_raw": _refused_engine_output()},
+        output={"reviewer_raw": _refused_engine_output(), "inbox_review": {"trigger": "inbox"}},
     )
     # A concurrent delivery flips the run to SUPERSEDED during the sticky-comment post (before the
     # terminal save), so the conditional .exclude(status=SUPERSEDED).update(...) matches nothing and the

--- a/products/stamphog/packages/pr-approval-agent/README.md
+++ b/products/stamphog/packages/pr-approval-agent/README.md
@@ -234,7 +234,7 @@ PostHog's auth system or its billing.
 
 The **migrations** deny-list is bypassed when the `Migration risk` check on the head commit concludes `success` (all migrations classified Safe). The check is published by `analyze_migration_risk` in `ci-backend.yml` and is the same signal humans see in the PR's Checks tab. See `migration_risk.py` for how stamphog reads it.
 
-If the check hasn't reported yet when stamphog runs, the hosted runtime returns `WAIT` rather than a verdict: the deny-list only matched because the engine could not tell a safe migration from a risky one, and a refusal would hand the PR to ReviewHog and strip the trigger label over a race with CI. The label is kept and the next push reviews against the now-classified head commit.
+If the check hasn't reported yet when stamphog runs, the hosted runtime returns `WAIT` rather than a verdict: the deny-list only matched because the engine could not tell a safe migration from a risky one, and a refusal would cost a trigger-label strip, and a ReviewHog handoff on a self-driving PR, over a race with CI. The label is kept and the next push reviews against the now-classified head commit.
 
 ### Ownership
 


### PR DESCRIPTION
## Problem

When stamphog refuses or escalates a PR it adds the `reviewhog` label, which starts a second, deeper bot review. It did that for every refusal, in both review modes.

A human author who got a refusal therefore also got a review nobody asked for. In automatic mode, where stamphog looks at every PR the repo opens, that fires on all of them.

## Changes

- A refusal on a human-authored PR no longer starts a ReviewHog review. The author reads the refusal and decides what comes next.
- A refusal on a self-driving PR still hands off. There is no author to read it, and the refusal otherwise sits unread until Inbox triage, so the deeper review is the point there.
- The gate reads the derived `ReviewTrigger` rather than the raw provenance flag, so it stays aligned with the sentence the reviewer prompt gets about its own invocation.
- Docs: two places gave "a refusal costs a ReviewHog handoff" as the reason a pending migration-risk check returns `WAIT`. That now holds only for self-driving runs.

Folded in unrelated, agreed with team-security beforehand:

- team-security is no longer a required reviewer on every stamphog engine change, including docs and test edits. Both `pr-approval-agent` entries are gone from CODEOWNERS.
- One of the two matched nothing already. The engine moved out of `tools/` in #85567 and the line stayed behind.
- CODEOWNERS still owns itself, so putting either entry back stays a team-security decision.

## How did you test this code?

Automated only.

- A new parameterized case crosses review mode against inbox provenance. It catches a gate keyed on review mode alone: an automatic-mode repo must still hand off its self-driving PRs, and must not hand off the human ones it reviews by default.
- The two existing handoff tests, fault injection and supersession, now stamp inbox provenance on the run. Without it they would pass because the trigger blocked the handoff rather than because of what each test claims to prove.
- Checked that `review-hog.yml` still accepts these PRs. Its trigger job takes any author including bots, and its bot-labeler skip keys off who applied the label, with `stamphog[bot]` exempt. Without that, this change would switch the handoff off rather than narrow it.
- Ran the stamphog backend suite and the engine suite locally against this branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`AGENTS.md` and the engine README are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) under direction. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.

Built on the trigger vocabulary the layer below introduces, which is why the gate reads `ReviewTrigger` instead of `ReviewRun.output["inbox_review"]` directly. The label added in `post_verdict` is the only path from stamphog into ReviewHog, so this one condition covers the handoff completely.

Public artifact: nothing in this PR draws on material that is not already in this repository.
