### PR TITLE
feat(query-cache): dedupe concurrent blocking runs of the same query

### DIFF
--- a/docs/internal/workflows/query-blocking-dedup.md
+++ b/docs/internal/workflows/query-blocking-dedup.md
@@ -1,0 +1,21 @@
+# Blocking query deduplication
+
+When one request is already computing a query, other blocking requests for the same cache key wait for its cached result instead of running the query again. This covers concurrent refreshes of one insight, repeated identical API queries, and a user's blocking refresh racing an async or warming run of the same query, since async workers compute through the same code path.
+
+## Mechanism
+
+- A run about to compute claims `posthog:query_claim:{cache_key}` in the query cache Redis: set-if-absent, value is the run's id, TTL `CLAIM_TTL_SECONDS` (30s).
+- A daemon thread in the claiming process extends the TTL of that process's claims every `CLAIM_REFRESH_INTERVAL_SECONDS` (5s), via a compare-then-extend script that never revives a claim another run took over. If the process dies, the thread dies with it and the claim expires within 30s.
+- A run that loses the claim polls every `WAIT_POLL_INTERVAL_SECONDS` (0.3s): a new cached result means join it and serve it as a cache hit; the claim disappearing without a result (the holder errored or died) means try to claim and compute; `QUERY_BLOCKING_DEDUP_MAX_WAIT_SECONDS` (env, default 90s) elapsing means compute anyway.
+- Release is compare-then-delete, so a run whose claim expired mid-computation cannot delete its successor's claim.
+
+Every failure direction degrades to computing the query, the behavior without deduplication: Redis unreachable grants claims without storing them, a dead holder frees its claim by TTL, and an unreadable joined result falls back to computing.
+
+Excluded: exports (they never write the cache, so there is no result to share) and runners whose `requires_fresh_calculation()` is true.
+
+## Operating it
+
+- `QUERY_BLOCKING_DEDUP_ENABLED` is an instance setting (editable on `/instance/settings`, via its API, or in Django admin), seeded from the env var of the same name and read on a 60s cache, so flipping it applies fleet-wide within about a minute with no restart. Default off.
+- Metrics: `posthog_query_dedup_wait_total` and `posthog_query_dedup_wait_seconds`, labeled by outcome (`result_ready` joins, `claim_released` takeovers after an error or death, `timed_out` deadline hits). A high `timed_out` rate means legitimate long queries are being waited on; raise the max wait or accept the duplicate computes.
+
+Code: `posthog/query_cache/inflight.py`, wired around blocking execution in `posthog/hogql_queries/query_runner.py`.

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -25,6 +25,7 @@ export type InstanceStatusTabName = 'overview' | 'metrics' | 'settings' | 'staff
  * For example: async migrations settings are handled in their own page.
  */
 const EDITABLE_INSTANCE_SETTINGS = [
+    'QUERY_BLOCKING_DEDUP_ENABLED',
     'RECORDINGS_PERFORMANCE_EVENTS_TTL_WEEKS',
     'EMAIL_ENABLED',
     'EMAIL_HOST',

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -151,11 +151,18 @@ from posthog.query_cache.failures import (
     Budget,
     QueryFailureRecord,
 )
+from posthog.query_cache.inflight import (
+    WaitOutcome,
+    acquire_claim,
+    blocking_dedup_enabled,
+    release_claim,
+    wait_for_cached_result,
+)
 from posthog.rbac.user_access_control import WAREHOUSE_ACCESS_SCOPES, UserAccessControl, UserAccessControlError
 from posthog.schema_helpers import to_dict
 from posthog.scopes import APIScopeObject
 from posthog.shared_link_user import SharedLinkUser
-from posthog.slo.context import JsonValue, SloSpec, slo_operation
+from posthog.slo.context import JsonValue, SloSpec, slo_operation, tag_current_slo
 from posthog.slo.types import SloArea, SloOperation, SloOutcome
 from posthog.synthetic_user import SyntheticUser
 from posthog.utils import generate_cache_key, get_from_dict_or_attr, to_json
@@ -2180,7 +2187,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     # cache_hit is left unset on this path: either the caller passed
                     # CALCULATE_BLOCKING_ALWAYS (cache skipped) or the cache returned nothing.
                     slo.tag(execution_path="blocking", calculation_trigger=trigger)
-                    return self._execute_and_cache_blocking(
+                    return self._execute_blocking_with_dedup(
                         cache_key=cache_key,
                         cache_manager=cache_manager,
                         execution_mode=execution_mode,
@@ -2221,6 +2228,108 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                                 failure_kind, str(exc), budget=budget_for_limit_context(self.limit_context)
                             )
                     raise
+
+    def _blocking_dedup_applies(self) -> bool:
+        # Exports skip the cache write, so there is no shared result to wait for; runners that
+        # must reflect live state cannot serve another run's result, however fresh.
+        if self.limit_context == LimitContext.EXPORT or self.requires_fresh_calculation():
+            return False
+        return blocking_dedup_enabled()
+
+    def _joined_cached_response(self, cache_manager: QueryCache) -> Optional[CR]:
+        """The cached response another run just stored, or None to fall back to computing."""
+        CachedResponse: type[CR] = self.cached_response_type
+        entry = cache_manager.lookup().entry
+        if entry is None:
+            return None
+        candidate = entry.as_full_response()
+        if not self.is_cached_response(candidate):
+            return None
+        candidate["is_cached"] = True
+        try:
+            response = CachedResponse(**candidate)
+        except Exception:
+            # A rolling deploy can store a shape this code can't validate; recompute instead.
+            return None
+        response, _ = self.apply_series_custom_names(response)
+        response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
+        return response
+
+    def _execute_blocking_with_dedup(
+        self,
+        *,
+        cache_key: str,
+        cache_manager: QueryCache,
+        execution_mode: ExecutionMode,
+        insight_id: Optional[int],
+        dashboard_id: Optional[int],
+        trigger: Optional[str],
+        user: Optional[User],
+        start_time: float,
+        analytics_props: Optional[AnalyticsProps] = None,
+    ) -> CR:
+        """One computation per cache key: claim it, or join the run that holds the claim.
+
+        Deduplication is best-effort. Whenever joining fails (the claim holder died, its
+        result never became readable, or the wait hit its deadline) this falls back to
+        computing, so the worst case is the undeduplicated behavior plus a bounded wait.
+        """
+
+        def compute() -> CR:
+            return self._execute_and_cache_blocking(
+                cache_key=cache_key,
+                cache_manager=cache_manager,
+                execution_mode=execution_mode,
+                insight_id=insight_id,
+                dashboard_id=dashboard_id,
+                trigger=trigger,
+                user=user,
+                start_time=start_time,
+                analytics_props=analytics_props,
+            )
+
+        if not self._blocking_dedup_applies():
+            return compute()
+
+        deadline = monotonic() + settings.QUERY_BLOCKING_DEDUP_MAX_WAIT_SECONDS
+        while True:
+            claim = acquire_claim(cache_key)
+            if claim is not None:
+                try:
+                    return compute()
+                finally:
+                    release_claim(claim)
+            outcome = wait_for_cached_result(cache_key, self.team.pk, deadline=deadline)
+            if outcome == WaitOutcome.CLAIM_RELEASED:
+                # The other run ended without caching a result (an error, or a dead process);
+                # loop back and try to claim the computation ourselves.
+                continue
+            if outcome == WaitOutcome.RESULT_READY:
+                joined = self._joined_cached_response(cache_manager)
+                if joined is not None:
+                    tag_current_slo(execution_path="blocking_dedup_join", cache_hit=True)
+                    report_user_or_team_action(
+                        "query executed",
+                        {
+                            "insight_id": insight_id,
+                            "dashboard_id": dashboard_id,
+                            "cache_hit": True,
+                            "dedup_joined": True,
+                            "cache_key": cache_key,
+                            "calculation_trigger": joined.calculation_trigger,
+                            "execution_mode": execution_mode.value,
+                            "query_type": getattr(self.query, "kind", "Other"),
+                            "response_time_ms": round((perf_counter() - start_time) * 1000, 2),
+                        },
+                        user=user,
+                        team=self.team,
+                        organization=self.team.organization,
+                        analytics_props=analytics_props,
+                    )
+                    return joined
+                # The entry disappeared or failed validation between the freshness probe and
+                # the read; compute rather than spin on an unreadable entry.
+            return compute()
 
     def _execute_and_cache_blocking(
         self,

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -62,6 +62,7 @@ from posthog.hogql_queries.query_runner import (
     shared_insights_execution_mode,
 )
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.instance_setting import override_instance_config
 from posthog.models.organization import OrganizationMembership
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.team.team import Team, WeekStartDay
@@ -74,6 +75,7 @@ from posthog.query_cache.failures import (
     QUERY_FAILURE_CACHING_FLAG,
     QueryFailureCache,
 )
+from posthog.query_cache.inflight import WaitOutcome, acquire_claim, release_claim
 from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlError
 from posthog.shared_link_user import SharedLinkUser
 
@@ -1989,3 +1991,83 @@ class TestQueryFailureCaching(BaseTest):
                     runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
             mock_enqueue.assert_not_called()
             assert getattr(ctx.exception, "served_from_query_failure_cache", False)
+
+
+class TestBlockingDedup(BaseTest):
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()
+
+    def test_second_blocking_run_joins_instead_of_computing(self):
+        runner_class = setup_test_query_runner_class()
+        with override_instance_config("QUERY_BLOCKING_DEDUP_ENABLED", True):
+            first = runner_class(query={"some_attr": "bla"}, team=self.team)
+            first.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            cache_key = first.get_cache_key()
+
+            claim = acquire_claim(cache_key)
+            assert claim is not None
+            try:
+                second = runner_class(query={"some_attr": "bla"}, team=self.team)
+                with (
+                    mock.patch(
+                        "posthog.hogql_queries.query_runner.wait_for_cached_result",
+                        return_value=WaitOutcome.RESULT_READY,
+                    ),
+                    mock.patch.object(runner_class, "_calculate", autospec=True) as mock_calculate,
+                ):
+                    response = second.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            finally:
+                release_claim(claim)
+
+        mock_calculate.assert_not_called()
+        assert response.is_cached is True
+        assert response.cache_key == cache_key
+        assert response.results
+
+    def test_dedup_disabled_computes_despite_held_claim(self):
+        runner_class = setup_test_query_runner_class()
+        runner = runner_class(query={"some_attr": "bla"}, team=self.team)
+        claim = acquire_claim(runner.get_cache_key())
+        assert claim is not None
+        try:
+            with mock.patch(
+                "posthog.hogql_queries.query_runner.wait_for_cached_result",
+                side_effect=AssertionError("waited with deduplication disabled"),
+            ):
+                response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        finally:
+            release_claim(claim)
+        assert response.is_cached is False
+
+    def test_export_computes_despite_held_claim(self):
+        runner_class = setup_test_query_runner_class()
+        with override_instance_config("QUERY_BLOCKING_DEDUP_ENABLED", True):
+            runner = runner_class(query={"some_attr": "bla"}, team=self.team, limit_context=LimitContext.EXPORT)
+            claim = acquire_claim(runner.get_cache_key())
+            assert claim is not None
+            try:
+                with mock.patch(
+                    "posthog.hogql_queries.query_runner.wait_for_cached_result",
+                    side_effect=AssertionError("an export waited on a claim"),
+                ):
+                    response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            finally:
+                release_claim(claim)
+        assert response.is_cached is False
+
+    def test_wait_timeout_falls_back_to_computing(self):
+        runner_class = setup_test_query_runner_class()
+        with override_instance_config("QUERY_BLOCKING_DEDUP_ENABLED", True):
+            runner = runner_class(query={"some_attr": "bla"}, team=self.team)
+            claim = acquire_claim(runner.get_cache_key())
+            assert claim is not None
+            try:
+                with mock.patch(
+                    "posthog.hogql_queries.query_runner.wait_for_cached_result",
+                    return_value=WaitOutcome.TIMED_OUT,
+                ):
+                    response = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            finally:
+                release_claim(claim)
+        assert response.is_cached is False

--- a/posthog/query_cache/inflight.py
+++ b/posthog/query_cache/inflight.py
@@ -1,0 +1,239 @@
+"""One computation per cache key: concurrent blocking runs of one query share one result.
+
+A process about to compute a query claims the cache key in Redis. The claim carries a short
+TTL that a background thread in the claiming process keeps extending, so a claim outlives a
+dead process by at most CLAIM_TTL_SECONDS. Concurrent runs of the same query wait instead of
+computing: the cached result appearing means join it; the claim disappearing means the
+computation ended without a cacheable result (an error, or a dead process), so one waiter
+claims and computes. Every failure direction degrades to computing the query, the behavior
+without deduplication, never to a hang or a stale result.
+"""
+
+import time
+import uuid
+import threading
+from collections.abc import Callable
+from datetime import timedelta
+from enum import StrEnum
+from typing import Optional
+
+from django.conf import settings
+from django.db import DatabaseError
+
+import structlog
+from prometheus_client import Counter, Histogram
+
+from posthog.cache_utils import cache_for
+from posthog.dataclasses import frozen
+from posthog.query_cache import storage
+from posthog.query_cache.results import fetch_entry_freshness
+
+logger = structlog.get_logger(__name__)
+
+# The TTL bounds how long a dead process's claim can make waiters hold on; the refresh
+# interval keeps a live claim from expiring even when several refresh cycles are missed.
+CLAIM_TTL_SECONDS = 30
+CLAIM_REFRESH_INTERVAL_SECONDS = 5
+WAIT_POLL_INTERVAL_SECONDS = 0.3
+
+_CLAIM_KEY_PREFIX = "posthog:query_claim:"
+
+DEDUP_WAIT_COUNTER = Counter(
+    "posthog_query_dedup_wait_total",
+    "Blocking query runs that found another run computing the same cache key, by wait outcome.",
+    labelnames=["outcome"],
+)
+
+DEDUP_WAIT_DURATION = Histogram(
+    "posthog_query_dedup_wait_seconds",
+    "Time spent waiting on another run's computation, by wait outcome.",
+    labelnames=["outcome"],
+    buckets=[0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, float("inf")],
+)
+
+# Extends a claim's TTL only while it still holds the refresher's run id, so a refresh cycle
+# that raced a takeover cannot revive a claim that now belongs to another run.
+_EXTEND_IF_OWNED_SCRIPT = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+end
+return 0
+"""
+
+# Deletes a claim only while it still holds the releaser's run id, so a run whose claim
+# expired mid-computation cannot delete the claim of the waiter that took over.
+_RELEASE_IF_OWNED_SCRIPT = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
+"""
+
+
+class WaitOutcome(StrEnum):
+    RESULT_READY = "result_ready"
+    CLAIM_RELEASED = "claim_released"
+    TIMED_OUT = "timed_out"
+
+
+@frozen
+class InflightClaim:
+    cache_key: str
+    run_id: str
+
+
+@cache_for(timedelta(seconds=60))
+def blocking_dedup_enabled() -> bool:
+    from posthog.models.instance_setting import get_instance_setting
+
+    try:
+        # An instance setting rather than env so the fleet-wide kill switch applies within a
+        # minute, without a rolling restart.
+        return bool(get_instance_setting("QUERY_BLOCKING_DEDUP_ENABLED"))
+    except DatabaseError:
+        # The gate runs on the query hot path and must not add a hard Postgres dependency.
+        logger.warning("query_dedup_setting_lookup_failed", exc_info=True)
+    return settings.QUERY_BLOCKING_DEDUP_ENABLED
+
+
+def _claim_redis_key(cache_key: str) -> str:
+    return _CLAIM_KEY_PREFIX + cache_key
+
+
+# The heartbeat thread refreshes every claim this process holds. Claims register on acquire
+# and deregister on release, on takeover, and on expiry, so a claim key present here always
+# belongs to a computation this process still believes is running. If the process dies the
+# thread dies with it and the claims expire by TTL, which is the liveness signal waiters use.
+_active_claims: dict[str, str] = {}
+_claims_lock = threading.Lock()
+_heartbeat_thread: Optional[threading.Thread] = None
+
+
+def _register_claim(redis_key: str, run_id: str) -> None:
+    global _heartbeat_thread
+    with _claims_lock:
+        _active_claims[redis_key] = run_id
+        # Started on first use so the thread lives in the serving process, not in a pre-fork
+        # parent whose threads would not survive the fork. is_alive() re-checks because the
+        # loop catches broadly but a thread can still die on an error outside its try.
+        if _heartbeat_thread is None or not _heartbeat_thread.is_alive():
+            _heartbeat_thread = threading.Thread(target=_heartbeat_loop, name="query-dedup-claims", daemon=True)
+            _heartbeat_thread.start()
+
+
+def _deregister_claim(redis_key: str, run_id: str) -> None:
+    with _claims_lock:
+        if _active_claims.get(redis_key) == run_id:
+            del _active_claims[redis_key]
+
+
+def _heartbeat_loop() -> None:
+    while True:
+        time.sleep(CLAIM_REFRESH_INTERVAL_SECONDS)
+        _refresh_active_claims()
+
+
+def _refresh_active_claims() -> None:
+    with _claims_lock:
+        claims = dict(_active_claims)
+    if not claims:
+        return
+    try:
+        client = storage.query_cache_raw_client()
+        for redis_key, run_id in claims.items():
+            # redis-py's stubs omit eval on RedisCluster; the runtime supports it.
+            extended = client.eval(_EXTEND_IF_OWNED_SCRIPT, 1, redis_key, run_id, CLAIM_TTL_SECONDS)  # type: ignore[union-attr]
+            if not extended:
+                # The claim expired or another run took it over; stop refreshing it. The
+                # computation still finishes and its release safely no-ops.
+                _deregister_claim(redis_key, run_id)
+    except Exception:
+        # A missed cycle only shortens the claim's remaining TTL. With Redis down long
+        # enough the claim expires and a waiter recomputes, which is the safe direction.
+        logger.warning("query_dedup_claim_refresh_failed", exc_info=True)
+
+
+def acquire_claim(cache_key: str) -> Optional[InflightClaim]:
+    """Claim the cache key for this process's computation.
+
+    None only when another run verifiably holds the key. With Redis unreachable the claim is
+    granted without being stored, so deduplication degrades to every caller computing rather
+    than every caller waiting on a claim nobody can hold.
+    """
+    run_id = uuid.uuid4().hex
+    redis_key = _claim_redis_key(cache_key)
+    try:
+        stored = storage.query_cache_raw_client().set(redis_key, run_id, nx=True, ex=CLAIM_TTL_SECONDS)
+    except Exception:
+        logger.warning("query_dedup_claim_write_failed", cache_key=cache_key, exc_info=True)
+        return InflightClaim(cache_key=cache_key, run_id=run_id)
+    if not stored:
+        return None
+    _register_claim(redis_key, run_id)
+    return InflightClaim(cache_key=cache_key, run_id=run_id)
+
+
+def release_claim(claim: InflightClaim) -> None:
+    """Never raises: a claim that fails to release expires by TTL within CLAIM_TTL_SECONDS."""
+    redis_key = _claim_redis_key(claim.cache_key)
+    _deregister_claim(redis_key, claim.run_id)
+    try:
+        # redis-py's stubs omit eval on RedisCluster; the runtime supports it.
+        storage.query_cache_raw_client().eval(_RELEASE_IF_OWNED_SCRIPT, 1, redis_key, claim.run_id)  # type: ignore[union-attr]
+    except Exception:
+        logger.warning("query_dedup_claim_release_failed", cache_key=claim.cache_key, exc_info=True)
+
+
+def _claim_exists(cache_key: str) -> bool:
+    try:
+        return bool(storage.query_cache_raw_client().exists(_claim_redis_key(cache_key)))
+    except Exception:
+        # Redis unreachable reads as released so the waiter falls back to computing.
+        return False
+
+
+def wait_for_cached_result(
+    cache_key: str,
+    team_id: int,
+    *,
+    deadline: float,
+    poll_interval: float = WAIT_POLL_INTERVAL_SECONDS,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> WaitOutcome:
+    """Wait for the run holding this cache key's claim to finish.
+
+    RESULT_READY: the cache holds a result stored after this wait began; join it.
+    CLAIM_RELEASED: the claim is gone and no new result appeared; try to claim and compute.
+    TIMED_OUT: the deadline passed with the claim still held; compute anyway.
+
+    The freshness snapshot is taken here rather than before the caller's claim attempt, so a
+    result stored in the gap between the two reads goes undetected and is recomputed. The gap
+    is two adjacent Redis calls; the cost of losing that race is one duplicate computation.
+    """
+    started = monotonic()
+    snapshot = fetch_entry_freshness(cache_key, team_id)
+    while True:
+        current = fetch_entry_freshness(cache_key, team_id)
+        # A change to None is eviction, not a result; only a present, different entry joins.
+        if current is not None and current != snapshot:
+            outcome = WaitOutcome.RESULT_READY
+            break
+        if not _claim_exists(cache_key):
+            # The runner stores its result before releasing, so the release can land between
+            # the freshness read above and the claim check; re-read before concluding the
+            # computation produced nothing.
+            current = fetch_entry_freshness(cache_key, team_id)
+            if current is not None and current != snapshot:
+                outcome = WaitOutcome.RESULT_READY
+            else:
+                outcome = WaitOutcome.CLAIM_RELEASED
+            break
+        if monotonic() >= deadline:
+            outcome = WaitOutcome.TIMED_OUT
+            break
+        sleep(poll_interval)
+
+    DEDUP_WAIT_COUNTER.labels(outcome=outcome.value).inc()
+    DEDUP_WAIT_DURATION.labels(outcome=outcome.value).observe(monotonic() - started)
+    return outcome

--- a/posthog/query_cache/test/test_inflight.py
+++ b/posthog/query_cache/test/test_inflight.py
@@ -1,0 +1,149 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+import orjson
+
+from posthog.query_cache import storage
+from posthog.query_cache.inflight import (
+    WaitOutcome,
+    _claim_redis_key,
+    _refresh_active_claims,
+    acquire_claim,
+    release_claim,
+    wait_for_cached_result,
+)
+from posthog.query_cache.results import EntryFreshness
+
+
+class TestInflightClaims(SimpleTestCase):
+    CACHE_KEY = "inflight_test_key"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.redis = storage.query_cache_raw_client()
+        self._cleanup()
+
+    def tearDown(self) -> None:
+        self._cleanup()
+        super().tearDown()
+
+    def _cleanup(self) -> None:
+        self.redis.delete(_claim_redis_key(self.CACHE_KEY), storage.entry_redis_key(self.CACHE_KEY))
+
+    def _store_entry(self, last_refresh: str) -> None:
+        value = orjson.dumps({"results": [1], "is_cached": False, "last_refresh": last_refresh})
+        self.redis.set(storage.entry_redis_key(self.CACHE_KEY), value)
+
+    def test_claim_is_exclusive_until_released(self):
+        claim = acquire_claim(self.CACHE_KEY)
+        assert claim is not None
+        assert acquire_claim(self.CACHE_KEY) is None
+
+        release_claim(claim)
+        second = acquire_claim(self.CACHE_KEY)
+        assert second is not None
+        release_claim(second)
+
+    def test_release_ignores_a_claim_it_no_longer_owns(self):
+        stale = acquire_claim(self.CACHE_KEY)
+        assert stale is not None
+        # The claim expires (dead-process TTL) and a waiter takes over.
+        self.redis.delete(_claim_redis_key(self.CACHE_KEY))
+        successor = acquire_claim(self.CACHE_KEY)
+        assert successor is not None
+
+        release_claim(stale)
+
+        assert self.redis.get(_claim_redis_key(self.CACHE_KEY)) == successor.run_id.encode()
+        release_claim(successor)
+
+    def test_refresh_extends_owned_and_drops_lost_claims(self):
+        claim = acquire_claim(self.CACHE_KEY)
+        assert claim is not None
+        self.redis.expire(_claim_redis_key(self.CACHE_KEY), 5)
+
+        _refresh_active_claims()
+        assert self.redis.ttl(_claim_redis_key(self.CACHE_KEY)) > 5
+
+        self.redis.set(_claim_redis_key(self.CACHE_KEY), "another-run", ex=5)
+        _refresh_active_claims()
+        assert self.redis.ttl(_claim_redis_key(self.CACHE_KEY)) <= 5
+
+        # The lost claim left the registry, so later cycles cannot revive the key either.
+        self.redis.delete(_claim_redis_key(self.CACHE_KEY))
+        _refresh_active_claims()
+        assert not self.redis.exists(_claim_redis_key(self.CACHE_KEY))
+        release_claim(claim)
+
+    def test_wait_returns_result_ready_when_result_lands(self):
+        self._store_entry("2026-08-20T00:00:00+00:00")
+        claim = acquire_claim(self.CACHE_KEY)
+        assert claim is not None
+
+        def store_new_result(_seconds: float) -> None:
+            self._store_entry("2026-08-20T00:01:00+00:00")
+
+        outcome = wait_for_cached_result(self.CACHE_KEY, team_id=1, deadline=10**9, sleep=store_new_result)
+        assert outcome == WaitOutcome.RESULT_READY
+        release_claim(claim)
+
+    def test_wait_returns_claim_released_when_claim_vanishes_without_result(self):
+        claim = acquire_claim(self.CACHE_KEY)
+        assert claim is not None
+
+        def release_it(_seconds: float) -> None:
+            release_claim(claim)
+
+        outcome = wait_for_cached_result(self.CACHE_KEY, team_id=1, deadline=10**9, sleep=release_it)
+        assert outcome == WaitOutcome.CLAIM_RELEASED
+
+    def test_wait_rechecks_freshness_when_release_lands_mid_iteration(self):
+        # The runner stores, then releases. A waiter that read freshness just before the
+        # store and the claim just after the release must join the result, not recompute.
+        freshness_sequence = iter(
+            [
+                EntryFreshness(last_refresh="old"),  # snapshot
+                EntryFreshness(last_refresh="old"),  # first poll, before the store landed
+                EntryFreshness(last_refresh="new"),  # re-check after the claim vanished
+            ]
+        )
+        with patch(
+            "posthog.query_cache.inflight.fetch_entry_freshness", side_effect=lambda *a, **k: next(freshness_sequence)
+        ):
+            outcome = wait_for_cached_result(self.CACHE_KEY, team_id=1, deadline=10**9)
+        assert outcome == WaitOutcome.RESULT_READY
+
+    def test_wait_times_out_while_claim_held(self):
+        claim = acquire_claim(self.CACHE_KEY)
+        assert claim is not None
+        clock = iter([0.0, 0.0, 5.0, 10.0, 15.0])
+
+        outcome = wait_for_cached_result(
+            self.CACHE_KEY,
+            team_id=1,
+            deadline=9.0,
+            monotonic=lambda: next(clock),
+            sleep=lambda _seconds: None,
+        )
+        assert outcome == WaitOutcome.TIMED_OUT
+        release_claim(claim)
+
+    def test_eviction_is_not_a_result(self):
+        self._store_entry("2026-08-20T00:00:00+00:00")
+        claim = acquire_claim(self.CACHE_KEY)
+        assert claim is not None
+
+        def evict_then_release(_seconds: float) -> None:
+            self.redis.delete(storage.entry_redis_key(self.CACHE_KEY))
+            release_claim(claim)
+
+        outcome = wait_for_cached_result(self.CACHE_KEY, team_id=1, deadline=10**9, sleep=evict_then_release)
+        assert outcome == WaitOutcome.CLAIM_RELEASED
+
+    def test_acquire_grants_unstored_claim_when_redis_is_down(self):
+        with patch.object(storage, "query_cache_raw_client", side_effect=RuntimeError("redis down")):
+            claim = acquire_claim(self.CACHE_KEY)
+            assert claim is not None
+            release_claim(claim)
+        assert not self.redis.exists(_claim_redis_key(self.CACHE_KEY))

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -251,6 +251,12 @@ CONSTANCE_CONFIG = {
         "Whether rate limiting is enabled",
         bool,
     ),
+    "QUERY_BLOCKING_DEDUP_ENABLED": (
+        get_from_env("QUERY_BLOCKING_DEDUP_ENABLED", False, type_cast=str_to_bool),
+        "When one request is already computing a query, other blocking requests for the same query "
+        "wait for its result instead of running the query again.",
+        bool,
+    ),
     "CLICKHOUSE_KILL_SWITCH": (
         get_from_env("CLICKHOUSE_KILL_SWITCH", "off"),
         "ClickHouse overload protection. Values: 'off', 'light' (reduce resources, shed background work), 'full' (aggressive caps on everything).",
@@ -382,6 +388,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "PARALLEL_DASHBOARD_ITEM_CACHE",
     "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS",
     "RATE_LIMIT_ENABLED",
+    "QUERY_BLOCKING_DEDUP_ENABLED",
     "RATE_LIMITING_ALLOW_LIST_TEAMS",
     "FLAGS_LOG_BODIES_TEAMS",
     "CLICKHOUSE_KILL_SWITCH",

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -1,5 +1,5 @@
 from posthog.settings.base_variables import TEST
-from posthog.settings.utils import get_from_env
+from posthog.settings.utils import get_from_env, str_to_bool
 
 USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
 
@@ -42,6 +42,13 @@ CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
 # Per-team cache size limit (default 1GB, can be overridden per-team via Team.extra_settings)
 TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 1_000_000_000, type_cast=int)
+
+# Fallback for the QUERY_BLOCKING_DEDUP_ENABLED instance setting when Postgres is unreachable;
+# the instance setting (seeded from the same env var) is what operators actually flip.
+QUERY_BLOCKING_DEDUP_ENABLED = get_from_env("QUERY_BLOCKING_DEDUP_ENABLED", False, type_cast=str_to_bool)
+
+# How long a blocking run waits on another run's computation before computing anyway.
+QUERY_BLOCKING_DEDUP_MAX_WAIT_SECONDS = get_from_env("QUERY_BLOCKING_DEDUP_MAX_WAIT_SECONDS", 90, type_cast=int)
 
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.
 # Use empty string to prevent this


### PR DESCRIPTION
## Problem

- Two identical blocking queries arriving together each run the full query on ClickHouse.
- Only async requests deduplicate against an in-flight run today; blocking requests have no equivalent.
- The duplicates come from concurrent viewers of one insight, repeated API queries, and a user's refresh racing a warming or async run of the same query.

## Changes

- While one request computes a query, other blocking requests for the same cache key now wait for its cached result and serve it as a cache hit, instead of running the query again.
- Off by default behind the `QUERY_BLOCKING_DEDUP_ENABLED` instance setting. Staff can flip it on `/instance/settings`, via its API, or in Django admin, and it applies fleet-wide within about a minute with no restart.
- The computing run claims the cache key in Redis with a 30-second TTL. A background thread in its process extends the claim every 5 seconds, so a dead process frees its claim within 30 seconds and one waiter takes over.
- Waiters poll the cache every 300ms. The claim vanishing without a result (the holder errored or died) makes one waiter claim and compute. After `QUERY_BLOCKING_DEDUP_MAX_WAIT_SECONDS` (env, default 90s) a waiter computes anyway.
- Async workers compute through the same code path, so a blocking refresh also joins an in-flight async or warming run of the same query.
- Exports and always-fresh runners bypass deduplication. Redis being unreachable grants claims without storing them, so every failure direction degrades to computing, never to a hang.
- The riskiest part is the claim loop around blocking execution in `query_runner.py`; the new `posthog/query_cache/inflight.py` module and its wait outcomes carry the semantics.
- New metrics: `posthog_query_dedup_wait_total` and `posthog_query_dedup_wait_seconds`, labeled by outcome.
- Mechanical: setting registration in `dynamic_settings.py`, the `/instance/settings` page allowlist, and the doc page.

> [!NOTE]
> Behavior is identical until the instance setting is turned on. Nothing user-visible changes in the UI beyond the new row on `/instance/settings`.

## How did you test this code?

- `posthog/query_cache/test/test_inflight.py` (new): claim exclusivity and release ownership (a stale run must not delete its successor's claim), heartbeat refresh that cannot revive a lost claim, and the wait outcomes, including the store-then-release race, eviction mid-wait, and Redis-down fail-open.
- `TestBlockingDedup` in `test_query_runner.py` (new): a second blocking run joins without computing; the kill switch, exports, and a wait timeout each compute immediately instead of waiting.
- The full `test_query_runner.py` and `posthog/query_cache/test/` suites pass locally against fakeredis; repo-wide mypy is clean for the changed files.
- Not run: a multi-process test against real Redis; the claim scripts are single-key operations, valid on Redis Cluster.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- `docs/internal/workflows/query-blocking-dedup.md` (new): mechanism, failure behavior, the setting, and the metrics.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in a terminal session directed by the assignee.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-dataclasses, /writing-user-facing-copy, /writing-pr-descriptions.
- Design iterated with the assignee across the session: liveness via the `poll_query_performance` ClickHouse poller and via async ClickHouse calls were both considered and rejected (unreliable signal, protocol migration); the shipped in-process heartbeat came out of that discussion.
- Planned follow-ups in separate PRs: async zombie-status cleanup using the same claim, and dashed default async query ids.
- Public artifact: no customer data or session material is in the diff or this description.
