### PR TITLE
fix(self-driving): let members enable session replay

### DIFF
--- a/posthog/api/product_enablement.py
+++ b/posthog/api/product_enablement.py
@@ -14,6 +14,8 @@ import secrets
 from collections.abc import Callable
 from typing import cast
 
+from django.db import transaction
+
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.exceptions import PermissionDenied
@@ -110,43 +112,47 @@ class ProductEnablementViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         serializer = ProductEnablementSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        team = self.team
-        before = team.__dict__.copy()
-        touched: set[str] = set()
-        # dict.fromkeys dedupes while preserving the caller's order.
-        results = {
-            product: RECIPES[product](team, touched) for product in dict.fromkeys(serializer.validated_data["products"])
-        }
+        # Lock the row for the read-modify-write: the recipes only write a companion default when the
+        # field is unset, so a stale read would let this clobber a concurrent admin's stricter config.
+        with transaction.atomic():
+            team = Team.objects.select_for_update().get(pk=self.team.pk)
+            before = team.__dict__.copy()
+            touched: set[str] = set()
+            # dict.fromkeys dedupes while preserving the caller's order.
+            results = {
+                product: RECIPES[product](team, touched)
+                for product in dict.fromkeys(serializer.validated_data["products"])
+            }
 
-        # conversations is admin-only on the normal Team-update API; replicate that gate so this endpoint
-        # can't be a bypass (error_tracking + the replay opt-in stay member-safe).
-        admin_fields = (touched - SERVER_DEFAULT_FIELDS) & TEAM_CONFIG_ADMIN_FIELDS_SET
-        if admin_fields:
-            level = self.user_permissions.team(team).effective_membership_level
-            if level is None or level < OrganizationMembership.Level.ADMIN:
-                raise PermissionDenied(
-                    "Only project admins can enable products that change these settings: "
-                    + ", ".join(sorted(admin_fields))
+            # conversations is admin-only on the normal Team-update API; replicate that gate so this endpoint
+            # can't be a bypass (error_tracking + the replay opt-in stay member-safe).
+            admin_fields = (touched - SERVER_DEFAULT_FIELDS) & TEAM_CONFIG_ADMIN_FIELDS_SET
+            if admin_fields:
+                level = self.user_permissions.team(team).effective_membership_level
+                if level is None or level < OrganizationMembership.Level.ADMIN:
+                    raise PermissionDenied(
+                        "Only project admins can enable products that change these settings: "
+                        + ", ".join(sorted(admin_fields))
+                    )
+
+            if touched:
+                team.save(update_fields=sorted(touched))
+                # Audit the enable like the Team-update API does; drop conversations_settings so the
+                # minted widget token never lands in the activity log.
+                changes = [
+                    change
+                    for change in dict_changes_between("Team", before, team.__dict__, use_field_exclusions=True)
+                    if change.field != "conversations_settings"
+                ]
+                log_activity(
+                    organization_id=team.organization_id,
+                    team_id=team.pk,
+                    user=cast(User, request.user),
+                    was_impersonated=is_impersonated(request),
+                    scope="Team",
+                    item_id=team.pk,
+                    activity="updated",
+                    detail=Detail(name=str(team.name), changes=changes),
                 )
-
-        if touched:
-            team.save(update_fields=sorted(touched))
-            # Audit the enable like the Team-update API does; drop conversations_settings so the
-            # minted widget token never lands in the activity log.
-            changes = [
-                change
-                for change in dict_changes_between("Team", before, team.__dict__, use_field_exclusions=True)
-                if change.field != "conversations_settings"
-            ]
-            log_activity(
-                organization_id=team.organization_id,
-                team_id=team.pk,
-                user=cast(User, request.user),
-                was_impersonated=is_impersonated(request),
-                scope="Team",
-                item_id=team.pk,
-                activity="updated",
-                detail=Detail(name=str(team.name), changes=changes),
-            )
 
         return Response({"results": results}, status=status.HTTP_200_OK)

--- a/posthog/api/product_enablement.py
+++ b/posthog/api/product_enablement.py
@@ -69,6 +69,10 @@ def _enable_conversations(team: Team, touched: set[str]) -> str:
     return "enabled"
 
 
+# Companion defaults the server writes only when the field is unset: they pin a conservative floor
+# rather than express a caller's choice, so they never require admin even where the Team API gates them.
+SERVER_DEFAULT_FIELDS: frozenset[str] = frozenset({"session_recording_masking_config", "conversations_settings"})
+
 RECIPES: dict[str, Recipe] = {
     "session_replay": _enable_session_replay,
     "error_tracking": _enable_error_tracking,
@@ -114,9 +118,9 @@ class ProductEnablementViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             product: RECIPES[product](team, touched) for product in dict.fromkeys(serializer.validated_data["products"])
         }
 
-        # conversations + replay masking are admin-only on the normal Team-update API; replicate that
-        # gate so this endpoint can't be a bypass (error_tracking + the replay opt-in stay member-safe).
-        admin_fields = touched & TEAM_CONFIG_ADMIN_FIELDS_SET
+        # conversations is admin-only on the normal Team-update API; replicate that gate so this endpoint
+        # can't be a bypass (error_tracking + the replay opt-in stay member-safe).
+        admin_fields = (touched - SERVER_DEFAULT_FIELDS) & TEAM_CONFIG_ADMIN_FIELDS_SET
         if admin_fields:
             level = self.user_permissions.team(team).effective_membership_level
             if level is None or level < OrganizationMembership.Level.ADMIN:

--- a/posthog/api/test/test_product_enablement.py
+++ b/posthog/api/test/test_product_enablement.py
@@ -9,8 +9,8 @@ from posthog.models.activity_logging.activity_log import ActivityLog
 class TestProductEnablementAPI(APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
-        # The endpoint's admin-gated recipes (conversations, replay masking) need an admin caller;
-        # the member-denial path is covered by test_admin_gated_products_require_project_admin.
+        # The endpoint's admin-gated recipe (conversations) needs an admin caller; the member-denial
+        # path is covered by test_admin_gated_products_require_project_admin.
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
@@ -88,14 +88,20 @@ class TestProductEnablementAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_admin_gated_products_require_project_admin(self):
-        # A non-admin member can enable member-safe products but not the admin-gated ones
-        # (conversations / replay masking), matching the team-update API's gate.
+        # A non-admin member can enable member-safe products but not conversations, matching the
+        # team-update API's gate.
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
         self.assertEqual(self._enable(["error_tracking"]).status_code, status.HTTP_200_OK)
         self.team.refresh_from_db()
         self.assertTrue(self.team.autocapture_exceptions_opt_in)
+
+        # The server's own masking floor must not gate the member-safe replay opt-in.
+        self.assertEqual(self._enable(["session_replay"]).status_code, status.HTTP_200_OK)
+        self.team.refresh_from_db()
+        self.assertTrue(self.team.session_recording_opt_in)
+        self.assertEqual(self.team.session_recording_masking_config, {"maskAllInputs": True})
 
         response = self._enable(["conversations"])
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
## Problem

A project member cannot enable Session Replay through `/api/projects/:id/product_enablement/`, even though enabling it is a member-safe action everywhere else.

- `_enable_session_replay` writes a masking floor whenever `session_recording_masking_config` is unset, which is the default on every new project.
- That field is not in `TEAM_CONFIG_MEMBER_FIELDS`, so it lands in the admin-gated set, `touched` always contains an admin field, and the caller gets a 403 naming `session_recording_masking_config`.
- The thing actually being turned on, `session_recording_opt_in`, is explicitly member-safe on the Team update API.
- It fires on the idempotent path too, because the floor is written before the `already_enabled` return.

The practical effect: a non-admin running `npx @posthog/wizard replay-vision` on a fresh project gets a 403 on the step that turns recording on, then finishes with scanners and nothing to watch.

## Changes

- Exempt server-written companion defaults from the admin gate. These pin a conservative floor when a field is unset rather than express a caller's choice, so a write can only tighten.
- The gate keeps working where it matters. `conversations` is still admin-only, because its primary toggle `conversations_enabled` is gated on its own and is not a companion default.

The endpoint now also locks the team row for the read-modify-write. The recipes only write a companion default when the field is unset, so on a stale read this could clobber a stricter config an admin set concurrently. That race predates this PR but was unreachable for members while the gate rejected them, so it is fixed here rather than left behind.

The gate exists to stop a member weakening masking. It cannot do that here: the value is chosen by the server, written only when nothing is set, and `posthog-js` already masks inputs by default, so the floor pins the existing behavior rather than changing it.

Worth flagging for the reviewer: the comment this replaces described the old behavior as intended, so this is a deliberate narrowing rather than a typo fix. If you would rather members not enable Session Replay at all, the right change is the opposite one, and `session_recording_opt_in` should stop being member-safe on the Team API too.

## How did you test this code?

- Extended `test_admin_gated_products_require_project_admin` with the member enabling `session_replay`: asserts 200, `session_recording_opt_in` set, and the floor written.
- Verified the test fails without the fix (403) and passes with it, so it catches the regression rather than just describing current behavior.
- Full file passes: 11 tests. `ruff check` and `ruff format` clean.
- No test for the locking. A deterministic one needs concurrent transactions and a `TransactionTestCase`, which buys a slow, flake-prone test for a standard guard; `test_does_not_clobber_existing_masking_config` already covers the non-concurrent path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Skills: `writing-tests`, `shepherd-pr`.

Found by a review agent while shepherding #86979, which exposes this endpoint as the `products-enable` MCP tool and is what makes the 403 reachable in practice. Kept separate from that PR so a change to an admin gate gets its own review.
