### PR TITLE
feat(code): add activity item read state menu

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -60,6 +60,7 @@ import type {
   SuggestedReviewerWriteEntry,
   Task,
   TaskActivityMarkReadResult,
+  TaskActivityMarkUnreadResult,
   TaskActivityPage,
   TaskActivityReadMarker,
   TaskChannel,
@@ -2930,6 +2931,27 @@ export class PostHogAPIClient {
       );
     }
     return (await response.json()) as TaskActivityMarkReadResult;
+  }
+
+  async markTaskActivityUnread(
+    activities: TaskActivityReadMarker[],
+  ): Promise<TaskActivityMarkUnreadResult> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/task_activity/mark_unread/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: {
+        body: JSON.stringify({ activities }),
+      },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to mark task activity unread: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as TaskActivityMarkUnreadResult;
   }
 
   async getTaskThreadMessages(taskId: string): Promise<TaskThreadMessage[]> {

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1011,6 +1011,8 @@ export type ChannelActionType =
   | "copy_link"
   | "mention_member"
   | "view_activity"
+  | "mark_activity_read"
+  | "mark_activity_unread"
   | "open_mention"
   | "activity_tab_change";
 

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -276,6 +276,11 @@ export interface TaskActivityMarkReadResult {
   unread_count: number;
 }
 
+export interface TaskActivityMarkUnreadResult {
+  marked_unread: number;
+  unread_count: number;
+}
+
 export type TaskRunStatus =
   | "not_started"
   | "queued"

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   isFetchingNextPage: false,
   items: [] as TaskActivityItem[],
   markRead: vi.fn(),
+  markUnread: vi.fn(),
 }));
 
 vi.mock("@posthog/quill", () => ({
@@ -71,6 +72,12 @@ vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead", () => ({
   useMarkTaskActivityRead: () => ({
     mutate: mocks.markRead,
+    isPending: false,
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useMarkTaskActivityUnread", () => ({
+  useMarkTaskActivityUnread: () => ({
+    mutate: mocks.markUnread,
     isPending: false,
   }),
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
@@ -16,6 +16,7 @@ import { ActivityUnreadsToggle } from "@posthog/ui/features/canvas/components/Ac
 import { ActivityRow } from "@posthog/ui/features/canvas/components/ActivityView";
 import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
+import { useMarkTaskActivityUnread } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityUnread";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
 import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
@@ -59,6 +60,8 @@ export function ActivityHoverCard({
   const shownItems = unreadsOnly ? unreadItems : visibleItems;
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
+  const { mutate: markTasksUnread, isPending: isMarkingUnread } =
+    useMarkTaskActivityUnread();
   useEffect(() => {
     track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
       action_type: "view_activity",
@@ -73,6 +76,26 @@ export function ActivityHoverCard({
 
   const markRead = (item: (typeof items)[number]) => {
     markTasksRead(activityReadPayload([item]));
+  };
+
+  const markReadFromMenu = (item: (typeof items)[number]) => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "mark_activity_read",
+      surface: "activity_panel",
+      channel_id: item.channelId ?? undefined,
+      task_id: item.taskId,
+    });
+    markRead(item);
+  };
+
+  const markUnread = (item: (typeof items)[number]) => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "mark_activity_unread",
+      surface: "activity_panel",
+      channel_id: item.channelId ?? undefined,
+      task_id: item.taskId,
+    });
+    markTasksUnread(activityReadPayload([item]));
   };
 
   const markAllRead = () => {
@@ -133,7 +156,9 @@ export function ActivityHoverCard({
                 item={item}
                 channelId={item.channelId}
                 onOpen={markRead}
-                onMarkRead={markRead}
+                onMarkRead={markReadFromMenu}
+                onMarkUnread={markUnread}
+                isUpdatingReadState={isMarkingRead || isMarkingUnread}
                 currentUser={currentUser}
                 blockedTaskIds={blockedTaskIds}
                 surface="activity_panel"

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
@@ -137,6 +137,7 @@ describe("activityHeadline", () => {
         channelId="channel-1"
         onOpen={vi.fn()}
         onMarkRead={vi.fn()}
+        onMarkUnread={vi.fn()}
         blockedTaskIds={NO_BLOCKED_TASKS}
       />,
     );
@@ -156,5 +157,40 @@ describe("activityHeadline", () => {
       openCommentsTab: true,
       intent: "navigate",
     });
+  });
+
+  it.each([
+    [
+      "more actions menu",
+      (): void => {
+        fireEvent.click(screen.getByLabelText("More actions for Say hello"));
+      },
+    ],
+    [
+      "context menu",
+      (): void => {
+        const row = screen.getByText("Say hello").closest("button");
+        if (!row) throw new Error("Expected activity row button");
+        fireEvent.contextMenu(row);
+      },
+    ],
+  ])("marks read activity unread from the %s", async (_name, openMenu) => {
+    const activity = item({ isUnread: false });
+    const onMarkUnread = vi.fn();
+    render(
+      <ActivityRow
+        item={activity}
+        channelId="channel-1"
+        onOpen={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkUnread={onMarkUnread}
+        blockedTaskIds={NO_BLOCKED_TASKS}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(await screen.findByText("Mark as unread"));
+
+    expect(onMarkUnread).toHaveBeenCalledWith(activity);
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -2,6 +2,8 @@ import {
   BellIcon,
   CheckIcon,
   ChecksIcon,
+  DotsThreeIcon,
+  EnvelopeSimpleIcon,
   LinkIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
@@ -11,12 +13,24 @@ import {
   AvatarFallback,
   Badge,
   Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Heading,
   Spinner,
+  Text,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -29,6 +43,7 @@ import { MentionText } from "@posthog/ui/features/canvas/components/MentionText"
 import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
+import { useMarkTaskActivityUnread } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityUnread";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
 import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
 import { useCanvasChatPanelStore } from "@posthog/ui/features/canvas/stores/canvasChatPanelStore";
@@ -51,7 +66,6 @@ import {
   navigateToTaskDetail,
 } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
-import { Text } from "@radix-ui/themes";
 import { useCallback, useEffect, useMemo } from "react";
 import {
   activityReadPayload,
@@ -65,6 +79,8 @@ export function ActivityRow({
   channelId,
   onOpen,
   onMarkRead,
+  onMarkUnread,
+  isUpdatingReadState = false,
   currentUser,
   blockedTaskIds,
   surface = "activity",
@@ -76,6 +92,8 @@ export function ActivityRow({
   channelId: string | null;
   onOpen: (item: TaskActivityItem) => void;
   onMarkRead: (item: TaskActivityItem) => void;
+  onMarkUnread: (item: TaskActivityItem) => void;
+  isUpdatingReadState?: boolean;
   currentUser?: UserBasic | null;
   /**
    * Tasks whose session is waiting on you. Passed in rather than selected here:
@@ -134,99 +152,160 @@ export function ActivityRow({
 
   return (
     <div className="group relative">
-      <button
-        type="button"
-        onClick={openTask}
-        className={`flex w-full gap-2 rounded-md px-2 text-left transition-colors hover:bg-fill-hover ${compact ? "py-1.5 pr-14" : "py-2"} ${item.isUnread ? "bg-fill-secondary" : ""}`}
-      >
-        <span className="relative mt-0.5 shrink-0">
-          {isAgentActivity ? (
-            <Avatar size="xs">
-              <AvatarFallback>
-                <RobotIcon size={12} />
-              </AvatarFallback>
-            </Avatar>
-          ) : (
-            <UserAvatar user={item.author ?? currentUser} size="xs" />
-          )}
-          {/* Unread is a fact about the feed: you haven't looked at this yet.
+      <ContextMenu>
+        <ContextMenuTrigger
+          render={
+            <button
+              type="button"
+              onClick={openTask}
+              className={`flex w-full gap-2 rounded-md px-2 text-left transition-colors hover:bg-fill-hover ${compact ? "py-1.5 pr-14" : "py-2 pr-10"} ${item.isUnread ? "bg-fill-secondary" : ""}`}
+            />
+          }
+        >
+          <span className="relative mt-0.5 shrink-0">
+            {isAgentActivity ? (
+              <Avatar size="xs">
+                <AvatarFallback>
+                  <RobotIcon size={12} />
+                </AvatarFallback>
+              </Avatar>
+            ) : (
+              <UserAvatar user={item.author ?? currentUser} size="xs" />
+            )}
+            {/* Unread is a fact about the feed: you haven't looked at this yet.
               Waiting on you is a fact about the session, and reading the row
               doesn't answer the prompt — so it keeps its dot until you do. */}
-          {(item.isUnread || awaitsReply) && (
-            <span
-              className="-top-0.5 -right-0.5 absolute h-2 w-2 rounded-full"
-              // Off the table the status dots read, so a row that says the agent
-              // is waiting is the same blue as the session it is waiting in.
-              style={{
-                backgroundColor: awaitsReply
-                  ? DOT_TONE_VAR.blue
-                  : "var(--primary)",
-              }}
-              title={awaitsReply ? "Waiting on you" : "New activity"}
-            />
-          )}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="flex items-baseline gap-2">
-            <Text
-              size="1"
-              weight={item.isUnread ? "medium" : "regular"}
-              className="truncate"
-            >
-              {activityHeadline(item, currentUser?.email)}
-            </Text>
-            {item.isUnread && !compact && <Badge variant="info">New</Badge>}
-            {!compact && (
-              <Text size="1" className="shrink-0 text-muted-foreground">
-                {formatRelativeTimeShort(item.activityAt)}
-              </Text>
+            {(item.isUnread || awaitsReply) && (
+              <span
+                className="-top-0.5 -right-0.5 absolute h-2 w-2 rounded-full"
+                // Off the table the status dots read, so a row that says the agent
+                // is waiting is the same blue as the session it is waiting in.
+                style={{
+                  backgroundColor: awaitsReply
+                    ? DOT_TONE_VAR.blue
+                    : "var(--primary)",
+                }}
+                title={awaitsReply ? "Waiting on you" : "New activity"}
+              />
             )}
           </span>
-          <Text size="1" className="block truncate text-muted-foreground">
-            {item.taskTitle}
-          </Text>
-          {item.snippet && !compact && (
-            <MentionText
-              content={item.snippet}
-              currentUserEmail={currentUser?.email}
-              className="mt-1 block whitespace-pre-wrap break-words text-xs"
-            />
+          <span className="min-w-0 flex-1">
+            <span className="flex items-baseline gap-2">
+              <Text
+                size="xs"
+                weight={item.isUnread ? "medium" : "normal"}
+                className="truncate"
+              >
+                {activityHeadline(item, currentUser?.email)}
+              </Text>
+              {item.isUnread && !compact && <Badge variant="info">New</Badge>}
+              {!compact && (
+                <Text size="xs" className="shrink-0 text-muted-foreground">
+                  {formatRelativeTimeShort(item.activityAt)}
+                </Text>
+              )}
+            </span>
+            <Text size="xs" className="block truncate text-muted-foreground">
+              {item.taskTitle}
+            </Text>
+            {item.snippet && !compact && (
+              <MentionText
+                content={item.snippet}
+                currentUserEmail={currentUser?.email}
+                className="mt-1 block whitespace-pre-wrap break-words text-xs"
+              />
+            )}
+          </span>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-48">
+          {item.isUnread ? (
+            <ContextMenuItem
+              disabled={isUpdatingReadState}
+              onClick={() => onMarkRead(item)}
+            >
+              <CheckIcon size={14} />
+              Mark as read
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem
+              disabled={isUpdatingReadState}
+              onClick={() => onMarkUnread(item)}
+            >
+              <EnvelopeSimpleIcon size={14} />
+              Mark as unread
+            </ContextMenuItem>
           )}
-        </span>
-      </button>
+          {channelId && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                onClick={() =>
+                  void copyChannelLink(channelId, surface, item.taskId)
+                }
+              >
+                <LinkIcon size={14} />
+                Copy link
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
       {compact && (
         <Text
-          size="1"
+          size="xs"
           className="pointer-events-none absolute top-1.5 right-2 text-muted-foreground"
         >
           {formatRelativeTimeShort(item.activityAt)}
         </Text>
       )}
-      {item.isUnread && (
-        <Button
-          variant="default"
-          size="icon-xs"
-          aria-label="Mark as read"
-          title="Mark as read"
-          className={`absolute opacity-0 transition-opacity group-hover:opacity-100 ${compact ? "right-2 bottom-1" : `top-2 ${channelId ? "right-9" : "right-2"}`}`}
-          onClick={() => onMarkRead(item)}
-        >
-          <CheckIcon size={14} />
-        </Button>
-      )}
-      {channelId && !compact && (
-        <Button
-          variant="default"
-          size="icon-xs"
-          aria-label="Copy thread link"
-          className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100"
-          onClick={() =>
-            void copyChannelLink(channelId, "activity", item.taskId)
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="default"
+              size="icon-xs"
+              aria-label={`More actions for ${item.taskTitle}`}
+              data-attr="activity-item-menu"
+              className={`absolute opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 ${compact ? "right-2 bottom-1" : "top-2 right-2"}`}
+              onClick={(event) => event.stopPropagation()}
+            />
           }
         >
-          <LinkIcon size={14} />
-        </Button>
-      )}
+          <DotsThreeIcon size={14} weight="bold" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          {item.isUnread ? (
+            <DropdownMenuItem
+              disabled={isUpdatingReadState}
+              onClick={() => onMarkRead(item)}
+            >
+              <CheckIcon size={14} />
+              Mark as read
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              disabled={isUpdatingReadState}
+              onClick={() => onMarkUnread(item)}
+            >
+              <EnvelopeSimpleIcon size={14} />
+              Mark as unread
+            </DropdownMenuItem>
+          )}
+          {channelId && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() =>
+                  void copyChannelLink(channelId, surface, item.taskId)
+                }
+              >
+                <LinkIcon size={14} />
+                Copy link
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -250,6 +329,8 @@ export function ActivityView() {
   const blockedTaskIds = useBlockedTaskIds();
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
+  const { mutate: markTasksUnread, isPending: isMarkingUnread } =
+    useMarkTaskActivityUnread();
   const visibleItems = items;
   const unreadItems = useMemo(
     () => getUnreadActivityItems(visibleItems),
@@ -270,6 +351,30 @@ export function ActivityView() {
         },
       ]),
     [markTasksRead],
+  );
+  const markReadFromMenu = useCallback(
+    (item: TaskActivityItem) => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "mark_activity_read",
+        surface: "activity",
+        channel_id: item.channelId ?? undefined,
+        task_id: item.taskId,
+      });
+      markRead(item);
+    },
+    [markRead],
+  );
+  const markUnread = useCallback(
+    (item: TaskActivityItem) => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "mark_activity_unread",
+        surface: "activity",
+        channel_id: item.channelId ?? undefined,
+        task_id: item.taskId,
+      });
+      markTasksUnread(activityReadPayload([item]));
+    },
+    [markTasksUnread],
   );
   const markAllRead = useCallback(() => {
     markTasksRead(activityReadPayload(unreadItems));
@@ -344,7 +449,9 @@ export function ActivityView() {
               item={item}
               channelId={item.channelId}
               onOpen={markRead}
-              onMarkRead={markRead}
+              onMarkRead={markReadFromMenu}
+              onMarkUnread={markUnread}
+              isUpdatingReadState={isMarkingRead || isMarkingUnread}
               currentUser={currentUser}
               blockedTaskIds={blockedTaskIds}
             />
@@ -388,10 +495,10 @@ export function ActivityView() {
       <div className="mx-auto w-full max-w-[680px] px-4 py-6">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <Text size="5" weight="bold" className="block">
+            <Heading size="xl" render={<h1 aria-label="Activity" />}>
               Activity
-            </Text>
-            <Text size="2" className="block text-muted-foreground">
+            </Heading>
+            <Text size="sm" className="block text-muted-foreground">
               Task updates and comment notifications across{" "}
               {spacesLayout ? "spaces" : "channels"}.
             </Text>

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityUnread.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityUnread.ts
@@ -1,0 +1,91 @@
+import type {
+  TaskActivity,
+  TaskActivityMarkUnreadResult,
+  TaskActivityPage,
+  TaskActivityReadMarker,
+} from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { TASK_ACTIVITY_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
+import { toast } from "@posthog/ui/primitives/toast";
+import type { InfiniteData, UseMutationResult } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+interface MarkUnreadContext {
+  previous?: InfiniteData<TaskActivityPage>;
+}
+
+export function useMarkTaskActivityUnread(): UseMutationResult<
+  TaskActivityMarkUnreadResult | undefined,
+  Error,
+  TaskActivityReadMarker[],
+  MarkUnreadContext
+> {
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (activities: TaskActivityReadMarker[]) => {
+      if (!client) throw new Error("Not authenticated");
+      if (activities.length === 0) return;
+      return client.markTaskActivityUnread(activities);
+    },
+    onMutate: async (activities: TaskActivityReadMarker[]) => {
+      await queryClient.cancelQueries({ queryKey: TASK_ACTIVITY_QUERY_KEY });
+      const previous = queryClient.getQueryData<InfiniteData<TaskActivityPage>>(
+        TASK_ACTIVITY_QUERY_KEY,
+      );
+      const markedTasks = new Map(
+        activities.flatMap((activity) =>
+          activity.activity_id
+            ? []
+            : [[activity.task_id, activity.seen_before] as const],
+        ),
+      );
+      const markedCommentActivities = new Set(
+        activities.flatMap((activity) =>
+          activity.activity_id ? [activity.activity_id] : [],
+        ),
+      );
+
+      queryClient.setQueryData<InfiniteData<TaskActivityPage>>(
+        TASK_ACTIVITY_QUERY_KEY,
+        (data) => {
+          if (!data) return data;
+          const shouldMarkUnread = (row: TaskActivity): boolean => {
+            const seenBefore = markedTasks.get(row.task_id);
+            return (
+              markedCommentActivities.has(row.id) ||
+              (!row.latest_comment_id &&
+                !!seenBefore &&
+                row.activity_at <= seenBefore)
+            );
+          };
+          let restored = 0;
+          for (const page of data.pages) {
+            for (const row of page.results) {
+              if (!row.is_unread && shouldMarkUnread(row)) restored++;
+            }
+          }
+          return {
+            ...data,
+            pages: data.pages.map((page, index) => ({
+              ...page,
+              unread_count:
+                index === 0 ? page.unread_count + restored : page.unread_count,
+              results: page.results.map((row) =>
+                shouldMarkUnread(row) ? { ...row, is_unread: true } : row,
+              ),
+            })),
+          };
+        },
+      );
+      return { previous };
+    },
+    onError: (_error, _activities, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, context.previous);
+      }
+      toast.error("Couldn't mark activity as unread");
+    },
+  });
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockClient = vi.hoisted(() => ({
   getTaskActivity: vi.fn(),
   markTaskActivityRead: vi.fn(),
+  markTaskActivityUnread: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
@@ -21,6 +22,7 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 }));
 
 import { useMarkTaskActivityRead } from "./useMarkTaskActivityRead";
+import { useMarkTaskActivityUnread } from "./useMarkTaskActivityUnread";
 import { TASK_ACTIVITY_QUERY_KEY, useTaskActivity } from "./useTaskActivity";
 
 function activity(overrides: Partial<TaskActivity>): TaskActivity {
@@ -256,5 +258,54 @@ describe("task activity hooks", () => {
       true,
     ]);
     expect(cached?.pages[0]?.unread_count).toBe(2);
+  });
+
+  it("marks only the selected comment activity unread", async () => {
+    const page: TaskActivityPage = {
+      results: [
+        activity({
+          id: "comment-activity-1",
+          latest_comment_id: "comment-1",
+          is_unread: false,
+        }),
+        activity({
+          id: "comment-activity-2",
+          latest_comment_id: "comment-2",
+          is_unread: false,
+        }),
+      ],
+      unread_count: 0,
+    };
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, {
+      pages: [page],
+      pageParams: [undefined],
+    });
+    mockClient.markTaskActivityUnread.mockResolvedValue({
+      marked_unread: 1,
+      unread_count: 1,
+    });
+
+    const hook = renderHook(() => useMarkTaskActivityUnread(), { wrapper });
+    act(() => {
+      hook.result.current.mutate([
+        {
+          task_id: "task-1",
+          seen_before: "2026-07-01T10:00:00Z",
+          activity_id: "comment-activity-1",
+        },
+      ]);
+    });
+
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityUnread).toHaveBeenCalledOnce(),
+    );
+    const cached = queryClient.getQueryData<{
+      pages: TaskActivityPage[];
+    }>(TASK_ACTIVITY_QUERY_KEY);
+    expect(cached?.pages[0]?.results.map((row) => row.is_unread)).toEqual([
+      true,
+      false,
+    ]);
+    expect(cached?.pages[0]?.unread_count).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem

People reviewing Activity cannot return an item to the unread queue after opening it.

The server contract lands first in [#86928](https://github.com/PostHog/posthog/pull/86928) so desktop releases never call an unavailable endpoint.

## Changes

- Activity rows now offer contextual read or unread actions from an ellipsis menu and right-click menu.
- Channel-backed rows keep Copy link in the same menu.
- The Activity feed and unread count update immediately, then restore on request failure.
- Explicit read-state actions emit the existing channel action event.
- This PR contains only desktop changes and depends on the backend stack layer.

**Before**

```mermaid
flowchart LR
    A[Activity row] --> B[Open item]
    B --> C[Mark read API]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
    class C phRed;
```

**After**

```mermaid
flowchart LR
    A[Activity row] --> B{Item menu}
    B --> C[Mark read API]
    B --> D[Mark unread API]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
    class C,D phRed;
```

![Activity item actions menu](https://raw.githubusercontent.com/PostHog/pr-assets/c8df19b8efb1e028bec1a8de9be5b38712337f7a/2026/08/116b9d15-6b92-4722-a7ee-c6dd99dffc9f.png)

No before screenshot is included because the item menu did not exist.

## How did you test this code?

- Vitest covers both menu entry points and the exact comment selected by the optimistic unread update.
- TypeScript checks cover the shared types, API client, and UI package.
- React Doctor's chained-iteration warning is resolved without changing cache behavior.
- The screenshot uses Storybook with the menu opened by its play interaction.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No manual docs update. The Activity menu uses existing product language.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi using GPT-5.6 Sol implemented this change. A public session link was unavailable in the environment.

Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/investigating-ci-failures`, and `/stacking-prs`.

CI required a backend-first stack because desktop releases are not coordinated with backend deploys. The screenshot uses invented data.
