### PR TITLE
test(hogql): run parser memory-leak matrix on rust-py only (the production backend)

### DIFF
--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -93,8 +93,11 @@ def _snapshot_key(src: str) -> str:
     return f"{safe}-{digest}" if safe else digest
 
 
-def parser_test_factory(backend: HogQLParserBackend):
-    base_classes = (MemoryLeakTestMixin, BaseTest)
+def parser_test_factory(backend: HogQLParserBackend, leak_check: bool = True):
+    # 102 re-parses per test to measure leaks is expensive at this suite's scale,
+    # and one backend's matrix catches a leak in the shared parser core as well as three.
+    # Only cpp-json (the C++ boundary, where leaks actually originate) pays for it.
+    base_classes = (MemoryLeakTestMixin, BaseTest) if leak_check else (BaseTest,)
 
     class TestParser(*base_classes):  # type: ignore
         MEMORY_INCREASE_PER_PARSE_LIMIT_B = 10_000
@@ -124,10 +127,10 @@ def parser_test_factory(backend: HogQLParserBackend):
             kwargs: dict[str, Any] = {"backend": backend}
             if placeholders is not None:
                 kwargs["placeholders"] = placeholders
-            # Parse on every rerun so the leak mixin still exercises the parser 102x and a real
-            # per-parse leak is caught. Only COMPARE on the first run: syrupy / pretty_dataclasses
-            # allocate per call, so comparing on every rerun would trip the leak check with
-            # test-machinery growth that isn't a parser leak.
+            # Leak-checking backends parse on every mixin rerun so a real per-parse leak is
+            # caught. Only COMPARE on the first run: syrupy / pretty_dataclasses allocate per
+            # call, so comparing on every rerun would trip the leak check with test-machinery
+            # growth that isn't a parser leak.
             parsed = parse_fn(src, **kwargs)
             if getattr(self, "_memory_leak_run_index", 0) != 0:
                 return

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -94,9 +94,11 @@ def _snapshot_key(src: str) -> str:
 
 
 def parser_test_factory(backend: HogQLParserBackend, leak_check: bool = True):
-    # 102 re-parses per test to measure leaks is expensive at this suite's scale,
-    # and one backend's matrix catches a leak in the shared parser core as well as three.
-    # Only cpp-json (the C++ boundary, where leaks actually originate) pays for it.
+    # 102 re-parses per test to measure leaks is expensive at this suite's scale.
+    # The backends are separate parser implementations, so a leak is per-backend:
+    # keep the matrix on rust-py only, the production primary (PyO3-built objects
+    # are also the most binding-leak-prone path). cpp-json and rust-json run once
+    # per test — the shared snapshot still proves parity on all three.
     base_classes = (MemoryLeakTestMixin, BaseTest) if leak_check else (BaseTest,)
 
     class TestParser(*base_classes):  # type: ignore

--- a/posthog/hogql/test/test_parser_cpp_json.py
+++ b/posthog/hogql/test/test_parser_cpp_json.py
@@ -9,7 +9,7 @@ from posthog.hogql.parser import parse_program
 from ._test_parser import parser_test_factory
 
 
-class TestParserCppJson(parser_test_factory("cpp-json")):  # type: ignore
+class TestParserCppJson(parser_test_factory("cpp-json", leak_check=False)):  # type: ignore
     def test_empty(self):
         # this test only exists to make pycharm recognise this class as a test class
         # the actual tests are in the parent class

--- a/posthog/hogql/test/test_parser_rust_json.py
+++ b/posthog/hogql/test/test_parser_rust_json.py
@@ -8,7 +8,7 @@ the `rust-json` backend into that suite.
 from ._test_parser import parser_test_factory
 
 
-class TestParserRustJson(parser_test_factory("rust-json")):  # type: ignore
+class TestParserRustJson(parser_test_factory("rust-json", leak_check=False)):  # type: ignore
     def test_empty(self):
         # this test only exists to make pycharm recognise this class as a test class
         # the actual tests are in the parent class

--- a/posthog/hogql/test/test_parser_rust_py.py
+++ b/posthog/hogql/test/test_parser_rust_py.py
@@ -10,7 +10,7 @@ dataclass instances directly, skipping the JSON round-trip).
 from ._test_parser import parser_test_factory
 
 
-class TestParserRustPy(parser_test_factory("rust-py", leak_check=False)):  # type: ignore
+class TestParserRustPy(parser_test_factory("rust-py")):  # type: ignore
     def test_empty(self):
         # this test only exists to make pycharm recognise this class as a test class
         # the actual tests are in the parent class

--- a/posthog/hogql/test/test_parser_rust_py.py
+++ b/posthog/hogql/test/test_parser_rust_py.py
@@ -10,7 +10,7 @@ dataclass instances directly, skipping the JSON round-trip).
 from ._test_parser import parser_test_factory
 
 
-class TestParserRustPy(parser_test_factory("rust-py")):  # type: ignore
+class TestParserRustPy(parser_test_factory("rust-py", leak_check=False)):  # type: ignore
     def test_empty(self):
         # this test only exists to make pycharm recognise this class as a test class
         # the actual tests are in the parent class


### PR DESCRIPTION
🤖 This PR and its description were written by a robot (a PostHog cloud agent task directed by pauldambra).

## Problem

The HogQL parser suite runs the same ~460-test matrix against all three backends (`cpp-json`, `rust-json`, `rust-py`), and every test re-parses its snippet 102 times (2 priming + 100 check runs) via `MemoryLeakTestMixin`. That costs ~196s per CI run across the three files — while cross-backend parity is already proven by the shared `.ambr` snapshot (one entry per source, compared on every backend), so the re-parse loop only adds leak detection, which does not need to run three times.

## Changes

- `parser_test_factory` grows a `leak_check: bool = True` parameter; with `leak_check=False` the generated class uses `BaseTest` instead of `(MemoryLeakTestMixin, BaseTest)`.
- The leak matrix stays on **rust-py**, the production primary backend (`parser.py`: prod default is `RUST_PY_WITH_CPP_SHADOW` — rust-py parses every production query, cpp only shadows at 0.1%). rust-py is also the most leak-relevant path: it builds Python dataclasses through PyO3 directly, and a refcount leak there would be invisible to the cpp check.
- `test_parser_cpp_json.py` and `test_parser_rust_json.py` opt out and parse once per test.

Expected effect per CI run: cpp-json ≈115s → ~5s, rust-json ≈44s → ~4s, rust-py unchanged (~37s). Net ≈ -150s across the shard set that carries these files, with leak coverage moved onto the backend production actually runs.

## How did you test this code?

- Not run locally: no dev stack in the authoring environment (no Postgres/ClickHouse). The change is typed at the factory boundary and all three edited files pass `py_compile`.
- CI is the verifier: the rust suites should go green with the same test count (each test asserts the same shared snapshot, just parsed once), and the cpp suite should be unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal test-suite speed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog cloud agent task directed by pauldambra.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Session path: area analysis of the clean timing data showed `posthog/hogql` at 11.7 min with the parser parity files at 222s of it. The first version of this PR kept the leak matrix on cpp-json on the assumption of a shared parser core; the PR author's question about which backend production runs exposed that as wrong (`parser.py` resolves the prod default to `RUST_PY_WITH_CPP_SHADOW`), and the matrix moved to rust-py accordingly.
