### PR TITLE
test(dagster): reset clickhouse between dagster tests only when dirty

### DIFF
--- a/posthog/dags/tests/conftest.py
+++ b/posthog/dags/tests/conftest.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from uuid import UUID
 
 import pytest
-from posthog.test.base import reset_clickhouse_database
+from posthog.test.base import reset_clickhouse_database_if_dirty
 from unittest.mock import patch
 
 from django.conf import settings
@@ -93,8 +93,11 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
     """
     Cluster fixture with macOS Docker-compatible hostname resolution.
     Patches ClickhouseCluster to use host_name instead of host_address.
+
+    Resets the ClickHouse database only if something has checked out a client
+    since the last reset — a no-CH test that starts clean pays nothing.
     """
-    reset_clickhouse_database()
+    reset_clickhouse_database_if_dirty()
     try:
         with patch.object(
             ClickhouseCluster,
@@ -103,4 +106,4 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
         ):
             yield get_cluster()
     finally:
-        reset_clickhouse_database()
+        reset_clickhouse_database_if_dirty()

--- a/posthog/dags/tests/conftest.py
+++ b/posthog/dags/tests/conftest.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from uuid import UUID
 
 import pytest
-from posthog.test.base import reset_clickhouse_database_if_dirty
+from posthog.test.base import reset_clickhouse_database, reset_clickhouse_database_if_dirty
 from unittest.mock import patch
 
 from django.conf import settings
@@ -93,11 +93,11 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
     """
     Cluster fixture with macOS Docker-compatible hostname resolution.
     Patches ClickhouseCluster to use host_name instead of host_address.
-
-    Resets the ClickHouse database only if something has checked out a client
-    since the last reset — a no-CH test that starts clean pays nothing.
     """
-    reset_clickhouse_database_if_dirty()
+    # Setup reset stays unconditional (Kafka-engine arrivals don't advance the
+    # dirty counter, so a late row would leak into the next test); teardown can
+    # skip when nothing checked out a ClickHouse client.
+    reset_clickhouse_database()
     try:
         with patch.object(
             ClickhouseCluster,


### PR DESCRIPTION
🤖 This PR and its description were written by a robot (a PostHog cloud agent task directed by pauldambra).

## Problem

The dagster test suite's `cluster` fixture runs `reset_clickhouse_database()` before **and** after every test that uses it. That reset is not cheap: it drops and creates every ClickHouse table (dozens of DDL statements, executed across cluster hosts), so each of the 644 tests in `posthog/dags/tests/` pays it twice. In the recorded CI timings this suite costs ~14 min per run, with the integration classes dominated by reset time rather than test time (e.g. `TestClickHouseQueryIntegration` in the person-property-reconciliation suite: 147.6s across 37 tests).

## Changes

- `posthog/dags/tests/conftest.py`: the `cluster` fixture's **teardown** reset switches to `reset_clickhouse_database_if_dirty()`, skipping the DDL when no ClickHouse client was checked out during the test.
- The **setup** reset deliberately stays unconditional: rows arriving via Kafka-engine tables do not advance the pool-checkout counter (documented in `posthog/test/base.py`), so a dirty-checked setup could carry a late Kafka arrival into the next test. Codex review caught this edge.
- The pool-checkout counter this relies on already guards `ClickhouseDestroyTablesMixin` for the main suite (`posthog/test/base.py`), so the isolation contract is unchanged from what the repo already trusts.

Expected effect: tests that consume the `cluster` fixture without dirtying ClickHouse drop from 2 full resets to 1 (their setup). Tests that dirty ClickHouse still pay both resets, which is the isolation guarantee doing its job.

## How did you test this code?

- Not run locally: no dev stack in the authoring environment (no Postgres/ClickHouse). `py_compile` passes on the edited file.
- CI is the verifier: the Dagster suite should go green with the same 644 tests, and the per-shard duration of the dagster runs should drop measurably (the fixture is on the hot path of every integration class).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal test-suite speed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog cloud agent task directed by pauldambra.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Session path: analyzing `test_person_property_reconciliation.py` (~5.6 min recorded) showed its cost concentrated in the CH integration classes; reading the `cluster` fixture in `posthog/dags/tests/conftest.py` surfaced the unconditional double reset, and `posthog/test/base.py` already exports the dirty-aware variant used by the main suite. The fix is a scoped swap within the dagster test conftest only.

