### PR TITLE
fix(slack-app): stop duplicating thread messages in agent context

### DIFF
--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -193,6 +193,11 @@ def extract_message_text(msg: dict) -> str:
         pieces.append(text)
 
     blocks = msg.get("blocks") or []
+    if text:
+        # A `rich_text` block is Slack's structured mirror of `text`. Flattening it drops
+        # mentions and emoji, yielding a near-duplicate the exact-match dedup below can't
+        # catch — skip it and let `text` (which keeps both) speak for that content.
+        blocks = [b for b in blocks if not (isinstance(b, dict) and b.get("type") == "rich_text")]
     attachments = msg.get("attachments") or []
     try:
         pieces.extend(flatten_block_text(blocks))

--- a/products/slack_app/backend/tests/services/slack_messages/test_collect_thread_messages.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_collect_thread_messages.py
@@ -155,6 +155,65 @@ class TestExtractMessageText:
                 "duplicated\ndifferent",
             ),
             (
+                # Human messages carry a rich_text mirror of `text` whose flattening drops
+                # mentions and emoji — a near-duplicate that must not reach the agent prompt.
+                "rich_text_mirror_of_text_is_skipped",
+                {
+                    "text": "never seen it work anywhere :joy: cc <@UCLEO>",
+                    "blocks": [
+                        {
+                            "type": "rich_text",
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [
+                                        {"type": "text", "text": "never seen it work anywhere "},
+                                        {"type": "emoji", "name": "joy"},
+                                        {"type": "text", "text": " cc "},
+                                        {"type": "user", "user_id": "UCLEO"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "never seen it work anywhere :joy: cc <@UCLEO>",
+            ),
+            (
+                "rich_text_still_flattened_when_text_empty",
+                {
+                    "text": "",
+                    "blocks": [
+                        {
+                            "type": "rich_text",
+                            "elements": [
+                                {
+                                    "type": "rich_text_section",
+                                    "elements": [{"type": "text", "text": "bot content only in blocks"}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "bot content only in blocks",
+            ),
+            (
+                "non_rich_text_blocks_kept_alongside_text",
+                {
+                    "text": "🔴 Alert firing",
+                    "blocks": [
+                        {
+                            "type": "rich_text",
+                            "elements": [
+                                {"type": "rich_text_section", "elements": [{"type": "text", "text": "🔴 Alert firing"}]}
+                            ],
+                        },
+                        {"type": "section", "text": {"type": "mrkdwn", "text": "value 42 exceeded threshold 10"}},
+                    ],
+                },
+                "🔴 Alert firing\nvalue 42 exceeded threshold 10",
+            ),
+            (
                 "no_content_returns_empty",
                 {"text": "", "blocks": [], "attachments": []},
                 "",


### PR DESCRIPTION
## Problem

When a Slack thread is forwarded to a coding-agent task, messages containing an emoji, a user mention, or an HTML-escaped character (`&`, `<`, `>`) appear twice in the agent's `<slack_thread_context>` / `<slack_thread_context_update>` prompt — once verbatim and once as a mangled near-copy with mentions and emoji stripped, sometimes split across extra lines.

The cause: every human message carries a `rich_text` block that mirrors its `text` field. `extract_message_text` flattens both, and the flattened mirror loses mentions, emoji, and link URLs, so it slips past the exact-string dedup.

## Changes

- Agent prompts now show each Slack message once: when a message has a non-empty `text`, its `rich_text` blocks are skipped during flattening, since `text` already carries their full content in mrkdwn form.
- Bot posts with empty `text` and content only in blocks (alerts, webhooks) still flatten their blocks unchanged.

## How did you test this code?

Added three cases to the existing `TestExtractMessageText` parameterized suite:

- a human message with its real rich_text mirror (emoji + mention) — fails with the duplicated three-line output before this fix
- an empty-`text` bot message with only a rich_text block — guards against the filter over-applying and dropping bot content
- `text` plus rich_text mirror plus a `section` block — proves non-rich_text blocks still combine with `text`

Ran the full `test_collect_thread_messages.py` file locally (50 passed). Note: threads recently forwarded keep the duplicated form until their `cached_collect_thread_messages` cache entry expires; only newly built context blocks pick up the fix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal prompt-building behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a Slack report of duplicated lines in a task prompt's thread history. Investigation traced the duplication to the rich_text mirror of `text` failing exact-match dedup. A rich_text → mrkdwn serializer for empty-`text` bot posts was considered and deferred as a follow-up; the skip rule alone fixes the reported duplication. Skills invoked: /writing-tests. No customer data involved; test fixtures are invented, with one phrasing borrowed from a public-repo maintainer's message in the reporting thread.
