### PR TITLE
fix(tasks): gate desktop deep link by access

### DIFF
--- a/products/posthog_ai/frontend/scenes/TaskTracker/TaskTracker.stories.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/TaskTracker.stories.tsx
@@ -125,6 +125,7 @@ const meta: Meta = {
     decorators: [
         mswDecorator({
             get: {
+                '/api/code/invites/check-access/': { has_access: true, has_loops_access: false },
                 '/api/projects/:team_id/tasks/': listResponse(TASKS),
                 '/api/projects/:team_id/tasks/repositories/': { repositories: ['PostHog/posthog'] },
                 // Exact ids (not `:id`) so they never shadow the `repositories` action route.

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
@@ -26,7 +26,7 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
         useValues(sceneLogic)
     const { runTask, deleteTask, loadTask } = useActions(sceneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { activeCreation } = useValues(taskTrackerSceneLogic)
+    const { activeCreation, hasDesktopAccess } = useValues(taskTrackerSceneLogic)
     const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
 
     if (taskNotFound && !task) {
@@ -48,15 +48,17 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
             <TaskHeaderActionsSkeleton />
         ) : (
             <div className="flex items-center gap-2">
-                <LemonButton
-                    type="secondary"
-                    size="small"
-                    icon={<IconExternal />}
-                    onClick={() => window.open(`posthog-code://task/${task.id}`, '_blank')}
-                    className="hidden lg:inline-flex"
-                >
-                    Open in PostHog Desktop
-                </LemonButton>
+                {hasDesktopAccess && (
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        icon={<IconExternal />}
+                        onClick={() => window.open(`posthog-code://task/${task.id}`, '_blank')}
+                        className="hidden lg:inline-flex"
+                    >
+                        Open in PostHog Desktop
+                    </LemonButton>
+                )}
                 {prUrl && (
                     <LemonButton
                         type="secondary"

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
@@ -6,6 +6,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { urls } from 'scenes/urls'
 
 import { isPiTaskRuntime } from '../../../types/taskTypes'
 import { taskDetailSceneLogic } from '../taskDetailSceneLogic'
@@ -53,7 +54,8 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
                         type="secondary"
                         size="small"
                         icon={<IconExternal />}
-                        onClick={() => window.open(`posthog-code://task/${task.id}`, '_blank')}
+                        to={urls.codeTaskLink(task.id)}
+                        targetBlank
                         className="hidden lg:inline-flex"
                     >
                         Open in PostHog Desktop

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
@@ -45,6 +45,7 @@ describe('taskTrackerSceneLogic', () => {
         runBody = null
         useMocks({
             get: {
+                '/api/code/invites/check-access/': { has_access: true, has_loops_access: false },
                 '/api/projects/:team/tasks/': { results: [], count: 0 },
                 '/api/projects/:team/tasks/repositories/': { repositories: [] },
                 '/api/environments/:team/integrations/': { results: [] },
@@ -74,6 +75,16 @@ describe('taskTrackerSceneLogic', () => {
     afterEach(() => {
         logic?.unmount()
         toolEvents?.unmount()
+    })
+
+    it('loads PostHog Desktop access and exposes it to the task UI', async () => {
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.hasDesktopAccess).toBe(true)
+
+        logic.actions.loadDesktopAccessSuccess({ has_access: false, has_loops_access: false })
+        expect(logic.values.hasDesktopAccess).toBe(false)
     })
 
     // PostHog AI can run without a repo: a description-only submit must still create and run the task with a

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -11,7 +11,7 @@ import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
 
 import { codeInvitesCheckAccessRetrieve, tasksCreate, tasksRunCreate } from 'products/tasks/frontend/generated/api'
 import {
-    type CodeInviteAccessResponseApi,
+    type LegacyDesktopAccessResponseApi,
     type ModelChoiceApi,
     OriginProductEnumApi,
     ReasoningEffortEnumApi,
@@ -134,7 +134,7 @@ export interface taskTrackerSceneLogicValues {
     overrideHeadlines: string[] | null // welcomeOverrideLogic
     activeSuggestionGroup: SuggestionGroup | null
     consentBlocked: boolean
-    desktopAccess: CodeInviteAccessResponseApi | null
+    desktopAccess: LegacyDesktopAccessResponseApi | null
     desktopAccessLoading: boolean
     displayHeadline: string
     hasDesktopAccess: boolean
@@ -335,10 +335,10 @@ export interface taskTrackerSceneLogicActions {
         errorObject?: any
     }
     loadDesktopAccessSuccess: (
-        desktopAccess: CodeInviteAccessResponseApi,
+        desktopAccess: LegacyDesktopAccessResponseApi,
         payload?: any
     ) => {
-        desktopAccess: CodeInviteAccessResponseApi
+        desktopAccess: LegacyDesktopAccessResponseApi
         payload?: any
     }
     maybeAutoSelectIntegration: () => {
@@ -380,7 +380,7 @@ export interface taskTrackerSceneLogicActions {
 export interface taskTrackerSceneLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
-        hasDesktopAccess: (desktopAccess: any) => boolean
+        hasDesktopAccess: (desktopAccess: LegacyDesktopAccessResponseApi | null) => boolean
         displayHeadline: (overrideHeadlines: string[] | null, headlineSeed: number) => string
     }
 }
@@ -518,7 +518,7 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
 
     loaders({
         desktopAccess: [
-            null as CodeInviteAccessResponseApi | null,
+            null as LegacyDesktopAccessResponseApi | null,
             {
                 loadDesktopAccess: async () => codeInvitesCheckAccessRetrieve(),
             },
@@ -528,7 +528,7 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
     selectors({
         hasDesktopAccess: [
             (s) => [s.desktopAccess],
-            (desktopAccess: CodeInviteAccessResponseApi | null): boolean => desktopAccess?.has_access ?? false,
+            (desktopAccess: LegacyDesktopAccessResponseApi | null): boolean => desktopAccess?.has_access ?? false,
         ],
         // Contextual headlines registered by the active scene (welcomeOverrideLogic) win over the
         // generic defaults; the seed keeps the pick stable across re-renders.

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -1,4 +1,5 @@
 import { MakeLogicType, actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -8,8 +9,9 @@ import { uuid } from 'lib/utils/dom'
 import { projectLogic } from 'scenes/projectLogic'
 import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
 
-import { tasksCreate, tasksRunCreate } from 'products/tasks/frontend/generated/api'
+import { codeInvitesCheckAccessRetrieve, tasksCreate, tasksRunCreate } from 'products/tasks/frontend/generated/api'
 import {
+    type CodeInviteAccessResponseApi,
     type ModelChoiceApi,
     OriginProductEnumApi,
     ReasoningEffortEnumApi,
@@ -132,7 +134,10 @@ export interface taskTrackerSceneLogicValues {
     overrideHeadlines: string[] | null // welcomeOverrideLogic
     activeSuggestionGroup: SuggestionGroup | null
     consentBlocked: boolean
+    desktopAccess: CodeInviteAccessResponseApi | null
+    desktopAccessLoading: boolean
     displayHeadline: string
+    hasDesktopAccess: boolean
     headlineSeed: number
     isSubmittingTask: boolean
     newTaskData: TaskCreateForm
@@ -321,6 +326,21 @@ export interface taskTrackerSceneLogicActions {
     clearConsentBlock: () => {
         value: true
     }
+    loadDesktopAccess: () => any
+    loadDesktopAccessFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadDesktopAccessSuccess: (
+        desktopAccess: CodeInviteAccessResponseApi,
+        payload?: any
+    ) => {
+        desktopAccess: CodeInviteAccessResponseApi
+        payload?: any
+    }
     maybeAutoSelectIntegration: () => {
         value: true
     }
@@ -360,6 +380,7 @@ export interface taskTrackerSceneLogicActions {
 export interface taskTrackerSceneLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
+        hasDesktopAccess: (desktopAccess: any) => boolean
         displayHeadline: (overrideHeadlines: string[] | null, headlineSeed: number) => string
     }
 }
@@ -495,7 +516,20 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
         ],
     }),
 
+    loaders({
+        desktopAccess: [
+            null as CodeInviteAccessResponseApi | null,
+            {
+                loadDesktopAccess: async () => codeInvitesCheckAccessRetrieve(),
+            },
+        ],
+    }),
+
     selectors({
+        hasDesktopAccess: [
+            (s) => [s.desktopAccess],
+            (desktopAccess: CodeInviteAccessResponseApi | null): boolean => desktopAccess?.has_access ?? false,
+        ],
         // Contextual headlines registered by the active scene (welcomeOverrideLogic) win over the
         // generic defaults; the seed keeps the pick stable across re-renders.
         displayHeadline: [
@@ -748,6 +782,7 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
 
     events(({ actions, values, cache }) => ({
         afterMount: () => {
+            actions.loadDesktopAccess()
             actions.loadTasks(values.taskListParams)
             actions.loadRepositories()
             // Roll a headline seed once per mount (pickHeadline forces index 0 under Storybook for

--- a/products/tasks/backend/temporal/process_task/README.md
+++ b/products/tasks/backend/temporal/process_task/README.md
@@ -204,7 +204,7 @@ Set `SANDBOX_API_URL` to the ngrok URL. `SITE_URL` stays as `http://localhost:80
 
 ## Frontend
 
-- **TaskDetailPage** (`frontend/components/TaskDetailPage.tsx`) — Task detail view with run history, "Run task" button, "Open in PostHog Desktop" link
+- **TaskDetailPage** (`frontend/components/TaskDetailPage.tsx`) — Task detail view with run history, "Run task" button, and an "Open in PostHog Desktop" link for users with Desktop access
 - **TaskSessionView** (`frontend/components/TaskSessionView.tsx`) — Live log streaming with hedgehog animation during agent execution
 - PostHog Desktop integration via `posthog-code://task/{id}` deep links
 


### PR DESCRIPTION
## Problem

People without PostHog Desktop access see an “Open in PostHog Desktop” action that cannot work for them.

## Changes

- Show the Desktop action only when the user has rollout or redeemed-invite access.
- Route the action through the web bridge, which opens Desktop or offers the download.
- Type the existing access-check response and regenerate frontend and MCP API types.
- Document the Desktop access requirement.

## How did you test this code?

- Added a Tasks scene logic regression test for allowed and denied access.
- Ran the focused Tasks and Desktop bridge Jest suites.
- Ran frontend lint and formatting.
- Ran `hogli ci:preflight --strict` with no failures.
- Full frontend typecheck was attempted but the VM killed it for memory usage.
- Focused backend tests were attempted but local database setup did not finish.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the Tasks process documentation to describe when the Desktop link appears.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented this from an authenticated Slack request. Repo skills used: `posthog-desktop`, `writing-tests`, `writing-kea-logics`, `improving-drf-endpoints`, and `writing-pr-descriptions`.

The access decision remains server-authoritative and reuses the existing rollout-or-invite check. No customer data or private operational details are included.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787269336382159?thread_ts=1787269336.382159&cid=C09SK2PAGKF)*