### PR TITLE
feat(desktop): space descriptions — set at creation, shown in the intro, searchable via ⌘K

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2614,11 +2614,11 @@ export class PostHogAPIClient {
   }
 
   // Resolve-or-create a public channel by name (idempotent server-side). `star`
-  // only applies when this call creates the channel; an existing one keeps the
-  // requester's star as it was.
+  // and `description` only apply when this call creates the channel; an
+  // existing one keeps the requester's star and its own description as they were.
   async resolveTaskChannel(
     name: string,
-    options: { star: boolean },
+    options: { star: boolean; description?: string },
   ): Promise<TaskChannel> {
     const teamId = await this.getTeamId();
     const urlPath = `/api/projects/${teamId}/task_channels/`;
@@ -2627,7 +2627,11 @@ export class PostHogAPIClient {
       url: new URL(`${this.api.baseUrl}${urlPath}`),
       path: urlPath,
       overrides: {
-        body: JSON.stringify({ name, star: options.star }),
+        body: JSON.stringify({
+          name,
+          star: options.star,
+          ...(options.description ? { description: options.description } : {}),
+        }),
       },
     });
     if (!response.ok) {

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1041,6 +1041,8 @@ export interface ChannelActionProperties {
   suggestion_label?: string;
   /** For activity_tab_change: the tab landed on. */
   tab?: string;
+  /** For create: whether the space was given a description. */
+  has_description?: boolean;
   /** Whether the underlying mutation resolved successfully. */
   success?: boolean;
 }

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -123,6 +123,8 @@ export interface ProvisionedTaskChannels {
 export interface TaskChannel {
   id: string;
   name: string;
+  /** Short human-written summary (≤200 chars) shown in the space's empty area. */
+  description?: string;
   channel_type: "public" | "personal";
   starred: boolean;
   github_integration?: number | null;

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelIntro.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelIntro.tsx
@@ -79,6 +79,11 @@ export function ChannelIntro({
             created this {noun} {creationDatePhrase(channel.created_at)}.
           </Text>
         )}
+        {channel?.description && (
+          <Text size="2" className="mt-1">
+            {channel.description}
+          </Text>
+        )}
       </div>
       <div className="flex gap-2">
         {contextMdState === "created" && (

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -43,6 +43,11 @@ import { useEffect, useId, useRef, useState } from "react";
 // Matches Slack's "Create a channel" naming constraint.
 const MAX_CONTEXT_NAME_LENGTH = 80;
 
+// The short space description shown in the space's empty area and searched by
+// the command palette. Distinct from the CONTEXT.md seed the describe step asks
+// for — this one is stored on the channel itself.
+const MAX_SPACE_DESCRIPTION_LENGTH = 200;
+
 const DESCRIPTION_EXAMPLES = [
   "Feature flags help teams control feature access, target specific users, and manage gradual rollouts.",
   "The onboarding experience guides new customers from creating an account to completing their first successful setup.",
@@ -131,6 +136,7 @@ export function CreateChannelModal({
   const navigate = useNavigate();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [spaceDescription, setSpaceDescription] = useState("");
   const [repositories, setRepositories] = useState<string[]>([]);
   const [repositoryIntegration, setRepositoryIntegration] = useState<
     number | null
@@ -161,6 +167,7 @@ export function CreateChannelModal({
     if (open) {
       setName("");
       setDescription("");
+      setSpaceDescription("");
       setRepositories([]);
       setRepositoryIntegration(null);
       setStar(true);
@@ -170,7 +177,10 @@ export function CreateChannelModal({
 
   const trimmedName = normalizeChannelName(name);
   const trimmedDescription = description.trim();
+  const trimmedSpaceDescription = spaceDescription.trim();
   const remaining = MAX_CONTEXT_NAME_LENGTH - name.length;
+  const spaceDescriptionRemaining =
+    MAX_SPACE_DESCRIPTION_LENGTH - spaceDescription.length;
   const nameError = isDescribeMode ? null : validateChannelName(trimmedName);
 
   const busy = isCreating || isStarting || linkRepositories.isPending;
@@ -195,11 +205,15 @@ export function CreateChannelModal({
   const submitCreate = async (linkSelectedRepositories: boolean) => {
     let contextId: string;
     try {
-      const channel = await createChannel(trimmedName, { star });
+      const channel = await createChannel(trimmedName, {
+        star,
+        description: trimmedSpaceDescription || undefined,
+      });
       track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
         action_type: "create",
         surface: "sidebar",
         channel_id: channel.id,
+        has_description: trimmedSpaceDescription.length > 0,
         success: true,
       });
       contextId = channel.id;
@@ -415,6 +429,31 @@ export function CreateChannelModal({
                     {remaining} left
                   </span>
                 )}
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="space-description">
+                  Description{" "}
+                  <span className="font-normal text-muted-foreground">
+                    (optional)
+                  </span>
+                </FieldLabel>
+                <Textarea
+                  id="space-description"
+                  rows={2}
+                  className="text-xs leading-4"
+                  value={spaceDescription}
+                  placeholder={`What's this ${spacesLayout ? "space" : "channel"} for?`}
+                  maxLength={MAX_SPACE_DESCRIPTION_LENGTH}
+                  disabled={busy}
+                  onChange={(e) => setSpaceDescription(e.target.value)}
+                />
+                <FieldDescription>
+                  Shown at the top of the {spacesLayout ? "space" : "channel"}{" "}
+                  and searchable from the command palette.
+                </FieldDescription>
+                <span className="text-gray-9 text-xs tabular-nums">
+                  {spaceDescriptionRemaining} left
+                </span>
               </Field>
             </DialogBody>
 

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.test.tsx
@@ -103,6 +103,7 @@ function channel(over: Partial<Channel> = {}): Channel {
   return {
     id: "c1",
     name: "eng",
+    description: "",
     channelType: "public",
     starred: false,
     repositories: [],

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelStars.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelStars.test.tsx
@@ -33,6 +33,7 @@ function channel(id: string, name: string, starred = false): Channel {
   return {
     id,
     name,
+    description: "",
     channelType: "public",
     starred,
     repositories: [],

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -13,6 +13,8 @@ export interface Channel {
   id: string;
   /** Normalized display name (lowercase-dashed; rendered "#name"). */
   name: string;
+  /** Short human-written summary (≤200 chars). Empty where none was given. */
+  description: string;
   /** `personal` is the user's private "#me" channel. */
   channelType: "public" | "personal";
   /** Whether the current user starred this channel. */
@@ -29,6 +31,7 @@ function toChannel(channel: TaskChannel): Channel {
   return {
     id: channel.id,
     name: channel.name,
+    description: channel.description ?? "",
     channelType: channel.channel_type,
     starred: channel.starred,
     repositories: channel.repositories ?? NO_REPOSITORIES,
@@ -69,7 +72,15 @@ export function useChannelMutations() {
   }, [queryClient]);
 
   const createMutation = useMutation({
-    mutationFn: async ({ name, star }: { name: string; star: boolean }) => {
+    mutationFn: async ({
+      name,
+      star,
+      description,
+    }: {
+      name: string;
+      star: boolean;
+      description?: string;
+    }) => {
       if (!client) throw new Error("Not authenticated");
       // Resolve-or-create is idempotent server-side, so racing creators of the
       // same name converge on one channel.
@@ -81,7 +92,10 @@ export function useChannelMutations() {
       const isNewToTheList = queryClient
         .getQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY)
         ?.every((channel) => channel.name !== name);
-      const created = await client.resolveTaskChannel(name, { star });
+      const created = await client.resolveTaskChannel(name, {
+        star,
+        description,
+      });
       if (!star || created.starred || !isNewToTheList) return created;
       // TODO: delete once `star` on create is live on Cloud. A backend that
       // predates it drops the flag and hands back an unstarred channel, so ask
@@ -129,8 +143,17 @@ export function useChannelMutations() {
   });
 
   return {
-    createChannel: (name: string, options: { star: boolean }) =>
-      createMutation.mutateAsync({ name, star: options.star }).then(toChannel),
+    createChannel: (
+      name: string,
+      options: { star: boolean; description?: string },
+    ) =>
+      createMutation
+        .mutateAsync({
+          name,
+          star: options.star,
+          description: options.description,
+        })
+        .then(toChannel),
     deleteChannel: (id: string) => deleteMutation.mutateAsync(id),
     renameChannel: (id: string, name: string) =>
       renameMutation.mutateAsync({ id, name }).then(toChannel),

--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -637,7 +637,9 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         items: channels.map((channel) => ({
           id: `channel-${channel.id}`,
           label: channel.name,
-          keywords: "space channel",
+          detail: channel.description || undefined,
+          // Include the description so searching what a space is about finds it.
+          keywords: `space channel ${channel.description}`,
           icon: channelGlyph(channel.name, {
             personal: channel.channelType === "personal",
             size: 12,

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarBulkActionBar.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarBulkActionBar.test.tsx
@@ -24,6 +24,7 @@ function makeActions(
       {
         id: "c1",
         name: "support",
+        description: "",
         channelType: "public",
         starred: false,
         repositories: [],


### PR DESCRIPTION
## Problem

Desktop half of space descriptions. The backend half is #86996 — split into two PRs per the desktop-backend coupling gate (desktop releases auto-update independently of backend deploys).

**Merge order: land #86996 and wait for its deploy before merging this.** The UI degrades gracefully against an older backend (description only sent when non-empty; reads fall back to `""`), but a description typed before the backend is live would be silently dropped.

## Changes

- **Creation flow** — optional "Description" field (max 200 chars, live counter) on the first step of the create-space dialog. Distinct from the "What's this space about?" step, which seeds the CONTEXT.md build; this one is stored on the space itself.
- **Space empty area** — description renders in the space intro, under the "@creator created this space" line.
- **⌘K search** — space entries include the description in match keywords and show it as the item detail; remote search matches it via the channel search document (indexed in #86996).
- `TaskChannel.description` in shared domain types; `resolveTaskChannel` sends it; `useChannels` exposes it; `Channel action` create event gains `has_description` so adoption is measurable.

## Testing

`pnpm typecheck` clean, Biome clean, affected vitest suites pass (command palette, channel hooks, sidebar, channel home).