### PR TITLE
fix(tasks): deliver pending user messages exactly once and drop cancelled queued prompts

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -625,6 +625,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       isLocalOnlyCommand,
       commandName: command,
       broadcast: () => this.broadcastUserMessage(params),
+      pendingInput: userMessage,
       settled: false,
       resolve: () => {},
       reject: () => {},
@@ -635,9 +636,25 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     });
 
     this.session.turnQueue.push(turn);
-    this.session.input.push(userMessage);
+    this.dispatchQueuedInput(this.session);
     this.ensureConsumer(params.sessionId);
     return response;
+  }
+
+  private dispatchQueuedInput(session: Session): void {
+    if (session.queryClosed) {
+      return;
+    }
+    if (session.activeTurn && !session.activeTurn.settled) {
+      return;
+    }
+    const head = session.turnQueue.find((turn) => !turn.settled);
+    if (!head?.pendingInput) {
+      return;
+    }
+    const input = head.pendingInput;
+    head.pendingInput = undefined;
+    session.input.push(input);
   }
 
   private ensureConsumer(sessionId: string): void {
@@ -840,6 +857,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       }
       session.turnQueue = session.turnQueue.filter((t) => t !== turn);
       session.activeTurn = null;
+      this.dispatchQueuedInput(session);
       turn.resolve(result);
     };
 
@@ -858,6 +876,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       session.turnQueue = session.turnQueue.filter((t) => t !== turn);
       session.activeTurn = null;
       this.toolUseStreamCache.clear();
+      this.dispatchQueuedInput(session);
       turn.reject(error);
     };
 
@@ -1090,6 +1109,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                 head.settled = true;
                 declinePendingSteers(head);
                 session.turnQueue = session.turnQueue.filter((t) => t !== head);
+                this.dispatchQueuedInput(session);
                 head.resolve({ stopReason: "end_turn" });
                 break;
               }
@@ -1570,8 +1590,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     }
     session.cancelled = true;
 
-    // Settle not-yet-echoed turns immediately; the SDK still runs their
-    // pushed messages, so count the echo-less results they owe as orphans.
+    // Settle not-yet-echoed turns immediately; the SDK still runs the messages
+    // already pushed, so count the echo-less results those owe as orphans.
     for (const turn of [...session.turnQueue]) {
       if (turn === session.activeTurn || turn.settled) {
         continue;
@@ -1579,7 +1599,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       turn.settled = true;
       declinePendingSteers(turn);
       session.turnQueue = session.turnQueue.filter((t) => t !== turn);
-      session.pendingOrphanResults += 1;
+      if (!turn.pendingInput) {
+        session.pendingOrphanResults += 1;
+      }
+      turn.pendingInput = undefined;
       turn.resolve(this.cancelledResponse());
     }
 

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.turn-queue.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.turn-queue.test.ts
@@ -1,0 +1,182 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import type {
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockQuery,
+  createSuccessResult,
+  type MockQuery,
+} from "../../test/mocks/claude-sdk";
+import { Pushable } from "../../utils/streams";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("./mcp/tool-metadata", () => ({
+  fetchMcpToolMetadata: vi.fn().mockResolvedValue(undefined),
+  getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  setMcpToolApprovalStates: vi.fn(),
+  isMcpToolReadOnly: vi.fn().mockReturnValue(false),
+  getMcpToolMetadata: vi.fn().mockReturnValue(undefined),
+  getMcpToolApprovalState: vi.fn().mockReturnValue(undefined),
+}));
+
+const { ClaudeAcpAgent } = await import("./claude-agent");
+type Agent = InstanceType<typeof ClaudeAcpAgent>;
+
+interface Harness {
+  agent: Agent;
+  query: MockQuery;
+  pushed: SDKUserMessage[];
+}
+
+function installHarness(sessionId: string): Harness {
+  const client = {
+    sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    extNotification: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentSideConnection;
+  const agent = new ClaudeAcpAgent(client);
+
+  const query = createMockQuery();
+  const input = new Pushable<SDKUserMessage>();
+  const pushed: SDKUserMessage[] = [];
+  const originalPush = input.push.bind(input);
+  input.push = (item: SDKUserMessage) => {
+    pushed.push(item);
+    originalPush(item);
+  };
+  const abortController = new AbortController();
+
+  const session = {
+    query,
+    sdkSessionId: sessionId,
+    queryOptions: { sessionId, cwd: "/tmp/repo", abortController },
+    buildInProcessMcpServers: () => ({}),
+    localToolsServerNames: [] as string[],
+    input,
+    cancelled: false,
+    interruptReason: undefined,
+    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
+    permissionMode: "default" as const,
+    abortController,
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    sessionResources: new Set(),
+    configOptions: [],
+    turnQueue: [],
+    activeTurn: null,
+    pendingOrphanResults: 0,
+    queryGeneration: 0,
+    cwd: "/tmp/repo",
+    notificationHistory: [] as unknown[],
+    taskRunId: "run-1",
+    lastContextWindowSize: 200_000,
+    modelId: "claude-sonnet-4-6",
+  };
+
+  (agent as unknown as { session: typeof session }).session = session;
+  (agent as unknown as { sessionId: string }).sessionId = sessionId;
+
+  return { agent, query, pushed };
+}
+
+function sessionOf(agent: Agent): {
+  turnQueue: Array<{ promptUuid: string }>;
+  pendingOrphanResults: number;
+} {
+  return (
+    agent as unknown as {
+      session: {
+        turnQueue: Array<{ promptUuid: string }>;
+        pendingOrphanResults: number;
+      };
+    }
+  ).session;
+}
+
+function echoTurn(query: MockQuery, promptUuid: string): void {
+  query._mockHelpers.sendMessage({
+    type: "user",
+    uuid: promptUuid,
+    session_id: "s",
+    parent_tool_use_id: null,
+    message: { role: "user", content: "echo" },
+  } as unknown as SDKMessage);
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function runningTurnWithQueuedSecond(sessionId: string): Promise<
+  Harness & {
+    first: Promise<unknown>;
+    second: Promise<unknown>;
+  }
+> {
+  const harness = installHarness(sessionId);
+  const first = harness.agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "first" }],
+  });
+  await tick();
+  echoTurn(harness.query, sessionOf(harness.agent).turnQueue[0].promptUuid);
+  await tick();
+  const second = harness.agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "second" }],
+  });
+  await tick();
+  return { ...harness, first, second };
+}
+
+describe("ClaudeAcpAgent turn queue input dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("holds a queued prompt out of the SDK input until the running turn settles", async () => {
+    const sessionId = "s-serialize";
+    const { query, pushed, first, second } =
+      await runningTurnWithQueuedSecond(sessionId);
+
+    expect(pushed).toHaveLength(1);
+
+    query._mockHelpers.sendMessage(createSuccessResult());
+    await tick();
+
+    expect(pushed).toHaveLength(2);
+
+    query._mockHelpers.complete();
+    await expect(first).resolves.toBeDefined();
+    await expect(second).rejects.toThrow(/session has ended/);
+  });
+
+  it("never hands a prompt cancelled while queued to the SDK", async () => {
+    const sessionId = "s-cancel-queued";
+    const { agent, query, pushed, first, second } =
+      await runningTurnWithQueuedSecond(sessionId);
+    query.interrupt.mockImplementation(async () => {});
+
+    await agent.cancel({ sessionId });
+
+    await expect(second).resolves.toMatchObject({ stopReason: "cancelled" });
+    expect(pushed).toHaveLength(1);
+    expect(sessionOf(agent).pendingOrphanResults).toBe(0);
+
+    query._mockHelpers.sendMessage({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    } as unknown as SDKMessage);
+    await expect(first).resolves.toMatchObject({ stopReason: "cancelled" });
+    expect(pushed).toHaveLength(1);
+  });
+});

--- a/products/desktop/packages/agent/src/adapters/claude/types.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/types.ts
@@ -60,6 +60,7 @@ export type Turn = {
   commandName?: string;
   /** Invoked once at activation, matching the pre-consumer broadcast timing. */
   broadcast: () => Promise<void>;
+  pendingInput?: SDKUserMessage;
   settled: boolean;
   resolve: (response: PromptResponse) => void;
   reject: (error: unknown) => void;

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -323,6 +323,7 @@ interface InstalledSkillBundle {
 interface BuiltPrompt {
   prompt: ContentBlock[];
   meta?: Record<string, unknown>;
+  messageId?: string;
 }
 
 function hiddenTextBlock(text: string): ContentBlock {
@@ -1233,19 +1234,10 @@ export class AgentServer {
         if (messageId) {
           this.inFlightMessageDeliveries.set(messageId, deliveryOutcome);
         }
-        let deliveryCommitted = retryCompactContinuation;
         let releaseNonSteerDelivery: (() => void) | undefined;
         const commitDelivery = (): void => {
-          deliveryCommitted = true;
           if (!messageId) return;
-          this.deliveredMessageIds.add(messageId);
-          if (this.deliveredMessageIds.size > 500) {
-            const oldest = this.deliveredMessageIds.values().next().value;
-            if (oldest !== undefined) {
-              this.deliveredMessageIds.delete(oldest);
-              this.pendingCompactContinuationMessageIds.delete(oldest);
-            }
-          }
+          this.markMessageDelivered(messageId);
         };
 
         try {
@@ -1455,9 +1447,6 @@ export class AgentServer {
           resolveDelivery(outcome);
           return outcome;
         } catch (error) {
-          if (messageId && !deliveryCommitted) {
-            this.deliveredMessageIds.delete(messageId);
-          }
           rejectDelivery(error);
           throw error;
         } finally {
@@ -2362,6 +2351,8 @@ export class AgentServer {
       return;
     }
 
+    let promptDispatched = false;
+    let releaseSelfDelivery: (() => void) | undefined;
     try {
       const task = await this.posthogAPI.getTask(payload.task_id);
 
@@ -2377,9 +2368,11 @@ export class AgentServer {
       )?.prewarmed;
       let initialPrompt: ContentBlock[] = [];
       let initialPromptMeta: Record<string, unknown> | undefined;
+      let initialPromptMessageId: string | undefined;
       if (pendingUserPrompt?.prompt.length) {
         initialPrompt = pendingUserPrompt.prompt;
         initialPromptMeta = pendingUserPrompt.meta;
+        initialPromptMessageId = pendingUserPrompt.messageId;
       } else if (initialPromptOverride) {
         initialPrompt = [{ type: "text", text: initialPromptOverride }];
       } else if (task.description && !prewarmed) {
@@ -2407,6 +2400,21 @@ export class AgentServer {
       if (!acpSessionId) {
         throw new Error("Agent session is missing its ACP session ID");
       }
+
+      if (initialPromptMessageId) {
+        if (
+          this.deliveredMessageIds.has(initialPromptMessageId) ||
+          this.inFlightMessageDeliveries.has(initialPromptMessageId)
+        ) {
+          this.logger.info(
+            "Pending message already delivered by a forwarded command; skipping the startup prompt",
+            { messageId: initialPromptMessageId },
+          );
+          return;
+        }
+        releaseSelfDelivery = this.beginSelfDelivery(initialPromptMessageId);
+      }
+      promptDispatched = true;
 
       const result = await this.runStartupTurn(() =>
         this.promptWithUpstreamRetry({
@@ -2439,7 +2447,12 @@ export class AgentServer {
       if (this.session) {
         await this.session.logWriter.flushAll();
       }
+      if (promptDispatched) {
+        await this.clearPendingInitialPromptState(payload, taskRun);
+      }
       await this.handleTurnFailure(payload, "initial", error);
+    } finally {
+      releaseSelfDelivery?.();
     }
   }
 
@@ -2466,8 +2479,10 @@ export class AgentServer {
 
       let resumePromptBlocks: ContentBlock[];
       let resumePromptMeta: Record<string, unknown> | undefined;
+      let resumePromptMessageId: string | undefined;
       if (pendingUserPrompt?.prompt.length) {
         resumePromptMeta = pendingUserPrompt.meta;
+        resumePromptMessageId = pendingUserPrompt.messageId;
         resumePromptBlocks = [
           hiddenTextBlock(
             `You are resuming a previous conversation. ${checkpointContext}\n\n` +
@@ -2504,6 +2519,7 @@ export class AgentServer {
       return {
         prompt: resumePromptBlocks,
         ...(resumePromptMeta ? { meta: resumePromptMeta } : {}),
+        messageId: resumePromptMessageId,
       };
     });
   }
@@ -2533,7 +2549,6 @@ export class AgentServer {
                 text: "Continue from where you left off. The user is waiting for your response.",
               },
             ];
-
         this.logger.debug("Sending resume continuation", {
           taskId: payload.task_id,
           sessionId: this.nativeResume?.sessionId,
@@ -2545,6 +2560,7 @@ export class AgentServer {
         return {
           prompt,
           ...(pendingUserPrompt?.meta ? { meta: pendingUserPrompt.meta } : {}),
+          messageId: pendingUserPrompt?.messageId,
         };
       },
       { retryOnOversizedPrompt: true },
@@ -2637,6 +2653,8 @@ export class AgentServer {
   ): Promise<void> {
     if (!this.session) return;
 
+    let promptDispatched = false;
+    let releaseSelfDelivery: (() => void) | undefined;
     try {
       const builtPrompt = await buildPrompt();
 
@@ -2645,6 +2663,11 @@ export class AgentServer {
       if (!acpSessionId) {
         throw new Error("Agent session is missing its ACP session ID");
       }
+
+      if (builtPrompt.messageId) {
+        releaseSelfDelivery = this.beginSelfDelivery(builtPrompt.messageId);
+      }
+      promptDispatched = true;
 
       const result = await this.runStartupTurn(() =>
         this.promptWithUpstreamRetry({
@@ -2688,7 +2711,12 @@ export class AgentServer {
       ) {
         return;
       }
+      if (promptDispatched) {
+        await this.clearPendingInitialPromptState(payload, taskRun);
+      }
       await this.handleTurnFailure(payload, "resume", error);
+    } finally {
+      releaseSelfDelivery?.();
     }
   }
 
@@ -2741,12 +2769,28 @@ export class AgentServer {
     return trimmed.length > 0 ? trimmed : null;
   }
 
+  private markMessageDelivered(messageId: string): void {
+    this.deliveredMessageIds.add(messageId);
+    if (this.deliveredMessageIds.size > 500) {
+      const oldest = this.deliveredMessageIds.values().next().value;
+      if (oldest !== undefined) {
+        this.deliveredMessageIds.delete(oldest);
+        this.pendingCompactContinuationMessageIds.delete(oldest);
+      }
+    }
+  }
+
   private async getPendingUserPrompt(
     taskRun: TaskRun | null,
   ): Promise<BuiltPrompt | null> {
     if (!taskRun) return null;
     const state = taskRun.state as Record<string, unknown> | undefined;
     const message = state?.pending_user_message;
+    const pendingMessageId =
+      typeof state?.pending_user_message_id === "string" &&
+      state.pending_user_message_id
+        ? state.pending_user_message_id
+        : undefined;
     const artifactIds = Array.isArray(state?.pending_user_artifact_ids)
       ? state.pending_user_artifact_ids.filter(
           (artifactId): artifactId is string =>
@@ -2821,7 +2865,10 @@ export class AgentServer {
       lostAttachmentCount,
       blockTypes: prompt.prompt.map((block) => block.type),
     });
-    return prompt.prompt.length > 0 ? prompt : null;
+    if (prompt.prompt.length === 0) {
+      return null;
+    }
+    return { ...prompt, messageId: pendingMessageId };
   }
 
   private async resolvePendingArtifactManifest(
@@ -2900,6 +2947,7 @@ export class AgentServer {
     const pendingKeys = [
       "pending_user_message",
       "pending_user_artifact_ids",
+      "pending_user_message_id",
       "pending_user_message_ts",
     ].filter((key) => key in state);
 
@@ -2915,9 +2963,31 @@ export class AgentServer {
       return;
     }
 
-    await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
-      state_remove_keys: stateRemoveKeys,
+    try {
+      await this.posthogAPI.updateTaskRun(payload.task_id, payload.run_id, {
+        state_remove_keys: stateRemoveKeys,
+      });
+    } catch (error) {
+      this.logger.warn("Failed to clear pending prompt state", {
+        taskId: payload.task_id,
+        runId: payload.run_id,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  private beginSelfDelivery(messageId: string): () => void {
+    this.markMessageDelivered(messageId);
+    let release: () => void = () => {};
+    const outcome = new Promise<unknown>((resolve) => {
+      release = () => {
+        this.inFlightMessageDeliveries.delete(messageId);
+        resolve({ stopReason: "duplicate_delivery", duplicate: true });
+      };
     });
+    void outcome.catch(() => {});
+    this.inFlightMessageDeliveries.set(messageId, outcome);
+    return release;
   }
 
   private async buildPromptFromContentAndArtifacts({

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -408,6 +408,7 @@ _TASK_RUN_PUBLIC_STATE_KEYS = frozenset(
         "model",
         "pending_user_artifact_ids",
         "pending_user_message",
+        "pending_user_message_id",
         "pr_authorship_mode",
         "pr_base_branch",
         "provider",

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -83,6 +83,19 @@ def _task_ownership_version(state: dict | None) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _has_pending_user_input(state: dict[str, Any]) -> bool:
+    return bool(state.get("pending_user_message") or state.get("pending_user_artifact_ids"))
+
+
+def stamp_pending_user_message_id(state: dict[str, Any], *, refresh: bool = False) -> None:
+    if not _has_pending_user_input(state):
+        return
+    existing = state.get("pending_user_message_id")
+    if not refresh and isinstance(existing, str) and existing:
+        return
+    state["pending_user_message_id"] = str(uuid.uuid4())
+
+
 class TaskOwnershipChangedError(RuntimeError):
     pass
 
@@ -586,9 +599,8 @@ class Task(DeletedMetaFields, models.Model):
             # Pin the stream-routing decision once so every reader/writer agrees for this run's life.
             state.setdefault("use_dedicated_stream", dedicated_stream)
             is_resume = bool(resume_from_run_id)
-            has_pending = bool(
-                (extra_state or {}).get("pending_user_message") or (extra_state or {}).get("pending_user_artifact_ids")
-            )
+            has_pending = _has_pending_user_input(extra_state or {})
+            stamp_pending_user_message_id(state)
             task_run = TaskRun.objects.create(
                 task=task,
                 team=task.team,
@@ -2112,8 +2124,13 @@ class TaskRun(models.Model):
         def _mutator(state: dict[str, Any]) -> None:
             for key in remove_keys or []:
                 state.pop(key, None)
-            if updates:
-                state.update(updates)
+            if not updates:
+                return
+            state.update(updates)
+            if "pending_user_message_id" in updates:
+                return
+            if "pending_user_message" in updates or "pending_user_artifact_ids" in updates:
+                stamp_pending_user_message_id(state, refresh=True)
 
         return cls.mutate_state_atomic(run_id, _mutator)
 

--- a/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -63,7 +62,7 @@ def forward_pending_user_message(run_id: str) -> None:
     from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
     from products.tasks.backend.logic.services.staged_artifacts import get_task_run_artifacts_by_id
     from products.tasks.backend.metrics import observe_followup_delivery_failed
-    from products.tasks.backend.models import TaskRun
+    from products.tasks.backend.models import TaskRun, stamp_pending_user_message_id
 
     try:
         task_run = TaskRun.objects.select_related("task__created_by", "task__team", "task__loop").get(id=run_id)
@@ -90,15 +89,9 @@ def forward_pending_user_message(run_id: str) -> None:
         activity_failure=activity_failure,
         **_task_run_log_context(task_run),
     ):
-
-        def _ensure_pending_message_id(state: dict[str, Any]) -> None:
-            if not state.get("pending_user_message") and not state.get("pending_user_artifact_ids"):
-                return
-            pending_message_id = state.get("pending_user_message_id")
-            if not isinstance(pending_message_id, str) or not pending_message_id:
-                state["pending_user_message_id"] = str(uuid.uuid4())
-
-        state = TaskRun.mutate_state_atomic(run_id, _ensure_pending_message_id)
+        state = dict(task_run.state or {})
+        if not state.get("pending_user_message_id"):
+            state = TaskRun.mutate_state_atomic(run_id, stamp_pending_user_message_id)
         pending_message = state.get("pending_user_message")
         pending_user_artifact_ids = state.get("pending_user_artifact_ids") or []
         if not pending_message and not pending_user_artifact_ids:

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -803,6 +803,51 @@ class TestTaskRun(TestCase):
         with self.assertRaises(TaskOwnershipChangedError):
             task.create_run(extra_state={"resume_from_run_id": str(previous_run.id)})
 
+    @parameterized.expand(
+        [
+            ("message_only", {"pending_user_message": "Look at this"}, True),
+            ("artifacts_only", {"pending_user_artifact_ids": ["artifact-1"]}, True),
+            ("nothing_pending", {"mode": "interactive"}, False),
+        ]
+    )
+    def test_create_run_stamps_pending_user_message_id(self, _name, extra_state, expects_id):
+        run = self.task.create_run(extra_state=extra_state)
+
+        if expects_id:
+            self.assertIsInstance(run.state["pending_user_message_id"], str)
+            self.assertTrue(run.state["pending_user_message_id"])
+        else:
+            self.assertNotIn("pending_user_message_id", run.state)
+
+    def test_create_run_keeps_a_carried_pending_user_message_id(self):
+        carried_id = str(uuid.uuid4())
+
+        run = self.task.create_run(
+            extra_state={"pending_user_message": "Carried over", "pending_user_message_id": carried_id}
+        )
+
+        self.assertEqual(run.state["pending_user_message_id"], carried_id)
+
+    @parameterized.expand(
+        [
+            ("restaged_message", {"pending_user_message": "Second"}, False),
+            ("unrelated_update", {"sandbox_id": "sandbox-1"}, True),
+        ]
+    )
+    def test_update_state_atomic_refreshes_the_id_only_for_restaged_messages(self, _name, updates, keeps_id):
+        existing_id = str(uuid.uuid4())
+        run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            state={"pending_user_message": "First", "pending_user_message_id": existing_id},
+        )
+
+        state = TaskRun.update_state_atomic(run.id, updates=updates)
+
+        self.assertTrue(state["pending_user_message_id"])
+        self.assertEqual(state["pending_user_message_id"] == existing_id, keeps_id)
+
     @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
     def test_prepare_for_cloud_handoff_clears_stale_sandbox_routing(self, _publish):
         run = TaskRun.objects.create(


### PR DESCRIPTION
## Problem

Cloud-task users get their message delivered to the agent more than once, and after cancelling a turn the agent later receives a merged backlog of messages that were already answered.

- The boot/resume self-delivery path prompts the agent directly with no message id, bypassing the `deliveredMessageIds` dedupe, while the Temporal forward activity sends the same text with an id. The double is documented as known in `workflow_tasks.py`.
- Pending message state clears only when the startup turn succeeds, so a failed or cancelled startup turn redelivers the same message on every reboot.
- The Claude adapter hands every prompt to the SDK immediately, even mid-turn. Cancel settles the turn but cannot withdraw the queued message, and the SDK flushes the backlog merged into the next turn.

## Changes

- A user message now reaches the agent exactly once. The backend stamps `pending_user_message_id` wherever a pending message is written, the run-detail endpoint exposes it, and the agent server marks it delivered before self-delivering, so the forwarded copy dedupes.
- A forward that races the startup turn now awaits the turn instead of getting an instant duplicate ack, so downstream reply relays do not scrape logs before the reply exists.
- Cancelling a queued message now removes it: the adapter holds a prompt until it is head of queue, so a turn cancelled while queued never reaches the SDK and cannot be flushed later as a merged backlog. Steer delivery is unchanged.
- A failed or cancelled startup turn now clears the pending message state, ending the redeliver-on-every-reboot loop.
- Mechanical: the delivered-set eviction block is one helper; a dead rollback flag and a write-only variable are removed.


