### PR TITLE
fix(data-imports): treat pooler shutdown as a transient db error

### DIFF
--- a/posthog/temporal/common/db_errors.py
+++ b/posthog/temporal/common/db_errors.py
@@ -29,6 +29,11 @@ _TRANSIENT_DB_ERROR_MARKERS = (
     # unexpectedly" marker above, just detected client-side instead of reported by the server.
     # Reaches us standalone too, not only wrapped in the cached-login message above.
     "server conn crashed",
+    # The pooler (pgbouncer/pgcat) itself draining for a restart or deploy, refusing new
+    # connections while it does. Same self-healing shape as "the database system is shutting
+    # down" above, just raised by the pooler in front of Postgres rather than Postgres itself.
+    # A connect failure through a pooler, so no SQLSTATE — falls through to this message match.
+    "pooler is shutting down",
 )
 
 # SQLSTATE class 57P (operator intervention): the server is shutting down or restarting and

--- a/posthog/temporal/common/test_db_errors.py
+++ b/posthog/temporal/common/test_db_errors.py
@@ -27,6 +27,13 @@ class _WithSqlstate(Exception):
         # The dead-socket message on its own, without pgbouncer's cached-login wrapper — the case
         # the marker above doesn't cover.
         (OperationalError("server conn crashed?"), True),
+        (
+            OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 6543 failed: '
+                "FATAL:  pooler is shutting down"
+            ),
+            True,
+        ),
         (OperationalError("connection failed: FATAL: password authentication failed for user"), False),
         (OperationalError("no such database"), False),
     ],


### PR DESCRIPTION
## Problem

A data warehouse import activity failed when the Postgres connection pooler drained for a restart (`OperationalError: ... FATAL: pooler is shutting down`), and PostHog's own error tracking created a fresh issue for it: https://us.posthog.com/project/2/error_tracking/01a023d3-293c-7230-9027-0d1b3dd06003

The condition self-heals once the pooler comes back, the same as the other pooler/database restart messages already on the transient-error allowlist in `is_transient_db_error` (`posthog/temporal/common/db_errors.py`). This message just wasn't recognized yet, so it fell through to `capture_exception` in the Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`) instead of being logged and left to Temporal's normal retry.

## Changes

- `is_transient_db_error` now matches "pooler is shutting down", so a pooler restart no longer creates an error tracking issue.
- Temporal's retry behavior is unchanged: the exception still propagates and Temporal retries the activity exactly as before. This only changes whether the error reaches error tracking.

## How did you test this code?

- Added a parametrized case to `test_db_errors.py` for the exact pooler-shutdown message shape.
- Ran `pytest posthog/temporal/common/test_db_errors.py` (14 passed) and `mypy` on both changed files (clean).
- Not run: a live pooler restart against a real Temporal worker — no environment to reproduce that end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Code triaged an error tracking issue webhook for a data-warehouse import pipeline `OperationalError`. Investigation traced the stack trace to `create_external_data_job_model_activity` (`products/warehouse_sources/backend/temporal/data_imports/workflow_activities/create_job_model.py`) and the shared Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`), which already has a purpose-built `is_transient_db_error` allowlist for exactly this class of self-healing pooler/database restart error. The pooler-shutdown message just wasn't on that list.

No skills from this repo were invoked for the fix itself (the change is a small addition to an existing allowlist plus one parametrized test case, following the existing style in `db_errors.py` and `test_db_errors.py`).