### PR TITLE
feat(customer-analytics): add evidence to new requests

### DIFF
--- a/products/customer_analytics/backend/facade/contracts.py
+++ b/products/customer_analytics/backend/facade/contracts.py
@@ -678,12 +678,23 @@ class FeatureRequestListFilters:
 
 
 @dataclass(frozen=True)
+class FeatureRequestEvidenceInput:
+    summary: str
+    customer_quote: str
+    evidence_source: str
+    source_url: str
+    requested_on: date | None
+    image_ids: tuple[UUID, ...] = ()
+
+
+@dataclass(frozen=True)
 class CreateFeatureRequestInput:
     title: str
     description: str
     account_id: UUID
     product_area_ids: tuple[UUID, ...]
     idempotency_key: UUID
+    evidence: FeatureRequestEvidenceInput | None = None
 
 
 @dataclass(frozen=True)
@@ -702,16 +713,6 @@ class UpdateFeatureRequestInput:
     request_status: str | None = None
     request_priority: str | None = None
     request_priority_is_set: bool = False
-
-
-@dataclass(frozen=True)
-class FeatureRequestEvidenceInput:
-    summary: str
-    customer_quote: str
-    evidence_source: str
-    source_url: str
-    requested_on: date | None
-    image_ids: tuple[UUID, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/products/customer_analytics/backend/logic/feature_requests.py
+++ b/products/customer_analytics/backend/logic/feature_requests.py
@@ -423,6 +423,7 @@ def _ensure_initial_history(
     *,
     accounts: list[Account] | None = None,
     product_areas: list[FeatureRequestProductArea] | None = None,
+    evidence: FeatureRequestEvidence | None = None,
 ) -> None:
     if accounts is None:
         accounts = list(
@@ -437,21 +438,30 @@ def _ensure_initial_history(
                 request_links__feature_request=feature_request
             )
         )
+    changes: list[contracts.FeatureRequestHistoryChange] = [
+        {"field": "status", "before": None, "after": feature_request.status},
+        {"field": "priority", "before": None, "after": feature_request.priority},
+        {"field": "accounts", "before": [], "after": _account_snapshots(accounts)},
+        {
+            "field": "product_areas",
+            "before": [],
+            "after": _product_area_snapshots(product_areas),
+        },
+    ]
+    if evidence is not None:
+        changes.append(
+            {
+                "field": "evidence",
+                "before": None,
+                "after": _evidence_snapshot(evidence),
+            }
+        )
     FeatureRequestHistory.objects.for_team(feature_request.team_id).get_or_create(
         team_id=feature_request.team_id,
         feature_request=feature_request,
         is_initial=True,
         defaults={
-            "changes": [
-                {"field": "status", "before": None, "after": feature_request.status},
-                {"field": "priority", "before": None, "after": feature_request.priority},
-                {"field": "accounts", "before": [], "after": _account_snapshots(accounts)},
-                {
-                    "field": "product_areas",
-                    "before": [],
-                    "after": _product_area_snapshots(product_areas),
-                },
-            ],
+            "changes": changes,
             "source": FeatureRequestHistorySource.MANUAL,
             "actor_id": feature_request.created_by_id,
             "changed_at": feature_request.created_at,
@@ -578,6 +588,10 @@ def create_feature_request(
     if not input.product_area_ids:
         raise FeatureRequestValidationError("product_area_ids", "Select at least one product area.")
 
+    evidence_input = input.evidence
+    validated_evidence = (
+        _validate_evidence(team_id=team_id, input=evidence_input) if evidence_input is not None else None
+    )
     existing = FeatureRequest.objects.for_team(team_id).filter(idempotency_key=input.idempotency_key).first()
     if existing is not None:
         accessible_existing = _feature_request_queryset(team_id, user_access_control).filter(id=existing.id).first()
@@ -615,11 +629,25 @@ def create_feature_request(
             },
         )
         if created:
-            FeatureRequestAccountLink.objects.for_team(team_id).create(
+            account_link = FeatureRequestAccountLink.objects.for_team(team_id).create(
                 team_id=team_id,
                 feature_request=feature_request,
                 account=accessible_account,
             )
+            initial_evidence = None
+            if validated_evidence is not None and evidence_input is not None:
+                initial_evidence = FeatureRequestEvidence.objects.for_team(team_id).create(
+                    team_id=team_id,
+                    account_link=account_link,
+                    summary=validated_evidence.summary,
+                    customer_quote=validated_evidence.customer_quote,
+                    source=validated_evidence.source,
+                    source_url=validated_evidence.source_url,
+                    requested_on=evidence_input.requested_on,
+                    image_ids=list(validated_evidence.image_ids),
+                    created_by_id=actor_id,
+                    updated_by_id=actor_id,
+                )
             FeatureRequestProductAreaLink.objects.for_team(team_id).bulk_create(
                 [
                     FeatureRequestProductAreaLink(
@@ -634,6 +662,7 @@ def create_feature_request(
                 feature_request,
                 accounts=[accessible_account],
                 product_areas=product_areas,
+                evidence=initial_evidence,
             )
 
     return contracts.FeatureRequestCreateOutcome(

--- a/products/customer_analytics/backend/logic/feature_requests.py
+++ b/products/customer_analytics/backend/logic/feature_requests.py
@@ -866,7 +866,9 @@ def _validate_evidence(
         and input.requested_on is None
         and input.evidence_source == "conversation"
     ):
-        raise FeatureRequestValidationError("evidence", "Enter a summary, customer quote, source URL, or image.")
+        raise FeatureRequestValidationError(
+            "evidence", "Enter a summary, customer quote, source URL, image, request date, or change the source."
+        )
     if source_url:
         parsed_url = urlparse(source_url)
         if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:

--- a/products/customer_analytics/backend/logic/feature_requests.py
+++ b/products/customer_analytics/backend/logic/feature_requests.py
@@ -858,7 +858,14 @@ def _validate_evidence(
         if requested_image_ids is None
         else _validate_image_ids(team_id=team_id, image_ids=requested_image_ids)
     )
-    if not summary and not customer_quote and not source_url and not image_ids:
+    if (
+        not summary
+        and not customer_quote
+        and not source_url
+        and not image_ids
+        and input.requested_on is None
+        and input.evidence_source == "conversation"
+    ):
         raise FeatureRequestValidationError("evidence", "Enter a summary, customer quote, source URL, or image.")
     if source_url:
         parsed_url = urlparse(source_url)

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -556,6 +556,45 @@ class FeatureRequestListQuerySerializer(serializers.Serializer):
     )
 
 
+class FeatureRequestEvidencePayloadSerializer(serializers.Serializer):
+    summary = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        trim_whitespace=True,
+        help_text="Internal summary of this account's request evidence.",
+    )
+    customer_quote = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        trim_whitespace=True,
+        help_text="Customer quote kept with this evidence item.",
+    )
+    evidence_source = serializers.CharField(
+        max_length=200,
+        help_text="Free-form name of the source where this evidence was recorded.",
+    )
+    source_url = serializers.URLField(
+        required=False,
+        allow_blank=True,
+        default="",
+        max_length=2000,
+        help_text="Optional HTTP or HTTPS link to the source.",
+    )
+    requested_on = serializers.DateField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Date the account made the request, or null when unknown.",
+    )
+    image_ids = serializers.ListField(
+        required=False,
+        child=serializers.UUIDField(),
+        help_text="Uploaded image IDs from this project to attach in display order.",
+    )
+
+
 class FeatureRequestCreateSerializer(serializers.Serializer):
     title = serializers.CharField(
         max_length=400,
@@ -577,6 +616,11 @@ class FeatureRequestCreateSerializer(serializers.Serializer):
     )
     idempotency_key = serializers.UUIDField(
         help_text="Client-generated key that makes retries return the original request instead of creating a duplicate.",
+    )
+    evidence = FeatureRequestEvidencePayloadSerializer(
+        required=False,
+        allow_null=True,
+        help_text="Optional first evidence item to create for the selected account.",
     )
 
 
@@ -623,45 +667,6 @@ class FeatureRequestUpdateSerializer(serializers.Serializer):
         allow_null=True,
         choices=_FEATURE_REQUEST_PRIORITY_CHOICES,
         help_text="Updated manual priority. Pass null to remove the priority.",
-    )
-
-
-class FeatureRequestEvidencePayloadSerializer(serializers.Serializer):
-    summary = serializers.CharField(
-        required=False,
-        allow_blank=True,
-        default="",
-        trim_whitespace=True,
-        help_text="Internal summary of this account's request evidence.",
-    )
-    customer_quote = serializers.CharField(
-        required=False,
-        allow_blank=True,
-        default="",
-        trim_whitespace=True,
-        help_text="Customer quote kept with this evidence item.",
-    )
-    evidence_source = serializers.CharField(
-        max_length=200,
-        help_text="Free-form name of the source where this evidence was recorded.",
-    )
-    source_url = serializers.URLField(
-        required=False,
-        allow_blank=True,
-        default="",
-        max_length=2000,
-        help_text="Optional HTTP or HTTPS link to the source.",
-    )
-    requested_on = serializers.DateField(
-        required=False,
-        allow_null=True,
-        default=None,
-        help_text="Date the account made the request, or null when unknown.",
-    )
-    image_ids = serializers.ListField(
-        required=False,
-        child=serializers.UUIDField(),
-        help_text="Uploaded image IDs from this project to attach in display order.",
     )
 
 

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -297,6 +297,19 @@ class FeatureRequestProductAreaViewSet(
         return self.update(request, *args, **kwargs)
 
 
+def _feature_request_evidence_input(data: dict[str, Any] | None) -> contracts.FeatureRequestEvidenceInput | None:
+    if data is None:
+        return None
+    return contracts.FeatureRequestEvidenceInput(
+        summary=data["summary"],
+        customer_quote=data["customer_quote"],
+        evidence_source=data["evidence_source"],
+        source_url=data["source_url"],
+        requested_on=data["requested_on"],
+        image_ids=tuple(data.get("image_ids", ())),
+    )
+
+
 class FeatureRequestViewSet(
     TeamAndOrgViewSetMixin,
     AccessControlViewSetMixin,
@@ -367,6 +380,7 @@ class FeatureRequestViewSet(
                     account_id=data["account_id"],
                     product_area_ids=tuple(data["product_area_ids"]),
                     idempotency_key=data["idempotency_key"],
+                    evidence=_feature_request_evidence_input(data.get("evidence")),
                 ),
                 actor_id=cast(User, request.user).id,
                 user_access_control=self.user_access_control,
@@ -420,19 +434,7 @@ class FeatureRequestViewSet(
         serializer = FeatureRequestAddAccountSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        evidence_data = data.get("evidence")
-        evidence = (
-            contracts.FeatureRequestEvidenceInput(
-                summary=evidence_data["summary"],
-                customer_quote=evidence_data["customer_quote"],
-                evidence_source=evidence_data["evidence_source"],
-                source_url=evidence_data["source_url"],
-                requested_on=evidence_data["requested_on"],
-                image_ids=tuple(evidence_data.get("image_ids", ())),
-            )
-            if evidence_data is not None
-            else None
-        )
+        evidence = _feature_request_evidence_input(data.get("evidence"))
         try:
             feature_request = api.add_feature_request_account(
                 team_id=self.team_id,

--- a/products/customer_analytics/backend/test/test_feature_requests.py
+++ b/products/customer_analytics/backend/test/test_feature_requests.py
@@ -140,6 +140,26 @@ class TestFeatureRequestsAPI(APIBaseTest):
         self.assertEqual(retrieved.json()["request_status"], "requested")
         self.assertEqual(FeatureRequest.objects.for_team(self.team.id).count(), 1)
 
+    def test_create_can_include_initial_evidence(self) -> None:
+        payload = self._payload()
+        payload["evidence"] = {
+            "summary": "Acme needs this export for its weekly review.",
+            "customer_quote": "We need this every Monday.",
+            "evidence_source": "meeting",
+            "source_url": "https://example.com/meetings/1",
+            "requested_on": "2026-01-01",
+        }
+
+        response = self.client.post(self.requests_url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        evidence = response.json()["account_links"][0]["evidence"]
+        self.assertEqual(len(evidence), 1)
+        self.assertEqual(evidence[0]["summary"], "Acme needs this export for its weekly review.")
+        history = self.client.get(f"{self.requests_url}{response.json()['id']}/history/").json()
+        initial_changes = {change["field"]: change for change in history[0]["changes"]}
+        self.assertEqual(initial_changes["evidence"]["after"]["summary"], evidence[0]["summary"])
+
     def test_description_can_be_omitted_or_cleared(self) -> None:
         payload_without_description = self._payload()
         payload_without_description.pop("description")

--- a/products/customer_analytics/backend/test/test_feature_requests.py
+++ b/products/customer_analytics/backend/test/test_feature_requests.py
@@ -143,10 +143,7 @@ class TestFeatureRequestsAPI(APIBaseTest):
     def test_create_can_include_initial_evidence(self) -> None:
         payload = self._payload()
         payload["evidence"] = {
-            "summary": "Acme needs this export for its weekly review.",
-            "customer_quote": "We need this every Monday.",
             "evidence_source": "meeting",
-            "source_url": "https://example.com/meetings/1",
             "requested_on": "2026-01-01",
         }
 
@@ -155,10 +152,12 @@ class TestFeatureRequestsAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         evidence = response.json()["account_links"][0]["evidence"]
         self.assertEqual(len(evidence), 1)
-        self.assertEqual(evidence[0]["summary"], "Acme needs this export for its weekly review.")
+        self.assertEqual(evidence[0]["summary"], "")
+        self.assertEqual(evidence[0]["evidence_source"], "meeting")
+        self.assertEqual(evidence[0]["requested_on"], "2026-01-01")
         history = self.client.get(f"{self.requests_url}{response.json()['id']}/history/").json()
         initial_changes = {change["field"]: change for change in history[0]["changes"]}
-        self.assertEqual(initial_changes["evidence"]["after"]["summary"], evidence[0]["summary"])
+        self.assertEqual(initial_changes["evidence"]["after"]["requested_on"], evidence[0]["requested_on"])
 
     def test_description_can_be_omitted_or_cleared(self) -> None:
         payload_without_description = self._payload()

--- a/products/customer_analytics/frontend/components/FeatureRequests/FeatureRequestAccountEvidenceModal.tsx
+++ b/products/customer_analytics/frontend/components/FeatureRequests/FeatureRequestAccountEvidenceModal.tsx
@@ -124,7 +124,7 @@ export function FeatureRequestAccountEvidenceModal(): JSX.Element {
                                 onChange={(values) => setAddAccountId(values[0] ?? null)}
                                 onInputChange={setAccountSearch}
                                 options={addAccountOptions}
-                                placeholder="Search for an account"
+                                placeholder="Search by account name or external key"
                                 loading={accountsLoading}
                                 fullWidth
                             />

--- a/products/customer_analytics/frontend/components/FeatureRequests/FeatureRequestCreateModal.tsx
+++ b/products/customer_analytics/frontend/components/FeatureRequests/FeatureRequestCreateModal.tsx
@@ -7,9 +7,15 @@ import {
     LemonInputSelect,
     LemonLabel,
     LemonModal,
+    LemonSelect,
     LemonTextArea,
 } from '@posthog/lemon-ui'
 
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+
+import { FeatureRequestEvidenceImagePicker } from './FeatureRequestEvidenceImagePicker'
+import { FEATURE_REQUEST_EVIDENCE_SOURCE_OPTIONS } from './featureRequestEvidenceOptions'
 import { featureRequestsLogic } from './featureRequestsLogic'
 
 export function FeatureRequestCreateModal(): JSX.Element {
@@ -27,6 +33,12 @@ export function FeatureRequestCreateModal(): JSX.Element {
         productAreasError,
         submittingRequest,
         submitDisabledReason,
+        evidenceSummary,
+        evidenceQuote,
+        evidenceSource,
+        evidenceUrl,
+        evidenceRequestedOn,
+        uploadingEvidenceImages,
     } = useValues(featureRequestsLogic)
     const {
         closeCreateRequest,
@@ -35,6 +47,11 @@ export function FeatureRequestCreateModal(): JSX.Element {
         setAccountId,
         setAccountSearch,
         setProductAreaIds,
+        setEvidenceSummary,
+        setEvidenceQuote,
+        setEvidenceSource,
+        setEvidenceUrl,
+        setEvidenceRequestedOn,
         submitRequest,
         loadAccounts,
         loadProductAreas,
@@ -43,12 +60,20 @@ export function FeatureRequestCreateModal(): JSX.Element {
     return (
         <LemonModal
             isOpen={createRequestOpen}
-            onClose={closeCreateRequest}
+            onClose={() => {
+                if (!uploadingEvidenceImages) {
+                    closeCreateRequest()
+                }
+            }}
             title="New feature request"
             width={640}
             footer={
                 <>
-                    <LemonButton type="secondary" onClick={closeCreateRequest}>
+                    <LemonButton
+                        type="secondary"
+                        onClick={closeCreateRequest}
+                        disabledReason={uploadingEvidenceImages ? 'Uploading images' : undefined}
+                    >
                         Cancel
                     </LemonButton>
                     <LemonButton
@@ -102,7 +127,7 @@ export function FeatureRequestCreateModal(): JSX.Element {
                         onChange={(values) => setAccountId(values[0] ?? null)}
                         onInputChange={setAccountSearch}
                         options={accountOptions}
-                        placeholder="Search for an account"
+                        placeholder="Search by account name or external key"
                         loading={accountsLoading}
                         fullWidth
                     />
@@ -118,6 +143,58 @@ export function FeatureRequestCreateModal(): JSX.Element {
                         loading={productAreasLoading}
                     />
                 </div>
+                <div className="font-medium">Evidence (optional)</div>
+                <div className="flex flex-col gap-1">
+                    <LemonLabel>Summary</LemonLabel>
+                    <LemonTextArea
+                        value={evidenceSummary}
+                        onChange={setEvidenceSummary}
+                        placeholder="Summarize what this account needs"
+                        minRows={3}
+                    />
+                </div>
+                <div className="flex flex-col gap-1">
+                    <LemonLabel>Customer quote</LemonLabel>
+                    <LemonTextArea
+                        value={evidenceQuote}
+                        onChange={setEvidenceQuote}
+                        placeholder="Add the customer's words"
+                        minRows={3}
+                    />
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1">
+                        <LemonLabel>Source</LemonLabel>
+                        <LemonSelect
+                            value={evidenceSource}
+                            onChange={setEvidenceSource}
+                            options={FEATURE_REQUEST_EVIDENCE_SOURCE_OPTIONS}
+                            fullWidth
+                        />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <LemonLabel>Request date</LemonLabel>
+                        <LemonCalendarSelectInput
+                            value={evidenceRequestedOn ? dayjs(evidenceRequestedOn) : null}
+                            onChange={(value) => setEvidenceRequestedOn(value?.format('YYYY-MM-DD') ?? null)}
+                            selectionPeriod="past"
+                            granularity="day"
+                            clearable
+                            placeholder="Select a date"
+                        />
+                    </div>
+                </div>
+                <div className="flex flex-col gap-1">
+                    <LemonLabel>Source URL</LemonLabel>
+                    <LemonInput
+                        type="url"
+                        value={evidenceUrl}
+                        onChange={setEvidenceUrl}
+                        placeholder="https://example.com/source"
+                        fullWidth
+                    />
+                </div>
+                <FeatureRequestEvidenceImagePicker />
             </div>
         </LemonModal>
     )

--- a/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.test.ts
@@ -124,14 +124,12 @@ describe('featureRequestsLogic', () => {
         )
     })
 
-    it('creates initial evidence with the selected account', async () => {
+    it('creates initial evidence from a source and request date', async () => {
         const createSpy = jest.spyOn(generatedApi, 'featureRequestsCreate').mockResolvedValue(createdRequest)
         logic.actions.openCreateRequest()
         logic.actions.setTitle(createdRequest.title)
         logic.actions.setAccountId(createdRequest.account.id)
         logic.actions.setProductAreaIds(['area-1'])
-        logic.actions.setEvidenceSummary('Acme needs a weekly export.')
-        logic.actions.setEvidenceQuote('We need this every Monday.')
         logic.actions.setEvidenceSource('meeting')
         logic.actions.setEvidenceRequestedOn('2026-01-01')
 
@@ -144,16 +142,16 @@ describe('featureRequestsLogic', () => {
             product_area_ids: ['area-1'],
             idempotency_key: expect.any(String),
             evidence: {
-                summary: 'Acme needs a weekly export.',
-                customer_quote: 'We need this every Monday.',
+                summary: '',
+                customer_quote: '',
                 evidence_source: 'meeting',
                 source_url: '',
                 requested_on: '2026-01-01',
                 image_ids: [],
             },
         })
-        expect(logic.values.evidenceSummary).toBe('')
-        expect(logic.values.evidenceQuote).toBe('')
+        expect(logic.values.evidenceSource).toBe('conversation')
+        expect(logic.values.evidenceRequestedOn).toBeNull()
     })
 
     it('keeps the selected account name and external key while search results reload', () => {

--- a/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.test.ts
@@ -22,6 +22,7 @@ import {
 const account: AccountApi = {
     id: 'account-1',
     name: 'Acme',
+    external_id: 'cust_acme_001',
     notebooks: [],
     ignored_at: null,
     created_at: '2026-01-01T00:00:00Z',
@@ -123,12 +124,46 @@ describe('featureRequestsLogic', () => {
         )
     })
 
-    it('keeps the selected account name while search results reload', () => {
+    it('creates initial evidence with the selected account', async () => {
+        const createSpy = jest.spyOn(generatedApi, 'featureRequestsCreate').mockResolvedValue(createdRequest)
+        logic.actions.openCreateRequest()
+        logic.actions.setTitle(createdRequest.title)
+        logic.actions.setAccountId(createdRequest.account.id)
+        logic.actions.setProductAreaIds(['area-1'])
+        logic.actions.setEvidenceSummary('Acme needs a weekly export.')
+        logic.actions.setEvidenceQuote('We need this every Monday.')
+        logic.actions.setEvidenceSource('meeting')
+        logic.actions.setEvidenceRequestedOn('2026-01-01')
+
+        await expectLogic(logic, () => logic.actions.submitRequest()).toFinishAllListeners()
+
+        expect(createSpy).toHaveBeenCalledWith(String(MOCK_DEFAULT_TEAM.id), {
+            title: createdRequest.title,
+            description: '',
+            account_id: createdRequest.account.id,
+            product_area_ids: ['area-1'],
+            idempotency_key: expect.any(String),
+            evidence: {
+                summary: 'Acme needs a weekly export.',
+                customer_quote: 'We need this every Monday.',
+                evidence_source: 'meeting',
+                source_url: '',
+                requested_on: '2026-01-01',
+                image_ids: [],
+            },
+        })
+        expect(logic.values.evidenceSummary).toBe('')
+        expect(logic.values.evidenceQuote).toBe('')
+    })
+
+    it('keeps the selected account name and external key while search results reload', () => {
         logic.actions.loadAccountsSuccess([account])
         logic.actions.setAccountId(account.id)
         logic.actions.loadAccountsSuccess([])
 
-        expect(logic.values.accountOptions).toEqual([{ key: account.id, label: account.name }])
+        expect(logic.values.accountOptions).toEqual([
+            { key: account.id, label: `${account.name} (${account.external_id})` },
+        ])
     })
 
     it('filters product areas by name without changing the available areas', () => {
@@ -398,6 +433,7 @@ describe('featureRequestsLogic', () => {
             ...account,
             id: 'account-2',
             name: 'Globex',
+            external_id: 'cust_globex_001',
         }
         const updatedRequest: FeatureRequestApi = {
             ...createdRequest,
@@ -437,7 +473,9 @@ describe('featureRequestsLogic', () => {
         logic.actions.setAddAccountId(otherAccount.id)
         logic.actions.setEvidenceSummary('Globex needs a weekly export.')
         logic.actions.setEvidenceSource('meeting')
-        expect(logic.values.addAccountOptions).toEqual([{ key: otherAccount.id, label: otherAccount.name }])
+        expect(logic.values.addAccountOptions).toEqual([
+            { key: otherAccount.id, label: `${otherAccount.name} (${otherAccount.external_id})` },
+        ])
 
         await expectLogic(logic, () => logic.actions.saveEvidence()).toFinishAllListeners()
 

--- a/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.ts
+++ b/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.ts
@@ -34,6 +34,7 @@ import type {
     FeatureRequestAccountLinkApi,
     FeatureRequestApi,
     FeatureRequestEvidenceApi,
+    FeatureRequestEvidencePayloadApi,
     FeatureRequestHistoryApi,
     FeatureRequestProductAreaApi,
     FeatureRequestStatusEnumApi,
@@ -65,6 +66,17 @@ export function featureRequestAccountElementId(accountId: string): string {
 
 export function featureRequestEvidenceElementId(evidenceId: string): string {
     return `feature-request-evidence-${evidenceId}`
+}
+
+function hasFeatureRequestEvidence(evidence: FeatureRequestEvidencePayloadApi): boolean {
+    return Boolean(
+        evidence.summary?.trim() ||
+        evidence.customer_quote?.trim() ||
+        evidence.source_url?.trim() ||
+        evidence.image_ids?.length ||
+        evidence.requested_on ||
+        evidence.evidence_source !== 'conversation'
+    )
 }
 
 const FILTER_URL_KEYS = [
@@ -674,7 +686,9 @@ export interface featureRequestsLogicMeta {
             addAccountId: string | null,
             evidenceSummary: string,
             evidenceQuote: string,
+            evidenceSource: string,
             evidenceUrl: string,
+            evidenceRequestedOn: string | null,
             evidenceImageIds: string[],
             uploadingEvidenceImages: boolean,
             savingEvidence: boolean
@@ -1500,7 +1514,9 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                 selectors.addAccountId,
                 selectors.evidenceSummary,
                 selectors.evidenceQuote,
+                selectors.evidenceSource,
                 selectors.evidenceUrl,
+                selectors.evidenceRequestedOn,
                 selectors.evidenceImageIds,
                 selectors.uploadingEvidenceImages,
                 selectors.savingEvidence,
@@ -1510,7 +1526,9 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                 addAccountId: string | null,
                 summary: string,
                 quote: string,
+                source: string,
                 sourceUrl: string,
+                requestedOn: string | null,
                 imageIds: string[],
                 uploadingImages: boolean,
                 saving: boolean
@@ -1524,8 +1542,18 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                 if (addingAccount && !addAccountId) {
                     return 'Select an account'
                 }
-                if (!addingAccount && !summary.trim() && !quote.trim() && !sourceUrl.trim() && imageIds.length === 0) {
-                    return 'Enter a summary, customer quote, source URL, or image'
+                if (
+                    !addingAccount &&
+                    !hasFeatureRequestEvidence({
+                        summary,
+                        customer_quote: quote,
+                        evidence_source: source,
+                        source_url: sourceUrl,
+                        requested_on: requestedOn,
+                        image_ids: imageIds,
+                    })
+                ) {
+                    return 'Enter a summary, customer quote, source URL, image, request date, or change the source'
                 }
                 return undefined
             },
@@ -1700,9 +1728,7 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                     requested_on: values.evidenceRequestedOn,
                     image_ids: values.evidenceImageIds,
                 }
-                const hasEvidence = Boolean(
-                    evidence.summary || evidence.customer_quote || evidence.source_url || evidence.image_ids.length
-                )
+                const hasEvidence = hasFeatureRequestEvidence(evidence)
                 const created = await featureRequestsCreate(values.currentTeamId, {
                     title: values.title.trim(),
                     description: values.description.trim(),
@@ -1851,12 +1877,7 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                     requested_on: values.evidenceRequestedOn,
                     image_ids: values.evidenceImageIds,
                 }
-                const hasEvidence = Boolean(
-                    evidenceFields.summary ||
-                    evidenceFields.customer_quote ||
-                    evidenceFields.source_url ||
-                    evidenceFields.image_ids.length
-                )
+                const hasEvidence = hasFeatureRequestEvidence(evidenceFields)
                 let updated: FeatureRequestApi
                 if (addingAccount && values.addAccountId) {
                     updated = await featureRequestsAddAccountCreate(values.currentTeamId, values.activeRequest.id, {

--- a/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.ts
+++ b/products/customer_analytics/frontend/components/FeatureRequests/featureRequestsLogic.ts
@@ -660,7 +660,8 @@ export interface featureRequestsLogicMeta {
             title: string,
             accountId: string | null,
             productAreaIds: string[],
-            submittingRequest: boolean
+            submittingRequest: boolean,
+            uploadingEvidenceImages: boolean
         ) => string | undefined
         editDisabledReason: (
             editTitle: string,
@@ -1207,6 +1208,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceSummary: [
             '',
             {
+                openCreateRequest: () => '',
+                closeCreateRequest: () => '',
                 openAddAccount: () => '',
                 openNewEvidence: () => '',
                 openEditEvidence: (_, { evidence }) => evidence.summary,
@@ -1216,6 +1219,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceQuote: [
             '',
             {
+                openCreateRequest: () => '',
+                closeCreateRequest: () => '',
                 openAddAccount: () => '',
                 openNewEvidence: () => '',
                 openEditEvidence: (_, { evidence }) => evidence.customer_quote,
@@ -1225,6 +1230,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceSource: [
             'conversation',
             {
+                openCreateRequest: () => 'conversation',
+                closeCreateRequest: () => 'conversation',
                 openAddAccount: () => 'conversation',
                 openNewEvidence: () => 'conversation',
                 openEditEvidence: (_, { evidence }) => evidence.evidence_source,
@@ -1234,6 +1241,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceUrl: [
             '',
             {
+                openCreateRequest: () => '',
+                closeCreateRequest: () => '',
                 openAddAccount: () => '',
                 openNewEvidence: () => '',
                 openEditEvidence: (_, { evidence }) => evidence.source_url,
@@ -1243,6 +1252,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceRequestedOn: [
             null as string | null,
             {
+                openCreateRequest: () => null,
+                closeCreateRequest: () => null,
                 openAddAccount: () => null,
                 openNewEvidence: () => null,
                 openEditEvidence: (_, { evidence }) => evidence.requested_on,
@@ -1252,6 +1263,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceDraftVersion: [
             0,
             {
+                openCreateRequest: (state) => state + 1,
+                closeCreateRequest: (state) => state + 1,
                 openAddAccount: (state) => state + 1,
                 openNewEvidence: (state) => state + 1,
                 openEditEvidence: (state) => state + 1,
@@ -1262,6 +1275,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceFilesToUpload: [
             [] as File[],
             {
+                openCreateRequest: () => [],
+                closeCreateRequest: () => [],
                 openAddAccount: () => [],
                 openNewEvidence: () => [],
                 openEditEvidence: () => [],
@@ -1273,6 +1288,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceImageIds: [
             [] as string[],
             {
+                openCreateRequest: () => [],
+                closeCreateRequest: () => [],
                 openAddAccount: () => [],
                 openNewEvidence: () => [],
                 openEditEvidence: (_, { evidence }) => [...evidence.image_ids],
@@ -1288,6 +1305,8 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
         evidenceError: [
             null as string | null,
             {
+                openCreateRequest: () => null,
+                closeCreateRequest: () => null,
                 openAddAccount: () => null,
                 openNewEvidence: () => null,
                 openEditEvidence: () => null,
@@ -1331,16 +1350,24 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                 selectedAccount: FeatureRequestAccountApi | null,
                 activeRequest: FeatureRequestApi | null
             ): { key: string; label: string }[] => {
-                const accountById = new Map<string, FeatureRequestAccountApi>(
+                const accountById = new Map<string, AccountApi | FeatureRequestAccountApi>(
                     accounts.map((account) => [account.id, account])
                 )
-                if (selectedAccount) {
+                if (selectedAccount && !accountById.has(selectedAccount.id)) {
                     accountById.set(selectedAccount.id, selectedAccount)
                 }
                 for (const link of activeRequest?.account_links ?? []) {
-                    accountById.set(link.account.id, link.account)
+                    if (!accountById.has(link.account.id)) {
+                        accountById.set(link.account.id, link.account)
+                    }
                 }
-                return [...accountById.values()].map((account) => ({ key: account.id, label: account.name }))
+                return [...accountById.values()].map((account) => ({
+                    key: account.id,
+                    label:
+                        'external_id' in account && account.external_id
+                            ? `${account.name} (${account.external_id})`
+                            : account.name,
+                }))
             },
         ],
         addAccountOptions: [
@@ -1412,13 +1439,18 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
                 selectors.accountId,
                 selectors.productAreaIds,
                 selectors.submittingRequest,
+                selectors.uploadingEvidenceImages,
             ],
             (
                 title: string,
                 accountId: string | null,
                 productAreaIds: string[],
-                submittingRequest: boolean
+                submittingRequest: boolean,
+                uploadingEvidenceImages: boolean
             ): string | undefined => {
+                if (uploadingEvidenceImages) {
+                    return 'Uploading images'
+                }
                 if (submittingRequest) {
                     return 'Saving request'
                 }
@@ -1660,12 +1692,24 @@ export const featureRequestsLogic = kea<featureRequestsLogicType>([
             }
             actions.setSubmittingRequest(true)
             try {
+                const evidence = {
+                    summary: values.evidenceSummary.trim(),
+                    customer_quote: values.evidenceQuote.trim(),
+                    evidence_source: values.evidenceSource,
+                    source_url: values.evidenceUrl.trim(),
+                    requested_on: values.evidenceRequestedOn,
+                    image_ids: values.evidenceImageIds,
+                }
+                const hasEvidence = Boolean(
+                    evidence.summary || evidence.customer_quote || evidence.source_url || evidence.image_ids.length
+                )
                 const created = await featureRequestsCreate(values.currentTeamId, {
                     title: values.title.trim(),
                     description: values.description.trim(),
                     account_id: values.accountId,
                     product_area_ids: values.productAreaIds,
                     idempotency_key: values.idempotencyKey,
+                    evidence: hasEvidence ? evidence : undefined,
                 })
                 actions.closeCreateRequest()
                 router.actions.push(urls.customerAnalyticsFeatureRequests(created.id), values.listSearchParams)

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -1716,6 +1716,30 @@ export interface PaginatedFeatureRequestListApi {
     results: FeatureRequestApi[]
 }
 
+export interface FeatureRequestEvidencePayloadApi {
+    /** Internal summary of this account's request evidence. */
+    summary?: string
+    /** Customer quote kept with this evidence item. */
+    customer_quote?: string
+    /**
+     * Free-form name of the source where this evidence was recorded.
+     * @maxLength 200
+     */
+    evidence_source: string
+    /**
+     * Optional HTTP or HTTPS link to the source.
+     * @maxLength 2000
+     */
+    source_url?: string
+    /**
+     * Date the account made the request, or null when unknown.
+     * @nullable
+     */
+    requested_on?: string | null
+    /** Uploaded image IDs from this project to attach in display order. */
+    image_ids?: string[]
+}
+
 export interface FeatureRequestCreateApi {
     /**
      * Required customer-facing request title.
@@ -1730,6 +1754,8 @@ export interface FeatureRequestCreateApi {
     product_area_ids: string[]
     /** Client-generated key that makes retries return the original request instead of creating a duplicate. */
     idempotency_key: string
+    /** Optional first evidence item to create for the selected account. */
+    evidence?: FeatureRequestEvidencePayloadApi | null
 }
 
 export interface FeatureRequestUpdateApi {
@@ -1800,30 +1826,6 @@ export interface PatchedFeatureRequestUpdateApi {
      * * `medium` - Medium
      * * `low` - Low */
     request_priority?: RequestPriorityEnumApi | null
-}
-
-export interface FeatureRequestEvidencePayloadApi {
-    /** Internal summary of this account's request evidence. */
-    summary?: string
-    /** Customer quote kept with this evidence item. */
-    customer_quote?: string
-    /**
-     * Free-form name of the source where this evidence was recorded.
-     * @maxLength 200
-     */
-    evidence_source: string
-    /**
-     * Optional HTTP or HTTPS link to the source.
-     * @maxLength 2000
-     */
-    source_url?: string
-    /**
-     * Date the account made the request, or null when unknown.
-     * @nullable
-     */
-    requested_on?: string | null
-    /** Uploaded image IDs from this project to attach in display order. */
-    image_ids?: string[]
 }
 
 export interface FeatureRequestAddAccountApi {

--- a/products/customer_analytics/frontend/generated/api.zod.ts
+++ b/products/customer_analytics/frontend/generated/api.zod.ts
@@ -981,6 +981,12 @@ export const FeatureRequestProductAreasPartialUpdateBody = /* @__PURE__ */ zod.o
 export const featureRequestsCreateBodyTitleMax = 400
 
 export const featureRequestsCreateBodyDescriptionDefault = ``
+export const featureRequestsCreateBodyEvidenceOneSummaryDefault = ``
+export const featureRequestsCreateBodyEvidenceOneCustomerQuoteDefault = ``
+export const featureRequestsCreateBodyEvidenceOneEvidenceSourceMax = 200
+
+export const featureRequestsCreateBodyEvidenceOneSourceUrlDefault = ``
+export const featureRequestsCreateBodyEvidenceOneSourceUrlMax = 2000
 
 export const FeatureRequestsCreateBody = /* @__PURE__ */ zod.object({
     title: zod.string().max(featureRequestsCreateBodyTitleMax).describe('Required customer-facing request title.'),
@@ -995,6 +1001,39 @@ export const FeatureRequestsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Client-generated key that makes retries return the original request instead of creating a duplicate.'
         ),
+    evidence: zod
+        .union([
+            zod.object({
+                summary: zod
+                    .string()
+                    .default(featureRequestsCreateBodyEvidenceOneSummaryDefault)
+                    .describe("Internal summary of this account's request evidence."),
+                customer_quote: zod
+                    .string()
+                    .default(featureRequestsCreateBodyEvidenceOneCustomerQuoteDefault)
+                    .describe('Customer quote kept with this evidence item.'),
+                evidence_source: zod
+                    .string()
+                    .max(featureRequestsCreateBodyEvidenceOneEvidenceSourceMax)
+                    .describe('Free-form name of the source where this evidence was recorded.'),
+                source_url: zod
+                    .url()
+                    .max(featureRequestsCreateBodyEvidenceOneSourceUrlMax)
+                    .default(featureRequestsCreateBodyEvidenceOneSourceUrlDefault)
+                    .describe('Optional HTTP or HTTPS link to the source.'),
+                requested_on: zod.iso
+                    .date()
+                    .nullish()
+                    .describe('Date the account made the request, or null when unknown.'),
+                image_ids: zod
+                    .array(zod.uuid())
+                    .optional()
+                    .describe('Uploaded image IDs from this project to attach in display order.'),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Optional first evidence item to create for the selected account.'),
 })
 
 export const featureRequestsUpdateBodyTitleMax = 400

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37982,6 +37982,8 @@ export namespace Schemas {
       product_area_ids: string[];
       /** Client-generated key that makes retries return the original request instead of creating a duplicate. */
       idempotency_key: string;
+      /** Optional first evidence item to create for the selected account. */
+      evidence?: FeatureRequestEvidencePayload | null;
     }
 
     export interface FeatureRequestEvidenceCreate {

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -1235,6 +1235,12 @@ export const FeatureRequestsCreateParams = /* @__PURE__ */ zod.object({
 export const featureRequestsCreateBodyTitleMax = 400
 
 export const featureRequestsCreateBodyDescriptionDefault = ``
+export const featureRequestsCreateBodyEvidenceOneSummaryDefault = ``
+export const featureRequestsCreateBodyEvidenceOneCustomerQuoteDefault = ``
+export const featureRequestsCreateBodyEvidenceOneEvidenceSourceMax = 200
+
+export const featureRequestsCreateBodyEvidenceOneSourceUrlDefault = ``
+export const featureRequestsCreateBodyEvidenceOneSourceUrlMax = 2000
 
 export const FeatureRequestsCreateBody = /* @__PURE__ */ zod.object({
     title: zod.string().max(featureRequestsCreateBodyTitleMax).describe('Required customer-facing request title.'),
@@ -1251,6 +1257,39 @@ export const FeatureRequestsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Client-generated key that makes retries return the original request instead of creating a duplicate.'
         ),
+    evidence: zod
+        .union([
+            zod.object({
+                summary: zod
+                    .string()
+                    .default(featureRequestsCreateBodyEvidenceOneSummaryDefault)
+                    .describe("Internal summary of this account's request evidence."),
+                customer_quote: zod
+                    .string()
+                    .default(featureRequestsCreateBodyEvidenceOneCustomerQuoteDefault)
+                    .describe('Customer quote kept with this evidence item.'),
+                evidence_source: zod
+                    .string()
+                    .max(featureRequestsCreateBodyEvidenceOneEvidenceSourceMax)
+                    .describe('Free-form name of the source where this evidence was recorded.'),
+                source_url: zod
+                    .url()
+                    .max(featureRequestsCreateBodyEvidenceOneSourceUrlMax)
+                    .default(featureRequestsCreateBodyEvidenceOneSourceUrlDefault)
+                    .describe('Optional HTTP or HTTPS link to the source.'),
+                requested_on: zod.iso
+                    .date()
+                    .nullish()
+                    .describe('Date the account made the request, or null when unknown.'),
+                image_ids: zod
+                    .array(zod.string())
+                    .optional()
+                    .describe('Uploaded image IDs from this project to attach in display order.'),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Optional first evidence item to create for the selected account.'),
 })
 
 export const FeatureRequestsRetrieveParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -1411,6 +1411,9 @@ const featureRequestsCreate = (): ToolBase<
         if (params.idempotency_key !== undefined) {
             body['idempotency_key'] = params.idempotency_key
         }
+        if (params.evidence !== undefined) {
+            body['evidence'] = params.evidence
+        }
         const result = await context.api.request<Schemas.FeatureRequest>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/feature_requests/`,


### PR DESCRIPTION
## Problem

Creating a feature request requires a second edit to add evidence, and pasted account external keys disappear from the account selector.

Part of #57014. Stacked on #87079.

## Changes

- Adds optional evidence fields to the new feature request modal.
- Creates the request, account link, evidence, and initial history in one transaction.
- Shows account external keys in selector options so pasted keys remain searchable and identifiable.
- Regenerates the API and MCP types for optional initial evidence.

![feature-request-create-evidence](https://raw.githubusercontent.com/PostHog/pr-assets/0b1ac626069e8f856390b6d752283bd3417015b8/2026/08/9edd85b6-b77e-4ce9-91d2-21e879dbb18e.png)

## How did you test this code?

- The feature request backend suite guards atomic initial evidence, history, validation, and existing evidence flows.
- The focused frontend logic suite guards initial evidence payloads, draft reset, and account labels containing external keys.
- Mypy, Ruff, frontend linting, formatting, and OpenAPI generation completed successfully.
- The Storybook feature request modal rendered the evidence fields and external-key account prompt with synthetic data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. The modal labels describe the optional evidence and account search behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Pi using GPT-5.6.
- Invoked `/stacking-prs`, `/improving-drf-endpoints`, `/writing-dataclasses`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, and the shared `no-slop` skill.
- Reused the existing evidence payload and account search endpoint instead of adding parallel API shapes.
- All test and Storybook data is synthetic or already public in the repository.