### PR TITLE
fix(dashboards): evaluate customization flags remotely

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -699,6 +699,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
             evaluation_runtime="all",
         )
+        self.assertGreater(len(_mock_get_flags.call_args_list), 0)
         self.assertTrue(all(flag_call == expected_flag_call for flag_call in _mock_get_flags.call_args_list))
 
     @patch(

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -4,8 +4,9 @@ import datetime
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest, snapshot_postgres_queries
 from unittest import mock
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 from django.utils.timezone import now
@@ -690,6 +691,15 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             updated["customization"],
             {"tile_spacing": "condensed", "layout_compaction": "horizontal"},
         )
+        expected_flag_call = call(
+            self.team.api_token,
+            self.user.distinct_id,
+            groups={"organization": str(self.team.organization_id), "project": str(self.team.id)},
+            flag_keys=["dashboard-customization"],
+            internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
+            evaluation_runtime="all",
+        )
+        self.assertTrue(all(flag_call == expected_flag_call for flag_call in _mock_get_flags.call_args_list))
 
     @patch(
         "products.dashboards.backend.feature_flags.get_flags_from_service",

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -674,6 +674,41 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             Dashboard.objects.get(id=copied_id).customization, {"show_legend": False, "tile_spacing": "wide"}
         )
 
+    @patch(
+        "products.dashboards.backend.feature_flags.get_flags_from_service",
+        return_value={"flags": {"dashboard-customization": {"enabled": True}}},
+    )
+    def test_dashboard_customization_uses_remote_flag_evaluation(self, _mock_get_flags: MagicMock) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, updated = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"grid_spacing": "condensed", "layout_compaction": "horizontal"},
+        )
+
+        self.assertEqual(
+            updated["customization"],
+            {"tile_spacing": "condensed", "layout_compaction": "horizontal"},
+        )
+
+    @patch(
+        "products.dashboards.backend.feature_flags.get_flags_from_service",
+        side_effect=ConnectionError,
+    )
+    def test_dashboard_customization_fails_closed_when_remote_evaluation_fails(
+        self, _mock_get_flags: MagicMock
+    ) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"grid_spacing": "condensed"},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertEqual(response["attr"], "grid_spacing")
+        self.assertEqual(response["detail"], "Tile density isn't available.")
+
     @parameterized.expand([("horizontal",), ("stable",)])
     @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)
     def test_dashboard_layout_compaction_is_saved_and_duplicated(

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import posthoganalytics
-
+from posthog.api.services.flags_service import get_flags_from_service
 from posthog.permissions import _FORCE_ENABLED_FLAGS
 
 if TYPE_CHECKING:
@@ -23,16 +22,18 @@ def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> b
     organization_id = str(team.organization_id)
     project_id = str(team.id)
 
-    return bool(
-        posthoganalytics.feature_enabled(
-            flag,
+    try:
+        # Cohort targeting needs the remote evaluator; process-local definitions do not include membership.
+        result = get_flags_from_service(
+            team.api_token,
             distinct_id,
             groups={"organization": organization_id, "project": project_id},
-            group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
+            flag_keys=[flag],
+            evaluation_runtime="all",
         )
-    )
+    except Exception:
+        return False
+    return bool(result.get("flags", {}).get(flag, {}).get("enabled"))
 
 
 def dashboard_widgets_enabled(*, team: Team, user: User | None = None) -> bool:

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.conf import settings
+
 from posthog.api.services.flags_service import get_flags_from_service
 from posthog.permissions import _FORCE_ENABLED_FLAGS
 
@@ -29,6 +31,7 @@ def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> b
             distinct_id,
             groups={"organization": organization_id, "project": project_id},
             flag_keys=[flag],
+            internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
             evaluation_runtime="all",
         )
     except Exception:


### PR DESCRIPTION
## Problem

- Cohort-targeted dashboard editors cannot save tile density or tile movement settings when the process-local flag cache lacks cohort membership.

```mermaid
flowchart LR
    Request[Dashboard PATCH] --> Cache[Local flag cache]
    Cache --> Deny[Flag false]
    Deny --> Error[Customization rejected]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Request phYellow;
    class Cache phBlue;
    class Deny,Error phRed;
```

## Changes

- Dashboard editors now receive a flags-service decision, which resolves cohort membership before saving customization settings.
- Dashboard updates deny customization settings when the flags service is unavailable.
- No visual UI change; the existing controls now follow their cohort rollout.

```mermaid
flowchart LR
    Request[Dashboard PATCH] --> Flags[Flags service]
    Flags --> Allow[Flag true]
    Allow --> Save[Customization saved]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#c7ccd1,color:#000;
    class Request phYellow;
    class Flags,Allow,Save phBlue;
```

## How did you test this code?

- Added dashboard PATCH coverage for a flags-service allow decision and a flags-service failure.
- The tests verify that the requested customization saves or returns the existing validation response.
- Did not test a deployed build because this change needs deployment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This changes internal feature-flag evaluation only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used PostHog MCP plus `/writing-tests` and `/writing-pr-descriptions`.
- The change uses the shared flags-service client instead of SDK-local evaluation.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*