### PR TITLE
chore(agents): gate test placement, not just existence

### DIFF
--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -37,9 +37,13 @@ Find the test that already covers the nearest behavior and answer:
 
 > **Why can't this be a case in that test?**
 
-Default to extending it — a `@parameterized` case in Python, a `test.each` row in Jest, an extra assertion in the existing body.
+When your case is a variation of that behavior, extend it: a `@parameterized` case in Python, a `test.each` row in Jest.
 A new standalone test is what you write when extending doesn't work, and you should be able to say why in a sentence: the setup differs, the behavior belongs to a different unit, or no relevant test exists.
-"It's cleaner as its own test" isn't a reason — a fresh function re-pays every setup and fixture cost the existing one already paid.
+"It's cleaner as its own test" isn't a reason on its own; name which of those three applies.
+
+Extend to remove duplication, not to save setup time.
+A parameterized case is still its own test invocation, so `setUp` and `beforeEach` run for it just as they would for a standalone function.
+That sets the limit too: fold in variations of the same behavior, and don't bolt assertions about unrelated behavior onto a test that already passes.
 
 Search before you write.
 If you haven't looked for the nearest existing test, you can't answer this question.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -3,7 +3,7 @@ name: writing-tests
 description: >
   Gates whether a new test should exist and forces it to be efficient, protecting CI from low-value test bloat.
   Use before adding or substantially changing any pytest, Jest, or Playwright test — whenever an agent or engineer is about to write tests for a new feature, bugfix, or PR.
-  Front-loads the value bar (every test must catch a realistic regression no existing test already catches; test behavior through the public interface, not implementation details; collapse near-duplicates into parameterized cases) and the efficiency bar (deterministic, isolated, fast; pick the cheapest test level; Django TestCase over TransactionTestCase; no sleeps, no real network).
+  Front-loads the value bar (every test must catch a realistic regression no existing test already catches; extend the nearest existing test before writing a new standalone one; test behavior through the public interface, not implementation details; collapse near-duplicates into parameterized cases) and the efficiency bar (deterministic, isolated, fast; pick the cheapest test level; Django TestCase over TransactionTestCase; no sleeps, no real network).
   Includes a "don't write it" decision tree. For fixing an existing flaky test use `/fixing-flaky-tests`; after this gate says a Playwright test is warranted, use `/playwright-test` for mechanics.
 ---
 
@@ -12,9 +12,11 @@ description: >
 The rationale and the same rules in human-facing form live in the handbook: [Backend coding conventions › Testing](https://posthog.com/handbook/engineering/conventions/backend-coding#testing) (`docs/published/handbook/engineering/conventions/backend-coding.md`).
 This skill is the operational gate — run it before writing tests. It carries the decision procedure plus [a catalog of the bug shapes we actually ship](references/mistakes-we-make.md).
 
-## The gate: one question
+## The gate: two questions
 
-Before writing any test, answer in one sentence:
+Before writing any test, answer both in one sentence each.
+
+### 1. Does it earn its place?
 
 > **What realistic regression does this test catch that no existing test already catches?**
 
@@ -27,6 +29,20 @@ That is a test worth keeping.
 Aim each test at a failure mode we actually hit, not a hypothetical.
 The bugs PostHog ships and reverts cluster into a handful of shapes — cataloged with the test that catches each, and the failure modes no unit test should, in [references/mistakes-we-make.md](references/mistakes-we-make.md).
 If your test doesn't map to one of them, be skeptical it's worth keeping.
+
+### 2. Where does it go?
+
+Passing the first question buys the _coverage_, not a new test function.
+Find the test that already covers the nearest behavior and answer:
+
+> **Why can't this be a case in that test?**
+
+Default to extending it — a `@parameterized` case in Python, a `test.each` row in Jest, an extra assertion in the existing body.
+A new standalone test is what you write when extending doesn't work, and you should be able to say why in a sentence: the setup differs, the behavior belongs to a different unit, or no relevant test exists.
+"It's cleaner as its own test" isn't a reason — a fresh function re-pays every setup and fixture cost the existing one already paid.
+
+Search before you write.
+If you haven't looked for the nearest existing test, you can't answer this question.
 
 ## Don't write it — the five no's
 

--- a/docs/published/handbook/engineering/conventions/backend-coding.md
+++ b/docs/published/handbook/engineering/conventions/backend-coding.md
@@ -97,6 +97,10 @@ Most low-value tests are one of these — recognize them and extend an existing 
 - **Redundant coverage**: a new test that's a variation of an existing one is a `@parameterized` case (Python) or a `test.each` row (Jest), not a new test function.
 - **Coverage-chasing**: an uncovered line is information, not a defect — don't add a test just to move the number.
 
+Then answer a second question: **why can't this be a case in the test that already covers the nearest behavior?**
+Earning the coverage doesn't earn a new test function.
+Default to extending the existing test, and write a standalone one only when you can say why extending doesn't work — different setup, a different unit, or nothing relevant exists.
+
 #### Weight tests down the pyramid
 
 Each rung is roughly an order of magnitude slower and flakier than the one below:

--- a/docs/published/handbook/engineering/conventions/backend-coding.md
+++ b/docs/published/handbook/engineering/conventions/backend-coding.md
@@ -99,7 +99,9 @@ Most low-value tests are one of these — recognize them and extend an existing 
 
 Then answer a second question: **why can't this be a case in the test that already covers the nearest behavior?**
 Earning the coverage doesn't earn a new test function.
-Default to extending the existing test, and write a standalone one only when you can say why extending doesn't work — different setup, a different unit, or nothing relevant exists.
+Default to extending the existing test with a parameterized case, and write a standalone one only when you can say why extending doesn't work: different setup, a different unit, or nothing relevant exists.
+Extend to remove duplication, not to save setup time, since a parameterized case still runs `setUp` for itself.
+Fold in variations of the same behavior, and don't attach unrelated assertions to a test that already passes.
 
 #### Weight tests down the pyramid
 


### PR DESCRIPTION
## Problem

Agents that decide a new test is warranted write it as a fresh standalone function, because that is the only shape `/writing-tests` describes for a test that passes its gate. The skill mentions extending an existing test twice, but both times as the fallback for a test that *failed* the gate. So the suite grows by whole test functions where a parameterized case would do.

Companion to #87170, which added the same preference to AGENTS.md and has since merged.

## Changes

- Agents now have to justify a new standalone test, not just the coverage: the skill's gate is two questions, and the second asks why the case can't live in the test that already covers the nearest behavior.
- The skill tells agents to search for that nearest test first, so the question is answerable rather than rhetorical.
- It names the acceptable reasons to write standalone anyway (different setup, different unit, nothing relevant exists) and rejects "it's cleaner as its own test".
- The rule rests on removing duplication, not on saving setup time. A parameterized case is its own test invocation, so `setUp` and `beforeEach` run for it exactly as they would for a standalone function. That framing also caps the rule: fold in variations of the same behavior, and don't attach assertions about unrelated behavior to a test that already passes.
- The handbook's human-facing testing section gets the same second question and the same limit, so the two stay in sync.
- Mechanical: the skill's frontmatter description picks up the placement rule so it surfaces when the skill is matched.

## How did you test this code?

Documentation and agent-instruction change only, with no code path to exercise, so no tests were added or run. Verified that the handbook wording matches the skill, which links to it as its human-facing form, and that this skill is not embedded in any `products/*/frontend/generated/agentContext.ts` payload, so no regeneration is needed.

Preflight was not run: this environment has no `hogli` or `flox` on PATH.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Included. `docs/published/handbook/engineering/conventions/backend-coding.md` is the human-facing version of these rules and is updated in the same PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app, asked in a Slack thread to report what `/writing-tests` steers and to adjust it if useful. Skills invoked: `/writing-tests` (as the subject), `/writing-pr-descriptions`, `/babysit-pr`.

The skill already carried the substance of #87170: its "redundant coverage" rule says a variation of an existing test is a `@parameterized` case, not a new test function. The gap was structural rather than missing content, since both mentions of extending sat in the "don't write it" branch, so an agent whose test cleared the value bar never met the placement question. Adding it as a second gate step, instead of another bullet, puts it on the path every test takes.

Review round: Codex caught that the first draft justified extending with a fixture-cost saving that does not exist, which could have pushed agents toward grab-bag tests. That rationale is now replaced with deduplication plus an explicit limit. Copilot's two em dash notes are folded into the same rewrite.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1787325960627359?thread_ts=1787325960.627359&cid=C09G8QA6740)*
