### PR TITLE
fix(desktop): warn on #general in the space name field

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelName.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.test.ts
@@ -123,7 +123,16 @@ describe("validateChannelName", () => {
   it.each(["personal", "me", "  personal  "])(
     "reserves %j for the private space",
     (name) => {
-      expect(validateChannelName(name)).toContain("reserved");
+      expect(validateChannelName(name)).toContain("private space");
+    },
+  );
+
+  // The API rejects this name too, so accepting it here submits a form that
+  // comes back 400 with nothing pointing at the field that caused it.
+  it.each(["general", "  general  "])(
+    "reserves %j for the shared space",
+    (name) => {
+      expect(validateChannelName(name)).toContain("shared space");
     },
   );
 });

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -109,7 +109,7 @@ export function validateChannelName(name: string): string | null {
   if (RESERVED_PERSONAL_NAMES.has(lowered)) {
     return `"${trimmed}" is reserved for your private space.`;
   }
-  if (lowered === GENERAL_CHANNEL_NAME) {
+  if (normalizeChannelName(lowered) === GENERAL_CHANNEL_NAME) {
     return `"${trimmed}" is reserved for your team's shared space.`;
   }
   return null;

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -88,13 +88,13 @@ export function normalizeChannelName(name: string): string {
 // treated as valid here — callers already gate on a non-empty trimmed value, so
 // this validator only judges the character set.
 /**
- * Names a space can't take, because the private space already answers to them
- * and a second space wearing one is a space pretending to be yours.
+ * Names a space can't take, because a default space already answers to them and
+ * a second space wearing one is a space pretending to be that one.
  *
  * Client-side only, so it stops the two forms that create and rename spaces —
  * not the API, and not a space that took the name before this landed.
  */
-const RESERVED_CHANNEL_NAMES = new Set([
+const RESERVED_PERSONAL_NAMES = new Set([
   PERSONAL_CHANNEL_NAME,
   PERSONAL_CHANNEL_LABEL,
 ]);
@@ -105,8 +105,12 @@ export function validateChannelName(name: string): string | null {
   if (!CHANNEL_NAME_PATTERN.test(trimmed)) {
     return "Use only lowercase letters, numbers, and hyphens.";
   }
-  if (RESERVED_CHANNEL_NAMES.has(trimmed.toLowerCase())) {
+  const lowered = trimmed.toLowerCase();
+  if (RESERVED_PERSONAL_NAMES.has(lowered)) {
     return `"${trimmed}" is reserved for your private space.`;
+  }
+  if (lowered === GENERAL_CHANNEL_NAME) {
+    return `"${trimmed}" is reserved for your team's shared space.`;
   }
   return null;
 }


### PR DESCRIPTION
## Problem

Naming a space `general` submits a form the API rejects. The 400 comes back with nothing pointing at the field that caused it, so the name just fails to save.

The field already warns on the private space's names (`me`, `personal`). The shared space's name was left out when it gained the same server-side reservation.

## Changes

- Typing `general` into the create or rename field now warns before submitting, the way `me` and `personal` already do.
- The two messages say which space the name belongs to. "Reserved for your private space" was wrong for the one the whole team shares.

Client-side only, as before: it stops the two forms, not the API, and not a space that took the name before the server-side reservation landed.

## How did you test this code?

Two cases added to `channelName.test.ts`, alongside the existing private-space ones.

The regression is a form that submits and fails with no field-level explanation. The existing private-space case would not catch it, since it asserts on a message this name never reached.

Both cases assert on which space the message names rather than just the word "reserved", so the two branches cannot be swapped without a test noticing. The existing private-space assertion was tightened the same way.

`"General"` is deliberately not a case: uppercase fails the lowercase-pattern check first and never reaches the reserved branch, which is why the existing cases have no capitals either.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.

Found while reviewing a stack that adds first-run behavior around #general. Independent of that work and based on master, since the server-side reservation it mirrors has already merged.

**Public artifact:** nothing here carries material from the agent session that is not already public.
