### PR TITLE
feat(web-analytics): apply path cleaning to the live top pages panel

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -30,6 +30,7 @@ import { COUNTRY_CODE_TO_LONG_NAME, countryCodeToFlag } from 'lib/utils/country'
 import { LiveEventsFeed, LiveEventsFeedColumn } from 'scenes/activity/live/LiveEventsFeed'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { PathCleaningToggle } from '../PathCleaningToggle'
 import { LIVE_STREAM_OPERATORS, isLiveStreamFilter, webAnalyticsFilterLogic } from '../webAnalyticsFilterLogic'
 import { WebAnalyticsDomainSelector, WebAnalyticsLiveDeviceToggle } from '../WebAnalyticsFilters'
 import { webAnalyticsLogic } from '../webAnalyticsLogic'
@@ -94,8 +95,9 @@ const LiveDashboardFilterRow = ({
     setEditing: (isEditing: boolean) => void
 }): JSX.Element => {
     const [displayFilters, setDisplayFilters] = useState(false)
-    const { rawWebAnalyticsFilters, deviceTypeFilter, validatedDomainFilter } = useValues(webAnalyticsLogic)
-    const { setDeviceTypeFilter, setWebAnalyticsFilters } = useActions(webAnalyticsLogic)
+    const { rawWebAnalyticsFilters, deviceTypeFilter, validatedDomainFilter, isPathCleaningEnabled } =
+        useValues(webAnalyticsLogic)
+    const { setDeviceTypeFilter, setWebAnalyticsFilters, setIsPathCleaningEnabled } = useActions(webAnalyticsLogic)
     const { clearFilters } = useActions(webAnalyticsFilterLogic)
     const { isRefreshing } = useValues(liveWebAnalyticsMetricsLogic)
 
@@ -213,6 +215,7 @@ const LiveDashboardFilterRow = ({
                             Filters
                         </LemonButton>
                     </Popover>
+                    <PathCleaningToggle value={isPathCleaningEnabled} onChange={setIsPathCleaningEnabled} />
                     <WebAnalyticsDomainSelector />
                 </>
             }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.test.ts
@@ -1,5 +1,6 @@
 import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
 
+import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -63,5 +64,26 @@ describe('liveWebAnalyticsMetricsLogic', () => {
         )
 
         expect(logic.values.topPaths).toEqual([{ path: '/classes/928q3hr9paw8hfe', views: 1 }])
+    })
+
+    it('queues a reload for a path cleaning change that lands during the initial load', async () => {
+        // Rebuild the logic against a gated query mock so the initial load stays in flight.
+        logic.unmount()
+        let openGate: () => void = () => {}
+        const gate = new Promise<void>((resolve) => {
+            openGate = resolve
+        })
+        jest.spyOn(api, 'query').mockImplementation(async () => {
+            await gate
+            return { results: [] } as any
+        })
+        logic = liveWebAnalyticsMetricsLogic()
+        logic.mount()
+
+        // The in-flight load captured the old setting; this change must not be dropped.
+        webAnalyticsLogic.actions.setIsPathCleaningEnabled(!webAnalyticsLogic.values.isPathCleaningEnabled)
+        openGate()
+
+        await expectLogic(logic).toDispatchActions(['scheduleReload', 'loadInitialData'])
     })
 })

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.test.ts
@@ -1,0 +1,67 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+
+import { initKeaTests } from '~/test/init'
+import { AvailableFeature, LiveEvent } from '~/types'
+
+import { liveWebAnalyticsMetricsLogic } from './liveWebAnalyticsMetricsLogic'
+
+const CLASSES_RULE = { alias: '/classes/:id', regex: '/classes/[^/]+', order: 0 }
+
+const pageview = (pathname: string, distinctId: string): LiveEvent => ({
+    uuid: `${distinctId}-${pathname}`,
+    event: '$pageview',
+    properties: { $pathname: pathname, $device_id: distinctId },
+    timestamp: new Date().toISOString(),
+    team_id: MOCK_DEFAULT_TEAM.id,
+    distinct_id: distinctId,
+    created_at: new Date().toISOString(),
+})
+
+describe('liveWebAnalyticsMetricsLogic', () => {
+    let logic: ReturnType<typeof liveWebAnalyticsMetricsLogic.build>
+
+    beforeEach(() => {
+        initKeaTests(true, { ...MOCK_DEFAULT_TEAM, path_cleaning_filters: [CLASSES_RULE] }, MOCK_DEFAULT_PROJECT, {
+            ...MOCK_DEFAULT_ORGANIZATION,
+            available_product_features: [
+                { key: AvailableFeature.PATHS_ADVANCED, name: AvailableFeature.PATHS_ADVANCED },
+            ],
+        })
+        jest.spyOn(api, 'query').mockResolvedValue({ results: [] } as any)
+        ;(posthog as any).setPersonProperties = jest.fn()
+        logic = liveWebAnalyticsMetricsLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it('collapses streamed pageviews that clean to the same path into one row', () => {
+        logic.actions.addEvents(
+            [pageview('/classes/928q3hr9paw8hfe', 'user-1'), pageview('/classes/j2k4l6m8n0p', 'user-2')],
+            new Date(Date.now() - 60_000),
+            logic.values.pathCleaningFilters
+        )
+
+        expect(logic.values.topPaths).toEqual([{ path: '/classes/:id', views: 2 }])
+    })
+
+    it('leaves streamed paths untouched once path cleaning is switched off', () => {
+        webAnalyticsLogic.actions.setIsPathCleaningEnabled(false)
+
+        logic.actions.addEvents(
+            [pageview('/classes/928q3hr9paw8hfe', 'user-1')],
+            new Date(Date.now() - 60_000),
+            logic.values.pathCleaningFilters
+        )
+
+        expect(logic.values.topPaths).toEqual([{ path: '/classes/928q3hr9paw8hfe', views: 1 }])
+    })
+})

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -741,6 +741,12 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     actions.setIsRefreshing(false)
                 }
                 cache.hasInitialized = true
+                // A filter change that arrived mid-load was queued rather than dropped:
+                // this load captured the old filters, so run one more with the new ones.
+                if (!signal.aborted && cache.reloadQueuedDuringInit) {
+                    cache.reloadQueuedDuringInit = false
+                    resetStreamStateAndReload(cache, actions)
+                }
             }
         },
         scheduleReload: async (_, breakpoint) => {
@@ -842,13 +848,10 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
     subscriptions(({ actions, cache }) => {
         const reloadForFilterChange = (): void => {
             if (!cache.hasInitialized) {
+                cache.reloadQueuedDuringInit = true
                 return
             }
-            cache.batch = []
-            cache.geoBatch = []
-            actions.clearRecentEvents()
-            actions.clearFilteredLiveUsers()
-            actions.scheduleReload()
+            resetStreamStateAndReload(cache, actions)
         }
         return {
             liveFilters: reloadForFilterChange,
@@ -909,6 +912,25 @@ interface FlushActions {
 
 const stopFlushInterval = (cache: FlushCache): void => {
     cache.disposables.dispose('flushInterval')
+}
+
+interface ReloadActions {
+    clearRecentEvents: () => void
+    clearFilteredLiveUsers: () => void
+    scheduleReload: () => void
+}
+
+// Drops buffered stream state and schedules a fresh backfill; the window is
+// rebuilt from scratch whenever the filters feeding it change.
+const resetStreamStateAndReload = (
+    cache: { batch: LiveEvent[]; geoBatch: LiveGeoEvent[] },
+    actions: ReloadActions
+): void => {
+    cache.batch = []
+    cache.geoBatch = []
+    actions.clearRecentEvents()
+    actions.clearFilteredLiveUsers()
+    actions.scheduleReload()
 }
 
 // Drives the "Users online" count so users drop off within ~5s of leaving the 60s window

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -5,6 +5,7 @@ import { subscriptions } from 'kea-subscriptions'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { createStreamConnection } from 'lib/api-stream'
+import { applyPathCleaning } from 'lib/components/PathCleanFilters/pathCleaningUtils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -31,7 +32,7 @@ import {
     TrendsQueryResponse,
     WebAnalyticsPropertyFilter,
 } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter, BaseMathType, LiveEvent, PropertyOperator } from '~/types'
+import { AnyPropertyFilter, BaseMathType, LiveEvent, PathCleaningFilter, PropertyOperator } from '~/types'
 
 import type { FeatureFlagsSet } from '../../../lib/logic/featureFlagLogic'
 import type { TeamPublicType, TeamType } from '../../../types'
@@ -131,6 +132,7 @@ export interface liveWebAnalyticsMetricsLogicValues {
     rawSelectedHost: string | null // webAnalyticsFilterLogic
     productTab: ProductTab // webAnalyticsLogic
     shouldFilterTestAccounts: boolean // webAnalyticsLogic
+    isPathCleaningEnabled: boolean // webAnalyticsLogic
     botBreakdown: BotBreakdownItem[]
     browserBreakdown: BrowserBreakdownItem[]
     chartData: ChartDataPoint[]
@@ -144,6 +146,7 @@ export interface liveWebAnalyticsMetricsLogicValues {
     isRefreshing: boolean
     liveFilters: WebAnalyticsPropertyFilter[]
     liveUserCount: number
+    pathCleaningFilters: PathCleaningFilter[]
     recentEvents: LiveEvent[]
     recentUsersByLastSeen: Map<string, number>
     selectedHost: string | null
@@ -166,10 +169,12 @@ export interface liveWebAnalyticsMetricsLogicValues {
 export interface liveWebAnalyticsMetricsLogicActions {
     addEvents: (
         events: LiveEvent[],
-        newerThan: Date
+        newerThan: Date,
+        pathCleaningFilters?: PathCleaningFilter[]
     ) => {
         events: LiveEvent[]
         newerThan: Date
+        pathCleaningFilters: PathCleaningFilter[]
     }
     addGeoEvents: (events: LiveGeoEvent[]) => {
         events: LiveGeoEvent[]
@@ -246,6 +251,10 @@ export interface liveWebAnalyticsMetricsLogicMeta {
         liveUserCount: (recentUsersByLastSeen: Map<string, number>) => number
         selectedHost: (rawSelectedHost: string | null, productTab: ProductTab) => string | null
         liveFilters: (rawLiveFilters: WebAnalyticsPropertyFilter[]) => WebAnalyticsPropertyFilter[]
+        pathCleaningFilters: (
+            currentTeam: TeamPublicType | TeamType | null,
+            isPathCleaningEnabled: boolean
+        ) => PathCleaningFilter[]
         testAccountFilters: (
             currentTeam: TeamPublicType | TeamType | null,
             shouldFilterTestAccounts: boolean
@@ -281,11 +290,15 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 'liveStreamFilters as rawLiveStreamFilters',
             ],
             webAnalyticsLogic,
-            ['productTab', 'shouldFilterTestAccounts'],
+            ['productTab', 'shouldFilterTestAccounts', 'isPathCleaningEnabled'],
         ],
     })),
     actions(() => ({
-        addEvents: (events: LiveEvent[], newerThan: Date) => ({ events, newerThan }),
+        addEvents: (events: LiveEvent[], newerThan: Date, pathCleaningFilters: PathCleaningFilter[] = []) => ({
+            events,
+            newerThan,
+            pathCleaningFilters,
+        }),
         addGeoEvents: (events: LiveGeoEvent[]) => ({ events }),
         setInitialData: (
             buckets: { timestamp: number; bucket: SlidingWindowBucket }[],
@@ -316,13 +329,19 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     freshWindow.prune()
                     return freshWindow
                 },
-                addEvents: (window, { events, newerThan }) => {
+                addEvents: (window, { events, newerThan, pathCleaningFilters }) => {
                     for (const event of events) {
                         const eventTs = new Date(event.timestamp).getTime() / 1000
                         const newerThanTs = newerThan.getTime() / 1000
 
                         if (eventTs > newerThanTs) {
-                            const pathname = event.properties?.$pathname
+                            // Streamed events arrive raw, so the same cleaning the backfill query
+                            // does server-side has to happen here for both to land on one key.
+                            const rawPathname = event.properties?.$pathname
+                            const pathname =
+                                typeof rawPathname === 'string'
+                                    ? applyPathCleaning(rawPathname, pathCleaningFilters)
+                                    : rawPathname
                             const deviceType = event.properties?.$device_type
                             const deviceId = event.properties?.$device_id
                             const browser = event.properties?.$browser
@@ -575,6 +594,16 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             (s) => [s.rawLiveFilters],
             (rawLiveFilters: WebAnalyticsPropertyFilter[]): WebAnalyticsPropertyFilter[] => rawLiveFilters,
         ],
+        pathCleaningFilters: [
+            (s) => [s.currentTeam, s.isPathCleaningEnabled],
+            (currentTeam: TeamPublicType | TeamType | null, isPathCleaningEnabled: boolean): PathCleaningFilter[] => {
+                if (!isPathCleaningEnabled || !currentTeam || !('path_cleaning_filters' in currentTeam)) {
+                    return []
+                }
+                return currentTeam.path_cleaning_filters ?? []
+            },
+            { resultEqualityCheck: equal },
+        ],
         testAccountFilters: [
             (s) => [s.currentTeam, s.shouldFilterTestAccounts],
             (currentTeam: TeamPublicType | TeamType | null, shouldFilterTestAccounts: boolean): AnyPropertyFilter[] =>
@@ -663,6 +692,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     filterTestAccounts: values.shouldFilterTestAccounts,
                     includeCity: !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_CITY_BREAKDOWN],
                     filtersEnabled: true,
+                    doPathCleaning: values.pathCleaningFilters.length > 0,
                     abortController,
                 })
 
@@ -823,12 +853,15 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         return {
             liveFilters: reloadForFilterChange,
             shouldFilterTestAccounts: reloadForFilterChange,
+            // The window holds already-cleaned paths, so new rules only apply once it's rebuilt.
+            pathCleaningFilters: reloadForFilterChange,
         }
     }),
-    events(({ actions, cache }) => ({
+    events(({ actions, values, cache }) => ({
         afterMount: () => {
             cache.batch = [] as LiveEvent[]
             cache.geoBatch = [] as LiveGeoEvent[]
+            cache.getPathCleaningFilters = () => values.pathCleaningFilters
 
             actions.loadInitialData()
             startFlushInterval(cache as FlushCache, actions as FlushActions)
@@ -863,11 +896,13 @@ interface FlushCache {
     batch: LiveEvent[]
     geoBatch: LiveGeoEvent[]
     newerThan: Date
+    // Read at flush time rather than captured, so a rule change reaches the next batch.
+    getPathCleaningFilters: () => PathCleaningFilter[]
     disposables: DisposablesManager
 }
 
 interface FlushActions {
-    addEvents: (events: LiveEvent[], newerThan: Date) => void
+    addEvents: (events: LiveEvent[], newerThan: Date, pathCleaningFilters: PathCleaningFilter[]) => void
     addGeoEvents: (events: LiveGeoEvent[]) => void
     tickLiveUserCount: () => void
 }
@@ -916,7 +951,7 @@ const startFlushInterval = (cache: FlushCache, actions: FlushActions): void => {
     cache.disposables.add(() => {
         const intervalId = setInterval(() => {
             if (cache.batch.length > 0) {
-                actions.addEvents(cache.batch, cache.newerThan)
+                actions.addEvents(cache.batch, cache.newerThan, cache.getPathCleaningFilters())
                 cache.batch = []
             }
             if (cache.geoBatch.length > 0) {
@@ -963,6 +998,7 @@ const loadQueryData = async ({
     filterTestAccounts,
     includeCity,
     filtersEnabled,
+    doPathCleaning,
     abortController,
 }: {
     dateFrom: Date
@@ -971,6 +1007,7 @@ const loadQueryData = async ({
     filterTestAccounts: boolean
     includeCity: boolean
     filtersEnabled: boolean
+    doPathCleaning: boolean
     abortController: AbortController
 }): Promise<LiveQueryData> => {
     const { signal } = abortController
@@ -1057,6 +1094,9 @@ const loadQueryData = async ({
             breakdown: '$pathname',
             breakdown_limit: 10,
             breakdown_hide_other_aggregation: true,
+            // Cleaning runs before the breakdown is ranked, so a path that only reaches the top
+            // once its ids collapse still makes the list.
+            breakdown_path_cleaning: doPathCleaning,
         },
         dateRange: {
             date_from: dateFrom.toISOString(),

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -130,9 +130,9 @@ export interface liveWebAnalyticsMetricsLogicValues {
     rawLiveFilters: WebAnalyticsPropertyFilter[] // webAnalyticsFilterLogic
     rawLiveStreamFilters: WebAnalyticsPropertyFilter[] // webAnalyticsFilterLogic
     rawSelectedHost: string | null // webAnalyticsFilterLogic
+    isPathCleaningEnabled: boolean // webAnalyticsLogic
     productTab: ProductTab // webAnalyticsLogic
     shouldFilterTestAccounts: boolean // webAnalyticsLogic
-    isPathCleaningEnabled: boolean // webAnalyticsLogic
     botBreakdown: BotBreakdownItem[]
     browserBreakdown: BrowserBreakdownItem[]
     chartData: ChartDataPoint[]

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -745,7 +745,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 // this load captured the old filters, so run one more with the new ones.
                 if (!signal.aborted && cache.reloadQueuedDuringInit) {
                     cache.reloadQueuedDuringInit = false
-                    resetStreamStateAndReload(cache, actions)
+                    resetStreamStateAndReload(cache as FlushCache, actions)
                 }
             }
         },
@@ -851,7 +851,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 cache.reloadQueuedDuringInit = true
                 return
             }
-            resetStreamStateAndReload(cache, actions)
+            resetStreamStateAndReload(cache as FlushCache, actions)
         }
         return {
             liveFilters: reloadForFilterChange,
@@ -922,10 +922,7 @@ interface ReloadActions {
 
 // Drops buffered stream state and schedules a fresh backfill; the window is
 // rebuilt from scratch whenever the filters feeding it change.
-const resetStreamStateAndReload = (
-    cache: { batch: LiveEvent[]; geoBatch: LiveGeoEvent[] },
-    actions: ReloadActions
-): void => {
+const resetStreamStateAndReload = (cache: Pick<FlushCache, 'batch' | 'geoBatch'>, actions: ReloadActions): void => {
     cache.batch = []
     cache.geoBatch = []
     actions.clearRecentEvents()


### PR DESCRIPTION
## Problem

Anyone using the Live tab in web analytics sees raw URLs in "Top pages" — `/classes/928q3hr9paw8hfe` instead of `/classes/:id` — even with project path cleaning rules configured. Every other web analytics tab applies those rules, so the same page looks split into hundreds of one-view rows only here.

The panel merges two sources and neither cleaned: the 30-minute backfill query breaks down on raw `$pathname`, and the live event stream feeds raw pathnames into the client-side sliding window.

## Changes

- Top pages on the Live tab now groups by cleaned path, so high-cardinality routes collapse into one row that ranks on its real traffic.
- The live filter bar gets the same path cleaning toggle the other tabs have, and flipping it rebuilds the 30-minute window.
- Mechanical: the backfill sets `breakdown_path_cleaning` so ClickHouse cleans before ranking the top 10, and streamed pageviews run the existing `applyPathCleaning` helper before entering the sliding window. Both sides have to clean or the two sources produce separate keys for the same page.

Cleaning the backfill server-side matters beyond consistency: a route only reaches the top 10 once its ids collapse, so cleaning after the breakdown limit would drop it entirely.

No screenshots — the visual change is the existing toggle button appearing in one more filter bar.

## How did you test this code?

Added `liveWebAnalyticsMetricsLogic.test.ts` with two kea logic cases. They catch the regression where streamed pageviews skip cleaning and re-split a cleaned path into per-id rows, and the inverse where cleaning is applied despite the toggle being off. No existing test mounted this logic.

Ran the frontend typecheck and the `src/scenes/web-analytics` Jest suites locally. Not manually verified in a running app — the backfill path relies on `breakdown_path_cleaning`, which is already covered by `test_trends_query_runner.py`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a request in a Slack thread. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Two design decisions worth a reviewer's attention. First, the backfill cleans server-side rather than client-side, because the query's `breakdown_limit: 10` is applied to raw values — cleaning the response afterwards would silently drop the routes this change exists to surface. Second, the streamed side reuses the frontend `applyPathCleaning` helper, which mirrors the backend's `replaceRegexpAll` semantics; a rule using re2-only syntax that JS `RegExp` cannot compile is skipped there, so it would clean in the backfill but not in the stream.

The path cleaning filters reach the reducer through the `addEvents` payload rather than being read from state, since kea reducers have no access to other logics' values.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0APW95TSTV/p1787317818611559?thread_ts=1787317818.611559&cid=C0APW95TSTV)*
