### PR TITLE
fix(google_sheets): handle unparseable header range on empty worksheets

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -356,7 +356,16 @@ def google_sheets_source(
 
     worksheet = _get_worksheet(config.spreadsheet_url, worksheet_id, api_version)
 
-    headers = _retry_on_transient_api_error(lambda: worksheet.get_all_values("1:1"))  # Get the first row
+    try:
+        headers = _retry_on_transient_api_error(lambda: worksheet.get_all_values("1:1"))  # Get the first row
+    except gspread.exceptions.APIError as e:
+        # Same deterministic 400 handled in `get_schema_incremental_fields` above (e.g. empty
+        # sheets, or sheets resized to have no columns) — treat it as a worksheet with no header
+        # row rather than failing the sync.
+        if e.code == 400 and "Unable to parse range" in str(e):
+            headers = []
+        else:
+            raise
     if len(headers) > 0:
         _assert_unique_normalized_column_names(headers[0])
     primary_keys = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -675,6 +675,38 @@ def test_get_schema_incremental_fields_skips_unparseable_range():
         assert get_schema_incremental_fields(config, "csm_followups") == []
 
 
+def test_google_sheets_source_skips_unparseable_header_range():
+    """Google rejects the unbounded "1:1" header-row range with the same deterministic 400 'Unable
+    to parse range' handled in `get_schema_incremental_fields` above (e.g. an empty sheet, or a
+    sheet resized to have no columns). The sync must treat this as a worksheet with no header row
+    instead of failing outright."""
+    config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+
+    mock_worksheet = mock.MagicMock()
+    mock_worksheet.get_all_values.side_effect = _api_error(
+        400, "Unable to parse range: 'empty_sheet'!1:1", "INVALID_ARGUMENT"
+    )
+    mock_worksheet.get.return_value = [[]]
+
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets.get_schemas",
+            return_value=[("empty_sheet", 123)],
+        ),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets._get_worksheet",
+            return_value=mock_worksheet,
+        ),
+    ):
+        response = google_sheets_source(
+            config, "empty_sheet", db_incremental_field_last_value=None, api_version=GOOGLE_SHEETS_API_VERSION_V4
+        )
+        tables = list(cast(Iterable[Any], response.items()))
+
+    assert response.primary_keys is None
+    assert tables[0].num_rows == 0
+
+
 def test_get_schema_incremental_fields_reraises_other_api_errors():
     """Only the deterministic 'Unable to parse range' 400 is swallowed. Transient 5xx errors are
     retried with backoff and, once retries are exhausted, must still propagate so Temporal can retry


### PR DESCRIPTION
## Problem

Importing a Google Sheet with an empty (or zero-column) worksheet crashes
the whole sync, surfaced in error tracking as `APIError: [400]: Unable to
parse range: '<sheet title>'!1:1`.

Google returns this same 400 for `get_schema_incremental_fields`'s own
probe read, and that code path already treats it as expected (no columns
to detect an incremental field on). The header-row read in
`google_sheets_source` hits the identical 400 but was never given the same
handling, so it fails outright instead of degrading gracefully.

## Changes

- `google_sheets_source` now catches the deterministic "Unable to parse
  range" 400 on the header-row read and treats the worksheet as having no
  header row, matching the existing handling in
  `get_schema_incremental_fields`. Other API errors still propagate
  unchanged.

## How did you test this code?

Added `test_google_sheets_source_skips_unparseable_header_range`, which
mocks the header read to raise the 400 and asserts the sync completes with
an empty result instead of raising — the regression this PR fixes.

Ran the full `google_sheets` test suite locally (88 passed) and `mypy` on
the changed module (clean). Did not check against a live Google Sheets
API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue `01a020dd-c0d5-7da1-8607-ae4d22726931`),
which pointed at `google_sheets.py:359`. Read the stack trace, the source
module, and the existing `get_schema_incremental_fields` handling for the
same error class to confirm this was a gap rather than a new bug shape.
Confirmed no duplicate open PR addresses this (`gh pr list --search`, and
the maintainer's own open PRs). Skills invoked: `/writing-tests`,
`/writing-pr-descriptions`.