### PR TITLE
fix(tasks): bypass compute quota for staff

### DIFF
--- a/products/tasks/backend/logic/services/compute_quota.py
+++ b/products/tasks/backend/logic/services/compute_quota.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 from django.conf import settings
 
-from posthog.models import Team
+from posthog.models import Team, User
 
 from products.tasks.backend.metrics import observe_compute_quota_check
 from products.tasks.backend.models import Task, TaskClientProvenance
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 def organization_deactivated(team_id: int) -> bool:
     return Team.objects.filter(id=team_id, organization__is_active=False).exists()
+
+
+def task_creator_is_staff(task: Task) -> bool:
+    return bool(task.created_by_id and User.objects.filter(id=task.created_by_id, is_staff=True).exists())
 
 
 def is_task_billable_compute(task: Task) -> bool:
@@ -54,6 +58,8 @@ def get_compute_quota_denial_reason(task: Task) -> ComputeQuotaDenialReason | No
     if organization_deactivated(task.team_id):
         observe_compute_quota_check("checked_blocked")
         return ComputeQuotaDenialReason.ORGANIZATION_DEACTIVATED
+    if task_creator_is_staff(task):
+        return None
     if not getattr(settings, "TASKS_COMPUTE_QUOTA_ENFORCEMENT_ENABLED", False):
         return None
     if not is_task_billable_compute(task):

--- a/products/tasks/backend/logic/services/tests/test_compute_quota.py
+++ b/products/tasks/backend/logic/services/tests/test_compute_quota.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
-from posthog.models import Organization, Team
+from posthog.models import Organization, Team, User
 
 from products.tasks.backend.logic.services.compute_quota import (
     ComputeQuotaDenialReason,
@@ -57,6 +57,25 @@ class TestComputeQuota:
         assert is_compute_quota_exhausted(task)
         assert not is_compute_quota_exhausted(task)
         limited.assert_called_with(self.team.api_token)
+
+    @override_settings(TASKS_COMPUTE_QUOTA_ENFORCEMENT_ENABLED=True)
+    @patch("products.tasks.backend.logic.services.compute_quota._is_posthog_code_quota_limited", return_value=True)
+    def test_staff_task_bypasses_compute_quota(self, limited):
+        staff_user = User.objects.create(email="staff@example.com", is_staff=True)
+
+        assert not is_compute_quota_exhausted(self.task(created_by=staff_user))
+        limited.assert_not_called()
+
+    @override_settings(TASKS_COMPUTE_QUOTA_ENFORCEMENT_ENABLED=True)
+    def test_deactivated_organization_still_blocks_staff_task(self):
+        staff_user = User.objects.create(email="staff@example.com", is_staff=True)
+        self.team.organization.is_active = False
+        self.team.organization.save(update_fields=["is_active"])
+
+        assert (
+            get_compute_quota_denial_reason(self.task(created_by=staff_user))
+            == ComputeQuotaDenialReason.ORGANIZATION_DEACTIVATED
+        )
 
     @override_settings(TASKS_COMPUTE_QUOTA_ENFORCEMENT_ENABLED=True)
     @patch(


### PR DESCRIPTION
## Problem

Staff members can bypass PostHog Desktop model-usage limits, but sandbox compute enforcement can still reject their tasks at the combined billing limit.

## Changes

- Staff-created tasks bypass compute quota exhaustion consistently across API and background execution paths.
- Deactivated organizations remain blocked regardless of staff status.
- Compute usage remains metered.

## How did you test this code?

- Ruff lint and formatting checks pass.
- Added regression coverage for staff quota bypass and deactivated-organization precedence.
- Database-backed tests could not run locally because PostgreSQL was unavailable; CI will run them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This aligns enforcement with existing staff behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Desktop after a human-directed review of the compute enforcement path.
- No repository skills were invoked.
- The change uses task creator identity so HTTP and Temporal paths share one rule.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*