### PR TITLE
fix(replay-vision): make the observations skill readable by scanner scouts

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/scannerScout.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScout.ts
@@ -82,7 +82,7 @@ Every run leaves exactly one report: your digest. That report is what the team r
 1. \`vision-scanners-get\` with scanner_id \`${scannerId}\` — the scanner's current name, type, prompt, and enabled state. If it no longer exists, close out with a one-line summary and no report.
 2. \`scout-runs-list\` filtered to your own skill_name — find your previous successful run. Your window is everything since it (fall back to the last 24 hours on the first run or after a gap).
 3. \`scout-scratchpad-search\` (text: \`${scannerId}\`) — baselines, known noise, and \`report:\`/\`dedupe:\` pointers from prior runs. Every entry you write is keyed on that id, so it is what finds them again.
-4. Load the packaged skill \`posthog:exploring-replay-vision-observations\` through the runtime's packaged-skill mechanism for the observation data model and query patterns.
+4. \`llma-skill-get\` \`exploring-replay-vision-observations\` — the observation data model, what \`confidence\` and each status mean, and how to cite a finding.
 
 ## Read the window
 
@@ -118,7 +118,7 @@ Write the report so it stands alone for a reader with no prior context:
 
 - Open with the takeaway in one line, then at most three bullets ordered by impact.
 - Each bullet: what changed, with only the numbers needed to judge it; why it matters; the evidence-backed cause or best next investigation; and the specific next action.
-- Ground every claim in specific observations, as real markdown links: \`[what it shows](/replay-vision/observations/<observation_id>)\`, taking \`<observation_id>\` from the \`id\` of an observation you actually read. A bare \`[obs 3]\` is not a link and leaves the reader nowhere to go. Two or three per bullet is plenty; link the clearest cases, not every one.
+- Ground every claim in observations you actually read, as real markdown links to the recording: \`[what it shows](/project/<project_id>/replay/<session_id>?t=<seconds>)\`, so the link opens on the moment being claimed. A bare \`[obs 3]\` is not a link and leaves the reader nowhere to go. Two or three per bullet is plenty; link the clearest cases, not every one.
 - Close with what you checked, and name anything you could not cover and why.
 
 When nothing clears the bar, still file the report, with the verdict \`Nothing notable\` and a short coverage line ("42 observations across 30 sessions, distributions steady"). ${focus.priority}

--- a/products/signals/backend/scout_harness/lazy_seed.py
+++ b/products/signals/backend/scout_harness/lazy_seed.py
@@ -39,6 +39,17 @@ _SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
 # means cleaning up its rows out-of-band.
 _COMPANION_SKILL_DIRS = ("authoring-scouts",)
 
+# Companions that another product ships and maintains, seeded on the same terms as the ones above.
+# A scout is exactly the agent the companion rule is written for: it reads skills through
+# `llma-skill-get`, which only sees per-team rows, so a skill that lives solely in
+# `dist/skills.zip` is unreachable from a run no matter what the scout's prompt says. The
+# alternative — each product bundling a private copy onto every scout it creates — freezes the
+# copy at creation, so an edit to the source never reaches a scout already in rotation.
+# Cross-product by file path, not by import: the harness reads the markdown and never imports the
+# owning product. The stranding caveat above applies here too.
+_PRODUCTS_DIR = Path(__file__).resolve().parents[3]
+_EXTERNAL_COMPANION_SKILL_DIRS = (_PRODUCTS_DIR / "replay_vision" / "skills" / "exploring-replay-vision-observations",)
+
 # Mirrors the regex in `products/posthog_ai/scripts/build_skills.py` so frontmatter parsing
 # stays consistent across the two consumers. Keep these in sync if the skill spec evolves.
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
@@ -312,15 +323,19 @@ def discover_canonical_skills(skills_dir: Path | None = None) -> tuple[Canonical
     on the first read instead of flapping silently.
     """
     base = skills_dir or _SKILLS_DIR
+    # `skills_dir` means "read this fleet in isolation", which is what the tests want; the
+    # cross-product companions belong to the real fleet only.
+    external = _EXTERNAL_COMPANION_SKILL_DIRS if skills_dir is None else ()
     if not base.is_dir():
         return ()
     discovered: list[CanonicalSkill] = []
     by_name: dict[str, Path] = {}
-    for entry in sorted(base.iterdir()):
+    candidates = [(entry, entry.name.startswith(SIGNALS_SCOUT_SKILL_PREFIX)) for entry in sorted(base.iterdir())]
+    candidates.extend((entry, False) for entry in external)
+    for entry, is_scout in candidates:
         if not entry.is_dir():
             continue
-        is_scout = entry.name.startswith(SIGNALS_SCOUT_SKILL_PREFIX)
-        if not is_scout and entry.name not in _COMPANION_SKILL_DIRS:
+        if not is_scout and entry.name not in _COMPANION_SKILL_DIRS and entry not in external:
             continue
         if not (entry / "SKILL.md").is_file():
             continue

--- a/products/signals/backend/scout_harness/lazy_seed.py
+++ b/products/signals/backend/scout_harness/lazy_seed.py
@@ -328,15 +328,25 @@ def discover_canonical_skills(skills_dir: Path | None = None) -> tuple[Canonical
     external = _EXTERNAL_COMPANION_SKILL_DIRS if skills_dir is None else ()
     if not base.is_dir():
         return ()
-    discovered: list[CanonicalSkill] = []
-    by_name: dict[str, Path] = {}
-    candidates = [(entry, entry.name.startswith(SIGNALS_SCOUT_SKILL_PREFIX)) for entry in sorted(base.iterdir())]
-    candidates.extend((entry, False) for entry in external)
-    for entry, is_scout in candidates:
+    candidates: list[tuple[Path, bool]] = []
+    for entry in sorted(base.iterdir()):
         if not entry.is_dir():
             continue
-        if not is_scout and entry.name not in _COMPANION_SKILL_DIRS and entry not in external:
+        is_scout = entry.name.startswith(SIGNALS_SCOUT_SKILL_PREFIX)
+        if is_scout or entry.name in _COMPANION_SKILL_DIRS:
+            candidates.append((entry, is_scout))
+    for entry in external:
+        if not (entry / "SKILL.md").is_file():
+            # Warn rather than raise: `canonical_skill_names` turns a parse error into an empty
+            # fleet, so a moved directory in another product would make every scout read as
+            # custom. The fleet lock in the tests is what fails loud on this.
+            logger.warning("discover_canonical_skills: external companion skill missing at %s", entry)
             continue
+        candidates.append((entry, False))
+
+    discovered: list[CanonicalSkill] = []
+    by_name: dict[str, Path] = {}
+    for entry, is_scout in candidates:
         if not (entry / "SKILL.md").is_file():
             continue
         skill = _parse_canonical_skill(entry, is_scout=is_scout)

--- a/products/signals/backend/test/test_scout_harness_lazy_seed.py
+++ b/products/signals/backend/test/test_scout_harness_lazy_seed.py
@@ -401,6 +401,10 @@ class TestDiscoverCanonicalSkills:
             # Companion (non-scout) skill, seeded so store-only agents can read the
             # authoring guide via llma-skill-get.
             "authoring-scouts",
+            # Companion owned by another product, resolved by file path. Moving or renaming
+            # that directory drops it from every team's store, and a scout told to read it
+            # would report it missing instead of failing.
+            "exploring-replay-vision-observations",
         }
         assert expected.issubset(names), f"missing canonical skills: {expected - names}"
 


### PR DESCRIPTION
## Problem

Every scanner scout's digest is written without the guidance we wrote for it. The scout's prompt tells it to read `exploring-replay-vision-observations` for the observation data model and citation conventions, and the skill is never there.

A scout reads skills with `llma-skill-get`, which only sees rows in the team's skills store. That store is filled by the Signals harness, which seeds `products/signals/skills/` plus the companions named in `_COMPANION_SKILL_DIRS`. The Replay Vision skill lives in `products/replay_vision/skills/` and ships only in `dist/skills.zip`, which the scout sandbox cannot read.

The first three scouts to run in production each reported it, in the report body: "The packaged `exploring-replay-vision-observations` skill was unavailable, so I used the live scanner tools and the bound digest procedure." Every run since has done the same.

## Changes

- Scouts can now read the observations skill, so a digest is written with the observation data model, what `confidence` means, and what each status means. The harness seeds it per team like `authoring-scouts`.
- Digests now cite the recording at the moment being claimed, `[what it shows](/project/<id>/replay/<session_id>?t=<seconds>)`, instead of the observation row. That link opens on the paywall, the rage click, the drop-off. This is the form the skill teaches and the form the scouts already produced on their own.
- `_EXTERNAL_COMPANION_SKILL_DIRS` takes companions from another product by file path. The harness reads the markdown and never imports the owning product.

Bundling a private copy onto each scout at creation was the alternative, and it keeps the change inside Replay Vision. It also freezes the copy: an edit to the skill never reaches a scout already in rotation. Seeding keeps every scout on the current text through the existing divergence-aware sync, which leaves a team's edited copy alone.

> [!NOTE]
> This adds one row to every team's skills store, including teams with no scanners, and the stranding caveat in `lazy_seed.py` applies: removing a companion later leaves its per-team rows behind, because prune only reaps `signals-scout-*`.

## How did you test this code?

The fleet lock in `test_scout_harness_lazy_seed.py` gains the companion's name. It catches the failure that shipped: move or rename the Vision skill directory and discovery silently skips it, then scouts report the skill missing rather than anything failing. Reverting the `lazy_seed.py` change fails that test.

Discovery only adds the external companions when no `skills_dir` override is passed. Tests that build a fleet in a `tmp_path` assert exact name lists, so a leak would fail them.

Not tested: no scout has run against the seeded skill. The seeding path reaches a team through the coordinator's sync, and this was verified by reading the manifest (`discover_canonical_skills()` returns the companion with an 11,761-byte body), not by dispatching a run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @TueHaulund. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/toolbox-access`.

Found by reading the first production scout reports for a scanner on the internal project: all three said the skill was unavailable, and none of them used the `/replay-vision/observations/<id>` citation format the prompt asked for. A read-only toolbox query confirmed the skill is absent from that team's store while 48,693 other skills are present.

The citation change reverses a decision from the PR that added scouts. Observation links looked better on paper. The evidence says otherwise: the agents produced replay links with timestamps without being told to, and the skill documents that form as what makes a finding checkable.

**Public artifact:** nothing here came from a customer conversation, ticket, or log.
