### PR TITLE
feat(s3): Refreshable credentials for S3 clients

### DIFF
--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -407,6 +407,14 @@ class AWSCredentials:
     aws_access_key_id: str
     aws_secret_access_key: str = field(repr=False)
     aws_session_token: str | None = field(default=None, repr=False)
+    expiration: dt.datetime | None = field(default=None)
+
+    @property
+    def expiry_time(self) -> str | None:
+        """ISO-8601 expiration time for temporary credentials, if available."""
+        if self.expiration is None:
+            return None
+        return self.expiration.isoformat()
 
 
 @dataclass

--- a/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
@@ -1,9 +1,9 @@
 import re
 import json
 import uuid
-import typing
 import asyncio
 import datetime as dt
+import functools
 import dataclasses
 
 from django.conf import settings
@@ -18,7 +18,11 @@ from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
 
 from products.batch_exports.backend.models.batch_export import BatchExportFileDownload
-from products.batch_exports.backend.service import BatchExportInsertInputs, FileDownloadBatchExportInputs
+from products.batch_exports.backend.service import (
+    AWSCredentials,
+    BatchExportInsertInputs,
+    FileDownloadBatchExportInputs,
+)
 from products.batch_exports.backend.temporal.batch_exports import (
     DataInterval,
     StartBatchExportRunInputs,
@@ -47,15 +51,9 @@ NON_RETRYABLE_ERROR_TYPES = ()
 SESSION = aioboto3.Session()
 
 
-class Credentials(typing.NamedTuple):
-    aws_access_key_id: str
-    aws_secret_access_key: str
-    aws_session_token: str
-
-
 async def _get_temporary_credentials_for_multipart_upload(
     bucket: str, prefix: str, /, role_arn: str, duration: int = 3600
-) -> Credentials:
+) -> AWSCredentials:
     """Get temporary AWS credentials for a multipart upload to keys under prefix."""
     creds = await _get_temporary_credentials_for_bucket_prefix(
         bucket,
@@ -70,7 +68,7 @@ async def _get_temporary_credentials_for_multipart_upload(
 
 async def _get_temporary_credentials_to_head_object(
     bucket: str, prefix: str, /, role_arn: str, duration: int = 900
-) -> Credentials:
+) -> AWSCredentials:
     """Get temporary AWS credentials for HEAD object requests for keys under prefix."""
     creds = await _get_temporary_credentials_for_bucket_prefix(
         bucket,
@@ -93,7 +91,7 @@ async def _get_temporary_credentials_for_bucket_prefix(
     duration: int = 3600,
     max_attempts: int = 5,
     delay: int | float = 1.0,
-) -> Credentials:
+) -> AWSCredentials:
     """Get temporary credentials scoped to operate only on the bucket's prefix.
 
     The credentials should be limited to a set of actions using the `actions` argument.
@@ -127,11 +125,14 @@ async def _get_temporary_credentials_for_bucket_prefix(
                     raise
 
                 await asyncio.sleep(delay * (2**attempt))
+            else:
+                break
 
-    return Credentials(
-        response["Credentials"]["AccessKeyId"],
-        response["Credentials"]["SecretAccessKey"],
-        response["Credentials"]["SessionToken"],
+    return AWSCredentials(
+        aws_access_key_id=response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+        aws_session_token=response["Credentials"]["SessionToken"],
+        expiration=response["Credentials"]["Expiration"],
     )
 
 
@@ -244,7 +245,8 @@ async def export_to_file_download_bucket_with_temporary_credentials(inputs: Expo
         batch_export_id=inputs.batch_export.batch_export_id, batch_export_run_id=inputs.batch_export.run_id
     )
 
-    credentials = await _get_temporary_credentials_for_multipart_upload(
+    refresh_credentials = functools.partial(
+        _get_temporary_credentials_for_multipart_upload,
         inputs.s3_bucket.name,
         f"batch-exports/{inputs.batch_export.batch_export_id}/{inputs.batch_export.run_id}",
         role_arn=inputs.aws_role_arn,
@@ -257,9 +259,6 @@ async def export_to_file_download_bucket_with_temporary_credentials(inputs: Expo
         compression=inputs.compression,
         file_format=inputs.file_format,
         max_file_size_mb=inputs.max_file_size_mb,
-        aws_access_key_id=credentials.aws_access_key_id,
-        aws_secret_access_key=credentials.aws_secret_access_key,
-        aws_session_token=credentials.aws_session_token,
         data_interval_start=inputs.batch_export.data_interval_start,
         data_interval_end=inputs.batch_export.data_interval_end,
         exclude_events=inputs.batch_export.exclude_events,
@@ -270,6 +269,7 @@ async def export_to_file_download_bucket_with_temporary_credentials(inputs: Expo
         batch_export_model=inputs.batch_export.batch_export_model,
         batch_export_id=inputs.batch_export.batch_export_id,
         destination_default_fields=inputs.batch_export.destination_default_fields,
+        refresh_credentials=refresh_credentials,
     )
     result = await insert_into_s3_activity_from_stage(s3_insert_inputs)
 

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1066,9 +1066,7 @@ async def upload_manifest_file(
     """
 
     async with s3_client(
-        credentials.aws_access_key_id,
-        credentials.aws_secret_access_key,
-        credentials.aws_session_token,
+        credentials,
         region=region_name,
         # Required for unit tests which run against a local bucket, otherwise always None.
         endpoint_url=settings.OBJECT_STORAGE_ENDPOINT if settings.TEST else None,
@@ -1154,9 +1152,7 @@ async def delete_uploaded_files(
     this fails.
     """
     async with s3_client(
-        credentials.aws_access_key_id,
-        credentials.aws_secret_access_key,
-        credentials.aws_session_token,
+        credentials,
         region=region_name,
     ) as client:
 
@@ -1190,9 +1186,7 @@ async def is_s3_read_access_denied(
     """
     try:
         async with s3_client(
-            credentials.aws_access_key_id,
-            credentials.aws_secret_access_key,
-            credentials.aws_session_token,
+            credentials,
             region=region_name,
         ) as client:
             for key in keys:
@@ -1424,9 +1418,7 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
                     )
 
         async with s3_client(
-            credentials.aws_access_key_id,
-            credentials.aws_secret_access_key,
-            credentials.aws_session_token,
+            credentials,
             region=inputs.copy.s3_bucket.region_name,
         ) as client:
             consumer = ConcurrentS3Consumer(

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -3,6 +3,7 @@ import typing
 import asyncio
 import secrets
 import datetime as dt
+import functools
 import contextlib
 import dataclasses
 import collections.abc
@@ -11,6 +12,8 @@ import pyarrow as pa
 import aioboto3
 import botocore.exceptions
 from aiobotocore.config import AioConfig
+from aiobotocore.credentials import AioRefreshableCredentials
+from aiobotocore.session import get_session
 from opentelemetry import trace
 
 if typing.TYPE_CHECKING:
@@ -114,6 +117,8 @@ EXTERNAL_LOGGER = get_logger("EXTERNAL")
 TRACER = trace.get_tracer(__name__)
 SESSION = aioboto3.Session()
 
+RefreshCoroutine = typing.Callable[[], typing.Awaitable[AWSCredentials]]
+
 
 class UnsupportedFileFormatError(Exception):
     """Raised when an unsupported file format is requested."""
@@ -190,6 +195,8 @@ class S3InsertInputs(BatchExportInsertInputs):
     file_format: str = "JSONLines"
     max_file_size_mb: int | None = None
     use_virtual_style_addressing: bool = False
+    # Only usable when calling the activity as a function, Temporal cannot serialize this.
+    refresh_credentials: RefreshCoroutine | None = None
 
 
 def get_s3_key_from_inputs(inputs: S3InsertInputs, file_number: int = 0) -> str:
@@ -488,23 +495,66 @@ async def get_credentials_using_user_aws_role(
         aws_access_key_id=second_response["Credentials"]["AccessKeyId"],
         aws_secret_access_key=second_response["Credentials"]["SecretAccessKey"],
         aws_session_token=second_response["Credentials"]["SessionToken"],
+        expiration=second_response["Credentials"]["Expiration"],
     )
+
+
+def make_refresh_credentials_as_metadata(
+    refresh_using: RefreshCoroutine,
+) -> typing.Callable[[], typing.Awaitable[dict[str, str]]]:
+    async def _refresh():
+        creds = await refresh_using()
+
+        assert creds.aws_session_token
+        assert creds.expiry_time
+
+        return {
+            "access_key": creds.aws_access_key_id,
+            "secret_key": creds.aws_secret_access_key,
+            "token": creds.aws_session_token,
+            "expiry_time": creds.expiry_time,
+        }
+
+    return _refresh
+
+
+def get_refreshable_session(credentials: AWSCredentials, refresh_using: RefreshCoroutine) -> aioboto3.Session:
+    wrapped = make_refresh_credentials_as_metadata(refresh_using)
+
+    assert credentials.aws_session_token
+    assert credentials.expiration
+
+    refreshable_credentials = AioRefreshableCredentials(
+        access_key=credentials.aws_access_key_id,
+        secret_key=credentials.aws_secret_access_key,
+        token=credentials.aws_session_token,
+        expiry_time=credentials.expiration,
+        refresh_using=wrapped,
+        method="sts-assume-role",
+    )
+
+    botocore_session = get_session()
+    botocore_session._credentials = refreshable_credentials  # type: ignore[attr-defined]
+
+    return aioboto3.Session(botocore_session=botocore_session)
 
 
 @contextlib.asynccontextmanager
 async def s3_client(
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-    aws_session_token: str | None,
+    aws_credentials: AWSCredentials,
     region: str,
     use_virtual_style_addressing: bool = False,
     endpoint_url: str | None = None,
+    refresh_using: RefreshCoroutine | None = None,
 ) -> collections.abc.AsyncIterator["S3Client"]:
-    session = aioboto3.Session(
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_session_token=aws_session_token,
-    )
+    if refresh_using is not None:
+        session = get_refreshable_session(aws_credentials, refresh_using)
+    else:
+        session = aioboto3.Session(
+            aws_access_key_id=aws_credentials.aws_access_key_id,
+            aws_secret_access_key=aws_credentials.aws_secret_access_key,
+            aws_session_token=aws_credentials.aws_session_token,
+        )
 
     config: dict[str, typing.Any] = {
         # Increase connection pool, so to ensure we're not limited by this
@@ -560,17 +610,17 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> S3BatchE
     async with Heartbeater():
         # Integration-backed exports resolve credentials at run time; legacy exports carry them inline.
         # TODO: require integration
-        aws_access_key_id = inputs.aws_access_key_id
-        aws_secret_access_key = inputs.aws_secret_access_key
-        aws_session_token = inputs.aws_session_token
         endpoint_url = inputs.endpoint_url
+        refresh_credentials = inputs.refresh_credentials
 
         if inputs.integration_id is not None:
             integration = await _get_s3_integration(inputs.integration_id, inputs.team_id)
 
             if isinstance(integration, AWSS3Integration):
-                aws_access_key_id = integration.aws_access_key_id
-                aws_secret_access_key = integration.aws_secret_access_key
+                credentials = AWSCredentials(
+                    aws_access_key_id=integration.aws_access_key_id,
+                    aws_secret_access_key=integration.aws_secret_access_key,
+                )
 
             if isinstance(integration, AWSS3RoleBasedIntegration):
                 team = await Team.objects.aget(id=inputs.team_id)
@@ -619,27 +669,33 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> S3BatchE
                         )
                     )
 
-                credentials = await get_credentials_using_user_aws_role(
+                refresh_credentials = functools.partial(
+                    get_credentials_using_user_aws_role,
                     integration.aws_role_arn,
                     external_id,
                     session_name=f"PostHog-batch-exports-{inputs.batch_export_id}",
                     policy_statements=policy_statements,
                 )
-                aws_access_key_id, aws_secret_access_key, aws_session_token = (
-                    credentials.aws_access_key_id,
-                    credentials.aws_secret_access_key,
-                    credentials.aws_session_token,
-                )
+                credentials = await refresh_credentials()
 
             if isinstance(integration, S3CompatibleIntegration):
-                aws_access_key_id = integration.aws_access_key_id
-                aws_secret_access_key = integration.aws_secret_access_key
+                credentials = AWSCredentials(
+                    aws_access_key_id=integration.aws_access_key_id,
+                    aws_secret_access_key=integration.aws_secret_access_key,
+                )
                 endpoint_url = integration.endpoint_url
 
-        if not aws_access_key_id or not aws_secret_access_key:
-            # At these point these need to be defined: either by us assuming a new
-            # role, by an integration, or by the inputs.
-            raise InvalidCredentialsError("AWS access key ID and secret access key cannot be empty")
+        else:
+            if refresh_credentials is not None:
+                credentials = await refresh_credentials()
+            else:
+                if not inputs.aws_access_key_id or not inputs.aws_secret_access_key:
+                    raise InvalidCredentialsError("AWS access key ID and secret access key cannot be empty")
+                credentials = AWSCredentials(
+                    aws_access_key_id=inputs.aws_access_key_id,
+                    aws_secret_access_key=inputs.aws_secret_access_key,
+                    aws_session_token=inputs.aws_session_token,
+                )
 
         external_logger = EXTERNAL_LOGGER.bind()
         external_logger.info(
@@ -695,12 +751,11 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> S3BatchE
             )
 
         async with s3_client(
-            aws_access_key_id,
-            aws_secret_access_key,
-            aws_session_token,
+            credentials,
             use_virtual_style_addressing=inputs.use_virtual_style_addressing,
             region=inputs.region,
             endpoint_url=endpoint_url,
+            refresh_using=refresh_credentials,
         ) as client:
             consumer = ConcurrentS3Consumer.from_inputs(
                 s3_client=client,

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_refreshable_credentials.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_refreshable_credentials.py
@@ -1,0 +1,77 @@
+import typing
+import datetime as dt
+import collections.abc
+
+import pytest
+
+import aioboto3
+from aiobotocore.credentials import AioRefreshableCredentials
+from botocore.credentials import ReadOnlyCredentials
+
+from products.batch_exports.backend.service import AWSCredentials
+from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
+    RefreshCoroutine,
+    get_refreshable_session,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def make_refresh_stub(refreshed: AWSCredentials) -> tuple[list[int], RefreshCoroutine]:
+    calls: list[int] = []
+
+    async def refresh() -> AWSCredentials:
+        calls.append(1)
+        return refreshed
+
+    return calls, refresh
+
+
+async def get_frozen_session_credentials(session: aioboto3.Session) -> ReadOnlyCredentials:
+    # aioboto3 sessions return a coroutine at runtime, but the stubs carry boto3's sync signature.
+    credentials = await typing.cast(collections.abc.Awaitable[AioRefreshableCredentials], session.get_credentials())
+    return await credentials.get_frozen_credentials()
+
+
+async def test_get_refreshable_session_refreshes_expired_credentials():
+    now = dt.datetime.now(dt.UTC)
+    initial = AWSCredentials(
+        aws_access_key_id="initial-key",
+        aws_secret_access_key="initial-secret",
+        aws_session_token="initial-token",
+        expiration=now - dt.timedelta(minutes=5),
+    )
+    refreshed = AWSCredentials(
+        aws_access_key_id="refreshed-key",
+        aws_secret_access_key="refreshed-secret",
+        aws_session_token="refreshed-token",
+        expiration=now + dt.timedelta(hours=1),
+    )
+    calls, refresh = make_refresh_stub(refreshed)
+
+    session = get_refreshable_session(initial, refresh)
+    frozen = await get_frozen_session_credentials(session)
+
+    assert len(calls) == 1
+    assert frozen.access_key == "refreshed-key"
+    assert frozen.secret_key == "refreshed-secret"
+    assert frozen.token == "refreshed-token"
+
+
+async def test_get_refreshable_session_does_not_refresh_valid_credentials():
+    now = dt.datetime.now(dt.UTC)
+    initial = AWSCredentials(
+        aws_access_key_id="initial-key",
+        aws_secret_access_key="initial-secret",
+        aws_session_token="initial-token",
+        expiration=now + dt.timedelta(hours=1),
+    )
+    calls, refresh = make_refresh_stub(initial)
+
+    session = get_refreshable_session(initial, refresh)
+    frozen = await get_frozen_session_credentials(session)
+
+    assert len(calls) == 0
+    assert frozen.access_key == "initial-key"
+    assert frozen.secret_key == "initial-secret"
+    assert frozen.token == "initial-token"


### PR DESCRIPTION

<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

S3 and file download batch exports have a fixed 1h time limit when using AWS role authentication, imposed by AWS. We can extend this limit by refreshing the credentials, which boto3/aioboto3 supports. So, by supporting refreshable credentials in the insert into s3 activity function, we can support them for both file download and s3 batch exports (each one using a different callable to refresh credentials).

This change required also updating all the callsites where s3_client is used, but the changes should be a no-op everywhere that doesn't do refreshable credentials (i.e. in redshift_batch_export.py).

Redshift COPY is TODO as we are doing other work first (integration support).

s3_batch_export.py module is getting a tad annoying to work with as there is a lot if nesting, but I am leaving that for later.


<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Construct a session with refreshable credentials when a refresh callable exists.
Set the refresh callable when using role based auth in s3 and in file download batch exports.

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran existing tests + added new ones.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Had the robot review + help with tests.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
