### PR TITLE
fix(product-tours): hide create action when flag is off

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1805,6 +1805,7 @@ export const getTreeItemsNew = (): FileSystemImport[] => [
         path: `Product tour`,
         type: 'product_tour',
         href: urls.productTour('new'),
+        flag: FEATURE_FLAGS.PRODUCT_TOURS,
         iconType: 'product_tour',
         iconColor: [
             'var(--color-product-product-tours-light)',


### PR DESCRIPTION
## Problem

Users without Product Tours enabled can still see “New Product tour” in the project tree, which leads to a dead-end route.

## Changes

- Gate the Product tour create entry with the existing `product-tours-2025` feature flag.

## How did you test this code?

- `git diff --check` passed.
- The focused Jest test could not run because Jest dependencies are not installed in the checkout (`Command "jest" not found`).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The shared New-tree definition now uses the same feature flag already used by the main Product tours navigation. No public or customer data was added.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BPULZFS84/p1787323769357649?thread_ts=1787323769.357649&cid=C0BPULZFS84)*