### PR TITLE
fix(alerts): declare quill charts dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2464,6 +2464,9 @@ importers:
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1)))(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@posthog/quill-charts':
+        specifier: workspace:*
+        version: link:../../packages/quill/packages/charts
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27

--- a/products/alerts/package.json
+++ b/products/alerts/package.json
@@ -4,6 +4,7 @@
         "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
     },
     "dependencies": {
+        "@posthog/quill-charts": "workspace:*",
         "kea": "catalog:",
         "kea-forms": "catalog:",
         "kea-loaders": "catalog:",


### PR DESCRIPTION
## Problem

- Alerts users can see a Vite import-analysis error when the alerts frontend imports Quill Charts.
- A clean workspace install does not link `@posthog/quill-charts` into the alerts product.

## Changes

- The alerts product now declares `@posthog/quill-charts` as a workspace dependency.
- The lockfile records the workspace link for reproducible installs.
- No user-facing layout changes require a screenshot.

## How did you test this code?

- `pnpm install --frozen-lockfile --prefer-offline --ignore-scripts`
- Verified `products/alerts/node_modules/@posthog/quill-charts` resolves to the workspace package.
- Verified the Quill Charts distribution files exist after installation.
- Not run: a full alerts frontend build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update needed for this dependency correction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Codex shell and GitHub CLI.
- Skills invoked: `/writing-pr-descriptions`.
- The change stays separate from the dashboard customization fix because it corrects an independent workspace dependency omission.
- The PR contains no customer data or internal operational details.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
