### PR TITLE
fix(desktop): hide remote announcements in dev builds

### DIFF
--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -20,8 +20,9 @@ the What's New changelog and the update modals.
   entry drops alone and is counted, never crashing the batch.
 - `selectAnnouncement.ts` is the pure decision function: Zod parse → time
   window (`startsAt`/`endsAt`) → version gate → per-id dismissals → priority.
-  It returns nothing when the app version is unknown, which is what keeps the
-  web host (no `os.getAppVersion`) announcement-free by construction.
+  It returns nothing for development builds or when the app version is unknown,
+  which keeps local development and the web host (no `os.getAppVersion`)
+  announcement-free by construction.
 - Dismissals persist per announcement `id` in `announcementsStore.ts`;
   changing an announcement's `id` resurfaces it for everyone.
 - Surfaces: `AnnouncementBanner` (top of the framed content pane in
@@ -82,20 +83,23 @@ after an announcement was handled in the same session.
 browser. Author payloads with the production scheme; `announcementCta.ts`
 swaps in the dev scheme on dev builds.
 
-## Testing a payload locally
+## Observability
 
-Dev builds expose `window.posthog` in the renderer devtools:
+The app captures these events with `announcement_id`, `announcement_kind`, and
+`announcement_style` properties. CTA clicks add `cta_type`; acknowledgements
+add `ack_type`.
 
-```js
-posthog.featureFlags.overrideFeatureFlags({
-  flags: { "posthog-desktop-announcements": true },
-  payloads: {
-    "posthog-desktop-announcements": {
-      announcements: [
-        { kind: "announcement", id: "test-1", title: "Hello", body: "It works." },
-      ],
-    },
-  },
-});
-// clear with: posthog.featureFlags.overrideFeatureFlags(false)
-```
+- `Announcement shown`
+- `Announcement CTA clicked`
+- `Announcement dismissed`
+- `Announcement acknowledged`
+
+Filter these events by an announcement ID to measure unique people shown,
+CTA engagement, dismissals, and acknowledgements.
+
+## Testing
+
+Development builds intentionally never render remote announcements, including
+feature-flag overrides. Exercise the selection behavior through
+`selectAnnouncement.test.ts` and the announcement component stories. Use a
+production build to smoke-test a live flag payload.

--- a/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.test.ts
+++ b/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.test.ts
@@ -30,6 +30,7 @@ function select(
   {
     now = NOW,
     appVersion = APP_VERSION as string | null,
+    isDevBuild = false,
     dismissedIds = new Set<string>(),
     handledThisSession = false,
   } = {},
@@ -38,6 +39,7 @@ function select(
     payload,
     now,
     appVersion,
+    isDevBuild,
     dismissedIds,
     handledThisSession,
   });
@@ -48,6 +50,14 @@ describe("selectAnnouncement", () => {
     const result = select(
       { announcements: [announcement(), requiredUpdate()] },
       { appVersion: null },
+    );
+    expect(result.active).toBeNull();
+  });
+
+  it("selects nothing in a development build", () => {
+    const result = select(
+      { announcements: [announcement(), requiredUpdate()] },
+      { isDevBuild: true },
     );
     expect(result.active).toBeNull();
   });

--- a/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.ts
+++ b/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.ts
@@ -17,6 +17,7 @@ export interface SelectAnnouncementInput {
   now: number;
   /** null = version unknown (web host, query unresolved) — nothing is shown. */
   appVersion: string | null;
+  isDevBuild: boolean;
   dismissedIds: ReadonlySet<string>;
   /**
    * An announcement was already dismissed or acknowledged this session — the
@@ -63,11 +64,12 @@ export function selectAnnouncement(
     payload,
     now,
     appVersion,
+    isDevBuild,
     dismissedIds,
     handledThisSession = false,
   } = input;
 
-  if (appVersion === null) return none();
+  if (isDevBuild || appVersion === null) return none();
   if (payload === undefined || payload === null) return none();
 
   const envelope = announcementsEnvelopeSchema.safeParse(payload);

--- a/products/desktop/packages/ui/src/features/announcements/useActiveAnnouncement.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useActiveAnnouncement.ts
@@ -37,6 +37,7 @@ export function useActiveAnnouncement(): ActiveAnnouncement | null {
         payload,
         now,
         appVersion: appVersion ?? null,
+        isDevBuild: import.meta.env.DEV,
         dismissedIds: dismissedSet,
         handledThisSession,
       }),


### PR DESCRIPTION
## Summary
- Do not select remotely configured Desktop announcements in Vite development builds
- Cover the development-build gate in announcement selection tests
- Document engagement events and production-only live-payload smoke testing

## Validation
- `pnpm --filter @posthog/ui test -- selectAnnouncement.test.ts`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check packages/ui/src/features/announcements/selectAnnouncement.ts packages/ui/src/features/announcements/useActiveAnnouncement.ts packages/ui/src/features/announcements/selectAnnouncement.test.ts docs/ANNOUNCEMENTS.md`