### PR TITLE
chore(marketing-analytics): cover the touchpoint gate's negative cases in demo data

### DIFF
--- a/products/marketing_analytics/backend/demo/events.py
+++ b/products/marketing_analytics/backend/demo/events.py
@@ -110,6 +110,8 @@ class MarketingEventGenerator:
                 properties["utm_medium"] = channel.utm_medium
             if channel.utm_campaign:
                 properties["utm_campaign"] = channel.utm_campaign
+            if channel.click_id_property:
+                properties[channel.click_id_property] = uuid.uuid5(PERSON_NAMESPACE, f"click-{distinct_id}").hex
             properties.update(channel.extra_properties)
             session_id = self._pageview(distinct_id, person_uuid, ts, properties)
             self._maybe_convert(

--- a/products/marketing_analytics/backend/demo/test_world.py
+++ b/products/marketing_analytics/backend/demo/test_world.py
@@ -52,3 +52,22 @@ class TestDemoWorldPaidSignals(SimpleTestCase):
     def test_a_paid_click_id_exists_without_any_medium(self):
         autotagged = [c for c in FREE_CHANNELS if c.extra_properties.get("gad_source") and not c.utm_medium]
         assert autotagged, "nothing covers paid traffic detectable only by gad_source"
+
+    def test_a_paid_click_id_exists_without_any_utm(self):
+        # gad_source above still rides alongside a utm_source, so it never exercises the
+        # click-id branch on its own.
+        assert [c for c in FREE_CHANNELS if c.click_id_property == "gclid" and not c.utm_source], (
+            "nothing covers a paid click whose only evidence is the click id"
+        )
+
+    def test_fbclid_exists_without_any_other_paid_signal(self):
+        assert [
+            c for c in FREE_CHANNELS if c.click_id_property == "fbclid" and not c.utm_source and not c.extra_properties
+        ], "nothing covers fbclid as the sole identifier, so excluding it proves nothing"
+
+    def test_a_campaign_exists_with_nothing_naming_its_source(self):
+        assert [
+            c
+            for c in FREE_CHANNELS
+            if c.utm_campaign and not c.utm_source and not c.click_id_property and not c.extra_properties
+        ], "nothing covers a campaign-only pageview, so the source requirement is untested"

--- a/products/marketing_analytics/backend/demo/world.py
+++ b/products/marketing_analytics/backend/demo/world.py
@@ -57,6 +57,9 @@ class DemoFreeChannel:
     signup_rate: float = 0.03
     purchase_rate: float = 0.008
     utm_source_variants: dict[str, float] = field(default_factory=dict)
+    # Same unprefixed name the SDK writes, as on DemoCampaign. Emitted per person, so a
+    # channel can carry a click id without carrying any UTM at all.
+    click_id_property: str | None = None
     extra_properties: dict[str, str] = field(default_factory=dict)
     scenario: str = ""
 
@@ -676,6 +679,36 @@ FREE_CHANNELS: tuple[DemoFreeChannel, ...] = (
         purchase_rate=0.015,
         extra_properties={"gad_source": "1"},
         scenario="Paid traffic carrying gad_source and no utm_medium",
+    ),
+    # The three gate cases below carry no utm_source, so each one isolates a single
+    # branch of the touchpoint rule. Without them the rule's negative half is
+    # untestable against demo data: every tagged pageview names a source.
+    DemoFreeChannel(
+        key="google_clickid_only",
+        daily_sessions=11,
+        referring_domain="google.com",
+        click_id_property="gclid",
+        signup_rate=0.06,
+        purchase_rate=0.014,
+        scenario="Paid click with the UTMs stripped: a gclid is the only evidence",
+    ),
+    DemoFreeChannel(
+        key="meta_fbclid_only",
+        daily_sessions=16,
+        referring_domain="facebook.com",
+        click_id_property="fbclid",
+        signup_rate=0.03,
+        purchase_rate=0.006,
+        scenario="fbclid rides on organic Facebook links too, so it must not qualify alone",
+    ),
+    DemoFreeChannel(
+        key="campaign_only_orphan",
+        daily_sessions=9,
+        referring_domain="",
+        utm_campaign="orphan_campaign",
+        signup_rate=0.03,
+        purchase_rate=0.006,
+        scenario="utm_campaign with nothing naming the source: stays excluded",
     ),
 )
 


### PR DESCRIPTION
## Problem

Anyone testing marketing attribution against the demo world cannot exercise three branches of the touchpoint rule, because no generated pageview reaches them. Every tagged pageview in `world.py` names a `utm_source`, so a rule change that turns on a click id, or that must keep rejecting one, produces the same numbers either way.

The three unreachable branches:

- A click id as the only evidence. `google_autotagged` looks like this case but carries `utm_source=google` alongside `gad_source`, so it always qualifies on the source.
- An `fbclid` with no other paid signal. Excluding it proves nothing when nothing generates it.
- A `utm_campaign` with nothing naming its source.

## Changes

- The generator emits three new free channels, each carrying one signal and no `utm_source`, so each isolates a single branch:

| channel | carries | isolates |
| --- | --- | --- |
| `google_clickid_only` | `gclid` | a paid click whose only evidence is the click id |
| `meta_fbclid_only` | `fbclid` | that `fbclid` must not qualify alone |
| `campaign_only_orphan` | `utm_campaign` | that campaign without a source stays excluded |

- `DemoFreeChannel` gains `click_id_property`, matching `DemoCampaign`. A free channel can now carry a click id without carrying any UTM, which `extra_properties` could not express: it holds one fixed value for every person, while a click id is per person.
- Three assertions in `test_world.py` keep the cases present, in the style of the existing coverage assertions.

Nothing user-visible changes. The generator is a local-development command, gated on `DEBUG`.

## How did you test this code?

- Regenerated team 6 locally with `generate_marketing_demo_data --days-past 30`. The three cases reach ClickHouse: 316 pageviews carrying only `gclid`, 434 only `fbclid`, 241 only `utm_campaign`. All three counted zero before this change.
- The new assertions catch a demo world that stops covering a branch. Verified by deleting the three channels and re-running: each assertion fails, and passes again once restored.
- Not checked: whether the excluded branches stay excluded end to end. That needs a rule change to test against, and #86141 is where it belongs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The generator is not documented outside its own module docstring.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code while testing #86141 locally. The gap surfaced from a ClickHouse query over team 7: every candidate for the click-id branch also carried a `utm_source`, so the branch had no data behind it and the dashboard read identically with the rule on or off.

Skills invoked: `/writing-pr-descriptions`.

`click_id_property` on `DemoFreeChannel` replaced a first attempt that used `extra_properties`, which gives every person the same click id. The campaigns already emit a per-person `uuid5`, so the free channels now use the same helper rather than a second mechanism.

All generated values are synthetic and come from the existing demo catalog. No customer data is involved.
