### PR TITLE
fix(experiments): add breathing room to replay vision checkbox in wizard

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentWizard/steps/AnalyticsStep.tsx
+++ b/frontend/src/scenes/experiments/ExperimentWizard/steps/AnalyticsStep.tsx
@@ -83,9 +83,9 @@ export function AnalyticsStep(): JSX.Element {
                 disabledReason={getReplayVisionEditDisabledReason() ?? undefined}
                 data-attr="experiment-create-replay-vision-scanner"
                 label={
-                    <div className="py-1">
+                    <div className="py-3">
                         <div className="font-semibold">Watch participant behavior with Replay Vision</div>
-                        <div className="font-normal text-sm text-muted">
+                        <div className="mt-1 font-normal text-sm text-muted">
                             Set up a scanner that classifies what participants do after experiment exposure. It is
                             created turned off, so nothing is scanned and no credits are used until you turn it on. You
                             can adjust its prompt, filters, and sampling first. A scanner keeps running after the


### PR DESCRIPTION
## Problem

The Replay Vision checkbox in the experiment wizard looks cramped: its multi-line description sits nearly flush against the top and bottom of the box.

The bordered `LemonCheckbox` only pads horizontally, and the label wrapper added just 4px vertically.

## Changes

- The checkbox content now has even 12px padding on all sides, and a small gap separates the title from the description.
- Mechanical: two Tailwind class changes in `AnalyticsStep.tsx`.

No after screenshot: the change was not rendered locally (light worktree without a frontend build).

## How did you test this code?

Not run: no build or visual check in this environment; the diff is two utility classes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-pr-descriptions.
