### PR TITLE
fix(desktop): restore pointer cursor on space session list rows

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -198,6 +198,10 @@ export function ChannelItemRowView({
   const pinBadge = item.pinned && showPinBadge;
   return (
     <SidebarItem
+      // The space's lists follow web conventions — every clickable row shows a
+      // pointer, like the feed and activity rows — unlike the Code sidebar,
+      // which keeps SidebarItem's native cursor-default.
+      className="cursor-pointer"
       depth={0}
       icon={<ChannelItemDot item={item} status={status} />}
       // A non-string label opts out of SidebarItem's truncation tooltip.

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -65,6 +65,7 @@ export function SidebarItem({
   endHint,
   disabled,
   ref,
+  className,
   ...buttonProps
 }: SidebarItemProps) {
   const { reveal, hoverProps, focusProps } = useOverflowTickerReveal();
@@ -91,6 +92,9 @@ export function SidebarItem({
         // part of a bulk selection.
         "relative data-in-selection:before:absolute data-in-selection:before:inset-y-0 data-in-selection:before:left-0 data-in-selection:before:w-0.5 data-in-selection:before:bg-primary data-in-selection:before:content-['']",
         isDimmed && "opacity-50",
+        // Last, so a caller can override the row's cursor-default — the
+        // spread above sits before this prop and would otherwise drop it.
+        className,
       )}
       data-active={isActive || undefined}
       data-in-selection={isSelected || undefined}


### PR DESCRIPTION
## Problem

Hovering a session or canvas row in a space's sidebar shows the default arrow cursor, so the rows no longer look clickable. The rest of the space UI (feed rows, activity rows, item previews) shows a pointer on clickable rows.

The rows render through the shared `SidebarItem`, which hard-codes `cursor-default` and silently drops any `className` a caller passes — the props spread sits before the computed `className`, so there was no way to override it.

## Changes

- Session and canvas rows in a space's sidebar show `cursor: pointer` on hover again.
- Mechanical: `SidebarItem` now merges a caller-passed `className` last in its `cn(...)` call, so callers can override its defaults; `ChannelItemRowView` passes `cursor-pointer`. The Code sidebar's rows keep their native `cursor-default` — no other `SidebarItem` caller passes a `className`.

## How did you test this code?

- `pnpm exec tsc --noEmit` for `@posthog/ui` and Biome on both files — clean.
- `hogli ci:preflight --fix` — passed (desktop-biome).
- Not checked: no visual before/after in the running app; the change is a single Tailwind class resolved by quill's `tailwind-merge`-backed `cn`, which keeps the last conflicting utility.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by an agent (PostHog Code cloud task, pi harness) from a user report with a screenshot of the space session list. Skills invoked: /writing-pr-descriptions. Considered flipping `SidebarItem` itself to `cursor-pointer`, but scoped the fix to the space rows since the Code sidebar deliberately keeps the native default cursor. No customer data involved.
