### PR TITLE
fix(slack_app): keep tagged replies out of the untagged-followup path

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1404,6 +1404,25 @@ def _resolve_untagged_followup_mapping(
     return mapping
 
 
+def _message_tags_bot(event: dict[str, Any], integration: Integration) -> bool:
+    """Whether the message text mentions the app's own bot user.
+
+    Slack delivers a thread reply that tags the bot twice — as ``app_mention``
+    and as a plain ``message`` — under two different event ids, so the queue
+    workflow's event-id dedup never collapses them. The mention pipeline owns
+    the tagged copy; this gate keeps the ``message`` copy out of the
+    untagged-followup path. When the bot user id can't be resolved the gate
+    stays open: a duplicate prompt beats silently dropping a genuine follow-up.
+    """
+    text = event.get("text") or ""
+    if "<@" not in text:
+        return False
+    bot_user_id = get_cached_bot_user_id(SlackIntegration(integration), integration)
+    if not bot_user_id:
+        return False
+    return re.search(rf"<@{re.escape(bot_user_id)}(\|[^>]*)?>", text) is not None
+
+
 def _untagged_followups_switched_off(
     event: dict[str, Any],
     integration: Integration,
@@ -2261,6 +2280,18 @@ def route_posthog_code_event_to_relevant_region(
                 slack_team_id=slack_team_id,
             )
             if untagged_followup_mapping is None:
+                return ROUTE_HANDLED_LOCALLY
+            # A tagged reply also arrives as its own ``app_mention`` event, which owns
+            # it. Letting this copy through would run the untagged-followup classifier
+            # (and the ``ask`` prompt) on a message that explicitly addressed the app.
+            if _message_tags_bot(event, untagged_followup_mapping.integration):
+                logger.info(
+                    "slack_app_thread_message_ignored",
+                    reason="tagged_reply",
+                    slack_team_id=slack_team_id,
+                    channel=channel_str,
+                    message_ts=event.get("ts"),
+                )
                 return ROUTE_HANDLED_LOCALLY
 
         # Both event types share the rest of the pipeline. Mention-only side

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1417,6 +1417,12 @@ def _message_tags_bot(event: dict[str, Any], integration: Integration) -> bool:
     text = event.get("text") or ""
     if "<@" not in text:
         return False
+    # Mirror the ``app_mention`` gate: when every mention is glued to a ``/`` the
+    # message names package paths rather than tagging the app, and the
+    # ``app_mention`` copy was dropped as ``path_mention`` — this copy is the
+    # only one left, so it must stay in the untagged pipeline.
+    if _every_mention_is_a_path_segment(event):
+        return False
     bot_user_id = get_cached_bot_user_id(SlackIntegration(integration), integration)
     if not bot_user_id:
         return False

--- a/products/slack_app/backend/tests/test_thread_message_routing.py
+++ b/products/slack_app/backend/tests/test_thread_message_routing.py
@@ -527,6 +527,34 @@ class TestRouteThreadMessage(TestCase):
         assert first.kwargs["posthog_user"].id == self.user.id
         assert second.kwargs["untagged_followup"] is True
         assert second.kwargs["posthog_user"].id == self.user.id
+    @parameterized.expand(
+        [
+            ("bot_id_resolved", "U_BOTAPP", False),
+            ("bot_id_unresolvable", None, True),
+        ]
+    )
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+    def test_tagged_reply_skips_untagged_followup_path(self, _name, bot_user_id, expect_workflow):
+        """Slack delivers a tagged thread reply as both ``app_mention`` and
+        ``message``, under different event ids. The ``message`` copy must not
+        enter the untagged-followup pipeline — otherwise the classifier and the
+        ``ask`` prompt run on a message that explicitly addressed the app. If
+        the bot user id can't be resolved the gate fails open and the reply
+        dispatches as before."""
+        from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY
+
+        event = self._make_event(text="<@U_BOTAPP> another one using opus 5")
+        with (
+            patch("products.slack_app.backend.api.get_cached_bot_user_id", return_value=bot_user_id),
+            patch(
+                "products.slack_app.backend.api._start_mention_workflow", return_value=ROUTE_HANDLED_LOCALLY
+            ) as mock_start,
+        ):
+            result = self._route(event)
+        assert result == ROUTE_HANDLED_LOCALLY
+        assert mock_start.called is expect_workflow
+        if expect_workflow:
+            assert mock_start.call_args.kwargs["untagged_followup"] is True
 
 
 class TestMirrorSlackMessageEventTask(SimpleTestCase):

--- a/products/slack_app/backend/tests/test_thread_message_routing.py
+++ b/products/slack_app/backend/tests/test_thread_message_routing.py
@@ -527,23 +527,27 @@ class TestRouteThreadMessage(TestCase):
         assert first.kwargs["posthog_user"].id == self.user.id
         assert second.kwargs["untagged_followup"] is True
         assert second.kwargs["posthog_user"].id == self.user.id
+
     @parameterized.expand(
         [
-            ("bot_id_resolved", "U_BOTAPP", False),
-            ("bot_id_unresolvable", None, True),
+            ("bot_id_resolved", "U0BOT", "<@U0BOT> another one using opus 5", False),
+            ("bot_id_unresolvable", None, "<@U0BOT> another one using opus 5", True),
+            ("path_mention", "U0BOT", "<@U0BOT>/posthog-js still fails", True),
         ]
     )
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
-    def test_tagged_reply_skips_untagged_followup_path(self, _name, bot_user_id, expect_workflow):
+    def test_tagged_reply_skips_untagged_followup_path(self, _name, bot_user_id, text, expect_workflow):
         """Slack delivers a tagged thread reply as both ``app_mention`` and
         ``message``, under different event ids. The ``message`` copy must not
         enter the untagged-followup pipeline — otherwise the classifier and the
         ``ask`` prompt run on a message that explicitly addressed the app. If
         the bot user id can't be resolved the gate fails open and the reply
-        dispatches as before."""
+        dispatches as before. A mention glued to a ``/`` is a package path, not
+        a tag — its ``app_mention`` copy is dropped as ``path_mention``, so the
+        ``message`` copy must keep flowing or the reply reaches nothing."""
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY
 
-        event = self._make_event(text="<@U_BOTAPP> another one using opus 5")
+        event = self._make_event(text=text)
         with (
             patch("products.slack_app.backend.api.get_cached_bot_user_id", return_value=bot_user_id),
             patch(


### PR DESCRIPTION
## Problem

- Tagging @PostHog in a task thread still ran the untagged-followup flow: in `ask` mode the author got the "Want me to pick up your message?" prompt on top of the normal answer.
- Slack delivers a tagged thread reply twice, as `app_mention` and as a plain `message`, each with its own event id. The queue workflow dedups on event id, so the `message` copy entered the untagged-followup pipeline.

## Changes

- The webhook drops the `message` copy of a reply that mentions the bot's own user id, so the classifier and the `ask` prompt only run on genuinely untagged replies.
- If the bot user id cannot be resolved, the gate fails open and routing is unchanged.

## How did you test this code?

- Verified on a local dev stack with a connected Slack workspace: tagged replies in a task thread get one answer and no prompt; untagged replies still go through the classifier and ask flow.
- New parameterized routing test covers the dual delivery, which no existing test did: no untagged dispatch when the bot id matches, unchanged dispatch when it cannot be resolved.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a bug report with a Slack screenshot. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Deduping the queue workflow on `channel:ts` instead of event id was rejected: delivery order of the two copies races, and the `message` copy winning would misroute a real mention through the classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
