### PR TITLE
fix(tasks): stop warm cloud runs answering the first message twice

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -412,6 +412,7 @@ _TASK_RUN_PUBLIC_STATE_KEYS = frozenset(
         "pending_user_message_id",
         "pr_authorship_mode",
         "pr_base_branch",
+        "prewarmed",
         "provider",
         "reasoning_effort",
         "repositories",


### PR DESCRIPTION
## Problem

- A cloud task on a pre-warmed sandbox answers the user's first message twice.
- The sandbox reads `state.prewarmed` from the run detail API to learn its first message arrives separately, as a forwarded `user_message`.
- The run detail response filters `state` through an allowlist that omits `prewarmed`.
- The sandbox therefore prompts itself from the task description, then answers the forwarded message as well.
- The same omission left two more warm-run behaviors dead: the reasoning effort chosen at submit never applied, and run attribution always reported `prewarmed=false`.

## Changes

- Warm cloud runs answer the first message once.
- Warm runs use the reasoning effort picked at submit, not the effort the sandbox booted with.
- `prewarmed` joins `_TASK_RUN_PUBLIC_STATE_KEYS`, the allowlist behind the run detail `state` field.
- The key is a provisioning boolean and carries no sensitive value.
- Nothing in the web UI changes.


