### PR TITLE
fix(data-warehouse): stagger managed warehouse reconciliation

### DIFF
--- a/products/data_warehouse/backend/logic/external_data_source/test/test_tasks.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_tasks.py
@@ -204,16 +204,24 @@ class TestManagedWarehouseTasks:
             ),
         ]
 
-    def test_periodic_wave_drops_expired_reconciliations(self) -> None:
+    def test_periodic_wave_drops_elapsed_slots_instead_of_catching_up(self) -> None:
+        wave_due_at = datetime.now(UTC) - timedelta(seconds=30)
         with patch(
             "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_task.apply_async"
         ) as apply_async:
             reconcile_managed_warehouse_tables_wave_task(
-                [{"team_id": 1, "organization_id": "org-a", "countdown": 0}],
-                (datetime.now(UTC) - timedelta(minutes=10)).isoformat(),
+                [
+                    {"team_id": 1, "organization_id": "org-a", "countdown": 0},
+                    {"team_id": 2, "organization_id": "org-b", "countdown": 59},
+                ],
+                wave_due_at.isoformat(),
             )
 
-        apply_async.assert_not_called()
+        apply_async.assert_called_once_with(
+            kwargs={"team_id": 2, "organization_id": "org-b"},
+            eta=wave_due_at + timedelta(seconds=59),
+            expires=wave_due_at + timedelta(seconds=359),
+        )
 
     @pytest.mark.parametrize("memberships", [None, []])
     def test_periodic_sweep_schedules_nothing_without_memberships(self, memberships: list[object] | None) -> None:

--- a/products/data_warehouse/backend/logic/external_data_source/test/test_tasks.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_tasks.py
@@ -1,9 +1,16 @@
-from unittest.mock import patch
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import call, patch
 
 from posthog.redis import get_client
 
 from products.data_warehouse.backend.tasks import (
+    reconcile_all_managed_warehouse_tables_task,
     reconcile_managed_warehouse_tables_task,
+    reconcile_managed_warehouse_tables_wave_task,
     schedule_managed_warehouse_tables_reconcile,
     send_external_data_failure_digest_catchup,
     send_external_data_failure_digest_task,
@@ -74,3 +81,151 @@ class TestManagedWarehouseTasks:
             get_client().delete(schedule_key)
 
         mock_delay.assert_called_once_with(team_id=456, organization_id="organization-id")
+
+    def test_periodic_sweep_evenly_staggers_reconciliations_in_stable_order(self) -> None:
+        sweep_started_at = datetime(2026, 1, 1, tzinfo=UTC)
+        rows = [
+            SimpleNamespace(team_id=4, organization_id="org-b"),
+            SimpleNamespace(team_id=3, organization_id="org-a"),
+            SimpleNamespace(team_id=2, organization_id="org-b"),
+            SimpleNamespace(team_id=1, organization_id="org-a"),
+        ]
+
+        with (
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.list_enabled_backfill_team_memberships",
+                return_value=rows,
+            ),
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_wave_task.apply_async"
+            ) as apply_async,
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_task.apply_async"
+            ) as reconcile_apply_async,
+            patch("products.data_warehouse.backend.tasks.tasks.datetime") as mock_datetime,
+        ):
+            mock_datetime.now.return_value = sweep_started_at
+            reconcile_all_managed_warehouse_tables_task()
+
+        reconcile_apply_async.assert_not_called()
+        assert apply_async.call_args_list == [
+            call(
+                kwargs={
+                    "items": [{"team_id": 1, "organization_id": "org-a", "countdown": 0}],
+                    "wave_due_at": sweep_started_at.isoformat(),
+                },
+                countdown=0,
+                expires=sweep_started_at + timedelta(seconds=300),
+            ),
+            call(
+                kwargs={
+                    "items": [{"team_id": 3, "organization_id": "org-a", "countdown": 30}],
+                    "wave_due_at": (sweep_started_at + timedelta(seconds=420)).isoformat(),
+                },
+                countdown=420,
+                expires=sweep_started_at + timedelta(seconds=720),
+            ),
+            call(
+                kwargs={
+                    "items": [{"team_id": 2, "organization_id": "org-b", "countdown": 0}],
+                    "wave_due_at": (sweep_started_at + timedelta(seconds=900)).isoformat(),
+                },
+                countdown=900,
+                expires=sweep_started_at + timedelta(seconds=1200),
+            ),
+            call(
+                kwargs={
+                    "items": [{"team_id": 4, "organization_id": "org-b", "countdown": 30}],
+                    "wave_due_at": (sweep_started_at + timedelta(seconds=1320)).isoformat(),
+                },
+                countdown=1320,
+                expires=sweep_started_at + timedelta(seconds=1620),
+            ),
+        ]
+
+    def test_periodic_sweep_stays_even_with_more_memberships_than_seconds(self) -> None:
+        rows = [SimpleNamespace(team_id=team_id, organization_id="org") for team_id in range(1801)]
+
+        with (
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.list_enabled_backfill_team_memberships",
+                return_value=rows,
+            ),
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_wave_task.apply_async"
+            ) as apply_async,
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_task.apply_async"
+            ) as reconcile_apply_async,
+        ):
+            reconcile_all_managed_warehouse_tables_task()
+
+        reconcile_apply_async.assert_not_called()
+        assert apply_async.call_count == 30
+        countdowns = [
+            task_call.kwargs["countdown"] + item["countdown"]
+            for task_call in apply_async.call_args_list
+            for item in task_call.kwargs["kwargs"]["items"]
+        ]
+        assert countdowns[0] == 0
+        assert countdowns[-1] == 1799
+        assert set(Counter(countdowns).values()) == {1, 2}
+        assert (
+            max(
+                item["countdown"]
+                for task_call in apply_async.call_args_list
+                for item in task_call.kwargs["kwargs"]["items"]
+            )
+            == 59
+        )
+
+    def test_periodic_wave_enqueues_reconciliations_with_post_due_expiry(self) -> None:
+        wave_due_at = datetime.now(UTC) + timedelta(minutes=1)
+        items = [
+            {"team_id": 1, "organization_id": "org-a", "countdown": 0},
+            {"team_id": 2, "organization_id": "org-b", "countdown": 59},
+        ]
+
+        with patch(
+            "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_task.apply_async"
+        ) as apply_async:
+            reconcile_managed_warehouse_tables_wave_task(items, wave_due_at.isoformat())
+
+        assert apply_async.call_args_list == [
+            call(
+                kwargs={"team_id": 1, "organization_id": "org-a"},
+                eta=wave_due_at,
+                expires=wave_due_at + timedelta(seconds=300),
+            ),
+            call(
+                kwargs={"team_id": 2, "organization_id": "org-b"},
+                eta=wave_due_at + timedelta(seconds=59),
+                expires=wave_due_at + timedelta(seconds=359),
+            ),
+        ]
+
+    def test_periodic_wave_drops_expired_reconciliations(self) -> None:
+        with patch(
+            "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_task.apply_async"
+        ) as apply_async:
+            reconcile_managed_warehouse_tables_wave_task(
+                [{"team_id": 1, "organization_id": "org-a", "countdown": 0}],
+                (datetime.now(UTC) - timedelta(minutes=10)).isoformat(),
+            )
+
+        apply_async.assert_not_called()
+
+    @pytest.mark.parametrize("memberships", [None, []])
+    def test_periodic_sweep_schedules_nothing_without_memberships(self, memberships: list[object] | None) -> None:
+        with (
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.list_enabled_backfill_team_memberships",
+                return_value=memberships,
+            ),
+            patch(
+                "products.data_warehouse.backend.tasks.tasks.reconcile_managed_warehouse_tables_wave_task.apply_async"
+            ) as apply_async,
+        ):
+            reconcile_all_managed_warehouse_tables_task()
+
+        apply_async.assert_not_called()

--- a/products/data_warehouse/backend/tasks/tasks.py
+++ b/products/data_warehouse/backend/tasks/tasks.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+from typing import TypedDict
 from uuid import UUID
 
 import structlog
@@ -52,6 +54,15 @@ EXTERNAL_DATA_FAILURE_DIGEST_LOCK_TIMEOUT_SECONDS = 120
 # serial queries so another task cannot overlap catalog writes near the lock boundary.
 MANAGED_WAREHOUSE_RECONCILE_LOCK_TIMEOUT_SECONDS = 30 * 60
 MANAGED_WAREHOUSE_RECONCILE_INTERVAL_SECONDS = 60
+MANAGED_WAREHOUSE_RECONCILE_SWEEP_SECONDS = 30 * 60
+MANAGED_WAREHOUSE_RECONCILE_WAVE_SECONDS = 60
+MANAGED_WAREHOUSE_RECONCILE_EXPIRY_GRACE_SECONDS = 5 * 60
+
+
+class _ManagedWarehouseReconcileWaveItem(TypedDict):
+    team_id: int
+    organization_id: str
+    countdown: int
 
 
 @shared_task(ignore_result=True, name="products.data_warehouse.backend.tasks.reconcile_managed_warehouse_tables")
@@ -78,6 +89,24 @@ def schedule_managed_warehouse_tables_reconcile(*, team_id: int, organization_id
     except Exception:
         client.delete(schedule_key)
         raise
+
+
+@shared_task(ignore_result=True, name="products.data_warehouse.backend.tasks.reconcile_managed_warehouse_tables_wave")
+@skip_team_scope_audit
+def reconcile_managed_warehouse_tables_wave_task(
+    items: list[_ManagedWarehouseReconcileWaveItem], wave_due_at: str
+) -> None:
+    wave_due_datetime = datetime.fromisoformat(wave_due_at)
+    for item in items:
+        eta = wave_due_datetime + timedelta(seconds=item["countdown"])
+        expires = eta + timedelta(seconds=MANAGED_WAREHOUSE_RECONCILE_EXPIRY_GRACE_SECONDS)
+        if expires <= datetime.now(UTC):
+            continue
+        reconcile_managed_warehouse_tables_task.apply_async(
+            kwargs={"team_id": item["team_id"], "organization_id": item["organization_id"]},
+            eta=eta,
+            expires=expires,
+        )
 
 
 @shared_task(
@@ -168,8 +197,29 @@ def reconcile_all_managed_warehouse_tables_task() -> None:
         # scheduled sweep retries.
         logger.warning("Managed warehouse reconcile sweep skipped: control plane unreachable")
         return
-    for row in rows:
-        schedule_managed_warehouse_tables_reconcile(team_id=row.team_id, organization_id=row.organization_id)
+    if not rows:
+        return
+    ordered_rows = sorted(rows, key=lambda row: (row.organization_id, row.team_id))
+    row_count = len(ordered_rows)
+    sweep_started_at = datetime.now(UTC)
+    waves: dict[int, list[_ManagedWarehouseReconcileWaveItem]] = {}
+    for index, row in enumerate(ordered_rows):
+        countdown = index * MANAGED_WAREHOUSE_RECONCILE_SWEEP_SECONDS // row_count
+        wave_countdown = countdown - countdown % MANAGED_WAREHOUSE_RECONCILE_WAVE_SECONDS
+        waves.setdefault(wave_countdown, []).append(
+            {
+                "team_id": row.team_id,
+                "organization_id": row.organization_id,
+                "countdown": countdown - wave_countdown,
+            }
+        )
+    for wave_countdown, items in waves.items():
+        wave_due_at = sweep_started_at + timedelta(seconds=wave_countdown)
+        reconcile_managed_warehouse_tables_wave_task.apply_async(
+            kwargs={"items": items, "wave_due_at": wave_due_at.isoformat()},
+            countdown=wave_countdown,
+            expires=wave_due_at + timedelta(seconds=MANAGED_WAREHOUSE_RECONCILE_EXPIRY_GRACE_SECONDS),
+        )
 
 
 def schedule_external_data_failure_digest(team_id: int, *, trigger: str = "inline") -> None:

--- a/products/data_warehouse/backend/tasks/tasks.py
+++ b/products/data_warehouse/backend/tasks/tasks.py
@@ -100,7 +100,7 @@ def reconcile_managed_warehouse_tables_wave_task(
     for item in items:
         eta = wave_due_datetime + timedelta(seconds=item["countdown"])
         expires = eta + timedelta(seconds=MANAGED_WAREHOUSE_RECONCILE_EXPIRY_GRACE_SECONDS)
-        if expires <= datetime.now(UTC):
+        if eta <= datetime.now(UTC):
             continue
         reconcile_managed_warehouse_tables_task.apply_async(
             kwargs={"team_id": item["team_id"], "organization_id": item["organization_id"]},

--- a/products/managed_warehouse/backend/tests/test_connection.py
+++ b/products/managed_warehouse/backend/tests/test_connection.py
@@ -16,7 +16,6 @@ from posthog.hogql.query import HogQLQueryExecutor
 from posthog.models import Organization, Team
 
 from products.data_warehouse.backend.facade.api import DIRECT_POSTGRES_URL_PATTERN
-from products.data_warehouse.backend.facade.tasks import reconcile_all_managed_warehouse_tables_task
 from products.data_warehouse.backend.tasks.tasks import (
     ensure_managed_warehouse_direct_source_v2_task,
     schedule_managed_warehouse_direct_source_ensure,
@@ -1113,41 +1112,6 @@ class TestReconcileManagedWarehouseTables:
         table = DataWarehouseTable.raw_objects.get(id=schema.table_id)
         assert schema.deleted is False
         assert table.deleted is False
-
-    def test_periodic_sweep_schedules_every_managed_project(self) -> None:
-        org, team = self._setup()
-        all_rows = _MEMBERSHIPS[str(org.id)] + [
-            # Legacy shared-table membership remains an enrolled project, so the sweep schedules it.
-            _membership(team.id + 1, str(org.id), "team_x", legacy_shared=True),
-        ]
-
-        with (
-            patch(
-                "products.data_warehouse.backend.tasks.tasks.list_enabled_backfill_team_memberships",
-                return_value=all_rows,
-            ),
-            patch(
-                "products.data_warehouse.backend.tasks.tasks.schedule_managed_warehouse_tables_reconcile"
-            ) as schedule,
-        ):
-            reconcile_all_managed_warehouse_tables_task()
-
-        assert schedule.call_count == 2
-        assert {call.kwargs["team_id"] for call in schedule.call_args_list} == {team.id, team.id + 1}
-
-    def test_periodic_sweep_skips_run_when_control_plane_unreachable(self) -> None:
-        with (
-            patch(
-                "products.data_warehouse.backend.tasks.tasks.list_enabled_backfill_team_memberships",
-                return_value=None,
-            ),
-            patch(
-                "products.data_warehouse.backend.tasks.tasks.schedule_managed_warehouse_tables_reconcile"
-            ) as schedule,
-        ):
-            reconcile_all_managed_warehouse_tables_task()
-
-        schedule.assert_not_called()
 
     def test_periodic_reconcile_does_not_create_a_missing_connection(self) -> None:
         org = Organization.objects.create(name="Org")


### PR DESCRIPTION
## Problem

Managed Warehouse reconciliations start together twice an hour, concentrating control-plane requests and worker startup load.

The periodic sweep directly publishes every eligible reconciliation with the same execution time.

## Changes

- Reconciliations now start at deterministic, evenly spaced ranks across each 30-minute window.
- The sweep queues at most 30 minute waves, avoiding a fleet-sized Celery ETA heap.
- Each wave publishes absolute leaf deadlines, so delayed waves cannot create stale catch-up bursts.
- The interactive warehouse-status path remains immediate and Redis-coalesced.
- This internal scheduling change has no user-visible UI effect.

Before:

```mermaid
flowchart LR
    Beat{{Celery Beat}} --> Sweep[Periodic sweep]
    Sweep --> Reconciles[All reconciliations at once]
    Reconciles --> Workers[Warehouse workers]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Beat phYellow;
    class Sweep phBlue;
    class Reconciles phRed;
    class Workers phGray;
```

After:

```mermaid
flowchart LR
    Beat{{Celery Beat}} --> Sweep[Periodic sweep]
    Sweep --> Waves[Up to 30 minute waves]
    Waves --> Reconciles[Evenly timed reconciliations]
    Reconciles --> Workers[Warehouse workers]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Beat phYellow;
    class Sweep,Waves phBlue;
    class Reconciles phRed;
    class Workers phGray;
```

## How did you test this code?

- Focused task tests guard stable ordering, exact spacing, bounded waves, stale expiry, empty results, and the immediate path.
- Repository-wide mypy checked the typed Celery payload boundary.
- `hogli ci:preflight --fix` checked branch freshness, Ruff lint, and formatting.
- Not run against production traffic because this changes background task scheduling.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes an internal scheduler and no documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the change in an isolated worktree. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/qa-team`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

An independent adversarial review changed direct delayed fan-out into bounded waves with absolute deadlines.

Operational diagnosis informed the change, but the diff contains no log material. All new test identifiers are invented.