### PR TITLE
fix(google_sheets): handle Invalid range 400 on the full-sheet data read

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -388,7 +388,17 @@ def google_sheets_source(
         # Read the raw grid and build the records ourselves rather than calling
         # `get_all_records`, which can't cope with a blank header cell. `pad_values=True` mirrors
         # what `get_all_records` asks for, so every row is the same width as the widest one.
-        grid = cast(list[list[str]], _retry_on_transient_api_error(lambda: worksheet.get(pad_values=True)))
+        try:
+            grid = cast(list[list[str]], _retry_on_transient_api_error(lambda: worksheet.get(pad_values=True)))
+        except gspread.exceptions.APIError as e:
+            # Same deterministic 400 handled above for the header/incremental-field reads (e.g. an
+            # empty sheet, or a sheet resized to have no columns) — this call has no explicit range,
+            # so Google rejects the bare sheet-name reference as "Invalid range: '<title>'" instead
+            # of "Unable to parse range". Treat it as an empty grid rather than failing the sync.
+            if e.code == 400 and "Invalid range" in str(e):
+                grid = []
+            else:
+                raise
         values = _records_from_grid(grid)
 
         if should_use_incremental_field and db_incremental_field_last_value is not None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -707,6 +707,36 @@ def test_google_sheets_source_skips_unparseable_header_range():
     assert tables[0].num_rows == 0
 
 
+def test_google_sheets_source_skips_unparseable_invalid_range_on_data_read():
+    """The full-grid read in `get_rows` has no explicit A1 range (it asks for the whole sheet by
+    name), so the same deterministic 400 handled above for the header/incremental-field reads
+    surfaces as 'Invalid range: <title>' instead of 'Unable to parse range'. This call had no
+    handling for it at all, so a zero-dimension worksheet crashed the sync outright instead of
+    syncing as an empty table."""
+    config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+
+    mock_worksheet = mock.MagicMock()
+    mock_worksheet.get_all_values.return_value = [[]]
+    mock_worksheet.get.side_effect = _api_error(400, "Invalid range: 'empty_sheet'", "INVALID_ARGUMENT")
+
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets.get_schemas",
+            return_value=[("empty_sheet", 123)],
+        ),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets._get_worksheet",
+            return_value=mock_worksheet,
+        ),
+    ):
+        response = google_sheets_source(
+            config, "empty_sheet", db_incremental_field_last_value=None, api_version=GOOGLE_SHEETS_API_VERSION_V4
+        )
+        tables = list(cast(Iterable[Any], response.items()))
+
+    assert tables[0].num_rows == 0
+
+
 def test_get_schema_incremental_fields_reraises_other_api_errors():
     """Only the deterministic 'Unable to parse range' 400 is swallowed. Transient 5xx errors are
     retried with backoff and, once retries are exhausted, must still propagate so Temporal can retry


### PR DESCRIPTION
## Problem

A Google Sheets sync fails outright when a worksheet has zero rows or columns, instead of syncing that sheet as empty.

Google rejects the full-sheet data read with a 400 `Invalid range: '<title>'` for that worksheet shape. Surfaced as an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a021e1-f4dc-7fe0-b252-65a39e85305e).

The header and incremental-field reads already treat this worksheet shape as empty (they hit a sibling 400, `Unable to parse range`, on their explicit A1 ranges) — the full-sheet data read had no such handling and raised straight through, failing the whole sync.

## Changes

- The full-sheet data read now treats Google's `Invalid range` 400 as an empty grid, so the sheet syncs with zero rows instead of failing the sync.
- Mechanical: mirrors the existing `Unable to parse range` handling already applied to the header and incremental-field reads in the same file.

## How did you test this code?

- Added `test_google_sheets_source_skips_unparseable_invalid_range_on_data_read`, which reproduces the exact 400 from the error tracking issue and asserts the source now yields a zero-row table instead of raising.
- Ran the `google_sheets` test suite locally: all 89 tests pass.
- Not run: an end-to-end sync against a live Google Sheet, since this environment has no Google Sheets credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in `google_sheets.py`. Read gspread's `Worksheet.get`/`absolute_range_name` to understand why a bare sheet-name reference fails differently than an explicit A1 range for the same zero-dimension worksheet shape. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.