### PR TITLE
fix(frontend): open the internal-user filter gear in a new tab

### DIFF
--- a/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
@@ -61,12 +61,18 @@ export function TestAccountFilterSwitch({
             label={
                 <div className="flex items-center">
                     <span>Filter out internal and test users</span>
+                    {/* Opens in a new tab: this switch sits inside forms that hold unsaved work (a
+                        half-built scanner, an unsaved cohort, an insight in progress), and the
+                        disabledReason below actively sends people here when no filters are set up. */}
                     <LemonButton
                         icon={<IconGear />}
                         size="small"
                         noPadding
                         className="ml-1"
                         to={urls.settings('environment-customization', 'internal-user-filtering')}
+                        targetBlank
+                        hideExternalLinkIcon
+                        tooltip="Configure internal and test users. Opens in a new tab."
                     />
                 </div>
             }

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -605,6 +605,26 @@ describe('replayScannerLogic', () => {
             info.mockRestore()
         })
 
+        // Leaving mid-wizard is routine (the recordings step links out to settings), so resuming has to
+        // land where the work was. Always returning to the first step reads as having lost the later ones.
+        it('resumes on the step the last edit was made on', async () => {
+            const info = jest.spyOn(lemonToast, 'info')
+            const editorLogic = scannerEditorSceneLogic()
+            editorLogic.mount()
+            try {
+                editorLogic.actions.setStep('budget')
+                logic.actions.setScannerValues({ name: 'Drafted' })
+                logic.unmount()
+
+                info.mock.calls[0][1]?.button?.action?.()
+                expect(router.values.location.pathname).toContain(urls.replayVisionScannerBudget('new'))
+            } finally {
+                info.mockRestore()
+                editorLogic.unmount()
+                router.actions.push(urls.replayVision())
+            }
+        })
+
         it('stays quiet on the way out when the draft was only restored', async () => {
             logic.actions.setScannerValues({ name: 'Drafted' })
             logic.unmount()

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -1449,6 +1449,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 clearScannerDraft()
             }
             cache.draftTouched = savedAt !== null
+            // Recorded here for the resume toast. By the time the scene unmounts the router already
+            // points at wherever the user navigated, so the step has to be captured while editing.
+            cache.lastEditedStep = scannerEditorSceneLogic.findMounted()?.values.step ?? cache.lastEditedStep
             actions.setScannerDraftSavedAt(savedAt)
         }
         return {
@@ -2117,10 +2120,15 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
 
     beforeUnmount(({ values, props, cache }) => {
         if (props.id === 'new' && cache.draftTouched && values.scannerDraftSavedAt !== null) {
+            // Back to the step the last edit was on, not always the first one — returning to details
+            // after editing recordings or budget reads as having lost those steps, even though the
+            // values were restored. The template step holds no edits, so it falls through to details.
+            const step = cache.lastEditedStep
+            const resumeUrl = scannerStepUrl(step && step !== 'template' ? step : 'details', 'new')
             lemonToast.info('Draft saved', {
                 button: {
                     label: 'Resume',
-                    action: () => router.actions.push(urls.replayVisionScannerDetails('new')),
+                    action: () => router.actions.push(resumeUrl),
                     dataAttr: 'vision-draft-resume-toast',
                 },
             })


### PR DESCRIPTION
## Problem

Someone building a Replay Vision scanner clicks the gear on the "Filter out internal and test users" switch and lands in Settings, with the wizard gone.

- The switch tells them to click it. With no filters configured it disables itself with "You haven't set any internal test filters. Click the gear icon to configure."
- The gear links to settings in the same tab, so the router unmounts the form around it.
- The switch renders at 20 call sites: insights, cohorts, experiments, hog functions, AI observability, and the scanner wizard. Each sits inside a form holding unsaved work.
- The scanner wizard's values do survive. `persistDraft` writes to localStorage on every edit, with no debounce.
- The recovery affordance was the real gap. The "Draft saved / Resume" toast always returned to the first step, so a user who was editing recordings or budget came back to a wizard that read as reset.

## Changes

- The gear opens settings in a new tab, so the form it sits in stays mounted. A tooltip says so before the click.
- The scanner wizard's "Resume" toast returns to the step the last edit was on. `persistDraft` records that step while editing, because by unmount time the router already points at wherever the user went.
- Nothing else changes. The switch looks identical: `hideExternalLinkIcon` keeps the external-link glyph off, so the only visible difference is the new tooltip on hover.

## How did you test this code?

Automated tests, run locally:

- `replayScannerLogic.test.ts` — a new case asserts the Resume toast routes to the last-edited step. No existing test checked the toast's destination, so the always-first-step behavior was invisible to the suite.
- `TestAccountFiltersSwitch.test.tsx` — the existing gear-navigation test covers the new-tab link unchanged.

Not done: no manual browser check. The change was never exercised against a running app, and none of the other 19 call sites were opened.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.5) via PostHog Desktop. Repo skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Both bugs surfaced during a review of Replay Vision product feedback. None of that material reaches this diff. The code, comments, tests, and this description are written fresh, and the feedback is not quoted or paraphrased anywhere.

Two decisions worth flagging for review:

- The gear change lands in a shared component rather than behind an opt-in prop. Every one of the 20 call sites sits inside a form with unsaved work, so the narrower fix would leave the same bug in 19 places.
- The session also drafted a fix for a separate report about the AI-consent gate. That work is dropped and uncommitted. The root cause was never reproduced, so the change would have been a guard rather than a repair.

An earlier version of the new test leaked a mounted `scannerEditorSceneLogic` into the following test and broke an unrelated assertion. It now cleans up in a `finally`.
