### PR TITLE
feat(signals): say which scouts need you in the roster tooltip

### DIFF
--- a/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterHeader.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterHeader.tsx
@@ -6,6 +6,7 @@ import { cn } from 'lib/utils/css-classes'
 
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { scratchpadLogic } from '../../../logics/scratchpadLogic'
+import type { NeedsYouScout } from '../../../utils/scoutGroups'
 import { SCOUT_ROSTER_WINDOW_LABEL } from '../../../utils/scoutRunsWindow'
 import { ScoutsRosterFilters } from './ScoutsRosterFilters'
 
@@ -34,12 +35,37 @@ export function ScoutsRosterHeader(): JSX.Element {
     )
 }
 
+/** Longest list the tooltip shows before it stops being readable at a glance. */
+const NEEDS_YOU_TOOLTIP_MAX = 8
+
+/**
+ * Which scouts are waiting on you and why. The count alone sends you hunting through a roster of
+ * a hundred-odd rows for the two that stopped, so the stat names them and states the reason the
+ * scheduler recorded.
+ */
+function NeedsYouTooltip({ scouts }: { scouts: NeedsYouScout[] }): JSX.Element {
+    const shown = scouts.slice(0, NEEDS_YOU_TOOLTIP_MAX)
+    const hidden = scouts.length - shown.length
+    return (
+        <div className="flex flex-col gap-1.5">
+            <span className="font-semibold">Waiting on a decision from you</span>
+            {shown.map((scout) => (
+                <div key={scout.name} className="flex flex-col">
+                    <span className="font-semibold">{scout.name}</span>
+                    <span>{scout.reason}</span>
+                </div>
+            ))}
+            {hidden > 0 && <span>and {hidden} more in the roster below</span>}
+        </div>
+    )
+}
+
 /**
  * The troop's headline numbers. Output is stated as reports filed rather than as a run success
  * rate: every run completing tells you nothing crashed, not that the troop is earning its keep.
  */
 function RosterStats(): JSX.Element {
-    const { rosterGroupCounts, enabledCount, emittedFindingsSummary, fleetFindingsSummaryLoadedOnce } =
+    const { rosterGroupCounts, needsYouScouts, enabledCount, emittedFindingsSummary, fleetFindingsSummaryLoadedOnce } =
         useValues(scoutFleetLogic)
     // Mounted here rather than by the fleet logic, so the 1,000-entry scratchpad read only happens
     // on the surfaces that show it, not on every inbox tab that mounts the fleet.
@@ -51,7 +77,11 @@ function RosterStats(): JSX.Element {
     return (
         <div className="flex flex-wrap items-center gap-4">
             {rosterGroupCounts.needs_you > 0 && (
-                <Stat value={String(rosterGroupCounts.needs_you)} label="need you" alert />
+                <Tooltip title={<NeedsYouTooltip scouts={needsYouScouts} />}>
+                    <span>
+                        <Stat value={String(rosterGroupCounts.needs_you)} label="need you" alert />
+                    </span>
+                </Tooltip>
             )}
             <Stat value={String(enabledCount)} label="on patrol" />
             <Tooltip title={`Runs your scouts made in the ${SCOUT_ROSTER_WINDOW_LABEL}, quiet ones included.`}>

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -37,7 +37,15 @@ import {
 } from '../inboxAnalytics'
 import { SignalScoutRunSummary } from '../types'
 import { aiConsentDisabledReason } from '../utils/aiConsent'
-import { compareScoutsByName, groupScouts, scoutGroup, ScoutGroupKey, ScoutRosterRow } from '../utils/scoutGroups'
+import {
+    compareScoutsByName,
+    groupScouts,
+    listNeedsYouScouts,
+    NeedsYouScout,
+    scoutGroup,
+    ScoutGroupKey,
+    ScoutRosterRow,
+} from '../utils/scoutGroups'
 
 export type ScoutEnabledFilter = 'all' | 'enabled' | 'disabled'
 import {
@@ -116,6 +124,7 @@ export interface scoutFleetLogicValues {
     fleetSummary: FleetSummary | null
     lastRunAt: string | null
     manualRunScoutIds: string[]
+    needsYouScouts: NeedsYouScout[]
     rollups: Map<string, ScoutRollup>
     rosterGroupCounts: Record<ScoutGroupKey, number>
     rosterScouts: ScoutRosterRow[]
@@ -318,6 +327,10 @@ export interface scoutFleetLogicMeta {
             scoutConfigs: SignalScoutConfigApi[] | null,
             rollups: Map<string, ScoutRollup>
         ) => Record<ScoutGroupKey, number>
+        needsYouScouts: (
+            scoutConfigs: SignalScoutConfigApi[] | null,
+            rollups: Map<string, ScoutRollup>
+        ) => NeedsYouScout[]
         emittedFindingsSummary: (fleetFindingsSummary: FleetFindingsSummaryApi | null) => {
             authoredReportCount: number
             count: number
@@ -707,6 +720,15 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                 }
                 return counts
             },
+        ],
+        /**
+         * The scouts behind that count, so the header stat can name them. Same inputs as
+         * `rosterGroupCounts`, so the tooltip can never disagree with the number it hangs off.
+         */
+        needsYouScouts: [
+            (s) => [s.scoutConfigs, s.rollups],
+            (scoutConfigs: SignalScoutConfig[] | null, rollups: Map<string, ScoutRollup>): NeedsYouScout[] =>
+                listNeedsYouScouts(scoutConfigs ?? [], rollups, new Date()),
         ],
         // Fleet-wide output tally for the "Scout findings" callout, read from the cheap backend
         // summary rather than the paginated runs window. Covers both emit channels — legacy findings

--- a/products/signals/frontend/inbox/utils/scoutGroups.test.ts
+++ b/products/signals/frontend/inbox/utils/scoutGroups.test.ts
@@ -1,7 +1,15 @@
 import type { SignalScoutConfigApi as SignalScoutConfig } from 'products/signals/frontend/generated/api.schemas'
 
 import { SignalScoutRunSummary } from '../types'
-import { groupScouts, nextRunAt, scoutCadenceLabel, scoutGroup, ScoutGroupKey, scoutSubtitle } from './scoutGroups'
+import {
+    groupScouts,
+    listNeedsYouScouts,
+    nextRunAt,
+    scoutCadenceLabel,
+    scoutGroup,
+    ScoutGroupKey,
+    scoutSubtitle,
+} from './scoutGroups'
 import { computeScoutRollups, ScoutRollup } from './scoutRunsWindow'
 
 const NOW = new Date('2026-06-27T22:00:00Z')
@@ -109,6 +117,32 @@ describe('scoutGroups', () => {
             )
             expect(buckets.map((bucket) => bucket.key)).toEqual(['needs_you', 'watching', 'off'])
             expect(buckets[0].configs.map((config) => config.id)).toEqual(['c'])
+        })
+    })
+
+    describe('listNeedsYouScouts', () => {
+        it('names only the scouts waiting on a decision, and why', () => {
+            const configs = [
+                makeConfig({ id: 'b', skill_name: 'signals-scout-web-vitals' }),
+                makeConfig({
+                    id: 'c',
+                    skill_name: 'signals-scout-apm',
+                    status: 'pending_pause',
+                    pause_reason: 'ignored',
+                }),
+                makeConfig({
+                    id: 'a',
+                    skill_name: 'signals-scout-surveys',
+                    status: 'paused_by_system',
+                    pause_reason: 'repeated_failures',
+                    consecutive_failure_count: 3,
+                    enabled: false,
+                }),
+            ]
+            expect(listNeedsYouScouts(configs, new Map(), NOW)).toEqual([
+                { name: 'Apm', reason: 'Pauses soon — nobody acted on its reports' },
+                { name: 'Surveys', reason: 'Paused itself — 3 runs in a row failed' },
+            ])
         })
     })
 

--- a/products/signals/frontend/inbox/utils/scoutGroups.ts
+++ b/products/signals/frontend/inbox/utils/scoutGroups.ts
@@ -200,6 +200,31 @@ export function scoutSubtitle(
     return description ? { text: truncate(description), tone: 'muted' } : null
 }
 
+/** A scout waiting on a decision, paired with the reason the scheduler recorded. */
+export interface NeedsYouScout {
+    name: string
+    reason: string
+}
+
+/**
+ * The scouts behind the roster's "need you" count, so the header can say which ones and why rather
+ * than only how many. Alphabetical, and unnarrowed by the roster's search — it backs a stat that
+ * counts the whole fleet.
+ */
+export function listNeedsYouScouts(
+    configs: SignalScoutConfig[],
+    rollups: Map<string, ScoutRollup>,
+    now: Date
+): NeedsYouScout[] {
+    return [...configs]
+        .filter((config) => scoutGroup(config, rollups.get(config.skill_name), now) === 'needs_you')
+        .sort(compareScoutsByName)
+        .map((config) => ({
+            name: prettifyScoutSkillName(config.skill_name),
+            reason: scoutSubtitle(config, rollups.get(config.skill_name), now)?.text ?? 'Waiting on a decision',
+        }))
+}
+
 /**
  * When this scout is next due, or null when that can't be said: no run yet (the coordinator picks
  * it up on its next tick), a paused scout, or an expression that doesn't parse.


### PR DESCRIPTION
## Problem

The Scouts roster header shows a red "N need you" count, but nothing about which scouts those are. On a fleet of a hundred-odd scouts, acting on that number means scrolling the roster hunting for the rows that stopped.

## Changes

- Hovering the "need you" stat now lists each scout waiting on a decision, with the reason the scheduler recorded (paused itself after repeated failures, warned because nothing surfaced, and so on).
- The list caps at 8 names and says how many more are in the roster below.
- Mechanical: a `listNeedsYouScouts` helper next to the existing grouping code, and a `needsYouScouts` selector fed by the same inputs as the count, so the tooltip cannot disagree with the number it hangs off.

No screenshot: the change is a hover state and this environment could not run the app or Storybook to capture it.

## How did you test this code?

- Added a unit test for `listNeedsYouScouts` covering the regression that matters here: it must pick only the scouts in the `needs_you` group and pair each with its recorded reason, so the tooltip can't name a healthy scout or show a blank reason.
- Verified the rendered tooltip locally with a throwaway React test (not committed): hovering the stat portals a popup containing the heading, the scout name, and its reason.
- Ran the signals inbox Jest suites for the touched files and a repo-wide TypeScript check; the pre-existing failures there are unbuilt `@posthog/quill` workspace imports in unrelated products, and none are in the touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop cloud task, from a request to make the "need you" stat explain itself on hover. No repo skills were invoked; the reason strings are the existing `scoutSubtitle` copy rather than new wording, so the tooltip says the same thing the roster row already says.

The count selector was left alone rather than reshaped to return rows, so the number keeps its current behavior and the tooltip is purely additive.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
