### PR TITLE
feat(desktop): mobile hand off a task to a colleague

### DIFF
--- a/products/desktop/apps/mobile/src/app/task/[id].tsx
+++ b/products/desktop/apps/mobile/src/app/task/[id].tsx
@@ -935,6 +935,10 @@ export default function TaskDetailScreen() {
           visible={handoffOpen}
           task={task}
           onClose={() => setHandoffOpen(false)}
+          onHandedOff={() => {
+            setHandoffOpen(false);
+            if (router.canGoBack()) router.back();
+          }}
         />
       ) : null}
     </View>

--- a/products/desktop/apps/mobile/src/app/task/[id].tsx
+++ b/products/desktop/apps/mobile/src/app/task/[id].tsx
@@ -24,6 +24,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { UserSwitch } from "phosphor-react-native";
 import { useFeatureFlag } from "posthog-react-native";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -36,9 +37,11 @@ import {
 import { useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { FloatingBackButton } from "@/components/FloatingBackButton";
+import { useUserQuery } from "@/features/auth";
 import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
 import { CustomImageBadge } from "@/features/tasks/components/CustomImageBadge";
 import { FloatingTaskHeader } from "@/features/tasks/components/FloatingTaskHeader";
+import { HandoffTaskSheet } from "@/features/tasks/components/HandoffTaskSheet";
 import { PrDiffStatsBadge } from "@/features/tasks/components/PrDiffStatsBadge";
 import { PrStatusBadge } from "@/features/tasks/components/PrStatusBadge";
 import { StopRunButton } from "@/features/tasks/components/StopRunButton";
@@ -104,6 +107,8 @@ export default function TaskDetailScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
+  const [handoffOpen, setHandoffOpen] = useState(false);
+  const { data: currentUser } = useUserQuery();
 
   const {
     connectToTask,
@@ -732,6 +737,10 @@ export default function TaskDetailScreen() {
     [router],
   );
 
+  // Only the owner may hand a task off, matching the desktop menu gate.
+  const canHandoff =
+    !!task && currentUser != null && task.created_by?.id === currentUser.id;
+
   const prUrl = readPrUrls(task?.latest_run?.output)[0];
 
   const activityPhase = getSessionActivityPhase({ retrying, session });
@@ -789,6 +798,17 @@ export default function TaskDetailScreen() {
         rightSlot={
           <>
             {task ? <CustomImageBadge task={task} /> : null}
+            {canHandoff ? (
+              <Pressable
+                onPress={() => setHandoffOpen(true)}
+                hitSlop={8}
+                className="h-9 w-9 items-center justify-center rounded-full active:bg-gray-3"
+                accessibilityRole="button"
+                accessibilityLabel="Hand off task"
+              >
+                <UserSwitch size={20} color={themeColors.gray[12]} />
+              </Pressable>
+            ) : null}
             {canStopRun ? (
               <StopRunButton onPress={handleStopRun} />
             ) : prUrl ? (
@@ -910,6 +930,13 @@ export default function TaskDetailScreen() {
           />
         </Animated.View>
       </Animated.View>
+      {task ? (
+        <HandoffTaskSheet
+          visible={handoffOpen}
+          task={task}
+          onClose={() => setHandoffOpen(false)}
+        />
+      ) : null}
     </View>
   );
 }

--- a/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.test.tsx
@@ -5,11 +5,14 @@ import { Pressable } from "react-native";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { handoffMutate, membersRef, currentUserRef } = vi.hoisted(() => ({
-  handoffMutate: vi.fn(),
-  membersRef: { current: [] as UserBasic[] },
-  currentUserRef: { current: { id: 1 } as { id: number } | undefined },
-}));
+const { handoffMutate, onHandedOff, membersRef, currentUserRef } = vi.hoisted(
+  () => ({
+    handoffMutate: vi.fn(),
+    onHandedOff: vi.fn(),
+    membersRef: { current: [] as UserBasic[] },
+    currentUserRef: { current: { id: 1 } as { id: number } | undefined },
+  }),
+);
 
 // The global react-native mock renders Modal through a DOM portal that is a
 // no-op under the node test env, so its children never mount. Substitute plain
@@ -124,6 +127,7 @@ function render(task: Task = TASK): ReactTestRenderer {
         visible: true,
         task,
         onClose: vi.fn(),
+        onHandedOff,
       }),
     );
   });
@@ -135,6 +139,10 @@ let HandoffTaskSheet: typeof import("./HandoffTaskSheet").HandoffTaskSheet;
 describe("HandoffTaskSheet", () => {
   beforeEach(async () => {
     handoffMutate.mockReset();
+    handoffMutate.mockImplementation(
+      (_vars, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.(),
+    );
+    onHandedOff.mockReset();
     membersRef.current = [
       member(1, "me@example.com", "Me"),
       member(2, "alice@example.com", "Alice"),
@@ -168,6 +176,7 @@ describe("HandoffTaskSheet", () => {
       { taskId: "task-1", userId: 2 },
       expect.anything(),
     );
+    expect(onHandedOff).toHaveBeenCalled();
   });
 
   it("warns that the requester can lose access", () => {

--- a/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.test.tsx
@@ -1,6 +1,6 @@
 import type { Task } from "@posthog/shared";
 import type { UserBasic } from "@posthog/shared/domain-types";
-import { createElement } from "react";
+import { createElement, type ReactElement } from "react";
 import { Pressable } from "react-native";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,9 +20,28 @@ vi.mock("react-native", () => {
   return {
     ActivityIndicator: host("ActivityIndicator"),
     Alert: { alert: vi.fn() },
+    FlatList: <T,>({
+      data,
+      renderItem,
+      keyExtractor,
+    }: {
+      data: readonly T[];
+      renderItem: (info: { item: T; index: number }) => ReactElement;
+      keyExtractor?: (item: T, index: number) => string;
+    }) =>
+      createElement(
+        "FlatList",
+        {},
+        (data ?? []).map((item, index) =>
+          createElement(
+            "FlatListItem",
+            { key: keyExtractor?.(item, index) ?? index },
+            renderItem({ item, index }),
+          ),
+        ),
+      ),
     Modal: host("Modal"),
     Pressable: host("Pressable"),
-    ScrollView: host("ScrollView"),
     TextInput: host("TextInput"),
     View: host("View"),
   };

--- a/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.test.tsx
@@ -1,0 +1,162 @@
+import type { Task } from "@posthog/shared";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { createElement } from "react";
+import { Pressable } from "react-native";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { handoffMutate, membersRef, currentUserRef } = vi.hoisted(() => ({
+  handoffMutate: vi.fn(),
+  membersRef: { current: [] as UserBasic[] },
+  currentUserRef: { current: { id: 1 } as { id: number } | undefined },
+}));
+
+// The global react-native mock renders Modal through a DOM portal that is a
+// no-op under the node test env, so its children never mount. Substitute plain
+// host elements for the components the sheet uses so the body is inspectable.
+vi.mock("react-native", () => {
+  const host = (name: string) => (props: Record<string, unknown>) =>
+    createElement(name, props);
+  return {
+    ActivityIndicator: host("ActivityIndicator"),
+    Alert: { alert: vi.fn() },
+    Modal: host("Modal"),
+    Pressable: host("Pressable"),
+    ScrollView: host("ScrollView"),
+    TextInput: host("TextInput"),
+    View: host("View"),
+  };
+});
+
+vi.mock("../hooks/useOrgMembers", () => ({
+  useOrgMembers: () => ({ members: membersRef.current, isLoading: false }),
+}));
+
+vi.mock("../hooks/useTasks", () => ({
+  useHandoffTask: () => ({ mutate: handoffMutate, isPending: false }),
+}));
+
+vi.mock("@/features/auth", () => ({
+  useUserQuery: () => ({ data: currentUserRef.current }),
+}));
+
+vi.mock("@/hooks/useDebouncedValue", () => ({
+  useDebouncedValue: (value: unknown) => value,
+}));
+
+vi.mock("@/hooks/useScreenInsets", () => ({
+  useScreenInsets: () => ({ bottom: () => 0, sheetContentTop: () => 0 }),
+}));
+
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({ gray: {}, accent: {} }),
+}));
+
+vi.mock("@components/text", () => ({
+  Text: (props: Record<string, unknown>) => createElement("Text", props),
+}));
+
+vi.mock("expo-haptics", () => ({
+  impactAsync: vi.fn(),
+  ImpactFeedbackStyle: { Medium: "medium" },
+}));
+
+vi.mock("phosphor-react-native", () => ({
+  Check: (props: Record<string, unknown>) => createElement("Check", props),
+  MagnifyingGlass: (props: Record<string, unknown>) =>
+    createElement("MagnifyingGlass", props),
+}));
+
+function member(id: number, email: string, firstName?: string): UserBasic {
+  return { id, uuid: `u-${id}`, email, first_name: firstName };
+}
+
+const TASK: Task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Fix the thing",
+  description: "",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  origin_product: "code",
+};
+
+function textOf(node: { props: { children?: unknown } }): string {
+  const children = node.props.children;
+  return Array.isArray(children) ? children.join("") : String(children ?? "");
+}
+
+function pressableWithText(tree: ReactTestRenderer, text: string) {
+  return tree.root
+    .findAllByType(Pressable)
+    .find((pressable) =>
+      pressable
+        .findAll((n) => String(n.type) === "Text")
+        .some((t) => textOf(t).includes(text)),
+    );
+}
+
+function render(task: Task = TASK): ReactTestRenderer {
+  let tree!: ReactTestRenderer;
+  act(() => {
+    tree = create(
+      createElement(HandoffTaskSheet, {
+        visible: true,
+        task,
+        onClose: vi.fn(),
+      }),
+    );
+  });
+  return tree;
+}
+
+let HandoffTaskSheet: typeof import("./HandoffTaskSheet").HandoffTaskSheet;
+
+describe("HandoffTaskSheet", () => {
+  beforeEach(async () => {
+    handoffMutate.mockReset();
+    membersRef.current = [
+      member(1, "me@example.com", "Me"),
+      member(2, "alice@example.com", "Alice"),
+    ];
+    currentUserRef.current = { id: 1 };
+    ({ HandoffTaskSheet } = await import("./HandoffTaskSheet"));
+  });
+
+  it("excludes the current user from the roster", () => {
+    const tree = render();
+    const emails = tree.root
+      .findAll((n) => String(n.type) === "Text")
+      .map(textOf);
+    expect(emails).toContain("alice@example.com");
+    expect(emails).not.toContain("me@example.com");
+  });
+
+  it("locks the commit until a colleague is picked and acknowledged", () => {
+    const tree = render();
+    expect(pressableWithText(tree, "Hand off")?.props.disabled).toBe(true);
+
+    act(() => pressableWithText(tree, "alice@example.com")?.props.onPress());
+    expect(pressableWithText(tree, "Hand off")?.props.disabled).toBe(true);
+
+    act(() => pressableWithText(tree, "I understand")?.props.onPress());
+    const button = pressableWithText(tree, "Hand off");
+    expect(button?.props.disabled).toBe(false);
+
+    act(() => button?.props.onPress());
+    expect(handoffMutate).toHaveBeenCalledWith(
+      { taskId: "task-1", userId: 2 },
+      expect.anything(),
+    );
+  });
+
+  it("warns that the requester can lose access", () => {
+    const tree = render();
+    const copy = tree.root
+      .findAll((n) => String(n.type) === "Text")
+      .map(textOf)
+      .join(" ");
+    expect(copy).toContain("you lose access");
+  });
+});

--- a/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.tsx
@@ -1,0 +1,247 @@
+import { Text } from "@components/text";
+import { getUserInitials } from "@posthog/core/auth/userInitials";
+import type { Task } from "@posthog/shared";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import * as Haptics from "expo-haptics";
+import { Check, MagnifyingGlass } from "phosphor-react-native";
+import { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from "react-native";
+import { useUserQuery } from "@/features/auth";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useScreenInsets } from "@/hooks/useScreenInsets";
+import { useThemeColors } from "@/lib/theme";
+import { useOrgMembers } from "../hooks/useOrgMembers";
+import { useHandoffTask } from "../hooks/useTasks";
+import { userDisplayName } from "../utils/userDisplayName";
+
+interface HandoffTaskSheetProps {
+  visible: boolean;
+  task: Task;
+  onClose: () => void;
+}
+
+function MemberRow({
+  member,
+  selected,
+  onPress,
+}: {
+  member: UserBasic;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const themeColors = useThemeColors();
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center justify-between rounded-md px-2 py-2.5 active:bg-gray-3"
+    >
+      <View className="min-w-0 flex-1 flex-row items-center gap-2.5">
+        <View className="h-6 w-6 items-center justify-center rounded-full bg-gray-4">
+          <Text className="text-[11px] text-gray-10">
+            {getUserInitials(member)}
+          </Text>
+        </View>
+        <View className="min-w-0 flex-1">
+          <Text className="text-[14px] text-gray-12" numberOfLines={1}>
+            {userDisplayName(member)}
+          </Text>
+          <Text className="text-[12px] text-gray-9" numberOfLines={1}>
+            {member.email}
+          </Text>
+        </View>
+      </View>
+      {selected && <Check size={16} color={themeColors.gray[12]} />}
+    </Pressable>
+  );
+}
+
+export function HandoffTaskSheet({
+  visible,
+  task,
+  onClose,
+}: HandoffTaskSheetProps) {
+  const { bottom, sheetContentTop } = useScreenInsets();
+  const themeColors = useThemeColors();
+  const { data: currentUser } = useUserQuery();
+  const { mutate: handoffTask, isPending } = useHandoffTask();
+  const { members, isLoading } = useOrgMembers({ enabled: visible });
+
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  const [wasVisible, setWasVisible] = useState(visible);
+  if (visible !== wasVisible) {
+    setWasVisible(visible);
+    if (visible) {
+      setQuery("");
+      setSelectedId(null);
+      setAcknowledged(false);
+    }
+  }
+
+  const options = useMemo(() => {
+    const needle = debouncedQuery.trim().toLowerCase();
+    return members.filter((member) => {
+      if (member.id === currentUser?.id) return false;
+      if (!needle) return true;
+      return (
+        userDisplayName(member).toLowerCase().includes(needle) ||
+        member.email.toLowerCase().includes(needle)
+      );
+    });
+  }, [members, currentUser?.id, debouncedQuery]);
+
+  const selected = options.find((member) => member.id === selectedId);
+  const canSubmit = selected !== undefined && acknowledged && !isPending;
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    handoffTask(
+      { taskId: task.id, userId: selected.id },
+      {
+        onSuccess: onClose,
+        onError: () => {
+          Alert.alert(
+            "Couldn't hand off",
+            "The task could not be handed off. Please try again.",
+          );
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={isPending ? undefined : onClose}
+    >
+      <View
+        className="flex-1 bg-background"
+        style={{ paddingTop: sheetContentTop() }}
+      >
+        <View className="flex-row items-center justify-between border-gray-6 border-b px-4 pb-3">
+          <Text className="font-semibold text-[18px] text-gray-12">
+            Hand off task
+          </Text>
+          <Pressable onPress={onClose} disabled={isPending}>
+            <Text className="font-semibold text-[14px] text-accent-9">
+              Cancel
+            </Text>
+          </Pressable>
+        </View>
+
+        <View className="gap-1 px-4 pt-3">
+          <Text className="text-[13px] text-gray-11">
+            <Text className="font-medium text-gray-12">{task.title}</Text> goes
+            to the person you pick. They steer it and get its notifications.
+          </Text>
+          <Text className="text-[13px] text-gray-11">
+            If it's in your personal space, it moves to theirs and you lose
+            access. Only they can hand it back.
+          </Text>
+        </View>
+
+        <View className="px-4 pt-3">
+          <View className="flex-row items-center gap-2 rounded-lg bg-gray-2 px-3 py-2">
+            <MagnifyingGlass size={16} color={themeColors.gray[9]} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Search people…"
+              placeholderTextColor={themeColors.gray[9]}
+              autoCapitalize="none"
+              autoCorrect={false}
+              className="min-w-0 flex-1 text-[14px] text-gray-12"
+            />
+          </View>
+        </View>
+
+        {options.length === 0 ? (
+          isLoading ? (
+            <View className="flex-1 items-center justify-center">
+              <ActivityIndicator size="large" color={themeColors.accent[9]} />
+            </View>
+          ) : (
+            <View className="flex-1 items-center justify-center p-6">
+              <Text className="text-[14px] text-gray-10">No people found</Text>
+            </View>
+          )
+        ) : (
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 12 }}
+          >
+            {options.map((member) => (
+              <MemberRow
+                key={member.id}
+                member={member}
+                selected={member.id === selectedId}
+                onPress={() => setSelectedId(member.id)}
+              />
+            ))}
+          </ScrollView>
+        )}
+
+        <View
+          className="gap-3 border-gray-6 border-t px-4 pt-3"
+          style={{ paddingBottom: bottom("roomy") }}
+        >
+          <Pressable
+            onPress={() => setAcknowledged((prev) => !prev)}
+            disabled={isPending}
+            className="flex-row items-center gap-2.5 active:opacity-70"
+          >
+            <View
+              className={`h-5 w-5 items-center justify-center rounded border ${acknowledged ? "border-transparent" : "border-gray-7"}`}
+              style={
+                acknowledged ? { backgroundColor: themeColors.accent[9] } : null
+              }
+            >
+              {acknowledged ? (
+                <Check size={12} color="#fff" weight="bold" />
+              ) : null}
+            </View>
+            <Text className="flex-1 text-[13px] text-gray-11">
+              I understand I can't undo this myself.
+            </Text>
+          </Pressable>
+
+          <Pressable
+            onPress={handleConfirm}
+            disabled={!canSubmit}
+            className="h-11 flex-row items-center justify-center rounded-lg active:opacity-80"
+            style={{
+              backgroundColor: canSubmit
+                ? themeColors.accent[9]
+                : themeColors.gray[4],
+            }}
+          >
+            {isPending ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text
+                className="font-semibold text-[15px]"
+                style={{ color: canSubmit ? "#fff" : themeColors.gray[9] }}
+              >
+                Hand off
+              </Text>
+            )}
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.tsx
@@ -8,9 +8,9 @@ import { useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  FlatList,
   Modal,
   Pressable,
-  ScrollView,
   TextInput,
   View,
 } from "react-native";
@@ -180,19 +180,20 @@ export function HandoffTaskSheet({
             </View>
           )
         ) : (
-          <ScrollView
+          <FlatList
+            className="flex-1"
+            data={options}
+            keyExtractor={(member) => String(member.id)}
             keyboardShouldPersistTaps="handled"
             contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 12 }}
-          >
-            {options.map((member) => (
+            renderItem={({ item }) => (
               <MemberRow
-                key={member.id}
-                member={member}
-                selected={member.id === selectedId}
-                onPress={() => setSelectedId(member.id)}
+                member={item}
+                selected={item.id === selectedId}
+                onPress={() => setSelectedId(item.id)}
               />
-            ))}
-          </ScrollView>
+            )}
+          />
         )}
 
         <View

--- a/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/HandoffTaskSheet.tsx
@@ -26,6 +26,9 @@ interface HandoffTaskSheetProps {
   visible: boolean;
   task: Task;
   onClose: () => void;
+  // The detail screen holds its own task/session state that a handoff makes
+  // stale (and may revoke access to), so the host leaves the screen on success.
+  onHandedOff: () => void;
 }
 
 function MemberRow({
@@ -67,6 +70,7 @@ export function HandoffTaskSheet({
   visible,
   task,
   onClose,
+  onHandedOff,
 }: HandoffTaskSheetProps) {
   const { bottom, sheetContentTop } = useScreenInsets();
   const themeColors = useThemeColors();
@@ -110,7 +114,7 @@ export function HandoffTaskSheet({
     handoffTask(
       { taskId: task.id, userId: selected.id },
       {
-        onSuccess: onClose,
+        onSuccess: onHandedOff,
         onError: () => {
           Alert.alert(
             "Couldn't hand off",

--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useOrgMembers.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useOrgMembers.ts
@@ -24,8 +24,7 @@ export function useOrgMembers(options?: { enabled?: boolean }): {
   const members = useMemo(
     () =>
       (query.data?.members ?? [])
-        .map((member) => member.user)
-        .filter((user) => !!user?.email)
+        .flatMap((member) => (member.user?.email ? [member.user] : []))
         .sort((a, b) => userDisplayName(a).localeCompare(userDisplayName(b))),
     [query.data],
   );

--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useOrgMembers.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useOrgMembers.ts
@@ -1,0 +1,34 @@
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useAuthStore } from "@/features/auth";
+import { getPostHogApiClient } from "@/lib/posthogApiClient";
+import { userDisplayName } from "../utils/userDisplayName";
+
+// Membership churn is slow; one fetch per session window is plenty.
+const ORG_MEMBERS_STALE_MS = 5 * 60_000;
+
+export function useOrgMembers(options?: { enabled?: boolean }): {
+  members: UserBasic[];
+  isLoading: boolean;
+} {
+  const { projectId, oauthAccessToken } = useAuthStore();
+
+  const query = useQuery({
+    queryKey: ["org-members"],
+    queryFn: () => getPostHogApiClient().listOrganizationMembersWithStatus(),
+    enabled: (options?.enabled ?? true) && !!projectId && !!oauthAccessToken,
+    staleTime: ORG_MEMBERS_STALE_MS,
+  });
+
+  const members = useMemo(
+    () =>
+      (query.data?.members ?? [])
+        .map((member) => member.user)
+        .filter((user) => !!user?.email)
+        .sort((a, b) => userDisplayName(a).localeCompare(userDisplayName(b))),
+    [query.data],
+  );
+
+  return { members, isLoading: query.isLoading };
+}

--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useTasks.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useTasks.ts
@@ -169,6 +169,23 @@ export function useDeleteTask() {
   });
 }
 
+export function useHandoffTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ taskId, userId }: { taskId: string; userId: number }) =>
+      getPostHogApiClient().handoffTask(taskId, userId),
+    // The task may leave the requester's own list, so nothing is seeded.
+    onSuccess: (_, { taskId }) => {
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: taskKeys.detail(taskId) });
+    },
+    onError: (error) => {
+      log.error("Failed to hand off task", error.message);
+    },
+  });
+}
+
 export function useRunTask() {
   const queryClient = useQueryClient();
 

--- a/products/desktop/apps/mobile/src/features/tasks/utils/userDisplayName.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/utils/userDisplayName.ts
@@ -1,0 +1,6 @@
+import type { UserBasic } from "@posthog/shared/domain-types";
+
+export function userDisplayName(user: UserBasic): string {
+  const name = [user.first_name, user.last_name].filter(Boolean).join(" ");
+  return name || user.email;
+}


### PR DESCRIPTION
## Problem

A task owner on the mobile app cannot hand a task to a teammate. The desktop app added this in #84646, but mobile had no equivalent, so an owner on their phone had no way to transfer a task they no longer wanted to run.

This ports that feature to the React Native app (`products/desktop/apps/mobile`).

## Changes

- The task detail screen shows a hand-off button in the header, but only when the current user owns the task.
- Tapping it opens a native member-picker sheet: search the org roster, pick one colleague, tick an acknowledgement, then confirm.
- The sheet warns that if the task is in the owner's personal space it moves to the recipient's, so the owner loses access, and only the recipient can hand it back. The commit button stays disabled until a colleague is picked and the box is ticked.
- After a successful handoff the task list and detail refetch. The task can leave the owner's own list, so nothing is seeded optimistically.
- Reuses the shared `handoffTask(taskId, userId)` and `listOrganizationMembersWithStatus()` on `@posthog/api-client` (both landed in #84646); mobile only adds the React Query hooks and the screen.

Mobile does not consume `@posthog/ui` or `@posthog/quill`, so the sheet is built from mobile's own native components, matching `EditReviewersSheet` rather than porting the desktop quill dialog.

Mobile has no channels data, so the personal-space warning is shown unconditionally and phrased conditionally ("if it's in your personal space"), rather than desktop's channel-type check.

### Screenshots

No screenshot: this sandbox cannot run the Expo app or a device simulator. The UI follows the existing `EditReviewersSheet` sheet and `FloatingTaskHeader` patterns.

## How did you test this code?

- Added `HandoffTaskSheet.test.tsx` (vitest): excludes the current user from the roster, locks the commit until a colleague is picked and acknowledged then calls `handoffTask` with the recipient id, and shows the lose-access warning.
- Ran `pnpm --filter @posthog/mobile test` (full suite), `lint`, and `node scripts/check-mobile-types.mjs`. Not run: the app on a device or simulator (unavailable here).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Ported from #84646 by an agent. Only the mobile host changed; the shared client methods already existed. Invoked `/simplify` on the diff, which moved `userDisplayName` into a util, reused `getUserInitials` from `@posthog/core` for avatars, memoized the org-members derivation, and dropped a lossy `!task.channel` special-case in favor of unconditional warning copy. Also invoked `/writing-tests` and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
