### PR TITLE
fix(desktop): preserve task timeline scroll position

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -51,6 +51,7 @@ import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTe
 import { MentionComposer } from "@posthog/ui/features/canvas/components/MentionComposer";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { usePinnedAutoScroll } from "@posthog/ui/features/canvas/hooks/usePinnedAutoScroll";
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { canvasArtifactOpenHandler } from "@posthog/ui/features/canvas/utils/canvasArtifactNavigation";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
@@ -59,7 +60,6 @@ import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifac
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
 
 export function ThreadMessageRow({
   message,
@@ -542,11 +542,7 @@ function ThreadConversation({
     onMentionInsert,
   } = conversation;
 
-  const scrollRef = useRef<HTMLDivElement>(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when rendered thread content changes
-  useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [timeline, agentStatus?.phase]);
+  const { containerRef, contentRef, onScroll } = usePinnedAutoScroll();
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-gray-1">
@@ -562,17 +558,23 @@ function ThreadConversation({
           <TaskCard task={task} channelId={channelId} inThread />
         </div>
       )}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto">
-        <ThreadTimeline
-          timeline={timeline}
-          isReady={isReady}
-          currentUserUuid={currentUser?.uuid}
-          currentUserEmail={currentUser?.email}
-          isTaskAuthor={isTaskAuthor}
-          canForward={canForward}
-          onSendToAgent={sendMessageToAgent}
-          onDelete={deleteMessage}
-        />
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-y-auto"
+        onScroll={onScroll}
+      >
+        <div ref={contentRef}>
+          <ThreadTimeline
+            timeline={timeline}
+            isReady={isReady}
+            currentUserUuid={currentUser?.uuid}
+            currentUserEmail={currentUser?.email}
+            isTaskAuthor={isTaskAuthor}
+            canForward={canForward}
+            onSendToAgent={sendMessageToAgent}
+            onDelete={deleteMessage}
+          />
+        </div>
       </div>
 
       {agentStatus && <AgentStatusLine status={agentStatus} />}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/usePinnedAutoScroll.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/usePinnedAutoScroll.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePinnedAutoScroll } from "./usePinnedAutoScroll";
+
+let resizeCallback: ResizeObserverCallback;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback;
+  }
+
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+function TestScroller() {
+  const { containerRef, contentRef, onScroll } = usePinnedAutoScroll();
+
+  return (
+    <div ref={containerRef} data-testid="scroller" onScroll={onScroll}>
+      <div ref={contentRef}>Timeline</div>
+    </div>
+  );
+}
+
+describe("usePinnedAutoScroll", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("follows growth only while the viewer is at the bottom", () => {
+    const { getByTestId } = render(<TestScroller />);
+    const scroller = getByTestId("scroller");
+    let scrollHeight = 200;
+
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+    });
+
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    scrollHeight = 250;
+    resizeCallback([], {} as ResizeObserver);
+    expect(scroller.scrollTop).toBe(250);
+
+    scroller.scrollTop = 80;
+    fireEvent.scroll(scroller);
+    scrollHeight = 300;
+    resizeCallback([], {} as ResizeObserver);
+    expect(scroller.scrollTop).toBe(80);
+
+    scroller.scrollTop = 200;
+    fireEvent.scroll(scroller);
+    scrollHeight = 350;
+    resizeCallback([], {} as ResizeObserver);
+    expect(scroller.scrollTop).toBe(350);
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/hooks/usePinnedAutoScroll.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/usePinnedAutoScroll.ts
@@ -1,0 +1,46 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+const BOTTOM_TOLERANCE_PX = 1;
+
+export function isScrolledToBottom(element: HTMLElement): boolean {
+  return (
+    element.scrollHeight - element.scrollTop - element.clientHeight <=
+    BOTTOM_TOLERANCE_PX
+  );
+}
+
+/** Keeps growing content in view until the viewer deliberately scrolls away. */
+export function usePinnedAutoScroll() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const isPinnedRef = useRef(true);
+
+  const scrollToBottom = useCallback(() => {
+    const container = containerRef.current;
+    if (container && isPinnedRef.current) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, []);
+
+  const onScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (container) {
+      isPinnedRef.current = isScrolledToBottom(container);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    scrollToBottom();
+
+    if (!content) {
+      return;
+    }
+
+    const observer = new ResizeObserver(scrollToBottom);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [scrollToBottom]);
+
+  return { containerRef, contentRef, onScroll };
+}


### PR DESCRIPTION
## Problem

The task timeline pulls viewers back to the latest activity after they scroll up to read earlier entries.

## Changes

- The timeline follows new activity while the viewer remains at the bottom.
- Scrolling up pauses automatic scrolling, and returning to the bottom resumes it.
- A resize observer also follows content that grows after rendering. The layout itself is unchanged, so screenshots would look identical.

## How did you test this code?

- The focused hook test covers following, pausing, and resuming as content grows.
- The UI package typecheck passes.
- Manual desktop testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change corrects existing task timeline behavior without changing documented workflows.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this change. The repository writing-pr-descriptions skill shaped this description. No private data informed the patch.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*