### PR TITLE
fix(dev): unblock the local Slack setup guide

### DIFF
--- a/bin/start-local-ngrok
+++ b/bin/start-local-ngrok
@@ -11,8 +11,11 @@ elif [[ $# -gt 0 ]]; then
 fi
 
 site_url="${SITE_URL:-}"
-if [[ ! "$site_url" =~ ^https://[A-Za-z0-9-]+\.ngrok(-free)?\.dev/?$ ]]; then
-    echo "ngrok tunnel disabled: SITE_URL is not an ngrok URL"
+# ngrok issues .ngrok.app domains by default now, and .ngrok.dev to older accounts.
+# Accept both: a domain this pattern misses disables the tunnel with an exit 0, so the
+# only symptom is Slack webhooks that never arrive.
+if [[ ! "$site_url" =~ ^https://[A-Za-z0-9-]+\.ngrok(-free)?\.(app|dev)/?$ ]]; then
+    echo "ngrok tunnel disabled: SITE_URL is not an ngrok URL (expected https://<domain>.ngrok.app or .ngrok.dev)"
     exit 0
 fi
 

--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -119,6 +119,15 @@ MODAL_TOKEN_ID=<token_id>
 MODAL_TOKEN_SECRET=<token_secret>
 ```
 
+> **Docker sandboxes derive the LLM gateway from `SITE_URL`.** It reaches the sandbox as
+> `POSTHOG_API_URL`, and `getCloudTaskGatewayUrl` maps only `localhost` and
+> `host.docker.internal` to the local gateway on 3308. Any other host — an ngrok domain set for
+> Slack or webhook testing, for instance — falls through to the production gateway, which a local
+> run token cannot authenticate against. The failure is silent: the agent boots, sends its first
+> prompt, and idles until its inactivity window closes it, with nothing in the gateway or agent
+> logs. If `SITE_URL` is not localhost, set
+> `SANDBOX_LLM_GATEWAY_URL=http://host.docker.internal:3308` as well.
+
 ### Tunnel gateway, API, and MCP
 
 If you run in a docker sandbox you don't need to do this. If you are testing with Modal sandboxes, since they run in the cloud and can't reach `localhost` directly,

--- a/docs/internal/slack-local-setup-guide.md
+++ b/docs/internal/slack-local-setup-guide.md
@@ -121,6 +121,7 @@ settings:
     bot_events:
       - app_mention
       - app_home_opened
+      - message.channels
   interactivity:
     is_enabled: true
     request_url: https://<you>-posthog.ngrok.dev/slack/interactivity-callback
@@ -140,6 +141,11 @@ Django must be up at that moment.
 > Sign in with Slack (OpenID Connect) flow needs `user` scopes `openid` + `email` + `profile` and
 > the second redirect URL (`/complete/slack-link/`). Drop those if you don't want either feature
 > locally — they're behind the `slack-app-home` and `slack-app-oauth` flags.
+
+> `message.channels` is what makes Slack deliver plain channel messages. Without it you get
+> `app_mention` only, so `@PostHog` works and everything driven by an untagged message —
+> workflow Slack triggers, untagged thread follow-ups — receives nothing. There is no error:
+> Slack simply never sends the event, so the ngrok inspector stays empty too.
 
 ## Step 3 — backend credentials and `SITE_URL`
 
@@ -164,6 +170,14 @@ curl -sS https://<you>-posthog.ngrok.dev/_preflight | jq '.slack_service'
 `SITE_URL` must point at your tunnel for the OAuth step (Step 5), or the redirect goes to
 `https://localhost:8010/...` and the browser fails with an SSL error. Put it in `.env.local` so
 it is available every time you run `hogli start`.
+
+> **A tunnel `SITE_URL` breaks local sandbox agents.** It reaches the sandbox as
+> `POSTHOG_API_URL`, and `getCloudTaskGatewayUrl` maps only `localhost` and
+> `host.docker.internal` to the local LLM gateway on 3308. Every other host falls through to
+> the production gateway, where a local run token does not authenticate. The agent starts, sends
+> its first prompt, and hangs until its inactivity window ends, with nothing in any log. Set
+> `SANDBOX_LLM_GATEWAY_URL=http://host.docker.internal:3308` alongside the tunnel `SITE_URL`, or
+> keep `SITE_URL` on localhost and hand-write the integration row (Step 5).
 
 > There's also an `NGROK_URL` env var that `redirect_uri()` checks before `SITE_URL` in DEBUG —
 > it would override just the OAuth redirect and leave `SITE_URL` alone. We used `SITE_URL` and
@@ -198,6 +212,15 @@ print(list(Integration.objects.filter(kind='slack').values('id','team_id','integ
 ```
 
 The `tasks` flag from Step 4 still gates the Tasks UI on top of the connected integration.
+
+> **The connect cannot complete against the Vite dev server.** `redirect_uri` is built from
+> `SITE_URL` (`OauthIntegration.redirect_uri()`), so Slack returns you to the tunnel origin, and
+> `/integrations/:kind/callback` is a frontend route rather than a Django view. The dev SPA loads
+> its modules from `http://localhost:8234`, which an https page may not fetch, so the callback
+> page never renders and the flow stops there. Serve a built frontend if you need the real OAuth
+> round-trip. To skip it, install the app to your workspace in the Slack console and write the row
+> from the bot token instead — but note that a hand-written row has no `config["authed_user"]`, and
+> the channel picker reads that field, so channel lists fail until you add it.
 
 **GitHub** (Settings → Integrations): connect a _team_ GitHub with at least one repo (otherwise
 the repo cascade has nothing to pick and creates a no-repo task), and connect your _personal_


### PR DESCRIPTION
## Problem

Following `slack-local-setup-guide.md` end to end does not produce a working setup. Four things fail, and every one of them fails silently: no error, no log line, nothing in the ngrok inspector.

## Changes

- `bin/start-local-ngrok` accepts `.ngrok.app` as well as `.ngrok.dev`. ngrok issues `.ngrok.app` by default now, and an unmatched domain disabled the tunnel with an `exit 0`, so Slack webhooks never arrived.
- The app manifest subscribes to `message.channels`. Without it Slack sends `app_mention` only, so `@PostHog` works and anything driven by an untagged message gets nothing. This restores #83764, which was closed unmerged.
- Step 5 states that the OAuth connect cannot complete against the Vite dev server, and how to work around it. The callback is a frontend route, the dev SPA loads its modules over http, and an https page may not fetch them, so the page never renders.
- Both guides warn that a non-localhost `SITE_URL` sends Docker sandboxes to the production LLM gateway. `getCloudTaskGatewayUrl` maps only `localhost` and `host.docker.internal` to the local gateway, so the agent boots, prompts, and hangs until its inactivity window closes it.

## How did you test this code?

The regex change is verified against `.ngrok.app`, `.ngrok.dev`, `.ngrok-free.app`, a non-ngrok host, and an empty value. The first three start the tunnel and the last two skip it.

Every documented claim comes from hitting it: the tunnel that would not start, the channel messages that never arrived, the OAuth callback that would not render, and the agent that hung against the production gateway.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this under Harley's direction, extracted from the local testing done for #86731.
