### PR TITLE
fix(conversations): darken verified identity badge icon in light mode

### DIFF
--- a/products/conversations/frontend/components/IdentityBadge/IdentityBadge.tsx
+++ b/products/conversations/frontend/components/IdentityBadge/IdentityBadge.tsx
@@ -22,7 +22,14 @@ export function IdentityBadge({ verified, iconOnly = false }: IdentityBadgeProps
     // verified → shield+tick, unverified → shield+exclamation, unknown → empty shield
     const icon = verified ? <IconShield /> : verified === false ? <IconShieldExclamation /> : <IconShieldEmpty />
     // verified → green, unverified → amber, unknown → muted grayscale
-    const iconColor = verified ? 'text-success' : verified === false ? 'text-warning' : 'text-muted-alt'
+    // The green is a shade darker than text-success in light mode: that token only reaches 3:1 on a
+    // light surface, too faint for a glyph this thin, and green-700 puts it level with the amber.
+    // Dark mode keeps the green text-success already resolves to.
+    const iconColor = verified
+        ? 'text-[var(--color-green-700)] dark:text-[var(--color-green-400)]'
+        : verified === false
+          ? 'text-warning'
+          : 'text-muted-alt'
     const tagType = verified ? 'success' : verified === false ? 'warning' : 'muted'
 
     if (iconOnly) {


### PR DESCRIPTION
## Problem

A support teammate reading a ticket in light mode can barely see the green shield that marks a customer's identity as verified.

- The shield is a thin outline glyph, and its green reaches only 3:1 against the light scene background.
- The amber unverified shield next to it sits at 4.5:1, so the two states read with very different strength.

## Changes

- The verified shield now renders in a darker green in light mode, at 4.5:1 against the scene background, level with the amber shield.
- Dark mode is untouched. The badge keeps the exact green it renders today.
- The other two states, unverified and unknown, keep their colors.
- Mechanical: the color comes from `var(--color-green-700)` rather than a `text-green-700` class, because this Tailwind setup does not emit palette utilities for text colors.

The shared `text-success` token is the wider version of this problem. It resolves to the same 3:1 green on light surfaces for every one of its call sites. Changing it would recolor success text across the app, so this PR fixes the badge only and leaves that decision to design.

Light mode, before and after:

![verified-badge-light](https://raw.githubusercontent.com/PostHog/pr-assets/97b7cf7d5ed3ec6cbed9b2877bc2b3c9f41328ef/2026/08/a1e56637-4a43-4866-997c-e983fdeadef7.png)

Dark mode, unchanged:

![verified-badge-dark](https://raw.githubusercontent.com/PostHog/pr-assets/d345894add464e9a4f5eb7d8b5a27d328d893799/2026/08/12b86ddb-69df-4a23-99db-3aa252e01501.png)

## How did you test this code?

- Rendered the badge in Storybook in both themes through a temporary story, then sampled the icon pixels: `#00a447` before and `#00813a` after in light mode, unchanged `#05df72` in dark. The screenshots above come from those runs. The story was not committed.
- No tests added. A color class carries no branch a test can catch that a visual snapshot does not.
- Not run: `typescript:check`, which the sandbox kills for memory. The diff changes one string literal, and CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread. The requester's GitHub handle was not verifiable from that thread, so the PR is unassigned rather than assigned to a guessed account.

- Written by the PostHog Slack app. Skills invoked: `/writing-ui-components`, `/writing-pr-descriptions`.
- The reported screenshot showed a green far paler than this component renders, and no surface in this repo reproduces that exact header. The badge may also be styled outside this repo. This change fixes the contrast of the badge that does live here.
- An earlier attempt used `text-green-700 dark:text-green-400`. Rendering it showed the icon fall back to near-black, because the utility is never emitted, so it moved to the CSS variable.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B4F70U140/p1787300376020169)*
