### PR TITLE
fix(health-checks): import JobOwners without booting the dagster package

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -129,6 +129,7 @@ jobs:
                         - 'posthog/exceptions_capture.py'
                         - 'posthog/metrics.py'
                         - 'posthog/git.py'
+                        - 'posthog/job_owners.py'
                         - 'posthog/llm/**'
                         - 'posthog/person_db_router.py'
                         - 'posthog/persons_db.py'

--- a/posthog/dags/common/__init__.py
+++ b/posthog/dags/common/__init__.py
@@ -1,3 +1,5 @@
+from posthog.job_owners import JobOwners
+
 from .common import (
     check_for_concurrent_runs,
     chunk_ranges,
@@ -5,7 +7,6 @@ from .common import (
     settings_with_log_comment,
     skip_if_already_running,
 )
-from .owners import JobOwners
 
 __all__ = [
     "JobOwners",

--- a/posthog/dags/common/owners.py
+++ b/posthog/dags/common/owners.py
@@ -1,3 +1,0 @@
-from posthog.job_owners import JobOwners
-
-__all__ = ["JobOwners"]

--- a/posthog/dags/common/owners.py
+++ b/posthog/dags/common/owners.py
@@ -1,23 +1,3 @@
-from enum import Enum
+from posthog.job_owners import JobOwners
 
-
-class JobOwners(str, Enum):
-    TEAM_ANALYTICS_PLATFORM = "team-analytics-platform"
-    TEAM_BILLING = "team-billing"
-    TEAM_CLICKHOUSE = "team-clickhouse"
-    TEAM_DATA_MODELING = "team-data-modeling"
-    TEAM_DATA_STACK = "team-data-stack"
-    TEAM_DATA_TOOLS = "team-data-tools"
-    TEAM_ERROR_TRACKING = "team-error-tracking"
-
-    TEAM_GROWTH = "team-growth"
-    TEAM_INGESTION = "team-ingestion"
-    TEAM_LOGS = "team-logs"
-    TEAM_AI_OBSERVABILITY = "team-ai-observability"
-    TEAM_MANAGED_WAREHOUSE = "team-managed-warehouse"
-    TEAM_POSTHOG_AI = "team-posthog-ai"
-    TEAM_QUERY_PERFORMANCE = "team-query-performance"
-    TEAM_SECURITY = "team-security"
-    TEAM_SELF_DRIVING = "team-self-driving"
-    TEAM_WAREHOUSE_SOURCES = "team-warehouse-sources"
-    TEAM_WEB_ANALYTICS = "team-web-analytics"
+__all__ = ["JobOwners"]

--- a/posthog/job_owners.py
+++ b/posthog/job_owners.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+
+class JobOwners(str, Enum):
+    """Team that owns a scheduled job, used for alert routing.
+
+    Lives outside `posthog.dags` because Temporal and product code tag jobs with it too, and
+    importing anything under `posthog.dags` runs that package's Django bootstrap.
+    """
+
+    TEAM_ANALYTICS_PLATFORM = "team-analytics-platform"
+    TEAM_BILLING = "team-billing"
+    TEAM_CLICKHOUSE = "team-clickhouse"
+    TEAM_DATA_MODELING = "team-data-modeling"
+    TEAM_DATA_STACK = "team-data-stack"
+    TEAM_DATA_TOOLS = "team-data-tools"
+    TEAM_ERROR_TRACKING = "team-error-tracking"
+
+    TEAM_GROWTH = "team-growth"
+    TEAM_INGESTION = "team-ingestion"
+    TEAM_LOGS = "team-logs"
+    TEAM_AI_OBSERVABILITY = "team-ai-observability"
+    TEAM_MANAGED_WAREHOUSE = "team-managed-warehouse"
+    TEAM_POSTHOG_AI = "team-posthog-ai"
+    TEAM_QUERY_PERFORMANCE = "team-query-performance"
+    TEAM_SECURITY = "team-security"
+    TEAM_SELF_DRIVING = "team-self-driving"
+    TEAM_WAREHOUSE_SOURCES = "team-warehouse-sources"
+    TEAM_WEB_ANALYTICS = "team-web-analytics"

--- a/posthog/job_owners.py
+++ b/posthog/job_owners.py
@@ -15,7 +15,6 @@ class JobOwners(str, Enum):
     TEAM_DATA_STACK = "team-data-stack"
     TEAM_DATA_TOOLS = "team-data-tools"
     TEAM_ERROR_TRACKING = "team-error-tracking"
-
     TEAM_GROWTH = "team-growth"
     TEAM_INGESTION = "team-ingestion"
     TEAM_LOGS = "team-logs"

--- a/posthog/temporal/health_checks/framework.py
+++ b/posthog/temporal/health_checks/framework.py
@@ -7,7 +7,7 @@ from typing import Any
 from django.conf import settings
 
 from posthog.clickhouse.query_tagging import Product
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import DEFAULT_EXECUTION_POLICY, HealthExecutionPolicy
 from posthog.temporal.health_checks.models import DEFAULT_ACTIVE_SINCE_DAYS, HealthCheckResult

--- a/posthog/temporal/health_checks/tests/test_framework.py
+++ b/posthog/temporal/health_checks/tests/test_framework.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.temporal.health_checks.framework import HealthCheckRegistration
 
 

--- a/posthog/test/repo_invariants/test_dagster_package_isolation.py
+++ b/posthog/test/repo_invariants/test_dagster_package_isolation.py
@@ -9,6 +9,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 import django
 django.setup()
 import posthog.temporal.health_checks.processing
+from posthog.temporal.health_checks.registry import ensure_registry_loaded
+ensure_registry_loaded()
 import sys
 print("posthog.dags" in sys.modules)
 """

--- a/posthog/test/repo_invariants/test_dagster_package_isolation.py
+++ b/posthog/test/repo_invariants/test_dagster_package_isolation.py
@@ -1,0 +1,25 @@
+import sys
+import subprocess
+
+# A clean interpreter: pytest has already imported half the world, so this process cannot tell
+# which import pulled the package in.
+_SNAPSHOT = """
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+import django
+django.setup()
+import posthog.temporal.health_checks.processing
+import sys
+print("posthog.dags" in sys.modules)
+"""
+
+
+def test_health_check_processing_does_not_import_the_dagster_package() -> None:
+    result = subprocess.run([sys.executable, "-c", _SNAPSHOT], capture_output=True, text=True, timeout=120)
+
+    assert result.returncode == 0, f"import failed:\n{result.stderr[-2000:]}"
+    assert result.stdout.strip() == "False", (
+        "Importing the Temporal health checks pulled in posthog.dags, whose __init__ runs "
+        "django.setup(). That re-applies LOGGING, and disable_existing_loggers turns off every "
+        "logger built before it. Import shared symbols such as JobOwners from posthog.job_owners."
+    )

--- a/products/cdp/backend/temporal/health_checks/ingestion_warnings.py
+++ b/products/cdp/backend/temporal/health_checks/ingestion_warnings.py
@@ -1,6 +1,6 @@
 import structlog
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.models.ingestion_warnings.sql_v2 import DISTRIBUTED_TABLE_NAME
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY

--- a/products/data_warehouse/backend/temporal/health_checks/external_data_failure.py
+++ b/products/data_warehouse/backend/temporal/health_checks/external_data_failure.py
@@ -3,7 +3,7 @@ import datetime as dt
 from django.db.models import Q
 from django.utils import timezone
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import DEFAULT_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import AlertContent, HealthCheck, Remediation

--- a/products/data_warehouse/backend/temporal/health_checks/materialized_view_failure.py
+++ b/products/data_warehouse/backend/temporal/health_checks/materialized_view_failure.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import DEFAULT_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (

--- a/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
+++ b/products/error_tracking/backend/temporal/health_checks/missing_source_maps.py
@@ -1,5 +1,5 @@
 from posthog.clickhouse.query_tagging import Product
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import HealthExecutionPolicy
 from posthog.temporal.health_checks.framework import AlertContent, HealthCheck, Remediation

--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import structlog
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.redis import get_client
 from posthog.temporal.health_checks.detectors import HealthExecutionPolicy

--- a/products/web_analytics/backend/max_tools.py
+++ b/products/web_analytics/backend/max_tools.py
@@ -18,9 +18,9 @@ from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tags_context
-from posthog.dags.common.owners import JobOwners
 from posthog.hogql_queries.property_values_query_runner import PropertyValuesQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.job_owners import JobOwners
 from posthog.models import Team, User
 from posthog.models.health_issue import HealthIssue
 from posthog.queries.property_values import get_person_property_values_for_key

--- a/products/web_analytics/backend/temporal/health_checks/authorized_urls.py
+++ b/products/web_analytics/backend/temporal/health_checks/authorized_urls.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.models.team import Team
 from posthog.temporal.health_checks.detectors import DEFAULT_EXECUTION_POLICY

--- a/products/web_analytics/backend/temporal/health_checks/no_live_events.py
+++ b/products/web_analytics/backend/temporal/health_checks/no_live_events.py
@@ -1,5 +1,5 @@
 from posthog.clickhouse.query_tagging import Product
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (

--- a/products/web_analytics/backend/temporal/health_checks/no_pageleave_events.py
+++ b/products/web_analytics/backend/temporal/health_checks/no_pageleave_events.py
@@ -1,5 +1,5 @@
 from posthog.clickhouse.query_tagging import Product
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (

--- a/products/web_analytics/backend/temporal/health_checks/partial_proxy.py
+++ b/products/web_analytics/backend/temporal/health_checks/partial_proxy.py
@@ -1,7 +1,7 @@
 import re
 from collections import defaultdict
 
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (

--- a/products/web_analytics/backend/temporal/health_checks/path_cleaning_suggestions.py
+++ b/products/web_analytics/backend/temporal/health_checks/path_cleaning_suggestions.py
@@ -3,7 +3,7 @@ from django.conf import settings
 import structlog
 
 from posthog.clickhouse.query_tagging import Product
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models import Team
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import HealthExecutionPolicy

--- a/products/web_analytics/backend/temporal/health_checks/reverse_proxy.py
+++ b/products/web_analytics/backend/temporal/health_checks/reverse_proxy.py
@@ -1,4 +1,4 @@
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (

--- a/products/web_analytics/backend/temporal/health_checks/scroll_depth.py
+++ b/products/web_analytics/backend/temporal/health_checks/scroll_depth.py
@@ -1,4 +1,4 @@
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (

--- a/products/web_analytics/backend/temporal/health_checks/web_vitals.py
+++ b/products/web_analytics/backend/temporal/health_checks/web_vitals.py
@@ -1,4 +1,4 @@
-from posthog.dags.common.owners import JobOwners
+from posthog.job_owners import JobOwners
 from posthog.models.health_issue import HealthIssue
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (


### PR DESCRIPTION
## Problem

A Celery worker stops logging once it runs a health check. Every logger the process built before that point goes silent for the life of the worker, including `posthog.tasks.health_checks`, the module doing the work.

- `posthog/tasks/health_checks.py` imports `posthog.temporal.health_checks` at task run time, which imported `JobOwners` from `posthog/dags/common/owners.py`.
- Importing anything under `posthog/dags/` runs that package's `__init__`, which calls `django.setup()`.
- Django re-applies `LOGGING`. `disable_existing_loggers` is `True`, so every logger not named in the config is switched off.
- The import is deferred to run time on purpose, to avoid re-entering `django.setup()` during boot. That deferral is what puts the re-configuration after the worker has built its loggers.

Measured in a plain Django shell on master, with no pytest involved:

```
before: 247 loggers, 51 disabled
after:  257 loggers, 184 disabled
```

The visible symptom is two tests. `test_maximum_page_cap_stops_pagination` and `test_stops_and_warns_at_query_cap` assert on records captured by `caplog`, and see none whenever another test in the same process creates a team, because `Team.objects.create()` schedules that health check on commit. Both fail on master today and pass alone, so CI hides them by splitting the tree across shards.

The enum is a plain `str, Enum` with no Django in it. It only triggers this because of where it lives.

## Changes

- Workers keep logging after a health check runs. `JobOwners` moves to `posthog/job_owners.py`, and the 16 modules outside `posthog/dags/` import it from there, so tagging a job by owner no longer boots Django a second time.
- `posthog/dags/common/owners.py` re-exports the enum, so every Dagster module keeps its current import and all paths resolve to the same class.
- The rest is mechanical: 16 one-line import changes.

Repairing the two tests instead was the cheaper option and is rejected here. Three tests in the repo already work around this by hand, and each one removes a signal while leaving the worker behavior in place.

Nothing user-visible changes.

> [!NOTE]
> This closes the import path that fires today, not the underlying hazard. `disable_existing_loggers` stays `True`, so any other import that triggers a second `django.setup()` does the same thing. That deserves its own ticket.

## How did you test this code?

Before and after on the same master commit, `b48ca706d031`, running `sources/opencorporates`, `sources/trustpilot` and `workflow_activities/`:

| | Result |
| --- | --- |
| master | 2 failed, 304 passed |
| this branch | 306 passed |

- The full original command, `sources/` plus `workflow_activities/`, on this branch: 51358 passed.
- `posthog/temporal/health_checks/`, `posthog/test/repo_invariants/`, and the five product health check suites whose imports moved: 57 passed.
- Not run: the rest of the repo, and any suite needing services this sandbox does not have.

`posthog/test/repo_invariants/test_dagster_package_isolation.py` loads the health check registry in a clean interpreter and asserts `posthog.dags` stays out of `sys.modules`. Pointing any registered check back at the old import makes it fail. No existing test covered which packages that import chain pulls in.

<details>
<summary>Locating the cause</summary>

`sources/` alone passes all 51162 tests. Adding `workflow_activities/` fails both `caplog` tests, because pytest orders those items first and one of them creates a team. A `logging.Logger.__setattr__` hook caught the assignment inside `logging/config.py` `_handle_existing_loggers`, reached from `posthog/dags/__init__.py`.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) traced the failure and wrote the fix. Skills invoked: `/writing-pr-descriptions`, `/posthog-skill-store:dc-review-pr`.

Two approaches were rejected along the way. Guarding the `django.setup()` call in `posthog/dags/__init__.py` behind an app-registry check fixed the whole class of bug but was too broad for this PR. Repairing the two failing tests was cheaper, and the logger measurements above are what ruled it out.

The guard test first covered only the processing module, which left the 15 product health checks unprotected; it now loads the registry, and a regression in any of them fails it.

An unrelated flaky test in the same tree is split into https://github.com/PostHog/posthog/pull/86777, so neither blocks the other.
