### PR TITLE
chore(desktop): cover persisted space filters

### DIFF
--- a/products/desktop/packages/ui/src/features/sidebar/sidebarStore.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/sidebarStore.test.ts
@@ -1,7 +1,25 @@
+import { DEFAULT_CHANNEL_ITEM_FILTERS } from "@posthog/core/canvas/channelItems";
 import { describe, expect, it } from "vitest";
 import { useSidebarStore } from "./sidebarStore";
 
 describe("sidebarStore", () => {
+  it("persists channel item filters", () => {
+    const filters = {
+      ...DEFAULT_CHANNEL_ITEM_FILTERS,
+      createdBy: "me" as const,
+    };
+
+    useSidebarStore.getState().setChannelItemFilters(filters);
+
+    expect(
+      JSON.parse(localStorage.getItem("sidebar-storage") ?? "{}"),
+    ).toMatchObject({ state: { channelItemFilters: filters } });
+    useSidebarStore.setState({
+      channelItemFilters: DEFAULT_CHANNEL_ITEM_FILTERS,
+    });
+    localStorage.removeItem("sidebar-storage");
+  });
+
   it("rehydration sanitizes list item metadata fields", async () => {
     localStorage.setItem(
       "sidebar-storage",


### PR DESCRIPTION
## Problem

Space filters now persist after restart, but existing coverage only verifies a sidebar remount.

**Why:** Removing filters from persisted sidebar state could silently restore reset-on-restart behavior.

## Changes

- The test now verifies that a chosen space filter reaches persisted sidebar state.
- No user-visible code changes. The existing sidebar store remains the single source of truth.

## How did you test this code?

- pnpm --filter @posthog/ui test --run src/features/sidebar/sidebarStore.test.ts
- pnpm typecheck
- pnpm lint
- pnpm --filter @posthog/ui test
- Not run: manual app testing. This PR changes unit coverage only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex reassessed this stale PR against current master. Skills invoked: /posthog-desktop, /writing-tests, and /writing-pr-descriptions.

Recent code moved filter state into the persisted sidebar store, so this PR drops duplicate production logic and keeps direct regression coverage.

Origin: [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787310806832599)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*