### PR TITLE
feat(cdp): alerts for failing destinations and transformations

### DIFF
--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -59,9 +59,18 @@ import { HogInvocations } from './invocations/HogInvocations'
 import { TransformationInvocations } from './invocations/TransformationInvocations'
 import { HogFunctionMetrics } from './metrics/HogFunctionMetrics'
 import { HogFunctionSkeleton } from './misc/HogFunctionSkeleton'
+import { HogFunctionNotifications } from './notifications/HogFunctionNotifications'
 import { HogFunctionRuns } from './runs/HogFunctionRuns'
 
-const HOG_FUNCTION_SCENE_TABS = ['configuration', 'metrics', 'runs', 'invocations', 'backfills', 'history'] as const
+const HOG_FUNCTION_SCENE_TABS = [
+    'configuration',
+    'metrics',
+    'runs',
+    'invocations',
+    'backfills',
+    'notifications',
+    'history',
+] as const
 export type HogFunctionSceneTab = (typeof HOG_FUNCTION_SCENE_TABS)[number]
 
 const HogFunctionSceneMapping: Partial<
@@ -101,7 +110,7 @@ export interface hogFunctionSceneLogicActions {
         payload?: any
     } // hogFunctionConfigurationLogic
     setCurrentTab: (tab: HogFunctionSceneTab) => {
-        tab: 'backfills' | 'configuration' | 'history' | 'invocations' | 'metrics' | 'runs'
+        tab: 'backfills' | 'configuration' | 'history' | 'invocations' | 'metrics' | 'notifications' | 'runs'
     }
 }
 
@@ -568,6 +577,16 @@ export function HogFunctionScene(): JSX.Element {
                   content: <HogFunctionRuns id={id} />,
               }
             : null,
+
+        // Site functions run client-side and never pass through the HogWatcher, so there
+        // are no state changes to notify about.
+        type === 'site_app' || type === 'site_destination'
+            ? null
+            : {
+                  label: 'Notifications',
+                  key: 'notifications',
+                  content: <HogFunctionNotifications id={id} type={type} />,
+              },
 
         {
             label: 'History',

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -92,6 +92,13 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     value: '$batch_export_run_failed',
                 },
             ]
+        case 'hog-function-alerts':
+            return [
+                {
+                    label: 'Destination or transformation state changed',
+                    value: '$hog_function_state_changed',
+                },
+            ]
         default:
             return [
                 {
@@ -131,6 +138,8 @@ export const getProductEventPropertyFilterOptions = (contextId: HogFunctionConfi
                 '$exception_functions',
                 '$exception_handled',
             ]
+        case 'hog-function-alerts':
+            return ['hog_function_id', 'hog_function_name', 'hog_function_type', 'state', 'previous_state']
     }
 
     return []
@@ -145,6 +154,14 @@ const ACTIVITY_LOG_SCOPE_VALUES: PropValue[] = Object.values(ActivityLogListScop
 // The standard lifecycle activities. Scopes also log custom activities (e.g. 'exported'),
 // which can still be entered as custom values.
 const ACTIVITY_LOG_ACTIVITY_VALUES: PropValue[] = ['created', 'updated', 'deleted'].map((name) => ({ name }))
+// Mirrors the effective HogWatcherState names the plugin-server emits on $hog_function_state_changed.
+const HOG_FUNCTION_STATE_VALUES: PropValue[] = ['healthy', 'degraded', 'disabled'].map((name) => ({ name }))
+const HOG_FUNCTION_TYPE_VALUES: PropValue[] = [
+    'destination',
+    'transformation',
+    'source_webhook',
+    'internal_destination',
+].map((name) => ({ name }))
 const NO_SUGGESTED_VALUES: PropValue[] = []
 
 /**
@@ -157,17 +174,28 @@ export const getProductEventPropertyValues = (
     contextId: HogFunctionConfigurationContextId,
     propertyKey: string
 ): PropValue[] | null => {
-    if (contextId !== 'activity-log') {
-        return null
+    if (contextId === 'activity-log') {
+        switch (propertyKey) {
+            case 'scope':
+                return ACTIVITY_LOG_SCOPE_VALUES
+            case 'activity':
+                return ACTIVITY_LOG_ACTIVITY_VALUES
+            default:
+                return NO_SUGGESTED_VALUES
+        }
     }
-    switch (propertyKey) {
-        case 'scope':
-            return ACTIVITY_LOG_SCOPE_VALUES
-        case 'activity':
-            return ACTIVITY_LOG_ACTIVITY_VALUES
-        default:
-            return NO_SUGGESTED_VALUES
+    if (contextId === 'hog-function-alerts') {
+        switch (propertyKey) {
+            case 'state':
+            case 'previous_state':
+                return HOG_FUNCTION_STATE_VALUES
+            case 'hog_function_type':
+                return HOG_FUNCTION_TYPE_VALUES
+            default:
+                return NO_SUGGESTED_VALUES
+        }
     }
+    return null
 }
 
 const getSimpleFilterValue = (value?: CyclotronJobFiltersType): string | undefined => {
@@ -189,11 +217,11 @@ const setSimpleFilterValue = (
             },
         ],
     }
-    // Preserve properties bound by Logs alerting (alert_id) and batch export alerts
-    // (batch_export_id) — the trigger event id changes between the context's events, but the
-    // binding to the parent resource must survive.
+    // Preserve properties bound by Logs alerting (alert_id), batch export alerts
+    // (batch_export_id) and hog function alerts (hog_function_id) — the trigger event id changes
+    // between the context's events, but the binding to the parent resource must survive.
     if (
-        (contextId === 'logs-alerting' || contextId === 'batch-export-alerts') &&
+        (contextId === 'logs-alerting' || contextId === 'batch-export-alerts' || contextId === 'hog-function-alerts') &&
         previous?.properties &&
         previous.properties.length > 0
     ) {

--- a/frontend/src/scenes/hog-functions/notifications/HogFunctionNotifications.tsx
+++ b/frontend/src/scenes/hog-functions/notifications/HogFunctionNotifications.tsx
@@ -1,0 +1,38 @@
+import { humanizeHogFunctionType } from 'scenes/hog-functions/hog-function-utils'
+import { LinkedHogFunctions, getFiltersFromSubTemplateId } from 'scenes/hog-functions/list/LinkedHogFunctions'
+import { urls } from 'scenes/urls'
+
+import { CyclotronJobFiltersType, HogFunctionTypeType, PropertyFilterType, PropertyOperator } from '~/types'
+
+export function HogFunctionNotifications({ id, type }: { id: string; type: HogFunctionTypeType }): JSX.Element {
+    const humanizedType = humanizeHogFunctionType(type)
+
+    // The sub-template's own event filter plus a binding to this function, so the
+    // list shows only notifications scoped to the function whose page we are on.
+    const filterGroup: CyclotronJobFiltersType = {
+        ...getFiltersFromSubTemplateId('hog-function-state-changed'),
+        properties: [
+            {
+                key: 'hog_function_id',
+                type: PropertyFilterType.Event,
+                value: id,
+                operator: PropertyOperator.Exact,
+            },
+        ],
+    }
+
+    return (
+        <div className="deprecated-space-y-2">
+            <p className="text-secondary mb-0">
+                Get notified when PostHog disables or slows down this {humanizedType} because it keeps failing.
+            </p>
+            <LinkedHogFunctions
+                type="internal_destination"
+                subTemplateIds={['hog-function-state-changed']}
+                forceFilterGroups={[filterGroup]}
+                emptyText={`No notifications configured for this ${humanizedType}.`}
+                queryParams={{ returnTo: urls.hogFunction(id, 'notifications') }}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -70,6 +70,16 @@ const BATCH_EXPORT_ALERT_MASKING_TTL_SECONDS = 60 * 60
 const BATCH_EXPORT_ALERT_MASKING_HASH =
     "{event.properties.batch_export_id ? event.properties.batch_export_id : 'unknown-batch-export'}"
 
+// A function flapping between degraded and healthy would otherwise post on every transition,
+// so dedupe to one message per function per state per hour.
+const HOG_FUNCTION_STATE_ALERT_MASKING_TTL_SECONDS = 60 * 60
+
+// Keyed per function AND state so a disable arriving shortly after a degrade still alerts
+// within the TTL. The producer always sets hog_function_id, but HogMaskerService skips masking
+// on falsy hashes, so fall back defensively.
+const HOG_FUNCTION_STATE_ALERT_MASKING_HASH =
+    "{concat(event.properties.hog_function_id ? event.properties.hog_function_id : 'unknown-function', '/', event.properties.state)}"
+
 // The page a rageclick happened on: $pathname when posthog-js set it, else the full URL.
 const PA_RAGECLICK_PAGE_EXPR = 'event.properties.$pathname ? event.properties.$pathname : event.properties.$current_url'
 
@@ -242,6 +252,35 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
             threshold: null,
         },
         flag: FEATURE_FLAGS.BATCH_EXPORT_ALERTS,
+    },
+    'hog-function-state-changed': {
+        sub_template_id: 'hog-function-state-changed',
+        type: 'internal_destination',
+        context_id: 'hog-function-alerts',
+        filters: {
+            events: [
+                {
+                    // Emitted by the plugin-server HogWatcher on every state transition — see
+                    // HOG_FUNCTION_STATE_CHANGED_EVENT in hog-watcher.service.ts. Defaults to the
+                    // two states that mean the function is failing; users can widen the filter.
+                    id: '$hog_function_state_changed',
+                    type: 'events',
+                    properties: [
+                        {
+                            key: 'state',
+                            type: PropertyFilterType.Event,
+                            value: ['disabled', 'degraded'],
+                            operator: PropertyOperator.Exact,
+                        },
+                    ],
+                },
+            ],
+        },
+        masking: {
+            hash: HOG_FUNCTION_STATE_ALERT_MASKING_HASH,
+            ttl: HOG_FUNCTION_STATE_ALERT_MASKING_TTL_SECONDS,
+            threshold: null,
+        },
     },
 }
 
@@ -618,6 +657,20 @@ function notificationVariants({
 const BATCH_EXPORT_NAME_SLACK = `{${slackEscapeExpr('event.properties.batch_export_name')}}`
 const BATCH_EXPORT_ERROR_SLACK = `{${slackEscapeExpr('event.properties.error', 1000)}}`
 
+// hog_function_name is user-controlled (the customer named their own function), so it gets the
+// same escaping + bounds as the other user-controlled notification fields. State and type come
+// from the plugin-server watcher's enums, so they interpolate raw.
+const HOG_FUNCTION_NAME_SLACK = `{${slackEscapeExpr('event.properties.hog_function_name')}}`
+const HOG_FUNCTION_NAME_MARKDOWN = `{${markdownEscapeExpr('event.properties.hog_function_name')}}`
+
+const HOG_FUNCTION_STATE_PHRASE =
+    "{event.properties.state == 'disabled' ? 'was disabled because it kept failing' : event.properties.state == 'degraded' ? 'is degraded because of failures or slow runs' : 'recovered and is healthy again'}"
+
+const HOG_FUNCTION_STATE_LINK = '{project.url}/functions/{event.properties.hog_function_id}'
+
+const HOG_FUNCTION_STATE_SLACK_MESSAGE = `Your {event.properties.hog_function_type} *${HOG_FUNCTION_NAME_SLACK}* ${HOG_FUNCTION_STATE_PHRASE}.`
+const HOG_FUNCTION_STATE_MARKDOWN_MESSAGE = `Your {event.properties.hog_function_type} **${HOG_FUNCTION_NAME_MARKDOWN}** ${HOG_FUNCTION_STATE_PHRASE}.`
+
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
     'mcp-tool-error': notificationVariants({
         subTemplateId: 'mcp-tool-error',
@@ -638,6 +691,16 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
         slackFallbackText: 'Users are rage clicking',
         markdownMessage: `${PA_RAGECLICK_MARKDOWN_MESSAGE}\n\n${PA_RAGECLICK_LINK}`,
         slackButton: { url: PA_RAGECLICK_LINK, label: PA_NOTIFICATION_BUTTON_LABELS['pa-rageclick'] },
+    }),
+    'hog-function-state-changed': notificationVariants({
+        subTemplateId: 'hog-function-state-changed',
+        nameSuffix: 'when a destination or transformation is failing',
+        description: 'Know when PostHog disables or slows down a function because it keeps failing',
+        webhookDescription: 'Send destination and transformation state changes to your own endpoint',
+        slackMessage: HOG_FUNCTION_STATE_SLACK_MESSAGE,
+        slackFallbackText: 'A destination or transformation changed state',
+        markdownMessage: `${HOG_FUNCTION_STATE_MARKDOWN_MESSAGE}\n\n${HOG_FUNCTION_STATE_LINK}`,
+        slackButton: { url: HOG_FUNCTION_STATE_LINK, label: 'View function' },
     }),
     'survey-response': [
         {
@@ -1722,6 +1785,8 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
             return 'health-alerts'
         case '$batch_export_run_failed':
             return 'batch-export-alerts'
+        case '$hog_function_state_changed':
+            return 'hog-function-alerts'
         default:
             return 'standard'
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7385,6 +7385,7 @@ export type HogFunctionConfigurationContextId =
     | 'logs-alerting'
     | 'health-alerts'
     | 'batch-export-alerts'
+    | 'hog-function-alerts'
 
 export type HogFunctionSubTemplateIdType =
     | 'early-access-feature-enrollment'
@@ -7406,6 +7407,7 @@ export type HogFunctionSubTemplateIdType =
     | 'health-check-firing'
     | 'health-check-resolved'
     | 'batch-export-run-failed'
+    | 'hog-function-state-changed'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -11,7 +11,7 @@ import { TeamManager } from '~/common/utils/team-manager'
 import type { CommonConfig } from '../common/config'
 import { InternalCaptureService } from '../common/services/internal-capture'
 import type { CdpConfig } from './config'
-import { WarehouseSourceWebhooksOutput } from './outputs/outputs'
+import { CDP_INTERNAL_EVENTS_OUTPUT, CdpInternalEventsOutput, WarehouseSourceWebhooksOutput } from './outputs/outputs'
 import { CdpProducerName } from './outputs/producers'
 import { createCdpOutputsRegistry } from './outputs/registry'
 import { CapturedEventsService } from './services/captured-events/captured-events.service'
@@ -47,7 +47,12 @@ import { configureValkeyReads } from './utils/dual-store'
 import { EncryptedFields } from './utils/encryption-utils'
 
 /** Union of every output name resolved by `createCdpOutputsRegistry()`. */
-export type CdpOutput = AppMetricsOutput | LogEntriesOutput | HogInvocationResultsOutput | WarehouseSourceWebhooksOutput
+export type CdpOutput =
+    | AppMetricsOutput
+    | LogEntriesOutput
+    | HogInvocationResultsOutput
+    | WarehouseSourceWebhooksOutput
+    | CdpInternalEventsOutput
 
 export type CdpOutputs = IngestionOutputs<CdpOutput>
 
@@ -157,6 +162,8 @@ export type CdpCoreServicesConfig = Pick<
         | 'MESSAGE_ASSETS_PRODUCER'
         | 'CDP_WAREHOUSE_SOURCE_WEBHOOKS_TOPIC'
         | 'CDP_WAREHOUSE_SOURCE_WEBHOOKS_PRODUCER'
+        | 'CDP_INTERNAL_EVENTS_TOPIC'
+        | 'CDP_INTERNAL_EVENTS_PRODUCER'
     >
 
 export interface CdpCoreServicesDeps {
@@ -375,12 +382,19 @@ export function createCdpCoreServices(
         observeResultsBufferMaxResults: config.CDP_WATCHER_OBSERVE_RESULTS_BUFFER_MAX_RESULTS,
     }
 
-    const hogWatcher = new HogWatcherService(deps.teamManager, hogWatcherConfig, redis, redisReader)
+    const outputs = createCdpOutputsRegistry().build(deps.cdpProducerRegistry, config)
 
-    // Valkey-bound twin of the watcher. `sendEvents: false` so it never emits duplicate
-    // billable team events on state transitions; the Prom counter
-    // `cdp_hog_function_state_change` may double-emit when both pools detect the same
-    // transition — rare, accepted during dual-write mode.
+    const hogWatcher = new HogWatcherService(deps.teamManager, hogWatcherConfig, redis, redisReader, (event) =>
+        outputs.produce(CDP_INTERNAL_EVENTS_OUTPUT, {
+            value: Buffer.from(JSON.stringify(event)),
+            key: event.event.uuid,
+        })
+    )
+
+    // Valkey-bound twin of the watcher. `sendEvents: false` and no internal-event producer so
+    // it never emits duplicate billable team events or customer notifications on state
+    // transitions; the Prom counter `cdp_hog_function_state_change` may double-emit when both
+    // pools detect the same transition — rare, accepted during dual-write mode.
     const hogWatcherMirror = new HogWatcherService(
         deps.teamManager,
         { ...hogWatcherConfig, sendEvents: false },
@@ -390,7 +404,6 @@ export function createCdpCoreServices(
 
     const trackingCodeSigner = new EmailTrackingCodeSigner(config.ENCRYPTION_SALT_KEYS, config.CDP_EMAIL_TRACKING_URL)
     const teamWorkflowsConfigService = new TeamWorkflowsConfigService(deps.postgres)
-    const outputs = createCdpOutputsRegistry().build(deps.cdpProducerRegistry, config)
     const messageAssetsService = new MessageAssetsService(outputs)
     // Constructed here (rather than below with the other messaging services) so it can be threaded
     // into EmailService — the pre-send suppression check lives there so every send path shares one

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -1,5 +1,6 @@
 import {
     KAFKA_APP_METRICS_2,
+    KAFKA_CDP_INTERNAL_EVENTS,
     KAFKA_EVENTS_JSON,
     KAFKA_HOG_INVOCATION_RESULTS,
     KAFKA_LOG_ENTRIES,
@@ -116,6 +117,10 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_RERUN_WORKER_BATCH_SIZE: number
     CDP_WAREHOUSE_SOURCE_WEBHOOKS_TOPIC: string
     CDP_WAREHOUSE_SOURCE_WEBHOOKS_PRODUCER: CdpProducerName
+    // Customer-facing internal events (e.g. hog function state changes) that
+    // trigger `internal_destination` functions via the internal-events consumer.
+    CDP_INTERNAL_EVENTS_TOPIC: string
+    CDP_INTERNAL_EVENTS_PRODUCER: CdpProducerName
 
     CDP_EMAIL_TRACKING_URL: string
 
@@ -285,6 +290,11 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_RERUN_WORKER_BATCH_SIZE: 1,
         CDP_WAREHOUSE_SOURCE_WEBHOOKS_TOPIC: KAFKA_WAREHOUSE_SOURCE_WEBHOOKS,
         CDP_WAREHOUSE_SOURCE_WEBHOOKS_PRODUCER: WAREHOUSE_PRODUCER,
+        CDP_INTERNAL_EVENTS_TOPIC: KAFKA_CDP_INTERNAL_EVENTS,
+        // Cyclotron Warpstream cluster — Django's internal-events producer routes this
+        // topic to the CYCLOTRON cluster profile (posthog/kafka_client/routing.py), so the
+        // Node producer targets the same cluster the internal-events consumer reads from.
+        CDP_INTERNAL_EVENTS_PRODUCER: WARPSTREAM_CYCLOTRON_PRODUCER,
 
         CDP_EMAIL_TRACKING_URL: 'http://localhost:8010',
 

--- a/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
@@ -299,19 +299,23 @@ describe('CdpDatawarehouseEventsConsumer', () => {
             expect(invocations).toHaveLength(0)
             expect(mockQueueInvocations).toHaveBeenCalledWith([])
 
-            expect(mockProducerObserver.getProducedKafkaMessages()).toMatchObject([
-                {
-                    topic: 'clickhouse_app_metrics2_test',
-                    value: {
-                        app_source: 'hog_function',
-                        app_source_id: fnFetchNoFilters.id,
-                        count: 1,
-                        metric_kind: 'failure',
-                        metric_name: 'disabled_permanently',
-                        team_id: team.id,
+            // Scoped to app metrics — the disable transition itself also produces a
+            // $hog_function_state_changed internal event, asserted in the events consumer test.
+            expect(mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')).toMatchObject(
+                [
+                    {
+                        topic: 'clickhouse_app_metrics2_test',
+                        value: {
+                            app_source: 'hog_function',
+                            app_source_id: fnFetchNoFilters.id,
+                            count: 1,
+                            metric_kind: 'failure',
+                            metric_name: 'disabled_permanently',
+                            team_id: team.id,
+                        },
                     },
-                },
-            ])
+                ]
+            )
         })
 
         it('should handle degraded state by setting queue priority', async () => {

--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -296,9 +296,13 @@ describe('CdpEventsConsumer', () => {
                 const { invocations } = await processor.processBatch([globals])
 
                 expect(invocations).toHaveLength(0)
-                expect(mockProducerObserver.produceSpy).toHaveBeenCalledTimes(2)
+                // 2 disabled_permanently app metrics + 2 $hog_function_state_changed internal
+                // events (one per disable transition, produced by the watcher).
+                expect(mockProducerObserver.produceSpy).toHaveBeenCalledTimes(4)
 
-                expect(mockProducerObserver.getProducedKafkaMessages()).toMatchObject([
+                expect(
+                    mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+                ).toMatchObject([
                     {
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
@@ -319,6 +323,41 @@ describe('CdpEventsConsumer', () => {
                             metric_kind: 'failure',
                             metric_name: 'disabled_permanently',
                             team_id: 2,
+                        },
+                    },
+                ])
+
+                // The disable transition emits the customer-facing internal event through the
+                // wired-up producer — this is what internal_destination alerts trigger on.
+                expect(
+                    mockProducerObserver.getProducedKafkaMessagesForTopic('cdp_internal_events_test')
+                ).toMatchObject([
+                    {
+                        topic: 'cdp_internal_events_test',
+                        value: {
+                            team_id: 2,
+                            event: {
+                                event: '$hog_function_state_changed',
+                                properties: {
+                                    hog_function_id: fnFetchNoFilters.id,
+                                    state: 'disabled',
+                                    previous_state: 'healthy',
+                                },
+                            },
+                        },
+                    },
+                    {
+                        topic: 'cdp_internal_events_test',
+                        value: {
+                            team_id: 2,
+                            event: {
+                                event: '$hog_function_state_changed',
+                                properties: {
+                                    hog_function_id: fnPrinterPageviewFilters.id,
+                                    state: 'disabled',
+                                    previous_state: 'healthy',
+                                },
+                            },
                         },
                     },
                 ])

--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -329,38 +329,38 @@ describe('CdpEventsConsumer', () => {
 
                 // The disable transition emits the customer-facing internal event through the
                 // wired-up producer — this is what internal_destination alerts trigger on.
-                expect(
-                    mockProducerObserver.getProducedKafkaMessagesForTopic('cdp_internal_events_test')
-                ).toMatchObject([
-                    {
-                        topic: 'cdp_internal_events_test',
-                        value: {
-                            team_id: 2,
-                            event: {
-                                event: '$hog_function_state_changed',
-                                properties: {
-                                    hog_function_id: fnFetchNoFilters.id,
-                                    state: 'disabled',
-                                    previous_state: 'healthy',
+                expect(mockProducerObserver.getProducedKafkaMessagesForTopic('cdp_internal_events_test')).toMatchObject(
+                    [
+                        {
+                            topic: 'cdp_internal_events_test',
+                            value: {
+                                team_id: 2,
+                                event: {
+                                    event: '$hog_function_state_changed',
+                                    properties: {
+                                        hog_function_id: fnFetchNoFilters.id,
+                                        state: 'disabled',
+                                        previous_state: 'healthy',
+                                    },
                                 },
                             },
                         },
-                    },
-                    {
-                        topic: 'cdp_internal_events_test',
-                        value: {
-                            team_id: 2,
-                            event: {
-                                event: '$hog_function_state_changed',
-                                properties: {
-                                    hog_function_id: fnPrinterPageviewFilters.id,
-                                    state: 'disabled',
-                                    previous_state: 'healthy',
+                        {
+                            topic: 'cdp_internal_events_test',
+                            value: {
+                                team_id: 2,
+                                event: {
+                                    event: '$hog_function_state_changed',
+                                    properties: {
+                                        hog_function_id: fnPrinterPageviewFilters.id,
+                                        state: 'disabled',
+                                        previous_state: 'healthy',
+                                    },
                                 },
                             },
                         },
-                    },
-                ])
+                    ]
+                )
             })
 
             {

--- a/nodejs/src/cdp/outputs/outputs.ts
+++ b/nodejs/src/cdp/outputs/outputs.ts
@@ -9,3 +9,6 @@
 
 export const WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT = 'warehouse_source_webhooks' as const
 export type WarehouseSourceWebhooksOutput = typeof WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT
+
+export const CDP_INTERNAL_EVENTS_OUTPUT = 'cdp_internal_events' as const
+export type CdpInternalEventsOutput = typeof CDP_INTERNAL_EVENTS_OUTPUT

--- a/nodejs/src/cdp/outputs/registry.ts
+++ b/nodejs/src/cdp/outputs/registry.ts
@@ -6,7 +6,7 @@ import {
 } from '~/common/outputs'
 import { IngestionOutputsBuilder } from '~/common/outputs/ingestion-outputs-builder'
 
-import { WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT } from './outputs'
+import { CDP_INTERNAL_EVENTS_OUTPUT, WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT } from './outputs'
 
 /**
  * Outputs the CDP deployments write to. Each output's topic + producer are
@@ -17,6 +17,8 @@ import { WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT } from './outputs'
  *   (also used for legacy plugin app metrics since they share the
  *   `clickhouse_app_metrics2` schema).
  * - `WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT` — warehouse source webhook payloads.
+ * - `CDP_INTERNAL_EVENTS_OUTPUT` — customer-facing internal events (consumed by
+ *   the internal-events consumer to trigger `internal_destination` functions).
  */
 export function createCdpOutputsRegistry() {
     return new IngestionOutputsBuilder()
@@ -39,5 +41,9 @@ export function createCdpOutputsRegistry() {
         .register(WAREHOUSE_SOURCE_WEBHOOKS_OUTPUT, {
             topicKey: 'CDP_WAREHOUSE_SOURCE_WEBHOOKS_TOPIC',
             producerKey: 'CDP_WAREHOUSE_SOURCE_WEBHOOKS_PRODUCER',
+        })
+        .register(CDP_INTERNAL_EVENTS_OUTPUT, {
+            topicKey: 'CDP_INTERNAL_EVENTS_TOPIC',
+            producerKey: 'CDP_INTERNAL_EVENTS_PRODUCER',
         })
 }

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
@@ -5,6 +5,7 @@ import { logger } from '~/common/utils/logger'
 
 import { Hub, ProjectId, Team } from '../../../types'
 import { createExampleInvocation, createHogFunction } from '../../_tests/fixtures'
+import { CdpInternalEventSchema } from '../../schema'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, HogFunctionType } from '../../types'
 import { createInvocationResult } from '../../utils/invocation-utils'
 import { BASE_REDIS_KEY, HogWatcherConfig, HogWatcherService, HogWatcherState } from './hog-watcher.service'
@@ -315,6 +316,42 @@ describe('HogWatcher', () => {
                     state: HogWatcherState.disabled,
                     previousState: HogWatcherState.degraded,
                 })
+            })
+
+            it('should produce a customer-facing internal event on state change', async () => {
+                const produceInternalEvent = jest.fn().mockResolvedValue(undefined)
+                watcher = new HogWatcherService(hub.teamManager, watcherConfig, redis, undefined, produceInternalEvent)
+
+                await watcher.forceStateChange(hogFunction, HogWatcherState.forcefully_disabled)
+
+                expect(produceInternalEvent).toHaveBeenCalledTimes(1)
+                const produced = produceInternalEvent.mock.calls[0][0]
+                // Must parse with the schema the internal-events consumer validates against.
+                expect(CdpInternalEventSchema.safeParse(produced).success).toBe(true)
+                expect(produced).toMatchObject({
+                    team_id: 2,
+                    event: {
+                        event: '$hog_function_state_changed',
+                        distinct_id: hogFunctionId,
+                        properties: {
+                            hog_function_id: hogFunctionId,
+                            hog_function_name: hogFunction.name,
+                            hog_function_type: hogFunction.type,
+                            state: 'disabled',
+                            previous_state: 'healthy',
+                        },
+                    },
+                })
+            })
+
+            it('should not fail the state transition when the internal event cannot be produced', async () => {
+                const produceInternalEvent = jest.fn().mockRejectedValue(new Error('kafka down'))
+                watcher = new HogWatcherService(hub.teamManager, watcherConfig, redis, undefined, produceInternalEvent)
+
+                await expect(watcher.forceStateChange(hogFunction, HogWatcherState.disabled)).resolves.not.toThrow()
+
+                expect(produceInternalEvent).toHaveBeenCalledTimes(1)
+                expect((await watcher.getPersistedState(hogFunctionId)).state).toEqual(HogWatcherState.disabled)
             })
 
             it('should not transition to disabled if not enabled', async () => {

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -6,7 +6,9 @@ import { LazyLoader } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
 import { captureTeamEvent } from '~/common/utils/posthog'
 import { TeamManager } from '~/common/utils/team-manager'
+import { UUIDT } from '~/common/utils/utils'
 
+import { CdpInternalEvent } from '../../schema'
 import {
     CyclotronJobInvocation,
     CyclotronJobInvocationHogFunction,
@@ -37,6 +39,11 @@ export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/ho
 const REDIS_KEY_TOKENS = `${BASE_REDIS_KEY}/tokens`
 const REDIS_KEY_STATE = `${BASE_REDIS_KEY}/state`
 const REDIS_KEY_STATE_LOCK = `${BASE_REDIS_KEY}/state-lock`
+
+// Customer-facing internal event emitted on every watcher state transition, so users can
+// wire internal_destination functions (Slack, Teams, Discord, webhook) to it. The frontend
+// sub-templates filter on this exact name — keep them in sync (sub-templates.ts).
+export const HOG_FUNCTION_STATE_CHANGED_EVENT = '$hog_function_state_changed'
 
 export enum HogWatcherState {
     healthy = 1,
@@ -137,7 +144,9 @@ export class HogWatcherService {
         private teamManager: TeamManager,
         private config: HogWatcherConfig,
         private redis: RedisV2,
-        redisReader?: RedisV2
+        redisReader?: RedisV2,
+        // Only set on the primary watcher — the Valkey mirror must not double-emit.
+        private produceInternalEvent?: (event: CdpInternalEvent) => Promise<void>
     ) {
         this.redisReader = redisReader ?? redis
         // Token-bucket rate limiter — `name: 'hog-watcher-2'` produces the same
@@ -207,6 +216,35 @@ export class HogWatcherService {
                 state: HogWatcherState[state], // Convert numeric state to readable string
                 previous_state: HogWatcherState[previousState], // Convert numeric state to readable string
             })
+        }
+
+        if (team && this.produceInternalEvent) {
+            try {
+                await this.produceInternalEvent({
+                    team_id: team.id,
+                    event: {
+                        uuid: new UUIDT().toString(),
+                        event: HOG_FUNCTION_STATE_CHANGED_EVENT,
+                        distinct_id: hogFunction.id,
+                        properties: {
+                            hog_function_id: hogFunction.id,
+                            hog_function_name: hogFunction.name,
+                            hog_function_type: hogFunction.type,
+                            hog_function_template_id: hogFunction.template_id,
+                            // Effective states: customers should see 'disabled', not 'forcefully_disabled'.
+                            state: HogWatcherState[effectiveState(state)],
+                            previous_state: HogWatcherState[effectiveState(previousState)],
+                        },
+                        timestamp: new Date().toISOString(),
+                    },
+                })
+            } catch (error) {
+                // A notification failure must not fail the state transition itself.
+                logger.error('[HogWatcherService] failed to produce state change internal event', {
+                    hogFunctionId: hogFunction.id,
+                    error,
+                })
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

When a destination, transformation, or source keeps failing, PostHog degrades it and can disable it automatically, and the user is never told. A function can silently stop delivering data until someone happens to open its page and see the status tag.

The email that was meant to cover the disable case is dead code: the plugin-server no longer calls the Celery task (`hog_function_state_transition`) that dispatched `send_hog_function_disabled`, so nothing fires on a state change today.

## Changes

- Users can now add Slack, Microsoft Teams, Discord, or webhook notifications for a destination, transformation, or source from a new Notifications tab on the function's page. Each notification is scoped to that function via a `hog_function_id` filter.
- The plugin-server HogWatcher now emits a customer-facing `$hog_function_state_changed` internal event on every state transition, with the function's id, name, type, and the old and new (effective) states. This follows the `$batch_export_run_failed` pattern, so delivery reuses the existing `internal_destination` pipeline end to end.
- New `hog-function-state-changed` sub-templates default to the `disabled` and `degraded` states and dedupe to one message per function per state per hour, so a flapping function cannot flood a channel.
- Mechanical: a `cdp_internal_events` output in the CDP outputs registry (topic and producer are env-configurable, defaulting to the same cluster Django's internal-events producer targets), and the `hog-function-alerts` filter context wiring.

> [!NOTE]
> Follow-ups, deliberately out of scope: HogFlow (workflow) results never feed the watcher (`isHogFunctionResult` excludes them), so workflows get no event yet; and the dead `send_hog_function_disabled` email plus an in-app notification could now hang off this same transition point.

The riskiest part is the producer wiring in `cdp-services.ts`; a produce failure is caught and logged so it cannot fail the state transition itself.

Screenshots: not included. The sandbox could not run the app; the new tab is a direct reuse of the batch export Notifications tab (`BatchExportNotifications`) with a different sub-template.

## How did you test this code?

- New jest cases in `hog-watcher.service.test.ts`: one validates the produced payload against `CdpInternalEventSchema`, catching any payload drift the internal-events consumer would reject; one proves a produce failure still persists the state transition.
- Ran locally: both hog-watcher suites, all `scenes/hog-functions` frontend suites, and the suites consuming the changed sub-template and filter modules. Node typecheck passes.
- Not run: the full frontend `tsgo` check (killed by the sandbox memory limit); plain `tsc` reported no errors in the changed files. Not verified end to end against a running CDP stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None in this repo; the pipeline destination docs on posthog.com should gain a section on setting up these notifications once this ships.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude in a PostHog Desktop task, from a request for a better way than email to learn that destinations, transformations, or workflows started failing. Investigation found the HogWatcher state machine fully built but with no customer-facing signal on transition, and the disable email unreachable. The shipped design reuses the internal-events alerting pipeline (per `/adding-product-alerting`) instead of reviving the Node-to-Celery bridge, which no longer exists. Skills invoked: `/adding-product-alerting`, `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
