### PR TITLE
fix(error-tracking): let cymbal-notifications reach the local Temporal

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -186,6 +186,24 @@ case "$RS_SVC" in
     export POSTHOG_API_KEY="${CYMBAL_NOTIFICATIONS_POSTHOG_API_KEY:-phc_localposthogprojecttoken}"
     export POSTHOG_ENDPOINT="${CYMBAL_NOTIFICATIONS_POSTHOG_ENDPOINT:-http://localhost:3307}"
     export TEMPORAL_HOST="${TEMPORAL_HOST:-temporal}"
+    export TEMPORAL_PORT="${TEMPORAL_PORT:-7233}"
+    export TEMPORAL_NAMESPACE="${TEMPORAL_NAMESPACE:-default}"
+    # The local Temporal serves plaintext gRPC, so there is no client certificate
+    # to present and TEMPORAL_CLIENT_CERT/KEY stay unset.
+    #
+    # Django derives its Fernet key by left-padding a short SECRET_KEY with NUL
+    # bytes (posthog/temporal/common/codec.py, _resize_key), and the local default
+    # is 31 bytes. The Rust client takes the first 32 bytes and rejects anything
+    # shorter, so pad it the same way here. Both sides accept the base64: prefix,
+    # and both then read the same 32 bytes, so the Python workers can decrypt the
+    # payloads this service writes.
+    if [ -z "${TEMPORAL_SECRET_KEY:-}" ]; then
+      TEMPORAL_SECRET_KEY="base64:$(
+        POSTHOG_SECRET_KEY="${SECRET_KEY:-<randomly generated secret key>}" python3 -c \
+          'import base64, os; k = os.environ["POSTHOG_SECRET_KEY"].encode(); print(base64.b64encode((b"\0" * max(32 - len(k), 0) + k)[:32]).decode())'
+      )"
+    fi
+    export TEMPORAL_SECRET_KEY
     ;;
 
   embedding-worker)

--- a/rust/common/temporal/src/lib.rs
+++ b/rust/common/temporal/src/lib.rs
@@ -38,6 +38,36 @@ pub struct TemporalClientConfig {
     pub identity: String,
 }
 
+impl TemporalClientConfig {
+    /// mTLS settings, or `None` for a plaintext connection.
+    ///
+    /// Temporal Cloud requires a client certificate. The Temporal in the local
+    /// dev stack serves plaintext gRPC and has no certificate to offer, which is
+    /// also how the Python workers connect to it. An empty cert and key therefore
+    /// mean "connect in the clear" rather than "misconfigured". Supplying only
+    /// one of the pair is a real mistake, so it is still rejected.
+    fn tls_options(&self) -> Result<Option<TlsOptions>, TemporalClientError> {
+        match (self.client_cert.is_empty(), self.client_key.is_empty()) {
+            (true, true) => Ok(None),
+            (true, false) => Err(TemporalClientError::MissingConfig("TEMPORAL_CLIENT_CERT")),
+            (false, true) => Err(TemporalClientError::MissingConfig("TEMPORAL_CLIENT_KEY")),
+            (false, false) => Ok(Some(TlsOptions {
+                server_root_ca_cert: self
+                    .server_root_ca_cert
+                    .as_ref()
+                    .filter(|value| !value.is_empty())
+                    .map(|value| value.as_bytes().to_vec()),
+                domain: Some(self.host.clone()),
+                client_tls_options: Some(ClientTlsOptions {
+                    client_cert: self.client_cert.as_bytes().to_vec(),
+                    client_private_key: self.client_key.as_bytes().to_vec(),
+                }),
+                server_cert_verifier: None,
+            })),
+        }
+    }
+}
+
 /// Options that identify and route one workflow execution.
 #[derive(Clone, Debug)]
 pub struct StartWorkflowOptions {
@@ -114,29 +144,24 @@ impl TemporalWorkflowClient {
     pub async fn connect(config: TemporalClientConfig) -> Result<Self, TemporalClientError> {
         require_config("TEMPORAL_HOST", &config.host)?;
         require_config("TEMPORAL_NAMESPACE", &config.namespace)?;
-        require_config("TEMPORAL_CLIENT_CERT", &config.client_cert)?;
-        require_config("TEMPORAL_CLIENT_KEY", &config.client_key)?;
         require_config("TEMPORAL_SECRET_KEY", &config.payload_encryption_key)?;
         require_config("identity", &config.identity)?;
 
-        let target = url::Url::parse(&format!("https://{}:{}", config.host, config.port))?;
-        let tls_options = TlsOptions {
-            server_root_ca_cert: config
-                .server_root_ca_cert
-                .as_ref()
-                .filter(|value| !value.is_empty())
-                .map(|value| value.as_bytes().to_vec()),
-            domain: Some(config.host.clone()),
-            client_tls_options: Some(ClientTlsOptions {
-                client_cert: config.client_cert.as_bytes().to_vec(),
-                client_private_key: config.client_key.as_bytes().to_vec(),
-            }),
-            server_cert_verifier: None,
+        let tls = config.tls_options()?;
+        let scheme = if tls.is_some() { "https" } else { "http" };
+        let target = url::Url::parse(&format!("{scheme}://{}:{}", config.host, config.port))?;
+
+        // The builder is typestate-based, so `tls_options` changes its type and the
+        // two arms cannot share one binding.
+        let connection_options = match tls {
+            Some(tls) => ConnectionOptions::new(target)
+                .identity(config.identity.clone())
+                .tls_options(tls)
+                .build(),
+            None => ConnectionOptions::new(target)
+                .identity(config.identity.clone())
+                .build(),
         };
-        let connection_options = ConnectionOptions::new(target)
-            .identity(config.identity.clone())
-            .tls_options(tls_options)
-            .build();
         let connection = Connection::connect(connection_options).await?;
         let client = Client::new(connection, ClientOptions::new(config.namespace).build())?;
 
@@ -315,6 +340,36 @@ mod tests {
     struct TestInput<'a> {
         team_id: i32,
         name: &'a str,
+    }
+
+    fn config(client_cert: &str, client_key: &str) -> TemporalClientConfig {
+        TemporalClientConfig {
+            host: "temporal".to_string(),
+            port: 7233,
+            namespace: "default".to_string(),
+            client_cert: client_cert.to_string(),
+            client_key: client_key.to_string(),
+            server_root_ca_cert: None,
+            payload_encryption_key: "key".to_string(),
+            identity: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn tls_is_used_only_when_both_halves_of_the_keypair_are_present() {
+        assert!(config("", "").tls_options().unwrap().is_none());
+        assert!(config("cert", "key").tls_options().unwrap().is_some());
+
+        for (cert, key, missing) in [
+            ("cert", "", "TEMPORAL_CLIENT_KEY"),
+            ("", "key", "TEMPORAL_CLIENT_CERT"),
+        ] {
+            let error = config(cert, key).tls_options().unwrap_err();
+            assert!(
+                matches!(error, TemporalClientError::MissingConfig(name) if name == missing),
+                "expected {missing}, got {error}"
+            );
+        }
     }
 
     fn options() -> StartWorkflowOptions {


### PR DESCRIPTION
## Problem

cymbal-notifications cannot start on a dev machine. It panics at boot, mprocs restarts it, and it loops.

```
thread 'main' panicked at cymbal/src/modes/notifications/mod.rs:36:10:
failed to create notifications context: Other("missing Temporal client configuration: TEMPORAL_NAMESPACE")
```

The service is wired into the dev stack, so anyone who enables error tracking sees this. `bin/mprocs.yaml` runs it under capability `error_notifications`, which `devenv/intent-map.yaml` lists in the `error_tracking` intent.

Three things block it, and the namespace is only the first one the code reaches.

## Changes

- cymbal-notifications now starts against the local Temporal and consumes its topic. `hogli start` with error tracking selected no longer shows a restart loop.
- `TemporalWorkflowClient::connect` accepts a plaintext connection. An empty `TEMPORAL_CLIENT_CERT` and `TEMPORAL_CLIENT_KEY` now mean "connect in the clear" rather than "misconfigured".
- Supplying one half of the certificate pair without the other is still rejected. That is a real mistake, not a local-dev shape.
- The local Temporal serves plaintext gRPC and has no certificate to offer. The Python workers already reach it that way, since `posthog/settings/temporal.py` defaults both values to `None`.
- `bin/start-rust-service` sets `TEMPORAL_PORT`, `TEMPORAL_NAMESPACE`, and `TEMPORAL_SECRET_KEY`. It previously set only `TEMPORAL_HOST`, while `connect` requires four values.
- The script pads the secret key the way Django does. Django left-pads a short `SECRET_KEY` with NUL bytes before deriving its Fernet key, and the local default is 31 bytes. The Rust client takes the first 32 and rejects anything shorter.

Nothing a user sees changes. No frontend code is touched, and no production path changes: a deployment that sets both certificate values behaves exactly as before.

### Before

```mermaid
flowchart LR
    C{{cymbal-notifications}} -- "always https + client cert" --> X[panic at boot]
    T[(local Temporal, plaintext)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class C phBlue;
    class X phRed;
    class T phGray;
```

### After

```mermaid
flowchart LR
    C{{cymbal-notifications}} -- "cert and key set: https" --> P[(Temporal Cloud)]
    C -- "cert and key empty: http" --> T[(local Temporal)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class C phBlue;
    class P phGray;
    class T phYellow;
```

## How did you test this code?

Ran the service against the local dev stack. It reaches the consumer loop and picks up a real partition offset:

<details>
<summary>Local run against Temporal and Kafka</summary>

```
INFO cymbal::modes::notifications: Starting cymbal-notifications consumer topic=error_tracking_ingestion_notifications group=error_tracking_ingestion_notifications
WARN librdkafka: OFFSET [thrd:main]: error_tracking_ingestion_notifications [0]: offset reset (at offset 125 ...) to cached BEGINNING offset offset 129
INFO cymbal::modes::notifications: Metrics server listening on 0.0.0.0:9207
```

</details>

A new unit test covers the certificate pairing, because getting it wrong in the other direction would silently drop TLS in production: both empty gives no TLS, both set gives TLS, and either half alone is an error naming the missing variable.

The two key derivations were compared directly. Rust decodes the `base64:` value and takes the first 32 bytes; Python left-pads then takes the first 32. Both produce `ADxyYW5kb21seSBnZW5lcmF0ZWQgc2VjcmV0IGtleT4=` for the default local `SECRET_KEY`, so the Python workers can decrypt what this service writes.

Not checked: no workflow was started end to end, so the payload codec is verified by key equality rather than by a decrypted payload. Nothing was run against Temporal Cloud.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change restores documented behavior rather than adding any.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Claude Opus 5). Skill invoked: `/writing-pr-descriptions`.

Found while checking why cymbal-notifications was restarting in a local mprocs session. It is unrelated to the rate limit work in #86494 and is kept separate from it.

`common/temporal` is used by cymbal-notifications and nothing else in the Rust tree, so the blast radius is one service.

Public artifact: everything here comes from this repository.
