### PR TITLE
fix(alerts): clarify snoozed alert status

### DIFF
--- a/products/alerts/frontend/components/AlertDefinition.tsx
+++ b/products/alerts/frontend/components/AlertDefinition.tsx
@@ -33,7 +33,7 @@ export function AlertStateIndicator({ alert }: { alert: AlertType }): JSX.Elemen
         case AlertState.ERRORED:
             return <LemonTag type="danger">Errored</LemonTag>
         case AlertState.SNOOZED:
-            return <LemonTag type="muted">Snoozed</LemonTag>
+            return <LemonTag type="completion">Snoozed</LemonTag>
         case AlertState.NOT_FIRING:
             return <LemonTag type="success">Not firing</LemonTag>
     }

--- a/products/alerts/frontend/logic/alertFormLogic.ts
+++ b/products/alerts/frontend/logic/alertFormLogic.ts
@@ -906,7 +906,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                         parent.actions.loadAlerts()
                     }
                 } catch (error) {
-                    lemonToast.error("Couldn't unsnooze alert. Try again.")
+                    lemonToast.error("We couldn't unsnooze this alert. Please try again.")
                     posthog.captureException(error, {
                         action: 'clear alert snooze',
                         alertId: values.alertForm.id,

--- a/products/alerts/frontend/logic/alertFormLogic.ts
+++ b/products/alerts/frontend/logic/alertFormLogic.ts
@@ -905,6 +905,12 @@ export const alertFormLogic = kea<alertFormLogicType>([
                         parent.actions.upsertAlert(updatedAlert)
                         parent.actions.loadAlerts()
                     }
+                } catch (error) {
+                    lemonToast.error("Couldn't unsnooze alert. Try again.")
+                    posthog.captureException(error, {
+                        action: 'clear alert snooze',
+                        alertId: values.alertForm.id,
+                    })
                 } finally {
                     actions.setClearSnoozeLoading(false)
                 }

--- a/products/alerts/frontend/logic/alertFormLogic.ts
+++ b/products/alerts/frontend/logic/alertFormLogic.ts
@@ -274,6 +274,7 @@ export interface alertFormLogicValues {
     alertFormTouched: boolean
     alertFormTouches: Record<string, boolean>
     alertFormValidationErrors: DeepPartialMap<AlertFormType, ValidationErrorType>
+    clearSnoozeLoading: boolean
     funnelAlertPreview: FunnelAlertPreview | null
     hogqlAlertPreview: HogQLAlertPreview | null
     hogqlConfigPrefill: Partial<Pick<HogQLAlertConfig, 'column' | 'label_column'>> | null
@@ -344,6 +345,9 @@ export interface alertFormLogicActions {
     }
     setAlertFormValues: (values: DeepPartial<AlertFormType>) => {
         values: DeepPartial<AlertFormType>
+    }
+    setClearSnoozeLoading: (loading: boolean) => {
+        loading: boolean
     }
     setSimulationDateFrom: (dateFrom: string) => {
         dateFrom: string
@@ -473,6 +477,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
         clearSimulation: true,
         setSimulationDateFrom: (dateFrom: string) => ({ dateFrom }),
         setAlertFormSubmitAttempted: true,
+        setClearSnoozeLoading: (loading: boolean) => ({ loading }),
     }),
 
     reducers({
@@ -487,6 +492,12 @@ export const alertFormLogic = kea<alertFormLogicType>([
             {
                 setAlertFormSubmitAttempted: () => true,
                 submitAlertFormSuccess: () => false,
+            },
+        ],
+        clearSnoozeLoading: [
+            false,
+            {
+                setClearSnoozeLoading: (_, { loading }) => loading,
             },
         ],
     }),
@@ -883,14 +894,19 @@ export const alertFormLogic = kea<alertFormLogicType>([
                 if (!values.alertForm.id) {
                     throw new Error("Cannot resolve alert that doesn't exist")
                 }
-                const updatedAlert: AlertType = await api.alerts.update(values.alertForm.id, {
-                    snoozed_until: null,
-                })
-                hydrateAlertLogicFromSaveResponse(updatedAlert)
-                const parent = getParentLogic()
-                if (parent) {
-                    parent.actions.upsertAlert(updatedAlert)
-                    parent.actions.loadAlerts()
+                actions.setClearSnoozeLoading(true)
+                try {
+                    const updatedAlert: AlertType = await api.alerts.update(values.alertForm.id, {
+                        snoozed_until: null,
+                    })
+                    hydrateAlertLogicFromSaveResponse(updatedAlert)
+                    const parent = getParentLogic()
+                    if (parent) {
+                        parent.actions.upsertAlert(updatedAlert)
+                        parent.actions.loadAlerts()
+                    }
+                } finally {
+                    actions.setClearSnoozeLoading(false)
                 }
             },
             submitAlertForm: () => {

--- a/products/alerts/frontend/views/EditAlertModal.tsx
+++ b/products/alerts/frontend/views/EditAlertModal.tsx
@@ -166,6 +166,7 @@ export function EditAlertModal(props: AlertModalProps): JSX.Element {
         simulationResult,
         simulationResultLoading,
         simulationDateFrom,
+        clearSnoozeLoading,
         thresholdBoundsFormError,
         hogqlAlertPreview,
         funnelAlertPreview,
@@ -306,6 +307,7 @@ export function EditAlertModal(props: AlertModalProps): JSX.Element {
             onDeleteAlert={deleteAlert}
             onSnoozeAlert={snoozeAlert}
             onClearSnooze={clearSnooze}
+            clearSnoozeLoading={clearSnoozeLoading}
             onSendTestDelivery={sendTestDelivery}
             testDeliveryLoading={testDeliveryResultLoading}
             testDeliveryDisabledReason={

--- a/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.test.tsx
+++ b/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.test.tsx
@@ -28,6 +28,7 @@ describe('AlertLeadingActions', () => {
                 onDeleteAlert={() => {}}
                 onSnoozeAlert={() => {}}
                 onClearSnooze={() => {}}
+                clearSnoozeLoading={false}
                 onSendTestDelivery={() => {}}
                 testDeliveryLoading={false}
                 showTestDelivery={false}
@@ -40,5 +41,32 @@ describe('AlertLeadingActions', () => {
             return
         }
         expect(deleteAction).toBeNull()
+    })
+
+    it('shows the snoozed state and unsnooze action instead of the snooze control', () => {
+        const snoozedAlert = {
+            ...alert,
+            state: AlertState.SNOOZED,
+            snoozed_until: '2026-08-21T14:30:00Z',
+        } as AlertType
+
+        render(
+            <AlertLeadingActions
+                alertForm={alertForm}
+                alert={snoozedAlert}
+                onDeleteAlert={() => {}}
+                onSnoozeAlert={() => {}}
+                onClearSnooze={() => {}}
+                clearSnoozeLoading={false}
+                onSendTestDelivery={() => {}}
+                testDeliveryLoading={false}
+                showTestDelivery={false}
+            />
+        )
+
+        expect(screen.getByText(/Snoozed until/)).not.toBeNull()
+        expect(screen.getByLabelText('Unsnooze alert')).not.toBeNull()
+        expect(screen.queryByText('Snooze until')).toBeNull()
+        expect(screen.queryByText('Clear snooze')).toBeNull()
     })
 })

--- a/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.test.tsx
+++ b/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.test.tsx
@@ -43,11 +43,15 @@ describe('AlertLeadingActions', () => {
         expect(deleteAction).toBeNull()
     })
 
-    it('shows the snoozed state and unsnooze action instead of the snooze control', () => {
+    it.each([
+        ['with an expiry', '2026-08-21T14:30:00Z', false, /Snoozed until/],
+        ['without an expiry', null, false, /^Snoozed$/],
+        ['while unsnoozing', '2026-08-21T14:30:00Z', true, /Snoozed until/],
+    ])('shows the snoozed state %s', (_, snoozedUntil, loading, expectedLabel) => {
         const snoozedAlert = {
             ...alert,
             state: AlertState.SNOOZED,
-            snoozed_until: '2026-08-21T14:30:00Z',
+            snoozed_until: snoozedUntil,
         } as AlertType
 
         render(
@@ -57,15 +61,15 @@ describe('AlertLeadingActions', () => {
                 onDeleteAlert={() => {}}
                 onSnoozeAlert={() => {}}
                 onClearSnooze={() => {}}
-                clearSnoozeLoading={false}
+                clearSnoozeLoading={loading}
                 onSendTestDelivery={() => {}}
                 testDeliveryLoading={false}
                 showTestDelivery={false}
             />
         )
 
-        expect(screen.getByText(/Snoozed until/)).not.toBeNull()
-        expect(screen.getByLabelText('Unsnooze alert')).not.toBeNull()
+        expect(screen.getByText(expectedLabel)).not.toBeNull()
+        expect(screen.getByLabelText('Unsnooze alert').getAttribute('aria-disabled')).toBe(String(loading))
         expect(screen.queryByText('Snooze until')).toBeNull()
         expect(screen.queryByText('Clear snooze')).toBeNull()
     })

--- a/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.tsx
+++ b/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.tsx
@@ -1,3 +1,4 @@
+import { IconClock, IconX } from '@posthog/icons'
 import { LemonDialog } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -18,6 +19,7 @@ interface AlertLeadingActionsProps {
     onDeleteAlert: () => void
     onSnoozeAlert: (snoozeUntil: string) => void
     onClearSnooze: () => void
+    clearSnoozeLoading: boolean
     onSendTestDelivery: () => void
     testDeliveryLoading: boolean
     testDeliveryDisabledReason?: string
@@ -30,6 +32,7 @@ export function AlertLeadingActions({
     onDeleteAlert,
     onSnoozeAlert,
     onClearSnooze,
+    clearSnoozeLoading,
     onSendTestDelivery,
     testDeliveryLoading,
     testDeliveryDisabledReason,
@@ -59,11 +62,14 @@ export function AlertLeadingActions({
                     Delete alert
                 </LemonButton>
             ) : null}
-            <SnoozeButton
-                onChange={onSnoozeAlert}
-                value={alert?.snoozed_until}
-                disabledReason={alert?.state === AlertState.FIRING ? undefined : 'Only firing alerts can be snoozed'}
-            />
+            {alert?.state !== AlertState.SNOOZED ? (
+                <SnoozeButton
+                    onChange={onSnoozeAlert}
+                    disabledReason={
+                        alert?.state === AlertState.FIRING ? undefined : 'Only firing alerts can be snoozed'
+                    }
+                />
+            ) : null}
             {showTestDelivery ? (
                 <LemonButton
                     type="secondary"
@@ -75,14 +81,23 @@ export function AlertLeadingActions({
                 </LemonButton>
             ) : null}
             {alert?.state === AlertState.SNOOZED ? (
-                <LemonButton
-                    type="secondary"
-                    status="default"
-                    onClick={onClearSnooze}
-                    tooltip={`Currently snoozed until ${formatDate(dayjs(alert.snoozed_until), 'MMM D, HH:mm')}`}
-                >
-                    Clear snooze
-                </LemonButton>
+                <div className="flex items-center gap-1.5 text-sm text-muted-alt">
+                    <IconClock className="size-4" />
+                    <span>
+                        {alert.snoozed_until
+                            ? `Snoozed until ${formatDate(dayjs(alert.snoozed_until), 'MMM D, HH:mm')}`
+                            : 'Snoozed'}
+                    </span>
+                    <LemonButton
+                        type="tertiary"
+                        size="xsmall"
+                        icon={<IconX />}
+                        onClick={onClearSnooze}
+                        loading={clearSnoozeLoading}
+                        tooltip="Unsnooze alert"
+                        aria-label="Unsnooze alert"
+                    />
+                </div>
             ) : null}
         </div>
     )

--- a/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.tsx
+++ b/products/alerts/frontend/views/EditAlertModal/AlertLeadingActions.tsx
@@ -38,6 +38,8 @@ export function AlertLeadingActions({
     testDeliveryDisabledReason,
     showTestDelivery,
 }: AlertLeadingActionsProps): JSX.Element {
+    const isSnoozed = alert?.state === AlertState.SNOOZED
+
     return (
         <div className="flex flex-wrap items-center gap-2">
             {alert ? (
@@ -62,7 +64,7 @@ export function AlertLeadingActions({
                     Delete alert
                 </LemonButton>
             ) : null}
-            {alert?.state !== AlertState.SNOOZED ? (
+            {!isSnoozed ? (
                 <SnoozeButton
                     onChange={onSnoozeAlert}
                     disabledReason={
@@ -80,7 +82,7 @@ export function AlertLeadingActions({
                     Test delivery
                 </LemonButton>
             ) : null}
-            {alert?.state === AlertState.SNOOZED ? (
+            {isSnoozed ? (
                 <div className="flex items-center gap-1.5 text-sm text-muted-alt">
                     <IconClock className="size-4" />
                     <span>


### PR DESCRIPTION
## Problem

Snoozed alerts are difficult to distinguish while scanning the alerts page or detail modal.

## Changes

- Snoozed alerts now use a distinct purple-neutral status tag.
- The detail modal replaces the snooze picker with the snooze expiry and a compact unsnooze action.
- The unsnooze action prevents duplicate requests and handles missing expiry values safely.

### Alerts list

| Before | After |
| --- | --- |
| ![Before: muted snoozed status in the alerts list](https://raw.githubusercontent.com/PostHog/pr-assets/1c4304af6a76ac0578bf4c0ea808fd2cbd715d74/2026/08/1b7ce0d5-6d4c-44d5-aab2-32f6124841c8.png) | ![After: highlighted snoozed status in the alerts list](https://raw.githubusercontent.com/PostHog/pr-assets/c047accb08ccfbda5b89a2dd5819d34e3da140a2/2026/08/2e77d6c5-0203-4af0-bd80-7a58cee1b437.png) |

### Alert detail

| Before | After |
| --- | --- |
| ![Before: muted snoozed tag with disabled snooze and clear snooze buttons](https://raw.githubusercontent.com/PostHog/pr-assets/2e0f1884ef4990814545f571111e9e808861abe9/2026/08/1c96ee40-c840-4f35-a7e8-747ff9c5b652.png) | ![After: highlighted snoozed tag with inline expiry and unsnooze icon](https://raw.githubusercontent.com/PostHog/pr-assets/b8263b57cf0601450369a8a033b36f851df8d6ff/2026/08/636d53bb-70a5-4433-b718-84272066de4f.png) |

## How did you test this code?

- Focused Jest coverage verifies the snoozed label, unsnooze action, and hidden snooze control.
- Storybook screenshots verify the list and detail states with invented data.
- Kea type generation, focused lint, formatting, and diff validation pass.
- The full frontend typecheck exceeded the sandbox memory limit after dependencies built.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. The update only clarifies existing alert controls.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented the change and used the `qa-team`, `qa-frontend`, and `writing-pr-descriptions` skills. Independent reviewers found two edge cases that the final implementation addresses.

The PR remains unassigned because the requester did not provide a verified GitHub identity.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1787265973550439?thread_ts=1787265973.550439&cid=C09BDQLM8KA)*