### PR TITLE
fix(provisioning): forward the caller IP from the region proxy

### DIFF
--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -62,6 +62,7 @@ PROXY_HEADER_ALLOWLIST = frozenset(
         "accept",
         "authorization",
         "user-agent",
+        "x-forwarded-for",
     }
 )
 

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -157,7 +157,7 @@ class TestShouldProxyBearerLookup(BaseTest):
 
 class TestProxyHeaderAllowlist(BaseTest):
     @patch("ee.api.agentic_provisioning.region_proxy.requests")
-    def test_strips_cookies_and_forwarded_headers(self, mock_requests):
+    def test_strips_cookies_and_carries_the_caller_address(self, mock_requests):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.content = b'{"status": "ok"}'
@@ -169,7 +169,7 @@ class TestProxyHeaderAllowlist(BaseTest):
             data={},
             format="json",
             HTTP_COOKIE="sessionid=secret123",
-            HTTP_X_FORWARDED_FOR="10.0.0.1",
+            HTTP_X_FORWARDED_FOR="203.0.113.7, 10.0.0.1",
             HTTP_STRIPE_SIGNATURE="t=123,v1=abc",
             HTTP_AUTHORIZATION="Bearer pha_test",
         )
@@ -182,8 +182,10 @@ class TestProxyHeaderAllowlist(BaseTest):
         header_keys_lower = {k.lower() for k in forwarded_headers}
 
         assert "cookie" not in header_keys_lower
-        assert "x-forwarded-for" not in header_keys_lower
         assert "stripe-signature" not in header_keys_lower
+        # Carried through, so the other region's per-IP limits key on the caller
+        # rather than on this region's egress address.
+        assert forwarded_headers["X-Forwarded-For"] == "203.0.113.7, 10.0.0.1"
         assert "authorization" in header_keys_lower
         assert "host" in header_keys_lower
         assert forwarded_headers["Host"] == "eu.posthog.com"


### PR DESCRIPTION
## Problem

A partner call that PostHog forwards between the US and EU regions arrives at the far region looking like it came from PostHog, not from the partner. That region reads `X-Forwarded-For` to identify a caller, and the cross-region proxy at `/api/agentic/provisioning/` strips it.

Every per-IP limit at the receiving end then keys on the forwarding region's egress address. All forwarded traffic from all callers shares one bucket, including the far region's own `RegionProxyThrottle`.

## Changes

- The far region now rate-limits the caller that sent the request, not the region that forwarded it.
- `x-forwarded-for` joins `PROXY_HEADER_ALLOWLIST`. That is the whole behavior change.
- `test_strips_cookies_and_forwarded_headers` becomes `test_strips_cookies_and_carries_the_caller_address`. It asserted the header was dropped, so leaving it would fail.

Nothing user-visible changes, and no UI is touched.

The strip was not a decision about the caller IP. `2a03f7f1200` replaced `headers = dict(request.headers)` with the allowlist to stop cookies crossing the hop, and `X-Forwarded-For` fell on the deny side of a default-deny list. Forwarding it back is not a new spoofing vector: `get_ip_address` reads the leftmost entry of the chain, our edge appends rather than overwrites, and both regions are public, so a caller can already present any chain it likes to either one directly. Cookies stay stripped.

The Stripe provisioning proxy at `/api/partners/stripe/provisioning/` is untouched. Its cross-region cap is being removed in #83938, so it has nothing at the far end that needs the caller's address.

## How did you test this code?

- The renamed test sends `203.0.113.7, 10.0.0.1` and asserts the chain reaches the outbound request intact, alongside the existing assertions that cookies and the signature header do not. It catches a future edit that drops `x-forwarded-for` from the allowlist again.
- Not checked: forwarding between two deployed regions. That needs both, so the throttle behavior at the receiving end rests on reading `get_ip_address`, which takes the leftmost entry of the chain.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Opus 5), directed by @rafaeelaudibert, who spotted the missing header while reviewing the cross-region cap in #83938.
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.
- An earlier revision covered both provisioning namespaces and set the header from the resolved caller address instead of allowlisting it. Tracing the strip to the cookie fix showed pass-through carries no extra risk, and the Stripe namespace dropped out of scope once its cap was removed.
