### PR TITLE
chore(cdp): require workflows review on the cdp api, models and worker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,3 +74,26 @@ products/mcp_store/backend/catalog.py @PostHog/team-self-driving @cvolzer3
 # `hogli product:bootstrap` scaffolds a sealed product, so a new one should never need an
 # entry. Removals are the mechanical result of a product sealing and are a rubber stamp.
 products/isolation_baseline.txt @PostHog/team-devex
+
+# Workflows owns CDP, Workflows and Messaging, and the entries below gate the parts
+# where another team's change breaks a customer silently: the API and models decide
+# which of a tenant's rows get listed and updated, and the plugin-server worker
+# decides what gets delivered. Other teams edit these as a side effect of shipping
+# their own product, usually by carving out an exception so their own rows behave
+# differently, and nothing errors when they get it wrong: their tests still pass, and
+# existing customer configurations just stop appearing, or stop being delivered.
+# #66355 did that, and it took #83993, #86202 and #86614 to unwind. Product frontends
+# stay out, because a mistake there is visible rather than silent.
+products/cdp/backend/api/** @PostHog/team-workflows
+products/cdp/backend/models/** @PostHog/team-workflows
+products/workflows/backend/api/** @PostHog/team-workflows
+products/workflows/backend/models/** @PostHog/team-workflows
+products/messaging/backend/api/** @PostHog/team-workflows
+products/messaging/backend/models/** @PostHog/team-workflows
+nodejs/src/cdp/** @PostHog/team-workflows
+# ...except the tests beside those gates. Nothing else under the worker is exempt:
+# the template, legacy-plugin, legacy-webhook and segment directories all hold live
+# delivery code and mutable registries, so an edit there can redirect a customer's
+# events and the credentials that go with them.
+products/*/backend/api/test/**
+nodejs/src/cdp/**/*.test.ts


### PR DESCRIPTION
## Problem

Customers ran active transformations that never appeared in their transformations list, so they could not see, edit, or disable them ([#86614](https://github.com/PostHog/posthog/pull/86614)).
Destinations filtered on all events stopped receiving deliveries ([#86202](https://github.com/PostHog/posthog/pull/86202)).

- Both regressions came out of one PR that carved out an exception so another product's managed rows behaved differently ([#66355](https://github.com/PostHog/posthog/pull/66355)).
- Neither failure raised an error, and the authoring team's tests passed.
- The auto-assigner requested Team Workflows on all three PRs. That request is advisory, so a single approval from any reviewer merged them.
- On #86202 the author removed the team's review request 35 minutes after the bot added it, then merged on another approval.

## Changes

Seven paths now need an approval from `@PostHog/team-workflows` before they merge, and two reset lines keep the tests beside them out.

- The backend `api/` and `models/` directories of CDP, Workflows and Messaging decide which of a tenant's rows get listed, retrieved, and updated.
- `nodejs/src/cdp/**` decides what gets delivered, and nothing inside it is exempt.
- Product frontends stay out. A mistake there is visible rather than silent, which is the property that makes the gated paths dangerous.
- `backend/services/`, `backend/migrations/` and the rest of each product stay out too.

The file's header sets an extraordinary-justification bar, so the scope is drawn from measurement rather than from the product boundary. Over the last 100 merged commits to these products, gating the whole trees would hold 32 of them. This scope holds 18, and still gates every commit in the regression chain above.

| Scope | Commits gated | Held for want of a team approval |
| --- | --- | --- |
| The whole `products/{cdp,workflows,messaging}/**` and `nodejs/src/cdp/**` trees | 99 | 32 |
| Trees minus the product frontends | 86 | 27 |
| This PR | 69 | 18 |

Trimming the worker tree further was measured and rejected. The held commits spread across `services` (7), the root files (6) and `consumers` (3), which is where the regressions above landed, so cutting the low-traffic subdirectories would save 2 held commits per 100 and leave a pattern set nobody can reason about.

> [!WARNING]
> 7 of the 18 are the owning team's own PRs, held because `stamphog[bot]` approved them rather than a person. A GitHub App can neither be listed in CODEOWNERS nor join a team, so a gated path always costs the owning team its bot approvals. `@PostHog/team-workflows` also has four members and does not include everyone who reviews this code, so the membership has to match before this merges.

## How did you test this code?

GitHub enforces this file, so there is no code path to exercise and no test to add.

- Ran the repo's vendored matcher, `.github/scripts/codeowners.js`, over the nine patterns against representative paths. `backend/api/`, `backend/models/` and every subtree of the worker gate, including `templates/`, `legacy-plugins/` and `segment/`. The API test directories, the worker's own `*.test.ts` files, `backend/services/`, the product frontends, and `products/alerts/**` stay open.
- Produced the table by resolving every file of the last 100 merged commits to these products against each candidate pattern set, then checking each commit's approving reviewers against the team roster. All four PRs in the regression chain stay gated under the pattern set in this PR.
- All nine entries sit at the end of the file, so no later pattern overrides them under last-match-wins.
- Not checked: that GitHub applies the entries. That becomes observable on the first PR that touches a gated path after this merges.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/establishing-code-ownership`, `/writing-pr-descriptions`.

Four scopes were drafted and measured before this one: two exact files, the API directories only, the whole product trees, and then this. The whole-trees version was dropped once the numbers showed that half of what it held was the owning team's own bot-approved work.

An earlier revision also exempted `nodejs/src/cdp/templates/**`, `legacy-plugins/**`, `legacy-webhooks/**` and `segment/**` as additive. That was wrong: those directories hold live delivery implementations and mutable registries, so a CODEOWNERS reset there ungates edits to existing credential-bearing code, not just new files. The resets are gone, which costs two more held commits per 100.
