### PR TITLE
chore(warehouse-sources): reduce mysql e2e runtime

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/conftest.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/conftest.py
@@ -94,7 +94,7 @@ def mysql_container():
     local flox envs have Docker too. If Docker is unreachable the
     fixture errors loudly so the breakage isn't silently hidden.
     """
-    container = MySqlContainer("mysql:9.2")
+    container = MySqlContainer("mysql:9.2").with_env("MYSQL_INITDB_SKIP_TZINFO", "1")
     container.start()
     try:
         yield container

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -4554,9 +4554,11 @@ async def _mysql_setup(mysql_connection, statements: list[tuple[str, tuple | Non
     await sync_to_async(_run)()
 
 
+# test_mysql_source_full_refresh covers the non-DLT path against real MySQL.
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_mysql_full_refresh(team, mysql_config, mysql_connection):
+@pytest.mark.parametrize("pipeline_mode", ["v3"], indirect=True)
+async def test_mysql_full_refresh(team, mysql_config, mysql_connection, pipeline_mode):
     """Full-refresh sync of a simple table with a mix of common MySQL types."""
     await _mysql_setup(
         mysql_connection,
@@ -4597,9 +4599,11 @@ async def test_mysql_full_refresh(team, mysql_config, mysql_connection):
     assert row[2] == 30
 
 
+# test_mysql_source_incremental covers the non-DLT path against real MySQL.
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_mysql_incremental_integer_cursor(team, mysql_config, mysql_connection):
+@pytest.mark.parametrize("pipeline_mode", ["v3"], indirect=True)
+async def test_mysql_incremental_integer_cursor(team, mysql_config, mysql_connection, pipeline_mode):
     """Incremental sync with an INT cursor field — second run should pick up only new rows."""
     await _mysql_setup(
         mysql_connection,


### PR DESCRIPTION
## Problem

MySQL warehouse E2E runs repeatedly execute non-DLT workflows that dedicated real-MySQL tests already cover.

The disposable MySQL container also initializes timezone tables that these tests never use.

## Changes

- The test container skips MySQL timezone-table initialization.
- The generic full-refresh and incremental tests now cover V3 only.
- Dedicated MySQL source tests continue to cover both non-DLT behaviors against real MySQL.
- Zero-date, schema-evolution, decimal, and unsigned-type cases still run in both pipelines.

| Local measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| MySQL E2E family pytest runtime | 48.80s | 42.36s | -13.2% |
| Focused affected-selection wall time | 56.25s | 49.06s | -12.8% |
| Warm MySQL container startup | 7.21s | 6.15s | -14.6% |

## How did you test this code?

- `uv run pytest -q --no-migrations products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_mysql_source.py --durations=20`
- `uv run pytest -q --no-migrations products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py -k 'test_mysql_' --durations=20`
- `uv run hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed because production behavior is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used repository file tools, shell commands, PostHog CI timing data, and the PostHog MCP commit tool. The work invoked `/writing-tests`, `/writing-code-comments`, `/querying-posthog-data`, and `/writing-pr-descriptions`.

Profiling rejected Temporal-worker reuse because it did not reduce family wall time. The final change removes only behavior covered by stronger dedicated integration tests.
