### PR TITLE
fix(tasks): surface degraded resumes and reset idle timer on client commands

### DIFF
--- a/products/desktop/packages/agent/src/handoff-checkpoint.ts
+++ b/products/desktop/packages/agent/src/handoff-checkpoint.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -128,7 +128,7 @@ export class HandoffCheckpointTracker {
         !!capture.headPack && !uploads.pack?.storagePath;
       const indexUploadMissing = !uploads.index?.storagePath;
       if (packUploadMissing || indexUploadMissing) {
-        this.logger.debug(
+        this.logger.warn(
           "Discarding handoff checkpoint: required artifact uploads did not complete",
           {
             checkpointId: capture.checkpoint.checkpointId,
@@ -243,18 +243,20 @@ export class HandoffCheckpointTracker {
       return { rawBytes: 0, wireBytes: 0 };
     }
 
-    const content = await readFile(filePath);
-    if (content.byteLength > MAX_ARTIFACT_UPLOAD_BYTES) {
-      this.logger.debug(
+    const { size } = await stat(filePath);
+    if (size > MAX_ARTIFACT_UPLOAD_BYTES) {
+      this.logger.warn(
         "Skipping handoff artifact upload: file exceeds the artifact size limit",
         {
           name,
-          rawBytes: content.byteLength,
+          rawBytes: size,
           maxBytes: MAX_ARTIFACT_UPLOAD_BYTES,
         },
       );
-      return { rawBytes: content.byteLength, wireBytes: 0 };
+      return { rawBytes: size, wireBytes: 0 };
     }
+
+    const content = await readFile(filePath);
 
     try {
       const storagePath = await this.uploadArtifactDirect(

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -256,6 +256,7 @@ __all__ = [
     "record_comment_activity",
     "record_task_activity_for_users",
     "set_task_activity_target",
+    "signal_task_run_client_activity",
     "update_shared_task_context",
     "redeem_code_invite",
     "redispatch_task_run",
@@ -1538,6 +1539,16 @@ def update_task_run_state(
 ) -> dict:
     """Atomically merge state updates into a run's ``state`` and return the new state."""
     return TaskRun.update_state_atomic(run_id, updates=updates, remove_keys=remove_keys)
+
+
+def signal_task_run_client_activity(run_id: str | UUID, task_id: str | UUID, team_id: int) -> None:
+    """Best-effort: tell the run's workflow a client command landed, so the idle timer resets."""
+    try:
+        run = TaskRun.objects.filter(id=run_id, task_id=task_id, team_id=team_id).only("id", "task_id", "state").first()
+        if run is not None:
+            run.signal_client_activity()
+    except Exception:
+        logger.warning("Failed to signal client activity for task run %s", run_id)
 
 
 def slack_actor_state_updates(*, user_id: int, slack_user_id: str | None = None) -> dict[str, Any]:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -2217,6 +2217,26 @@ class TaskRun(models.Model):
         except Exception as e:
             logger.warning("task_run.heartbeat_failed", task_run_id=str(self.id), error=str(e))
 
+    def signal_client_activity(self) -> None:
+        from products.tasks.backend.redis import get_tasks_cache
+
+        cache_key = f"tasks:task_run:client_activity:{self.id}"
+        if not get_tasks_cache().add(cache_key, True, timeout=60):
+            return
+
+        import asyncio
+
+        from posthog.temporal.common.client import sync_connect
+
+        from products.tasks.backend.temporal.process_task.workflow import ProcessTaskWorkflow
+
+        try:
+            client = sync_connect()
+            handle = client.get_workflow_handle(self.workflow_id)
+            asyncio.run(handle.signal(ProcessTaskWorkflow.client_activity))
+        except Exception as e:
+            logger.warning("task_run.client_activity_signal_failed", task_run_id=str(self.id), error=str(e))
+
     @property
     def log_url(self) -> str:
         """Generate the S3 path for this run's logs."""

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2506,6 +2506,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 pk, task_id, self.team_id, method=method, params=params, success=agent_response.ok
             )
             if agent_response.ok:
+                tasks_facade.signal_task_run_client_activity(pk, task_id, self.team_id)
                 return Response(agent_response.json())
 
             try:

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -110,6 +110,25 @@ def _runtime_adapter_label(value: str | None) -> str:
     return value if value in _ALLOWED_RUNTIME_ADAPTERS else "other"
 
 
+def resume_mode_label(*, handoff_resumed: bool, using_modal_snapshot: bool) -> str:
+    if handoff_resumed:
+        return "handoff_and_snapshot" if using_modal_snapshot else "handoff"
+    return "snapshot_only" if using_modal_snapshot else "neither"
+
+
+def increment_resume_mode(mode: str, *, origin_product: str | None) -> None:
+    try:
+        _metric_meter({"mode": mode, "origin_product": origin_product or "unknown"}).create_counter(
+            "tasks_process_resume_mode",
+            "Resuming process-task runs by the resume state available at provision time. "
+            "handoff labels record that a handoff was requested, not that its git checkpoint "
+            "was captured. neither means no snapshot and no handoff state accompanied the "
+            "resume, so the agent's prior working tree could not be restored.",
+        ).add(1)
+    except Exception:
+        pass
+
+
 def increment_snapshot_usage(
     used_snapshot: bool,
     *,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -65,11 +65,13 @@ from products.tasks.backend.logic.services.sandbox_usage import (
 from products.tasks.backend.models import TASK_OWNERSHIP_VERSION_STATE_KEY, SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.temporal.metrics import (
     StepTimer,
+    increment_resume_mode,
     increment_snapshot_restore,
     increment_snapshot_usage,
     modal_sandbox_backend_label,
     record_network_enforcement,
     record_sandbox_created,
+    resume_mode_label,
     sandbox_runtime_label,
 )
 from products.tasks.backend.temporal.oauth import create_oauth_access_token_for_run, create_wizard_oauth_access_token
@@ -619,10 +621,19 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
                 snapshot_kind = run_state.resume_snapshot_kind()
                 snapshot_mount_path = run_state.resume_snapshot_mount_path()
 
-        activity.logger.info(
+        is_resume = bool(run_state.handoff_resumed or run_state.resume_from_run_id)
+        resume_mode = resume_mode_label(
+            handoff_resumed=run_state.handoff_resumed,
+            using_modal_snapshot=resume_snapshot_external_id is not None,
+        )
+        resume_decision_log = (
+            activity.logger.warning if is_resume and resume_mode == "neither" else activity.logger.info
+        )
+        resume_decision_log(
             "resume_decision",
             extra={
                 "run_id": ctx.run_id,
+                "resume_mode": resume_mode,
                 "state_snapshot_external_id": run_state.snapshot_external_id,
                 "state_snapshot_kind": run_state.snapshot_kind,
                 "effective_snapshot_external_id": resume_snapshot_external_id,
@@ -634,7 +645,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
                 "used_snapshot": used_snapshot,
             },
         )
-        if run_state.handoff_resumed or run_state.resume_from_run_id:
+        if is_resume:
             emit_agent_log(
                 ctx.run_id,
                 "debug",
@@ -642,6 +653,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
                 f"resume_from_run_id={run_state.resume_from_run_id}, "
                 f"using_modal_snapshot={resume_snapshot_external_id is not None}",
             )
+            increment_resume_mode(resume_mode, origin_product=ctx.origin_product)
 
         provider = getattr(settings, "SANDBOX_PROVIDER", None)
         image_source, image_source_label = _get_image_source_label(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -13,7 +13,7 @@ from products.tasks.backend.exceptions import RepositoryCloneError
 from products.tasks.backend.logic.services.docker_sandbox import DockerSandbox
 from products.tasks.backend.logic.services.sandbox import ExecutionResult, Sandbox
 from products.tasks.backend.models import Task
-from products.tasks.backend.temporal.metrics import modal_sandbox_backend_label
+from products.tasks.backend.temporal.metrics import modal_sandbox_backend_label, resume_mode_label
 from products.tasks.backend.temporal.process_task.activities import provision_sandbox as provision_sandbox_module
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
@@ -140,6 +140,19 @@ def test_modal_sandbox_backend_label(monkeypatch: pytest.MonkeyPatch, value: str
         monkeypatch.setenv("MODAL_SANDBOX_V2", value)
 
     assert modal_sandbox_backend_label() == expected
+
+
+@pytest.mark.parametrize(
+    ("handoff_resumed", "using_modal_snapshot", "expected"),
+    [
+        (True, False, "handoff"),
+        (True, True, "handoff_and_snapshot"),
+        (False, True, "snapshot_only"),
+        (False, False, "neither"),
+    ],
+)
+def test_resume_mode_label(handoff_resumed: bool, using_modal_snapshot: bool, expected: str) -> None:
+    assert resume_mode_label(handoff_resumed=handoff_resumed, using_modal_snapshot=using_modal_snapshot) == expected
 
 
 @pytest.mark.asyncio

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -2470,6 +2470,7 @@ class TestContinueAsNew:
                 ),
             ),
             ("heartbeat_pending", lambda wf: setattr(wf, "_heartbeat_received", True)),
+            ("client_activity_pending", lambda wf: setattr(wf, "_client_activity_received", True)),
             ("slack_relay_active", lambda wf: setattr(wf, "_current_slack_relay_workflow_id", "relay-1")),
         ]
     )

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -404,6 +404,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         # reason a run ended stays machine-readable without abusing error_message.
         self._completion_timeout_marker: Optional[str] = None
         self._heartbeat_received: bool = False
+        self._client_activity_received: bool = False
         self._agent_active: Optional[bool] = None
         self._end_of_turn_received: Optional[bool] = None
         self._last_agent_heartbeat_at: Optional[datetime] = None
@@ -485,6 +486,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 self._task_completed
                 or self._sandbox_gone
                 or self._heartbeat_received
+                or self._client_activity_received
                 or self._has_dispatchable_followup()
                 or len(self._pending_permission_responses) > 0
             )
@@ -1145,6 +1147,15 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                                 extra={"run_id": self.context.run_id},
                             )
                             self._heartbeat_received = False
+                            self._client_activity_received = False
+                            continue
+
+                        if self._client_activity_received and not self._task_completed:
+                            workflow.logger.info(
+                                "Client activity received, resetting inactivity timer",
+                                extra={"run_id": self.context.run_id},
+                            )
+                            self._client_activity_received = False
                             continue
                     case _:
                         raise ValueError(f"Unknown event type: {event}")
@@ -1439,6 +1450,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             or self._pending_followups
             or self._pending_permission_responses
             or self._heartbeat_received
+            or self._client_activity_received
             or self._current_slack_relay_workflow_id is not None
         ):
             return False
@@ -2553,6 +2565,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         self._heartbeat_received = True
         self._last_active_time = now
         self._last_agent_heartbeat_at = now
+
+    @temporalio.workflow.signal
+    async def client_activity(self) -> None:
+        self._client_activity_received = True
+        self._last_active_time = workflow.now()
 
     @temporalio.workflow.signal
     async def agent_state_changed(self, agent_active: bool) -> None:


### PR DESCRIPTION
## Problem

Two silent reliability gaps in cloud tasks:

- Resumes of large-repo tasks silently lose the agent's uncommitted work. The teardown handoff checkpoint's git pack (166 MB for a posthog checkout) exceeds the 30 MB artifact cap, so every checkpoint is discarded at debug log level and resume falls back to a filesystem snapshot. No metric or warning exists.
- The idle timer tears the sandbox down while a client is actively using it. Control commands like `set_config_option` are proxied straight to the sandbox and never reach the workflow, so a user changing settings looks idle. Production logs show a teardown starting seconds before the client's next commands landed.

## Changes

- A control command sent from the desktop now resets the run's inactivity timer: a new `client_activity` workflow signal, sent best-effort from the command endpoint and rate-limited to one per run per 60s through the same Redis gate the heartbeat uses. Signal handlers add no workflow commands, so no patch id is needed.
- Degraded resumes are now visible: a `tasks_process_resume_mode` counter (handoff / handoff_and_snapshot / snapshot_only / neither) and the existing `resume_decision` log at warning level when a resume runs without a handoff checkpoint.
- The agent-server's checkpoint-discard logs move from debug (invisible at default level) to warn, and the oversized-pack check stats the file instead of buffering hundreds of MB before rejecting.

