### PR TITLE
feat(canvas): offer to switch to the project that owns a canvas

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -817,8 +817,8 @@ quality:
             "$@"
         description: Format CSS/SCSS files
     format:js:
-        cmd: pnpm oxlint --fix --fix-suggestions --quiet "$@" && pnpm exec oxfmt
-            --no-error-on-unmatched-pattern "$@"
+        cmd: pnpm oxlint --fix --fix-suggestions --quiet --no-error-on-unmatched-pattern
+            "$@" && pnpm exec oxfmt --no-error-on-unmatched-pattern "$@"
         description: Format JavaScript/TypeScript files (frontend)
     format:nodejs:
         cmd: pnpm --dir nodejs exec eslint --fix "$@" && pnpm --dir nodejs exec prettier

--- a/products/canvas/backend/presentation/location_views.py
+++ b/products/canvas/backend/presentation/location_views.py
@@ -1,0 +1,124 @@
+from typing import cast
+
+from django.utils.functional import cached_property
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import serializers, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.models.team import Team
+from posthog.models.user import User
+from posthog.permissions import APIScopePermission
+
+from products.canvas.backend.models import Canvas
+from products.canvas.backend.presentation.serializers import _CANVAS_URL_HELP_TEXT, canvas_url
+from products.tasks.backend.facade import api as tasks_facade
+
+
+class CanvasLocationSerializer(serializers.Serializer):
+    """Where a canvas lives: the project and organization that own it."""
+
+    canvas_id = serializers.UUIDField(help_text="Id of the canvas that was looked up.")
+    canvas_name = serializers.CharField(help_text="Display name of the canvas.")
+    channel_id = serializers.UUIDField(help_text="Id of the channel the canvas is filed into.")
+    project_id = serializers.IntegerField(
+        help_text=(
+            "Id of the project that owns the canvas. Use it as the project_id path segment on "
+            "/api/projects/<project_id>/canvases/ to read the canvas itself."
+        )
+    )
+    project_name = serializers.CharField(help_text="Display name of the owning project.")
+    organization_id = serializers.UUIDField(help_text="Id of the organization the owning project belongs to.")
+    organization_name = serializers.CharField(help_text="Display name of that organization.")
+    url = serializers.URLField(help_text=_CANVAS_URL_HELP_TEXT)
+
+
+class CanvasLocationViewSet(viewsets.ViewSet):
+    """Resolve which project owns a canvas, for clients holding only a share link.
+
+    A canvas share link carries the channel and canvas ids but no project, while reading the
+    canvas needs one. A client that lands on the wrong project has no other way to find out
+    where the canvas actually lives.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "canvas"
+    http_method_names = ["get", "head", "options"]
+
+    @cached_property
+    def _canvas(self) -> Canvas:
+        """The canvas, resolved through every access gate at once.
+
+        A canvas that does not exist, lives in a project this user cannot reach, sits in
+        someone else's personal channel, or is soft-deleted are all the same 404. Separating
+        them would turn this endpoint into an oracle for which canvas ids exist.
+        """
+        user = cast(User, self.request.user)
+        canvas = (
+            # unscoped() because a root route carries no team-scope context; the team filter
+            # below is what replaces it.
+            Canvas.objects.unscoped()
+            .filter(id=self.kwargs["pk"], deleted=False)
+            # user.teams already accounts for org membership and project-level RBAC.
+            .filter(team__in=user.teams)
+            # A canvas inherits its channel's visibility, and a personal channel is visible
+            # only to its creator.
+            .filter(tasks_facade.visible_channels_q(user.id, relation="channel"))
+            .select_related("team", "team__organization")
+            .first()
+        )
+        if canvas is None:
+            raise NotFound()
+        return canvas
+
+    @property
+    def team(self) -> Team:
+        """The owning team, which APIScopePermission reads to enforce a token's scoped_teams.
+
+        Without it, any token carrying scoped_teams is rejected outright as "not a project-based
+        endpoint". Exposing the resolved team instead gives the right semantic: such a token
+        learns where a canvas lives only when it was granted that project.
+        """
+        return self._canvas.team
+
+    @extend_schema(
+        operation_id="canvas_locations_retrieve",
+        summary="Find the project that owns a canvas",
+        description=(
+            "Resolve a canvas id to the project and organization that own it, without knowing the "
+            "project up front. For clients that hold only a canvas share link "
+            "(/code/canvas/<channel_id>/<canvas_id>) and need to know which project to open. "
+            "Returns 404 for any canvas the caller cannot read, including canvases in projects "
+            "they cannot access."
+        ),
+        responses={
+            200: CanvasLocationSerializer,
+            404: OpenApiResponse(description="No canvas with this id is visible to the caller."),
+        },
+    )
+    def retrieve(self, request: Request, pk: str) -> Response:
+        canvas = self._canvas
+        return Response(
+            CanvasLocationSerializer(
+                {
+                    "canvas_id": canvas.id,
+                    "canvas_name": canvas.name,
+                    "channel_id": canvas.channel_id,
+                    "project_id": canvas.team_id,
+                    "project_name": canvas.team.name,
+                    "organization_id": canvas.team.organization_id,
+                    "organization_name": canvas.team.organization.name,
+                    "url": canvas_url(canvas),
+                }
+            ).data
+        )

--- a/products/canvas/backend/routes.py
+++ b/products/canvas/backend/routes.py
@@ -1,7 +1,10 @@
 from posthog.api.routing import RouterRegistry
 
-from products.canvas.backend.presentation import views
+from products.canvas.backend.presentation import location_views, views
 
 
 def register_routes(routers: RouterRegistry) -> None:
     routers.projects.register(r"canvases", views.CanvasViewSet, "project_canvases", ["team_id"])
+    # Root-level, because the caller is asking which project a canvas belongs to and so cannot
+    # supply one. Every denial is a 404, so this cannot enumerate canvases.
+    routers.root.register(r"canvas_locations", location_views.CanvasLocationViewSet, "canvas_locations")

--- a/products/canvas/backend/tests/test_canvas_location_api.py
+++ b/products/canvas/backend/tests/test_canvas_location_api.py
@@ -1,0 +1,93 @@
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models.organization import Organization
+from posthog.models.scoping import team_scope
+from posthog.models.team import Team
+from posthog.models.user import User
+
+from products.canvas.backend.models import Canvas
+from products.canvas.backend.tests.test_canvas_api import CanvasAPIBaseTest
+from products.tasks.backend.models import Channel
+
+
+class TestCanvasLocationAPI(CanvasAPIBaseTest):
+    def _location(self, canvas_id: str):
+        return self.client.get(f"/api/canvas_locations/{canvas_id}/")
+
+    def test_resolves_a_canvas_in_another_project_of_the_same_organization(self):
+        other_team = Team.objects.create(organization=self.organization, name="Second project")
+        with team_scope(other_team.id):
+            channel = Channel.objects.create(team=other_team, name="general", created_by=self.user)
+            canvas = Canvas.objects.create(team=other_team, channel=channel, name="Revenue", created_by=self.user)
+
+        response = self._location(str(canvas.id))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        body = response.json()
+        assert body["project_id"] == other_team.id
+        assert body["project_name"] == "Second project"
+        assert body["organization_id"] == str(self.organization.id)
+        assert body["canvas_name"] == "Revenue"
+        assert body["channel_id"] == str(channel.id)
+        assert body["url"].endswith(f"/code/canvas/{channel.id}/{canvas.id}")
+
+    # Every one of these has to be indistinguishable, or the endpoint tells a caller which
+    # canvas ids exist in projects they cannot read.
+    @parameterized.expand(
+        [
+            ("unknown_id",),
+            ("team_the_user_cannot_access",),
+            ("another_users_personal_channel",),
+            ("soft_deleted",),
+        ]
+    )
+    def test_hides_every_unreachable_canvas_behind_the_same_404(self, case: str):
+        canvas_id = self._canvas_id_for(case)
+
+        response = self._location(canvas_id)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["code"] == "not_found"
+
+    def _canvas_id_for(self, case: str) -> str:
+        if case == "unknown_id":
+            return "01a020ca-0000-7000-8000-000000000000"
+
+        if case == "team_the_user_cannot_access":
+            other_org = Organization.objects.create(name="Someone else")
+            other_team = Team.objects.create(organization=other_org, name="Theirs")
+            outsider = User.objects.create_and_join(other_org, "outsider@example.com", None)
+            with team_scope(other_team.id):
+                channel = Channel.objects.create(team=other_team, name="general", created_by=outsider)
+                canvas = Canvas.objects.create(team=other_team, channel=channel, name="Theirs", created_by=outsider)
+            return str(canvas.id)
+
+        if case == "another_users_personal_channel":
+            teammate = User.objects.create_and_join(self.organization, "teammate@example.com", None)
+            with team_scope(self.team.id):
+                personal = Channel.objects.create(
+                    team=self.team,
+                    name=Channel.PERSONAL_CHANNEL_NAME,
+                    channel_type=Channel.ChannelType.PERSONAL,
+                    created_by=teammate,
+                )
+                canvas = Canvas.objects.create(team=self.team, channel=personal, name="Private", created_by=teammate)
+            return str(canvas.id)
+
+        with team_scope(self.team.id):
+            canvas = Canvas.objects.create(
+                team=self.team, channel=self.channel, name="Gone", created_by=self.user, deleted=True
+            )
+        return str(canvas.id)
+
+    # Guards the permission classes, not DRF: without IsAuthenticated this endpoint would
+    # hand out the location of any canvas to anyone.
+    def test_denies_an_unauthenticated_caller(self):
+        with team_scope(self.team.id):
+            canvas = Canvas.objects.create(team=self.team, channel=self.channel, name="Mine", created_by=self.user)
+        self.client.logout()
+
+        response = self._location(str(canvas.id))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/products/canvas/frontend/generated/api.schemas.ts
+++ b/products/canvas/frontend/generated/api.schemas.ts
@@ -8,6 +8,28 @@
  * OpenAPI spec version: 1.0.0
  */
 /**
+ * Where a canvas lives: the project and organization that own it.
+ */
+export interface CanvasLocationApi {
+    /** Id of the canvas that was looked up. */
+    canvas_id: string
+    /** Display name of the canvas. */
+    canvas_name: string
+    /** Id of the channel the canvas is filed into. */
+    channel_id: string
+    /** Id of the project that owns the canvas. Use it as the project_id path segment on /api/projects/<project_id>/canvases/ to read the canvas itself. */
+    project_id: number
+    /** Display name of the owning project. */
+    project_name: string
+    /** Id of the organization the owning project belongs to. */
+    organization_id: string
+    /** Display name of that organization. */
+    organization_name: string
+    /** Canonical link to the canvas in the PostHog app. The only valid way to link to a canvas — share this when pointing a user at it; never construct a canvas URL. */
+    url: string
+}
+
+/**
  * * `freeform` - freeform
  * * `grid` - grid
  * * `component` - component

--- a/products/canvas/frontend/generated/api.ts
+++ b/products/canvas/frontend/generated/api.ts
@@ -25,6 +25,7 @@ import type {
     CanvasLayoutPublishApi,
     CanvasLayoutPublishResponseApi,
     CanvasLayoutResponseApi,
+    CanvasLocationApi,
     CanvasPromoteApi,
     CanvasPublishCurrentVersionApi,
     CanvasReportErrorApi,
@@ -53,6 +54,21 @@ import type {
     PaginatedCanvasVersionListApi,
     PatchedCanvasUpdateApi,
 } from './api.schemas'
+
+export const getCanvasLocationsRetrieveUrl = (id: string) => {
+    return `/api/canvas_locations/${id}/`
+}
+
+/**
+ * Resolve a canvas id to the project and organization that own it, without knowing the project up front. For clients that hold only a canvas share link (/code/canvas/<channel_id>/<canvas_id>) and need to know which project to open. Returns 404 for any canvas the caller cannot read, including canvases in projects they cannot access.
+ * @summary Find the project that owns a canvas
+ */
+export const canvasLocationsRetrieve = async (id: string, options?: RequestInit): Promise<CanvasLocationApi> => {
+    return apiMutator<CanvasLocationApi>(getCanvasLocationsRetrieveUrl(id), {
+        ...options,
+        method: 'GET',
+    })
+}
 
 export const getCanvasesListUrl = (projectId: string, params?: CanvasesListParams) => {
     const normalizedParams = new URLSearchParams()

--- a/products/desktop/packages/core/src/canvas/canvas.module.ts
+++ b/products/desktop/packages/core/src/canvas/canvas.module.ts
@@ -11,6 +11,7 @@ import {
   CHANNEL_TASKS_SERVICE,
   DASHBOARDS_SERVICE,
 } from "./identifiers";
+import { INSTANCE_API_CLIENT, InstanceApiClient } from "./instanceApiClient";
 import { PROJECT_API_CLIENT, ProjectApiClient } from "./projectApiClient";
 
 // Host-agnostic canvas services (dashboards + freeform canvas data). They only
@@ -19,6 +20,8 @@ import { PROJECT_API_CLIENT, ProjectApiClient } from "./projectApiClient";
 export const canvasCoreModule = new ContainerModule(({ bind }) => {
   bind(ProjectApiClient).toSelf().inSingletonScope();
   bind(PROJECT_API_CLIENT).toService(ProjectApiClient);
+  bind(InstanceApiClient).toSelf().inSingletonScope();
+  bind(INSTANCE_API_CLIENT).toService(InstanceApiClient);
 
   bind(CanvasDataService).toSelf().inSingletonScope();
   bind(CANVAS_DATA_SERVICE).toService(CanvasDataService);

--- a/products/desktop/packages/core/src/canvas/canvasBuildSchemas.test.ts
+++ b/products/desktop/packages/core/src/canvas/canvasBuildSchemas.test.ts
@@ -11,6 +11,7 @@ import {
   publishedCanvasBuild,
 } from "./canvasBuildSchemas";
 import { DashboardsService } from "./dashboardsService";
+import type { InstanceApiClient } from "./instanceApiClient";
 import type { ProjectApiClient } from "./projectApiClient";
 
 function build(
@@ -214,12 +215,16 @@ describe("canvas build lifecycle", () => {
           { status: 200 },
         ),
     );
-    const service = new DashboardsService({
-      json: async (path: string) => {
-        expect(path).toBe("canvases/canvas-1/builds/");
-        return (await fetchMock()).json();
-      },
-    } as unknown as ProjectApiClient);
+    const service = new DashboardsService(
+      {
+        json: async (path: string) => {
+          expect(path).toBe("canvases/canvas-1/builds/");
+          return (await fetchMock()).json();
+        },
+      } as unknown as ProjectApiClient,
+      // This case never reaches the instance-level location endpoint.
+      {} as unknown as InstanceApiClient,
+    );
 
     const result = await service.getBuilds({ id: "canvas-1" });
 

--- a/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
@@ -235,3 +235,16 @@ export type CanvasActionResult = z.infer<typeof canvasActionResultSchema>;
 export const requestCanvasAgentInput = canvasAgentRequestInputSchema.extend({
   id: z.string().min(1),
 });
+
+/** Where a canvas lives, for a canvas the signed-in project does not have. */
+export const canvasLocationSchema = z.object({
+  canvasId: z.string(),
+  canvasName: z.string(),
+  channelId: z.string(),
+  projectId: z.number(),
+  projectName: z.string(),
+  organizationId: z.string(),
+  organizationName: z.string(),
+  url: z.string(),
+});
+export type CanvasLocation = z.infer<typeof canvasLocationSchema>;

--- a/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DashboardsService } from "./dashboardsService";
+import type { InstanceApiClient } from "./instanceApiClient";
 import type { ProjectApiClient } from "./projectApiClient";
 
 // A canvas as the PostHog canvases API returns it.
@@ -52,12 +53,29 @@ function fakeApi(
   return { api: api as unknown as ProjectApiClient, calls };
 }
 
+// The location endpoint is instance-level, so it takes its own client. Most cases never
+// reach it; those pass this stub and assert nothing about it.
+function fakeInstanceApi(
+  responses: Record<string, { status: number; body?: unknown }> = {},
+): InstanceApiClient {
+  return {
+    fetch: async (path: string) => {
+      const match = responses[path] ?? { status: 404 };
+      return {
+        ok: match.status >= 200 && match.status < 300,
+        status: match.status,
+        json: async () => match.body,
+      } as Response;
+    },
+  } as unknown as InstanceApiClient;
+}
+
 describe("DashboardsService.list", () => {
   it("maps API canvases to camelCase records", async () => {
     const { api, calls } = fakeApi({
       "canvases/?channel=chan-1": [apiCanvas()],
     });
-    const service = new DashboardsService(api);
+    const service = new DashboardsService(api, fakeInstanceApi());
 
     const rows = await service.list("chan-1");
 
@@ -95,12 +113,70 @@ describe("DashboardsService.getBuilds", () => {
         ],
       },
     });
-    const service = new DashboardsService(api);
+    const service = new DashboardsService(api, fakeInstanceApi());
 
     const lifecycle = await service.getBuilds({ id: "c1", versionId: "v1" });
 
     expect(lifecycle.publishedBuildId).toBe("b1");
     expect(lifecycle.currentVersionId).toBe("v1");
     expect(lifecycle.builds[0].buildStatus).toBe("ready");
+  });
+});
+
+describe("DashboardsService.location", () => {
+  const path = "canvas_locations/c1/";
+
+  it("maps the API body to a camelCase location", async () => {
+    const service = new DashboardsService(
+      fakeApi({}).api,
+      fakeInstanceApi({
+        [path]: {
+          status: 200,
+          body: {
+            canvas_id: "c1",
+            canvas_name: "Revenue",
+            channel_id: "chan-1",
+            project_id: 42,
+            project_name: "Marketing",
+            organization_id: "org-1",
+            organization_name: "Acme",
+            url: "https://us.posthog.com/code/canvas/chan-1/c1",
+          },
+        },
+      }),
+    );
+
+    const location = await service.location("c1");
+
+    expect(location).toEqual({
+      canvasId: "c1",
+      canvasName: "Revenue",
+      channelId: "chan-1",
+      projectId: 42,
+      projectName: "Marketing",
+      organizationId: "org-1",
+      organizationName: "Acme",
+      url: "https://us.posthog.com/code/canvas/chan-1/c1",
+    });
+  });
+
+  // 403 is the scoped-token case: the instance will not say where the canvas is. Treating it
+  // as an error instead would put a pointless retry button in front of a settled answer.
+  it.each([[404], [403]])("returns null for %i", async (status) => {
+    const service = new DashboardsService(
+      fakeApi({}).api,
+      fakeInstanceApi({ [path]: { status } }),
+    );
+
+    await expect(service.location("c1")).resolves.toBeNull();
+  });
+
+  it("throws on an unexpected status", async () => {
+    const service = new DashboardsService(
+      fakeApi({}).api,
+      fakeInstanceApi({ [path]: { status: 500 } }),
+    );
+
+    await expect(service.location("c1")).rejects.toThrow("500");
   });
 });

--- a/products/desktop/packages/core/src/canvas/dashboardsService.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.ts
@@ -5,16 +5,18 @@ import {
   type CanvasBuildRecord,
   canvasBuildRecordSchema,
 } from "./canvasBuildSchemas";
-import type {
-  CanvasActionDefinition,
-  CanvasActionResult,
-  CanvasDraft,
-  CanvasSource,
-  CanvasSourceProject,
-  CanvasStateEntry,
-  CanvasStateScope,
-  CanvasVersion,
-  DashboardRecord,
+import {
+  type CanvasActionDefinition,
+  type CanvasActionResult,
+  type CanvasDraft,
+  type CanvasLocation,
+  type CanvasSource,
+  type CanvasSourceProject,
+  type CanvasStateEntry,
+  type CanvasStateScope,
+  type CanvasVersion,
+  canvasLocationSchema,
+  type DashboardRecord,
 } from "./dashboardSchemas";
 import {
   type CanvasAgentRequestResult,
@@ -27,6 +29,10 @@ import {
   componentMetaSchema,
   type LayoutOperation,
 } from "./gridLayoutSchemas";
+import {
+  INSTANCE_API_CLIENT,
+  type InstanceApiClient,
+} from "./instanceApiClient";
 import {
   PROJECT_API_CLIENT,
   type ProjectApiClient,
@@ -151,6 +157,8 @@ export class DashboardsService {
   constructor(
     @inject(PROJECT_API_CLIENT)
     private readonly api: ProjectApiClient,
+    @inject(INSTANCE_API_CLIENT)
+    private readonly instanceApi: InstanceApiClient,
   ) {}
 
   async list(channelId: string): Promise<DashboardRecord[]> {
@@ -167,6 +175,32 @@ export class DashboardsService {
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`Failed to load canvas (${res.status})`);
     return toRecord((await res.json()) as ApiCanvas);
+  }
+
+  /**
+   * Which project owns a canvas the signed-in project does not have.
+   *
+   * Null when the instance will not say: the canvas does not exist, the account cannot reach
+   * its project, or the session token is scoped to a single project. Those are settled answers
+   * rather than failures, so callers show the plain not-found state and offer no retry.
+   */
+  async location(id: string): Promise<CanvasLocation | null> {
+    const res = await this.instanceApi.fetch(
+      `canvas_locations/${encodeURIComponent(id)}/`,
+    );
+    if (res.status === 404 || res.status === 403) return null;
+    if (!res.ok) throw new Error(`Failed to locate canvas (${res.status})`);
+    const body = (await res.json()) as Record<string, unknown>;
+    return canvasLocationSchema.parse({
+      canvasId: body.canvas_id,
+      canvasName: body.canvas_name,
+      channelId: body.channel_id,
+      projectId: body.project_id,
+      projectName: body.project_name,
+      organizationId: body.organization_id,
+      organizationName: body.organization_name,
+      url: body.url,
+    });
   }
 
   // The component store: component-kind canvases across every channel visible

--- a/products/desktop/packages/core/src/canvas/instanceApiClient.ts
+++ b/products/desktop/packages/core/src/canvas/instanceApiClient.ts
@@ -1,0 +1,32 @@
+import type { AuthService } from "@posthog/core/auth/auth";
+import { AUTH_SERVICE } from "@posthog/core/auth/auth.module";
+import { inject, injectable } from "inversify";
+
+export const INSTANCE_API_CLIENT = Symbol.for(
+  "posthog.core.canvas.instanceApiClient",
+);
+
+/**
+ * Thin client for instance-level PostHog REST endpoints, the ones under `/api/` that are not
+ * scoped to a project.
+ *
+ * Separate from `ProjectApiClient` because that one refuses to build a URL without a selected
+ * project, which is exactly the situation these endpoints exist to resolve.
+ */
+@injectable()
+export class InstanceApiClient {
+  constructor(
+    @inject(AUTH_SERVICE)
+    private readonly authService: AuthService,
+  ) {}
+
+  // `path` is appended after `/api/` — e.g. `canvas_locations/<id>/`.
+  async fetch(path: string, init?: RequestInit): Promise<Response> {
+    const { apiHost } = await this.authService.getValidAccessToken();
+    return this.authService.authenticatedFetch(
+      fetch,
+      `${apiHost}/api/${path}`,
+      init,
+    );
+  }
+}

--- a/products/desktop/packages/core/src/canvas/services.ts
+++ b/products/desktop/packages/core/src/canvas/services.ts
@@ -8,6 +8,7 @@ import type {
   CanvasActionDefinition,
   CanvasActionResult,
   CanvasDraft,
+  CanvasLocation,
   CanvasSource,
   CanvasStateEntry,
   CanvasStateScope,
@@ -43,6 +44,8 @@ export interface IDashboardsService {
   // The component store: component-kind canvases visible to the caller.
   listComponents(input: { search?: string }): Promise<DashboardRecord[]>;
   get(id: string): Promise<DashboardRecord | null>;
+  // Which project owns a canvas, for one the signed-in project does not have.
+  location(id: string): Promise<CanvasLocation | null>;
   create(input: {
     channelId: string;
     name: string;

--- a/products/desktop/packages/host-router/src/routers/dashboards.router.ts
+++ b/products/desktop/packages/host-router/src/routers/dashboards.router.ts
@@ -9,6 +9,7 @@ import {
   canvasActionResultSchema,
   canvasBuildsInput,
   canvasDraftSchema,
+  canvasLocationSchema,
   canvasSourceInput,
   canvasSourceSchema,
   canvasStateEntrySchema,
@@ -62,6 +63,14 @@ export const dashboardsRouter = router({
     .output(dashboardRecordSchema.nullable())
     .query(({ ctx, input }) =>
       ctx.container.get<IDashboardsService>(DASHBOARDS_SERVICE).get(input.id),
+    ),
+  location: publicProcedure
+    .input(dashboardIdInput)
+    .output(canvasLocationSchema.nullable())
+    .query(({ ctx, input }) =>
+      ctx.container
+        .get<IDashboardsService>(DASHBOARDS_SERVICE)
+        .location(input.id),
     ),
   // A query despite the POST underneath: home is an idempotent get-or-create,
   // and query semantics give the surface caching and dedupe for free.

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   currentProject: undefined as { id: number; name: string } | undefined,
   channels: [] as { id: string; name: string }[],
+  location: undefined as Record<string, unknown> | null | undefined,
+  orgProjectsMap: {} as Record<string, unknown>,
+  selectProject: vi.fn(),
+  navigate: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/projects/useProjects", () => ({
@@ -11,6 +15,24 @@ vi.mock("@posthog/ui/features/projects/useProjects", () => ({
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: state.channels, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useDashboards", () => ({
+  useCanvasLocation: () => ({ location: state.location, isFetching: false }),
+}));
+vi.mock("@posthog/ui/features/auth/store", () => ({
+  useAuthStateValue: (select: (s: unknown) => unknown) =>
+    select({ orgProjectsMap: state.orgProjectsMap }),
+}));
+vi.mock("@posthog/ui/features/auth/useAuthMutations", () => ({
+  useSelectProjectMutation: () => ({
+    mutateAsync: state.selectProject,
+    isPending: false,
+  }),
+}));
+vi.mock("@posthog/ui/router/navigationBridge", () => ({
+  // Delegates rather than passing the mock directly: this factory runs once, so a spy captured
+  // here would not be the one beforeEach installs.
+  navigateToChannelDashboard: (...args: unknown[]) => state.navigate(...args),
 }));
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children, to }: { children?: React.ReactNode; to: string }) => (
@@ -20,16 +42,33 @@ vi.mock("@tanstack/react-router", () => ({
 
 import { CanvasNotFound } from "@posthog/ui/features/canvas/components/CanvasNotFound";
 
+const ELSEWHERE = {
+  canvasId: "dash-1",
+  canvasName: "Revenue",
+  channelId: "chan-9",
+  projectId: 42,
+  projectName: "Marketing",
+  organizationId: "org-1",
+  organizationName: "Acme",
+  url: "https://us.posthog.com/code/canvas/chan-9/dash-1",
+};
+
 describe("CanvasNotFound", () => {
+  beforeEach(() => {
+    state.currentProject = { id: 2, name: "Website" };
+    state.channels = [];
+    state.location = null;
+    state.orgProjectsMap = {};
+    state.selectProject = vi.fn().mockResolvedValue(undefined);
+    state.navigate = vi.fn();
+  });
+
   // Naming the project is the whole point of the screen: without it the message is
   // indistinguishable from the empty-canvas state it replaced.
-  it("names the project it looked in and how to reach the canvas", () => {
-    state.currentProject = { id: 2, name: "Marketing" };
-    state.channels = [];
+  it("names the project it looked in when the canvas cannot be located", () => {
+    render(<CanvasNotFound channelId="chan-1" dashboardId="dash-1" />);
 
-    render(<CanvasNotFound channelId="chan-1" />);
-
-    expect(screen.getByText(/not in Marketing/)).toBeInTheDocument();
+    expect(screen.getByText(/not in Website/)).toBeInTheDocument();
     expect(screen.getByText(/Switch to the project/)).toBeInTheDocument();
   });
 
@@ -43,11 +82,48 @@ describe("CanvasNotFound", () => {
     ],
     ["falls back to spaces when it is not", [], "Go to spaces"],
   ])("%s", (_label, channels, expectedLabel) => {
-    state.currentProject = { id: 2, name: "Marketing" };
     state.channels = channels;
 
-    render(<CanvasNotFound channelId="chan-1" />);
+    render(<CanvasNotFound channelId="chan-1" dashboardId="dash-1" />);
 
     expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  it("offers a switch when the owning project is one the session holds", async () => {
+    state.location = ELSEWHERE;
+    state.orgProjectsMap = {
+      "org-1": { orgName: "Acme", projects: [{ id: 42, name: "Marketing" }] },
+    };
+
+    render(<CanvasNotFound channelId="chan-1" dashboardId="dash-1" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Switch to Marketing/ }),
+    );
+
+    await waitFor(() => expect(state.navigate).toHaveBeenCalled());
+    expect(state.selectProject).toHaveBeenCalledWith(42);
+    // The channel comes from the location, not the route that just 404ed.
+    expect(state.navigate).toHaveBeenCalledWith("chan-9", "dash-1");
+    // Selecting a project navigates away on its own, so opening the canvas has to land after
+    // it. This ordering is invisible in the source and easy to undo.
+    expect(state.selectProject.mock.invocationCallOrder[0]).toBeLessThan(
+      state.navigate.mock.invocationCallOrder[0],
+    );
+  });
+
+  // A session granted a single project cannot switch into another, so it must not be shown a
+  // button that would fail.
+  it("tells a single-project session to sign in again instead", () => {
+    state.location = ELSEWHERE;
+    state.orgProjectsMap = {
+      "org-2": { orgName: "Other", projects: [{ id: 2, name: "Website" }] },
+    };
+
+    render(<CanvasNotFound channelId="chan-1" dashboardId="dash-1" />);
+
+    expect(screen.queryByText("Switch to Marketing")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Sign in again and pick that project/),
+    ).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CanvasNotFound.tsx
@@ -1,4 +1,5 @@
 import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { flattenProjectIds } from "@posthog/core/auth/schemas";
 import {
   Button,
   Empty,
@@ -8,8 +9,12 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useSelectProjectMutation } from "@posthog/ui/features/auth/useAuthMutations";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useCanvasLocation } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useProjects } from "@posthog/ui/features/projects/useProjects";
+import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
 import { Link } from "@tanstack/react-router";
 
 /**
@@ -20,14 +25,40 @@ import { Link } from "@tanstack/react-router";
  * 404s here. That 404 used to render as the generic empty-canvas state, which reads as "this
  * canvas exists and has nothing in it" and sends people looking for the wrong problem.
  */
-export function CanvasNotFound({ channelId }: { channelId?: string }) {
+export function CanvasNotFound({
+  channelId,
+  dashboardId,
+}: {
+  channelId?: string;
+  dashboardId?: string;
+}) {
   const { currentProject } = useProjects();
   const { channels } = useChannels();
+  const { location, isFetching } = useCanvasLocation(dashboardId, {
+    enabled: true,
+  });
+  const orgProjectsMap = useAuthStateValue((state) => state.orgProjectsMap);
+  const selectProject = useSelectProjectMutation();
+
   // The channel belongs to the same project as the canvas, so a link from elsewhere names one
   // that isn't here either. Offering to go "back" to it would be a second dead end.
   const channel = channelId
     ? channels.find((candidate) => candidate.id === channelId)
     : undefined;
+  // A session granted only one project cannot switch into another, so it is told to sign in
+  // again rather than offered a button that would fail.
+  const switchable =
+    location != null &&
+    flattenProjectIds(orgProjectsMap).includes(location.projectId);
+
+  const switchAndOpen = async () => {
+    if (!location) return;
+    await selectProject.mutateAsync(location.projectId);
+    // After the await on purpose. Selecting a project runs onProjectSelected, which calls
+    // openTaskInput() and navigates away; mutateAsync resolves once that has run, so this
+    // navigation lands last. The channel id comes from the location, not the dead route.
+    navigateToChannelDashboard(location.channelId, location.canvasId);
+  };
 
   return (
     <Empty className="h-full border-0">
@@ -35,14 +66,23 @@ export function CanvasNotFound({ channelId }: { channelId?: string }) {
         <EmptyMedia variant="icon">
           <MagnifyingGlassIcon size={24} />
         </EmptyMedia>
-        <EmptyTitle>Canvas not found</EmptyTitle>
-        <EmptyDescription>
-          {currentProject
-            ? `This canvas is not in ${currentProject.name}. Switch to the project it belongs to and open the link again.`
-            : "This canvas is not in the project you are signed in to. Switch to the project it belongs to and open the link again."}
-        </EmptyDescription>
+        <EmptyTitle>
+          {location ? "This canvas is in another project" : "Canvas not found"}
+        </EmptyTitle>
+        <EmptyDescription>{describe()}</EmptyDescription>
       </EmptyHeader>
       <EmptyContent>
+        {switchable && (
+          <Button
+            variant="primary"
+            size="default"
+            loading={selectProject.isPending}
+            disabled={selectProject.isPending}
+            onClick={() => void switchAndOpen()}
+          >
+            Switch to {location.projectName}
+          </Button>
+        )}
         {channel ? (
           <Button
             variant="outline"
@@ -68,4 +108,19 @@ export function CanvasNotFound({ channelId }: { channelId?: string }) {
       </EmptyContent>
     </Empty>
   );
+
+  function describe(): string {
+    if (location && switchable) {
+      return `"${location.canvasName}" is in ${location.organizationName} / ${location.projectName}.`;
+    }
+    if (location) {
+      return `"${location.canvasName}" is in ${location.organizationName} / ${location.projectName}. This app is signed in to ${currentProject?.name ?? "another project"}. Sign in again and pick that project to open it here.`;
+    }
+    if (isFetching) {
+      return "Looking for this canvas in your other projects.";
+    }
+    return currentProject
+      ? `This canvas is not in ${currentProject.name}. Switch to the project it belongs to and open the link again.`
+      : "This canvas is not in the project you are signed in to. Switch to the project it belongs to and open the link again.";
+  }
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
@@ -35,7 +35,7 @@ export function WebsiteDashboard({
     return <CanvasLoadFailed error={error} onRetry={refetch} />;
   }
   if (!dashboard) {
-    return <CanvasNotFound channelId={channelId} />;
+    return <CanvasNotFound channelId={channelId} dashboardId={dashboardId} />;
   }
   if (dashboard.kind === "grid") {
     return <GridCanvasView canvasId={dashboardId} interactive={editing} />;

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -1,6 +1,7 @@
 import { UNTITLED_CANVAS_NAME } from "@posthog/core/canvas/canvasNaming";
 import type {
   CanvasDraft,
+  CanvasLocation,
   CanvasSource,
   CanvasVersion,
   DashboardRecord,
@@ -111,6 +112,30 @@ export function useDashboard(id: string | undefined): {
     error,
     refetch: () => void refetch(),
   };
+}
+
+/**
+ * Which project owns a canvas that this project does not have.
+ *
+ * Disabled unless a caller opts in, so the happy path never pays for it. Only the not-found
+ * screen has a reason to ask.
+ */
+export function useCanvasLocation(
+  id: string | undefined,
+  options?: { enabled?: boolean },
+): { location: CanvasLocation | null | undefined; isFetching: boolean } {
+  const trpc = useHostTRPC();
+  const { data, isFetching } = useQuery(
+    trpc.dashboards.location.queryOptions(
+      { id: id ?? "" },
+      {
+        enabled: !!id && (options?.enabled ?? false),
+        staleTime: SPACE_QUERY_STALE_TIME_MS,
+        meta: AUTH_SCOPED_QUERY_META,
+      },
+    ),
+  );
+  return { location: data, isFetching };
 }
 
 /** A canvas's source project — the head, or a historical version. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15825,6 +15825,28 @@ export namespace Schemas {
     }
 
     /**
+     * Where a canvas lives: the project and organization that own it.
+     */
+    export interface CanvasLocation {
+      /** Id of the canvas that was looked up. */
+      canvas_id: string;
+      /** Display name of the canvas. */
+      canvas_name: string;
+      /** Id of the channel the canvas is filed into. */
+      channel_id: string;
+      /** Id of the project that owns the canvas. Use it as the project_id path segment on /api/projects/<project_id>/canvases/ to read the canvas itself. */
+      project_id: number;
+      /** Display name of the owning project. */
+      project_name: string;
+      /** Id of the organization the owning project belongs to. */
+      organization_id: string;
+      /** Display name of that organization. */
+      organization_name: string;
+      /** Canonical link to the canvas in the PostHog app. The only valid way to link to a canvas — share this when pointing a user at it; never construct a canvas URL. */
+      url: string;
+    }
+
+    /**
      * Payload for promoting a draft version to the canvas's live head.
      */
     export interface CanvasPromote {


### PR DESCRIPTION
Stacked on [#86858](https://github.com/PostHog/posthog/pull/86858). Review that one first.

## Problem

[#86858](https://github.com/PostHog/posthog/pull/86858) makes Desktop say a canvas is not in the signed-in project. It cannot say where the canvas went, because a share link carries no project and nothing else does either.

A person following a link from a teammate is left to guess which of their projects to try.

## Changes

- The not-found screen now names the project and organization that own the canvas.
- When the owning project is one the session already holds, a button switches to it and reopens the canvas.
- When it is not, the screen says which project to pick and tells the person to sign in again.
- `GET /api/canvas_locations/<canvas_id>/` resolves a canvas id to its project. It registers on the root router, because the caller is asking which project to use and so cannot supply one.

Access runs as a single queryset, so an absent canvas, one in an unreachable project, one in someone else's personal channel, and a soft-deleted one all return the same 404. Splitting them would make the endpoint an oracle for which canvas ids exist. The viewset exposes the resolved team, so a token carrying `scoped_teams` is checked against it instead of being rejected as "not a project-based endpoint".

> [!IMPORTANT]
> The switch button cannot appear for most sessions today. Desktop requests OAuth with `required_access_level=project`, so the consent screen grants exactly one project and `orgProjectsMap` holds one entry. Those sessions get the naming and the sign-in-again instruction instead. Widening that OAuth request is a separate decision, not part of this PR.

Mechanical: `InstanceApiClient` is a new client for `/api/` endpoints that are not project-scoped. `ProjectApiClient` refuses to build a URL without a selected project, which is the situation this endpoint exists to resolve.

Also here, and unrelated to canvases: `hogli format:js` gains `--no-error-on-unmatched-pattern` on the oxlint half, which the oxfmt half already had. Committing only codegen output otherwise fails the pre-commit hook, because oxlint is handed paths its own ignore patterns exclude, finds nothing, and exits non-zero. That blocked the generated types in this PR.

No screenshot: the visible change is two sentences and a button inside the screen [#86858](https://github.com/PostHog/posthog/pull/86858) already shows.

## How did you test this code?

Automated only. The agent did not run the desktop app against a live Django stack, so the switch-and-reopen flow is unverified end to end.

- `test_canvas_location_api.py` resolves a canvas in a second project of the same organization, and asserts an identical 404 body across four unreachable cases: unknown id, a team the user cannot access, another member's personal channel, and a soft-deleted canvas. That parameterized table is the security-relevant part; it stops a refactor from making any one of them distinguishable.
- `dashboardsService.test.ts` covers the camelCase mapping, `null` for both 404 and 403, and a throw on 500. The 403 row is the scoped-token case a refactor would most likely turn into an error.
- `CanvasNotFound.test.tsx` covers the switch button appearing only when the session holds the project, and asserts the switch runs before the navigation. That ordering is load-bearing and invisible in the source: selecting a project calls `openTaskInput()` and navigates away, so reopening the canvas has to land after it.

Not run: the desktop Playwright suite, and anything needing a live desktop build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

Scoped as a separate PR at the reporter's request, after the OAuth constraint above turned up during planning and made the switch button narrower in value than it first looked. The plan also proposed intersecting `user.teams` with `UserPermissions.team_ids_visible_for_user`; `user.teams` already accounts for org membership and project RBAC, so the second filter was dropped rather than carried as unexplained belt-and-braces.

Public artifact: nothing here carries material from the agent session that is not already public. Test fixtures use invented ids and `example.com` addresses.
