### PR TITLE
chore(warehouse-sources): pin typeform responses to the fan-out api parent

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/typeform/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/typeform/settings.py
@@ -79,6 +79,10 @@ TYPEFORM_ENDPOINTS: dict[str, TypeformEndpointConfig] = {
             resolve_field="id",
             include_from_parent=["id"],
             parent_field_renames={"id": "form_id"},
+            # Not "warehouse": the child spends one request per form, while the `forms` listing
+            # costs one request per `page_size` forms. A Delta read saves too little of the run
+            # to pay for the fallback path it adds.
+            parent_source="api",
         ),
     ),
 }


### PR DESCRIPTION
## Problem

Typeform is next in line for warehouse fan-out parent reuse, and nothing in the config says the option was already weighed.

- The `responses` child fans out over `forms`, so a conversion replaces the `/forms` listing with a read of the synced `forms` table.
- The child spends one request per form on either path, while the listing costs one request per `page_size` forms.
- The saving is a small fraction of each run at any workspace size, and it buys a Delta read plus an API fallback path.

## Changes

- Nothing changes at runtime. `parent_source="api"` is the default this config already used.
- The `responses` fan-out now states `parent_source="api"` and the reason, the way Sentry's `issue_events` and `issue_hashes` record the same decision.

## How did you test this code?

- The diff is a comment and an explicit default, so there is no behavior to test.
- Ran locally: the Typeform suites, and the shared fan-out and warehouse-parent suites.
- Not run: the vendor probe in step 1 of the conversion skill. Step 0 ended the conversion, so no Typeform account was used.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Opus 5 in Claude Code. Skills invoked: `/converting-fanout-parents-to-warehouse` (its first use), `/writing-pr-descriptions`, `/writing-code-comments`.
- The task began as a conversion. Step 0 of the skill asks whether the parent listing is expensive enough to replace, and production job stats agreed with the structural argument above, so the conversion stopped there. Those measurements stay out of the repo because they are internal and they rot.
- Based on `claude/fanout-conversion-skill` (#86820), which carries the skill this followed.
