### PR TITLE
feat(tasks): add project-scoped desktop access policy

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -3,11 +3,12 @@ import json
 import time
 import hashlib
 from datetime import UTC, datetime, timedelta
-from enum import Enum
-from typing import Any, Optional, cast
+from enum import Enum, StrEnum
+from typing import Any, Literal, Optional, cast
 from uuid import UUID
 
 from django.conf import settings
+from django.core.cache import cache
 from django.db.models import F
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -19,6 +20,7 @@ from requests import JSONDecodeError
 from rest_framework.exceptions import NotAuthenticated
 
 from posthog.cloud_utils import get_cached_instance_license
+from posthog.dataclasses import frozen
 from posthog.event_usage import report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Organization
@@ -45,6 +47,27 @@ BILLING_TIMESERIES_REQUEST_TIMEOUT = (5, 30)
 # Marks tokens minted by the billing alerts evaluation job; billing recognizes this claim
 # on its read-only billing status path for tokens without a user role.
 BILLING_ALERTS_EVALUATION_SERVICE_ACTION = "billing_alerts_evaluation"
+
+
+StartupProgramLabel = Literal["Startup", "YC"]
+
+
+class PrepaidCreditState(StrEnum):
+    NONE = "none"
+    PENDING = "pending"
+    ACTIVE = "active"
+    EXHAUSTED = "exhausted"
+    EXPIRED = "expired"
+
+
+class FundingStatusUnavailable(Exception):
+    pass
+
+
+@frozen
+class OrganizationFundingStatus:
+    startup_program_label: StartupProgramLabel | None
+    prepaid_credit_state: PrepaidCreditState
 
 
 class BillingAPIErrorCodes(Enum):
@@ -198,6 +221,29 @@ def handle_billing_service_error(res: requests.Response, valid_codes=(200, 201, 
             raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", response)
         except JSONDecodeError:
             raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", res.text)
+
+
+def _parse_funding_status(data: object) -> OrganizationFundingStatus:
+    if not isinstance(data, dict):
+        raise FundingStatusUnavailable("Billing returned an invalid funding status response")
+
+    raw_startup_program_label = data.get("startup_program_label")
+    if raw_startup_program_label not in (None, "Startup", "YC"):
+        raise FundingStatusUnavailable("Billing returned an invalid startup program label")
+    startup_program_label = cast(StartupProgramLabel | None, raw_startup_program_label)
+
+    raw_prepaid_credit_state = data.get("prepaid_credit_state")
+    if not isinstance(raw_prepaid_credit_state, str):
+        raise FundingStatusUnavailable("Billing returned an invalid prepaid credit state")
+    try:
+        prepaid_credit_state = PrepaidCreditState(raw_prepaid_credit_state)
+    except ValueError as error:
+        raise FundingStatusUnavailable("Billing returned an invalid prepaid credit state") from error
+
+    return OrganizationFundingStatus(
+        startup_program_label=startup_program_label,
+        prepaid_credit_state=prepaid_credit_state,
+    )
 
 
 class BillingManager:
@@ -391,6 +437,38 @@ class BillingManager:
         )
 
         handle_billing_service_error(res)
+
+    def get_funding_status(self, organization: Organization) -> OrganizationFundingStatus:
+        cache_key = f"organization_funding_status:{organization.id}"
+        try:
+            cached_status = cache.get(cache_key)
+        except Exception:
+            logger.warning("funding_status_cache_read_failed", exc_info=True)
+            cached_status = None
+
+        if cached_status is not None:
+            return _parse_funding_status(cached_status)
+
+        try:
+            response = requests.get(
+                f"{BILLING_SERVICE_URL}/api/billing/funding-status/",
+                headers=self.get_auth_headers(organization),
+                timeout=5,
+            )
+            handle_billing_service_error(response, valid_codes=(200,))
+            raw_status = response.json()
+            funding_status = _parse_funding_status(raw_status)
+        except FundingStatusUnavailable:
+            raise
+        except Exception as error:
+            raise FundingStatusUnavailable("Could not resolve organization funding status") from error
+
+        try:
+            cache.set(cache_key, raw_status, timeout=30)
+        except Exception:
+            logger.warning("funding_status_cache_write_failed", exc_info=True)
+
+        return funding_status
 
     def _get_default_billing_response(self, organization: Organization | None) -> dict[str, Any]:
         products = self.get_default_products(organization)

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -227,6 +227,8 @@ def _parse_funding_status(data: object) -> OrganizationFundingStatus:
     if not isinstance(data, dict):
         raise FundingStatusUnavailable("Billing returned an invalid funding status response")
 
+    if "startup_program_label" not in data:
+        raise FundingStatusUnavailable("Billing returned an invalid startup program label")
     raw_startup_program_label = data.get("startup_program_label")
     if raw_startup_program_label not in (None, "Startup", "YC"):
         raise FundingStatusUnavailable("Billing returned an invalid startup program label")

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -64,6 +64,9 @@ class FundingStatusUnavailable(Exception):
     pass
 
 
+_FUNDING_STATUS_UNAVAILABLE_CACHE_VALUE = "__funding_status_unavailable__"
+
+
 @frozen
 class OrganizationFundingStatus:
     startup_program_label: StartupProgramLabel | None
@@ -448,6 +451,8 @@ class BillingManager:
             logger.warning("funding_status_cache_read_failed", exc_info=True)
             cached_status = None
 
+        if cached_status == _FUNDING_STATUS_UNAVAILABLE_CACHE_VALUE:
+            raise FundingStatusUnavailable("Could not resolve organization funding status")
         if cached_status is not None:
             return _parse_funding_status(cached_status)
 
@@ -460,9 +465,13 @@ class BillingManager:
             handle_billing_service_error(response, valid_codes=(200,))
             raw_status = response.json()
             funding_status = _parse_funding_status(raw_status)
-        except FundingStatusUnavailable:
-            raise
         except Exception as error:
+            try:
+                cache.set(cache_key, _FUNDING_STATUS_UNAVAILABLE_CACHE_VALUE, timeout=5)
+            except Exception:
+                logger.warning("funding_status_failure_cache_write_failed", exc_info=True)
+            if isinstance(error, FundingStatusUnavailable):
+                raise
             raise FundingStatusUnavailable("Could not resolve organization funding status") from error
 
         try:

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -104,6 +104,7 @@ class TestFundingStatusParsing(SimpleTestCase):
                 "invalid_program_label",
                 {"startup_program_label": "Growth", "prepaid_credit_state": "none"},
             ),
+            ("missing_program_label", {"prepaid_credit_state": "none"}),
             ("missing_credit_state", {"startup_program_label": None}),
             (
                 "invalid_credit_state",

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -27,7 +27,11 @@ from ee.billing.billing_manager import (
     BILLING_PROVIDER_WEBHOOK_SIGNATURE_VERSION,
     BILLING_PROVIDER_WEBHOOK_TIMESTAMP_HEADER,
     BillingManager,
+    FundingStatusUnavailable,
+    OrganizationFundingStatus,
+    PrepaidCreditState,
     _get_user_organization_role,
+    _parse_funding_status,
     build_billing_token,
 )
 from ee.billing.billing_types import BillingProvider, BillingStatus, Product
@@ -57,6 +61,59 @@ def create_default_products_response(**kwargs) -> dict[str, list[Product]]:
 
     data.update(kwargs)
     return data
+
+
+class TestFundingStatusParsing(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "normal",
+                {"startup_program_label": None, "prepaid_credit_state": "none"},
+                OrganizationFundingStatus(
+                    startup_program_label=None,
+                    prepaid_credit_state=PrepaidCreditState.NONE,
+                ),
+            ),
+            (
+                "startup_active",
+                {"startup_program_label": "Startup", "prepaid_credit_state": "active"},
+                OrganizationFundingStatus(
+                    startup_program_label="Startup",
+                    prepaid_credit_state=PrepaidCreditState.ACTIVE,
+                ),
+            ),
+            (
+                "yc_expired",
+                {"startup_program_label": "YC", "prepaid_credit_state": "expired"},
+                OrganizationFundingStatus(
+                    startup_program_label="YC",
+                    prepaid_credit_state=PrepaidCreditState.EXPIRED,
+                ),
+            ),
+        ]
+    )
+    def test_parses_funding_status(
+        self, _name: str, payload: dict[str, str | None], expected: OrganizationFundingStatus
+    ) -> None:
+        self.assertEqual(_parse_funding_status(payload), expected)
+
+    @parameterized.expand(
+        [
+            ("not_an_object", []),
+            (
+                "invalid_program_label",
+                {"startup_program_label": "Growth", "prepaid_credit_state": "none"},
+            ),
+            ("missing_credit_state", {"startup_program_label": None}),
+            (
+                "invalid_credit_state",
+                {"startup_program_label": None, "prepaid_credit_state": "paid"},
+            ),
+        ]
+    )
+    def test_rejects_invalid_funding_status(self, _name: str, payload: object) -> None:
+        with self.assertRaises(FundingStatusUnavailable):
+            _parse_funding_status(payload)
 
 
 class TestBillingManager(BaseTest):
@@ -129,6 +186,72 @@ class TestBillingManager(BaseTest):
         assert ("X-PostHog-Actor-IP" in headers) is expect_header
         if expect_header:
             assert headers["X-PostHog-Actor-IP"] == ip_address
+
+    @patch("ee.billing.billing_manager.BILLING_SERVICE_URL", "https://billing.posthog.com")
+    @patch("ee.billing.billing_manager.cache")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_get_funding_status_uses_organization_scoped_billing_token(
+        self, mock_get: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+        payload = {"startup_program_label": None, "prepaid_credit_state": "none"}
+        mock_cache.get.return_value = None
+        mock_get.return_value = MagicMock(status_code=200, json=MagicMock(return_value=payload))
+
+        result = BillingManager(license, self.user).get_funding_status(self.organization)
+
+        assert result == OrganizationFundingStatus(
+            startup_program_label=None,
+            prepaid_credit_state=PrepaidCreditState.NONE,
+        )
+        mock_get.assert_called_once()
+        call = mock_get.call_args
+        assert call.args[0] == "https://billing.posthog.com/api/billing/funding-status/"
+        assert call.kwargs["headers"]["Authorization"].startswith("Bearer ")
+        assert call.kwargs["timeout"] == 5
+        mock_cache.set.assert_called_once_with(
+            f"organization_funding_status:{self.organization.id}", payload, timeout=30
+        )
+
+    @patch("ee.billing.billing_manager.cache")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_get_funding_status_uses_cached_value(self, mock_get: MagicMock, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = {"startup_program_label": "YC", "prepaid_credit_state": "expired"}
+
+        result = BillingManager(MagicMock(), self.user).get_funding_status(self.organization)
+
+        assert result == OrganizationFundingStatus(
+            startup_program_label="YC",
+            prepaid_credit_state=PrepaidCreditState.EXPIRED,
+        )
+        mock_get.assert_not_called()
+
+    @patch("ee.billing.billing_manager.cache")
+    @patch("ee.billing.billing_manager.requests.get")
+    def test_get_funding_status_ignores_cache_failure(self, mock_get: MagicMock, mock_cache: MagicMock) -> None:
+        payload = {"startup_program_label": None, "prepaid_credit_state": "active"}
+        mock_cache.get.side_effect = RuntimeError("cache unavailable")
+        mock_cache.set.side_effect = RuntimeError("cache unavailable")
+        mock_get.return_value = MagicMock(status_code=200, json=MagicMock(return_value=payload))
+
+        manager = BillingManager(MagicMock(), self.user)
+        with patch.object(manager, "get_auth_headers", return_value={}):
+            result = manager.get_funding_status(self.organization)
+
+        assert result.prepaid_credit_state == PrepaidCreditState.ACTIVE
+
+    @patch("ee.billing.billing_manager.cache")
+    @patch("ee.billing.billing_manager.requests.get", side_effect=requests.Timeout)
+    def test_get_funding_status_wraps_billing_failure(self, _mock_get: MagicMock, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = None
+
+        manager = BillingManager(MagicMock(), self.user)
+        with patch.object(manager, "get_auth_headers", return_value={}), self.assertRaises(FundingStatusUnavailable):
+            manager.get_funding_status(self.organization)
 
     @patch(
         "ee.billing.billing_manager.requests.patch",

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -247,12 +247,20 @@ class TestBillingManager(BaseTest):
 
     @patch("ee.billing.billing_manager.cache")
     @patch("ee.billing.billing_manager.requests.get", side_effect=requests.Timeout)
-    def test_get_funding_status_wraps_billing_failure(self, _mock_get: MagicMock, mock_cache: MagicMock) -> None:
-        mock_cache.get.return_value = None
+    def test_get_funding_status_caches_billing_failure(self, mock_get: MagicMock, mock_cache: MagicMock) -> None:
+        cached_values: list[object | None] = [None]
+        mock_cache.get.side_effect = lambda _key: cached_values[-1]
+        mock_cache.set.side_effect = lambda _key, value, timeout: cached_values.append(value)
 
         manager = BillingManager(MagicMock(), self.user)
-        with patch.object(manager, "get_auth_headers", return_value={}), self.assertRaises(FundingStatusUnavailable):
-            manager.get_funding_status(self.organization)
+        with patch.object(manager, "get_auth_headers", return_value={}):
+            with self.assertRaises(FundingStatusUnavailable):
+                manager.get_funding_status(self.organization)
+            with self.assertRaises(FundingStatusUnavailable):
+                manager.get_funding_status(self.organization)
+
+        mock_get.assert_called_once()
+        assert mock_cache.set.call_args.kwargs["timeout"] == 5
 
     @patch(
         "ee.billing.billing_manager.requests.patch",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -689,6 +689,7 @@ SPECTACULAR_SETTINGS = {
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "TileSpacingEnum": ["tight", "condensed", "standard", "relaxed", "wide"],
         "LayoutCompactionEnum": ["vertical", "horizontal", "stable"],
+        "DesktopAccessReasonEnum": "products.tasks.backend.facade.contracts.DESKTOP_ACCESS_REASON_SCHEMA_VALUES",
         "PropertyGroupOperator": ["AND", "OR"],
         # `scope`/`state` are generic field names; one shared name for the canvas state scope set.
         "CanvasStateScopeEnum": ["user", "shared"],

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -690,7 +690,7 @@ def viewer_has_code_access(integration: Integration, slack_user_id: str | None) 
         )
         if user is None:
             return False
-        return get_desktop_access_decision(user, integration.team).allowed
+        return get_desktop_access_decision(user, integration.team.organization).allowed
     except Exception:
         logger.exception("slack_app_viewer_code_access_check_failed", integration_id=integration.id)
         return False

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -660,16 +660,6 @@ def _public_url(path: str) -> str:
     return absolute_uri(path)
 
 
-def workspace_org_ids(slack_team_id: str) -> set:
-    """Organizations connected to this Slack workspace — the scope a Slack identity may
-    resolve a PostHog user within."""
-    return set(
-        Integration.objects.filter(kind="slack", integration_id=slack_team_id).values_list(
-            "team__organization_id", flat=True
-        )
-    )
-
-
 def viewer_has_code_access(integration: Integration, slack_user_id: str | None) -> bool:
     """Whether the Slack identity reading this can open a PostHog Code link.
 
@@ -686,7 +676,7 @@ def viewer_has_code_access(integration: Integration, slack_user_id: str | None) 
         user = find_linked_posthog_user(
             slack_user_id=slack_user_id,
             slack_team_id=integration.integration_id,
-            candidate_org_ids=workspace_org_ids(integration.integration_id),
+            candidate_org_ids={integration.team.organization_id},
         )
         if user is None:
             return False

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -678,7 +678,7 @@ def viewer_has_code_access(integration: Integration, slack_user_id: str | None) 
     flag-service error means no link rather than one that dead-ends.
     """
     from products.slack_app.backend.services.slack_user_oauth import find_linked_posthog_user  # noqa: PLC0415
-    from products.tasks.backend.facade.access import has_tasks_access  # noqa: PLC0415
+    from products.tasks.backend.facade.access import get_desktop_access_decision  # noqa: PLC0415
 
     if not slack_user_id:
         return False
@@ -688,7 +688,9 @@ def viewer_has_code_access(integration: Integration, slack_user_id: str | None) 
             slack_team_id=integration.integration_id,
             candidate_org_ids=workspace_org_ids(integration.integration_id),
         )
-        return user is not None and has_tasks_access(user)
+        if user is None:
+            return False
+        return get_desktop_access_decision(user, integration.team).allowed
     except Exception:
         logger.exception("slack_app_viewer_code_access_check_failed", integration_id=integration.id)
         return False

--- a/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
@@ -83,7 +83,10 @@ class TestLoadRunFooter(SimpleTestCase):
 
 class TestViewerHasCodeAccess(SimpleTestCase):
     def _integration(self) -> Integration:
-        return cast(Integration, SimpleNamespace(config={}, integration_id="T1", id=1, team=object()))
+        return cast(
+            Integration,
+            SimpleNamespace(config={}, integration_id="T1", id=1, team=SimpleNamespace(organization=object())),
+        )
 
     @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
     def test_no_slack_identity_means_no_access_without_consulting_the_flag(self, mock_has_access) -> None:

--- a/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
@@ -83,36 +83,43 @@ class TestLoadRunFooter(SimpleTestCase):
 
 class TestViewerHasCodeAccess(SimpleTestCase):
     def _integration(self) -> Integration:
-        return cast(
-            Integration,
-            SimpleNamespace(config={}, integration_id="T1", id=1, team=SimpleNamespace(organization=object())),
-        )
+        organization = SimpleNamespace(id="org-1")
+        team = SimpleNamespace(organization=organization, organization_id=organization.id)
+        return cast(Integration, SimpleNamespace(config={}, integration_id="T1", id=1, team=team))
 
     @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
     def test_no_slack_identity_means_no_access_without_consulting_the_flag(self, mock_has_access) -> None:
         assert viewer_has_code_access(self._integration(), None) is False
         mock_has_access.assert_not_called()
 
-    @patch("products.slack_app.backend.services.slack_messages.workspace_org_ids", return_value=set())
     @patch("products.slack_app.backend.services.slack_user_oauth.find_linked_posthog_user", return_value=None)
     @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
-    def test_an_unlinked_slack_identity_means_no_access(self, mock_has_access, _mock_find, _mock_orgs) -> None:
+    def test_an_unlinked_slack_identity_means_no_access(self, mock_has_access, _mock_find) -> None:
         assert viewer_has_code_access(self._integration(), "U1") is False
         mock_has_access.assert_not_called()
 
     @parameterized.expand([("granted", True, True), ("denied", False, False)])
-    @patch("products.slack_app.backend.services.slack_messages.workspace_org_ids", return_value=set())
     @patch("products.slack_app.backend.services.slack_user_oauth.find_linked_posthog_user")
     @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
     def test_a_linked_identity_follows_its_own_code_access(
-        self, _name: str, granted: bool, expected: bool, mock_has_access, mock_find, _mock_orgs
+        self, _name: str, granted: bool, expected: bool, mock_has_access, mock_find
     ) -> None:
         # The reader, not the task creator: a thread outlives whoever opened it.
         mock_find.return_value = object()
         mock_has_access.return_value = SimpleNamespace(allowed=granted)
 
-        assert viewer_has_code_access(self._integration(), "U1") is expected
+        integration = self._integration()
 
-    @patch("products.slack_app.backend.services.slack_messages.workspace_org_ids", side_effect=RuntimeError("db down"))
-    def test_a_lookup_failure_withholds_the_links_rather_than_guessing(self, _mock_orgs) -> None:
+        assert viewer_has_code_access(integration, "U1") is expected
+        mock_find.assert_called_once_with(
+            slack_user_id="U1",
+            slack_team_id="T1",
+            candidate_org_ids={integration.team.organization_id},
+        )
+
+    @patch(
+        "products.slack_app.backend.services.slack_user_oauth.find_linked_posthog_user",
+        side_effect=RuntimeError("db down"),
+    )
+    def test_a_lookup_failure_withholds_the_links_rather_than_guessing(self, _mock_find) -> None:
         assert viewer_has_code_access(self._integration(), "U1") is False

--- a/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import cast
 from uuid import uuid4
 
 from unittest.mock import patch
@@ -82,16 +83,16 @@ class TestLoadRunFooter(SimpleTestCase):
 
 class TestViewerHasCodeAccess(SimpleTestCase):
     def _integration(self) -> Integration:
-        return Integration(config={}, integration_id="T1")
+        return cast(Integration, SimpleNamespace(config={}, integration_id="T1", id=1, team=object()))
 
-    @patch("products.tasks.backend.facade.access.has_tasks_access")
+    @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
     def test_no_slack_identity_means_no_access_without_consulting_the_flag(self, mock_has_access) -> None:
         assert viewer_has_code_access(self._integration(), None) is False
         mock_has_access.assert_not_called()
 
     @patch("products.slack_app.backend.services.slack_messages.workspace_org_ids", return_value=set())
     @patch("products.slack_app.backend.services.slack_user_oauth.find_linked_posthog_user", return_value=None)
-    @patch("products.tasks.backend.facade.access.has_tasks_access")
+    @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
     def test_an_unlinked_slack_identity_means_no_access(self, mock_has_access, _mock_find, _mock_orgs) -> None:
         assert viewer_has_code_access(self._integration(), "U1") is False
         mock_has_access.assert_not_called()
@@ -99,13 +100,13 @@ class TestViewerHasCodeAccess(SimpleTestCase):
     @parameterized.expand([("granted", True, True), ("denied", False, False)])
     @patch("products.slack_app.backend.services.slack_messages.workspace_org_ids", return_value=set())
     @patch("products.slack_app.backend.services.slack_user_oauth.find_linked_posthog_user")
-    @patch("products.tasks.backend.facade.access.has_tasks_access")
+    @patch("products.tasks.backend.facade.access.get_desktop_access_decision")
     def test_a_linked_identity_follows_its_own_code_access(
         self, _name: str, granted: bool, expected: bool, mock_has_access, mock_find, _mock_orgs
     ) -> None:
         # The reader, not the task creator: a thread outlives whoever opened it.
         mock_find.return_value = object()
-        mock_has_access.return_value = granted
+        mock_has_access.return_value = SimpleNamespace(allowed=granted)
 
         assert viewer_has_code_access(self._integration(), "U1") is expected
 

--- a/products/tasks/backend/access.py
+++ b/products/tasks/backend/access.py
@@ -1,48 +1,123 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import posthoganalytics
 
+from posthog.cloud_utils import get_cached_instance_license
+from posthog.dataclasses import frozen
 from posthog.models.user import User
 
-from .models import CodeInviteRedemption
+from products.tasks.backend.facade.contracts import DesktopAccessReason
+from products.tasks.backend.metrics import observe_desktop_access_decision
+
+from ee.billing.billing_manager import (
+    BillingManager,
+    FundingStatusUnavailable,
+    OrganizationFundingStatus,
+    PrepaidCreditState,
+)
 
 if TYPE_CHECKING:
     from posthog.models.team.team import Team
 
+DESKTOP_ACCESS_GATE_FLAG = "posthog-desktop-access-gate"
+DESKTOP_ACCESS_OVERRIDE_FLAG = "posthog-desktop-access-override"
 
-def _is_flag_enabled(flag_key: str, user: User, team: "Team | None" = None) -> bool:
+
+class DesktopAccessResolutionError(Exception):
+    pass
+
+
+@frozen
+class DesktopAccessDecision:
+    reason: DesktopAccessReason | None = None
+
+    @property
+    def allowed(self) -> bool:
+        return self.reason is None
+
+
+def _is_flag_enabled(
+    flag_key: str,
+    user: User,
+    team: "Team | None" = None,
+    *,
+    require_boolean: bool = False,
+) -> bool | None:
     if not user.distinct_id:
-        return False
+        return None
     org = team.organization if team is not None else getattr(user, "organization", None)
-    kwargs: dict = {
+    kwargs: dict[str, Any] = {
         "only_evaluate_locally": False,
         "send_feature_flag_events": False,
     }
     if org is not None:
-        # The `tasks` flag's release conditions are mostly person-level (email allowlist + domain),
-        # but maybe we want org level conditions later on.
         org_id = str(org.id)
         kwargs["groups"] = {"organization": org_id}
         kwargs["group_properties"] = {"organization": {"id": org_id}}
-    return bool(posthoganalytics.feature_enabled(flag_key, user.distinct_id, **kwargs))
+    if require_boolean:
+        result = posthoganalytics.get_feature_flag(flag_key, user.distinct_id, **kwargs)
+        return result if isinstance(result, bool) else None
+
+    result = posthoganalytics.feature_enabled(flag_key, user.distinct_id, **kwargs)
+    return bool(result) if result is not None else None
 
 
-def has_tasks_access(user: User) -> bool:
-    """
-    User has access to PostHog Desktop if the `tasks` feature flag is enabled for them
-    OR they have redeemed an invite code.
-    """
+def _is_rollout_enabled(user: User, team: "Team") -> bool | None:
+    return _is_flag_enabled(DESKTOP_ACCESS_GATE_FLAG, user, team)
+
+
+def _get_funding_status(user: User, team: "Team") -> OrganizationFundingStatus:
+    try:
+        return BillingManager(get_cached_instance_license(), user).get_funding_status(team.organization)
+    except FundingStatusUnavailable as error:
+        raise DesktopAccessResolutionError("Could not resolve organization funding status") from error
+
+
+def get_desktop_access_decision(user: User, team: "Team") -> DesktopAccessDecision:
     if not user or not user.is_authenticated:
-        return False
-    if _is_flag_enabled("tasks", user):
-        return True
-    return CodeInviteRedemption.objects.filter(user=user).exists()
+        raise DesktopAccessResolutionError("Authentication is required to evaluate Desktop access")
+
+    try:
+        rollout_enabled = _is_rollout_enabled(user, team)
+    except Exception as error:
+        observe_desktop_access_decision(outcome="resolution_failure")
+        raise DesktopAccessResolutionError("Could not evaluate the Desktop access rollout") from error
+
+    if rollout_enabled is None:
+        observe_desktop_access_decision(outcome="resolution_failure")
+        raise DesktopAccessResolutionError("Could not evaluate the Desktop access rollout")
+    if not rollout_enabled:
+        return DesktopAccessDecision()
+
+    try:
+        override_enabled = _is_flag_enabled(DESKTOP_ACCESS_OVERRIDE_FLAG, user, team, require_boolean=True)
+    except Exception as error:
+        observe_desktop_access_decision(outcome="resolution_failure")
+        raise DesktopAccessResolutionError("Could not evaluate the Desktop access override") from error
+
+    if not isinstance(override_enabled, bool):
+        observe_desktop_access_decision(outcome="resolution_failure")
+        raise DesktopAccessResolutionError("Could not evaluate the Desktop access override")
+    if override_enabled:
+        observe_desktop_access_decision(outcome="override")
+        return DesktopAccessDecision()
+
+    try:
+        funding_status = _get_funding_status(user, team)
+    except DesktopAccessResolutionError:
+        observe_desktop_access_decision(outcome="resolution_failure")
+        raise
+
+    if funding_status.startup_program_label is not None:
+        observe_desktop_access_decision(outcome="startup_plan")
+        return DesktopAccessDecision(reason=DesktopAccessReason.STARTUP_PLAN)
+    if funding_status.prepaid_credit_state in {PrepaidCreditState.PENDING, PrepaidCreditState.ACTIVE}:
+        observe_desktop_access_decision(outcome="prepaid_credits")
+        return DesktopAccessDecision(reason=DesktopAccessReason.PREPAID_CREDITS)
+
+    observe_desktop_access_decision(outcome="allowed")
+    return DesktopAccessDecision()
 
 
 def has_loops_access(user: User, team: "Team | None" = None) -> bool:
-    """Loops sits behind its own `loops` flag (see docs/LOOPS.md Rollout).
-
-    Independent of `has_tasks_access`: `tasks` gates the Desktop waitlist that user-triggered cloud
-    runs require (see code_access_required_response), while Loops gates on its own flag instead.
-    """
-    return _is_flag_enabled("loops", user, team)
+    return bool(_is_flag_enabled("loops", user, team))

--- a/products/tasks/backend/access.py
+++ b/products/tasks/backend/access.py
@@ -1,10 +1,9 @@
-from typing import TYPE_CHECKING, Any
-
-import posthoganalytics
+from typing import TYPE_CHECKING
 
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.dataclasses import frozen
 from posthog.models.user import User
+from posthog.ph_client import feature_enabled_or_false, get_feature_flag_or_none
 
 from products.tasks.backend.facade.contracts import DesktopAccessReason
 from products.tasks.backend.metrics import observe_desktop_access_decision
@@ -36,36 +35,6 @@ class DesktopAccessDecision:
         return self.reason is None
 
 
-def _is_flag_enabled(
-    flag_key: str,
-    user: User,
-    team: "Team | None" = None,
-    *,
-    require_boolean: bool = False,
-) -> bool | None:
-    if not user.distinct_id:
-        return None
-    org = team.organization if team is not None else getattr(user, "organization", None)
-    kwargs: dict[str, Any] = {
-        "only_evaluate_locally": False,
-        "send_feature_flag_events": False,
-    }
-    if org is not None:
-        org_id = str(org.id)
-        kwargs["groups"] = {"organization": org_id}
-        kwargs["group_properties"] = {"organization": {"id": org_id}}
-    if require_boolean:
-        result = posthoganalytics.get_feature_flag(flag_key, user.distinct_id, **kwargs)
-        return result if isinstance(result, bool) else None
-
-    result = posthoganalytics.feature_enabled(flag_key, user.distinct_id, **kwargs)
-    return bool(result) if result is not None else None
-
-
-def _is_rollout_enabled(user: User, team: "Team") -> bool | None:
-    return _is_flag_enabled(DESKTOP_ACCESS_GATE_FLAG, user, team)
-
-
 def _get_funding_status(user: User, team: "Team") -> OrganizationFundingStatus:
     try:
         return BillingManager(get_cached_instance_license(), user).get_funding_status(team.organization)
@@ -74,27 +43,34 @@ def _get_funding_status(user: User, team: "Team") -> OrganizationFundingStatus:
 
 
 def get_desktop_access_decision(user: User, team: "Team") -> DesktopAccessDecision:
-    if not user or not user.is_authenticated:
+    if not user or not user.is_authenticated or not user.distinct_id:
         raise DesktopAccessResolutionError("Authentication is required to evaluate Desktop access")
 
-    try:
-        rollout_enabled = _is_rollout_enabled(user, team)
-    except Exception as error:
-        observe_desktop_access_decision(outcome="resolution_failure")
-        raise DesktopAccessResolutionError("Could not evaluate the Desktop access rollout") from error
-
-    if rollout_enabled is None:
+    organization_id = str(team.organization_id)
+    groups = {"organization": organization_id}
+    group_properties = {"organization": {"id": organization_id}}
+    rollout_enabled = get_feature_flag_or_none(
+        DESKTOP_ACCESS_GATE_FLAG,
+        str(user.distinct_id),
+        groups=groups,
+        group_properties=group_properties,
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+    if not isinstance(rollout_enabled, bool):
         observe_desktop_access_decision(outcome="resolution_failure")
         raise DesktopAccessResolutionError("Could not evaluate the Desktop access rollout")
     if not rollout_enabled:
         return DesktopAccessDecision()
 
-    try:
-        override_enabled = _is_flag_enabled(DESKTOP_ACCESS_OVERRIDE_FLAG, user, team, require_boolean=True)
-    except Exception as error:
-        observe_desktop_access_decision(outcome="resolution_failure")
-        raise DesktopAccessResolutionError("Could not evaluate the Desktop access override") from error
-
+    override_enabled = get_feature_flag_or_none(
+        DESKTOP_ACCESS_OVERRIDE_FLAG,
+        str(user.distinct_id),
+        groups=groups,
+        group_properties=group_properties,
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
     if not isinstance(override_enabled, bool):
         observe_desktop_access_decision(outcome="resolution_failure")
         raise DesktopAccessResolutionError("Could not evaluate the Desktop access override")
@@ -120,4 +96,16 @@ def get_desktop_access_decision(user: User, team: "Team") -> DesktopAccessDecisi
 
 
 def has_loops_access(user: User, team: "Team | None" = None) -> bool:
-    return bool(_is_flag_enabled("loops", user, team))
+    if not user.distinct_id:
+        return False
+
+    organization = team.organization if team is not None else getattr(user, "organization", None)
+    organization_id = str(organization.id) if organization is not None else None
+    return feature_enabled_or_false(
+        "loops",
+        str(user.distinct_id),
+        groups={"organization": organization_id} if organization_id is not None else None,
+        group_properties={"organization": {"id": organization_id}} if organization_id is not None else None,
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )

--- a/products/tasks/backend/access.py
+++ b/products/tasks/backend/access.py
@@ -1,12 +1,13 @@
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from posthog.cloud_utils import get_cached_instance_license
-from posthog.dataclasses import frozen
 from posthog.models.user import User
 from posthog.ph_client import feature_enabled_or_false, get_feature_flag_or_none
 
 from products.tasks.backend.facade.contracts import DesktopAccessReason
 from products.tasks.backend.metrics import observe_desktop_access_decision
+from products.tasks.backend.models import CodeInviteRedemption
 
 from ee.billing.billing_manager import (
     BillingManager,
@@ -27,13 +28,41 @@ class DesktopAccessResolutionError(Exception):
     pass
 
 
-@frozen
-class DesktopAccessDecision:
-    reason: DesktopAccessReason | None = None
+class DesktopAccessDecision(StrEnum):
+    ALLOWED = "allowed"
+    LEGACY_ACCESS_REQUIRED = "legacy_access_required"
+    STARTUP_PLAN = "startup_plan"
+    PREPAID_CREDITS = "prepaid_credits"
 
     @property
     def allowed(self) -> bool:
-        return self.reason is None
+        return self == self.ALLOWED
+
+    @property
+    def reason(self) -> DesktopAccessReason | None:
+        if self == self.STARTUP_PLAN:
+            return DesktopAccessReason.STARTUP_PLAN
+        if self == self.PREPAID_CREDITS:
+            return DesktopAccessReason.PREPAID_CREDITS
+        return None
+
+
+def has_tasks_access(user: User) -> bool:
+    if not user or not user.is_authenticated or not user.distinct_id:
+        return False
+
+    organization = getattr(user, "organization", None)
+    organization_id = str(organization.id) if organization is not None else None
+    if feature_enabled_or_false(
+        "tasks",
+        str(user.distinct_id),
+        groups={"organization": organization_id} if organization_id is not None else None,
+        group_properties={"organization": {"id": organization_id}} if organization_id is not None else None,
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    ):
+        return True
+    return CodeInviteRedemption.objects.filter(user=user).exists()
 
 
 def _get_funding_status(user: User, organization: "Organization") -> OrganizationFundingStatus:
@@ -62,7 +91,16 @@ def get_desktop_access_decision(user: User, organization: "Organization") -> Des
         observe_desktop_access_decision(outcome="resolution_failure")
         raise DesktopAccessResolutionError("Could not evaluate the Desktop access rollout")
     if not rollout_enabled:
-        return DesktopAccessDecision()
+        try:
+            legacy_access_allowed = has_tasks_access(user)
+        except Exception as error:
+            observe_desktop_access_decision(outcome="resolution_failure")
+            raise DesktopAccessResolutionError("Could not evaluate legacy Desktop access") from error
+        if legacy_access_allowed:
+            observe_desktop_access_decision(outcome="legacy_allowed")
+            return DesktopAccessDecision.ALLOWED
+        observe_desktop_access_decision(outcome="legacy_denied")
+        return DesktopAccessDecision.LEGACY_ACCESS_REQUIRED
 
     override_enabled = get_feature_flag_or_none(
         DESKTOP_ACCESS_OVERRIDE_FLAG,
@@ -77,7 +115,7 @@ def get_desktop_access_decision(user: User, organization: "Organization") -> Des
         raise DesktopAccessResolutionError("Could not evaluate the Desktop access override")
     if override_enabled:
         observe_desktop_access_decision(outcome="override")
-        return DesktopAccessDecision()
+        return DesktopAccessDecision.ALLOWED
 
     try:
         funding_status = _get_funding_status(user, organization)
@@ -87,13 +125,13 @@ def get_desktop_access_decision(user: User, organization: "Organization") -> Des
 
     if funding_status.startup_program_label is not None:
         observe_desktop_access_decision(outcome="startup_plan")
-        return DesktopAccessDecision(reason=DesktopAccessReason.STARTUP_PLAN)
+        return DesktopAccessDecision.STARTUP_PLAN
     if funding_status.prepaid_credit_state in {PrepaidCreditState.PENDING, PrepaidCreditState.ACTIVE}:
         observe_desktop_access_decision(outcome="prepaid_credits")
-        return DesktopAccessDecision(reason=DesktopAccessReason.PREPAID_CREDITS)
+        return DesktopAccessDecision.PREPAID_CREDITS
 
     observe_desktop_access_decision(outcome="allowed")
-    return DesktopAccessDecision()
+    return DesktopAccessDecision.ALLOWED
 
 
 def has_loops_access(user: User, team: "Team | None" = None) -> bool:

--- a/products/tasks/backend/access.py
+++ b/products/tasks/backend/access.py
@@ -16,6 +16,7 @@ from ee.billing.billing_manager import (
 )
 
 if TYPE_CHECKING:
+    from posthog.models.organization import Organization
     from posthog.models.team.team import Team
 
 DESKTOP_ACCESS_GATE_FLAG = "posthog-desktop-access-gate"
@@ -35,18 +36,18 @@ class DesktopAccessDecision:
         return self.reason is None
 
 
-def _get_funding_status(user: User, team: "Team") -> OrganizationFundingStatus:
+def _get_funding_status(user: User, organization: "Organization") -> OrganizationFundingStatus:
     try:
-        return BillingManager(get_cached_instance_license(), user).get_funding_status(team.organization)
+        return BillingManager(get_cached_instance_license(), user).get_funding_status(organization)
     except FundingStatusUnavailable as error:
         raise DesktopAccessResolutionError("Could not resolve organization funding status") from error
 
 
-def get_desktop_access_decision(user: User, team: "Team") -> DesktopAccessDecision:
+def get_desktop_access_decision(user: User, organization: "Organization") -> DesktopAccessDecision:
     if not user or not user.is_authenticated or not user.distinct_id:
         raise DesktopAccessResolutionError("Authentication is required to evaluate Desktop access")
 
-    organization_id = str(team.organization_id)
+    organization_id = str(organization.id)
     groups = {"organization": organization_id}
     group_properties = {"organization": {"id": organization_id}}
     rollout_enabled = get_feature_flag_or_none(
@@ -79,7 +80,7 @@ def get_desktop_access_decision(user: User, team: "Team") -> DesktopAccessDecisi
         return DesktopAccessDecision()
 
     try:
-        funding_status = _get_funding_status(user, team)
+        funding_status = _get_funding_status(user, organization)
     except DesktopAccessResolutionError:
         observe_desktop_access_decision(outcome="resolution_failure")
         raise

--- a/products/tasks/backend/facade/access.py
+++ b/products/tasks/backend/facade/access.py
@@ -1,15 +1,10 @@
-"""
-Facade re-exports for tasks access / usage gating.
-
-``has_tasks_access`` reports Desktop waitlist access (the `tasks` flag or a redeemed invite).
-``has_loops_access`` gates Loops on its own `loops` flag (see docs/LOOPS.md Rollout).
-``code_access_required_response`` provides the HTTP-layer 403 that gates user-triggered cloud
-execution on Desktop access; ``usage_limit_response`` provides the HTTP-layer 429 that meters
-cloud execution paths. Presentation imports them from here rather than reaching the internal
-``access`` / ``logic.services.code_usage_gate`` modules directly.
-"""
-
-from products.tasks.backend.access import has_loops_access, has_tasks_access
+from products.tasks.backend.access import (
+    DesktopAccessDecision,
+    DesktopAccessResolutionError,
+    get_desktop_access_decision,
+    has_loops_access,
+)
+from products.tasks.backend.facade.contracts import DesktopAccessReason
 from products.tasks.backend.logic.services.code_usage_gate import (
     code_access_required_response,
     compute_quota_limit_response,
@@ -17,9 +12,12 @@ from products.tasks.backend.logic.services.code_usage_gate import (
 )
 
 __all__ = [
+    "DesktopAccessDecision",
+    "DesktopAccessReason",
+    "DesktopAccessResolutionError",
     "code_access_required_response",
     "compute_quota_limit_response",
+    "get_desktop_access_decision",
     "has_loops_access",
-    "has_tasks_access",
     "usage_limit_response",
 ]

--- a/products/tasks/backend/facade/access.py
+++ b/products/tasks/backend/facade/access.py
@@ -3,6 +3,7 @@ from products.tasks.backend.access import (
     DesktopAccessResolutionError,
     get_desktop_access_decision,
     has_loops_access,
+    has_tasks_access,
 )
 from products.tasks.backend.facade.contracts import DesktopAccessReason
 from products.tasks.backend.logic.services.code_usage_gate import (
@@ -19,5 +20,6 @@ __all__ = [
     "compute_quota_limit_response",
     "get_desktop_access_decision",
     "has_loops_access",
+    "has_tasks_access",
     "usage_limit_response",
 ]

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -16,11 +16,20 @@ their data results.
 """
 
 from datetime import datetime
+from enum import StrEnum
 from typing import Literal
 from uuid import UUID
 
 from pydantic import Field
 from pydantic.dataclasses import dataclass
+
+
+class DesktopAccessReason(StrEnum):
+    STARTUP_PLAN = "startup_plan"
+    PREPAID_CREDITS = "prepaid_credits"
+
+
+DESKTOP_ACCESS_REASON_SCHEMA_VALUES = [*(reason.value for reason in DesktopAccessReason), None]
 
 
 @dataclass(frozen=True)

--- a/products/tasks/backend/logic/services/code_usage_gate.py
+++ b/products/tasks/backend/logic/services/code_usage_gate.py
@@ -1,6 +1,7 @@
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID
 
 from django.conf import settings
 
@@ -9,12 +10,13 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.auth import OAuthAccessTokenAuthentication
 from posthog.models import OAuthAccessToken
 from posthog.permissions import get_authenticator_scopes
 
 if TYPE_CHECKING:
     from posthog.models import Organization, User
-from posthog.temporal.oauth import create_oauth_access_token_for_user
+from posthog.temporal.oauth import SANDBOX_OAUTH_APP_CLIENT_IDS, create_oauth_access_token_for_user
 from posthog.utils import get_instance_region
 
 from products.tasks.backend.access import DesktopAccessResolutionError, get_desktop_access_decision
@@ -171,9 +173,30 @@ def compute_quota_limit_response(reason: str = COMPUTE_QUOTA_DENIAL_CODE) -> Res
     )
 
 
-def code_access_required_response(request: Request, organization: "Organization") -> Response | None:
-    authenticator_scopes = get_authenticator_scopes(getattr(request, "successful_authenticator", None)) or []
-    if "internal_run:read" in authenticator_scopes:
+def _task_bound_internal_run(request: Request, task_id: str | UUID | None) -> bool:
+    authenticator = getattr(request, "successful_authenticator", None)
+    authenticator_scopes = get_authenticator_scopes(authenticator) or []
+    if "internal_run:read" not in authenticator_scopes or task_id is None:
+        return False
+    if not isinstance(authenticator, OAuthAccessTokenAuthentication):
+        return False
+
+    access_token = authenticator.access_token
+    application = access_token.application
+    if application is None or application.client_id not in SANDBOX_OAUTH_APP_CLIENT_IDS:
+        return False
+
+    try:
+        parsed_task_id = UUID(str(task_id))
+    except ValueError:
+        return False
+    return access_token.sandbox_task_id == parsed_task_id
+
+
+def code_access_required_response(
+    request: Request, organization: "Organization", *, task_id: str | UUID | None = None
+) -> Response | None:
+    if _task_bound_internal_run(request, task_id):
         return None
 
     try:

--- a/products/tasks/backend/logic/services/code_usage_gate.py
+++ b/products/tasks/backend/logic/services/code_usage_gate.py
@@ -13,7 +13,7 @@ from posthog.models import OAuthAccessToken
 from posthog.permissions import get_authenticator_scopes
 
 if TYPE_CHECKING:
-    from posthog.models import Team, User
+    from posthog.models import Organization, User
 from posthog.temporal.oauth import create_oauth_access_token_for_user
 from posthog.utils import get_instance_region
 
@@ -171,15 +171,15 @@ def compute_quota_limit_response(reason: str = COMPUTE_QUOTA_DENIAL_CODE) -> Res
     )
 
 
-def code_access_required_response(request: Request, team: "Team") -> Response | None:
+def code_access_required_response(request: Request, organization: "Organization") -> Response | None:
     authenticator_scopes = get_authenticator_scopes(getattr(request, "successful_authenticator", None)) or []
     if "internal_run:read" in authenticator_scopes:
         return None
 
     try:
-        decision = get_desktop_access_decision(cast("User", request.user), team)
+        decision = get_desktop_access_decision(cast("User", request.user), organization)
     except DesktopAccessResolutionError:
-        logger.warning("desktop_access_resolution_failed", extra={"team_id": team.id})
+        logger.warning("desktop_access_resolution_failed", extra={"organization_id": organization.id})
         return Response(
             TaskRunErrorResponseSerializer(
                 {

--- a/products/tasks/backend/logic/services/code_usage_gate.py
+++ b/products/tasks/backend/logic/services/code_usage_gate.py
@@ -1,21 +1,24 @@
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from django.conf import settings
 
 import requests
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.models import OAuthAccessToken
+from posthog.permissions import get_authenticator_scopes
 
 if TYPE_CHECKING:
-    from posthog.models import User
+    from posthog.models import Team, User
 from posthog.temporal.oauth import create_oauth_access_token_for_user
 from posthog.utils import get_instance_region
 
-from products.tasks.backend.access import has_tasks_access
+from products.tasks.backend.access import DesktopAccessResolutionError, get_desktop_access_decision
+from products.tasks.backend.facade.contracts import DesktopAccessReason
 from products.tasks.backend.logic.services.compute_quota import (
     COMPUTE_QUOTA_DENIAL_CODE,
     ORGANIZATION_DEACTIVATED_DENIAL_CODE,
@@ -168,25 +171,52 @@ def compute_quota_limit_response(reason: str = COMPUTE_QUOTA_DENIAL_CODE) -> Res
     )
 
 
-def code_access_required_response(user: "User") -> Response | None:
-    """Return a 403 when the user lacks PostHog Desktop access, else None.
-
-    The entitlement gate for user-triggered cloud execution: usage-based billing alone
-    doesn't control cost for credit-funded teams (startup-program credits cover the meter),
-    so cloud runs additionally require the Desktop waitlist (the `tasks` flag or a redeemed
-    invite). Endpoints serving generally-available Inbox surfaces skip this for tasks whose
-    Inbox entitlement is server-verifiable — see ``task_exempt_from_code_access``.
-    """
-    if has_tasks_access(user):
+def code_access_required_response(request: Request, team: "Team") -> Response | None:
+    authenticator_scopes = get_authenticator_scopes(getattr(request, "successful_authenticator", None)) or []
+    if "internal_run:read" in authenticator_scopes:
         return None
+
+    try:
+        decision = get_desktop_access_decision(cast("User", request.user), team)
+    except DesktopAccessResolutionError:
+        logger.warning("desktop_access_resolution_failed", extra={"team_id": team.id})
+        return Response(
+            TaskRunErrorResponseSerializer(
+                {
+                    "type": "service_unavailable",
+                    "code": "desktop_access_unavailable",
+                    "error": "We couldn't verify PostHog Desktop access. Try again.",
+                }
+            ).data,
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if decision.allowed:
+        return None
+
+    messages = {
+        DesktopAccessReason.STARTUP_PLAN: (
+            "PostHog Desktop isn't available for Startup or YC program organizations. "
+            "Select another organization to continue."
+        ),
+        DesktopAccessReason.PREPAID_CREDITS: (
+            "PostHog Desktop isn't available while this organization has prepaid credits. "
+            "Select another organization to continue."
+        ),
+    }
+    reason = decision.reason
+    error_message = (
+        messages[reason] if reason is not None else "PostHog Desktop access is required to run tasks in the cloud."
+    )
+    payload: dict[str, Any] = {
+        "type": "permission_denied",
+        "code": "code_access_required",
+        "error": error_message,
+    }
+    if reason is not None:
+        payload["reason"] = reason.value
     return Response(
-        TaskRunErrorResponseSerializer(
-            {
-                "type": "permission_denied",
-                "code": "code_access_required",
-                "error": "PostHog Desktop access is required to run tasks in the cloud.",
-            }
-        ).data,
+        TaskRunErrorResponseSerializer(payload).data,
         status=status.HTTP_403_FORBIDDEN,
     )
 

--- a/products/tasks/backend/logic/services/code_usage_gate.py
+++ b/products/tasks/backend/logic/services/code_usage_gate.py
@@ -194,7 +194,11 @@ def _task_bound_internal_run(request: Request, task_id: str | UUID | None) -> bo
 
 
 def code_access_required_response(
-    request: Request, organization: "Organization", *, task_id: str | UUID | None = None
+    request: Request,
+    organization: "Organization",
+    *,
+    task_id: str | UUID | None = None,
+    fail_open_on_resolution_error: bool = False,
 ) -> Response | None:
     if _task_bound_internal_run(request, task_id):
         return None
@@ -202,7 +206,12 @@ def code_access_required_response(
     try:
         decision = get_desktop_access_decision(cast("User", request.user), organization)
     except DesktopAccessResolutionError:
-        logger.warning("desktop_access_resolution_failed", extra={"organization_id": organization.id})
+        logger.warning(
+            "desktop_access_resolution_failed",
+            extra={"organization_id": organization.id, "fail_open": fail_open_on_resolution_error},
+        )
+        if fail_open_on_resolution_error:
+            return None
         return Response(
             TaskRunErrorResponseSerializer(
                 {

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -255,7 +255,15 @@ LOOP_AUTO_PAUSED_TOTAL = Counter(
 
 CodeUsageGateOutcome = Literal["checked_allowed", "checked_blocked", "fail_open", "org_deactivated"]
 ComputeQuotaOutcome = Literal["checked_allowed", "checked_blocked", "fail_open"]
-DesktopAccessOutcome = Literal["allowed", "startup_plan", "prepaid_credits", "override", "resolution_failure"]
+DesktopAccessOutcome = Literal[
+    "allowed",
+    "legacy_allowed",
+    "legacy_denied",
+    "startup_plan",
+    "prepaid_credits",
+    "override",
+    "resolution_failure",
+]
 
 # outcome: checked_allowed/checked_blocked when the LLM gateway answered the usage check,
 # fail_open when a gateway/token error let the run proceed unchecked (see LOOPS.md Security:

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -255,6 +255,7 @@ LOOP_AUTO_PAUSED_TOTAL = Counter(
 
 CodeUsageGateOutcome = Literal["checked_allowed", "checked_blocked", "fail_open", "org_deactivated"]
 ComputeQuotaOutcome = Literal["checked_allowed", "checked_blocked", "fail_open"]
+DesktopAccessOutcome = Literal["allowed", "startup_plan", "prepaid_credits", "override", "resolution_failure"]
 
 # outcome: checked_allowed/checked_blocked when the LLM gateway answered the usage check,
 # fail_open when a gateway/token error let the run proceed unchecked (see LOOPS.md Security:
@@ -269,6 +270,12 @@ CODE_USAGE_GATE_CHECK_TOTAL = Counter(
 COMPUTE_QUOTA_CHECK_TOTAL = Counter(
     "posthog_tasks_compute_quota_check_total",
     "Compute quota-check outcomes for billable PostHog Desktop runs",
+    labelnames=["outcome"],
+)
+
+DESKTOP_ACCESS_DECISIONS_TOTAL = Counter(
+    "posthog_tasks_desktop_access_decisions_total",
+    "PostHog Desktop access decisions by bounded outcome",
     labelnames=["outcome"],
 )
 
@@ -533,3 +540,7 @@ def observe_loop_auto_paused() -> None:
 
 def observe_code_usage_gate_check(*, outcome: CodeUsageGateOutcome) -> None:
     CODE_USAGE_GATE_CHECK_TOTAL.labels(outcome=outcome).inc()
+
+
+def observe_desktop_access_decision(*, outcome: DesktopAccessOutcome) -> None:
+    DESKTOP_ACCESS_DECISIONS_TOTAL.labels(outcome=outcome).inc()

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1039,7 +1039,7 @@ class Task(DeletedMetaFields, models.Model):
         title: str,
         description: str,
         origin_product: "Task.OriginProduct",
-        user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
+        user_id: int,
         repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
         channel: Channel | None = None,
         create_pr: bool = True,

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -922,12 +922,7 @@ class DesktopAccessResponseSerializer(serializers.Serializer):
 
 
 class LegacyDesktopAccessResponseSerializer(serializers.Serializer):
-    has_access = serializers.BooleanField(help_text="Whether the selected project can use PostHog Desktop.")
-    reason = serializers.ChoiceField(
-        choices=DESKTOP_ACCESS_REASON_CHOICES,
-        allow_null=True,
-        help_text="Why Desktop access is blocked, or null when access is allowed.",
-    )
+    has_access = serializers.BooleanField(help_text="Whether the user has legacy PostHog Desktop access.")
     has_loops_access = serializers.BooleanField(help_text="Whether the independent Loops feature is enabled.")
 
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -26,6 +26,7 @@ from products.tasks.backend.facade.contracts import (
     ChannelDTO,
     ChannelFeedMessageDTO,
     ChannelInstructionsDTO,
+    DesktopAccessReason,
     SandboxCustomImageDTO,
     SandboxEnvironmentDTO,
     SlackThreadReferenceDTO,
@@ -908,11 +909,38 @@ class TaskRunSetOutputRequestSerializer(serializers.Serializer):
     )
 
 
+DESKTOP_ACCESS_REASON_CHOICES = [reason.value for reason in DesktopAccessReason]
+
+
+class DesktopAccessResponseSerializer(serializers.Serializer):
+    allowed = serializers.BooleanField(help_text="Whether the selected project can use PostHog Desktop.")
+    reason = serializers.ChoiceField(
+        choices=DESKTOP_ACCESS_REASON_CHOICES,
+        allow_null=True,
+        help_text="Why Desktop access is blocked, or null when access is allowed.",
+    )
+
+
+class LegacyDesktopAccessResponseSerializer(serializers.Serializer):
+    has_access = serializers.BooleanField(help_text="Whether the selected project can use PostHog Desktop.")
+    reason = serializers.ChoiceField(
+        choices=DESKTOP_ACCESS_REASON_CHOICES,
+        allow_null=True,
+        help_text="Why Desktop access is blocked, or null when access is allowed.",
+    )
+    has_loops_access = serializers.BooleanField(help_text="Whether the independent Loops feature is enabled.")
+
+
 class TaskRunErrorResponseSerializer(serializers.Serializer):
     detail = serializers.CharField(required=False, help_text="Human-readable validation error")
     error = serializers.CharField(required=False, help_text="Human-readable error message")
     type = serializers.CharField(required=False, help_text="Machine-readable error type")
     code = serializers.CharField(required=False, help_text="Machine-readable error code")
+    reason = serializers.ChoiceField(
+        choices=DESKTOP_ACCESS_REASON_CHOICES,
+        required=False,
+        help_text="Why PostHog Desktop access was denied, when applicable.",
+    )
     attr = serializers.CharField(required=False, help_text="Request field associated with the error")
     missing_artifact_ids = serializers.ListField(
         child=serializers.CharField(),

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -3494,7 +3494,7 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
 
 @extend_schema(tags=["code-invites"])
 class CodeInviteViewSet(viewsets.ViewSet):
-    """Compatibility API for released clients that still send Desktop invite codes."""
+    """API for redeeming PostHog Desktop invite codes."""
 
     authentication_classes = [
         SessionAuthentication,
@@ -3523,8 +3523,8 @@ class CodeInviteViewSet(viewsets.ViewSet):
                 description="Invalid or expired invite code",
             ),
         },
-        summary="Redeem legacy invite code",
-        description="Record a legacy PostHog Desktop invite-code redemption. Redemptions no longer grant access.",
+        summary="Redeem invite code",
+        description="Redeem a PostHog Desktop invite code to enable legacy access.",
     )
     @action(detail=False, methods=["post"], url_path="redeem")
     def redeem(self, request, **kwargs):
@@ -3544,49 +3544,17 @@ class CodeInviteViewSet(viewsets.ViewSet):
         return Response({"success": True})
 
     @extend_schema(
-        responses={
-            200: OpenApiResponse(response=LegacyDesktopAccessResponseSerializer),
-            503: OpenApiResponse(response=TaskRunErrorResponseSerializer),
-        },
+        responses={200: OpenApiResponse(response=LegacyDesktopAccessResponseSerializer)},
         summary="Check access",
-        description="Check whether the authenticated user's selected project can use PostHog Desktop and Loops.",
+        description="Check whether the authenticated user has legacy PostHog Desktop access and Loops access.",
     )
     @action(detail=False, methods=["get"], url_path="check-access")
     def check_access(self, request, **kwargs):
-        team = getattr(request.user, "team", None)
-        if team is None:
-            return Response(
-                TaskRunErrorResponseSerializer(
-                    {
-                        "type": "service_unavailable",
-                        "code": "desktop_access_unavailable",
-                        "error": "We couldn't verify PostHog Desktop access. Try again.",
-                    }
-                ).data,
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
-
-        try:
-            decision = tasks_access.get_desktop_access_decision(request.user, team.organization)
-        except tasks_access.DesktopAccessResolutionError:
-            return Response(
-                TaskRunErrorResponseSerializer(
-                    {
-                        "type": "service_unavailable",
-                        "code": "desktop_access_unavailable",
-                        "error": "We couldn't verify PostHog Desktop access. Try again.",
-                    }
-                ).data,
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
-
-        reason = decision.reason.value if decision.reason is not None else None
         return Response(
             LegacyDesktopAccessResponseSerializer(
                 {
-                    "reason": reason,
-                    "has_access": decision.allowed,
-                    "has_loops_access": tasks_access.has_loops_access(request.user, team),
+                    "has_access": tasks_access.has_tasks_access(request.user),
+                    "has_loops_access": tasks_access.has_loops_access(request.user),
                 }
             ).data
         )

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2537,10 +2537,15 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 return limit_response
 
         if method in {"user_message", "permission_response", "mcp_response"}:
-            # Inbox discussion tasks are server-verifiable policy exemptions. Every other command
-            # that starts or resumes model work follows the same Desktop policy as TaskViewSet.run.
+            # Inbox discussion tasks are server-verifiable policy exemptions. Permission responses
+            # preserve an active sandbox during resolution failures, but known denials still block.
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request, self.organization, task_id=task_id)
+                access_response := code_access_required_response(
+                    request,
+                    self.organization,
+                    task_id=task_id,
+                    fail_open_on_resolution_error=method == "permission_response",
+                )
             ):
                 return access_response
 
@@ -2621,7 +2626,14 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     "get_state",
                 }
                 and not tasks_facade.task_exempt_from_code_access(task_id, self.team_id)
-                and (access_response := code_access_required_response(request, self.organization, task_id=task_id))
+                and (
+                    access_response := code_access_required_response(
+                        request,
+                        self.organization,
+                        task_id=task_id,
+                        fail_open_on_resolution_error=inner_type in {"permission_response", "mcp_permission_response"},
+                    )
+                )
             ):
                 return access_response
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -99,6 +99,7 @@ from products.tasks.backend.facade.streams import (
 from products.tasks.backend.presentation.serializers import (
     CodeInviteRedeemRequestSerializer,
     ConnectionTokenResponseSerializer,
+    LegacyDesktopAccessResponseSerializer,
     ModelCatalogueResponseSerializer,
     PinnedTaskIdsResponseSerializer,
     RepositoryReadinessQuerySerializer,
@@ -550,6 +551,14 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         request=TaskCreateSerializer,
         responses={
             201: TaskSerializer,
+            403: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access is required to activate a pre-warmed cloud run",
+            ),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer,
                 description=(
@@ -561,6 +570,14 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     def create(self, request, **kwargs):
         serializer = self._write_serializer(request.data, serializer_class=TaskCreateSerializer)
+        can_activate_warm_run = (
+            serializer.validated_data.get("origin_product", tasks_facade.TaskOriginProduct.USER_CREATED)
+            == tasks_facade.TaskOriginProduct.USER_CREATED
+            and "branch" in serializer.validated_data
+        )
+        if can_activate_warm_run and (access_response := code_access_required_response(request, self.team)):
+            return access_response
+
         # Read before create_task, which pops the relationship out of the dict it's handed.
         relationship = serializer.validated_data.get("signal_report_task_relationship")
         from products.signals.backend.facade.api import (  # noqa: PLC0415 — keeps the signals stack off this module's import path
@@ -996,6 +1013,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 description="PostHog Desktop access is required, or Pi cloud runtime is disabled",
             ),
             404: OpenApiResponse(description="Task not found"),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer,
                 description=(
@@ -1021,10 +1042,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return _pi_cloud_runtime_disabled_response()
 
         # The generally-available Inbox runs tasks through this endpoint too (report "Create PR" /
-        # "Discuss", scout chat), so the Desktop waitlist gate applies only to tasks whose Inbox
-        # entitlement the server can't verify — see task_exempt_from_code_access.
+        # "Discuss", scout chat), so the Desktop policy applies only to tasks whose Inbox
+        # entitlement the server can't verify. See task_exempt_from_code_access.
         if not tasks_facade.task_exempt_from_code_access(pk, self.team_id) and (
-            access_response := code_access_required_response(request.user)
+            access_response := code_access_required_response(request, self.team)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -1079,6 +1100,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
             ),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
         },
         summary="Warm a task sandbox",
         description=(
@@ -1097,7 +1122,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return Response(status=status.HTTP_200_OK)
 
         # Warming is a Desktop-composer feature with no Inbox caller, so no exemption applies.
-        if access_response := code_access_required_response(request.user):
+        if access_response := code_access_required_response(request, self.team):
             return access_response
 
         user_id = self._user_id()
@@ -1345,6 +1370,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
             ),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
         },
         summary="Create task run",
         description="Create a new run for a specific task without starting execution.",
@@ -1361,7 +1390,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             ) == tasks_facade.TaskRuntime.PI and not tasks_facade.pi_cloud_runtime_enabled(self.team, request.user):
                 return _pi_cloud_runtime_disabled_response()
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request.user)
+                access_response := code_access_required_response(request, self.team)
             ):
                 return access_response
             if limit_response := usage_limit_response(request.user, self.team_id):
@@ -1388,6 +1417,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             404: OpenApiResponse(description="Task run not found"),
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
+            ),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
             ),
         },
         summary="Start task run",
@@ -1423,7 +1456,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         # Backstop: don't launch the cloud workflow without Desktop access or for an over-limit team.
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request.user)
+            access_response := code_access_required_response(request, self.team)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -2377,6 +2410,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 response=TaskRunErrorResponseSerializer, description="PostHog Desktop access is required"
             ),
             404: OpenApiResponse(description="Task run not found"),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer,
                 description="Organization reached its PostHog Desktop usage limit",
@@ -2394,7 +2431,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def connection_token(self, request, pk=None, **kwargs):
         task_id = self._ensure_task_accessible()
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request.user)
+            access_response := code_access_required_response(request, self.team)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -2457,6 +2494,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 description="Organization reached its PostHog Desktop usage limit",
             ),
             502: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Agent server unreachable"),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
         },
         summary="Send command to task run",
         description="Queue user_message JSON-RPC commands through the task workflow and forward sandbox control "
@@ -2510,15 +2551,15 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             if limit_response := usage_limit_response(request.user, self.team_id):
                 return limit_response
 
-        if method == "user_message":
-            # The Inbox starts interactive runs and drops the user straight into this composer,
-            # so "Discuss" and scout chat replies must not require Desktop access. Their tasks
-            # are server-verifiable Inbox shapes (task_exempt_from_code_access); everything else
-            # is a Desktop conversation and follows the same gate as TaskViewSet.run.
+        if method in {"user_message", "permission_response", "mcp_response"}:
+            # Inbox discussion tasks are server-verifiable policy exemptions. Every other command
+            # that starts or resumes model work follows the same Desktop policy as TaskViewSet.run.
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request.user)
+                access_response := code_access_required_response(request, self.team)
             ):
                 return access_response
+
+        if method == "user_message":
             command_params = dict(params or {})
             artifact_ids = command_params.pop("artifact_ids", [])
             if artifact_ids:
@@ -2593,11 +2634,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     "get_entries",
                     "get_session_stats",
                     "get_state",
-                    "mcp_permission_response",
-                    "permission_response",
                 }
                 and not tasks_facade.task_exempt_from_code_access(task_id, self.team_id)
-                and (access_response := code_access_required_response(request.user))
+                and (access_response := code_access_required_response(request, self.team))
             ):
                 return access_response
 
@@ -2870,6 +2909,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
             ),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer,
+                description="PostHog Desktop access could not be verified",
+            ),
         },
         summary="Resume task run in cloud",
         description="Resume an existing task run in a cloud sandbox. Terminates any existing workflow and starts a new one.",
@@ -2891,7 +2934,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         # Resume also runs in cloud: gate before handoff.
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request.user)
+            access_response := code_access_required_response(request, self.team)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -3466,7 +3509,7 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
 
 @extend_schema(tags=["code-invites"])
 class CodeInviteViewSet(viewsets.ViewSet):
-    """API for redeeming PostHog Desktop invite codes."""
+    """Compatibility API for released clients that still send Desktop invite codes."""
 
     authentication_classes = [
         SessionAuthentication,
@@ -3495,8 +3538,8 @@ class CodeInviteViewSet(viewsets.ViewSet):
                 description="Invalid or expired invite code",
             ),
         },
-        summary="Redeem invite code",
-        description="Redeem a PostHog Desktop invite code to enable access.",
+        summary="Redeem legacy invite code",
+        description="Record a legacy PostHog Desktop invite-code redemption. Redemptions no longer grant access.",
     )
     @action(detail=False, methods=["post"], url_path="redeem")
     def redeem(self, request, **kwargs):
@@ -3517,18 +3560,50 @@ class CodeInviteViewSet(viewsets.ViewSet):
 
     @extend_schema(
         responses={
-            200: OpenApiResponse(description="Access check result"),
+            200: OpenApiResponse(response=LegacyDesktopAccessResponseSerializer),
+            503: OpenApiResponse(response=TaskRunErrorResponseSerializer),
         },
         summary="Check access",
-        description="Check whether the authenticated user has access to PostHog Desktop and to Loops.",
+        description="Check whether the authenticated user's selected project can use PostHog Desktop and Loops.",
     )
     @action(detail=False, methods=["get"], url_path="check-access")
     def check_access(self, request, **kwargs):
+        team = getattr(request.user, "team", None)
+        if team is None:
+            return Response(
+                TaskRunErrorResponseSerializer(
+                    {
+                        "type": "service_unavailable",
+                        "code": "desktop_access_unavailable",
+                        "error": "We couldn't verify PostHog Desktop access. Try again.",
+                    }
+                ).data,
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        try:
+            decision = tasks_access.get_desktop_access_decision(request.user, team)
+        except tasks_access.DesktopAccessResolutionError:
+            return Response(
+                TaskRunErrorResponseSerializer(
+                    {
+                        "type": "service_unavailable",
+                        "code": "desktop_access_unavailable",
+                        "error": "We couldn't verify PostHog Desktop access. Try again.",
+                    }
+                ).data,
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        reason = decision.reason.value if decision.reason is not None else None
         return Response(
-            {
-                "has_access": tasks_access.has_tasks_access(request.user),
-                "has_loops_access": tasks_access.has_loops_access(request.user),
-            }
+            LegacyDesktopAccessResponseSerializer(
+                {
+                    "reason": reason,
+                    "has_access": decision.allowed,
+                    "has_loops_access": tasks_access.has_loops_access(request.user, team),
+                }
+            ).data
         )
 
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -551,14 +551,6 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         request=TaskCreateSerializer,
         responses={
             201: TaskSerializer,
-            403: OpenApiResponse(
-                response=TaskRunErrorResponseSerializer,
-                description="PostHog Desktop access is required to activate a pre-warmed cloud run",
-            ),
-            503: OpenApiResponse(
-                response=TaskRunErrorResponseSerializer,
-                description="PostHog Desktop access could not be verified",
-            ),
             429: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer,
                 description=(
@@ -570,13 +562,6 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     def create(self, request, **kwargs):
         serializer = self._write_serializer(request.data, serializer_class=TaskCreateSerializer)
-        can_activate_warm_run = (
-            serializer.validated_data.get("origin_product", tasks_facade.TaskOriginProduct.USER_CREATED)
-            == tasks_facade.TaskOriginProduct.USER_CREATED
-            and "branch" in serializer.validated_data
-        )
-        if can_activate_warm_run and (access_response := code_access_required_response(request, self.team)):
-            return access_response
 
         # Read before create_task, which pops the relationship out of the dict it's handed.
         relationship = serializer.validated_data.get("signal_report_task_relationship")
@@ -1045,7 +1030,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         # "Discuss", scout chat), so the Desktop policy applies only to tasks whose Inbox
         # entitlement the server can't verify. See task_exempt_from_code_access.
         if not tasks_facade.task_exempt_from_code_access(pk, self.team_id) and (
-            access_response := code_access_required_response(request, self.team)
+            access_response := code_access_required_response(request, self.organization)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -1122,7 +1107,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return Response(status=status.HTTP_200_OK)
 
         # Warming is a Desktop-composer feature with no Inbox caller, so no exemption applies.
-        if access_response := code_access_required_response(request, self.team):
+        if access_response := code_access_required_response(request, self.organization):
             return access_response
 
         user_id = self._user_id()
@@ -1390,7 +1375,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             ) == tasks_facade.TaskRuntime.PI and not tasks_facade.pi_cloud_runtime_enabled(self.team, request.user):
                 return _pi_cloud_runtime_disabled_response()
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request, self.team)
+                access_response := code_access_required_response(request, self.organization)
             ):
                 return access_response
             if limit_response := usage_limit_response(request.user, self.team_id):
@@ -1456,7 +1441,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         # Backstop: don't launch the cloud workflow without Desktop access or for an over-limit team.
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request, self.team)
+            access_response := code_access_required_response(request, self.organization)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -2431,7 +2416,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def connection_token(self, request, pk=None, **kwargs):
         task_id = self._ensure_task_accessible()
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request, self.team)
+            access_response := code_access_required_response(request, self.organization)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -2555,7 +2540,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             # Inbox discussion tasks are server-verifiable policy exemptions. Every other command
             # that starts or resumes model work follows the same Desktop policy as TaskViewSet.run.
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request, self.team)
+                access_response := code_access_required_response(request, self.organization)
             ):
                 return access_response
 
@@ -2636,7 +2621,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     "get_state",
                 }
                 and not tasks_facade.task_exempt_from_code_access(task_id, self.team_id)
-                and (access_response := code_access_required_response(request, self.team))
+                and (access_response := code_access_required_response(request, self.organization))
             ):
                 return access_response
 
@@ -2934,7 +2919,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         # Resume also runs in cloud: gate before handoff.
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request, self.team)
+            access_response := code_access_required_response(request, self.organization)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -3582,7 +3567,7 @@ class CodeInviteViewSet(viewsets.ViewSet):
             )
 
         try:
-            decision = tasks_access.get_desktop_access_decision(request.user, team)
+            decision = tasks_access.get_desktop_access_decision(request.user, team.organization)
         except tasks_access.DesktopAccessResolutionError:
             return Response(
                 TaskRunErrorResponseSerializer(

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1030,7 +1030,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         # "Discuss", scout chat), so the Desktop policy applies only to tasks whose Inbox
         # entitlement the server can't verify. See task_exempt_from_code_access.
         if not tasks_facade.task_exempt_from_code_access(pk, self.team_id) and (
-            access_response := code_access_required_response(request, self.organization)
+            access_response := code_access_required_response(request, self.organization, task_id=pk)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -1375,7 +1375,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             ) == tasks_facade.TaskRuntime.PI and not tasks_facade.pi_cloud_runtime_enabled(self.team, request.user):
                 return _pi_cloud_runtime_disabled_response()
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request, self.organization)
+                access_response := code_access_required_response(request, self.organization, task_id=task_id)
             ):
                 return access_response
             if limit_response := usage_limit_response(request.user, self.team_id):
@@ -1441,7 +1441,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         # Backstop: don't launch the cloud workflow without Desktop access or for an over-limit team.
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request, self.organization)
+            access_response := code_access_required_response(request, self.organization, task_id=task_id)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -2416,7 +2416,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def connection_token(self, request, pk=None, **kwargs):
         task_id = self._ensure_task_accessible()
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request, self.organization)
+            access_response := code_access_required_response(request, self.organization, task_id=task_id)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):
@@ -2540,7 +2540,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             # Inbox discussion tasks are server-verifiable policy exemptions. Every other command
             # that starts or resumes model work follows the same Desktop policy as TaskViewSet.run.
             if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-                access_response := code_access_required_response(request, self.organization)
+                access_response := code_access_required_response(request, self.organization, task_id=task_id)
             ):
                 return access_response
 
@@ -2621,7 +2621,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     "get_state",
                 }
                 and not tasks_facade.task_exempt_from_code_access(task_id, self.team_id)
-                and (access_response := code_access_required_response(request, self.organization))
+                and (access_response := code_access_required_response(request, self.organization, task_id=task_id))
             ):
                 return access_response
 
@@ -2919,7 +2919,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         # Resume also runs in cloud: gate before handoff.
         if not tasks_facade.task_exempt_from_code_access(task_id, self.team_id) and (
-            access_response := code_access_required_response(request, self.organization)
+            access_response := code_access_required_response(request, self.organization, task_id=task_id)
         ):
             return access_response
         if limit_response := usage_limit_response(request.user, self.team_id):

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2531,7 +2531,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         # A side question drives the agent and spends model tokens on the caller's behalf. Unlike
         # user_message below, it has no Inbox surface to exempt, so every caller takes both gates.
         if method == "side_question":
-            if access_response := code_access_required_response(request.user):
+            if access_response := code_access_required_response(request, self.organization):
                 return access_response
             if limit_response := usage_limit_response(request.user, self.team_id):
                 return limit_response

--- a/products/tasks/backend/presentation/views/desktop_access.py
+++ b/products/tasks/backend/presentation/views/desktop_access.py
@@ -43,7 +43,7 @@ class DesktopAccessViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=False, methods=["get"], url_path="access", required_scopes=["llm_gateway:read"])
     def access(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
-            decision = get_desktop_access_decision(cast(User, request.user), self.team)
+            decision = get_desktop_access_decision(cast(User, request.user), self.organization)
         except DesktopAccessResolutionError:
             return Response(
                 TaskRunErrorResponseSerializer(

--- a/products/tasks/backend/presentation/views/desktop_access.py
+++ b/products/tasks/backend/presentation/views/desktop_access.py
@@ -1,0 +1,66 @@
+from typing import Any, cast
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.models import User
+from posthog.permissions import APIScopePermission
+
+from products.tasks.backend.facade.access import DesktopAccessResolutionError, get_desktop_access_decision
+from products.tasks.backend.presentation.serializers import (
+    DesktopAccessResponseSerializer,
+    TaskRunErrorResponseSerializer,
+)
+
+
+@extend_schema(tags=["tasks"])
+class DesktopAccessViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    pagination_class = None
+    serializer_class = DesktopAccessResponseSerializer
+
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(response=DesktopAccessResponseSerializer),
+            503: OpenApiResponse(response=TaskRunErrorResponseSerializer),
+        },
+        summary="Check PostHog Desktop access",
+        description="Evaluate Desktop access for the selected project and organization.",
+    )
+    @action(detail=False, methods=["get"], url_path="access", required_scopes=["llm_gateway:read"])
+    def access(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        try:
+            decision = get_desktop_access_decision(cast(User, request.user), self.team)
+        except DesktopAccessResolutionError:
+            return Response(
+                TaskRunErrorResponseSerializer(
+                    {
+                        "type": "service_unavailable",
+                        "code": "desktop_access_unavailable",
+                        "error": "We couldn't verify PostHog Desktop access. Try again.",
+                    }
+                ).data,
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        return Response(
+            DesktopAccessResponseSerializer(
+                {
+                    "allowed": decision.allowed,
+                    "reason": decision.reason.value if decision.reason is not None else None,
+                }
+            ).data
+        )

--- a/products/tasks/backend/presentation/views/loops.py
+++ b/products/tasks/backend/presentation/views/loops.py
@@ -103,7 +103,7 @@ class LoopTriggerProjectSecretApiKeyTeamSustainedThrottle(ProjectSecretApiKeyTea
 
 
 class HasLoopsAccess(BasePermission):
-    """Gate every Loops endpoint on `has_loops_access` (tasks access plus the `loops` flag).
+    """Gate every Loops endpoint on its independent `loops` flag.
 
     Exempts PSAK-authenticated service calls (`trigger`, and `runs` readback): a PSAK is a
     project-scoped service credential, not a real user, so the person-targeted `loops` flag

--- a/products/tasks/backend/routes.py
+++ b/products/tasks/backend/routes.py
@@ -5,6 +5,7 @@ import products.tasks.backend.presentation.views.loops as loops
 import products.tasks.backend.presentation.views.desktop as desktop
 import products.tasks.backend.presentation.views.seat_api as seats
 import products.tasks.backend.presentation.views.channels_api as channels
+import products.tasks.backend.presentation.views.desktop_access as desktop_access
 import products.tasks.backend.presentation.views.task_usage_api as task_usage
 import products.tasks.backend.presentation.views.sandbox_pricing_api as sandbox_pricing
 
@@ -16,6 +17,7 @@ def register_routes(routers: RouterRegistry) -> None:
         "organization_desktop_beta_terms",
         ["organization_id"],
     )
+    routers.projects.register(r"desktop", desktop_access.DesktopAccessViewSet, "project_desktop", ["team_id"])
     project_tasks_router = routers.projects.register(r"tasks", tasks.TaskViewSet, "project_tasks", ["team_id"])
     project_task_runs_router = project_tasks_router.register(
         r"runs", tasks.TaskRunViewSet, "project_task_runs", ["team_id", "task_id"]

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -197,8 +197,10 @@ class BaseTaskAPITest(TestCase):
 
         self.desktop_access_patcher = patch(
             "products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision",
-            side_effect=lambda *_args, **_kwargs: tasks_access.DesktopAccessDecision(
-                reason=None if self._desktop_access_enabled else tasks_access.DesktopAccessReason.STARTUP_PLAN,
+            side_effect=lambda *_args, **_kwargs: (
+                tasks_access.DesktopAccessDecision.ALLOWED
+                if self._desktop_access_enabled
+                else tasks_access.DesktopAccessDecision.STARTUP_PLAN
             ),
         )
         self.desktop_access_patcher.start()
@@ -12567,9 +12569,7 @@ class TestUsageLimitResponse(TestCase):
 
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision")
     def test_code_access_required_response_is_structured(self, mock_access):
-        mock_access.return_value = tasks_access.DesktopAccessDecision(
-            reason=tasks_access.DesktopAccessReason.STARTUP_PLAN,
-        )
+        mock_access.return_value = tasks_access.DesktopAccessDecision.STARTUP_PLAN
         request = MagicMock()
         request.successful_authenticator = None
         organization = MagicMock(id=1)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -39,7 +39,10 @@ from posthog.utils import absolute_uri
 
 from products.posthog_ai.backend.models.assistant import Conversation
 from products.slack_app.backend.models import SlackThreadTaskMapping
-from products.tasks.backend.facade import api as tasks_facade
+from products.tasks.backend.facade import (
+    access as tasks_access,
+    api as tasks_facade,
+)
 from products.tasks.backend.facade.repo_selection import RepoSelectionResult
 from products.tasks.backend.facade.run_config import TaskArtifactAdapter, TaskArtifactType
 from products.tasks.backend.logic.services.code_usage_gate import (
@@ -71,8 +74,6 @@ from products.tasks.backend.models import (
     TASK_OWNERSHIP_VERSION_STATE_KEY,
     AgentPeerMessage,
     Channel,
-    CodeInvite,
-    CodeInviteRedemption,
     SandboxCustomImage,
     SandboxEnvironment,
     SandboxSession,
@@ -172,6 +173,8 @@ class BaseTaskAPITest(TestCase):
     user: ClassVar[User]
     feature_flag_patcher: MagicMock
     mock_feature_flag: MagicMock
+    desktop_access_patcher: Any
+    _desktop_access_enabled: bool
     client: APIClient
 
     @classmethod
@@ -192,15 +195,24 @@ class BaseTaskAPITest(TestCase):
         # accumulates across tests (APIBaseTest clears it in setUp for the same reason).
         cache.clear()
 
-        # Enable tasks feature flag by default
+        self.desktop_access_patcher = patch(
+            "products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision",
+            side_effect=lambda *_args, **_kwargs: tasks_access.DesktopAccessDecision(
+                reason=None if self._desktop_access_enabled else tasks_access.DesktopAccessReason.STARTUP_PLAN,
+            ),
+        )
+        self.desktop_access_patcher.start()
         self.set_tasks_feature_flag(True)
 
     def tearDown(self):
         if hasattr(self, "feature_flag_patcher"):
             self.feature_flag_patcher.stop()
+        if hasattr(self, "desktop_access_patcher"):
+            self.desktop_access_patcher.stop()
         super().tearDown()
 
     def set_tasks_feature_flag(self, enabled=True):
+        self._desktop_access_enabled = enabled
         if hasattr(self, "feature_flag_patcher"):
             self.feature_flag_patcher.stop()
 
@@ -7834,6 +7846,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         mock_usage.assert_not_called()
 
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
@@ -9253,29 +9266,6 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             level=OrganizationMembership.Level.ADMIN
         )
 
-    def test_check_access_flag_on_no_redemption(self):
-        self.set_tasks_feature_flag(True)
-
-        response = self.client.get("/api/code/invites/check-access/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.json()["has_access"])
-
-    def test_check_access_flag_off_no_redemption(self):
-        self.set_tasks_feature_flag(False)
-
-        response = self.client.get("/api/code/invites/check-access/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.json()["has_access"])
-
-    def test_check_access_flag_off_with_redemption(self):
-        self.set_tasks_feature_flag(False)
-        invite = CodeInvite.objects.create(code="ACCESSCODE", max_redemptions=0, is_active=True)
-        CodeInviteRedemption.objects.create(invite_code=invite, user=self.user)
-
-        response = self.client.get("/api/code/invites/check-access/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.json()["has_access"])
-
     def test_authentication_required(self):
         task = self.create_task()
 
@@ -10243,9 +10233,51 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         mock_signal_followup.assert_not_called()
 
-    @parameterized.expand([("prompt",), ("steer",), ("follow_up",), ("bash",), ("compact",), ("set_model",)])
+    @parameterized.expand(
+        [
+            ("permission_response", {"requestId": "perm-1", "optionId": "allow"}),
+            (
+                "mcp_response",
+                {
+                    "requestId": "relay-1",
+                    "server": "playwright",
+                    "payload": {"jsonrpc": "2.0", "id": 1, "result": {"content": []}},
+                },
+            ),
+        ]
+    )
+    @patch("products.tasks.backend.presentation.views.api.http_requests.post")
+    def test_command_model_resuming_response_requires_code_access(self, method, params, mock_post):
+        self.set_tasks_feature_flag(False)
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {"jsonrpc": "2.0", "method": method, "params": params, "id": "req-1"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
+        mock_post.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("prompt",),
+            ("steer",),
+            ("follow_up",),
+            ("bash",),
+            ("compact",),
+            ("set_model",),
+            ("permission_response",),
+            ("mcp_permission_response",),
+        ]
+    )
     @patch("products.tasks.backend.presentation.views.api.http_requests.post")
     def test_command_pi_rpc_execution_requires_code_access(self, inner_type, mock_post):
         self.set_tasks_feature_flag(False)
@@ -10265,6 +10297,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         mock_post.assert_not_called()
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
@@ -10282,7 +10315,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
                 "jsonrpc": "2.0",
                 "method": "pi/rpc",
                 "id": "c1",
-                "params": {"command": {"id": "c1", "type": "permission_response", "approved": True}},
+                "params": {"command": {"id": "c1", "type": "get_state"}},
             },
             format="json",
         )
@@ -11957,6 +11990,20 @@ class TestCloudUsageGate(BaseTaskAPITest):
             status=status_value,
         )
 
+    def test_cloud_task_create_without_code_access_returns_403_before_warm_activation(self):
+        self.set_tasks_feature_flag(False)
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {"title": "Cloud task", "description": "Run this task", "branch": "main"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
+        self.assertFalse(Task.objects.filter(title="Cloud task").exists())
+
     @patch("products.tasks.backend.facade.api.warm_task_sandbox")
     @patch("products.tasks.backend.presentation.views.api.TaskViewSet._warm_enabled", return_value=True)
     def test_warm_without_code_access_returns_403_before_provisioning(self, _mock_warm_enabled, mock_warm):
@@ -11970,6 +12017,7 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         mock_warm.assert_not_called()
 
     @patch("products.tasks.backend.facade.api.warm_task_sandbox")
@@ -12050,6 +12098,7 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         self.assertFalse(TaskRun.objects.filter(task=task).exists())
         mock_gate.assert_not_called()
         mock_workflow.assert_not_called()
@@ -12072,6 +12121,7 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
@@ -12136,6 +12186,7 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         self.assertFalse(TaskRun.objects.filter(task=task).exists())
         mock_gate.assert_not_called()
 
@@ -12301,6 +12352,7 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
         run.refresh_from_db()
         self.assertEqual(run.status, TaskRun.Status.QUEUED)
 
@@ -12323,6 +12375,7 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json()["code"], "code_access_required")
+        self.assertEqual(response.json()["reason"], "startup_plan")
 
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
     def test_create_local_run_is_not_gated(self, mock_gate):
@@ -12418,9 +12471,9 @@ class TestCloudUsageGate(BaseTaskAPITest):
         self, _name, origin, gate_return, expected_status, mock_gate, _mock_workflow
     ):
         # Inbox tasks (report "Create PR" / "Discuss", scout chat) are entitled through
-        # self-driving, not PostHog Desktop, so they run with the `tasks` flag off — where a
-        # plain task 403s (see test_run_without_code_access_returns_403_before_usage_check).
-        # The usage cost-backstop must still fire on the entitlement-bypassed path.
+        # self-driving, not PostHog Desktop, so they run while the human Desktop policy denies
+        # access. A plain task returns 403 in the same state. The usage cost backstop must still
+        # fire on the entitlement-bypassed path.
         self.set_tasks_feature_flag(False)
         mock_gate.return_value = gate_return
         task = self._inbox_task(origin)
@@ -12526,13 +12579,20 @@ class TestUsageLimitResponse(TestCase):
         self.assertEqual(response.data["code"], "usage_limit_exceeded")
         self.assertEqual(response.data["limit_type"], "burst")
 
-    @patch("products.tasks.backend.logic.services.code_usage_gate.has_tasks_access", return_value=False)
-    def test_code_access_required_response_is_structured(self, _mock_access):
-        response = code_access_required_response(MagicMock())
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision")
+    def test_code_access_required_response_is_structured(self, mock_access):
+        mock_access.return_value = tasks_access.DesktopAccessDecision(
+            reason=tasks_access.DesktopAccessReason.STARTUP_PLAN,
+        )
+        request = MagicMock()
+        request.successful_authenticator = None
+        team = MagicMock(id=1)
+        response = code_access_required_response(request, team)
 
         assert response is not None
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data["code"], "code_access_required")
+        self.assertEqual(response.data["reason"], "startup_plan")
 
 
 def _make_custom_image(*, team: Team, user: User, **kwargs) -> SandboxCustomImage:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -39,6 +39,7 @@ from posthog.utils import absolute_uri
 
 from products.posthog_ai.backend.models.assistant import Conversation
 from products.slack_app.backend.models import SlackThreadTaskMapping
+from products.tasks.backend.access import DesktopAccessResolutionError
 from products.tasks.backend.facade import (
     access as tasks_access,
     api as tasks_facade,
@@ -10267,6 +10268,75 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertEqual(response.json()["code"], "code_access_required")
         self.assertEqual(response.json()["reason"], "startup_plan")
         mock_post.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                "permission_response",
+                Task.Runtime.ACP,
+                "permission_response",
+                {"requestId": "perm-1", "optionId": "allow"},
+                status.HTTP_200_OK,
+            ),
+            (
+                "pi_permission_response",
+                Task.Runtime.PI,
+                "pi/rpc",
+                {"command": {"id": "req-1", "type": "permission_response", "optionId": "allow"}},
+                status.HTTP_200_OK,
+            ),
+            (
+                "mcp_response",
+                Task.Runtime.ACP,
+                "mcp_response",
+                {
+                    "requestId": "relay-1",
+                    "server": "playwright",
+                    "payload": {"jsonrpc": "2.0", "id": 1, "result": {"content": []}},
+                },
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            ),
+            (
+                "pi_prompt",
+                Task.Runtime.PI,
+                "pi/rpc",
+                {"command": {"id": "req-1", "type": "prompt", "message": "continue"}},
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            ),
+        ]
+    )
+    @patch(
+        "products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision",
+        side_effect=DesktopAccessResolutionError("unavailable"),
+    )
+    @patch("products.tasks.backend.presentation.views.api.http_requests.post")
+    def test_command_access_resolution_failure_only_allows_permission_responses(
+        self,
+        _name: str,
+        runtime: Task.Runtime,
+        method: str,
+        params: dict[str, Any],
+        expected_status: int,
+        mock_post: MagicMock,
+        _mock_access: MagicMock,
+    ) -> None:
+        reset_sandbox_jwt_key_cache()
+        self._mock_agent_response(mock_post, {"jsonrpc": "2.0", "id": "req-1", "result": {"accepted": True}})
+        task = self.create_task(runtime=runtime)
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {"jsonrpc": "2.0", "method": method, "params": params, "id": "req-1"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, expected_status)
+        if expected_status == status.HTTP_200_OK:
+            mock_post.assert_called_once()
+        else:
+            self.assertEqual(response.json()["code"], "desktop_access_unavailable")
+            mock_post.assert_not_called()
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -11990,20 +11990,6 @@ class TestCloudUsageGate(BaseTaskAPITest):
             status=status_value,
         )
 
-    def test_cloud_task_create_without_code_access_returns_403_before_warm_activation(self):
-        self.set_tasks_feature_flag(False)
-
-        response = self.client.post(
-            "/api/projects/@current/tasks/",
-            {"title": "Cloud task", "description": "Run this task", "branch": "main"},
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.json()["code"], "code_access_required")
-        self.assertEqual(response.json()["reason"], "startup_plan")
-        self.assertFalse(Task.objects.filter(title="Cloud task").exists())
-
     @patch("products.tasks.backend.facade.api.warm_task_sandbox")
     @patch("products.tasks.backend.presentation.views.api.TaskViewSet._warm_enabled", return_value=True)
     def test_warm_without_code_access_returns_403_before_provisioning(self, _mock_warm_enabled, mock_warm):
@@ -12586,8 +12572,8 @@ class TestUsageLimitResponse(TestCase):
         )
         request = MagicMock()
         request.successful_authenticator = None
-        team = MagicMock(id=1)
-        response = code_access_required_response(request, team)
+        organization = MagicMock(id=1)
+        response = code_access_required_response(request, organization)
 
         assert response is not None
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -12092,6 +12092,42 @@ class TestCloudUsageGate(BaseTaskAPITest):
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage", return_value=None)
+    def test_task_bound_internal_run_bypasses_access_for_its_own_task(self, _mock_gate, mock_workflow):
+        self.set_tasks_feature_flag(False)
+        task = self.create_task()
+        client = self._sandbox_oauth_client(task.id, internal_scope=True)
+
+        response = client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"mode": "background"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(TaskRun.objects.filter(task=task).exists())
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
+    def test_task_bound_internal_run_cannot_bypass_access_for_another_task(self, mock_gate, mock_workflow):
+        self.set_tasks_feature_flag(False)
+        bound_task = self.create_task()
+        other_task = self.create_task()
+        client = self._sandbox_oauth_client(bound_task.id, internal_scope=True)
+
+        response = client.post(
+            f"/api/projects/@current/tasks/{other_task.id}/run/",
+            {"mode": "background"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(TaskRun.objects.filter(task=other_task).exists())
+        mock_gate.assert_not_called()
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
     def test_run_forged_signal_report_origin_without_report_still_403s(self, mock_gate, mock_workflow):
         # `origin_product` is client input on task create, so an FK-less signal_report claim

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -218,24 +218,31 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.assertEqual(blocked_response.json(), {"allowed": False, "reason": "startup_plan"})
 
     @patch("products.tasks.backend.presentation.views.api.tasks_access.has_loops_access", return_value=True)
-    @patch("products.tasks.backend.access._get_funding_status")
-    def test_legacy_endpoint_returns_boolean_and_reason(self, mock_funding, _mock_loops) -> None:
-        mock_funding.return_value = OrganizationFundingStatus(
-            startup_program_label=None,
-            prepaid_credit_state=PrepaidCreditState.ACTIVE,
-        )
+    @patch("products.tasks.backend.access.feature_enabled_or_false", return_value=True)
+    def test_legacy_endpoint_preserves_feature_flag_access(self, _mock_legacy_flag, _mock_loops) -> None:
+        response = self.client.get("/api/code/invites/check-access/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"has_access": True, "has_loops_access": True})
+
+    @patch("products.tasks.backend.presentation.views.api.tasks_access.has_loops_access", return_value=False)
+    @patch("products.tasks.backend.access.feature_enabled_or_false", return_value=False)
+    def test_legacy_endpoint_preserves_invite_access(self, _mock_legacy_flag, _mock_loops) -> None:
+        invite = CodeInvite.objects.create(code="ENDPOINTCODE", max_redemptions=1, is_active=True)
+        CodeInviteRedemption.objects.create(invite_code=invite, user=self.user)
 
         response = self.client.get("/api/code/invites/check-access/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {
-                "has_access": False,
-                "reason": "prepaid_credits",
-                "has_loops_access": True,
-            },
-        )
+        self.assertEqual(response.json(), {"has_access": True, "has_loops_access": False})
+
+    @patch("products.tasks.backend.presentation.views.api.tasks_access.has_loops_access", return_value=False)
+    @patch("products.tasks.backend.access.feature_enabled_or_false", return_value=False)
+    def test_legacy_endpoint_preserves_denial(self, _mock_legacy_flag, _mock_loops) -> None:
+        response = self.client.get("/api/code/invites/check-access/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"has_access": False, "has_loops_access": False})
 
     @patch(
         "products.tasks.backend.presentation.views.desktop_access.get_desktop_access_decision",

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -81,13 +81,37 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.assertEqual(decision.reason, expected_reason)
 
     @patch("products.tasks.backend.access._get_funding_status")
-    def test_rollout_flag_off_grants_access_without_resolving_policy(self, mock_funding) -> None:
+    @patch("products.tasks.backend.access.feature_enabled_or_false", return_value=True)
+    def test_rollout_flag_off_preserves_legacy_feature_flag_access(self, _mock_legacy_flag, mock_funding) -> None:
         self.mock_feature_flag.side_effect = [False]
 
         decision = get_desktop_access_decision(self.user, self.organization)
 
         self.assertTrue(decision.allowed)
         self.assertEqual(self.mock_feature_flag.call_count, 1)
+        mock_funding.assert_not_called()
+
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access.feature_enabled_or_false", return_value=False)
+    def test_rollout_flag_off_preserves_legacy_invite_access(self, _mock_legacy_flag, mock_funding) -> None:
+        invite = CodeInvite.objects.create(code="LEGACYCODE", max_redemptions=1, is_active=True)
+        CodeInviteRedemption.objects.create(invite_code=invite, user=self.user)
+        self.mock_feature_flag.side_effect = [False]
+
+        decision = get_desktop_access_decision(self.user, self.organization)
+
+        self.assertTrue(decision.allowed)
+        mock_funding.assert_not_called()
+
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access.feature_enabled_or_false", return_value=False)
+    def test_rollout_flag_off_preserves_legacy_denial(self, _mock_legacy_flag, mock_funding) -> None:
+        self.mock_feature_flag.side_effect = [False]
+
+        decision = get_desktop_access_decision(self.user, self.organization)
+
+        self.assertFalse(decision.allowed)
+        self.assertIsNone(decision.reason)
         mock_funding.assert_not_called()
 
     @patch("products.tasks.backend.access._get_funding_status")
@@ -134,7 +158,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
         mock_decision.assert_not_called()
 
     @patch("products.tasks.backend.access._get_funding_status")
-    def test_access_code_does_not_affect_authorization(self, mock_funding) -> None:
+    def test_access_code_does_not_affect_authorization_after_rollout(self, mock_funding) -> None:
         invite = CodeInvite.objects.create(code="ACCESSCODE", max_redemptions=1, is_active=True)
         CodeInviteRedemption.objects.create(invite_code=invite, user=self.user)
         mock_funding.return_value = OrganizationFundingStatus(

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -8,7 +8,12 @@ from rest_framework import status
 
 from posthog.models import Organization, OrganizationMembership, Team
 
-from products.tasks.backend.access import DesktopAccessReason, DesktopAccessResolutionError, get_desktop_access_decision
+from products.tasks.backend.access import (
+    DESKTOP_ACCESS_GATE_FLAG,
+    DesktopAccessReason,
+    DesktopAccessResolutionError,
+    get_desktop_access_decision,
+)
 from products.tasks.backend.logic.services.code_usage_gate import code_access_required_response
 from products.tasks.backend.models import CodeInvite, CodeInviteRedemption
 
@@ -19,11 +24,16 @@ class TestDesktopAccessPolicy(APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
         cache.clear()
-        self.rollout_patcher = patch("products.tasks.backend.access._is_rollout_enabled", return_value=True)
-        self.rollout_patcher.start()
+        self.feature_flag_patcher = patch("products.tasks.backend.access.get_feature_flag_or_none")
+        self.mock_feature_flag = self.feature_flag_patcher.start()
+
+        def feature_flag_value(flag_key: str, *_args: object, **_kwargs: object) -> bool:
+            return flag_key == DESKTOP_ACCESS_GATE_FLAG
+
+        self.mock_feature_flag.side_effect = feature_flag_value
 
     def tearDown(self) -> None:
-        self.rollout_patcher.stop()
+        self.feature_flag_patcher.stop()
         super().tearDown()
 
     @parameterized.expand(
@@ -51,7 +61,6 @@ class TestDesktopAccessPolicy(APIBaseTest):
         ]
     )
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
     def test_policy_matrix(
         self,
         _name: str,
@@ -59,7 +68,6 @@ class TestDesktopAccessPolicy(APIBaseTest):
         prepaid_credit_state: PrepaidCreditState,
         expected_allowed: bool,
         expected_reason: DesktopAccessReason | None,
-        _mock_override,
         mock_funding,
     ) -> None:
         mock_funding.return_value = OrganizationFundingStatus(
@@ -72,39 +80,30 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.assertEqual(decision.allowed, expected_allowed)
         self.assertEqual(decision.reason, expected_reason)
 
-    @patch("products.tasks.backend.access._is_rollout_enabled", return_value=False)
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled")
-    def test_rollout_flag_off_grants_access_without_resolving_policy(
-        self,
-        mock_override,
-        mock_funding,
-        _mock_rollout,
-    ) -> None:
+    def test_rollout_flag_off_grants_access_without_resolving_policy(self, mock_funding) -> None:
+        self.mock_feature_flag.side_effect = [False]
+
         decision = get_desktop_access_decision(self.user, self.team)
 
         self.assertTrue(decision.allowed)
-        mock_override.assert_not_called()
+        self.assertEqual(self.mock_feature_flag.call_count, 1)
         mock_funding.assert_not_called()
 
-    @patch("products.tasks.backend.access._is_rollout_enabled", return_value=None)
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled")
-    def test_indeterminate_rollout_flag_fails_closed(
-        self,
-        mock_override,
-        mock_funding,
-        _mock_rollout,
-    ) -> None:
+    def test_indeterminate_rollout_flag_fails_closed(self, mock_funding) -> None:
+        self.mock_feature_flag.side_effect = [None]
+
         with self.assertRaises(DesktopAccessResolutionError):
             get_desktop_access_decision(self.user, self.team)
 
-        mock_override.assert_not_called()
+        self.assertEqual(self.mock_feature_flag.call_count, 1)
         mock_funding.assert_not_called()
 
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled", return_value=True)
-    def test_override_grants_access_before_funding_resolution(self, _mock_override, mock_funding) -> None:
+    def test_override_grants_access_before_funding_resolution(self, mock_funding) -> None:
+        self.mock_feature_flag.side_effect = [True, True]
+
         decision = get_desktop_access_decision(self.user, self.team)
 
         self.assertTrue(decision.allowed)
@@ -135,8 +134,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
         mock_decision.assert_not_called()
 
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
-    def test_access_code_does_not_affect_authorization(self, _mock_override, mock_funding) -> None:
+    def test_access_code_does_not_affect_authorization(self, mock_funding) -> None:
         invite = CodeInvite.objects.create(code="ACCESSCODE", max_redemptions=1, is_active=True)
         CodeInviteRedemption.objects.create(invite_code=invite, user=self.user)
         mock_funding.return_value = OrganizationFundingStatus(
@@ -149,39 +147,23 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.assertFalse(decision.allowed)
         self.assertEqual(decision.reason, DesktopAccessReason.STARTUP_PLAN)
 
-    @patch("products.tasks.backend.access._is_flag_enabled", side_effect=RuntimeError("unavailable"))
-    def test_feature_flag_exception_fails_closed(self, _mock_override) -> None:
-        with self.assertRaises(DesktopAccessResolutionError):
-            get_desktop_access_decision(self.user, self.team)
-
     @parameterized.expand([(None,), ("control",), ("false",)])
-    @patch("products.tasks.backend.access._is_flag_enabled")
-    def test_indeterminate_feature_flag_fails_closed(self, flag_value, mock_override) -> None:
-        mock_override.return_value = flag_value
+    def test_indeterminate_feature_flag_fails_closed(self, flag_value) -> None:
+        self.mock_feature_flag.side_effect = [True, flag_value]
 
         with self.assertRaises(DesktopAccessResolutionError):
             get_desktop_access_decision(self.user, self.team)
-
-    @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access.posthoganalytics.get_feature_flag", return_value="control")
-    def test_multivariate_override_value_fails_closed(self, _mock_flag, mock_funding) -> None:
-        with self.assertRaises(DesktopAccessResolutionError):
-            get_desktop_access_decision(self.user, self.team)
-
-        mock_funding.assert_not_called()
 
     @patch(
         "products.tasks.backend.access._get_funding_status",
         side_effect=DesktopAccessResolutionError("unavailable"),
     )
-    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
-    def test_funding_failure_fails_closed(self, _mock_override, _mock_funding) -> None:
+    def test_funding_failure_fails_closed(self, _mock_funding) -> None:
         with self.assertRaises(DesktopAccessResolutionError):
             get_desktop_access_decision(self.user, self.team)
 
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
-    def test_project_endpoint_is_scoped_to_each_organization(self, _mock_override, mock_funding) -> None:
+    def test_project_endpoint_is_scoped_to_each_organization(self, mock_funding) -> None:
         other_organization = Organization.objects.create(name="Other organization")
         other_team = Team.objects.create(organization=other_organization, name="Other project")
         OrganizationMembership.objects.create(
@@ -213,8 +195,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
 
     @patch("products.tasks.backend.presentation.views.api.tasks_access.has_loops_access", return_value=True)
     @patch("products.tasks.backend.access._get_funding_status")
-    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
-    def test_legacy_endpoint_returns_boolean_and_reason(self, _mock_override, mock_funding, _mock_loops) -> None:
+    def test_legacy_endpoint_returns_boolean_and_reason(self, mock_funding, _mock_loops) -> None:
         mock_funding.return_value = OrganizationFundingStatus(
             startup_program_label=None,
             prepaid_credit_state=PrepaidCreditState.ACTIVE,

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -1,0 +1,243 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import Organization, OrganizationMembership, Team
+
+from products.tasks.backend.access import DesktopAccessReason, DesktopAccessResolutionError, get_desktop_access_decision
+from products.tasks.backend.logic.services.code_usage_gate import code_access_required_response
+from products.tasks.backend.models import CodeInvite, CodeInviteRedemption
+
+from ee.billing.billing_manager import OrganizationFundingStatus, PrepaidCreditState, StartupProgramLabel
+
+
+class TestDesktopAccessPolicy(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        self.rollout_patcher = patch("products.tasks.backend.access._is_rollout_enabled", return_value=True)
+        self.rollout_patcher.start()
+
+    def tearDown(self) -> None:
+        self.rollout_patcher.stop()
+        super().tearDown()
+
+    @parameterized.expand(
+        [
+            ("normal", None, PrepaidCreditState.NONE, True, None),
+            (
+                "startup",
+                "Startup",
+                PrepaidCreditState.NONE,
+                False,
+                DesktopAccessReason.STARTUP_PLAN,
+            ),
+            ("yc", "YC", PrepaidCreditState.NONE, False, DesktopAccessReason.STARTUP_PLAN),
+            ("pending", None, PrepaidCreditState.PENDING, False, DesktopAccessReason.PREPAID_CREDITS),
+            ("active", None, PrepaidCreditState.ACTIVE, False, DesktopAccessReason.PREPAID_CREDITS),
+            ("exhausted", None, PrepaidCreditState.EXHAUSTED, True, None),
+            ("expired", None, PrepaidCreditState.EXPIRED, True, None),
+            (
+                "combined",
+                "Startup",
+                PrepaidCreditState.ACTIVE,
+                False,
+                DesktopAccessReason.STARTUP_PLAN,
+            ),
+        ]
+    )
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
+    def test_policy_matrix(
+        self,
+        _name: str,
+        startup_program_label: StartupProgramLabel | None,
+        prepaid_credit_state: PrepaidCreditState,
+        expected_allowed: bool,
+        expected_reason: DesktopAccessReason | None,
+        _mock_override,
+        mock_funding,
+    ) -> None:
+        mock_funding.return_value = OrganizationFundingStatus(
+            startup_program_label=startup_program_label,
+            prepaid_credit_state=prepaid_credit_state,
+        )
+
+        decision = get_desktop_access_decision(self.user, self.team)
+
+        self.assertEqual(decision.allowed, expected_allowed)
+        self.assertEqual(decision.reason, expected_reason)
+
+    @patch("products.tasks.backend.access._is_rollout_enabled", return_value=False)
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled")
+    def test_rollout_flag_off_grants_access_without_resolving_policy(
+        self,
+        mock_override,
+        mock_funding,
+        _mock_rollout,
+    ) -> None:
+        decision = get_desktop_access_decision(self.user, self.team)
+
+        self.assertTrue(decision.allowed)
+        mock_override.assert_not_called()
+        mock_funding.assert_not_called()
+
+    @patch("products.tasks.backend.access._is_rollout_enabled", return_value=None)
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled")
+    def test_indeterminate_rollout_flag_fails_closed(
+        self,
+        mock_override,
+        mock_funding,
+        _mock_rollout,
+    ) -> None:
+        with self.assertRaises(DesktopAccessResolutionError):
+            get_desktop_access_decision(self.user, self.team)
+
+        mock_override.assert_not_called()
+        mock_funding.assert_not_called()
+
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled", return_value=True)
+    def test_override_grants_access_before_funding_resolution(self, _mock_override, mock_funding) -> None:
+        decision = get_desktop_access_decision(self.user, self.team)
+
+        self.assertTrue(decision.allowed)
+        mock_funding.assert_not_called()
+
+    @patch(
+        "products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision",
+        side_effect=DesktopAccessResolutionError("unavailable"),
+    )
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_authenticator_scopes", return_value=[])
+    def test_compute_gate_fails_closed_on_resolution_error(self, _mock_scopes, _mock_decision) -> None:
+        response = code_access_required_response(MagicMock(), self.team)
+
+        self.assertIsNotNone(response)
+        assert response is not None
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response.data["code"], "desktop_access_unavailable")
+
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision")
+    @patch(
+        "products.tasks.backend.logic.services.code_usage_gate.get_authenticator_scopes",
+        return_value=["task:write", "internal_run:read"],
+    )
+    def test_internal_run_credentials_bypass_human_gate(self, _mock_scopes, mock_decision) -> None:
+        request = MagicMock()
+
+        self.assertIsNone(code_access_required_response(request, self.team))
+        mock_decision.assert_not_called()
+
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
+    def test_access_code_does_not_affect_authorization(self, _mock_override, mock_funding) -> None:
+        invite = CodeInvite.objects.create(code="ACCESSCODE", max_redemptions=1, is_active=True)
+        CodeInviteRedemption.objects.create(invite_code=invite, user=self.user)
+        mock_funding.return_value = OrganizationFundingStatus(
+            startup_program_label="Startup",
+            prepaid_credit_state=PrepaidCreditState.NONE,
+        )
+
+        decision = get_desktop_access_decision(self.user, self.team)
+
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.reason, DesktopAccessReason.STARTUP_PLAN)
+
+    @patch("products.tasks.backend.access._is_flag_enabled", side_effect=RuntimeError("unavailable"))
+    def test_feature_flag_exception_fails_closed(self, _mock_override) -> None:
+        with self.assertRaises(DesktopAccessResolutionError):
+            get_desktop_access_decision(self.user, self.team)
+
+    @parameterized.expand([(None,), ("control",), ("false",)])
+    @patch("products.tasks.backend.access._is_flag_enabled")
+    def test_indeterminate_feature_flag_fails_closed(self, flag_value, mock_override) -> None:
+        mock_override.return_value = flag_value
+
+        with self.assertRaises(DesktopAccessResolutionError):
+            get_desktop_access_decision(self.user, self.team)
+
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access.posthoganalytics.get_feature_flag", return_value="control")
+    def test_multivariate_override_value_fails_closed(self, _mock_flag, mock_funding) -> None:
+        with self.assertRaises(DesktopAccessResolutionError):
+            get_desktop_access_decision(self.user, self.team)
+
+        mock_funding.assert_not_called()
+
+    @patch(
+        "products.tasks.backend.access._get_funding_status",
+        side_effect=DesktopAccessResolutionError("unavailable"),
+    )
+    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
+    def test_funding_failure_fails_closed(self, _mock_override, _mock_funding) -> None:
+        with self.assertRaises(DesktopAccessResolutionError):
+            get_desktop_access_decision(self.user, self.team)
+
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
+    def test_project_endpoint_is_scoped_to_each_organization(self, _mock_override, mock_funding) -> None:
+        other_organization = Organization.objects.create(name="Other organization")
+        other_team = Team.objects.create(organization=other_organization, name="Other project")
+        OrganizationMembership.objects.create(
+            organization=other_organization,
+            user=self.user,
+            level=OrganizationMembership.Level.MEMBER,
+        )
+
+        def funding_status(_user, team: Team) -> OrganizationFundingStatus:
+            if team.id == self.team.id:
+                return OrganizationFundingStatus(
+                    startup_program_label=None,
+                    prepaid_credit_state=PrepaidCreditState.NONE,
+                )
+            return OrganizationFundingStatus(
+                startup_program_label="YC",
+                prepaid_credit_state=PrepaidCreditState.NONE,
+            )
+
+        mock_funding.side_effect = funding_status
+
+        allowed_response = self.client.get(f"/api/projects/{self.team.id}/desktop/access/")
+        blocked_response = self.client.get(f"/api/projects/{other_team.id}/desktop/access/")
+
+        self.assertEqual(allowed_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(allowed_response.json(), {"allowed": True, "reason": None})
+        self.assertEqual(blocked_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(blocked_response.json(), {"allowed": False, "reason": "startup_plan"})
+
+    @patch("products.tasks.backend.presentation.views.api.tasks_access.has_loops_access", return_value=True)
+    @patch("products.tasks.backend.access._get_funding_status")
+    @patch("products.tasks.backend.access._is_flag_enabled", return_value=False)
+    def test_legacy_endpoint_returns_boolean_and_reason(self, _mock_override, mock_funding, _mock_loops) -> None:
+        mock_funding.return_value = OrganizationFundingStatus(
+            startup_program_label=None,
+            prepaid_credit_state=PrepaidCreditState.ACTIVE,
+        )
+
+        response = self.client.get("/api/code/invites/check-access/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "has_access": False,
+                "reason": "prepaid_credits",
+                "has_loops_access": True,
+            },
+        )
+
+    @patch(
+        "products.tasks.backend.presentation.views.desktop_access.get_desktop_access_decision",
+        side_effect=DesktopAccessResolutionError,
+    )
+    def test_project_endpoint_returns_retryable_service_error(self, _mock_decision) -> None:
+        response = self.client.get(f"/api/projects/{self.team.id}/desktop/access/")
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response.json()["code"], "desktop_access_unavailable")

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -75,7 +75,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
             prepaid_credit_state=prepaid_credit_state,
         )
 
-        decision = get_desktop_access_decision(self.user, self.team)
+        decision = get_desktop_access_decision(self.user, self.organization)
 
         self.assertEqual(decision.allowed, expected_allowed)
         self.assertEqual(decision.reason, expected_reason)
@@ -84,7 +84,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
     def test_rollout_flag_off_grants_access_without_resolving_policy(self, mock_funding) -> None:
         self.mock_feature_flag.side_effect = [False]
 
-        decision = get_desktop_access_decision(self.user, self.team)
+        decision = get_desktop_access_decision(self.user, self.organization)
 
         self.assertTrue(decision.allowed)
         self.assertEqual(self.mock_feature_flag.call_count, 1)
@@ -95,7 +95,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.mock_feature_flag.side_effect = [None]
 
         with self.assertRaises(DesktopAccessResolutionError):
-            get_desktop_access_decision(self.user, self.team)
+            get_desktop_access_decision(self.user, self.organization)
 
         self.assertEqual(self.mock_feature_flag.call_count, 1)
         mock_funding.assert_not_called()
@@ -104,7 +104,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
     def test_override_grants_access_before_funding_resolution(self, mock_funding) -> None:
         self.mock_feature_flag.side_effect = [True, True]
 
-        decision = get_desktop_access_decision(self.user, self.team)
+        decision = get_desktop_access_decision(self.user, self.organization)
 
         self.assertTrue(decision.allowed)
         mock_funding.assert_not_called()
@@ -115,7 +115,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
     )
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_authenticator_scopes", return_value=[])
     def test_compute_gate_fails_closed_on_resolution_error(self, _mock_scopes, _mock_decision) -> None:
-        response = code_access_required_response(MagicMock(), self.team)
+        response = code_access_required_response(MagicMock(), self.organization)
 
         self.assertIsNotNone(response)
         assert response is not None
@@ -130,7 +130,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
     def test_internal_run_credentials_bypass_human_gate(self, _mock_scopes, mock_decision) -> None:
         request = MagicMock()
 
-        self.assertIsNone(code_access_required_response(request, self.team))
+        self.assertIsNone(code_access_required_response(request, self.organization))
         mock_decision.assert_not_called()
 
     @patch("products.tasks.backend.access._get_funding_status")
@@ -142,7 +142,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
             prepaid_credit_state=PrepaidCreditState.NONE,
         )
 
-        decision = get_desktop_access_decision(self.user, self.team)
+        decision = get_desktop_access_decision(self.user, self.organization)
 
         self.assertFalse(decision.allowed)
         self.assertEqual(decision.reason, DesktopAccessReason.STARTUP_PLAN)
@@ -152,7 +152,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.mock_feature_flag.side_effect = [True, flag_value]
 
         with self.assertRaises(DesktopAccessResolutionError):
-            get_desktop_access_decision(self.user, self.team)
+            get_desktop_access_decision(self.user, self.organization)
 
     @patch(
         "products.tasks.backend.access._get_funding_status",
@@ -160,7 +160,7 @@ class TestDesktopAccessPolicy(APIBaseTest):
     )
     def test_funding_failure_fails_closed(self, _mock_funding) -> None:
         with self.assertRaises(DesktopAccessResolutionError):
-            get_desktop_access_decision(self.user, self.team)
+            get_desktop_access_decision(self.user, self.organization)
 
     @patch("products.tasks.backend.access._get_funding_status")
     def test_project_endpoint_is_scoped_to_each_organization(self, mock_funding) -> None:
@@ -172,8 +172,8 @@ class TestDesktopAccessPolicy(APIBaseTest):
             level=OrganizationMembership.Level.MEMBER,
         )
 
-        def funding_status(_user, team: Team) -> OrganizationFundingStatus:
-            if team.id == self.team.id:
+        def funding_status(_user, organization: Organization) -> OrganizationFundingStatus:
+            if organization.id == self.organization.id:
                 return OrganizationFundingStatus(
                     startup_program_label=None,
                     prepaid_credit_state=PrepaidCreditState.NONE,

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -146,17 +146,6 @@ class TestDesktopAccessPolicy(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
         self.assertEqual(response.data["code"], "desktop_access_unavailable")
 
-    @patch("products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision")
-    @patch(
-        "products.tasks.backend.logic.services.code_usage_gate.get_authenticator_scopes",
-        return_value=["task:write", "internal_run:read"],
-    )
-    def test_internal_run_credentials_bypass_human_gate(self, _mock_scopes, mock_decision) -> None:
-        request = MagicMock()
-
-        self.assertIsNone(code_access_required_response(request, self.organization))
-        mock_decision.assert_not_called()
-
     @patch("products.tasks.backend.access._get_funding_status")
     def test_access_code_does_not_affect_authorization_after_rollout(self, mock_funding) -> None:
         invite = CodeInvite.objects.create(code="ACCESSCODE", max_redemptions=1, is_active=True)

--- a/products/tasks/backend/tests/test_warm_facade.py
+++ b/products/tasks/backend/tests/test_warm_facade.py
@@ -53,7 +53,7 @@ TITLE_SRC = "products.tasks.backend.logic.services.title_generator"
 def _allow_desktop_access(test_case: APIBaseTest) -> None:
     access_patcher = patch(
         "products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision",
-        return_value=tasks_access.DesktopAccessDecision(),
+        return_value=tasks_access.DesktopAccessDecision.ALLOWED,
     )
     access_patcher.start()
     test_case.addCleanup(access_patcher.stop)

--- a/products/tasks/backend/tests/test_warm_facade.py
+++ b/products/tasks/backend/tests/test_warm_facade.py
@@ -12,6 +12,7 @@ from posthog.exceptions import QuotaLimitExceeded
 from posthog.models import Integration, User
 
 from products.tasks.backend.facade import (
+    access as tasks_access,
     api as facade,
     contracts,
 )
@@ -49,16 +50,21 @@ WARM_SRC = "products.tasks.backend.logic.services.warm.SandboxWarmer"
 TITLE_SRC = "products.tasks.backend.logic.services.title_generator"
 
 
+def _allow_desktop_access(test_case: APIBaseTest) -> None:
+    access_patcher = patch(
+        "products.tasks.backend.logic.services.code_usage_gate.get_desktop_access_decision",
+        return_value=tasks_access.DesktopAccessDecision(),
+    )
+    access_patcher.start()
+    test_case.addCleanup(access_patcher.stop)
+
+
 class TestWarmTaskSandbox(APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
         self.integration = Integration.objects.create(team=self.team, kind="github", config={})
         # The warm endpoint gates on Desktop access; these tests cover warm forwarding, not the gate.
-        access_patcher = patch(
-            "products.tasks.backend.logic.services.code_usage_gate.has_tasks_access", return_value=True
-        )
-        access_patcher.start()
-        self.addCleanup(access_patcher.stop)
+        _allow_desktop_access(self)
 
     def _warm(self, **overrides):
         kwargs: dict[str, Any] = {
@@ -362,6 +368,7 @@ class TestCreateTaskWarmReuse(APIBaseTest):
             repository_cache=[{"id": 1, "name": "posthog", "full_name": "posthog/posthog"}],
             repository_cache_updated_at=django_timezone.now(),
         )
+        _allow_desktop_access(self)
 
     def _warm_run(
         self,

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -7,6 +7,18 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+export interface LegacyDesktopAccessResponseApi {
+    /** Whether the user has legacy PostHog Desktop access. */
+    has_access: boolean
+    /** Whether the independent Loops feature is enabled. */
+    has_loops_access: boolean
+}
+
+export interface CodeInviteRedeemRequestApi {
+    /** @maxLength 50 */
+    code: string
+}
+
 /**
  * * `startup_plan` - startup_plan
  * * `prepaid_credits` - prepaid_credits
@@ -17,18 +29,6 @@ export const DesktopAccessReasonEnumApi = {
     StartupPlan: 'startup_plan',
     PrepaidCredits: 'prepaid_credits',
 } as const
-
-export interface LegacyDesktopAccessResponseApi {
-    /** Whether the selected project can use PostHog Desktop. */
-    has_access: boolean
-    /** Why Desktop access is blocked, or null when access is allowed.
-     *
-     * * `startup_plan` - startup_plan
-     * * `prepaid_credits` - prepaid_credits */
-    reason: DesktopAccessReasonEnumApi | null
-    /** Whether the independent Loops feature is enabled. */
-    has_loops_access: boolean
-}
 
 /**
  * * `burst` - burst
@@ -68,11 +68,6 @@ export interface TaskRunErrorResponseApi {
     reset_at?: string
     /** Whether the team is on a Pro plan (drives the upgrade-prompt copy) */
     is_pro?: boolean
-}
-
-export interface CodeInviteRedeemRequestApi {
-    /** @maxLength 50 */
-    code: string
 }
 
 export interface ComputeRateCardApi {

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -7,9 +7,27 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-export interface CodeInviteRedeemRequestApi {
-    /** @maxLength 50 */
-    code: string
+/**
+ * * `startup_plan` - startup_plan
+ * * `prepaid_credits` - prepaid_credits
+ */
+export type DesktopAccessReasonEnumApi = (typeof DesktopAccessReasonEnumApi)[keyof typeof DesktopAccessReasonEnumApi]
+
+export const DesktopAccessReasonEnumApi = {
+    StartupPlan: 'startup_plan',
+    PrepaidCredits: 'prepaid_credits',
+} as const
+
+export interface LegacyDesktopAccessResponseApi {
+    /** Whether the selected project can use PostHog Desktop. */
+    has_access: boolean
+    /** Why Desktop access is blocked, or null when access is allowed.
+     *
+     * * `startup_plan` - startup_plan
+     * * `prepaid_credits` - prepaid_credits */
+    reason: DesktopAccessReasonEnumApi | null
+    /** Whether the independent Loops feature is enabled. */
+    has_loops_access: boolean
 }
 
 /**
@@ -32,6 +50,11 @@ export interface TaskRunErrorResponseApi {
     type?: string
     /** Machine-readable error code */
     code?: string
+    /** Why PostHog Desktop access was denied, when applicable.
+     *
+     * * `startup_plan` - startup_plan
+     * * `prepaid_credits` - prepaid_credits */
+    reason?: DesktopAccessReasonEnumApi
     /** Request field associated with the error */
     attr?: string
     /** Artifact ids that could not be resolved for the run */
@@ -45,6 +68,11 @@ export interface TaskRunErrorResponseApi {
     reset_at?: string
     /** Whether the team is on a Pro plan (drives the upgrade-prompt copy) */
     is_pro?: boolean
+}
+
+export interface CodeInviteRedeemRequestApi {
+    /** @maxLength 50 */
+    code: string
 }
 
 export interface ComputeRateCardApi {
@@ -68,6 +96,16 @@ export interface SandboxComputePricingApi {
     current: ComputeRateCardApi | null
     /** Expired sandbox compute rate cards, newest first. */
     history: ComputeRateCardApi[]
+}
+
+export interface DesktopAccessResponseApi {
+    /** Whether the selected project can use PostHog Desktop. */
+    allowed: boolean
+    /** Why Desktop access is blocked, or null when access is allowed.
+     *
+     * * `startup_plan` - startup_plan
+     * * `prepaid_credits` - prepaid_credits */
+    reason: DesktopAccessReasonEnumApi | null
 }
 
 export interface DesktopBetaTermsAcceptanceDTOApi {

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -93,6 +93,11 @@ export interface SandboxComputePricingApi {
     history: ComputeRateCardApi[]
 }
 
+export interface DesktopBetaTermsAcceptanceDTOApi {
+    /** Whether the organization has accepted the PostHog Desktop beta terms. */
+    readonly is_desktop_beta_terms_accepted: boolean
+}
+
 export interface DesktopAccessResponseApi {
     /** Whether the selected project can use PostHog Desktop. */
     allowed: boolean
@@ -101,11 +106,6 @@ export interface DesktopAccessResponseApi {
      * * `startup_plan` - startup_plan
      * * `prepaid_credits` - prepaid_credits */
     reason: DesktopAccessReasonEnumApi | null
-}
-
-export interface DesktopBetaTermsAcceptanceDTOApi {
-    /** Whether the organization has accepted the PostHog Desktop beta terms. */
-    readonly is_desktop_beta_terms_accepted: boolean
 }
 
 export interface LoopRepositoryEntryDTOApi {

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -20,6 +20,8 @@ import type {
     CodeInviteRedeemRequestApi,
     ConnectionTokenResponseApi,
     DesktopBetaTermsAcceptanceDTOApi,
+    DesktopAccessResponseApi,
+    LegacyDesktopAccessResponseApi,
     LoopDTOApi,
     LoopFireResultApi,
     LoopPreviewDTOApi,
@@ -151,11 +153,13 @@ export const getCodeInvitesCheckAccessRetrieveUrl = () => {
 }
 
 /**
- * Check whether the authenticated user has access to PostHog Desktop and to Loops.
+ * Check whether the authenticated user's selected project can use PostHog Desktop and Loops.
  * @summary Check access
  */
-export const codeInvitesCheckAccessRetrieve = async (options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getCodeInvitesCheckAccessRetrieveUrl(), {
+export const codeInvitesCheckAccessRetrieve = async (
+    options?: RequestInit
+): Promise<LegacyDesktopAccessResponseApi> => {
+    return apiMutator<LegacyDesktopAccessResponseApi>(getCodeInvitesCheckAccessRetrieveUrl(), {
         ...options,
         method: 'GET',
     })
@@ -166,8 +170,8 @@ export const getCodeInvitesRedeemCreateUrl = () => {
 }
 
 /**
- * Redeem a PostHog Desktop invite code to enable access.
- * @summary Redeem invite code
+ * Record a legacy PostHog Desktop invite-code redemption. Redemptions no longer grant access.
+ * @summary Redeem legacy invite code
  */
 export const codeInvitesRedeemCreate = async (
     codeInviteRedeemRequestApi: CodeInviteRedeemRequestApi,
@@ -191,6 +195,24 @@ export const getCodeSandboxPricingListUrl = () => {
  */
 export const codeSandboxPricingList = async (options?: RequestInit): Promise<SandboxComputePricingApi> => {
     return apiMutator<SandboxComputePricingApi>(getCodeSandboxPricingListUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopAccessRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop/access/`
+}
+
+/**
+ * Evaluate Desktop access for the selected project and organization.
+ * @summary Check PostHog Desktop access
+ */
+export const desktopAccessRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DesktopAccessResponseApi> => {
+    return apiMutator<DesktopAccessResponseApi>(getDesktopAccessRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -153,7 +153,7 @@ export const getCodeInvitesCheckAccessRetrieveUrl = () => {
 }
 
 /**
- * Check whether the authenticated user's selected project can use PostHog Desktop and Loops.
+ * Check whether the authenticated user has legacy PostHog Desktop access and Loops access.
  * @summary Check access
  */
 export const codeInvitesCheckAccessRetrieve = async (
@@ -170,8 +170,8 @@ export const getCodeInvitesRedeemCreateUrl = () => {
 }
 
 /**
- * Record a legacy PostHog Desktop invite-code redemption. Redemptions no longer grant access.
- * @summary Redeem legacy invite code
+ * Redeem a PostHog Desktop invite code to enable legacy access.
+ * @summary Redeem invite code
  */
 export const codeInvitesRedeemCreate = async (
     codeInviteRedeemRequestApi: CodeInviteRedeemRequestApi,

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -19,8 +19,8 @@ import type {
     ChannelWriteApi,
     CodeInviteRedeemRequestApi,
     ConnectionTokenResponseApi,
-    DesktopBetaTermsAcceptanceDTOApi,
     DesktopAccessResponseApi,
+    DesktopBetaTermsAcceptanceDTOApi,
     LegacyDesktopAccessResponseApi,
     LoopDTOApi,
     LoopFireResultApi,
@@ -200,24 +200,6 @@ export const codeSandboxPricingList = async (options?: RequestInit): Promise<San
     })
 }
 
-export const getDesktopAccessRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/desktop/access/`
-}
-
-/**
- * Evaluate Desktop access for the selected project and organization.
- * @summary Check PostHog Desktop access
- */
-export const desktopAccessRetrieve = async (
-    projectId: string,
-    options?: RequestInit
-): Promise<DesktopAccessResponseApi> => {
-    return apiMutator<DesktopAccessResponseApi>(getDesktopAccessRetrieveUrl(projectId), {
-        ...options,
-        method: 'GET',
-    })
-}
-
 export const getDesktopBetaTermsListUrl = (organizationId: string) => {
     return `/api/organizations/${organizationId}/desktop_beta_terms/`
 }
@@ -243,6 +225,24 @@ export const desktopBetaTermsCreate = async (
     return apiMutator<DesktopBetaTermsAcceptanceDTOApi>(getDesktopBetaTermsCreateUrl(organizationId), {
         ...options,
         method: 'POST',
+    })
+}
+
+export const getDesktopAccessRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop/access/`
+}
+
+/**
+ * Evaluate Desktop access for the selected project and organization.
+ * @summary Check PostHog Desktop access
+ */
+export const desktopAccessRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DesktopAccessResponseApi> => {
+    return apiMutator<DesktopAccessResponseApi>(getDesktopAccessRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -10,8 +10,8 @@
 import * as zod from 'zod'
 
 /**
- * Redeem a PostHog Desktop invite code to enable access.
- * @summary Redeem invite code
+ * Record a legacy PostHog Desktop invite-code redemption. Redemptions no longer grant access.
+ * @summary Redeem legacy invite code
  */
 export const codeInvitesRedeemCreateBodyCodeMax = 50
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -10,8 +10,8 @@
 import * as zod from 'zod'
 
 /**
- * Record a legacy PostHog Desktop invite-code redemption. Redemptions no longer grant access.
- * @summary Redeem legacy invite code
+ * Redeem a PostHog Desktop invite code to enable legacy access.
+ * @summary Redeem invite code
  */
 export const codeInvitesRedeemCreateBodyCodeMax = 50
 

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -104,6 +104,9 @@ tools:
     code-sandbox-pricing-list:
         operation: code_sandbox_pricing_list
         enabled: false
+    desktop-access-retrieve:
+        operation: desktop_access_retrieve
+        enabled: false
     desktop-beta-terms-create:
         operation: desktop_beta_terms_create
         enabled: false
@@ -142,9 +145,6 @@ tools:
                 description: ID of the loop's context channel.
             base_version:
                 input_schema: ChannelInstructionsBaseVersionSchema
-    desktop-access-retrieve:
-        operation: desktop_access_retrieve
-        enabled: false
     loops-create:
         operation: loops_create
         enabled: true

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -142,6 +142,9 @@ tools:
                 description: ID of the loop's context channel.
             base_version:
                 input_schema: ChannelInstructionsBaseVersionSchema
+    desktop-access-retrieve:
+        operation: desktop_access_retrieve
+        enabled: false
     loops-create:
         operation: loops_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26467,6 +26467,28 @@ export namespace Schemas {
     }
 
     /**
+     * * `startup_plan` - startup_plan
+     * * `prepaid_credits` - prepaid_credits
+     */
+    export type DesktopAccessReasonEnum = typeof DesktopAccessReasonEnum[keyof typeof DesktopAccessReasonEnum];
+
+
+    export const DesktopAccessReasonEnum = {
+      StartupPlan: 'startup_plan',
+      PrepaidCredits: 'prepaid_credits',
+    } as const;
+
+    export interface DesktopAccessResponse {
+      /** Whether the selected project can use PostHog Desktop. */
+      allowed: boolean;
+      /** Why Desktop access is blocked, or null when access is allowed.
+       *
+       * * `startup_plan` - startup_plan
+       * * `prepaid_credits` - prepaid_credits */
+      reason: DesktopAccessReasonEnum | null;
+    }
+
+    /**
      * * `Desktop` - Desktop
      * * `Mobile` - Mobile
      * * `Tablet` - Tablet
@@ -45574,6 +45596,18 @@ export namespace Schemas {
        * * `oauth_access_token` - oauth_access_token
        * * `oauth_refresh_token` - oauth_refresh_token */
       type: LeakedKeyReportResponseTypeEnum | null;
+    }
+
+    export interface LegacyDesktopAccessResponse {
+      /** Whether the selected project can use PostHog Desktop. */
+      has_access: boolean;
+      /** Why Desktop access is blocked, or null when access is allowed.
+       *
+       * * `startup_plan` - startup_plan
+       * * `prepaid_credits` - prepaid_credits */
+      reason: DesktopAccessReasonEnum | null;
+      /** Whether the independent Loops feature is enabled. */
+      has_loops_access: boolean;
     }
 
     export interface LegalDocumentCreator {
@@ -81023,6 +81057,11 @@ export namespace Schemas {
       type?: string;
       /** Machine-readable error code */
       code?: string;
+      /** Why PostHog Desktop access was denied, when applicable.
+       *
+       * * `startup_plan` - startup_plan
+       * * `prepaid_credits` - prepaid_credits */
+      reason?: DesktopAccessReasonEnum;
       /** Request field associated with the error */
       attr?: string;
       /** Artifact ids that could not be resolved for the run */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -45599,13 +45599,8 @@ export namespace Schemas {
     }
 
     export interface LegacyDesktopAccessResponse {
-      /** Whether the selected project can use PostHog Desktop. */
+      /** Whether the user has legacy PostHog Desktop access. */
       has_access: boolean;
-      /** Why Desktop access is blocked, or null when access is allowed.
-       *
-       * * `startup_plan` - startup_plan
-       * * `prepaid_credits` - prepaid_credits */
-      reason: DesktopAccessReasonEnum | null;
       /** Whether the independent Loops feature is enabled. */
       has_loops_access: boolean;
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26461,11 +26461,6 @@ export namespace Schemas {
       index?: number;
     }
 
-    export interface DesktopBetaTermsAcceptanceDTO {
-      /** Whether the organization has accepted the PostHog Desktop beta terms. */
-      readonly is_desktop_beta_terms_accepted: boolean;
-    }
-
     /**
      * * `startup_plan` - startup_plan
      * * `prepaid_credits` - prepaid_credits
@@ -26486,6 +26481,11 @@ export namespace Schemas {
        * * `startup_plan` - startup_plan
        * * `prepaid_credits` - prepaid_credits */
       reason: DesktopAccessReasonEnum | null;
+    }
+
+    export interface DesktopBetaTermsAcceptanceDTO {
+      /** Whether the organization has accepted the PostHog Desktop beta terms. */
+      readonly is_desktop_beta_terms_accepted: boolean;
     }
 
     /**


### PR DESCRIPTION
## Problem

Desktop users can currently start cloud work through a user-wide invite-code decision that ignores the selected project and its billing state.

```mermaid
flowchart LR
    A[Desktop request] --> B[User-wide access check]
    B --> C[Invite redemption or tasks flag]
    C --> D[Cloud task]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D phRed;
```

## Changes

- Desktop access now uses the organization selected through the project-scoped endpoint and cloud compute boundaries.
- [`posthog-desktop-access-gate`](https://us.posthog.com/project/2/feature_flags/836044) controls rollout before the policy reads Billing funding facts.
- While that flag is off, the existing `tasks` flag and redeemed invite codes keep their current authorization behavior.
- [`posthog-desktop-access-override`](https://us.posthog.com/project/2/feature_flags/836049) grants approved organization exceptions.
- Billing failures and invalid flag responses return a retryable `503` instead of allowing compute.
- Trusted internal runs and server-verifiable Inbox and scout tasks remain exempt.
- The legacy invite check and redemption endpoints keep their existing behavior for released Desktop clients.
- Generated Tasks and MCP API clients document the new endpoint and typed denial reasons.

```mermaid
flowchart LR
    A[Desktop or task request] --> B[Selected project]
    B --> C[Rollout and override flags]
    C --> D[Billing funding facts]
    D --> E[Organization access decision]
    E --> F[Cloud task or typed denial]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,F phYellow;
    class B,C,E phBlue;
    class D phGray;
```

> [!WARNING]
> Deploy [Billing PR #2183](https://github.com/PostHog/billing/pull/2183) before this PR. 

## How did you test this code?

- Focused pytest suites cover policy outcomes, project isolation, flag failures, trusted exemptions, task boundaries, and the compatibility endpoint.
- Billing-manager tests cover strict response parsing, caching, and fail-closed lookup failures.
- Repository mypy, pre-commit type checks, OpenAPI generation, and `hogli ci:preflight --fix` completed locally.
- Not tested: a live PostHog-to-Billing request because the Billing endpoint is not deployed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The generated OpenAPI schema documents the project endpoint, access reasons, and retryable failure response.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the requested backend-only PR. Desktop UI and LLM Gateway changes remain excluded.

The session used `/improving-drf-endpoints`, `/implementing-mcp-tools`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/running-ci-preflight`, and `/writing-pr-descriptions`.



