### PR TITLE
fix(dashboards): capture standard tile density

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -382,6 +382,26 @@ describe('dashboardLogic', () => {
             }
         })
 
+        it('reports the tile density when reset to standard', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            const reportTileDensityConfigured = jest.spyOn(
+                eventUsageLogic.actions,
+                'reportDashboardTileDensityConfigured'
+            )
+            jest.useFakeTimers()
+
+            try {
+                logic.actions.saveDashboardTileSpacing('standard')
+
+                await jest.advanceTimersByTimeAsync(750)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(reportTileDensityConfigured).toHaveBeenCalledWith('standard')
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
         it('previews layout compaction immediately and persists only the final choice', async () => {
             await expectLogic(logic).toFinishAllListeners()
             ;(api.update as jest.Mock).mockClear()

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -382,26 +382,6 @@ describe('dashboardLogic', () => {
             }
         })
 
-        it('does not report the default tile density', async () => {
-            await expectLogic(logic).toFinishAllListeners()
-            const reportTileDensityConfigured = jest.spyOn(
-                eventUsageLogic.actions,
-                'reportDashboardTileDensityConfigured'
-            )
-            jest.useFakeTimers()
-
-            try {
-                logic.actions.saveDashboardTileSpacing('standard')
-
-                await jest.advanceTimersByTimeAsync(750)
-                await expectLogic(logic).toFinishAllListeners()
-
-                expect(reportTileDensityConfigured).not.toHaveBeenCalled()
-            } finally {
-                jest.useRealTimers()
-            }
-        })
-
         it('previews layout compaction immediately and persists only the final choice', async () => {
             await expectLogic(logic).toFinishAllListeners()
             ;(api.update as jest.Mock).mockClear()

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -3749,9 +3749,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     }
                 )
                 dashboardsModel.actions.updateDashboardSuccess(getQueryBasedDashboard(dashboard))
-                if (tileSpacing !== 'standard') {
-                    eventUsageLogic.actions.reportDashboardTileDensityConfigured(tileSpacing)
-                }
+                eventUsageLogic.actions.reportDashboardTileDensityConfigured(tileSpacing)
             } catch {
                 if (!cache.pendingDashboardTileSpacing) {
                     actions.setDashboardTileSpacing(persistedTileSpacing)


### PR DESCRIPTION
## Problem

- Dashboard users who reset tile density to standard do not appear in density analysis.

## Changes

- Dashboard resets now capture `tile_density: "standard"`.
- The change adds telemetry only. It does not change the dashboard interface.

```mermaid
flowchart LR
    A[Standard selection] --> B[No density event]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phYellow;
    class B phRed;
```

```mermaid
flowchart LR
    A[Standard selection] --> B[Density event]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A phYellow;
    class B phBlue;
```

## How did you test this code?

- Ran the focused dashboard logic suite.
- No new test was added. The prior test asserted the removed behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This change affects internal telemetry only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Skills: `/querying-posthog-data`, `/writing-clickhouse-queries`, `/writing-tests`, and `/writing-pr-descriptions`.
- The dashboard analysis revealed that standard resets were absent from the captured event stream.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*