### PR TITLE
fix(desktop): archive tasks optimistically in parallel

### DIFF
--- a/products/desktop/packages/core/src/archive/archiveOrchestration.test.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.test.ts
@@ -243,6 +243,25 @@ describe("archiveTasks", () => {
       failed: 0,
     });
   });
+
+  it("archives tasks in parallel", async () => {
+    const harness = makeDeps();
+    let releaseFirst: (() => void) | undefined;
+    harness.deps.archive = vi.fn().mockImplementation((taskId: string) => {
+      if (taskId !== "a") return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+    });
+
+    const result = archiveTasks(["a", "b"], harness.deps);
+    await vi.waitFor(() => {
+      expect(harness.deps.archive).toHaveBeenCalledWith("b");
+    });
+    releaseFirst?.();
+
+    await expect(result).resolves.toEqual({ archived: 2, failed: 0 });
+  });
 });
 
 describe("shouldNavigateAwayForBulkArchive", () => {

--- a/products/desktop/packages/core/src/archive/archiveOrchestration.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.ts
@@ -167,17 +167,11 @@ export async function archiveTasks(
 ): Promise<ArchiveTasksResult> {
   if (taskIds.length === 0) return { archived: 0, failed: 0 };
 
-  let archived = 0;
-  let failed = 0;
-  for (const id of taskIds) {
-    try {
-      await archiveTask(id, deps, { skipNavigate: true });
-      archived++;
-    } catch {
-      failed++;
-    }
-  }
-  return { archived, failed };
+  const results = await Promise.allSettled(
+    taskIds.map((id) => archiveTask(id, deps, { skipNavigate: true })),
+  );
+  const archived = results.filter((result) => result.status === "fulfilled");
+  return { archived: archived.length, failed: results.length - archived.length };
 }
 
 export function shouldNavigateAwayForBulkArchive(

--- a/products/desktop/packages/core/src/archive/archiveOrchestration.ts
+++ b/products/desktop/packages/core/src/archive/archiveOrchestration.ts
@@ -171,7 +171,10 @@ export async function archiveTasks(
     taskIds.map((id) => archiveTask(id, deps, { skipNavigate: true })),
   );
   const archived = results.filter((result) => result.status === "fulfilled");
-  return { archived: archived.length, failed: results.length - archived.length };
+  return {
+    archived: archived.length,
+    failed: results.length - archived.length,
+  };
 }
 
 export function shouldNavigateAwayForBulkArchive(

--- a/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
+++ b/products/desktop/packages/ui/src/features/archive/useArchiveTask.ts
@@ -228,10 +228,7 @@ export function useArchiveTask(options?: {
   const { restore } = useUnarchiveTask();
 
   const archiveTask = async ({ taskId }: { taskId: string }) => {
-    // Non-optimistic: keep the row in place (with a spinner) until the archive
-    // is confirmed, rather than removing it instantly and rolling back on error.
     await archiveTaskImperative(taskId, queryClient, keys, {
-      optimistic: false,
       navigateSpace: options?.navigateSpace,
     });
     const toastId = `archive-undo-${taskId}`;

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskRow.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskRow.tsx
@@ -67,6 +67,8 @@ export function TaskRow({
     state.archivingTaskIds.has(task.id),
   );
 
+  if (isArchiving) return null;
+
   return (
     <TaskItem
       depth={depth}
@@ -75,7 +77,6 @@ export function TaskRow({
       subtitle={subtitle}
       isActive={isActive}
       isSelected={isSelected}
-      isArchiving={isArchiving}
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}

--- a/products/desktop/packages/ui/src/features/sidebar/useBulkArchiveConfirm.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/useBulkArchiveConfirm.test.tsx
@@ -66,6 +66,7 @@ describe("useBulkArchiveConfirm", () => {
 
     await user.click(screen.getByRole("button", { name: "Archive" }));
     expect(actions.archiveSelected).toHaveBeenCalledOnce();
+    expect(screen.queryByText("Archive 3 sessions?")).not.toBeInTheDocument();
   });
 
   // Archiving clears the selection, so a dialog reading the count live would

--- a/products/desktop/packages/ui/src/features/sidebar/useBulkArchiveConfirm.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/useBulkArchiveConfirm.tsx
@@ -48,9 +48,9 @@ export function useBulkArchiveConfirm(
         runningCount={confirm?.runningCount ?? 0}
         stopsCloudSandbox={Boolean(confirm?.stopsCloudSandbox)}
         isArchiving={actions.isArchiving}
-        onConfirm={async () => {
-          await actions.archiveSelected();
+        onConfirm={() => {
           setConfirm(null);
+          void actions.archiveSelected();
         }}
         onCancel={() => setConfirm(null)}
       />

--- a/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useSidebarBulkActions.ts
@@ -138,7 +138,6 @@ export function useSidebarBulkActions(
     if (selectedCount === 0 || isArchiving) return;
     setIsArchiving(true);
     const store = useArchivingTasksStore.getState();
-    // Spinner the rows for the whole sequential batch, not just the current one.
     for (const id of taskIds) store.startArchiving(id);
     try {
       const { archived, failed } = await archiveTasksImperative(


### PR DESCRIPTION
## Problem

Desktop users wait for each task to archive before the next starts, while in-progress rows stay visible and dimmed.

## Changes

- Archived task rows disappear immediately while cleanup continues in the background.
- Bulk archive runs all selected tasks concurrently and closes its confirmation immediately.
- Failed archives restore their rows and remain available for retry.
- No screenshot included because the visible change is a transient interaction state.

## How did you test this code?

- Added a regression test that holds one archive open and verifies another starts concurrently.
- Ran the desktop core and UI unit suites, UI typecheck, and Biome checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update needed. The archive controls and labels are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented this from the linked Slack request. The `posthog-desktop` and `writing-pr-descriptions` skills shaped the app scope and review summary.

The patch contains no customer data or private operational details.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787301892133109?thread_ts=1787301892.133109&cid=C09G8Q32R6F)*
