### PR TITLE
chore(desktop): cover the onboarding branch matrix with stories

### DIFF
--- a/products/desktop/apps/code/.storybook/mocks/electron-trpc.ts
+++ b/products/desktop/apps/code/.storybook/mocks/electron-trpc.ts
@@ -1,8 +1,13 @@
+import { observable } from "@trpc/server/observable";
+
 (globalThis as unknown as { electronTRPC: unknown }).electronTRPC = {
   sendMessage: () => Promise.resolve(),
   onMessage: () => () => {},
 };
 
+// A terminating link that never emits. Queries stay pending, and subscriptions
+// attach instead of throwing "No more links to execute", which crashed any
+// story rendering a component that subscribes to the host (GitHubConnectPanel).
 export function ipcLink() {
-  return () => {};
+  return () => () => observable(() => () => {});
 }

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.stories.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.stories.tsx
@@ -1,0 +1,201 @@
+import type { AuthState } from "@posthog/core/auth/schemas";
+import { userGithubIntegrationKeys } from "@posthog/core/integrations/repositoryKeys";
+import type { OnboardingStep } from "@posthog/core/onboarding/steps";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useAuthStore } from "@posthog/ui/features/auth/store";
+import { authKeys } from "@posthog/ui/features/auth/useCurrentUser";
+import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useActiveRepoStore } from "@posthog/ui/shell/activeRepoStore";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { OnboardingFlow } from "./OnboardingFlow";
+
+const INSTALLATION_ID = "51234567";
+const CLOUD_REGION = "us" as const;
+
+const REPOS = [
+  "example-org/checkout-service",
+  "example-org/marketing-site",
+  "example-org/mobile-app",
+  "acme-labs/data-pipeline",
+];
+
+const ORG_PROJECTS_MAP: AuthState["orgProjectsMap"] = {
+  "org-1": {
+    orgName: "Example Org",
+    projects: [
+      { id: 1, name: "Production" },
+      { id: 2, name: "Staging" },
+    ],
+  },
+};
+
+const SOLO_ORG_PROJECTS_MAP: AuthState["orgProjectsMap"] = {
+  "org-1": {
+    orgName: "Example Org",
+    projects: [{ id: 1, name: "Production" }],
+  },
+};
+
+const IMPORT_SUMMARY = {
+  total: 21,
+  skills: { count: 9, paths: ["~/.claude/skills"] },
+  plugins: { count: 3, paths: ["~/.claude/plugins"] },
+  mcpServers: { count: 4, paths: ["~/.claude.json"] },
+  permissions: { count: 5, paths: ["~/.claude/settings.json"] },
+};
+
+const EMPTY_IMPORT_SUMMARY = {
+  total: 0,
+  skills: { count: 0, paths: [] },
+  plugins: { count: 0, paths: [] },
+  mcpServers: { count: 0, paths: [] },
+  permissions: { count: 0, paths: [] },
+};
+
+interface BranchArgs {
+  step: OnboardingStep;
+  githubConnected: boolean;
+  hasCodeAccess: boolean;
+  singleProject: boolean;
+  importableConfig: boolean;
+}
+
+function authStateFor(args: BranchArgs): AuthState {
+  return {
+    status: "authenticated",
+    bootstrapComplete: true,
+    cloudRegion: CLOUD_REGION,
+    orgProjectsMap: args.singleProject
+      ? SOLO_ORG_PROJECTS_MAP
+      : ORG_PROJECTS_MAP,
+    currentOrgId: "org-1",
+    currentProjectId: 1,
+    hasCodeAccess: args.hasCodeAccess,
+    needsScopeReauth: false,
+    sessionType: "oauth",
+    sessionExpiresAt: null,
+    sessionEndReason: null,
+  };
+}
+
+/**
+ * Seeds the stores and query cache the flow reads, so each story lands on one
+ * concrete branch of `computeActiveSteps` and `SelectRepoStep` without a host
+ * or a network. Runs during render so the first paint is already settled.
+ */
+function SeededFlow(args: BranchArgs) {
+  const queryClient = useQueryClient();
+  const trpc = useHostTRPC();
+
+  useState(() => {
+    useAuthStore.setState({ authState: authStateFor(args) });
+    useOnboardingStore.setState({
+      currentStep: args.step,
+      hasCompletedOnboarding: false,
+      selectedProjectId: 1,
+    });
+    useActiveRepoStore.setState({ path: "" });
+    useSettingsStore.setState({
+      cachedCloudRepositoryMap: args.githubConnected
+        ? Object.fromEntries(
+            REPOS.map((repo) => [
+              repo,
+              { userIntegrationId: "1", installationId: INSTALLATION_ID },
+            ]),
+          )
+        : {},
+      lastUsedCloudRepository: null,
+    });
+
+    queryClient.setQueryData(
+      userGithubIntegrationKeys.list(),
+      args.githubConnected
+        ? [
+            {
+              id: "1",
+              kind: "github",
+              installation_id: INSTALLATION_ID,
+              account: { type: "Organization", name: "example-org" },
+            },
+          ]
+        : [],
+    );
+    queryClient.setQueryData(
+      userGithubIntegrationKeys.repositories(INSTALLATION_ID),
+      { userIntegrationId: "1", installationId: INSTALLATION_ID, repos: REPOS },
+    );
+    queryClient.setQueryData(authKeys.currentUser(`${CLOUD_REGION}:1`), {
+      email: "sam@example.com",
+      first_name: "Sam",
+      organization: { id: "org-1", name: "Example Org" },
+      organizations: [{ id: "org-1", name: "Example Org", slug: "example" }],
+    });
+    queryClient.setQueryData(
+      trpc.onboardingImport.getSummary.queryOptions().queryKey,
+      args.importableConfig ? IMPORT_SUMMARY : EMPTY_IMPORT_SUMMARY,
+    );
+    queryClient.setQueryData(trpc.git.getGitStatus.queryOptions().queryKey, {
+      installed: true,
+      version: "2.43.0",
+    });
+    queryClient.setQueryData(trpc.git.getGhStatus.queryOptions().queryKey, {
+      installed: false,
+      version: null,
+      authenticated: false,
+      username: null,
+      error: null,
+    });
+  });
+
+  return <OnboardingFlow />;
+}
+
+const meta = {
+  title: "Onboarding/OnboardingFlow",
+  component: SeededFlow,
+  parameters: {
+    layout: "fullscreen",
+    testOptions: { viewport: { width: 1280, height: 860 } },
+  },
+  args: {
+    step: "welcome",
+    githubConnected: true,
+    hasCodeAccess: true,
+    singleProject: false,
+    importableConfig: true,
+  },
+} satisfies Meta<typeof SeededFlow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The featured bento card loops a video, so no two captures match.
+export const Welcome: Story = { tags: ["test-skip"] };
+
+export const ProjectSelect: Story = { args: { step: "project-select" } };
+
+export const InviteCode: Story = {
+  args: { step: "invite-code", hasCodeAccess: false },
+};
+
+export const ConnectGithubPending: Story = {
+  args: { step: "connect-github", githubConnected: false },
+};
+
+export const ConnectGithubDone: Story = { args: { step: "connect-github" } };
+
+export const InstallCli: Story = {
+  args: { step: "install-cli", githubConnected: false },
+};
+
+export const ImportConfig: Story = { args: { step: "import-config" } };
+
+export const SelectRepoFromGithub: Story = { args: { step: "select-repo" } };
+
+export const SelectRepoFromFolder: Story = {
+  args: { step: "select-repo", githubConnected: false },
+};


### PR DESCRIPTION
## Problem

Onboarding takes a different shape for every user, and there was no way to look at any of those shapes without owning the account that produces it. Whether GitHub is connected decides both how many steps a user walks and whether the repo step opens on a cloud picker or a folder picker — the change #85453 makes — and reviewing it meant reproducing the state by hand.

Storybook could not help. Any story whose tree subscribes to the host crashed into an error boundary, which covers the whole connect-github surface.

## Changes

- Storybook now renders every onboarding step in every branch it can take, so a reviewer opens a story instead of rebuilding an account.
- The connect-github step renders at all now: the stubbed `ipcLink` returned a plain no-op, so tRPC's chain found no terminating link and threw. It now returns a link whose observable never emits — queries stay pending as before, subscriptions attach and sit idle.
- Each story seeds the auth store, settings store, and query cache, then renders the real `OnboardingFlow`. `computeActiveSteps` and `SelectRepoStep` pick their own branch rather than being told which one to draw.
- `Welcome` carries `test-skip`. Its featured bento card loops a video, so no two captures match.

Stacked on [#85453](https://github.com/PostHog/posthog/pull/85453), whose props these stories exercise.

### GitHub connected: five steps, cloud repo picker

<img width="1854" alt="onboarding with github connected" src="https://raw.githubusercontent.com/PostHog/pr-assets/4888bfe42c8412f3f57f2959fb1da0b556fe2e9d/2026/08/2728791b-df98-4a23-aa7c-c4cf91b67466.png" />

### No GitHub connection: six steps, local folder picker

<img width="1854" alt="onboarding without github connected" src="https://raw.githubusercontent.com/PostHog/pr-assets/4888bfe42c8412f3f57f2959fb1da0b556fe2e9d/2026/08/dbbd2ab6-3aca-41d9-8d0c-545eae12768c.png" />

### The repo step in detail

<img width="1854" alt="repo step source switching" src="https://raw.githubusercontent.com/PostHog/pr-assets/4888bfe42c8412f3f57f2959fb1da0b556fe2e9d/2026/08/f296d2f4-5c71-477c-8370-2606ffdefe76.png" />

### Branches that do not turn on GitHub

<img width="1854" alt="invite code step and forward bounce" src="https://raw.githubusercontent.com/PostHog/pr-assets/4888bfe42c8412f3f57f2959fb1da0b556fe2e9d/2026/08/24546e9b-2a3a-48ed-ae9d-2c36af8115a6.png" />

## How did you test this code?

Ran the Storybook visual test runner over the new stories against a local Storybook: 8 stories pass, `Welcome` skipped, 16 captures written across both themes.

Drove the stories in headless Chromium to check the flow actually branches rather than just rendering:

<details>
<summary>Step sequence per branch, read off the live DOM</summary>

| Branch | Steps walked |
| --- | --- |
| GitHub connected | welcome → project-select → connect-github → import-config → select-repo |
| No GitHub | welcome → project-select → connect-github → **install-cli** → import-config → select-repo |
| One project, no importable config | welcome → connect-github → select-repo |
| No code access | welcome → project-select → **invite-code** (holds until redeemed) |

On the repo step with GitHub connected: picking a repo flips the CTA from "Skip & get started" to "Get started"; the source switch swaps the hint text and the picker, and the cloud pick survives switching away and back. Without GitHub, no source switch renders.

Landing on `install-cli` while GitHub is connected moves forward to import-config rather than resetting to welcome.
</details>

The full Storybook suite fails 13 unrelated suites both with and without the `ipcLink` change, so that change moves nothing outside the stories it fixes.

Not checked: this ran against Storybook, not a packaged Electron build, and `hogli ci:preflight` could not run here (no Python env).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by a PostHog Code agent asked to run live tests for #85453 and produce per-step, per-branch screenshots.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
- The first attempt drove the web host end to end, but that host is cloud-only, so it can never show the local-folder branch. Seeding the real flow in Storybook reaches every branch and leaves the coverage behind as stories.
- Both `ipcLink` fix attempts are worth knowing about: tRPC v11 curries links, so the stub needs `() => () => observable(...)`. One arrow short and the chain calls the observable as a function.
- All fixture data is invented — `example-org`, `acme-labs`, and `sam@example.com` are not real accounts.
