### PR TITLE
fix(desktop): make every error toast inspectable

### DIFF
--- a/products/desktop/packages/ui/src/features/notifications/ErrorDetailsDialog.tsx
+++ b/products/desktop/packages/ui/src/features/notifications/ErrorDetailsDialog.tsx
@@ -10,7 +10,8 @@ import {
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { formatCapturedLogs } from "@posthog/ui/shell/logCapture";
-import { serializeError, useErrorDetailsStore } from "./errorDetails";
+import { serializeError } from "./errorDetails";
+import { useErrorDetailsStore } from "./errorDetailsStore";
 
 // Keep the create-task prompt readable: the full 500-entry buffer belongs in
 // the downloaded bundle, not in a composer draft.
@@ -34,7 +35,7 @@ function buildBundle(
   ].join("\n");
 }
 
-// Global inspector behind every error toast's "Details" action: the full
+// Global inspector behind every error toast's "View larger" action: the full
 // pretty-printed payload the toast had no room for, a downloadable
 // error-plus-logs bundle, and (dev builds only) a one-click task prefilled
 // with the same context.

--- a/products/desktop/packages/ui/src/features/notifications/errorDetails.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/errorDetails.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 const toastMock = vi.hoisted(() => ({ error: vi.fn() }));
 vi.mock("@posthog/ui/primitives/toast", () => ({ toast: toastMock }));
 
-import {
-  serializeError,
-  summarizeError,
-  toastError,
-  useErrorDetailsStore,
-} from "./errorDetails";
+import { serializeError, summarizeError, toastError } from "./errorDetails";
 
 describe("serializeError", () => {
   it("pretty-prints plain objects", () => {
@@ -117,25 +112,18 @@ describe("toastError", () => {
   const rawError =
     'Failed request: [400] {"detail":"This field is required.","attr":"model"}';
 
-  it("shows a summary in the toast, not the raw payload, with a Details action", () => {
+  it("shows a summary in the toast and forwards the complete payload", () => {
     toastMock.error.mockClear();
-    useErrorDetailsStore.getState().close();
 
     toastError("Couldn't start generation", rawError);
 
     const [title, options] = toastMock.error.mock.calls[0] as [
       string,
-      { description: string; action: { label: string; onClick: () => void } },
+      { description: string; error: unknown },
     ];
     expect(title).toBe("Couldn't start generation");
     expect(options.description).toBe(summarizeError(rawError));
     expect(options.description.length).toBeLessThanOrEqual(141);
-
-    expect(options.action.label).toBe("Details");
-    options.action.onClick();
-    const detail = useErrorDetailsStore.getState().detail;
-    expect(detail?.title).toBe("Couldn't start generation");
-    expect(detail?.error).toBe(rawError);
-    useErrorDetailsStore.getState().close();
+    expect(options.error).toBe(rawError);
   });
 });

--- a/products/desktop/packages/ui/src/features/notifications/errorDetails.ts
+++ b/products/desktop/packages/ui/src/features/notifications/errorDetails.ts
@@ -1,13 +1,4 @@
 import { toast } from "@posthog/ui/primitives/toast";
-import { create } from "zustand";
-
-// The error behind an error-level toast, captured so the details dialog can
-// show the full payload the toast had no room for.
-export interface ErrorDetail {
-  title: string;
-  error: unknown;
-  occurredAt: number;
-}
 
 // API error messages routinely arrive as a string with a JSON payload embedded
 // in them (e.g. `Failed request: [400] {"detail":"..."}`). Pull that payload
@@ -72,7 +63,7 @@ export function serializeError(error: unknown): string {
 const SUMMARY_LIMIT = 140;
 
 // One-line summary of an error payload, sized for a toast description. The
-// full payload stays behind the toast's "Details" action.
+// full payload stays behind the toast's "View larger" action.
 export function summarizeError(error: unknown): string {
   let message: string;
   if (typeof error === "string") {
@@ -96,37 +87,11 @@ export function summarizeError(error: unknown): string {
     : `${flat.slice(0, SUMMARY_LIMIT)}…`;
 }
 
-interface ErrorDetailsState {
-  detail: ErrorDetail | null;
-  show: (detail: ErrorDetail) => void;
-  close: () => void;
-}
-
-// View state for the global error details dialog (rendered once in App).
-export const useErrorDetailsStore = create<ErrorDetailsState>((set) => ({
-  detail: null,
-  show: (detail) => set({ detail }),
-  close: () => set({ detail: null }),
-}));
-
-// Open the error details dialog for a given error. Shared by the notification
-// bus's error toasts and the standalone `toastError` helper so both land on the
-// same inspectable dialog.
-export function showErrorDetails(title: string, error: unknown): void {
-  useErrorDetailsStore.getState().show({
-    title,
-    error,
-    occurredAt: Date.now(),
-  });
-}
-
-// Fire an error toast whose payload stays inspectable: a one-line summary in
-// the toast body plus a "Details" action that opens the full pretty-printed
-// error (and its logs) in the dialog. Use this instead of a bare
-// `toast.error(title, { description: someRawError })` — that overflows the
-// toast and can't be opened. This is the lightweight, synchronous path for
-// errors raised by a user action; task-lifecycle notifications that need
-// focus-aware routing and sound still go through `NotificationBus.notifyError`.
+// Fire an error toast with a short summary while preserving the complete
+// payload for the central toast wrapper's "View larger" action. This is the
+// lightweight, synchronous path for errors raised by a user action;
+// task-lifecycle notifications that need focus-aware routing and sound still
+// go through `NotificationBus.notifyError`.
 export function toastError(
   title: string,
   error: unknown,
@@ -136,9 +101,6 @@ export function toastError(
     id: options?.id,
     duration: options?.duration,
     description: summarizeError(error),
-    action: {
-      label: "Details",
-      onClick: () => showErrorDetails(title, error),
-    },
+    error,
   });
 }

--- a/products/desktop/packages/ui/src/features/notifications/errorDetailsStore.ts
+++ b/products/desktop/packages/ui/src/features/notifications/errorDetailsStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+// The error behind an error-level toast, captured so the details dialog can
+// show the full payload the toast had no room for.
+export interface ErrorDetail {
+  title: string;
+  error: unknown;
+  occurredAt: number;
+}
+
+interface ErrorDetailsState {
+  detail: ErrorDetail | null;
+  show: (detail: ErrorDetail) => void;
+  close: () => void;
+}
+
+// View state for the global error details dialog (rendered once in App).
+export const useErrorDetailsStore = create<ErrorDetailsState>((set) => ({
+  detail: null,
+  show: (detail) => set({ detail }),
+  close: () => set({ detail: null }),
+}));
+
+// Open the error details dialog for a given error. The central toast wrapper
+// uses this for every error toast so even plain strings remain inspectable.
+export function showErrorDetails(title: string, error: unknown): void {
+  useErrorDetailsStore.getState().show({
+    title,
+    error,
+    occurredAt: Date.now(),
+  });
+}

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -17,7 +17,6 @@ const toastMock = vi.hoisted(() => ({
 vi.mock("@posthog/ui/primitives/toast", () => ({ toast: toastMock }));
 
 import { playCompletionSound } from "@posthog/ui/utils/sounds";
-import { useErrorDetailsStore } from "./errorDetails";
 import type {
   IActiveView,
   INotificationSettings,
@@ -235,28 +234,13 @@ describe("notifyError", () => {
     );
   });
 
-  it("attaches a Details action that opens the error details dialog", () => {
-    useErrorDetailsStore.getState().close();
+  it("forwards the complete payload for the toast wrapper's View larger action", () => {
     const { bus } = makeBus({ hasFocus: true });
     bus.notifyError("Sync failed", payload);
-    const options = toastMock.error.mock.calls[0]?.[1] as {
-      action?: { label: string; onClick: () => void };
-    };
-    expect(options.action?.label).toBe("Details");
-    options.action?.onClick();
-    const detail = useErrorDetailsStore.getState().detail;
-    expect(detail?.title).toBe("Sync failed");
-    expect(detail?.error).toBe(payload);
-    useErrorDetailsStore.getState().close();
-  });
-
-  it("the Details action wins over target navigation on error toasts", () => {
-    const { bus } = makeBus({ hasFocus: true });
-    bus.notifyError("Sync failed", payload, taskTarget(TASK_ID));
-    const options = toastMock.error.mock.calls[0]?.[1] as {
-      action?: { label: string };
-    };
-    expect(options.action?.label).toBe("Details");
+    expect(toastMock.error).toHaveBeenCalledWith(
+      "Sync failed",
+      expect.objectContaining({ error: payload }),
+    );
   });
 
   it("app unfocused → native notification with the summary as body", () => {

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -13,7 +13,7 @@ import {
   resolveSoundUrl,
 } from "@posthog/ui/utils/sounds";
 import { inject, injectable } from "inversify";
-import { showErrorDetails, summarizeError } from "./errorDetails";
+import { summarizeError } from "./errorDetails";
 import {
   ACTIVE_VIEW_PROVIDER,
   type IActiveView,
@@ -46,9 +46,8 @@ export interface NotificationDescriptor {
   // drives the completion sound's playback rate (fast task -> faster/higher).
   soundDurationMs?: number;
   // Raw error payload behind an error-level notification. Never rendered into
-  // the toast itself (it doesn't fit); the toast instead gets a "Details"
-  // action that opens the error details dialog — pretty-printed payload,
-  // downloadable error+logs bundle, and a dev-only create-task shortcut.
+  // the toast itself (it doesn't fit); the central toast wrapper adds a "View
+  // larger" action that opens the pretty-printed payload in the error dialog.
   error?: unknown;
 }
 
@@ -162,7 +161,7 @@ export class NotificationBus {
   }
 
   // Error entry point: the toast carries a one-line summary; the raw payload
-  // rides along on `error` and stays inspectable behind the Details action.
+  // rides along on `error` and stays inspectable behind the View larger action.
   notifyError(
     title: string,
     error: unknown,
@@ -184,22 +183,13 @@ export class NotificationBus {
       description: descriptor.toast?.description,
       duration: descriptor.toast?.duration,
       action: this.deriveAction(descriptor),
+      error: descriptor.error,
     });
   }
 
   private deriveAction(
     descriptor: NotificationDescriptor,
   ): { label: string; onClick: () => void } | undefined {
-    // Inspecting the payload beats navigation on error toasts: the error is
-    // the thing the user needs, and it never fits in the toast.
-    if (descriptor.error !== undefined) {
-      const title = descriptor.title ?? descriptor.body;
-      const error = descriptor.error;
-      return {
-        label: "Details",
-        onClick: () => showErrorDetails(title, error),
-      };
-    }
     const target = descriptor.target;
     if (!target) return undefined;
     // Route through the shared open-target handler so the toast click lands on

--- a/products/desktop/packages/ui/src/primitives/toast.test.ts
+++ b/products/desktop/packages/ui/src/primitives/toast.test.ts
@@ -157,6 +157,27 @@ describe("toast wrapper", () => {
     expect(callerAction).not.toHaveBeenCalled();
   });
 
+  it("opens the latest payload after a stable error toast is updated", () => {
+    toast.error("First failure", {
+      id: "updated-error",
+      error: { message: "first" },
+    });
+    const latestError = { message: "second" };
+    toast.error("Second failure", {
+      id: "updated-error",
+      error: latestError,
+    });
+
+    const update = quill.update.mock.calls[0]?.[1] as {
+      action: { label: string; onClick: () => void };
+    };
+    expect(update.action.label).toBe("View larger");
+    update.action.onClick();
+    expect(useErrorDetailsStore.getState().detail).toEqual(
+      expect.objectContaining({ title: "Second failure", error: latestError }),
+    );
+  });
+
   it.each([
     [undefined, undefined],
     ["stable-id", "stable-id"],

--- a/products/desktop/packages/ui/src/primitives/toast.test.ts
+++ b/products/desktop/packages/ui/src/primitives/toast.test.ts
@@ -28,12 +28,14 @@ vi.mock("@posthog/ui/features/settings/settingsStore", () => ({
   useSettingsStore: { getState: () => settings },
 }));
 
+import { useErrorDetailsStore } from "@posthog/ui/features/notifications/errorDetailsStore";
 import { toast } from "./toast";
 
 beforeEach(() => {
   vi.clearAllMocks();
   quill._reset();
   settings.toastNotifications = true;
+  useErrorDetailsStore.getState().close();
   // clearAllMocks resets the level fns to undefined returns; restore ids.
   let n = 0;
   for (const key of [
@@ -107,6 +109,52 @@ describe("toast wrapper", () => {
     settings.toastNotifications = false;
     toast.error("Offline");
     expect(quill.error).toHaveBeenCalled();
+  });
+
+  it("adds View larger to a bare error toast and shows its title", () => {
+    toast.error("Failed request");
+
+    const options = quill.error.mock.calls[0]?.[0] as {
+      action: { label: string; onClick: () => void };
+    };
+    expect(options.action.label).toBe("View larger");
+    options.action.onClick();
+    expect(useErrorDetailsStore.getState().detail).toEqual(
+      expect.objectContaining({
+        title: "Failed request",
+        error: "Failed request",
+      }),
+    );
+  });
+
+  it("shows the complete error payload instead of its toast summary", () => {
+    const error = { status: 400, body: { detail: "Invalid request" } };
+    toast.error("Failed request", {
+      description: "Invalid request",
+      error,
+    });
+
+    const options = quill.error.mock.calls[0]?.[0] as {
+      action: { label: string; onClick: () => void };
+    };
+    options.action.onClick();
+    expect(useErrorDetailsStore.getState().detail).toEqual(
+      expect.objectContaining({ title: "Failed request", error }),
+    );
+  });
+
+  it("replaces a caller action so error toasts always offer View larger", () => {
+    const callerAction = vi.fn();
+    toast.error("Failed request", {
+      action: { label: "Retry", onClick: callerAction },
+    });
+
+    const options = quill.error.mock.calls[0]?.[0] as {
+      action: { label: string; onClick: () => void };
+    };
+    expect(options.action.label).toBe("View larger");
+    options.action.onClick();
+    expect(callerAction).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/products/desktop/packages/ui/src/primitives/toast.tsx
+++ b/products/desktop/packages/ui/src/primitives/toast.tsx
@@ -1,4 +1,5 @@
 import { toast as quillToast } from "@posthog/quill";
+import { showErrorDetails } from "@posthog/ui/features/notifications/errorDetailsStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 
 // Thin wrapper over quill's toast so the whole app shares one import and a
@@ -18,6 +19,10 @@ export interface ToastOptions {
   // pick an id at create time, so the wrapper maps it (see idRegistry).
   id?: string;
   action?: ToastAction;
+  // The complete error payload to show in the global details dialog. Error
+  // toasts always replace `action` with a "View larger" action; when this is
+  // omitted, the dialog falls back to the description and then the title.
+  error?: unknown;
   // Auto-dismiss delay in ms. Maps to quill's `timeout`. Omit for the provider
   // default; loading toasts never auto-dismiss regardless.
   duration?: number;
@@ -56,11 +61,19 @@ function emit(
   // never auto-dismiss maps to `0`.
   const requested = o.duration ?? defaultTimeout;
   const timeout = requested === Number.POSITIVE_INFINITY ? 0 : requested;
+  const errorPayload =
+    o.error !== undefined ? o.error : (o.description ?? title);
   const fields = {
     title,
     description: o.description,
     timeout,
-    action: o.action,
+    action:
+      level === "error"
+        ? {
+            label: "View larger",
+            onClick: () => showErrorDetails(title, errorPayload),
+          }
+        : o.action,
   };
 
   if (o.id !== undefined) {


### PR DESCRIPTION
## Problem
Error toasts can contain long text or embedded JSON, but most have no way to inspect or copy the complete error.

## Changes
- add a mandatory **View larger** action to every error emitted through the shared toast wrapper
- open the existing error details dialog for bare titles and descriptions
- preserve complete structured payloads from `toastError` and `NotificationBus` instead of only the summary
- keep non-error toast actions unchanged

## Verification
- `pnpm --filter @posthog/ui typecheck`
- `pnpm --filter @posthog/ui exec vitest run src/primitives/toast.test.ts src/features/notifications/errorDetails.test.ts src/features/notifications/notifications.test.ts`
- `pnpm exec biome check` on all changed files
- full `@posthog/ui` test suite: 405 files / 3516 tests passed