### PR TITLE
fix(desktop): show per-task cost in pi sessions

### DIFF
--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -741,7 +741,9 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
         ) : (
           <PromptInput
             sessionId={taskId}
-            toolbarEndSlot={<ContextUsageIndicator usage={contextUsage} />}
+            toolbarEndSlot={
+              <ContextUsageIndicator usage={contextUsage} taskId={taskId} />
+            }
             taskId={taskId}
             repoPath={repoPath}
             placeholder="Type a message..."


### PR DESCRIPTION
## Problem

Per-task cost never appears on a PostHog Desktop pi session, whatever the task has spent. Claude and codex sessions show it.

`PiSessionView` renders the context usage indicator as `<ContextUsageIndicator usage={contextUsage} />` — with no `taskId`. `useTaskUsage` is gated on `enabled && taskId !== undefined`, so the query stays disabled, `GET /api/projects/:team/tasks/:id/usage/` is never called, and `showCost` is false. The same element passes `taskId={taskId}` to `PromptInput` on the next line, so the value was already in scope.

The backend side is fine. pi generations carry `task_id`, `team_id`, and `ai_product = posthog_code`, so the endpoint would answer with a real figure — pi tasks in the last 6 hours range up to about $169 of attributed spend.

This is independent of #87051. That fixed a 500 on tasks with a billable sandbox session; this one never issues the request at all.

## Changes

- Per-task cost now appears on pi sessions, next to the context ring and in the breakdown popover, the same as claude and codex sessions.
- Mechanical: pass the in-scope `taskId` to `ContextUsageIndicator`.

Left alone deliberately: `SessionView` also passes `focused={isActiveSession !== false}` so background sessions stop polling. `PiSessionView` has no `isActiveSession` concept to forward, and inventing one is a bigger change than this fix warrants, so `focused` keeps its default. If several pi views stay mounted at once, each polls on the hook's 60-second interval — worth a follow-up if that turns out to be real.

## How did you test this code?

In `products/desktop`: `@posthog/ui` typecheck (`tsc --noEmit`) clean, the existing `ContextUsageIndicator` suite passes (8 tests), and biome is clean on the changed file.

No new test. The regression is a missing prop in `PiSessionView`, and the lowest level that catches it is a full render of that component, which needs Inversify DI (`useService` for two controllers), two Zustand stores, an authenticated client, and react-query. No harness for it exists — every sibling test in `features/pi-sessions/` drives a plain-prop presentational component — and standing one up for a single prop-forwarding assertion would be disproportionate and brittle. The existing indicator tests already cover the rendering behavior once `taskId` is supplied.

I did not run the desktop app and watch a pi session render the figure.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported as never seeing pricing on pi-harness sessions. My first diagnosis was wrong: I traced it to pi not emitting the `_posthog/usage_update` ACP notification that `useContextUsage` reads, and concluded the whole indicator unmounted. The reporter pushed back that the cost comes from the new task usage endpoint, not from the ACP notification, which was correct. pi derives its context usage from `toPiContextUsage(session.stats)`, so the ring renders fine; the only thing missing was the `taskId` that enables the endpoint query. Worth knowing for reviewers, since the wrong version of this fix would have been a much larger change to the pi translator.

Written with Claude in a PostHog cloud task. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.
