### PR TITLE
fix(comments): stop discussion panel flickering on background poll

### DIFF
--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -137,7 +137,7 @@ const CommentBottomRow = ({ comment }: { comment: CommentType }): JSX.Element | 
 }
 
 const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element => {
-    const { editingComment, commentsLoading, editingCommentRichContentEditor, isEditingCommentEmpty } =
+    const { editingComment, isSavingEditedComment, editingCommentRichContentEditor, isEditingCommentEmpty } =
         useValues(commentsLogic)
     const {
         setEditingComment,
@@ -163,7 +163,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                     }
                 }}
                 onPressCmdEnter={persistEditedComment}
-                disabled={commentsLoading}
+                disabled={isSavingEditedComment}
             />
             <div className="flex justify-end items-center gap-2">
                 <LemonButton
@@ -173,7 +173,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                         setEditingComment(null)
                         setEditingCommentRichContentEditor(null)
                     }}
-                    disabled={commentsLoading}
+                    disabled={isSavingEditedComment}
                 >
                     Cancel
                 </LemonButton>
@@ -181,7 +181,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                     type="primary"
                     size="small"
                     onClick={persistEditedComment}
-                    disabledReason={isEditingCommentEmpty ? 'No message' : commentsLoading ? 'Saving...' : null}
+                    disabledReason={isEditingCommentEmpty ? 'No message' : isSavingEditedComment ? 'Saving...' : null}
                     sideIcon={<KeyboardShortcut command enter />}
                 >
                     Save

--- a/frontend/src/scenes/comments/CommentsList.test.tsx
+++ b/frontend/src/scenes/comments/CommentsList.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { Provider } from 'kea'
 
 import { useMocks } from '~/mocks/jest'
@@ -12,16 +12,13 @@ import { commentsLogic } from './commentsLogic'
 
 const PROPS = { scope: ActivityScope.TICKET, item_id: 'ticket-1' }
 
-afterEach(cleanup)
-
 describe('CommentsList', () => {
-    // Loading, empty, and loaded are three different screens, and a thread that has already answered
-    // is never the first of them again. The ticket page refreshes this one every 20 seconds, and
-    // every handler on the `comments` loader shares one loading flag with the first fetch.
-    it('shows the empty state once loaded and keeps it through a background refresh', async () => {
+    let logic: ReturnType<typeof commentsLogic.build>
+    let answerFirstLoad: () => void = () => {}
+
+    beforeEach(() => {
         initKeaTests()
 
-        let answerFirstLoad: () => void = () => {}
         const firstLoadReached = new Promise<void>((resolve) => {
             answerFirstLoad = resolve
         })
@@ -35,9 +32,13 @@ describe('CommentsList', () => {
             },
         })
 
-        const logic = commentsLogic(PROPS)
+        logic = commentsLogic(PROPS)
         logic.mount()
+    })
 
+    // The background poll shares one loading flag with the first fetch, so a skeleton keyed off
+    // that flag takes the empty state off screen every time the poll runs.
+    it('shows the empty state once loaded and keeps it through a background refresh', async () => {
         render(
             <Provider>
                 <CommentsList {...PROPS} />

--- a/frontend/src/scenes/comments/CommentsList.test.tsx
+++ b/frontend/src/scenes/comments/CommentsList.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { ActivityScope } from '~/types'
+
+import { CommentsList } from './CommentsList'
+import { commentsLogic } from './commentsLogic'
+
+const PROPS = { scope: ActivityScope.TICKET, item_id: 'ticket-1' }
+
+afterEach(cleanup)
+
+describe('CommentsList', () => {
+    // Loading, empty, and loaded are three different screens, and a thread that has already answered
+    // is never the first of them again. Branching the skeleton on `commentsLoading` broke that: the
+    // ticket page polls `refreshComments` every 20 seconds, that shares the loader's flag with the
+    // first fetch, so an open panel dropped its empty state and jumped the composer up the panel
+    // every 20 seconds while someone was typing into it.
+    it('shows the empty state once loaded and keeps it through a background refresh', async () => {
+        initKeaTests()
+
+        let answerFirstLoad: () => void = () => {}
+        const firstLoadReached = new Promise<void>((resolve) => {
+            answerFirstLoad = resolve
+        })
+        useMocks({
+            get: {
+                '/api/projects/:team_id/comments': async () => {
+                    await firstLoadReached
+                    return [200, { results: [] }]
+                },
+                '/api/organizations/@current/members/': { results: [] },
+            },
+        })
+
+        const logic = commentsLogic(PROPS)
+        logic.mount()
+
+        render(
+            <Provider>
+                <CommentsList {...PROPS} />
+            </Provider>
+        )
+
+        // Nothing has answered yet, so there is no empty thread to claim
+        expect(screen.queryByText('Start the discussion!')).not.toBeInTheDocument()
+
+        await act(async () => {
+            answerFirstLoad()
+        })
+        await waitFor(() => expect(screen.getByText('Start the discussion!')).toBeInTheDocument())
+
+        act(() => {
+            logic.actions.refreshComments()
+        })
+        expect(logic.values.commentsLoading).toBe(true)
+        expect(screen.getByText('Start the discussion!')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/comments/CommentsList.test.tsx
+++ b/frontend/src/scenes/comments/CommentsList.test.tsx
@@ -16,10 +16,8 @@ afterEach(cleanup)
 
 describe('CommentsList', () => {
     // Loading, empty, and loaded are three different screens, and a thread that has already answered
-    // is never the first of them again. Branching the skeleton on `commentsLoading` broke that: the
-    // ticket page polls `refreshComments` every 20 seconds, that shares the loader's flag with the
-    // first fetch, so an open panel dropped its empty state and jumped the composer up the panel
-    // every 20 seconds while someone was typing into it.
+    // is never the first of them again. The ticket page refreshes this one every 20 seconds, and
+    // every handler on the `comments` loader shares one loading flag with the first fetch.
     it('shows the empty state once loaded and keeps it through a background refresh', async () => {
         initKeaTests()
 
@@ -59,5 +57,8 @@ describe('CommentsList', () => {
         })
         expect(logic.values.commentsLoading).toBe(true)
         expect(screen.getByText('Start the discussion!')).toBeInTheDocument()
+
+        // Let the refresh land, so its request doesn't settle after teardown
+        await waitFor(() => expect(logic.values.commentsLoading).toBe(false))
     })
 })

--- a/frontend/src/scenes/comments/CommentsList.tsx
+++ b/frontend/src/scenes/comments/CommentsList.tsx
@@ -17,7 +17,7 @@ export interface CommentsListProps extends CommentsLogicProps {
 }
 
 export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JSX.Element => {
-    const { key, commentsWithReplies, commentsLoading } = useValues(commentsLogic(props))
+    const { key, commentsWithReplies, commentsInitialLoading } = useValues(commentsLogic(props))
     const { loadComments, setReplyingComment, clearRichContentEditor } = useActions(commentsLogic(props))
 
     // If the comment list focus changes we should load the comments
@@ -38,7 +38,7 @@ export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JS
     return (
         <BindLogic logic={commentsLogic} props={props}>
             <div className="flex flex-col">
-                {!commentsWithReplies?.length && commentsLoading ? (
+                {!commentsWithReplies?.length && commentsInitialLoading ? (
                     <div className="deprecated-space-y-2">
                         <LemonSkeleton className="h-10 w-full" />
                     </div>

--- a/frontend/src/scenes/comments/CommentsList.tsx
+++ b/frontend/src/scenes/comments/CommentsList.tsx
@@ -38,7 +38,7 @@ export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JS
     return (
         <BindLogic logic={commentsLogic} props={props}>
             <div className="flex flex-col">
-                {!commentsWithReplies?.length && commentsInitialLoading ? (
+                {commentsInitialLoading ? (
                     <div className="deprecated-space-y-2">
                         <LemonSkeleton className="h-10 w-full" />
                     </div>

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -885,10 +885,9 @@ export const commentsLogic = kea<commentsLogicType>([
     selectors({
         key: [() => [(_, props) => props], (props): string => `${props.scope}-${props.item_id || ''}`],
 
-        // Every handler on the `comments` loader shares `commentsLoading`, including the background
-        // poll's `refreshComments` and the local writes. Only the very first load has nothing to put
-        // on screen; once `comments` is an array the thread is renderable, empty or not, so a
-        // surface that swaps in a skeleton on `commentsLoading` would flash it away on every poll.
+        // `commentsLoading` is shared by every handler on the `comments` loader, including the
+        // background poll's `refreshComments`, so a surface that swaps in a skeleton on it would
+        // flash away a thread that has already loaded.
         commentsInitialLoading: [
             (s) => [s.comments, s.commentsLoading],
             (comments: CommentType[] | null, commentsLoading: boolean): boolean => !comments && commentsLoading,

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -68,6 +68,7 @@ export interface commentsLogicValues {
     user: UserType | null // userLogic
     commentContexts: Record<string, string>
     comments: CommentType[] | null
+    commentsInitialLoading: boolean
     commentsLoading: boolean
     commentsWithReplies: CommentWithRepliesType[]
     composerDrafts: Record<string, JSONContent | null>
@@ -84,6 +85,7 @@ export interface commentsLogicValues {
     isEditingCommentEmpty: boolean
     isEmpty: boolean
     isMyComment: (comment: CommentType) => boolean
+    isSavingEditedComment: boolean
     isSendingComment: boolean
     itemContext: CommentContext | null
     key: string
@@ -357,6 +359,7 @@ export interface commentsLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
         key: (arg: any) => string
+        commentsInitialLoading: (comments: CommentType[] | null, commentsLoading: boolean) => boolean
         sortedComments: (comments: CommentType[] | null) => CommentType[]
         commentsWithReplies: (sortedComments: CommentType[]) => CommentWithRepliesType[]
         emojiReactionsByComment: (sortedComments: CommentType[]) => Record<string, Record<string, CommentType[]>>
@@ -544,6 +547,14 @@ export const commentsLogic = kea<commentsLogicType>([
             {
                 onEditingCommentRichContentEditorUpdate: (_, { isEmpty }) => isEmpty,
                 persistEditedCommentSuccess: () => false,
+            },
+        ],
+        isSavingEditedComment: [
+            false,
+            {
+                persistEditedComment: () => true,
+                persistEditedCommentSuccess: () => false,
+                persistEditedCommentFailure: () => false,
             },
         ],
     }),
@@ -873,6 +884,16 @@ export const commentsLogic = kea<commentsLogicType>([
 
     selectors({
         key: [() => [(_, props) => props], (props): string => `${props.scope}-${props.item_id || ''}`],
+
+        // Every handler on the `comments` loader shares `commentsLoading`, including the background
+        // poll's `refreshComments` and the local writes. Only the very first load has nothing to put
+        // on screen; once `comments` is an array the thread is renderable, empty or not, so a
+        // surface that swaps in a skeleton on `commentsLoading` would flash it away on every poll.
+        commentsInitialLoading: [
+            (s) => [s.comments, s.commentsLoading],
+            (comments: CommentType[] | null, commentsLoading: boolean): boolean => !comments && commentsLoading,
+        ],
+
         sortedComments: [
             (s) => [s.comments],
             (comments: CommentType[] | null) => {


### PR DESCRIPTION
## Problem

Typing into the Discussion side panel on a support ticket makes the panel jump every 20 seconds: the "Start the discussion!" empty state disappears, the composer slides up to fill the gap, then the empty state comes back.

- The ticket page polls `refreshComments` every 20 seconds so a discussion started elsewhere shows up here.
- That handler shares the `comments` loader's `commentsLoading` flag with the first fetch.
- `CommentsList` swapped the thread for a loading skeleton whenever `commentsLoading` was true, so a thread that had already loaded returned to its loading screen on every poll.

Only threads with no comments yet jump, because the skeleton branch also requires an empty list.


<img width="431" height="800" alt="CleanShot 2026-08-21 at 09 26 27" src="https://github.com/user-attachments/assets/fa41da44-be5f-40fd-bea5-b0ac235490b4" />



## Changes

- The empty state stays on screen while a background poll runs. A new `commentsInitialLoading` selector is true only before the first fetch lands, and the skeleton branches on that instead.
- Editing a comment no longer disables the editor and flips Save to "Saving..." every 20 seconds. The edit form reads a new `isSavingEditedComment` flag rather than the shared loader flag.
- Both fixes are one-value swaps in the components. The rest of the diff adds those two values to `commentsLogic`.

No screenshot: the difference is an element vanishing for a fraction of a second, which a still frame cannot show, and the only recording of it is of an internal support ticket.

## How did you test this code?

- `CommentsList.test.tsx` is new and covers the reported regression. It renders the list, lets the first load land, dispatches `refreshComments`, then asserts the empty state is still on screen. No existing test rendered `CommentsList` at all. Reverting the branch back to `commentsLoading` fails it, which was checked both ways.
- Ran the `frontend/src/scenes/comments` and `products/conversations/frontend/scenes/ticket` suites locally, both green.
- Not run: no manual browser check, because this sandbox has no running app. The repo-wide `typescript:check` fails on unbuilt `@posthog/quill` and `@posthog/hogvm` workspaces here, which predates this branch; the four changed files report no errors.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a report in Slack. Left unassigned because the reporter's GitHub handle was not verifiable from the thread, so please assign them on review.

The report came with a screen recording. Diffing its frames located the flicker precisely (the empty state swapping for a `LemonSkeleton`, once in a 12-second clip), which pointed at the shared loader flag rather than at the composer or the Slack channel picker, both of which were the first suspects.

Fixing the `CommentsList` branch was the whole reported bug. The `Comment.tsx` edit form came along because it reads the same flag for the same wrong reason and glitches on the same 20-second timer.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1787329699212479)*
