### PR TITLE
fix(experiments): Reject compound aggregate expressions in HogQL metrics

### DIFF
--- a/products/experiments/backend/hogql_queries/base_query_utils.py
+++ b/products/experiments/backend/hogql_queries/base_query_utils.py
@@ -25,7 +25,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
-from posthog.hogql.property import action_to_expr, has_aggregation, property_to_expr
+from posthog.hogql.property import action_to_expr, property_to_expr
 
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.insights.trends.aggregation_operations import ALLOWED_SESSION_MATH_PROPERTIES
@@ -36,6 +36,7 @@ from products.actions.backend.models.action import Action
 from products.experiments.backend.hogql_queries.hogql_aggregation_utils import (
     aggregation_needs_numeric_input,
     build_aggregation_call,
+    contains_aggregation,
     extract_aggregation_and_inner_expr,
 )
 from products.experiments.backend.models.experiment import Experiment
@@ -154,7 +155,7 @@ def get_source_value_expr(source: Union[EventsNode, ActionsNode, ExperimentDataW
                 # left in it (a compound expression like sum(a) / count(), or a nested
                 # aggregate) would generate invalid SQL and fail in ClickHouse with
                 # NOT_AN_AGGREGATE. Reject it with an actionable error instead.
-                if has_aggregation(inner_expr):
+                if contains_aggregation(inner_expr):
                     raise ValidationError(
                         "HogQL metric expressions must be a single aggregation, e.g. sum(properties.revenue). "
                         "Compound expressions like sum(a) / count() are not supported."
@@ -166,7 +167,7 @@ def get_source_value_expr(source: Union[EventsNode, ActionsNode, ExperimentDataW
             tag_contains_user_hogql()
             parsed = parse_expr(metric_property)
             # Same constraint as math_hogql above: this is a per-row value expression.
-            if has_aggregation(parsed):
+            if contains_aggregation(parsed):
                 raise ValidationError(
                     "Data warehouse metric properties cannot contain aggregate functions; "
                     "reference a column or a per-row expression instead."

--- a/products/experiments/backend/hogql_queries/base_query_utils.py
+++ b/products/experiments/backend/hogql_queries/base_query_utils.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from typing import Literal, Optional, Union
 from zoneinfo import ZoneInfo
 
+from rest_framework.exceptions import ValidationError
+
 from posthog.schema import (
     ActionsNode,
     BaseMathType,
@@ -23,7 +25,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, has_aggregation, property_to_expr
 
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.insights.trends.aggregation_operations import ALLOWED_SESSION_MATH_PROPERTIES
@@ -148,12 +150,28 @@ def get_source_value_expr(source: Union[EventsNode, ActionsNode, ExperimentDataW
             if math_hogql:
                 tag_contains_user_hogql()
                 _, inner_expr, _, _ = extract_aggregation_and_inner_expr(math_hogql)
+                # The inner expression is evaluated per event row, so any aggregate call
+                # left in it (a compound expression like sum(a) / count(), or a nested
+                # aggregate) would generate invalid SQL and fail in ClickHouse with
+                # NOT_AN_AGGREGATE. Reject it with an actionable error instead.
+                if has_aggregation(inner_expr):
+                    raise ValidationError(
+                        "HogQL metric expressions must be a single aggregation, e.g. sum(properties.revenue). "
+                        "Compound expressions like sum(a) / count() are not supported."
+                    )
                 return inner_expr
     elif isinstance(source, ExperimentDataWarehouseNode):
         metric_property = getattr(source, "math_property", None)
         if metric_property:
             tag_contains_user_hogql()
-            return parse_expr(metric_property)
+            parsed = parse_expr(metric_property)
+            # Same constraint as math_hogql above: this is a per-row value expression.
+            if has_aggregation(parsed):
+                raise ValidationError(
+                    "Data warehouse metric properties cannot contain aggregate functions; "
+                    "reference a column or a per-row expression instead."
+                )
+            return parsed
 
     # Default to count - emit 1 so we can easily sum it up
     return ast.Constant(value=1)

--- a/products/experiments/backend/hogql_queries/hogql_aggregation_utils.py
+++ b/products/experiments/backend/hogql_queries/hogql_aggregation_utils.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 from posthog.hogql import ast
 from posthog.hogql.functions.mapping import HOGQL_AGGREGATIONS, HOGQL_CLICKHOUSE_FUNCTIONS, HOGQL_POSTHOG_FUNCTIONS
 from posthog.hogql.parser import parse_expr
+from posthog.hogql.visitor import TraversingVisitor
 
 
 def is_aggregation_function(function_name: str) -> bool:
@@ -75,6 +76,33 @@ def extract_aggregation_and_inner_expr(
     else:
         # Not an aggregation function - return the whole expression as the inner part
         return None, expr, None, False
+
+
+# Registered in HOGQL_AGGREGATIONS for their rewriting behavior but compile to scalar
+# expressions — not real aggregates (md5 -> hex(MD5(...))).
+_SCALAR_REGISTRY_QUIRKS = frozenset({"md5"})
+
+
+class _AggregationFinder(TraversingVisitor):
+    def __init__(self):
+        super().__init__()
+        self.found = False
+
+    def visit_call(self, node: ast.Call):
+        if node.name.lower() not in _SCALAR_REGISTRY_QUIRKS and is_aggregation_function(node.name):
+            self.found = True
+            return
+        for arg in node.args:
+            self.visit(arg)
+        for param in node.params or []:
+            self.visit(param)
+
+
+def contains_aggregation(expr: ast.Expr) -> bool:
+    """Whether a real aggregate call appears anywhere in the expression."""
+    finder = _AggregationFinder()
+    finder.visit(expr)
+    return finder.found
 
 
 _NON_NUMERIC_AGGREGATIONS = frozenset(

--- a/products/experiments/backend/hogql_queries/test/test_hogql_aggregation_integration.py
+++ b/products/experiments/backend/hogql_queries/test/test_hogql_aggregation_integration.py
@@ -1,10 +1,12 @@
 from posthog.test.base import BaseTest
 
-from posthog.schema import EventsNode, ExperimentMeanMetric, ExperimentMetricMathType
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import EventsNode, ExperimentDataWarehouseNode, ExperimentMeanMetric, ExperimentMetricMathType
 
 from posthog.hogql import ast
 
-from products.experiments.backend.hogql_queries.base_query_utils import get_metric_value
+from products.experiments.backend.hogql_queries.base_query_utils import get_metric_value, get_source_value_expr
 
 
 class TestHogQLAggregationIntegration(BaseTest):
@@ -38,3 +40,40 @@ class TestHogQLAggregationIntegration(BaseTest):
         # Should return the field expression directly
         self.assertIsInstance(result_no_agg, ast.Field)
         self.assertEqual(result_no_agg.chain, ["properties", "revenue"])  # type: ignore[attr-defined]
+
+    def test_rejects_compound_aggregate_expressions(self):
+        # The extracted value expression is evaluated per row; aggregates left inside it
+        # (compound or nested) would fail in ClickHouse with NOT_AN_AGGREGATE.
+        for expr in [
+            "sum(properties.revenue) / count()",
+            "sum(properties.a) + sum(properties.b)",
+            "toFloat(sum(properties.revenue))",
+            "avg(sum(properties.revenue))",
+        ]:
+            metric = ExperimentMeanMetric(
+                source=EventsNode(event="revenue_event", math=ExperimentMetricMathType.HOGQL, math_hogql=expr)
+            )
+            with self.assertRaises(ValidationError, msg=expr):
+                get_metric_value(metric)
+
+    def test_rejects_aggregates_in_data_warehouse_math_property(self):
+        source = ExperimentDataWarehouseNode(
+            table_name="payments",
+            events_join_key="person_id",
+            data_warehouse_join_key="user_id",
+            timestamp_field="ts",
+            math_property="sum(amount)",
+        )
+        with self.assertRaises(ValidationError):
+            get_source_value_expr(source)
+
+    def test_allows_plain_data_warehouse_math_property(self):
+        source = ExperimentDataWarehouseNode(
+            table_name="payments",
+            events_join_key="person_id",
+            data_warehouse_join_key="user_id",
+            timestamp_field="ts",
+            math_property="amount",
+        )
+        result = get_source_value_expr(source)
+        self.assertIsInstance(result, ast.Field)

--- a/products/experiments/backend/hogql_queries/test/test_hogql_aggregation_integration.py
+++ b/products/experiments/backend/hogql_queries/test/test_hogql_aggregation_integration.py
@@ -1,5 +1,6 @@
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import EventsNode, ExperimentDataWarehouseNode, ExperimentMeanMetric, ExperimentMetricMathType
@@ -41,20 +42,36 @@ class TestHogQLAggregationIntegration(BaseTest):
         self.assertIsInstance(result_no_agg, ast.Field)
         self.assertEqual(result_no_agg.chain, ["properties", "revenue"])  # type: ignore[attr-defined]
 
-    def test_rejects_compound_aggregate_expressions(self):
+    @parameterized.expand(
+        [
+            ("division", "sum(properties.revenue) / count()"),
+            ("addition", "sum(properties.a) + sum(properties.b)"),
+            ("wrapped", "toFloat(sum(properties.revenue))"),
+            ("nested", "avg(sum(properties.revenue))"),
+        ]
+    )
+    def test_rejects_compound_aggregate_expressions(self, _name: str, expr: str):
         # The extracted value expression is evaluated per row; aggregates left inside it
         # (compound or nested) would fail in ClickHouse with NOT_AN_AGGREGATE.
-        for expr in [
-            "sum(properties.revenue) / count()",
-            "sum(properties.a) + sum(properties.b)",
-            "toFloat(sum(properties.revenue))",
-            "avg(sum(properties.revenue))",
-        ]:
-            metric = ExperimentMeanMetric(
-                source=EventsNode(event="revenue_event", math=ExperimentMetricMathType.HOGQL, math_hogql=expr)
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="revenue_event", math=ExperimentMetricMathType.HOGQL, math_hogql=expr)
+        )
+        with self.assertRaises(ValidationError):
+            get_metric_value(metric)
+
+    def test_allows_scalar_md5_despite_registry_quirk(self):
+        # md5 lives in HOGQL_AGGREGATIONS for its rewriting but compiles to a scalar —
+        # it must not trip the aggregate check.
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="revenue_event",
+                math=ExperimentMetricMathType.HOGQL,
+                math_hogql="count(distinct md5(properties.user))",
             )
-            with self.assertRaises(ValidationError, msg=expr):
-                get_metric_value(metric)
+        )
+        result = get_metric_value(metric)
+        self.assertIsInstance(result, ast.Call)
+        self.assertEqual(result.name, "md5")  # type: ignore[attr-defined]
 
     def test_rejects_aggregates_in_data_warehouse_math_property(self):
         source = ExperimentDataWarehouseNode(
@@ -67,13 +84,18 @@ class TestHogQLAggregationIntegration(BaseTest):
         with self.assertRaises(ValidationError):
             get_source_value_expr(source)
 
-    def test_allows_plain_data_warehouse_math_property(self):
+    @parameterized.expand(
+        [
+            ("plain_column", "amount"),
+            ("scalar_md5", "md5(user_id)"),
+        ]
+    )
+    def test_allows_per_row_data_warehouse_math_property(self, _name: str, math_property: str):
         source = ExperimentDataWarehouseNode(
             table_name="payments",
             events_join_key="person_id",
             data_warehouse_join_key="user_id",
             timestamp_field="ts",
-            math_property="amount",
+            math_property=math_property,
         )
-        result = get_source_value_expr(source)
-        self.assertIsInstance(result, ast.Field)
+        get_source_value_expr(source)


### PR DESCRIPTION
## Problem
HogQL-math metrics only support a single top-level aggregation — the extracted inner expression is evaluated per event row. Compound expressions (`sum(a) / count()`, `sum(a) + sum(b)`, `toFloat(sum(x))`) pass validation, leave aggregate calls in the per-row expression, and fail in ClickHouse with `NOT_AN_AGGREGATE` (~26 occurrences/week, [error tracking](https://us.posthog.com/project/2/error_tracking/019f6c69-658d-7011-923b-54a1a668e386)). Data warehouse `math_property` has the same hole.

## Changes
In `get_source_value_expr`, raise a `ValidationError` ("HogQL metric expressions must be a single aggregation, e.g. sum(properties.revenue)") when the per-row expression still contains an aggregate call, for both `math_hogql` and data warehouse `math_property`.

## How did you test this code?
Tests for the four compound shapes plus DW cases; ran the aggregation and mean-metric test files (41 passed, snapshots unchanged). mypy on the changed file.