### PR TITLE
fix(desktop): give a repo-less pi session the tools to find a repo

### DIFF
--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -519,6 +519,9 @@ export class PiAgentServer {
         environment: "cloud",
         taskId: this.config.taskId,
         taskRunId: this.config.runId,
+        // Same condition the `repository-tools` extension uses below: with no repo on disk,
+        // the session needs the tools that find one and clone it.
+        channelMode: !this.config.repositoryPath,
         baseBranch: this.config.baseBranch,
         peerMessaging: process.env.POSTHOG_AGENT_PEER_MESSAGING === "1",
       },

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -519,8 +519,6 @@ export class PiAgentServer {
         environment: "cloud",
         taskId: this.config.taskId,
         taskRunId: this.config.runId,
-        // Same condition the `repository-tools` extension uses below: with no repo on disk,
-        // the session needs the tools that find one and clone it.
         channelMode: !this.config.repositoryPath,
         baseBranch: this.config.baseBranch,
         peerMessaging: process.env.POSTHOG_AGENT_PEER_MESSAGING === "1",


### PR DESCRIPTION
## Problem

A PostHog Desktop session that starts with no repository gets an agent that cannot go find one. The tools that discover and clone a repo are gated behind `channelMode`, and the pi runtime never sets it, so `clone_repo` is missing from every pi session.

The cloud agent server sets it (`agent-server.ts:1918`). The pi server hardcodes its session meta and skips it.

## Changes

- A repo-less pi session now offers the repository tools, so the agent can find and clone a repo mid-conversation instead of stopping.
- `pi-agent-server.ts` passes `channelMode: !this.config.repositoryPath` into the local-tools meta. That is the condition the file already uses two blocks below to add the `repository-tools` pi extension, so the two gates now agree.

`spokenNarration` is deliberately still unset. It comes from the desktop UI through workspace-server, and no cloud runtime sets it, including `agent-server`.

## How did you test this code?

- `tsc --noEmit` on `@posthog/agent`, clean.
- `vitest run src/server/pi-agent-server.test.ts`, 25 passing.
- No new test. The suite stubs `createSession` wholesale, so covering this needs a harness for the pi RPC client, the sandbox and the PostHog API, and the assertion would only restate the meta object.
- Not run: a live pi session. The pi runtime is not wired up for first sessions yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing surface or documented workflow changes.

## 🤖 Agent context

Human-driven (agent-assisted).

Found while auditing why pi sessions show neither `speak` nor `clone_repo` during work on the desktop first-run session. `speak` turned out to be correct, `channelMode` did not.

Skills invoked: `writing-pr-descriptions`, `writing-code-comments`, `writing-tests`.
