### PR TITLE
feat(replay-vision): gate observation reads on targeted experiment access

### DIFF
--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -54,6 +54,7 @@ from products.replay_vision.backend.models.replay_observation import (
 from products.replay_vision.backend.models.replay_observation_label import ReplayObservationLabel
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerType
 from products.replay_vision.backend.scanner_access import (
+    can_read_targeted_experiment,
     scanner_for_reading_observations,
     scanners_for_reading_observations,
 )
@@ -770,6 +771,11 @@ class ReplayObservationViewSet(
         self.check_object_permissions(self.request, scanner)
         if not self.user_access_control.check_access_level_for_resource("session_recording", required_level="viewer"):
             raise PermissionDenied("Reading replay observations requires session_recording read access.")
+        # An experiment scanner's observations are that experiment's exposed sessions, so reading them
+        # needs experiment access too. Not-found, not 403: a denied experiment scanner reads as if it
+        # doesn't exist, matching the serializer's targeting redaction.
+        if not can_read_targeted_experiment(self.user_access_control, self.team_id, scanner):
+            raise NotFound()
         self._scanner_for_url_cache = scanner
         return scanner
 
@@ -1075,12 +1081,16 @@ class SessionReplayObservationViewSet(ReplayObservationViewSet):
         if not self.user_access_control.check_access_level_for_resource("session_recording", required_level="viewer"):
             raise PermissionDenied("Reading replay observations requires session_recording read access.")
         # Observations inherit their scanner's RBAC. The generic access filter keys on the ReplayObservation
-        # row rather than its scanner, so scope explicitly to the scanners this caller can read.
-        readable_scanner_ids = list(
-            self.user_access_control.filter_queryset_by_access_level(
-                scanners_for_reading_observations(self.team_id)
-            ).values_list("id", flat=True)
-        )
+        # row rather than its scanner, so scope explicitly to the scanners this caller can read. Experiment
+        # scanners also need experiment access, since their observations are the experiment's exposed sessions.
+        readable_scanners = self.user_access_control.filter_queryset_by_access_level(
+            scanners_for_reading_observations(self.team_id)
+        ).only("id", "experiment_targeting")
+        readable_scanner_ids = [
+            scanner.id
+            for scanner in readable_scanners
+            if can_read_targeted_experiment(self.user_access_control, self.team_id, scanner)
+        ]
         queryset = (
             queryset.filter(team_id=self.team_id, scanner_id__in=readable_scanner_ids)
             .select_related("triggered_by_user", "label")

--- a/products/replay_vision/backend/scanner_access.py
+++ b/products/replay_vision/backend/scanner_access.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from posthog.models.team import Team
 from posthog.rbac.user_access_control import UserAccessControl
 
+from products.experiments.backend.models.experiment import Experiment
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner
 
 if TYPE_CHECKING:
@@ -37,6 +38,23 @@ def scanners_for_reading_observations(team_id: int) -> "QuerySet[ReplayScanner]"
     access-level filter on top — this widens origin, not RBAC.
     """
     return ReplayScanner.all_origins.filter(team_id=team_id)
+
+
+def can_read_targeted_experiment(access: UserAccessControl, team_id: int, scanner: ReplayScanner) -> bool:
+    """Whether the caller may read a scanner whose population is an experiment's exposed persons.
+
+    An experiment scanner's observations are that experiment's exposed sessions, so reading them
+    discloses the same protected data the exposure filter is gated on: which people and sessions
+    were exposed. Scanner and session-recording access alone don't cover that, so a caller denied
+    the experiment must not read the scanner's observations. A scanner with no experiment targeting
+    is unaffected. Mirrors the serializer's `_can_view_targeted_experiment` redaction, on the read
+    path this time.
+    """
+    targeting = scanner.experiment_targeting
+    if not targeting or targeting.get("experiment_id") is None:
+        return True
+    accessible = access.filter_queryset_by_access_level(Experiment.objects.filter(team_id=team_id))
+    return accessible.filter(id=targeting["experiment_id"]).exists()
 
 
 def scanner_for_reading_observations(team_id: int, scanner_id: "str | uuid.UUID") -> ReplayScanner | None:

--- a/products/replay_vision/backend/tests/test_access_control.py
+++ b/products/replay_vision/backend/tests/test_access_control.py
@@ -321,6 +321,37 @@ class TestReplayScannerAccessControl(_AccessControlTestCase):
         self.assertEqual(resp.status_code, 200, resp.json())
         self.assertEqual([s["name"] for s in resp.json()["results"]], ["targeted"])
 
+    def test_observations_of_a_denied_experiment_scanner_read_as_not_found(self) -> None:
+        # An experiment scanner's observations are the experiment's exposed sessions, so scanner +
+        # session_recording access is not enough to read them: a caller denied the experiment must
+        # not learn which sessions and people were exposed. Reads as not-found, not 403, matching
+        # the targeting redaction. A non-targeted scanner the same caller can read is the control.
+        experiment = create_experiment(self.team, "hidden-flag")
+        self._set_resource_default("replay_scanner", "editor")
+        self._set_resource_default("session_recording", "editor")
+        self._set_resource_default("experiment", "none")
+        self._grant_object_access(self.other_user, "experiment", str(experiment.id), "none")
+        targeted = self._create_scanner(name="targeted", experiment_targeting={"experiment_id": experiment.id})
+        plain = self._create_scanner(name="plain")
+        ReplayObservation.objects.create(scanner=targeted, session_id="exposed-sess")
+        ReplayObservation.objects.create(scanner=plain, session_id="plain-sess")
+
+        self.client.force_login(self.other_user)
+        targeted_url = self.observations_url(str(targeted.id))
+        self.assertEqual(self.client.get(targeted_url).status_code, 404)
+        self.assertEqual(self.client.get(f"{targeted_url}stats/").status_code, 404)
+
+        # Same access, non-targeted scanner: the experiment gate must not have widened to a blanket block.
+        plain_resp = self.client.get(self.observations_url(str(plain.id)))
+        self.assertEqual(plain_resp.status_code, 200, plain_resp.json())
+        self.assertEqual([o["session_id"] for o in plain_resp.json()["results"]], ["plain-sess"])
+
+        # The session-wide dock endpoint drops the exposed session but keeps the readable one.
+        dock_url = f"/api/environments/{self.team.id}/vision/observations/"
+        dock_resp = self.client.get(f"{dock_url}?session_id=exposed-sess")
+        self.assertEqual(dock_resp.status_code, 200, dock_resp.json())
+        self.assertEqual(dock_resp.json()["results"], [])
+
 
 class TestVisionActionAccessControlInheritance(_VisionActionAPITestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Problem

A person with scanner access but no access to a scanner's targeted experiment can read that scanner's observations, which are the experiment's exposed sessions.

- Sweeps run the exposure filter as the scanner's creator, so the scanner's observations cover the experiment's exposed people and sessions.
- The observation read endpoints check only scanner and session-recording access, not experiment access.
- So a scanner-viewer denied the experiment can list or open those observations and learn which sessions, distinct IDs, and subject emails were exposed, the data the experiment access check exists to protect.

Found by review bots on the base PR (#83362), which moved scanner targeting onto person-scoped exposure. The base PR gated the write and targeting-disclosure paths; this gates the read path.

> [!NOTE]
> Stacked on #83362. Both entry points stay behind `vision-entrypoint-experiments`, so nothing reaches users yet.

## Changes

- A caller denied a scanner's targeted experiment now reads that scanner's observations as not-found, matching how the targeting field is already redacted. A non-targeted scanner is unaffected.
- The session-wide replay-dock endpoint drops observations from experiment scanners the caller can't access, keeping the rest.
- One helper, `can_read_targeted_experiment`, holds the check, applied at the two chokepoints every observation read passes through (`_scanner_for_url` for per-scanner reads, the scanner-id filter for the dock).

## How did you test this code?

- Added one access-control test: a caller with scanner and session_recording editor access but denied the experiment gets 404 on the scanner's observation list and stats, while a non-targeted scanner still returns 200, and the dock endpoint returns the exposed session as empty. It fails without the gate and passes with it.
- The gate reads as not-found, so the test also pins that a denied experiment scanner can't be distinguished from a missing one.
- Backend `mypy` clean repo-wide. `ruff` clean. Access-control and observation API suites pass.
- Not run: the full Jest suite and Playwright. This change is backend-only. CI runs both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The entry points stay behind `vision-entrypoint-experiments`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude authored this, directed by Kim Dugan. It follows up #83362 on a finding two review bots raised independently: the base PR closed the write and disclosure paths for `experiment_targeting`, but observation reads, the scanner's actual output, still lacked the experiment check. Split into its own PR because it touches a different surface (observation endpoints) than the base and can be reviewed on its own. Skills invoked: /writing-tests, /improving-drf-endpoints, /stacking-prs, /writing-pr-descriptions.
