### PR TITLE
chore(alerts): pin the clock in the alert history chart stories

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4745,25 +4745,25 @@ snapshots:
     posthog-3000-keyboard-shortcut--within-tooltip--light:
         hash: v1.k794b7964.aa2d9701c9134d5c374b6517f2fa542eb24c7e15ebf0d65f64efbc0ec2a99efa.BL1mMRm5CNDAmAMk-2pf-lp8EI6t65oBqoy990BdgyQ
     products-alerts-alert-history-chart--anomaly-probability-cutoff--dark:
-        hash: v1.k794b7964.d8bfbcdf6258aaa31643fb641a3c4c5679ec385116869f16e892a23b657ff910.rSI-RaJqddtdxzgnTMB65ntFwfOTQ1FTvx5ISZT2VHY
+        hash: v1.k794b7964.460d616c71926ac3b4d7d721560023199bffc1a3b33af37255101afd682f18a2.74twsqxa1qeRVXM0BHTDnY7bI-_o8Bzxbx3ssYxCESg
     products-alerts-alert-history-chart--anomaly-probability-cutoff--light:
-        hash: v1.k794b7964.bf88e81ad8b34d4f9ece6568275319edd07ca1778e6767ada0cfbc8b11d409a5.wTXTtVDIcUl5_F3uuL3TkIgzQ4FfUi-42IXNLtWrgO4
+        hash: v1.k794b7964.bc13aa6e2a6d243086aabd81428cbc690cd903d2686404c982a4d93ab108b890.4YjEQvEKnoHpyAFn2nz4Q-qSxQcFMYUE0J320p2CIjs
     products-alerts-alert-history-chart--default--dark:
-        hash: v1.k794b7964.5f80261867dfc65f19ccef144fac19669df2765ae6d3059e3a8a713d18d02f2e.VltOzLJjhvhc6neuKq7VMBLqe9Z32JDVDdJeiJr5hnc
+        hash: v1.k794b7964.783b2c55180ce6d1a3f7ac39fbe5862d4e53e96cf70e0ae1883444d2728fa1b9.krWs2-HfZ24JBxrgJiK7Qdd8DhS-8Z2jiQt_0yF1AMk
     products-alerts-alert-history-chart--default--light:
-        hash: v1.k794b7964.3f9a52b3393d2509d9f34bc63feb257b1356478f17eb48d0866e23f5e60f6800.c8hZrHeK0bGi_ToWWPYQ3pKIFqBt9qpBMs2blvwMPEg
+        hash: v1.k794b7964.4d8a15cf51dd6c06f611bd30c470bebb3c69955a6593e0c9ddce1b5629b1a6f2.C2yasNUgK8nubifj4YkYkm6YGNtTBtDFtuKNO1LS7xg
     products-alerts-alert-history-chart--percentage-thresholds--dark:
-        hash: v1.k794b7964.47dfba3bed051ef991292a0975006f037917951e85532058204729b8ed96cfb6.8lvTV6Y5wRcXQvEkfE6Qw1SeeUoHHBJDpMJcvhoFa0Q
+        hash: v1.k794b7964.72dd845cdab5ccd82db26845a87e59e0494e507f65a2f7b7130c6cace3dbb29b.g8zQTIiMKNrsTMiDHLa6zyr2Vpl3IkLP3-JeN-JV0BM
     products-alerts-alert-history-chart--percentage-thresholds--light:
-        hash: v1.k794b7964.b783816797aa9d4dca9f2d98d5da87d33ed859efb98225c1497ea6915f8e1e69._oGhSZarZKQpZpBxyLY6LE4tEfU00k6ID_jdRwIz3e8
+        hash: v1.k794b7964.6b7544374f39f178d262ab4ab80c4b231d50c88d8a927fa0b032780e2e0ef1ac.d0sc4qztPZ29DYbDvJuVS8LSyXHslNtwpuTZkh4grEQ
     products-alerts-alert-history-chart--threshold-changed--dark:
-        hash: v1.k794b7964.7bf1274551a74797d5833aaef99e0a8e3b94601da2c9f0d404dc4242a11f13ee.lXzcaeoPoWGMrObwVAEvoMvMmF5GMk6QEOobb5_TFdM
+        hash: v1.k794b7964.a86779583b6f5eaab783be87b59da34298e177569483fa444b6ae114d97b067f.pa9QcCFp4qZiwobjNTtz6reNKwo9WYjR1P3Yvt53LQE
     products-alerts-alert-history-chart--threshold-changed--light:
-        hash: v1.k794b7964.2f3272da0133084fc9f0642a0c9fc6ef2d17966cb90f15a061af194de6aeb65a.cPsoLgzTHziozJsBVANa09XANxKRiJ9Ow6AmjKBTDuo
+        hash: v1.k794b7964.1897da3225f075e1d05f9c9468ef7122b4fd30740ae5e0c36184627315cc7a49.oRj-D7gnq-TSK4NhqB6GJvbZn52jkUv_r34jdKoAFuE
     products-alerts-alert-history-chart--truncated-history--dark:
-        hash: v1.k794b7964.90455fb16477e13cef13f6cb74b8abc051d4994e8367ef4b3f48eae05e3d60ac.xh6PbdClVykw-EidRF0HQ0qokwczbQ9Wp5O3otHOEbo
+        hash: v1.k794b7964.d688c7f23e7123952e3d25cbeac8b3f3fbf8625f584d47686702ae3806624d7b.x3xwtoY8DtamsjhqSqGKHEMBImwmvLKXTQMj3tjXZnE
     products-alerts-alert-history-chart--truncated-history--light:
-        hash: v1.k794b7964.a6451435f2289854bb80da841df8a6f9d7cbd9dcd5226a1f084df4a58e43ea15.NPQCI2X1Msq2OjxA2G-uDiMooR2KkSLUOa44T0ipv4c
+        hash: v1.k794b7964.6faf0ddd9885a43d2275daec0a6c2710828a27351aa16d13a5f43c7f810935d4.1pBJ2EvJL0Ol3b_sXqQRGjLdfgJwj7pz2i4bahQa-wY
     products-alerts-alert-modal--create-wizard--dark:
         hash: v1.k794b7964.e3efb1235db76f2fe8b3ccff465df9b84263211b8648d57a725cfcf3a92c08c9.mTtZUY5-gkDVf9yjhBIR_Cx1_5arKEIEJh-2g-cLQBQ
     products-alerts-alert-modal--create-wizard--light:

--- a/products/alerts/frontend/views/AlertHistoryChart.stories.tsx
+++ b/products/alerts/frontend/views/AlertHistoryChart.stories.tsx
@@ -25,6 +25,13 @@ const STORY_USER: UserBasicType = {
 
 const EMPTY_INSIGHT = {} as QueryBasedInsightModel
 
+/**
+ * Point labels land on the x-axis, so a live clock moves the snapshot on every visual-regression
+ * run. The `mockDate` parameter cannot cover this on its own, because story args are built at
+ * module load, before the decorator runs.
+ */
+const STORY_NOW = dayjs('2026-07-16T12:00:00')
+
 function buildStoryAlert(overrides: Partial<AlertType> & Pick<AlertType, 'threshold'>): AlertType {
     return {
         id: '11111111-1111-1111-1111-111111111111',
@@ -35,10 +42,10 @@ function buildStoryAlert(overrides: Partial<AlertType> & Pick<AlertType, 'thresh
         config: { type: 'TrendsAlertConfig', series_index: 0 },
         subscribed_users: [],
         created_by: STORY_USER,
-        created_at: dayjs().toISOString(),
+        created_at: STORY_NOW.toISOString(),
         state: AlertState.NOT_FIRING,
-        last_notified_at: dayjs().toISOString(),
-        last_checked_at: dayjs().toISOString(),
+        last_notified_at: STORY_NOW.toISOString(),
+        last_checked_at: STORY_NOW.toISOString(),
         checks: [],
         calculation_interval: AlertCalculationInterval.DAILY,
         detector_config: null,
@@ -49,9 +56,7 @@ function buildStoryAlert(overrides: Partial<AlertType> & Pick<AlertType, 'thresh
 function makePoints(count: number, seed = 0): AlertHistoryChartPoint[] {
     return Array.from({ length: count }, (_, i) => ({
         value: 45 + Math.sin((i + seed) / 2.5) * 22 + (i % 5) * 4 + (i === 12 ? 35 : 0),
-        label: dayjs()
-            .subtract(count - 1 - i, 'hour')
-            .format('MMM D, HH:mm'),
+        label: STORY_NOW.subtract(count - 1 - i, 'hour').format('MMM D, HH:mm'),
     }))
 }
 
@@ -75,6 +80,9 @@ function withHistoricalFirings(
 const meta: Meta<typeof AlertHistoryChart> = {
     title: 'Products/Alerts/Alert history chart',
     component: AlertHistoryChart,
+    parameters: {
+        mockDate: STORY_NOW.toISOString(),
+    },
     args: {
         historyLimit: CHART_CHECKS_LIMIT,
         checksTotal: null,
@@ -137,9 +145,7 @@ export const AnomalyProbabilityCutoff: Story = {
     args: {
         points: Array.from({ length: 16 }, (_, i) => ({
             value: Math.min(0.99, 0.15 + i * 0.045 + (i === 10 ? 0.25 : 0)),
-            label: dayjs()
-                .subtract(16 - 1 - i, 'hour')
-                .format('MMM D, HH:mm'),
+            label: STORY_NOW.subtract(16 - 1 - i, 'hour').format('MMM D, HH:mm'),
         })),
         valueLabel: 'Anomaly score',
         chartPlotsAnomalyScore: true,


### PR DESCRIPTION
## Problem

Every PR that runs Storybook visual review fails on ten `products-alerts-alert-history-chart--*` snapshots, whatever the PR touches.
The chart draws its point labels on the x-axis, and the story builds those labels from the current clock, so the image moves between runs.

[#86545](https://github.com/PostHog/posthog/pull/86545) made the labels visible rather than introducing them.
The old Chart.js canvas captured blank in visual review, so the timestamps never reached the image. The quill SVG chart renders them.

The drift is on master, not on any branch.
The `percentage-thresholds--dark` snapshot came back `changed` on two master runs on 21 August, at 09:27 UTC and 11:34 UTC, with no PR attached.

## Changes

- Visual review stops reporting ten unrelated alert chart failures on every PR.
- Story point labels derive from a fixed `STORY_NOW` instead of `dayjs()`, so the axis reads the same on every run.
- The `mockDate` parameter goes on the story meta too, which pins the clock the component renders against.
- `mockDate` alone does not fix this, because story args are built at module load, before the decorator runs. That is why the fixed constant carries the work.
- Nothing a user sees changes. This file only feeds Storybook.

The ten baselines need a one-time re-approval: the axis labels move from the current clock to 16 July 2026 and then stay put.

## How did you test this code?

- No test added. The regression is snapshot drift, and visual review is the check that catches it.
- Not run here: the Storybook build and the visual review capture. This sandbox has no `node_modules`.
- The visual review run on this PR is the evidence. A second run on the same commit should report the ten snapshots as unchanged against the first.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5) from a Slack thread reporting repeated visual review failures on an unrelated PR.
Skills invoked: `/writing-pr-descriptions`.

The first attempt was a `parameters: { mockDate }` line on the story meta. That is the usual fix for a story with a live clock, and it does not work here: `makePoints()` runs while the module loads, and the decorator only runs at render. Pinning the data source was the change that mattered.

`frontend/snapshots.yml` is deliberately untouched. Visual review auto-commits the new hashes after a human approves the run.

No assignee is set: the requester directed this work in Slack, and their GitHub handle was not verified in this session.
