### PR TITLE
feat(experiments): track cleanup PR usage on the end path

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -129,6 +129,15 @@ class CleanupRepositoryTarget(TypedDict):
     candidates: list[str]
 
 
+class CleanupRequestSummary(TypedDict):
+    """What _maybe_open_cleanup_pr decided, for the analytics on the end/ship path."""
+
+    attempted: bool
+    repository_source: CleanupRepositorySource | None
+    skip_reason: Literal["no_conclusion", "flag_disabled", "no_repository", "error"] | None
+    confident: bool | None
+
+
 DEFAULT_ROLLOUT_PERCENTAGE = 100
 
 ExperimentCreationMode = Literal["new", "duplicate", "copy_to_project"]
@@ -2705,23 +2714,37 @@ class ExperimentService:
         open_cleanup_pr: bool,
         requested_repository: str | None = None,
         set_repository_as_team_default: bool = False,
-    ) -> None:
+    ) -> CleanupRequestSummary:
         """When opted in (the checkbox) and the team's gate flag is on, open a draft PR that removes the
         experiment's feature-flag code, via the Tasks engine.
 
         Deferred to after commit (so a rolled-back end never opens a PR) and wrapped so it can never
         break ending an experiment.
         """
+        summary: CleanupRequestSummary = {
+            "attempted": False,
+            "repository_source": None,
+            "skip_reason": None,
+            "confident": None,
+        }
         try:
             conclusion = experiment.conclusion or ""
-            if not open_cleanup_pr or not conclusion or not self._cleanup_pr_flag_enabled():
-                return
+            if not open_cleanup_pr:
+                return summary
+            if not conclusion:
+                summary["skip_reason"] = "no_conclusion"
+                return summary
+            if not self._cleanup_pr_flag_enabled():
+                summary["skip_reason"] = "flag_disabled"
+                return summary
 
             flag_key = experiment.get_feature_flag_key()
             target = self.get_cleanup_repository_target(experiment, requested_repository=requested_repository)
+            summary["repository_source"] = target["source"]
             repository = target["repository"]
             if repository is None:
                 # No safe target — skipping beats opening a PR against the wrong repo.
+                summary["skip_reason"] = "no_repository"
                 logger.info(
                     "experiment_cleanup_pr_skipped_no_repository",
                     experiment_id=experiment.id,
@@ -2729,7 +2752,7 @@ class ExperimentService:
                     flag_key=flag_key,
                     requested_repository=requested_repository,
                 )
-                return
+                return summary
 
             picked_repository = requested_repository if target["source"] == "explicit" else None
             if picked_repository:
@@ -2775,6 +2798,8 @@ class ExperimentService:
                     logger.exception("experiment_cleanup_pr_task_failed", experiment_id=experiment_id)
 
             transaction.on_commit(_open)
+            summary["attempted"] = True
+            summary["confident"] = plan.confident
             logger.info(
                 "experiment_cleanup_pr_requested",
                 experiment_id=experiment.id,
@@ -2785,7 +2810,9 @@ class ExperimentService:
                 confident=plan.confident,
             )
         except Exception:
+            summary["skip_reason"] = "error"
             logger.exception("experiment_cleanup_pr_failed", experiment_id=experiment.id)
+        return summary
 
     def get_cleanup_repository_target(
         self, experiment: Experiment, requested_repository: str | None = None
@@ -2851,12 +2878,28 @@ class ExperimentService:
     ) -> None:
         # The opt-in cleanup PR doesn't depend on the request — run it before the request-gated
         # analytics below so it behaves the same regardless of call context.
-        self._maybe_open_cleanup_pr(experiment, open_cleanup_pr, repository, set_repository_as_team_default)
+        cleanup = self._maybe_open_cleanup_pr(experiment, open_cleanup_pr, repository, set_repository_as_team_default)
 
         if request is None:
             return
 
+        if cleanup["attempted"]:
+            self._report_lifecycle_event(
+                experiment,
+                "experiment cleanup pr requested",
+                request=request,
+                extra_metadata={
+                    "conclusion": experiment.conclusion,
+                    "repository_source": cleanup["repository_source"],
+                    "confident": cleanup["confident"],
+                },
+            )
+
         completed_metadata = experiment.get_analytics_metadata()
+        completed_metadata["open_cleanup_pr"] = open_cleanup_pr
+        completed_metadata["cleanup_task_attempted"] = cleanup["attempted"]
+        completed_metadata["cleanup_repository_source"] = cleanup["repository_source"]
+        completed_metadata["cleanup_skip_reason"] = cleanup["skip_reason"]
         completed_metadata["end_date"] = experiment.end_date.isoformat() if experiment.end_date else None
         completed_metadata["parameters"] = self._parameters_with_variant_detail(experiment)
         completed_metadata["stats_method"] = (experiment.stats_config or {}).get("method", "bayesian")

--- a/products/experiments/backend/test/test_experiment_cleanup_pr.py
+++ b/products/experiments/backend/test/test_experiment_cleanup_pr.py
@@ -51,11 +51,11 @@ class TestExperimentCleanupPr(APIBaseTest):
 
     @parameterized.expand(
         [
-            # (name, flag_enabled, open_cleanup_pr, conclusion, expect_task_created)
-            ("flag_on_and_opted_in", True, True, "won", True),
-            ("not_opted_in", True, False, "won", False),
-            ("flag_off", False, True, "won", False),
-            ("no_conclusion", True, True, None, False),
+            # (name, flag_enabled, open_cleanup_pr, conclusion, expect_task_created, expected_skip_reason)
+            ("flag_on_and_opted_in", True, True, "won", True, None),
+            ("not_opted_in", True, False, "won", False, None),
+            ("flag_off", False, True, "won", False, "flag_disabled"),
+            ("no_conclusion", True, True, None, False, "no_conclusion"),
         ]
     )
     @patch("products.experiments.backend.experiment_service.report_user_action")
@@ -69,10 +69,11 @@ class TestExperimentCleanupPr(APIBaseTest):
         open_cleanup_pr,
         conclusion,
         expect_task_created,
+        expected_skip_reason,
         mock_resolve_github,
         mock_create_task,
         mock_feature_enabled,
-        _mock_report,
+        mock_report,
     ):
         mock_resolve_github.return_value = SimpleNamespace(
             list_all_cached_repositories=lambda max_repos: [{"full_name": "posthog/posthog"}]
@@ -101,6 +102,26 @@ class TestExperimentCleanupPr(APIBaseTest):
         else:
             mock_create_task.assert_not_called()
             self.assertIsNone(experiment.flag_cleanup_task_id)
+
+        completed_calls = [call for call in mock_report.call_args_list if call.args[1] == "experiment completed"]
+        self.assertEqual(len(completed_calls), 1)
+        completed_metadata = completed_calls[0].args[2]
+        self.assertEqual(completed_metadata["open_cleanup_pr"], open_cleanup_pr)
+        self.assertEqual(completed_metadata["cleanup_task_attempted"], expect_task_created)
+        self.assertEqual(completed_metadata["cleanup_skip_reason"], expected_skip_reason)
+
+        requested_calls = [
+            call for call in mock_report.call_args_list if call.args[1] == "experiment cleanup pr requested"
+        ]
+        if expect_task_created:
+            self.assertEqual(len(requested_calls), 1)
+            requested_metadata = requested_calls[0].args[2]
+            self.assertEqual(requested_metadata["repository_source"], "explicit")
+            self.assertEqual(requested_metadata["conclusion"], "won")
+            self.assertTrue(requested_metadata["confident"])
+            self.assertEqual(completed_metadata["cleanup_repository_source"], "explicit")
+        else:
+            self.assertEqual(requested_calls, [])
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

The flag cleanup feature has no product analytics ahead of widening its rollout flag. Loki logs and task rows exist, but nothing supports charting opt-in rate or adoption per team.

## Changes

- `experiment completed` now carries `open_cleanup_pr`, `cleanup_task_attempted`, `cleanup_repository_source`, and `cleanup_skip_reason` (no_conclusion, flag_disabled, no_repository, error).
- A new `experiment cleanup pr requested` event fires when a cleanup task is created, with the conclusion, repository source, and decision confidence.
- `_maybe_open_cleanup_pr` returns a summary TypedDict instead of None; behavior on the end/ship path is unchanged.
- Nothing user-visible changes.

Task outcomes (PR opened, no changes, failed) are deliberately not evented here. The terminal state lives in the Tasks runtime; TaskRun rows remain the source of truth for that leg.

## How did you test this code?

- Extended the parameterized gating test in `test_experiment_cleanup_pr.py`: each opt-in, flag, and conclusion combination now also asserts the completed-event fields and that the requested event fires only when a task is created. Catches the fields silently dropping off, which would blank a rollout dashboard.
- Ran the cleanup test file (27 passed) and the three end-experiment analytics tests (3 passed). Repo-wide mypy clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @jurajmajerik. Skills invoked: /wt, /writing-tests, /writing-pr-descriptions. The dedicated event is emitted from _report_experiment_ended rather than inside _maybe_open_cleanup_pr so the action stays request-independent and the analytics stay request-gated, matching the surrounding lifecycle events.
