### PR TITLE
chore(signals): drop report canvas tables

### DIFF
--- a/products/canvas/backend/migrations/0016_drop_canvas_discussion_task_id.py
+++ b/products/canvas/backend/migrations/0016_drop_canvas_discussion_task_id.py
@@ -2,9 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    # Follow-up to the state-only removal in 0015. Runs after a full deploy cycle,
-    # once no code references this column. IF EXISTS keeps it idempotent under
-    # bin/migrate retries.
     dependencies = [
         ("canvas", "0015_remove_canvas_discussion_task_id"),
     ]

--- a/products/canvas/backend/migrations/0016_drop_canvas_discussion_task_id.py
+++ b/products/canvas/backend/migrations/0016_drop_canvas_discussion_task_id.py
@@ -5,8 +5,6 @@ class Migration(migrations.Migration):
     # Follow-up to the state-only removal in 0015. Runs after a full deploy cycle,
     # once no code references this column. IF EXISTS keeps it idempotent under
     # bin/migrate retries.
-    atomic = False
-
     dependencies = [
         ("canvas", "0015_remove_canvas_discussion_task_id"),
     ]

--- a/products/canvas/backend/migrations/0016_drop_canvas_discussion_task_id.py
+++ b/products/canvas/backend/migrations/0016_drop_canvas_discussion_task_id.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # Follow-up to the state-only removal in 0015. Runs after a full deploy cycle,
+    # once no code references this column. IF EXISTS keeps it idempotent under
+    # bin/migrate retries.
+    atomic = False
+
+    dependencies = [
+        ("canvas", "0015_remove_canvas_discussion_task_id"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="ALTER TABLE posthog_canvas DROP COLUMN IF EXISTS discussion_task_id;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/canvas/backend/migrations/max_migration.txt
+++ b/products/canvas/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0015_remove_canvas_discussion_task_id
+0016_drop_canvas_discussion_task_id

--- a/products/signals/backend/migrations/0101_drop_report_canvas_tables.py
+++ b/products/signals/backend/migrations/0101_drop_report_canvas_tables.py
@@ -5,8 +5,6 @@ class Migration(migrations.Migration):
     # Follow-up to the state-only removal in 0100. Runs after a full deploy cycle,
     # once no code references these tables. IF EXISTS keeps it idempotent under
     # bin/migrate retries.
-    atomic = False
-
     dependencies = [
         ("signals", "0100_remove_signalreportcanvasgeneration_report_and_more"),
     ]

--- a/products/signals/backend/migrations/0101_drop_report_canvas_tables.py
+++ b/products/signals/backend/migrations/0101_drop_report_canvas_tables.py
@@ -2,9 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    # Follow-up to the state-only removal in 0100. Runs after a full deploy cycle,
-    # once no code references these tables. IF EXISTS keeps it idempotent under
-    # bin/migrate retries.
     dependencies = [
         ("signals", "0100_remove_signalreportcanvasgeneration_report_and_more"),
     ]

--- a/products/signals/backend/migrations/0101_drop_report_canvas_tables.py
+++ b/products/signals/backend/migrations/0101_drop_report_canvas_tables.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # Follow-up to the state-only removal in 0100. Runs after a full deploy cycle,
+    # once no code references these tables. IF EXISTS keeps it idempotent under
+    # bin/migrate retries.
+    atomic = False
+
+    dependencies = [
+        ("signals", "0100_remove_signalreportcanvasgeneration_report_and_more"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS signals_signalreportcanvasgeneration;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS signals_signalreportcanvas;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/signals/backend/migrations/max_migration.txt
+++ b/products/signals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0100_remove_signalreportcanvasgeneration_report_and_more
+0101_drop_report_canvas_tables


### PR DESCRIPTION
## Problem

The report canvas revert (#86766) removes the models but keeps their tables and one canvas column in place, so a rollback within the deploy window still has its schema. Once that window closes the empty tables serve no purpose.

**Why:** completes the two-phase table drop the revert deferred.

> [!NOTE]
> Stacked on #86766. Merge this only after #86766 has been deployed for a full cycle — until then the tables must stay so a rollback keeps working.

## Changes

- Drops `signals_signalreportcanvas`, `signals_signalreportcanvasgeneration`, and `posthog_canvas.discussion_task_id`.
- Each statement uses `IF EXISTS` so `bin/migrate` retries are idempotent. The migrations stay atomic: the risk analyzer rejects `atomic = False` without a concurrent operation, and the `IF EXISTS` guards already carry the retry safety.

## How did you test this code?

- `manage.py migrate` applies both migrations cleanly on the dev stack; `makemigrations --check` reports no drift.
- Not run: the full CI matrix (draft).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by an agent. Skill invoked: /django-migrations. Split from the revert as a stacked follow-up so the schema drop lands only after the code removal has been deployed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*