### PR TITLE
fix(llma): answer an unusable publish installation with 503, not 502

### DIFF
--- a/docs/internal/skills/community-skills-api.md
+++ b/docs/internal/skills/community-skills-api.md
@@ -133,6 +133,11 @@ fail-safe that keeps publishing off until the GitHub App is installed.
 
 The three are kept apart on purpose, because each sends the publisher somewhere different. The skill
 is rendered before GitHub is touched, so a skill that has to be edited answers `400` even while the
-App is down. `503` is reserved for an installation GitHub says is absent or refuses the App's
-credentials for; any other failed status while minting the publish token is an outage and answers
-`502`, so a transient failure doesn't read as "this instance can't publish".
+App is down. `503` is reserved for the settings an operator has to change: an installation GitHub says
+is absent, one whose App credentials it refuses, and one that doesn't grant the `contents` and
+`pull_requests` write the mint asks for. Any other failed status while minting the publish token is an
+outage and answers `502`, so a transient failure doesn't read as "this instance can't publish".
+
+The 503 is logged as `llma_skill_publish_to_community_not_configured`, with the team, user and skill.
+Without it an instance meant to have publishing on is indistinguishable from one that never
+configured it, until somebody reports the toast.

--- a/products/skills/backend/api/community_publish_services.py
+++ b/products/skills/backend/api/community_publish_services.py
@@ -373,8 +373,9 @@ def _parent_directories(path: str) -> list[str]:
 PUBLISHER_TOKEN_PERMISSIONS = {"contents": "write", "pull_requests": "write", "metadata": "read"}
 # Statuses that mean the App isn't installed here or its credentials are rejected: unauthenticated,
 # not permitted, or no such installation. Rate limits never reach this set — the transport raises
-# them, including the 403 spellings.
-PUBLISHER_NOT_CONFIGURED_STATUSES = frozenset({401, 403, 404})
+# them, including the 403 spellings. 422 joins them because GitHub answers a mint asking for
+# permissions the installation does not grant that way, and only an admin can change that.
+PUBLISHER_NOT_CONFIGURED_STATUSES = frozenset({401, 403, 404, 422})
 
 
 def _publisher_token_request_body() -> dict[str, Any]:

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -1006,6 +1006,14 @@ class LLMSkillViewSet(
                 author_handle=payload.validated_data.get("author_handle", ""),
             )
         except CommunitySkillPublishNotConfiguredError:
+            # The fail-safe is otherwise silent, so an instance that meant to have publishing on
+            # looks like one that never configured it until somebody reports the toast.
+            logger.warning(
+                "llma_skill_publish_to_community_not_configured",
+                team_id=self.team.id,
+                user_id=cast(User, request.user).id,
+                skill_name=skill.name,
+            )
             return Response(
                 {"detail": "Publishing to the community is not available on this instance."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/products/skills/backend/api/test/test_community_publish_services.py
+++ b/products/skills/backend/api/test/test_community_publish_services.py
@@ -282,6 +282,7 @@ class TestCommunitySkillsPublisher:
         [
             ("the app is not installed here", 404, False),
             ("github refuses the app credentials", 401, False),
+            ("the installation does not grant the permissions a publish needs", 422, False),
             ("github fails the mint", 500, True),
         ]
     )


### PR DESCRIPTION
## Problem

Publishing a skill to the community catalog has been off on prod-us since the feature merged, and nobody noticed. The endpoint returns its 503 fail-safe when `COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID` is unset, and that path logs nothing, so an instance that meant to have publishing on looks identical to one that never configured it. The only signal was somebody reporting the toast.

The same endpoint gives wrong advice for a second config error. GitHub answers a token mint asking for permissions the installation does not grant with `422`. That status is not in the "not configured" set, so it surfaces as a `502` reading "Could not reach GitHub to publish this skill. Try again in a few minutes." Retrying never changes an installation's permission set.

## Changes

- A publisher whose installation lacks the permissions a publish needs now sees "Publishing to the community is not available on this instance" instead of an invitation to retry. `422` joins `401`, `403` and `404` in `PUBLISHER_NOT_CONFIGURED_STATUSES`.
- The 503 path logs `llma_skill_publish_to_community_not_configured` with the team, user and skill, so a misconfigured instance is findable without waiting for a report.
- `docs/internal/skills/community-skills-api.md` records both. Mechanical.
- Nothing changes for a correctly configured instance, and no UI changes.

The split is between "an operator has to change a setting" and "GitHub had a bad minute". A `422` is the first, so it belongs with the statuses that already answer 503, rather than in the outage branch that tells the publisher to come back later.

## How did you test this code?

- Added the `422` case to the existing parameterized test in `test_community_publish_services.py`. It catches a permanent permission error being presented as retryable, which no existing case covered: `401` and `404` were tested, and `422` fell through to the gateway-error branch.
- Not checked: whether GitHub returns `422` for the real prod installation. That needs the App private key, so it is unverified here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Included in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). The session started from a report that publishing failed in the app. The root cause was config rather than code: `COMMUNITY_SKILLS_GITHUB_INSTALLATION_ID` is unset on prod-us, fixed separately in [PostHog/charts#14558](https://github.com/PostHog/charts/pull/14558). This PR is the follow-on, covering the two ways that class of failure is reported badly.

Widening the "not configured" status set was chosen over adding a distinct exception type for `422`. The endpoint already maps that set to a single 503 whose message is correct for a missing permission grant, so a new type would add a branch without changing what a publisher sees.

Public artifact: nothing here carries material from the agent session. The diff is code, a test case, and doc prose.

Skills invoked: `/phs`, `/writing-pr-descriptions`, `/writing-code-comments`.
