### PR TITLE
feat(tasks): add activity unread endpoint

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7820,12 +7820,13 @@ def _bounded_activity_snippet(content: str, limit: int = 1024) -> str:
     return content.encode("utf-8")[:limit].decode("utf-8", errors="ignore")
 
 
-def mark_task_activity_read(
+def _set_task_activity_read_state(
     team_id: int,
     user_id: int | None,
     activities: Sequence[tuple[UUID, datetime, UUID | None]],
+    *,
+    is_read: bool,
 ) -> int:
-    """Mark feed rows read only when their latest activity was visible to the requester."""
     if user_id is None or not activities:
         return 0
     activity_versions = Q()
@@ -7835,24 +7836,42 @@ def mark_task_activity_read(
             comment_activity_ids.append(comment_activity_id)
         else:
             activity_versions |= Q(task_id=task_id, activity_at__lte=seen_before)
+    read_state_filter = {"read_at__isnull": is_read}
+    read_at = django_timezone.now() if is_read else None
     task_rows = 0
     if activity_versions:
         task_rows = (
             TaskActivity.objects.for_team(team_id)
-            .filter(user_id=user_id, read_at__isnull=True)
+            .filter(user_id=user_id, **read_state_filter)
             .filter(activity_versions)
-            .update(read_at=django_timezone.now())
+            .update(read_at=read_at)
         )
     comment_rows = (
         TaskCommentActivity.objects.for_team(team_id)
         .filter(
             user_id=user_id,
             id__in=comment_activity_ids,
-            read_at__isnull=True,
+            **read_state_filter,
         )
-        .update(read_at=django_timezone.now())
+        .update(read_at=read_at)
     )
     return task_rows + comment_rows
+
+
+def mark_task_activity_read(
+    team_id: int,
+    user_id: int | None,
+    activities: Sequence[tuple[UUID, datetime, UUID | None]],
+) -> int:
+    return _set_task_activity_read_state(team_id, user_id, activities, is_read=True)
+
+
+def mark_task_activity_unread(
+    team_id: int,
+    user_id: int | None,
+    activities: Sequence[tuple[UUID, datetime, UUID | None]],
+) -> int:
+    return _set_task_activity_read_state(team_id, user_id, activities, is_read=False)
 
 
 def delete_thread_message(message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None) -> str:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2175,14 +2175,14 @@ class TaskActivityPageSerializer(DataclassSerializer):
 
 
 class TaskActivityReadMarkerSerializer(serializers.Serializer):
-    task_id = serializers.UUIDField(help_text="Task whose displayed activity should be marked read.")
+    task_id = serializers.UUIDField(help_text="Task whose displayed activity should change read state.")
     activity_id = serializers.UUIDField(
         required=False,
         allow_null=True,
-        help_text="Comment activity row to mark read. Omit for collapsed task activity.",
+        help_text="Comment activity row whose read state should change. Omit for collapsed task activity.",
     )
     seen_before = serializers.DateTimeField(
-        help_text="Mark activity at or before this timestamp read without clearing newer activity."
+        help_text="Only change activity at or before this timestamp, leaving newer activity unchanged."
     )
 
 
@@ -2200,6 +2200,20 @@ class TaskActivityMarkReadSerializer(serializers.Serializer):
 class TaskActivityMarkReadResponseSerializer(serializers.Serializer):
     marked_read = serializers.IntegerField(help_text="How many feed rows changed from unread to read.")
     unread_count = serializers.IntegerField(help_text="The requester's remaining unread total after the update.")
+
+
+class TaskActivityMarkUnreadSerializer(serializers.Serializer):
+    activities = serializers.ListField(
+        child=TaskActivityReadMarkerSerializer(),
+        allow_empty=False,
+        max_length=500,
+        help_text="Displayed task activities to mark unread if they have not changed.",
+    )
+
+
+class TaskActivityMarkUnreadResponseSerializer(serializers.Serializer):
+    marked_unread = serializers.IntegerField(help_text="How many feed rows changed from read to unread.")
+    unread_count = serializers.IntegerField(help_text="The requester's unread total after the update.")
 
 
 class TaskRepositoriesResponseSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -33,6 +33,8 @@ from products.tasks.backend.presentation.serializers import (
     ProvisionedChannelsSerializer,
     TaskActivityMarkReadResponseSerializer,
     TaskActivityMarkReadSerializer,
+    TaskActivityMarkUnreadResponseSerializer,
+    TaskActivityMarkUnreadSerializer,
     TaskActivityPageSerializer,
     TaskActivityQuerySerializer,
     TaskActivitySerializer,
@@ -532,6 +534,33 @@ class TaskActivityViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 "unread_count": tasks_facade.count_unread_task_activity(self.team_id, self._user_id()),
             }
         )
+
+    @extend_schema(
+        request=TaskActivityMarkUnreadSerializer,
+        responses={
+            200: OpenApiResponse(response=TaskActivityMarkUnreadResponseSerializer, description="Updated unread total"),
+        },
+        summary="Mark task activity unread",
+        description=(
+            "Restore the unread state for collapsed task activity through task timestamps and individual comment "
+            "activity through activity IDs."
+        ),
+    )
+    @action(detail=False, methods=["post"], url_path="mark_unread", required_scopes=["task:write"])
+    @validated_request(request_serializer=TaskActivityMarkUnreadSerializer)
+    def mark_unread(self, request, *args, **kwargs):
+        activities = [
+            (activity["task_id"], activity["seen_before"], activity.get("activity_id"))
+            for activity in request.validated_data["activities"]
+        ]
+        marked_unread = tasks_facade.mark_task_activity_unread(self.team_id, self._user_id(), activities)
+        result = TaskActivityMarkUnreadResponseSerializer(
+            {
+                "marked_unread": marked_unread,
+                "unread_count": tasks_facade.count_unread_task_activity(self.team_id, self._user_id()),
+            }
+        )
+        return Response(result.data)
 
 
 class TaskThreadMessageViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -777,6 +777,11 @@ class TaskActivityAPITestCase(ChannelTaskAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         return response.json()
 
+    def _mark_unread(self, client, activities) -> dict:
+        response = client.post(self._activity_url() + "mark_unread/", {"activities": activities}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        return response.json()
+
     def _rows(self, client) -> list[dict]:
         return client.get(self._activity_url()).json()["results"]
 
@@ -940,6 +945,32 @@ class TaskActivityAPITestCase(ChannelTaskAPITestCase):
         self.assertEqual(body, {"marked_read": 1, "unread_count": 1})
         self.assertFalse(self._row_for(self.author_client, self.task)["is_unread"])
         self.assertTrue(self._row_for(self.author_client, second)["is_unread"])
+
+    def test_mark_unread_restores_only_the_named_task(self):
+        second = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            channel=self.channel,
+            title="Second",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        self._awaiting_input()
+        self._awaiting_input(second)
+        rows = [self._row_for(self.author_client, task) for task in (self.task, second)]
+        self._mark_read(
+            self.author_client,
+            [{"task_id": row["task_id"], "seen_before": row["activity_at"]} for row in rows],
+        )
+
+        body = self._mark_unread(
+            self.author_client,
+            [{"task_id": rows[0]["task_id"], "seen_before": rows[0]["activity_at"]}],
+        )
+
+        self.assertEqual(body, {"marked_unread": 1, "unread_count": 1})
+        self.assertTrue(self._row_for(self.author_client, self.task)["is_unread"])
+        self.assertFalse(self._row_for(self.author_client, second)["is_unread"])
 
     def test_reading_the_thread_does_not_mutate_activity(self):
         self._awaiting_input()

--- a/products/tasks/backend/tests/test_comment_activity.py
+++ b/products/tasks/backend/tests/test_comment_activity.py
@@ -299,7 +299,7 @@ class TestCommentActivity(CommentActivityTestCase):
 
         assert not TaskCommentActivity.objects.filter(comment=second_reply, user=mentioned).exists()
 
-    def test_marking_one_comment_read_keeps_sibling_notifications_unread(self):
+    def test_changing_one_comment_read_state_keeps_sibling_notifications_unchanged(self):
         first = self._comment(content="first")
         second = self._comment(content="second")
         self._record_activity(first)
@@ -313,13 +313,16 @@ class TestCommentActivity(CommentActivityTestCase):
             activity_at=first.created_at,
         )
 
-        tasks_facade.mark_task_activity_read(
-            self.team.id,
-            self.author.id,
-            [(self.task.id, first.created_at, first_activity.id)],
-        )
+        activity_marker = [(self.task.id, first.created_at, first_activity.id)]
+        tasks_facade.mark_task_activity_read(self.team.id, self.author.id, activity_marker)
 
         first_activity.refresh_from_db()
         assert first_activity.read_at is not None
+        assert TaskCommentActivity.objects.get(comment=second, user=self.author).read_at is None
+        assert TaskActivity.objects.get(team=self.team, user=self.author, task=self.task).read_at is None
+
+        tasks_facade.mark_task_activity_unread(self.team.id, self.author.id, activity_marker)
+
+        assert TaskCommentActivity.objects.get(comment=first, user=self.author).read_at is None
         assert TaskCommentActivity.objects.get(comment=second, user=self.author).read_at is None
         assert TaskActivity.objects.get(team=self.team, user=self.author, task=self.task).read_at is None

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1032,14 +1032,14 @@ export interface TaskActivityPageDTOApi {
 }
 
 export interface TaskActivityReadMarkerApi {
-    /** Task whose displayed activity should be marked read. */
+    /** Task whose displayed activity should change read state. */
     task_id: string
     /**
-     * Comment activity row to mark read. Omit for collapsed task activity.
+     * Comment activity row whose read state should change. Omit for collapsed task activity.
      * @nullable
      */
     activity_id?: string | null
-    /** Mark activity at or before this timestamp read without clearing newer activity. */
+    /** Only change activity at or before this timestamp, leaving newer activity unchanged. */
     seen_before: string
 }
 
@@ -1058,6 +1058,21 @@ export interface TaskActivityMarkReadResponseApi {
     /** How many feed rows changed from unread to read. */
     marked_read: number
     /** The requester's remaining unread total after the update. */
+    unread_count: number
+}
+
+export interface TaskActivityMarkUnreadApi {
+    /**
+     * Displayed task activities to mark unread if they have not changed.
+     * @maxItems 500
+     */
+    activities: TaskActivityReadMarkerApi[]
+}
+
+export interface TaskActivityMarkUnreadResponseApi {
+    /** How many feed rows changed from read to unread. */
+    marked_unread: number
+    /** The requester's unread total after the update. */
     unread_count: number
 }
 

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -67,6 +67,8 @@ import type {
     TaskActivityListParams,
     TaskActivityMarkReadApi,
     TaskActivityMarkReadResponseApi,
+    TaskActivityMarkUnreadApi,
+    TaskActivityMarkUnreadResponseApi,
     TaskActivityPageDTOApi,
     TaskArtifactsResponseApi,
     TaskChannelsFeedListParams,
@@ -720,6 +722,27 @@ export const taskActivityMarkReadCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(taskActivityMarkReadApi),
+    })
+}
+
+export const getTaskActivityMarkUnreadCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/task_activity/mark_unread/`
+}
+
+/**
+ * Restore the unread state for collapsed task activity through task timestamps and individual comment activity through activity IDs.
+ * @summary Mark task activity unread
+ */
+export const taskActivityMarkUnreadCreate = async (
+    projectId: string,
+    taskActivityMarkUnreadApi: TaskActivityMarkUnreadApi,
+    options?: RequestInit
+): Promise<TaskActivityMarkUnreadResponseApi> => {
+    return apiMutator<TaskActivityMarkUnreadResponseApi>(getTaskActivityMarkUnreadCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskActivityMarkUnreadApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -885,20 +885,48 @@ export const TaskActivityMarkReadCreateBody = /* @__PURE__ */ zod
         activities: zod
             .array(
                 zod.object({
-                    task_id: zod.uuid().describe('Task whose displayed activity should be marked read.'),
+                    task_id: zod.uuid().describe('Task whose displayed activity should change read state.'),
                     activity_id: zod
                         .uuid()
                         .nullish()
-                        .describe('Comment activity row to mark read. Omit for collapsed task activity.'),
+                        .describe(
+                            'Comment activity row whose read state should change. Omit for collapsed task activity.'
+                        ),
                     seen_before: zod.iso
                         .datetime({ offset: true })
-                        .describe('Mark activity at or before this timestamp read without clearing newer activity.'),
+                        .describe(
+                            'Only change activity at or before this timestamp, leaving newer activity unchanged.'
+                        ),
                 })
             )
             .max(taskActivityMarkReadCreateBodyActivitiesMax)
             .describe('Displayed task activities to mark read if they have not changed.'),
     })
     .describe('Request body for clearing the unread flag on specific tasks.')
+
+/**
+ * Restore the unread state for collapsed task activity through task timestamps and individual comment activity through activity IDs.
+ * @summary Mark task activity unread
+ */
+export const taskActivityMarkUnreadCreateBodyActivitiesMax = 500
+
+export const TaskActivityMarkUnreadCreateBody = /* @__PURE__ */ zod.object({
+    activities: zod
+        .array(
+            zod.object({
+                task_id: zod.uuid().describe('Task whose displayed activity should change read state.'),
+                activity_id: zod
+                    .uuid()
+                    .nullish()
+                    .describe('Comment activity row whose read state should change. Omit for collapsed task activity.'),
+                seen_before: zod.iso
+                    .datetime({ offset: true })
+                    .describe('Only change activity at or before this timestamp, leaving newer activity unchanged.'),
+            })
+        )
+        .max(taskActivityMarkUnreadCreateBodyActivitiesMax)
+        .describe('Displayed task activities to mark unread if they have not changed.'),
+})
 
 /**
  * Returns the existing public channel with the (normalized) name, creating it if needed. A channel created here is starred for the requester unless star is false. The general name returns the team's general space; names that read as a private space ("me", "personal") are rejected.

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -279,6 +279,9 @@ tools:
     task-activity-mark-read-create:
         operation: task_activity_mark_read_create
         enabled: false
+    task-activity-mark-unread-create:
+        operation: task_activity_mark_unread_create
+        enabled: false
     task-channels-context-generation-retrieve:
         operation: task_channels_context_generation_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -79477,14 +79477,14 @@ export namespace Schemas {
     }
 
     export interface TaskActivityReadMarker {
-      /** Task whose displayed activity should be marked read. */
+      /** Task whose displayed activity should change read state. */
       task_id: string;
       /**
-         * Comment activity row to mark read. Omit for collapsed task activity.
+         * Comment activity row whose read state should change. Omit for collapsed task activity.
          * @nullable
          */
       activity_id?: string | null;
-      /** Mark activity at or before this timestamp read without clearing newer activity. */
+      /** Only change activity at or before this timestamp, leaving newer activity unchanged. */
       seen_before: string;
     }
 
@@ -79503,6 +79503,21 @@ export namespace Schemas {
       /** How many feed rows changed from unread to read. */
       marked_read: number;
       /** The requester's remaining unread total after the update. */
+      unread_count: number;
+    }
+
+    export interface TaskActivityMarkUnread {
+      /**
+         * Displayed task activities to mark unread if they have not changed.
+         * @maxItems 500
+         */
+      activities: TaskActivityReadMarker[];
+    }
+
+    export interface TaskActivityMarkUnreadResponse {
+      /** How many feed rows changed from read to unread. */
+      marked_unread: number;
+      /** The requester's unread total after the update. */
       unread_count: number;
     }
 


### PR DESCRIPTION
## Problem

Activity clients can mark task and comment updates as read, but they cannot restore an item to the unread queue.

The desktop release must wait until this server contract reaches production.

## Changes

- The Tasks API now accepts guarded mark-unread requests for task and comment activity.
- Team and user filters keep read state scoped to the requester.
- Timestamp guards leave newer task activity unchanged.
- Response serialization matches the declared OpenAPI schema.
- Generated frontend and MCP contracts include the endpoint.

**Before**

```mermaid
flowchart LR
    A[Activity client] --> B[Mark read API]
    B --> C[(Read state)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phRed;
    class C phGray;
```

**After**

```mermaid
flowchart LR
    A[Activity client] --> B{Read state action}
    B --> C[Mark read API]
    B --> D[Mark unread API]
    C --> E[(Read state)]
    D --> E
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phBlue;
    class C,D phRed;
    class E phGray;
```

## How did you test this code?

- Django tests cover task-level and comment-level unread restoration without changing sibling activity.
- Ruff lint and formatting checks cover the changed Python files.
- OpenAPI generation produced the frontend and MCP contracts in this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No manual docs update. The generated OpenAPI clients document the new endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi using GPT-5.6 Sol implemented this stack layer. A public session link was unavailable in the environment.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`, `/investigating-ci-failures`, and `/stacking-prs`.

CI requires the backend contract to merge and deploy before the desktop client. The committed test data is invented.
