### PR TITLE
fix(data-warehouse): reassure users tables can be changed after setup

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -372,6 +372,11 @@ export default function SchemaForm(): JSX.Element {
     return (
         <>
             <div className="flex flex-col gap-2 flex-1 min-h-0">
+                {!isDirectQueryMode && (
+                    <p className="text-muted text-sm mb-0">
+                        You can enable more tables or change sync settings later on the source's Schemas tab.
+                    </p>
+                )}
                 {hasManySchemas && (
                     <div className="flex items-center gap-2">
                         <LemonInput


### PR DESCRIPTION
## Problem

Users setting up a new data-warehouse source hesitate on the table-selection step because nothing tells them the choice is reversible. Some leave the flow mid-setup to ask whether tables they skip now can be enabled later.

## Changes

- The table-selection step now shows a short note that more tables and sync settings can be changed later on the source's Schemas tab, so users can move forward without second-guessing the initial selection.
- The note appears only in standard sync mode. Direct-query mode already has its own descriptive copy, so it is left unchanged.

## How did you test this code?

Not manually run. Verified `pnpm --filter=@posthog/frontend fix` (lint + format) makes no changes to the touched file, and confirmed the copy claim is accurate against the source detail page, which exposes a Schemas tab that toggles `should_sync` per table and refreshes schemas after creation. The remaining frontend typecheck errors are a pre-existing `@posthog/quill` package-build issue unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent reviewing anonymized session summaries of the new-source onboarding flow. The summaries surfaced users unsure whether table selection is reversible. Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions. The copy points at the Schemas tab by name after confirming that tab exists and supports enabling previously-skipped tables.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
