### PR TITLE
fix(data-imports): stop reporting transient app-db blips from the reconcile sweep

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -21,6 +21,7 @@ import structlog
 from asgiref.sync import sync_to_async
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.common.db_errors import is_transient_db_error
 
 from products.warehouse_sources.backend.temporal.data_imports.metrics import (
     LOCK_TAKEOVER_LATEST_ERROR,
@@ -240,8 +241,16 @@ class DeltaBatchConsumerAdapter:
             )
         except Exception as e:
             # Leave the job for the reconcile sweep rather than crashing the consumer.
-            logger.exception("fail_run_job_status_update_failed", job_id=batch.job_id, run_uuid=batch.run_uuid)
-            capture_exception(e)
+            if is_transient_db_error(e):
+                logger.warning(
+                    "fail_run_job_status_update_app_db_not_ready",
+                    job_id=batch.job_id,
+                    run_uuid=batch.run_uuid,
+                    error=str(e),
+                )
+            else:
+                logger.exception("fail_run_job_status_update_failed", job_id=batch.job_id, run_uuid=batch.run_uuid)
+                capture_exception(e)
 
         workflow_run_id = batch.metadata.get("workflow_run_id")
         if workflow_run_id:
@@ -383,8 +392,16 @@ class DeltaBatchConsumerAdapter:
                     error=ref.reason or "run failed (reconciled from queue)",
                 )
             except Exception as e:
-                logger.exception("reconcile_job_status_update_failed", job_id=ref.job_id, run_uuid=ref.run_uuid)
-                capture_exception(e)
+                if is_transient_db_error(e):
+                    logger.warning(
+                        "reconcile_job_status_update_app_db_not_ready",
+                        job_id=ref.job_id,
+                        run_uuid=ref.run_uuid,
+                        error=str(e),
+                    )
+                else:
+                    logger.exception("reconcile_job_status_update_failed", job_id=ref.job_id, run_uuid=ref.run_uuid)
+                    capture_exception(e)
                 reconciled = False
 
             if reconciled:
@@ -475,8 +492,16 @@ class DeltaBatchConsumerAdapter:
                     error=STRANDED_RUN_ERROR,
                 )
             except Exception as e:
-                logger.exception("stranded_run_job_status_update_failed", job_id=ref.job_id, run_uuid=ref.run_uuid)
-                capture_exception(e)
+                if is_transient_db_error(e):
+                    logger.warning(
+                        "stranded_run_job_status_update_app_db_not_ready",
+                        job_id=ref.job_id,
+                        run_uuid=ref.run_uuid,
+                        error=str(e),
+                    )
+                else:
+                    logger.exception("stranded_run_job_status_update_failed", job_id=ref.job_id, run_uuid=ref.run_uuid)
+                    capture_exception(e)
                 reconciled = False
 
             # Count only fully terminalized runs: on a failed job write the failed-run
@@ -558,8 +583,13 @@ class DeltaBatchConsumerAdapter:
             job_dead = await self._is_job_dead(batch)
         except Exception as e:
             # Fail open: an app-DB hiccup must never wedge the loader.
-            logger.exception("job_status_check_failed", batch_id=batch.id, job_id=batch.job_id)
-            capture_exception(e)
+            if is_transient_db_error(e):
+                logger.warning(
+                    "job_status_check_app_db_not_ready", batch_id=batch.id, job_id=batch.job_id, error=str(e)
+                )
+            else:
+                logger.exception("job_status_check_failed", batch_id=batch.id, job_id=batch.job_id)
+                capture_exception(e)
             return True
 
         if not job_dead:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from django.db import OperationalError as DjangoOperationalError
+
 import psycopg
 import structlog
 
@@ -21,6 +23,9 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _is_server_not_ready_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.health import HealthState
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue import (
+    consumer as consumer_module,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer import (
     BatchConsumer,
     ConsumerConfig,
@@ -32,6 +37,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     FRESHNESS_WINDOW_SECONDS,
     FailedRunRef,
     PendingBatch,
+    StrandedRunRef,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.metrics import (
     CLAIMABLE_BATCHES,
@@ -1370,6 +1376,31 @@ class TestFailRun:
 
         mock_status.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_does_not_report_app_db_not_ready_error(self):
+        # Same self-healing app-DB refusal as TestReconcileFailedRuns, but hit while
+        # fail_run marks the job Failed directly rather than via the reconcile sweep.
+        consumer = _make_consumer()
+        batch = _make_batch()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.fail_run",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer._update_job_status_to_failed",
+                side_effect=DjangoOperationalError(
+                    "server login has been failing, cached error: the database system is in "
+                    "recovery mode (server_login_retry)"
+                ),
+            ),
+            patch(f"{consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            await consumer._fail_run(batch, reason="boom", conn=consumer._poll_conn)
+
+        mock_capture.assert_not_called()
+
 
 class TestUpdateJobStatusToFailed:
     def test_swallows_does_not_exist_when_job_deleted_mid_sync(self):
@@ -1482,6 +1513,35 @@ class TestShouldProcessBatch:
 
         assert result is True
         mock_queue_fail.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_status_check_does_not_report_app_db_not_ready_error(self):
+        # Same fail-open behavior as above, but for the self-healing app-DB refusal this
+        # was reported against: it must still fail open without paging error tracking,
+        # since the app DB accepts connections again within seconds.
+        consumer = _make_consumer()
+        conn = consumer._poll_conn
+        assert conn is not None
+        batch = _make_batch()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer._get_job_status_and_error",
+                side_effect=DjangoOperationalError(
+                    "server login has been failing, cached error: the database system is in "
+                    "recovery mode (server_login_retry)"
+                ),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.fail_run",
+                new_callable=AsyncMock,
+            ),
+            patch(f"{consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            result = await consumer._adapter.should_process_batch(conn, batch=batch)
+
+        assert result is True
+        mock_capture.assert_not_called()
 
 
 class TestDeadJobSkip:
@@ -1810,6 +1870,108 @@ class TestReconcileFailedRuns:
             await consumer._reconcile_failed_runs()
 
         assert mock_mark.call_count == 2  # error on the first ref does not abort the sweep
+
+    @pytest.mark.asyncio
+    async def test_does_not_report_app_db_not_ready_error(self):
+        # Reproduces the reported issue: the app DB (read via the Django ORM, not the queue
+        # DB) briefly refuses connections during a failover while the reconcile sweep is
+        # marking a job Failed. This self-heals within seconds and the sweep already retries
+        # every interval, so it must not be sent to error tracking.
+        consumer = _make_consumer()
+        ref = _make_failed_run_ref()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_oldest_unclaimed_batch_age_seconds",
+                new_callable=AsyncMock,
+                return_value=0.0,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_claimable_batch_count",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_failed_runs",
+                new_callable=AsyncMock,
+                return_value=[ref],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_stranded_runs",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.mark_job_failed_if_not_terminal",
+                side_effect=DjangoOperationalError(
+                    "server login has been failing, cached error: the database system is in "
+                    "recovery mode (server_login_retry)"
+                ),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.release_v3_pipeline_lock",
+            ),
+            patch(f"{consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            await consumer._reconcile_failed_runs()
+
+        mock_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stranded_run_sweep_does_not_report_app_db_not_ready_error(self):
+        # Same self-healing app-DB refusal, but hit by the stranded-run sweep the reconcile
+        # sweep runs after the main failed-runs pass, on the same mark_job_failed_if_not_terminal seam.
+        consumer = _make_consumer()
+        ref = StrandedRunRef(
+            run_uuid="run-1",
+            job_id="job-1",
+            team_id=1,
+            schema_id="schema-1",
+            workflow_run_id="wf-1",
+            non_terminal_batches=2,
+        )
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_oldest_unclaimed_batch_age_seconds",
+                new_callable=AsyncMock,
+                return_value=0.0,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_claimable_batch_count",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_failed_runs",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_stranded_runs",
+                new_callable=AsyncMock,
+                return_value=[ref],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.fail_run",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.mark_job_failed_if_not_terminal",
+                side_effect=DjangoOperationalError(
+                    "server login has been failing, cached error: the database system is in "
+                    "recovery mode (server_login_retry)"
+                ),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.release_v3_pipeline_lock",
+            ),
+            patch(f"{consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            await consumer._reconcile_failed_runs()
+
+        mock_capture.assert_not_called()
 
 
 class TestConnectionRecovery:


### PR DESCRIPTION
## Problem

The warehouse import reconcile sweep pages error tracking every time PostHog's own application database briefly fails over, even though the sweep already retries on its own schedule and nothing is actually broken.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0209b-3437-7ab2-ac18-5fa9d096e493): `OperationalError: server login has been failing, cached error: the database system is in recovery mode (server_login_retry)`, raised from `_get_job_status_and_error` via the Django ORM.
- That call reads/writes PostHog's own app DB to check or update an `ExternalDataJob`'s status, not a customer's source or destination.
- A sibling classifier already exists for this exact failure shape on the queue-DB connection (`_is_server_not_ready_error` in `batch_consumer.py`), but it only matches `psycopg.OperationalError`. Django re-raises the same failure as `django.db.utils.OperationalError`, so the app-DB path fell through to `capture_exception` on every occurrence.

## Changes

- Route the four app-DB call sites in `postgres_queue/consumer.py` through `is_transient_db_error` (`posthog/temporal/common/db_errors.py`), the classifier already used elsewhere in the codebase for this same failure class on the Django ORM path.
- A self-healing app-DB blip now logs a warning instead of creating an error-tracking event, in `fail_run`, the reconcile sweep, the stranded-run sweep, and the fail-open job-status check.
- Retry behavior, retry policy, and the existing fail-open contract are unchanged — only which failures reach error tracking.
- Mechanical: import cleanup for the new dependency.

## How did you test this code?

- Added regression tests reproducing the reported failure at each of the four call sites, asserting `capture_exception` is not called for the transient message while the existing fail-open/retry/reconcile behavior is preserved.
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py` — 127 passed.
- `pytest posthog/temporal/common/test_db_errors.py` — 13 passed (shared classifier unaffected).
- `mypy` on the changed file passed; the full-repo run did not finish in this sandbox before the session ended, so CI's run is the authoritative check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal error-classification change with no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered error tracking issue.
- Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.
- Considered adding a new bespoke classifier scoped to this file, then found `posthog/temporal/common/db_errors.py`'s `is_transient_db_error` already covers the exact reported message and is SQLSTATE-aware — reused it instead of duplicating substrings.
- Searched for duplicate open PRs; found only #83890, which fixes the same class of noise in an unrelated Temporal activity path (`compute_table_statistics.py`) rather than this reconcile sweep.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*