### PR TITLE
fix(desktop): hide rejected PR attribution diagnostics

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -4127,7 +4127,7 @@ describe("AgentServer HTTP Mode", () => {
       } | null>;
       detectedPrUrl: string | null;
       logger: {
-        debug: ReturnType<typeof vi.fn>;
+        info: ReturnType<typeof vi.fn>;
       };
       posthogAPI: {
         getTaskRun: ReturnType<typeof vi.fn>;
@@ -4188,12 +4188,12 @@ describe("AgentServer HTTP Mode", () => {
 
     it("does not attribute an older PR the run only viewed (e.g. on a long run)", async () => {
       const s = setup(longAgo);
-      const debugLog = vi.spyOn(s.logger, "debug");
+      const infoLog = vi.spyOn(s.logger, "info");
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
       expect(s.detectedPrUrl).toBeNull();
-      expect(debugLog).toHaveBeenCalledWith(
+      expect(infoLog).toHaveBeenCalledWith(
         "PR seen in output is not this run's, skipping attribution",
         expect.objectContaining({ prUrl: PR_URL }),
       );

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -4126,6 +4126,9 @@ describe("AgentServer HTTP Mode", () => {
         branch: string;
       } | null>;
       detectedPrUrl: string | null;
+      logger: {
+        debug: ReturnType<typeof vi.fn>;
+      };
       posthogAPI: {
         getTaskRun: ReturnType<typeof vi.fn>;
         updateTaskRun: ReturnType<typeof vi.fn>;
@@ -4185,10 +4188,15 @@ describe("AgentServer HTTP Mode", () => {
 
     it("does not attribute an older PR the run only viewed (e.g. on a long run)", async () => {
       const s = setup(longAgo);
+      const debugLog = vi.spyOn(s.logger, "debug");
       s.maybeAttachCreatedPr(payload, terminalUpdate(PR_URL));
       await flush();
       expect(s.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
       expect(s.detectedPrUrl).toBeNull();
+      expect(debugLog).toHaveBeenCalledWith(
+        "PR seen in output is not this run's, skipping attribution",
+        expect.objectContaining({ prUrl: PR_URL }),
+      );
     });
 
     it("ignores updates with no PR URL", async () => {

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4938,9 +4938,7 @@ ${commonInstructions}
       baseBranch: this.config.baseBranch ?? null,
     });
     if (!owned) {
-      // Info, not debug: a wrongly rejected PR leaves the run with no PR until the
-      // webhook backstop binds it, and this line is the only trace of why.
-      this.logger.info(
+      this.logger.debug(
         "PR seen in output is not this run's, skipping attribution",
         {
           runId: payload.run_id,

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4938,7 +4938,7 @@ ${commonInstructions}
       baseBranch: this.config.baseBranch ?? null,
     });
     if (!owned) {
-      this.logger.debug(
+      this.logger.info(
         "PR seen in output is not this run's, skipping attribution",
         {
           runId: payload.run_id,

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -826,6 +826,28 @@ describe("buildConversationItems", () => {
       ).toBe(true);
     });
 
+    it("hides persisted PR attribution diagnostics", () => {
+      const events: AcpMessage[] = [
+        consoleMsg(
+          1,
+          'PR seen in output is not this run\'s, skipping attribution {"prUrl":"https://github.com/PostHog/posthog/pull/1"}',
+        ),
+        consoleMsg(2, "Agent session initialized"),
+      ];
+
+      const result = buildConversationItems(events, null);
+      const consoleItems = result.items.filter(
+        (item) =>
+          item.type === "session_update" &&
+          item.update.sessionUpdate === "console",
+      );
+
+      expect(consoleItems).toHaveLength(1);
+      expect(consoleItems[0]).toMatchObject({
+        update: { message: "Agent session initialized" },
+      });
+    });
+
     it("emits no progress group for a conversation without progress notifications", () => {
       const events: AcpMessage[] = [userPromptMsg(1, 1, "hi")];
 

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -6,7 +6,7 @@ import {
   type ConversationItem,
 } from "./buildConversationItems";
 
-function consoleMsg(ts: number, message: string, level = "info"): AcpMessage {
+function consoleMsg(ts: number, message: unknown, level = "info"): AcpMessage {
   return {
     type: "acp_message",
     ts,
@@ -846,6 +846,15 @@ describe("buildConversationItems", () => {
       expect(consoleItems[0]).toMatchObject({
         update: { message: "Agent session initialized" },
       });
+    });
+
+    it("ignores malformed console messages", () => {
+      const result = buildConversationItems(
+        [consoleMsg(1, { message: "invalid console payload" })],
+        null,
+      );
+
+      expect(result.items).toHaveLength(0);
     });
 
     it("emits no progress group for a conversation without progress notifications", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -835,15 +835,16 @@ describe("buildConversationItems", () => {
         consoleMsg(2, "Agent session initialized"),
       ];
 
-      const result = buildConversationItems(events, null);
-      const consoleItems = result.items.filter(
+      const visibleConsoleItems = buildConversationItems(events, null, {
+        showDebugLogs: true,
+      }).items.filter(
         (item) =>
           item.type === "session_update" &&
           item.update.sessionUpdate === "console",
       );
 
-      expect(consoleItems).toHaveLength(1);
-      expect(consoleItems[0]).toMatchObject({
+      expect(visibleConsoleItems).toHaveLength(1);
+      expect(visibleConsoleItems[0]).toMatchObject({
         update: { message: "Agent session initialized" },
       });
     });

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -775,7 +775,7 @@ function handleNotification(
 
   if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.CONSOLE)) {
     const params = msg.params as { level?: string; message?: string };
-    if (!params?.message) return;
+    if (!params?.message || typeof params.message !== "string") return;
     const level = params.level ?? "info";
     if (level === "debug" && !options?.showDebugLogs) return;
     if (params.message.startsWith(PR_ATTRIBUTION_DIAGNOSTIC_PREFIX)) return;

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -289,6 +289,9 @@ export interface BuildConversationOptions {
   showDebugLogs?: boolean;
 }
 
+const PR_ATTRIBUTION_DIAGNOSTIC_PREFIX =
+  "PR seen in output is not this run's, skipping attribution";
+
 /**
  * The single ordering policy every conversation builder reads events in:
  * ascending timestamp, ties keeping arrival order (`Array.sort` is stable).
@@ -775,6 +778,7 @@ function handleNotification(
     if (!params?.message) return;
     const level = params.level ?? "info";
     if (level === "debug" && !options?.showDebugLogs) return;
+    if (params.message.startsWith(PR_ATTRIBUTION_DIAGNOSTIC_PREFIX)) return;
     ensureImplicitTurn(b, ts);
     pushItem(b, {
       sessionUpdate: "console",


### PR DESCRIPTION
## Problem

- Desktop chat can render an internal PR-attribution diagnostic after an agent references an unrelated pull request.

## Changes

- Desktop chat filters this diagnostic from persisted and new console events, including when debug logs are enabled.
- Server logs retain the diagnostic at `info` for operational investigation.
- The renderer ignores malformed stored console messages.
- No other visible UI changes.

## How did you test this code?

- Checked the affected local conversation. The diagnostic no longer renders.
- Added regression coverage for persisted diagnostics, debug-log mode, and malformed stored console messages.
- Agent-server coverage checks rejected PR attribution and the retained `info` diagnostic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This fixes an internal chat-rendering diagnostic.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/posthog-desktop`, `/qa-team`, and `/writing-pr-descriptions`.
- QA added malformed-event coverage and retained server-side diagnostics at `info`.
- The final diff contains no session-derived customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*