### PR TITLE
fix(postgres): stop reporting best-effort RLS probe timeouts to error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -1185,6 +1185,20 @@ def _is_unsupported_statement_timeout_error(error: Exception) -> bool:
     return "statement_timeout" in message and "not supported" in message
 
 
+def _is_statement_timeout_error(error: BaseException) -> bool:
+    """True when the guarding `SET LOCAL statement_timeout` on a best-effort catalog scan fires.
+
+    Distinct from `_is_unsupported_statement_timeout_error`, which recognises an engine
+    rejecting the `SET` itself. This recognises the `SET` succeeding and the guarded query
+    running long enough to hit it — the guard doing exactly what it's there for, on the same
+    best-effort metadata scan `_xmin_capable_tables_from_conn` already degrades quietly for.
+    """
+    return (
+        isinstance(error, psycopg.errors.QueryCanceled)
+        and "statement timeout" in " ".join(str(arg) for arg in error.args).lower()
+    )
+
+
 def _rls_active_from_conn(
     connection: psycopg.Connection,
     schema: str | None,
@@ -1261,13 +1275,19 @@ def _rls_active_from_conn(
         # Postgres-wire-compatible engines (DuckDB/Flight-SQL proxies, etc.) accept our connection
         # but don't implement `row_security_active`. RLS is a Postgres-only concept there, so a
         # missing-function error is an expected "no RLS" answer, not a bug — degrade quietly rather
-        # than flooding error tracking. Still capture genuinely unexpected failures.
+        # than flooding error tracking. A genuine statement timeout is the same kind of expected
+        # outcome: this lookup is best-effort like the PK/xmin/index lookups it runs alongside, and
+        # they all run under the same 30s SET LOCAL guard against a runaway catalog scan — hitting
+        # it is the guard working, not new information about a bug here (mirrors
+        # `_xmin_capable_tables_from_conn`, which already degrades quietly for it). Still capture
+        # genuinely unexpected failures.
         if (
             not connection.closed
             and not connection.broken
             and not isinstance(e, psycopg.errors.InFailedSqlTransaction)
             and not _is_unsupported_function_error(e, "row_security_active")
             and not _is_unsupported_statement_timeout_error(e)
+            and not _is_statement_timeout_error(e)
         ):
             capture_exception(e)
         return {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -100,6 +100,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.p
     _is_options_startup_param_unsupported,
     _is_partitioned_table,
     _is_read_replica,
+    _is_statement_timeout_error,
     _is_unsupported_function_error,
     _is_unsupported_statement_timeout_error,
     _next_recovery_conflict_chunk_size,
@@ -7517,6 +7518,25 @@ class TestIsUnsupportedStatementTimeoutError:
         assert _is_unsupported_statement_timeout_error(error) is expected
 
 
+class TestIsStatementTimeoutError:
+    @pytest.mark.parametrize(
+        "error,expected",
+        [
+            (psycopg.errors.QueryCanceled("canceling statement due to statement timeout"), True),
+            # A recovery conflict is also QueryCanceled but a different message entirely.
+            (psycopg.errors.QueryCanceled("canceling statement due to conflict with recovery"), False),
+            # The engine-rejects-the-SET case is a different exception type, not a cancellation.
+            (
+                psycopg.errors.FeatureNotSupported('setting configuration parameter "statement_timeout" not supported'),
+                False,
+            ),
+            (psycopg.OperationalError("connection reset by peer"), False),
+        ],
+    )
+    def test_recognises_statement_timeout(self, error, expected):
+        assert _is_statement_timeout_error(error) is expected
+
+
 class TestRlsActiveFromConnErrorHandling:
     @staticmethod
     def _conn_raising(exc: Exception):
@@ -7544,6 +7564,19 @@ class TestRlsActiveFromConnErrorHandling:
         conn = self._conn_raising(
             psycopg.errors.FeatureNotSupported('setting configuration parameter "statement_timeout" not supported')
         )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
+        ) as capture_mock:
+            result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
+        assert result == {}
+        capture_mock.assert_not_called()
+
+    def test_statement_timeout_error_is_not_captured(self):
+        # This lookup runs under the same 30s SET LOCAL statement_timeout guard as the sibling
+        # PK/xmin/index best-effort probes, which already degrade quietly when it fires (see
+        # _xmin_capable_tables_from_conn). Hitting it here is the guard working as intended, not a
+        # bug — must not flood error tracking.
+        conn = self._conn_raising(psycopg.errors.QueryCanceled("canceling statement due to statement timeout"))
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
         ) as capture_mock:


### PR DESCRIPTION
## Problem

Postgres source syncs report a false-alarm error whenever the row-level-security detection probe hits its own timeout guard, even though the probe already recovers gracefully and the sync is unaffected. This surfaced as [error tracking issue #01a023d9](https://us.posthog.com/project/2/error_tracking/01a023d9-83f2-7ac1-b495-0f840c90fd74) (`QueryCanceled: canceling statement due to statement timeout`).

`_rls_active_from_conn` runs a best-effort catalog scan under a 30 second `SET LOCAL statement_timeout` guard, used only to show a UI warning when a table has row-level security enabled. Three sibling probes run the identical guard for the same kind of best-effort catalog lookup (`_xmin_capable_tables_from_conn`, `get_primary_keys_for_schemas`, `get_leading_index_columns`), and all three already treat the guard firing as an expected outcome, logging a warning instead of reporting it. Only the RLS probe escalated it to error tracking.

## Changes

- `_rls_active_from_conn` no longer reports a genuine statement timeout to error tracking, matching how the sibling probes already handle it.
- Added `_is_statement_timeout_error` to recognize a real `QueryCanceled` cancellation, distinct from the existing `_is_unsupported_statement_timeout_error` (which recognizes an engine rejecting the `SET` itself, not the guard firing).
- The probe's behavior on timeout is unchanged: it already returned `{}` and let the sync continue either way. This only silences a non-actionable error report.

## How did you test this code?

Added two new test cases:
- `TestIsStatementTimeoutError` – the new predicate matches a genuine statement-timeout cancellation but not a recovery-conflict cancellation, an unsupported-feature rejection, or an unrelated error.
- `TestRlsActiveFromConnErrorHandling.test_statement_timeout_error_is_not_captured` – `_rls_active_from_conn` no longer calls `capture_exception` when the guard fires, mirroring the existing sibling-probe coverage.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -k "TestIsStatementTimeoutError or TestRlsActiveFromConnErrorHandling or TestIsUnsupportedStatementTimeoutError"` locally: 16 passed. Also ran `ruff check --fix` and `ruff format` on the changed files, and `mypy` on the changed file (clean). Not run: the full CI suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in this source's code. No repo skills were invoked beyond the mandatory `/writing-tests` and `/writing-pr-descriptions` gates. The fix scope stayed narrow: only the RLS probe's exception classification changed, no retry policy, timeout value, or `NonRetryableErrors` list was touched, since the exception never reaches the Temporal retry layer (it's swallowed locally either way).