### PR TITLE
chore(agents): prefer extending parameterized tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ See [.agents/security.md](.agents/security.md) for security guidelines — least
 - Python tests: do not add doc comments
 - Python: leave `__init__.py` alone unless a check asks for it. Whether a directory needs one depends on what sits above it. `hogli product:lint` and `posthog/test/repo_invariants/test_pytest_module_collisions.py` say where, and print the fix
 - jest tests: when writing jest tests, prefer a single top-level describe block in a file
-- Tests: prefer parameterized tests (use the `parameterized` library in Python) — if you're writing multiple assertions for variations of the same logic, it should be parameterized
+- Tests: when adding coverage, prefer extending a relevant existing test over creating a new standalone test when practical. Prefer parameterized cases (use the `parameterized` library in Python and `test.each` in Jest) when testing variations of the same behavior
 - Tests must earn their place: every new test has to catch a realistic regression no existing test already catches (if you can't name it, don't add it), assert observable behavior through the public interface rather than implementation details, and stay cheap — deterministic, isolated, and at the lowest level that catches the bug (see `/writing-tests`)
 - Reduce nesting: Use early returns, guard clauses, and helper methods to avoid deeply nested code
 - Markdown: prefer semantic line breaks; no hard wrapping


### PR DESCRIPTION
## Problem

Agents can add standalone tests when an existing test could cover the same behavior more efficiently.

## Changes

- Agents now prefer extending a relevant existing test when practical.
- Behavioral variations now use parameterized cases in Python and Jest.
- This guidance change has no user-visible product effect.

## How did you test this code?

- `git diff --check`
- Preflight was unavailable because this environment does not include `hogli` or `flox`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change updates the repository agent instructions directly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex updated the guidance using `/writing-tests` and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*