### PR TITLE
fix(canvas): stop canvas share links resolving to an empty canvas

### DIFF
--- a/frontend/src/lib/utils/kea-router.test.ts
+++ b/frontend/src/lib/utils/kea-router.test.ts
@@ -38,6 +38,24 @@ describe('router-utils', () => {
         expect(altered).toEqual('/feature_flags/staff/cohorts')
     })
 
+    describe('desktop share link routes', () => {
+        // /code/* are public bridges for PostHog Desktop share links. The desktop app's link
+        // parser only matches the unprefixed form, so a project id injected here produces an
+        // address-bar URL the app refuses to open once someone copies and shares it.
+        it.each([
+            ['/code/canvas/chan-1/dash-1', '/code/canvas/chan-1/dash-1'],
+            ['/code/channel/chan-1', '/code/channel/chan-1'],
+            ['/code/channel/chan-1/tasks/task-1', '/code/channel/chan-1/tasks/task-1'],
+            ['/code/task/task-1', '/code/task/task-1'],
+            // Links copied out of the address bar before this exemption existed carry the prefix.
+            ['/project/123/code/canvas/chan-1/dash-1', '/code/canvas/chan-1/dash-1'],
+            // /code-review is a separate first segment and stays project-scoped.
+            ['/code-review', '/project/123/code-review'],
+        ])('routes %s to %s', (input, expected) => {
+            expect(addProjectIdIfMissing(input, 123)).toEqual(expected)
+        })
+    })
+
     describe('relative path normalization', () => {
         it('normalizes ../ prefix to absolute path with project id', () => {
             expect(addProjectIdIfMissing('../dashboard/1663553', 112509)).toEqual('/project/112509/dashboard/1663553')

--- a/frontend/src/lib/utils/kea-router.ts
+++ b/frontend/src/lib/utils/kea-router.ts
@@ -15,6 +15,11 @@ const pathsWithoutProjectId = [
     'oauth',
     'shared',
     'embedded',
+    // The /code/* routes are public bridges for PostHog Desktop share links. Their ids are
+    // global rows rather than project-scoped ones, and the desktop app's link parser only
+    // recognizes the unprefixed form, so injecting a project id here yields an address-bar
+    // URL that the app refuses to open when someone copies and shares it.
+    'code',
     'interview',
     'cli',
     'render_query',

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -37,6 +37,39 @@ class TestUrls(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("canvas", "/code/canvas/chan-1/dash-1"),
+            ("channel", "/code/channel/chan-1"),
+            ("channel_thread", "/code/channel/chan-1/tasks/task-1"),
+            ("task", "/code/task/task-1"),
+            # The web app used to inject a project id into the address bar, so links copied
+            # from there are in circulation and a logged-out recipient still needs the bridge.
+            ("prefixed_canvas", "/project/2/code/canvas/chan-1/dash-1"),
+            ("prefixed_channel", "/project/2/code/channel/chan-1"),
+        ]
+    )
+    def test_desktop_share_link_bridge_loads_without_login(self, _name, path):
+        self.client.logout()
+
+        response = self.client.get(path)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @parameterized.expand(
+        [
+            ("project_scoped_app_route", "/project/2/insights"),
+            ("route_sharing_the_code_prefix", "/code-review"),
+        ]
+    )
+    def test_desktop_share_link_exemption_does_not_widen(self, _name, path):
+        self.client.logout()
+
+        response = self.client.get(path)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertTrue(response.headers["Location"].startswith("/login"))
+
+    @parameterized.expand(
+        [
             ("eu", "https://eu.posthog.com", "https://eu.posthog.com/organization/billing"),
             ("us", "https://us.posthog.com", "https://us.posthog.com/organization/billing"),
         ]

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -786,9 +786,15 @@ frontend_unauthenticated_routes = [
     "organization/confirm-creation",
     "login",
     "unsubscribe",
-    # Public bridges for desktop-app share links — deep-link into PostHog Desktop.
-    r"code/canvas/[^/]+/[^/]+",
-    r"code/task/[^/]+",
+    # Public bridges for desktop-app share links, which deep-link into PostHog Desktop.
+    # The optional project prefix has to be tolerated: the web app used to inject one into
+    # the address bar, so links copied from there and passed on are already in circulation,
+    # and a logged-out recipient of one still needs the bridge rather than a login redirect.
+    # These are anchored because re_path matches with re.search, which would otherwise
+    # exempt any path that merely contains one of them.
+    r"^(project/[^/]+/)?code/canvas/[^/]+/[^/]+",
+    r"^(project/[^/]+/)?code/channel/[^/]+",
+    r"^(project/[^/]+/)?code/task/[^/]+",
     "verify_email",
     r"agentic/account-mismatch",
     # OAuth redirect target when logging the local frontend into a remote cloud region;

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasLoadFailed.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasLoadFailed.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CanvasLoadFailed } from "./CanvasLoadFailed";
+
+/**
+ * The canvas request failed outright, as opposed to resolving to nothing. Separate from
+ * `CanvasNotFound` because retrying is worth offering here and never is there.
+ */
+const meta = {
+  title: "Canvas/CanvasLoadFailed",
+  component: CanvasLoadFailed,
+  parameters: { layout: "fullscreen" },
+  args: { onRetry: () => {} },
+  decorators: [
+    (Story) => (
+      <div className="h-100">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CanvasLoadFailed>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithMessage: Story = {
+  args: { error: { message: "Failed to load canvas (500)" } },
+};
+
+export const WithoutMessage: Story = {
+  args: { error: null },
+};

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasLoadFailed.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasLoadFailed.tsx
@@ -1,0 +1,49 @@
+import { WarningIcon } from "@phosphor-icons/react";
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@posthog/quill";
+
+/**
+ * Shown when the canvas request itself failed, as opposed to resolving to nothing.
+ *
+ * Kept separate from `CanvasNotFound` because the next action differs: a failed request is
+ * worth retrying, a missing canvas never is.
+ */
+export function CanvasLoadFailed({
+  error,
+  onRetry,
+}: {
+  error: { message: string } | null;
+  onRetry: () => void;
+}) {
+  // The title already says it failed, so the message leads as its own sentence rather than
+  // being introduced again. Trailing punctuation varies by error, so normalize it.
+  const detail = error?.message?.trim().replace(/\.+$/, "");
+  const nextStep =
+    "Try again, and if it keeps happening check your connection.";
+
+  return (
+    <Empty className="h-full border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <WarningIcon size={24} />
+        </EmptyMedia>
+        <EmptyTitle>Couldn't load this canvas</EmptyTitle>
+        <EmptyDescription>
+          {detail ? `${detail}. ${nextStep}` : nextStep}
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button variant="primary" size="default" onClick={onRetry}>
+          Try again
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CanvasNotFound } from "./CanvasNotFound";
+
+/**
+ * A share link opened against a project that does not have the canvas. The channel lookup goes
+ * through tRPC, which never resolves in Storybook, so this renders the branch where the channel
+ * is absent too, which is what a cross-project link actually hits.
+ */
+const meta = {
+  title: "Canvas/CanvasNotFound",
+  component: CanvasNotFound,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="h-100">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CanvasNotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { channelId: "chan-1" },
+};

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  currentProject: undefined as { id: number; name: string } | undefined,
+  channels: [] as { id: string; name: string }[],
+}));
+
+vi.mock("@posthog/ui/features/projects/useProjects", () => ({
+  useProjects: () => ({ currentProject: state.currentProject }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({ channels: state.channels, isLoading: false }),
+}));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children?: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+import { CanvasNotFound } from "@posthog/ui/features/canvas/components/CanvasNotFound";
+
+describe("CanvasNotFound", () => {
+  // Naming the project is the whole point of the screen: without it the message is
+  // indistinguishable from the empty-canvas state it replaced.
+  it("names the project it looked in and how to reach the canvas", () => {
+    state.currentProject = { id: 2, name: "Marketing" };
+    state.channels = [];
+
+    render(<CanvasNotFound channelId="chan-1" />);
+
+    expect(screen.getByText(/not in Marketing/)).toBeInTheDocument();
+    expect(screen.getByText(/Switch to the project/)).toBeInTheDocument();
+  });
+
+  // The channel lives in the canvas's project too, so a link from elsewhere names one that
+  // isn't here either and "back to it" would be a second dead end.
+  it.each([
+    [
+      "offers the channel when it is in this project",
+      [{ id: "chan-1", name: "Growth" }],
+      "Back to Growth",
+    ],
+    ["falls back to spaces when it is not", [], "Go to spaces"],
+  ])("%s", (_label, channels, expectedLabel) => {
+    state.currentProject = { id: 2, name: "Marketing" };
+    state.channels = channels;
+
+    render(<CanvasNotFound channelId="chan-1" />);
+
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.tsx
@@ -1,0 +1,71 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@posthog/quill";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useProjects } from "@posthog/ui/features/projects/useProjects";
+import { Link } from "@tanstack/react-router";
+
+/**
+ * Shown when a canvas id resolves to nothing in the signed-in project.
+ *
+ * A share link carries only the channel and canvas ids, but the record is fetched from
+ * `/api/projects/<currentProjectId>/canvases/<id>/`, so a link to a canvas in another project
+ * 404s here. That 404 used to render as the generic empty-canvas state, which reads as "this
+ * canvas exists and has nothing in it" and sends people looking for the wrong problem.
+ */
+export function CanvasNotFound({ channelId }: { channelId?: string }) {
+  const { currentProject } = useProjects();
+  const { channels } = useChannels();
+  // The channel belongs to the same project as the canvas, so a link from elsewhere names one
+  // that isn't here either. Offering to go "back" to it would be a second dead end.
+  const channel = channelId
+    ? channels.find((candidate) => candidate.id === channelId)
+    : undefined;
+
+  return (
+    <Empty className="h-full border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <MagnifyingGlassIcon size={24} />
+        </EmptyMedia>
+        <EmptyTitle>Canvas not found</EmptyTitle>
+        <EmptyDescription>
+          {currentProject
+            ? `This canvas is not in ${currentProject.name}. Switch to the project it belongs to and open the link again.`
+            : "This canvas is not in the project you are signed in to. Switch to the project it belongs to and open the link again."}
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        {channel ? (
+          <Button
+            variant="outline"
+            size="default"
+            render={
+              <Link
+                to="/website/$channelId"
+                params={{ channelId: channel.id }}
+              />
+            }
+          >
+            Back to {channel.name}
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="default"
+            render={<Link to="/website" />}
+          >
+            Go to spaces
+          </Button>
+        )}
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the module factory can read it and each case can steer what the record query
+// resolved to.
+const record = vi.hoisted(() => ({
+  current: {
+    dashboard: undefined as unknown,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null as { message: string } | null,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useDashboards", () => ({
+  useDashboard: () => record.current,
+}));
+// The two canvas views mount iframes, chat panels and grid layout; this suite only cares about
+// which of them the branch picks.
+vi.mock("@posthog/ui/features/canvas/freeform/FreeformCanvasView", () => ({
+  FreeformCanvasView: () => <div data-testid="freeform-view" />,
+}));
+vi.mock("@posthog/ui/features/canvas/grid/GridCanvasView", () => ({
+  GridCanvasView: () => <div data-testid="grid-view" />,
+}));
+vi.mock("@posthog/ui/features/canvas/stores/dashboardEditStore", () => ({
+  useIsDashboardEditing: () => false,
+}));
+vi.mock("@posthog/ui/router/routeSkeletons", () => ({
+  CanvasSkeleton: () => <div data-testid="canvas-skeleton" />,
+}));
+vi.mock("@posthog/ui/features/canvas/components/CanvasNotFound", () => ({
+  CanvasNotFound: () => <div data-testid="canvas-not-found" />,
+}));
+vi.mock("@posthog/ui/features/canvas/components/CanvasLoadFailed", () => ({
+  CanvasLoadFailed: () => <div data-testid="canvas-load-failed" />,
+}));
+
+import { WebsiteDashboard } from "@posthog/ui/features/canvas/components/WebsiteDashboard";
+
+describe("WebsiteDashboard", () => {
+  beforeEach(() => {
+    record.current = {
+      dashboard: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+  });
+
+  // The null row is the regression this file exists for: a canvas the signed-in project does
+  // not have used to fall through to the freeform view, which renders its own empty state and
+  // reads as a real, empty canvas.
+  it.each([
+    ["still resolving", { isLoading: true }, "canvas-skeleton"],
+    [
+      "failed to load",
+      { isError: true, error: { message: "boom" } },
+      "canvas-load-failed",
+    ],
+    ["absent from this project", { dashboard: null }, "canvas-not-found"],
+    ["a grid canvas", { dashboard: { kind: "grid" } }, "grid-view"],
+    ["a freeform canvas", { dashboard: { kind: "freeform" } }, "freeform-view"],
+  ])("renders %s as %s", (_label, state, expectedTestId) => {
+    record.current = { ...record.current, ...state };
+
+    render(<WebsiteDashboard dashboardId="dash-1" channelId="chan-1" />);
+
+    expect(screen.getByTestId(expectedTestId)).toBeInTheDocument();
+  });
+
+  it("does not render a canvas view when the record is absent", () => {
+    record.current = { ...record.current, dashboard: null };
+
+    render(<WebsiteDashboard dashboardId="dash-1" channelId="chan-1" />);
+
+    expect(screen.queryByTestId("freeform-view")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("grid-view")).not.toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
@@ -1,17 +1,43 @@
+import { CanvasLoadFailed } from "@posthog/ui/features/canvas/components/CanvasLoadFailed";
+import { CanvasNotFound } from "@posthog/ui/features/canvas/components/CanvasNotFound";
 import { FreeformCanvasView } from "@posthog/ui/features/canvas/freeform/FreeformCanvasView";
 import { GridCanvasView } from "@posthog/ui/features/canvas/grid/GridCanvasView";
 import { useDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useIsDashboardEditing } from "@posthog/ui/features/canvas/stores/dashboardEditStore";
+import { CanvasSkeleton } from "@posthog/ui/router/routeSkeletons";
 
 // Renders a canvas's app in a sandboxed iframe (view + edit). Edit mode adds
 // the chat panel + version controls; generation runs as a dedicated task. The
 // view fetches its own record/source/build lifecycle — including the author
 // context, which the side panel edits against the saved record directly.
 // Grid-kind canvases render the widget-grid surface instead of the single app.
-export function WebsiteDashboard({ dashboardId }: { dashboardId: string }) {
+//
+// Resolving the record is four states rather than two: undefined while it loads, null when the
+// signed-in project has no such canvas (which is what a share link from another project hits),
+// and an error when the request failed. Branching here means neither canvas view has to reason
+// about a record that never arrived, which is how a 404 used to reach the screen as an empty
+// canvas.
+export function WebsiteDashboard({
+  dashboardId,
+  channelId,
+}: {
+  dashboardId: string;
+  channelId?: string;
+}) {
   const editing = useIsDashboardEditing(dashboardId);
-  const { dashboard } = useDashboard(dashboardId);
-  if (dashboard?.kind === "grid") {
+  const { dashboard, isLoading, isError, error, refetch } =
+    useDashboard(dashboardId);
+
+  if (isLoading) {
+    return <CanvasSkeleton />;
+  }
+  if (isError) {
+    return <CanvasLoadFailed error={error} onRetry={refetch} />;
+  }
+  if (!dashboard) {
+    return <CanvasNotFound channelId={channelId} />;
+  }
+  if (dashboard.kind === "grid") {
     return <GridCanvasView canvasId={dashboardId} interactive={editing} />;
   }
   return (

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -383,7 +383,15 @@ export function WebsiteLayout() {
       ? "Space"
       : "Channel";
 
-  const isDashboardDetail = Boolean(channelId && dashboardId);
+  // Same query the canvas view branches on, so the toolbar disappears alongside a canvas the
+  // project doesn't have. Otherwise the not-found screen renders under its breadcrumb and a
+  // live Edit / Pin / Delete row acting on a record that was never fetched.
+  const { dashboard: toolbarCanvas, isLoading: toolbarCanvasLoading } =
+    useDashboard(dashboardId);
+  const canvasMissing =
+    Boolean(dashboardId) && !toolbarCanvasLoading && !toolbarCanvas;
+
+  const isDashboardDetail = Boolean(channelId && dashboardId) && !canvasMissing;
   // The canvases grid (its own sub-route now that the channel index is the
   // static homepage, which carries its own header content).
   const isDashboardsGrid =

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -58,6 +58,7 @@ import {
   useCanvasDrafts,
   useCanvasSource,
   useCanvasVersions,
+  useDashboard,
   useDashboardMutations,
 } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useCanvasChatPanelStore } from "@posthog/ui/features/canvas/stores/canvasChatPanelStore";
@@ -192,12 +193,12 @@ export function FreeformCanvasView({
   // The generation-task association lives in the canvas record's meta. Poll it
   // while a task is running so the fresh head version + the cleared association
   // show up without a manual refresh.
-  const { data: dashboard, isLoading: dashboardLoading } = useQuery(
-    trpc.dashboards.get.queryOptions(
-      { id: dashboardId },
-      { enabled: !!dashboardId, staleTime: 4000 },
-    ),
-  );
+  //
+  // Goes through useDashboard rather than its own useQuery so every observer of this key
+  // agrees on the options. React Query keeps `meta` on the query, so an observer that omits
+  // AUTH_SCOPED_QUERY_META clears it for the others and the record then outlives a project
+  // switch.
+  const { dashboard, isLoading: dashboardLoading } = useDashboard(dashboardId);
   const genTaskId = dashboard?.generationTaskId ?? null;
   const channelId = dashboard?.channelId ?? "";
 

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -84,18 +84,33 @@ export function usePrefetchDashboards(): (channelId: string) => void {
 
 /** A single saved canvas record (metadata + lifecycle pointers). */
 export function useDashboard(id: string | undefined): {
+  /** `undefined` while unresolved, `null` when the signed-in project has no such canvas. */
   dashboard: DashboardRecord | null | undefined;
   isLoading: boolean;
   isFetching: boolean;
+  isError: boolean;
+  // Narrowed to the message rather than the tRPC error shape, which is all any caller renders.
+  error: { message: string } | null;
+  refetch: () => void;
 } {
   const trpc = useHostTRPC();
-  const { data, isLoading, isFetching } = useQuery(
+  const { data, isLoading, isFetching, isError, error, refetch } = useQuery(
     trpc.dashboards.get.queryOptions(
       { id: id ?? "" },
-      { enabled: !!id, staleTime: 5_000 },
+      // AUTH_SCOPED_QUERY_META so switching project drops the entry. Without it a cached
+      // `null` from the previous project outlives the switch, and a canvas that now resolves
+      // still renders as missing.
+      { enabled: !!id, staleTime: 5_000, meta: AUTH_SCOPED_QUERY_META },
     ),
   );
-  return { dashboard: data, isLoading, isFetching };
+  return {
+    dashboard: data,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch: () => void refetch(),
+  };
 }
 
 /** A canvas's source project — the head, or a historical version. */

--- a/products/desktop/packages/ui/src/router/routes/website/$channelId/dashboards/$dashboardId.tsx
+++ b/products/desktop/packages/ui/src/router/routes/website/$channelId/dashboards/$dashboardId.tsx
@@ -13,6 +13,6 @@ export const Route = createFileRoute(
 });
 
 function DashboardRoute() {
-  const { dashboardId } = Route.useParams();
-  return <WebsiteDashboard dashboardId={dashboardId} />;
+  const { channelId, dashboardId } = Route.useParams();
+  return <WebsiteDashboard dashboardId={dashboardId} channelId={channelId} />;
 }

--- a/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
@@ -39,6 +39,21 @@ describe("parseShareLink", () => {
       "https://us.posthog.com/code/channel/chan1/tasks/task1",
       { kind: "channel", channelId: "chan1", taskId: "task1" },
     ],
+    [
+      "canvas link carrying the project prefix the web app used to inject",
+      "https://us.posthog.com/project/2/code/canvas/chan1/dash1",
+      { kind: "canvas", channelId: "chan1", dashboardId: "dash1" },
+    ],
+    [
+      "channel thread link prefixed with a project API key",
+      "https://eu.posthog.com/project/phc_gE7SWBNBgFbA4eQ154KPX/code/channel/chan1/tasks/task1",
+      { kind: "channel", channelId: "chan1", taskId: "task1" },
+    ],
+    [
+      "canvas filed in a channel named project",
+      "https://us.posthog.com/code/canvas/project/2",
+      { kind: "canvas", channelId: "project", dashboardId: "2" },
+    ],
   ])("parses a %s", (_label, href, expected) => {
     expect(parseShareLink(href)).toEqual(expected);
   });
@@ -58,6 +73,10 @@ describe("parseShareLink", () => {
       "https://us.posthog.com/code/channel/chan1/foo/task1",
     ],
     ["a malformed url", "not a url"],
+    [
+      "a project segment whose id is neither numeric nor a project API key",
+      "https://us.posthog.com/project/notanid/code/canvas/chan1/dash1",
+    ],
   ])("returns null for %s", (_label, href) => {
     expect(parseShareLink(href)).toBeNull();
   });

--- a/products/desktop/packages/ui/src/utils/posthogLinks.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.ts
@@ -188,6 +188,23 @@ function decodePathSegments(pathname: string): string[] {
     });
 }
 
+/**
+ * Drop a leading `project/<id>` pair from an otherwise unprefixed share link.
+ *
+ * Share links are built without a project (`canvasShareUrl`), but the web app used to inject
+ * the current project into the address bar, so links copied from there are already circulating
+ * and name the same global rows. A project is addressed by a numeric id or a `phc_` project API
+ * key, as in the web app's own `/^\/project\/(\d+|phc_)/`. Anything else stays a real path
+ * segment, so a canvas filed in a channel named "project" is still parsed as one.
+ */
+function stripProjectPrefix(segments: string[]): string[] {
+  const [first, second] = segments;
+  if (first === "project" && second && /^(\d+$|phc_)/.test(second)) {
+    return segments.slice(2);
+  }
+  return segments;
+}
+
 function matchRoute(
   segments: string[],
   route: ShareLinkRoute,
@@ -214,7 +231,7 @@ export function parseShareLink(href: string): ShareLinkTarget | null {
   }
   if (!POSTHOG_HOSTS.has(url.host)) return null;
 
-  const segments = decodePathSegments(url.pathname);
+  const segments = stripProjectPrefix(decodePathSegments(url.pathname));
   for (const route of SHARE_LINK_ROUTES) {
     const target = matchRoute(segments, route);
     if (target) return target;


### PR DESCRIPTION
## Problem

Opening a canvas share link for a canvas in another project shows "Freeform canvas / This canvas is empty. Hit Edit to build it with an agent." The canvas is not empty and nothing says so.

- Desktop fetches the record from `/api/projects/<currentProjectId>/canvases/<id>/`.
- A share link carries no project, so it resolves against whichever project Desktop is signed in to.
- A canvas owned by another project returns 404.
- `DashboardsService.get` maps that 404 to null, and no component tells null apart from a loaded, empty record.

A missing canvas, a deleted canvas, a cross-project canvas, and a failed request all render as a real, empty canvas.

The link in that report also carried a `/project/<id>/` prefix that no PostHog code generates. The web app injected it into the address bar, because `code` was missing from `pathsWithoutProjectId`. Anyone who opened a link and copied the URL passed on a shape the desktop link parser rejects, so clicking it in the app opened a browser instead of the canvas.

## Changes

- A canvas that is not in the signed-in project now says so and names the project that was searched, instead of rendering as an empty canvas.
- A failed request gets its own screen with a retry, instead of the same empty canvas.
- Copying a canvas link out of the address bar now yields a working link. `code` is exempt from the project prefix, and an already-shared prefixed link still parses.
- A logged-out person opening a channel share link reaches the interstitial instead of the login page. `code/channel/...` was missing from `frontend_unauthenticated_routes`.
- `WebsiteDashboard` resolves the record once and branches on all four outcomes, so neither canvas view reasons about a record that never arrived.
- The breadcrumb and the Edit / Pin / Delete controls follow the same query, so they no longer sit above a canvas that was never fetched.

Mechanical: `FreeformCanvasView` switches to the shared `useDashboard` instead of duplicating the query. That one is load-bearing, not cosmetic. React Query keeps `meta` on the query, so the observer omitting `AUTH_SCOPED_QUERY_META` cleared it for the others and a stale null survived a project switch.

> [!NOTE]
> The route regexes in `posthog/urls.py` are now anchored, and deliberately keep an optional project prefix. `re_path` matches with `re.search`, so the unanchored patterns exempted any path that merely contained one. Anchoring without the optional prefix would bounce logged-out recipients of every link already in circulation.

| Screen | |
| --- | --- |
| Canvas not in this project | ![shot-not-found](https://raw.githubusercontent.com/PostHog/pr-assets/6d336d06b12c165de680edbdc69228b8135b9de3/2026/08/3c175cee-19a5-41e6-953c-9a8fe39cd900.png) |
| Request failed | ![shot-load-failed](https://raw.githubusercontent.com/PostHog/pr-assets/d372560d42a86187388783cd1105a6b833dfddf3/2026/08/46a0e993-0e3a-4398-89a9-cc8a77d7760f.png) |

There is no before screenshot. The previous state is the existing empty-canvas copy quoted in Problem, rendered by `FreeformCanvasView`.

## How did you test this code?

Automated only. The agent did not run the desktop app against a live Django stack, so the end-to-end path from a share link to the new screen is unverified.

- `WebsiteDashboard.test.tsx` covers the five-way branch. The row that earns the file is `dashboard: null`, which no existing test covered. Removing the null branch fails exactly that row and renders the freeform view, reproducing the reported bug.
- `CanvasNotFound.test.tsx` covers the copy naming the current project, and the channel link falling back to spaces when the channel is not in this project either.
- `posthogLinks.test.ts` gains prefixed canvas and channel links, a non-numeric project segment that must not be stripped, and a canvas filed in a channel named `project`.
- `kea-router.test.ts` covers the three `/code/*` routes staying unprefixed, an already-prefixed link self-healing, and `/code-review` still getting its prefix.
- `test_urls.py` covers the channel and thread routes loading logged out, prefixed canvas routes still loading, and `/project/2/insights` still redirecting to login.

The API behavior behind the fix was confirmed live: canvas `01a020ca-032e-73ad-875a-9dcc1264a299` returns 404 from `/api/projects/290023/canvases/<id>/`, which is the exact call Desktop makes.

Not run: the full desktop Playwright suite, and any check needing a live desktop build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) investigated a canvas link that would not open, then implemented the fix.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-user-facing-copy`, `/improving-drf-endpoints`, `/writing-pr-descriptions`.

The investigation started from the assumption that the `/project/<id>/` prefix in the reported URL was user error. Two subagents concluded that. Checking `addProjectIdIfMissing` and `initKea` showed the web app produces it, which turned a suspected typo into a real defect. The prefix turned out not to be the cause of the reported symptom, so the diagnosis moved to the 404 handling; both are fixed here.

The plan originally proposed dropping the `!dashboard` guard in `GridCanvasView` as unreachable. `WebsiteHome` also renders that component, so the guard stayed.

A cross-project lookup endpoint plus a "switch project" button was scoped and is deliberately not in this PR. Desktop requests OAuth with `required_access_level=project`, so most sessions hold exactly one project and the button could never appear for them. That work will be stacked separately.

Public artifact: nothing here carries material from the agent session that is not already public. The canvas and channel ids in the tests are invented; the one real canvas id appears only in the live-check note above, and it is an opaque identifier for a canvas the reporter already has a link to.
