### PR TITLE
feat(warehouse): add read-only source admin

### DIFF
--- a/products/warehouse_sources/backend/admin/__init__.py
+++ b/products/warehouse_sources/backend/admin/__init__.py
@@ -4,4 +4,5 @@ from products.warehouse_sources.backend.admin import (  # noqa: F401
     custom_oauth2_integration_admin,
     data_warehouse_table_admin,
     external_data_schema_admin,
+    external_data_source_admin,
 )

--- a/products/warehouse_sources/backend/admin/external_data_source_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_source_admin.py
@@ -1,0 +1,161 @@
+from django.contrib import admin
+from django.db.models import Q, QuerySet
+from django.http import HttpRequest
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.safestring import SafeString
+
+from products.warehouse_sources.backend.models import ExternalDataSource
+
+_CREDENTIAL_KIND_CHOICES = (
+    ("duckgres_service", "duckgres_service"),
+    ("project_reader", "project_reader"),
+    ("org_root", "org_root"),
+    ("stored_server_login", "stored_server_login"),
+)
+_KNOWN_CREDENTIAL_KINDS = frozenset(value for value, _label in _CREDENTIAL_KIND_CHOICES)
+
+
+class CredentialKindFilter(admin.SimpleListFilter):
+    title = "credential kind"
+    parameter_name = "credential_kind"
+
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+        return list(_CREDENTIAL_KIND_CHOICES)
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet[ExternalDataSource]) -> QuerySet[ExternalDataSource]:
+        credential_kind = self.value()
+        if credential_kind not in _KNOWN_CREDENTIAL_KINDS:
+            return queryset
+        return queryset.filter(connection_metadata__credential_kind=credential_kind)
+
+
+class SystemManagedFilter(admin.SimpleListFilter):
+    title = "system managed"
+    parameter_name = "system_managed"
+
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+        return [("yes", "Yes"), ("no", "No")]
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet[ExternalDataSource]) -> QuerySet[ExternalDataSource]:
+        if self.value() == "yes":
+            return queryset.filter(connection_metadata__system_managed=True)
+        if self.value() == "no":
+            return queryset.filter(
+                Q(connection_metadata__system_managed=False) | Q(connection_metadata__system_managed__isnull=True)
+            )
+        return queryset
+
+
+@admin.register(ExternalDataSource)
+class ExternalDataSourceAdmin(admin.ModelAdmin):
+    actions = None
+    show_full_result_count = False
+    ordering = ("-id",)
+    list_display = (
+        "id",
+        "credential_kind",
+        "prefix",
+        "source_type",
+        "team_link",
+        "organization_link",
+        "deleted",
+        "direct_query_enabled",
+        "created_at",
+        "updated_at",
+    )
+    list_display_links = ("id",)
+    list_filter = (
+        CredentialKindFilter,
+        SystemManagedFilter,
+        "deleted",
+        "direct_query_enabled",
+        "source_type",
+        "access_method",
+    )
+    search_fields = (
+        "id__exact",
+        "source_id",
+        "connection_id",
+        "team__id__exact",
+        "team__name",
+        "team__organization__id__exact",
+        "team__organization__name",
+    )
+    readonly_fields = (
+        "id",
+        "team_link",
+        "organization_link",
+        "source_id",
+        "connection_id",
+        "destination_id",
+        "source_type",
+        "prefix",
+        "description",
+        "status",
+        "access_method",
+        "direct_query_enabled",
+        "are_tables_created",
+        "created_via",
+        "credential_kind",
+        "system_managed",
+        "lifecycle_generation",
+        "deleted",
+        "deleted_at",
+        "created_at",
+        "updated_at",
+    )
+    fields = readonly_fields
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet[ExternalDataSource]:
+        return (
+            super()
+            .get_queryset(request)
+            .select_related(None)
+            .select_related("team", "team__organization")
+            .defer("job_inputs")
+        )
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj: ExternalDataSource | None = None) -> bool:
+        return False
+
+    def has_delete_permission(self, request: HttpRequest, obj: ExternalDataSource | None = None) -> bool:
+        return False
+
+    @admin.display(description="Credential kind", ordering="connection_metadata__credential_kind")
+    def credential_kind(self, obj: ExternalDataSource) -> str:
+        metadata = obj.connection_metadata
+        value = metadata.get("credential_kind") if isinstance(metadata, dict) else None
+        return value if value in _KNOWN_CREDENTIAL_KINDS else "Other"
+
+    @admin.display(boolean=True, description="System managed")
+    def system_managed(self, obj: ExternalDataSource) -> bool:
+        metadata = obj.connection_metadata
+        return isinstance(metadata, dict) and metadata.get("system_managed") is True
+
+    @admin.display(description="Lifecycle generation")
+    def lifecycle_generation(self, obj: ExternalDataSource) -> int | None:
+        metadata = obj.connection_metadata
+        value = metadata.get("lifecycle_generation") if isinstance(metadata, dict) else None
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    @admin.display(description="Team")
+    def team_link(self, obj: ExternalDataSource) -> SafeString:
+        return format_html(
+            '<a href="{}">{} ({})</a>',
+            reverse("admin:posthog_team_change", args=[obj.team_id]),
+            obj.team.name,
+            obj.team_id,
+        )
+
+    @admin.display(description="Organization")
+    def organization_link(self, obj: ExternalDataSource) -> SafeString:
+        return format_html(
+            '<a href="{}">{} ({})</a>',
+            reverse("admin:posthog_organization_change", args=[obj.team.organization_id]),
+            obj.team.organization.name,
+            obj.team.organization_id,
+        )

--- a/products/warehouse_sources/backend/admin/external_data_source_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_source_admin.py
@@ -7,6 +7,8 @@ from django.utils.safestring import SafeString
 
 from products.warehouse_sources.backend.models import ExternalDataSource
 
+type _FilterChoice = tuple[str, str]
+
 _CREDENTIAL_KIND_CHOICES = (
     ("duckgres_service", "duckgres_service"),
     ("project_reader", "project_reader"),
@@ -20,7 +22,7 @@ class CredentialKindFilter(admin.SimpleListFilter):
     title = "credential kind"
     parameter_name = "credential_kind"
 
-    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[_FilterChoice]:
         return list(_CREDENTIAL_KIND_CHOICES)
 
     def queryset(self, request: HttpRequest, queryset: QuerySet[ExternalDataSource]) -> QuerySet[ExternalDataSource]:
@@ -34,7 +36,7 @@ class SystemManagedFilter(admin.SimpleListFilter):
     title = "system managed"
     parameter_name = "system_managed"
 
-    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+    def lookups(self, request: HttpRequest, model_admin: admin.ModelAdmin) -> list[_FilterChoice]:
         return [("yes", "Yes"), ("no", "No")]
 
     def queryset(self, request: HttpRequest, queryset: QuerySet[ExternalDataSource]) -> QuerySet[ExternalDataSource]:

--- a/products/warehouse_sources/backend/tests/test_external_data_source_admin.py
+++ b/products/warehouse_sources/backend/tests/test_external_data_source_admin.py
@@ -7,8 +7,7 @@ from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.urls import reverse
 
-from posthog.admin import register_all_admin
-
+from products.warehouse_sources.backend.admin.external_data_source_admin import ExternalDataSourceAdmin
 from products.warehouse_sources.backend.models import ExternalDataSource
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -18,9 +17,8 @@ class TestExternalDataSourceAdmin(BaseTest):
         super().setUp()
         self.user.is_staff = True
         self.user.save()
-        register_all_admin()
         registered_admin = admin.site._registry.get(ExternalDataSource)
-        assert registered_admin is not None
+        assert isinstance(registered_admin, ExternalDataSourceAdmin)
         self.admin = cast(ModelAdmin, registered_admin)
 
     def _source(

--- a/products/warehouse_sources/backend/tests/test_external_data_source_admin.py
+++ b/products/warehouse_sources/backend/tests/test_external_data_source_admin.py
@@ -2,6 +2,7 @@ import uuid
 from typing import cast
 
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
@@ -20,6 +21,12 @@ class TestExternalDataSourceAdmin(BaseTest):
         registered_admin = admin.site._registry.get(ExternalDataSource)
         assert isinstance(registered_admin, ExternalDataSourceAdmin)
         self.admin = cast(ModelAdmin, registered_admin)
+        # Product-scoped test runs keep some third-party admins registered while excluding their
+        # app URLs. The sidebar is unrelated to these model-admin assertions and cannot reverse
+        # those deliberately absent app URLs.
+        get_app_list_patcher = patch.object(admin.site, "get_app_list", return_value=[])
+        get_app_list_patcher.start()
+        self.addCleanup(get_app_list_patcher.stop)
 
     def _source(
         self,

--- a/products/warehouse_sources/backend/tests/test_external_data_source_admin.py
+++ b/products/warehouse_sources/backend/tests/test_external_data_source_admin.py
@@ -1,0 +1,137 @@
+import uuid
+from typing import cast
+
+from posthog.test.base import BaseTest
+
+from django.contrib import admin
+from django.contrib.admin import ModelAdmin
+from django.urls import reverse
+
+from posthog.admin import register_all_admin
+
+from products.warehouse_sources.backend.models import ExternalDataSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestExternalDataSourceAdmin(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        register_all_admin()
+        registered_admin = admin.site._registry.get(ExternalDataSource)
+        assert registered_admin is not None
+        self.admin = cast(ModelAdmin, registered_admin)
+
+    def _source(
+        self,
+        *,
+        credential_kind: str,
+        system_managed: bool | None = True,
+        deleted: bool = False,
+        job_inputs: dict[str, object] | None = None,
+    ) -> ExternalDataSource:
+        connection_metadata: dict[str, object] = {
+            "credential_kind": credential_kind,
+            "engine": "duckdb",
+        }
+        if system_managed is not None:
+            connection_metadata["system_managed"] = system_managed
+        return ExternalDataSource._base_manager.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type=ExternalDataSourceType.POSTGRES,
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            direct_query_enabled=True,
+            prefix="managed_warehouse",
+            deleted=deleted,
+            job_inputs=job_inputs or {},
+            connection_metadata=connection_metadata,
+        )
+
+    def test_admin_rejects_every_write_route(self) -> None:
+        source = self._source(credential_kind="project_reader")
+        self.client.force_login(self.user)
+
+        add_response = self.client.post(reverse("admin:warehouse_sources_externaldatasource_add"), {})
+        change_response = self.client.post(
+            reverse("admin:warehouse_sources_externaldatasource_change", args=[source.pk]),
+            {"description": "changed"},
+        )
+        delete_response = self.client.post(
+            reverse("admin:warehouse_sources_externaldatasource_delete", args=[source.pk]),
+            {"post": "yes"},
+        )
+
+        assert add_response.status_code == 403
+        assert change_response.status_code == 403
+        assert delete_response.status_code == 403
+        source.refresh_from_db()
+        assert source.description is None
+        assert ExternalDataSource._base_manager.filter(pk=source.pk).exists()
+
+    def test_change_view_never_renders_encrypted_job_inputs(self) -> None:
+        source = self._source(
+            credential_kind="org_root",
+            job_inputs={"host": "warehouse.example.test", "password": "admin-secret-sentinel"},
+        )
+        metadata = source.connection_metadata
+        assert isinstance(metadata, dict)
+        source.connection_metadata = {
+            **metadata,
+            "private_marker": "metadata-secret-sentinel",
+        }
+        source.save(update_fields=["connection_metadata", "updated_at"])
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("admin:warehouse_sources_externaldatasource_change", args=[source.pk]))
+
+        assert response.status_code == 200
+        assert b"Job inputs" not in response.content
+        assert b"Connection metadata" not in response.content
+        assert b"admin-secret-sentinel" not in response.content
+        assert b"metadata-secret-sentinel" not in response.content
+        assert "job_inputs" in response.context["original"].get_deferred_fields()
+
+    def test_credential_kind_filter_uses_connection_metadata(self) -> None:
+        project_reader = self._source(credential_kind="project_reader")
+        dynamic = self._source(credential_kind="duckgres_service")
+        self.client.force_login(self.user)
+
+        response = self.client.get(
+            reverse("admin:warehouse_sources_externaldatasource_changelist"),
+            {"credential_kind": "project_reader"},
+        )
+
+        assert response.status_code == 200
+        result_ids = {source.pk for source in response.context["cl"].result_list}
+        assert project_reader.pk in result_ids
+        assert dynamic.pk not in result_ids
+        assert all("job_inputs" in source.get_deferred_fields() for source in response.context["cl"].result_list)
+
+    def test_system_managed_and_deleted_filters_can_find_historical_sources(self) -> None:
+        historical = self._source(credential_kind="project_reader", deleted=True)
+        self._source(credential_kind="project_reader", deleted=False)
+        non_system_managed = self._source(credential_kind="org_root", system_managed=False, deleted=True)
+        missing_system_managed = self._source(credential_kind="org_root", system_managed=None, deleted=True)
+        self.client.force_login(self.user)
+
+        response = self.client.get(
+            reverse("admin:warehouse_sources_externaldatasource_changelist"),
+            {"credential_kind": "project_reader", "system_managed": "yes", "deleted__exact": "1"},
+        )
+
+        assert response.status_code == 200
+        assert [source.pk for source in response.context["cl"].result_list] == [historical.pk]
+
+        non_system_response = self.client.get(
+            reverse("admin:warehouse_sources_externaldatasource_changelist"),
+            {"system_managed": "no", "deleted__exact": "1"},
+        )
+        assert non_system_response.status_code == 200
+        assert {source.pk for source in non_system_response.context["cl"].result_list} == {
+            non_system_managed.pk,
+            missing_system_managed.pk,
+        }


### PR DESCRIPTION
## Problem

Support engineers cannot inspect managed warehouse source modes or historical rows in Django admin without a database query.

The model contains encrypted connection inputs, so a broad default admin would expose unsafe fields.

## Changes

- Support engineers can inspect and filter source rows in a read-only Django admin.
- The admin links teams and organizations and shows only allowlisted operational metadata.
- The queryset defers encrypted `job_inputs`, omits raw metadata, and denies every write route.
- No frontend code changed; the page uses the existing Django admin interface.

## How did you test this code?

- New route tests verify add, change, and delete requests return 403 without modifying rows.
- New rendering tests verify encrypted inputs and raw metadata stay unloaded and absent from HTML.
- New filter tests cover credential kind, deleted state, and explicit or missing system-managed metadata.
- Local checks ran the related admin tests, full mypy, and strict preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This adds internal inspection tooling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested the change. An independent Codex review checked secret exposure, query behavior, and write denial.

The repository writing-pr-descriptions skill shaped this description. All committed fixtures use invented public-safe data.