### PR TITLE
fix(surveys): clarify MCP property targeting

### DIFF
--- a/products/surveys/mcp/tools.yaml
+++ b/products/surveys/mcp/tools.yaml
@@ -135,8 +135,8 @@ tools:
         title: Get a specific survey by ID.
         description: >
             Get a specific survey by ID. Returns its questions, targeting flag — including current property targeting
-            rules under targeting_flag.filters — and scheduling details. To change targeting, use
-            targeting_flag_filters with survey-update.
+            rules under targeting_flag.filters — and scheduling details. To change targeting, use targeting_flag_filters
+            with survey-update.
         ui_app: survey
     survey-launch:
         operation: surveys_launch
@@ -246,8 +246,8 @@ tools:
                     Update an in-app survey's person, group, or cohort property targeting. Pass rules in
                     groups[].properties[], each with key, value, operator, and an optional type. Use this instead of
                     conditions for property targeting. Complete replacement: fetch the survey first, start from
-                    targeting_flag.filters, and send the full groups list — omitted groups are removed. Do not use
-                    this for external_survey forms.
+                    targeting_flag.filters, and send the full groups list — omitted groups are removed. Do not use this
+                    for external_survey forms.
             translations:
                 description: >
                     Complete replacement survey-level translations object. Do not provide this field unless changing

--- a/products/surveys/mcp/tools.yaml
+++ b/products/surveys/mcp/tools.yaml
@@ -79,9 +79,9 @@ tools:
             conditions:
                 description: >
                     Display conditions for in-app surveys, such as URL matching, event triggers, device filters, or
-                    linked flag variants. To target people, groups, or cohorts by properties, use
-                    targeting_flag_filters instead. Do not use URL, selector, event, device, or linkedFlagVariant
-                    conditions for external_survey forms.
+                    linked flag variants. To target people, groups, or cohorts by properties, use targeting_flag_filters
+                    instead. Do not use URL, selector, event, device, or linkedFlagVariant conditions for
+                    external_survey forms.
             start_date:
                 description: >
                     Setting this launches the survey immediately. Leave unset unless the user explicitly asks to launch
@@ -93,8 +93,8 @@ tools:
             targeting_flag_filters:
                 description: >
                     Target an in-app survey to a subset of users by person, group, or cohort properties. Pass one or
-                    more rules in groups[].properties[], each with key, value, operator, and an optional type. Use
-                    this instead of conditions for property targeting. Do not use this for external_survey forms.
+                    more rules in groups[].properties[], each with key, value, operator, and an optional type. Use this
+                    instead of conditions for property targeting. Do not use this for external_survey forms.
             enable_iframe_embedding:
                 description: >
                     Allows an external_survey form to be embedded in an iframe. Use only when the user explicitly asks

--- a/products/surveys/mcp/tools.yaml
+++ b/products/surveys/mcp/tools.yaml
@@ -78,8 +78,9 @@ tools:
                     user wants structured answers. Questions can include inline translations on each question.
             conditions:
                 description: >
-                    Display and targeting conditions for in-app surveys, such as URL matching, event triggers, device
-                    filters, or linked flag variants. Do not use URL, selector, event, device, or linkedFlagVariant
+                    Display conditions for in-app surveys, such as URL matching, event triggers, device filters, or
+                    linked flag variants. To target people, groups, or cohorts by properties, use
+                    targeting_flag_filters instead. Do not use URL, selector, event, device, or linkedFlagVariant
                     conditions for external_survey forms.
             start_date:
                 description: >
@@ -91,8 +92,9 @@ tools:
                     a feature flag. Resolve the flag ID first, preferably with SQL in v2.
             targeting_flag_filters:
                 description: >
-                    User targeting rules for in-app surveys. Use only when the user wants the survey shown to a subset
-                    of users. Do not use this for external_survey forms.
+                    Target an in-app survey to a subset of users by person, group, or cohort properties. Pass one or
+                    more rules in groups[].properties[], each with key, value, operator, and an optional type. Use
+                    this instead of conditions for property targeting. Do not use this for external_survey forms.
             enable_iframe_embedding:
                 description: >
                     Allows an external_survey form to be embedded in an iframe. Use only when the user explicitly asks
@@ -132,8 +134,8 @@ tools:
         enrich_url: '{id}'
         title: Get a specific survey by ID.
         description: >
-            Get a specific survey by ID. Returns the survey configuration including questions, targeting, and scheduling
-            details.
+            Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw
+            property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.
         ui_app: survey
     survey-launch:
         operation: surveys_launch
@@ -234,9 +236,15 @@ tools:
                     question list. New questions should omit id. Do not regenerate existing questions from scratch.
             conditions:
                 description: >
-                    Complete replacement display and targeting conditions object. Do not provide this field unless
-                    changing display targeting. Preserve existing URL, selector, event, device, wait-period, and linked
-                    flag variant conditions unless explicitly changing them.
+                    Complete replacement display conditions object. Do not provide this field unless changing display
+                    targeting. Use targeting_flag_filters for person, group, or cohort property targeting. Preserve
+                    existing URL, selector, event, device, wait-period, and linked flag variant conditions unless
+                    explicitly changing them.
+            targeting_flag_filters:
+                description: >
+                    Update an in-app survey's person, group, or cohort property targeting. Pass rules in
+                    groups[].properties[], each with key, value, operator, and an optional type. Use this instead of
+                    conditions for property targeting. Do not use this for external_survey forms.
             translations:
                 description: >
                     Complete replacement survey-level translations object. Do not provide this field unless changing

--- a/products/surveys/mcp/tools.yaml
+++ b/products/surveys/mcp/tools.yaml
@@ -134,8 +134,9 @@ tools:
         enrich_url: '{id}'
         title: Get a specific survey by ID.
         description: >
-            Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw
-            property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.
+            Get a specific survey by ID. Returns its questions, targeting flag — including current property targeting
+            rules under targeting_flag.filters — and scheduling details. To change targeting, use
+            targeting_flag_filters with survey-update.
         ui_app: survey
     survey-launch:
         operation: surveys_launch
@@ -244,7 +245,9 @@ tools:
                 description: >
                     Update an in-app survey's person, group, or cohort property targeting. Pass rules in
                     groups[].properties[], each with key, value, operator, and an optional type. Use this instead of
-                    conditions for property targeting. Do not use this for external_survey forms.
+                    conditions for property targeting. Complete replacement: fetch the survey first, start from
+                    targeting_flag.filters, and send the full groups list — omitted groups are removed. Do not use
+                    this for external_survey forms.
             translations:
                 description: >
                     Complete replacement survey-level translations object. Do not provide this field unless changing

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -10147,7 +10147,7 @@
         }
     },
     "survey-get": {
-        "description": "Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.",
+        "description": "Get a specific survey by ID. Returns its questions, targeting flag — including current property targeting rules under targeting_flag.filters — and scheduling details. To change targeting, use targeting_flag_filters with survey-update.",
         "category": "Surveys",
         "feature": "surveys",
         "summary": "Get a specific survey by ID.",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -10147,7 +10147,7 @@
         }
     },
     "survey-get": {
-        "description": "Get a specific survey by ID. Returns the survey configuration including questions, targeting, and scheduling details.",
+        "description": "Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.",
         "category": "Surveys",
         "feature": "surveys",
         "summary": "Get a specific survey by ID.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -10688,7 +10688,7 @@
         }
     },
     "survey-get": {
-        "description": "Get a specific survey by ID. Returns the survey configuration including questions, targeting, and scheduling details.",
+        "description": "Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.",
         "category": "Surveys",
         "feature": "surveys",
         "summary": "Get a specific survey by ID.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -10688,7 +10688,7 @@
         }
     },
     "survey-get": {
-        "description": "Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.",
+        "description": "Get a specific survey by ID. Returns its questions, targeting flag — including current property targeting rules under targeting_flag.filters — and scheduling details. To change targeting, use targeting_flag_filters with survey-update.",
         "category": "Surveys",
         "feature": "surveys",
         "summary": "Get a specific survey by ID.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -515,7 +515,7 @@
         }
     },
     "survey-get": {
-        "description": "Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.",
+        "description": "Get a specific survey by ID. Returns its questions, targeting flag — including current property targeting rules under targeting_flag.filters — and scheduling details. To change targeting, use targeting_flag_filters with survey-update.",
         "category": "Surveys",
         "summary": "Get a specific survey by ID.",
         "required_scopes": ["survey:read"],

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -515,7 +515,7 @@
         }
     },
     "survey-get": {
-        "description": "Get a specific survey by ID. Returns the survey configuration including questions, targeting, and scheduling details.",
+        "description": "Get a specific survey by ID. Returns its questions, targeting flag reference, and scheduling details. Raw property targeting rules are not returned. Use targeting_flag_filters with survey-update to change them.",
         "category": "Surveys",
         "summary": "Get a specific survey by ID.",
         "required_scopes": ["survey:read"],

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -254,7 +254,7 @@ const SurveyUpdateSchema = SurveysPartialUpdateParams.omit({ project_id: true })
             'Complete replacement display conditions object. Do not provide this field unless changing display targeting. Use targeting_flag_filters for person, group, or cohort property targeting. Preserve existing URL, selector, event, device, wait-period, and linked flag variant conditions unless explicitly changing them.'
         ),
         targeting_flag_filters: SurveysPartialUpdateBody.shape['targeting_flag_filters'].describe(
-            "Update an in-app survey's person, group, or cohort property targeting. Pass rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Do not use this for external_survey forms."
+            "Update an in-app survey's person, group, or cohort property targeting. Pass rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Complete replacement: fetch the survey first, start from targeting_flag.filters, and send the full groups list — omitted groups are removed. Do not use this for external_survey forms."
         ),
         translations: SurveysPartialUpdateBody.shape['translations'].describe(
             'Complete replacement survey-level translations object. Do not provide this field unless changing translations. Preserve existing language keys and translated fields that should remain. Use null only when the user explicitly asks to remove survey-level translations.'

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -51,7 +51,7 @@ const SurveyCreateSchema = SurveysCreateBody.omit({
         'Complete survey question list. Prefer 1-3 questions unless the user explicitly asks for a longer survey. Use rating questions for NPS/CSAT, open for freeform feedback, and choice questions when the user wants structured answers. Questions can include inline translations on each question.'
     ),
     conditions: SurveysCreateBody.shape['conditions'].describe(
-        'Display and targeting conditions for in-app surveys, such as URL matching, event triggers, device filters, or linked flag variants. Do not use URL, selector, event, device, or linkedFlagVariant conditions for external_survey forms.'
+        'Display conditions for in-app surveys, such as URL matching, event triggers, device filters, or linked flag variants. To target people, groups, or cohorts by properties, use targeting_flag_filters instead. Do not use URL, selector, event, device, or linkedFlagVariant conditions for external_survey forms.'
     ),
     start_date: SurveysCreateBody.shape['start_date'].describe(
         'Setting this launches the survey immediately. Leave unset unless the user explicitly asks to launch now.'
@@ -60,7 +60,7 @@ const SurveyCreateSchema = SurveysCreateBody.omit({
         'Feature flag ID linked to this survey. Use only when the user explicitly wants the survey linked to a feature flag. Resolve the flag ID first, preferably with SQL in v2.'
     ),
     targeting_flag_filters: SurveysCreateBody.shape['targeting_flag_filters'].describe(
-        'User targeting rules for in-app surveys. Use only when the user wants the survey shown to a subset of users. Do not use this for external_survey forms.'
+        'Target an in-app survey to a subset of users by person, group, or cohort properties. Pass one or more rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Do not use this for external_survey forms.'
     ),
     enable_iframe_embedding: SurveysCreateBody.shape['enable_iframe_embedding'].describe(
         'Allows an external_survey form to be embedded in an iframe. Use only when the user explicitly asks for iframe embedding.'
@@ -251,7 +251,10 @@ const SurveyUpdateSchema = SurveysPartialUpdateParams.omit({ project_id: true })
             "Complete replacement question list. Existing question IDs are tied to response data and must be preserved. Before sending this field, fetch the survey first, modify the existing question objects in place, keep every unchanged or edited question's id, and include the complete intended ordered question list. New questions should omit id. Do not regenerate existing questions from scratch."
         ),
         conditions: SurveysPartialUpdateBody.shape['conditions'].describe(
-            'Complete replacement display and targeting conditions object. Do not provide this field unless changing display targeting. Preserve existing URL, selector, event, device, wait-period, and linked flag variant conditions unless explicitly changing them.'
+            'Complete replacement display conditions object. Do not provide this field unless changing display targeting. Use targeting_flag_filters for person, group, or cohort property targeting. Preserve existing URL, selector, event, device, wait-period, and linked flag variant conditions unless explicitly changing them.'
+        ),
+        targeting_flag_filters: SurveysPartialUpdateBody.shape['targeting_flag_filters'].describe(
+            "Update an in-app survey's person, group, or cohort property targeting. Pass rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Do not use this for external_survey forms."
         ),
         translations: SurveysPartialUpdateBody.shape['translations'].describe(
             'Complete replacement survey-level translations object. Do not provide this field unless changing translations. Preserve existing language keys and translated fields that should remain. Use null only when the user explicitly asks to remove survey-level translations.'

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
@@ -181,7 +181,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Display and targeting conditions for in-app surveys, such as URL matching, event triggers, device filters, or linked flag variants. Do not use URL, selector, event, device, or linkedFlagVariant conditions for external_survey forms."
+            "description": "Display conditions for in-app surveys, such as URL matching, event triggers, device filters, or linked flag variants. To target people, groups, or cohorts by properties, use targeting_flag_filters instead. Do not use URL, selector, event, device, or linkedFlagVariant conditions for external_survey forms."
         },
         "description": {
             "description": "Survey description. Internal only: unlike the name and questions, it is never delivered to visitors.",
@@ -1178,7 +1178,7 @@
                     "type": "null"
                 }
             ],
-            "description": "User targeting rules for in-app surveys. Use only when the user wants the survey shown to a subset of users. Do not use this for external_survey forms."
+            "description": "Target an in-app survey to a subset of users by person, group, or cohort properties. Pass one or more rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Do not use this for external_survey forms."
         },
         "translations": {
             "description": "Optional survey-level translations keyed by language code. Use for translated survey name, description, and thank-you message fields. Question text translations belong inside each question's translations object."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
@@ -1209,7 +1209,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Update an in-app survey's person, group, or cohort property targeting. Pass rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Do not use this for external_survey forms."
+            "description": "Update an in-app survey's person, group, or cohort property targeting. Pass rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Complete replacement: fetch the survey first, start from targeting_flag.filters, and send the full groups list — omitted groups are removed. Do not use this for external_survey forms."
         },
         "targeting_flag_id": {
             "description": "An existing targeting flag to use for this survey.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
@@ -185,7 +185,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Complete replacement display and targeting conditions object. Do not provide this field unless changing display targeting. Preserve existing URL, selector, event, device, wait-period, and linked flag variant conditions unless explicitly changing them."
+            "description": "Complete replacement display conditions object. Do not provide this field unless changing display targeting. Use targeting_flag_filters for person, group, or cohort property targeting. Preserve existing URL, selector, event, device, wait-period, and linked flag variant conditions unless explicitly changing them."
         },
         "description": {
             "description": "Survey description. Internal only: unlike the name and questions, it is never delivered to visitors.",
@@ -1209,7 +1209,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Target specific users based on their properties. Example: {groups: [{properties: [{key: 'email', value: ['@company.com'], operator: 'icontains'}], rollout_percentage: 100}]}"
+            "description": "Update an in-app survey's person, group, or cohort property targeting. Pass rules in groups[].properties[], each with key, value, operator, and an optional type. Use this instead of conditions for property targeting. Do not use this for external_survey forms."
         },
         "targeting_flag_id": {
             "description": "An existing targeting flag to use for this survey.",


### PR DESCRIPTION
## Problem

Survey MCP agents can mistake property targeting for an unsupported capability because the tool guidance does not name the input field.

## Changes

- Survey tools now identify `targeting_flag_filters.groups[].properties` for person, group, and cohort targeting.
- Survey tools now distinguish property targeting from URL, event, device, and other display conditions.
- Survey retrieval now states that it returns a targeting flag reference, not raw targeting rules.

## How did you test this code?

- Ran the survey MCP schema snapshot test.
- Ran the feature-flag filter schema test.
- Ran MCP formatting checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. The MCP tool schema is the affected documented interface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex updated the MCP guidance and generated artifacts. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`. The raw targeting filters remain write-only to preserve the survey-read data contract.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*