### PR TITLE
chore(experiments): migrate experiments scene to the product frontend folder

### DIFF
--- a/frontend/src/productScenes.tsx
+++ b/frontend/src/productScenes.tsx
@@ -88,6 +88,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
         import('../../products/error_tracking/frontend/scenes/ErrorTrackingFingerprintsScene/ErrorTrackingIssueFingerprintsScene'),
     ErrorTrackingFingerprint: () =>
         import('../../products/error_tracking/frontend/scenes/ErrorTrackingFingerprintScene/ErrorTrackingFingerprintScene'),
+    Experiments: () => import('../../products/experiments/frontend/scenes/ExperimentsScene'),
     FeatureFlagTemplates: () => import('../../products/feature_flags/frontend/FeatureFlagTemplatesScene'),
     FeatureFlagsStaffTools: () => import('../../products/feature_flags/frontend/staff/FeatureFlagsStaffToolsScene'),
     Game368Hedgehogs: () => import('../../products/games/368Hedgehogs/368Hedgehogs'),

--- a/frontend/src/productScenes.tsx
+++ b/frontend/src/productScenes.tsx
@@ -89,6 +89,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     ErrorTrackingFingerprint: () =>
         import('../../products/error_tracking/frontend/scenes/ErrorTrackingFingerprintScene/ErrorTrackingFingerprintScene'),
     Experiments: () => import('../../products/experiments/frontend/scenes/ExperimentsScene'),
+    ExperimentsSharedMetrics: () => import('../../products/experiments/frontend/scenes/ExperimentsSharedMetricsScene'),
     FeatureFlagTemplates: () => import('../../products/feature_flags/frontend/FeatureFlagTemplatesScene'),
     FeatureFlagsStaffTools: () => import('../../products/feature_flags/frontend/staff/FeatureFlagsStaffToolsScene'),
     Game368Hedgehogs: () => import('../../products/games/368Hedgehogs/368Hedgehogs'),

--- a/frontend/src/productScenes.tsx
+++ b/frontend/src/productScenes.tsx
@@ -89,7 +89,6 @@ export const productScenes: Record<string, () => Promise<any>> = {
     ErrorTrackingFingerprint: () =>
         import('../../products/error_tracking/frontend/scenes/ErrorTrackingFingerprintScene/ErrorTrackingFingerprintScene'),
     Experiments: () => import('../../products/experiments/frontend/scenes/ExperimentsScene'),
-    ExperimentsSharedMetrics: () => import('../../products/experiments/frontend/scenes/ExperimentsSharedMetricsScene'),
     FeatureFlagTemplates: () => import('../../products/feature_flags/frontend/FeatureFlagTemplatesScene'),
     FeatureFlagsStaffTools: () => import('../../products/feature_flags/frontend/staff/FeatureFlagsStaffToolsScene'),
     Game368Hedgehogs: () => import('../../products/games/368Hedgehogs/368Hedgehogs'),

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -164,6 +164,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/error_tracking/alerts/:id': ['HogFunction', 'errorTrackingAlert'],
     '/error_tracking/:id': ['ErrorTrackingIssue', 'errorTrackingIssue'],
     '/error_tracking/:id/fingerprints': ['ErrorTrackingIssueFingerprints', 'errorTrackingIssueFingerprints'],
+    '/experiments': ['Experiments', 'experiments'],
     '/feature_flags/templates': ['FeatureFlagTemplates', 'featureFlagTemplates'],
     '/feature_flags/staff': ['FeatureFlagsStaffTools', 'featureFlagsStaffTools'],
     '/games/368hedgehogs': ['Game368Hedgehogs', 'game368Hedgehogs'],
@@ -691,6 +692,14 @@ export const productConfiguration: Record<string, any> = {
     ErrorTrackingIssue: { projectBased: true, name: 'Error tracking issue', layout: 'app-raw' },
     ErrorTrackingIssueFingerprints: { projectBased: true, name: 'Error tracking issue fingerprints' },
     ErrorTrackingFingerprint: { projectBased: true, name: 'Error tracking fingerprint' },
+    Experiments: {
+        projectBased: true,
+        name: 'Experiments',
+        activityScope: ActivityScope.EXPERIMENT,
+        description:
+            'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or due to chance.',
+        iconType: 'experiment',
+    },
     FeatureFlagTemplates: { projectBased: true, name: 'Feature flag templates' },
     FeatureFlagsStaffTools: { instanceLevel: true, name: 'Flags staff tools' },
     Game368Hedgehogs: { name: '368Hedgehogs', projectBased: true, activityScope: 'Games' },

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -39,7 +39,6 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.EventDefinition]: () => import('./data-management/definition/DefinitionView'),
     [Scene.Experiment]: () => import('./experiments/Experiment'),
     [Scene.ExperimentsSharedMetric]: () => import('./experiments/SharedMetrics/SharedMetric'),
-    [Scene.ExperimentsSharedMetrics]: () => import('./experiments/SharedMetrics/SharedMetrics'),
     [Scene.ExperimentsStaffTools]: () => import('./experiments/staff/ExperimentsStaffTools'),
     [Scene.ExploreEvents]: () => import('./activity/explore/EventsScene'),
     [Scene.ExploreSessions]: () => import('./activity/explore/SessionsScene'),

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -41,7 +41,6 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.ExperimentsSharedMetric]: () => import('./experiments/SharedMetrics/SharedMetric'),
     [Scene.ExperimentsSharedMetrics]: () => import('./experiments/SharedMetrics/SharedMetrics'),
     [Scene.ExperimentsStaffTools]: () => import('./experiments/staff/ExperimentsStaffTools'),
-    [Scene.Experiments]: () => import('./experiments/Experiments'),
     [Scene.ExploreEvents]: () => import('./activity/explore/EventsScene'),
     [Scene.ExploreSessions]: () => import('./activity/explore/SessionsScene'),
     [Scene.FeatureFlag]: () => import('./feature-flags/FeatureFlag'),

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -31,7 +31,6 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.Destinations]: () => import('./data-pipelines/DestinationsScene'),
     [Scene.DebugHog]: () => import('./debug/hog/HogRepl'),
     [Scene.DebugQuery]: () => import('./debug/DebugScene'),
-
     [Scene.Error404]: () => ({ default: preloadedScenes[Scene.Error404].component }),
     [Scene.ErrorNetwork]: () => ({ default: preloadedScenes[Scene.ErrorNetwork].component }),
     [Scene.ErrorProjectUnavailable]: () => ({ default: preloadedScenes[Scene.ErrorProjectUnavailable].component }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3292,6 +3292,9 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+      ts-pattern:
+        specifier: 'catalog:'
+        version: 4.3.0
     devDependencies:
       '@storybook/react':
         specifier: 'catalog:'

--- a/products/experiments/frontend/scenes/ExperimentsHoldoutsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsHoldoutsScene.tsx
@@ -16,12 +16,11 @@ import {
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import { NEW_HOLDOUT, holdoutsLogic } from 'scenes/experiments/holdoutsLogic'
 
 import { AccessControlLevel, AccessControlResourceType, ExperimentHoldoutType } from '~/types'
 
-import { NEW_HOLDOUT, holdoutsLogic } from './holdoutsLogic'
-
-export function Holdouts(): JSX.Element {
+export function ExperimentsHoldoutsScene(): JSX.Element {
     const { holdouts, holdoutsLoading, holdout } = useValues(holdoutsLogic)
     const { createHoldout, deleteHoldout, setHoldout, updateHoldout } = useActions(holdoutsLogic)
 

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -44,7 +44,6 @@ import {
 import { ExperimentsSettings } from 'scenes/experiments/ExperimentsSettings'
 import { ExperimentVelocityStats } from 'scenes/experiments/ExperimentVelocityStats'
 import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
-import { Holdouts } from 'scenes/experiments/Holdouts'
 import MaxTool from 'scenes/max/MaxTool'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -67,6 +66,7 @@ import {
 } from '~/types'
 
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
+import { ExperimentsHoldoutsScene } from 'products/experiments/frontend/scenes/ExperimentsHoldoutsScene'
 import { ExperimentsSharedMetricsScene } from 'products/experiments/frontend/scenes/ExperimentsSharedMetricsScene'
 
 export const scene: SceneExport = {
@@ -643,7 +643,7 @@ export function ExperimentsScene(): JSX.Element {
                         label: 'Shared metrics',
                         content: <ExperimentsSharedMetricsScene />,
                     },
-                    { key: ExperimentsTabs.Holdouts, label: 'Holdout groups', content: <Holdouts /> },
+                    { key: ExperimentsTabs.Holdouts, label: 'Holdout groups', content: <ExperimentsHoldoutsScene /> },
                     {
                         key: ExperimentsTabs.History,
                         label: 'History',

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -25,6 +25,27 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { pluralize } from 'lib/utils/strings'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
+import { CopyExperimentToProjectModal } from 'scenes/experiments/CopyExperimentToProjectModal'
+import { DuplicateExperimentModal } from 'scenes/experiments/DuplicateExperimentModal'
+import {
+    canArchiveExperiment,
+    confirmArchiveExperiment,
+    confirmDeleteExperiment,
+} from 'scenes/experiments/experimentActions'
+import {
+    EXPERIMENTS_PER_PAGE,
+    ExperimentsFilters,
+    experimentsLogic,
+    getExperimentStatus,
+    getShippedVariantKey,
+    isSingleVariantShipped,
+} from 'scenes/experiments/experimentsLogic'
+import { ExperimentsSettings } from 'scenes/experiments/ExperimentsSettings'
+import { ExperimentVelocityStats } from 'scenes/experiments/ExperimentVelocityStats'
+import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
+import { Holdouts } from 'scenes/experiments/Holdouts'
+import { SharedMetrics } from 'scenes/experiments/SharedMetrics/SharedMetrics'
 import MaxTool from 'scenes/max/MaxTool'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -48,26 +69,8 @@ import {
 
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
 
-import { CONCLUSION_DISPLAY_CONFIG } from './constants'
-import { CopyExperimentToProjectModal } from './CopyExperimentToProjectModal'
-import { DuplicateExperimentModal } from './DuplicateExperimentModal'
-import { canArchiveExperiment, confirmArchiveExperiment, confirmDeleteExperiment } from './experimentActions'
-import {
-    EXPERIMENTS_PER_PAGE,
-    ExperimentsFilters,
-    experimentsLogic,
-    getExperimentStatus,
-    getShippedVariantKey,
-    isSingleVariantShipped,
-} from './experimentsLogic'
-import { ExperimentsSettings } from './ExperimentsSettings'
-import { ExperimentVelocityStats } from './ExperimentVelocityStats'
-import { StatusTag } from './ExperimentView/StatusTag'
-import { Holdouts } from './Holdouts'
-import { SharedMetrics } from './SharedMetrics/SharedMetrics'
-
 export const scene: SceneExport = {
-    component: Experiments,
+    component: ExperimentsScene,
     logic: experimentsLogic,
     productKey: ProductKey.EXPERIMENTS,
     emptyState: experimentsEmptyState,
@@ -537,7 +540,7 @@ const ExperimentsTable = ({
     )
 }
 
-export function Experiments(): JSX.Element {
+export function ExperimentsScene(): JSX.Element {
     const { tab } = useValues(experimentsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { setExperimentsTab, loadExperiments } = useActions(experimentsLogic)
@@ -680,3 +683,5 @@ export function Experiments(): JSX.Element {
         </SceneContent>
     )
 }
+
+export default ExperimentsScene

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -45,7 +45,6 @@ import { ExperimentsSettings } from 'scenes/experiments/ExperimentsSettings'
 import { ExperimentVelocityStats } from 'scenes/experiments/ExperimentVelocityStats'
 import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import { Holdouts } from 'scenes/experiments/Holdouts'
-import { SharedMetrics } from 'scenes/experiments/SharedMetrics/SharedMetrics'
 import MaxTool from 'scenes/max/MaxTool'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -68,6 +67,7 @@ import {
 } from '~/types'
 
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
+import { ExperimentsSharedMetricsScene } from 'products/experiments/frontend/scenes/ExperimentsSharedMetricsScene'
 
 export const scene: SceneExport = {
     component: ExperimentsScene,
@@ -641,7 +641,7 @@ export function ExperimentsScene(): JSX.Element {
                     {
                         key: ExperimentsTabs.SharedMetrics,
                         label: 'Shared metrics',
-                        content: <SharedMetrics />,
+                        content: <ExperimentsSharedMetricsScene />,
                     },
                     { key: ExperimentsTabs.Holdouts, label: 'Holdout groups', content: <Holdouts /> },
                     {

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -41,7 +41,6 @@ import {
     getShippedVariantKey,
     isSingleVariantShipped,
 } from 'scenes/experiments/experimentsLogic'
-import { ExperimentsSettings } from 'scenes/experiments/ExperimentsSettings'
 import { ExperimentVelocityStats } from 'scenes/experiments/ExperimentVelocityStats'
 import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import MaxTool from 'scenes/max/MaxTool'
@@ -66,7 +65,12 @@ import {
 } from '~/types'
 
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
+/**
+ * these scenes are handled as child components. This works fine, but breaks the expectation of scenes
+ * having their own routes.
+ */
 import { ExperimentsHoldoutsScene } from 'products/experiments/frontend/scenes/ExperimentsHoldoutsScene'
+import { ExperimentsSettingsScene } from 'products/experiments/frontend/scenes/ExperimentsSettingsScene'
 import { ExperimentsSharedMetricsScene } from 'products/experiments/frontend/scenes/ExperimentsSharedMetricsScene'
 
 export const scene: SceneExport = {
@@ -652,7 +656,7 @@ export function ExperimentsScene(): JSX.Element {
                     {
                         key: ExperimentsTabs.Settings,
                         label: 'Settings',
-                        content: <ExperimentsSettings />,
+                        content: <ExperimentsSettingsScene />,
                     },
                 ]}
             />

--- a/products/experiments/frontend/scenes/ExperimentsSettingsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsSettingsScene.tsx
@@ -5,6 +5,7 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { MAX_LOOKBACK_DAYS, MIN_LOOKBACK_DAYS } from 'scenes/experiments/constants'
+import { DefaultMinimumDetectableEffect } from 'scenes/experiments/DefaultMinimumDetectableEffect'
 import { DefaultCupedEnabled } from 'scenes/settings/environment/DefaultCupedEnabled'
 import { DefaultCupedLookbackDays } from 'scenes/settings/environment/DefaultCupedLookbackDays'
 import { DefaultExperimentConfidenceLevel } from 'scenes/settings/environment/DefaultExperimentConfidenceLevel'
@@ -15,8 +16,6 @@ import { DefaultSequentialTuningParameter } from 'scenes/settings/environment/De
 import { ExperimentRecalculationTime } from 'scenes/settings/environment/ExperimentRecalculationTime'
 import { experimentsConfigLogic } from 'scenes/settings/environment/experimentsConfigLogic'
 import { FlagCleanupRepository } from 'scenes/settings/environment/FlagCleanupRepository'
-
-import { DefaultMinimumDetectableEffect } from './DefaultMinimumDetectableEffect'
 
 function SettingsSection({
     title,
@@ -58,7 +57,7 @@ function SettingsItem({
  * although this works fine for now, if we keep adding more settings we need to refactor this to use the
  * <Settings /> component. That will require we create a new section for experiments on the SettingsMap.
  */
-export function ExperimentsSettings(): JSX.Element {
+export function ExperimentsSettingsScene(): JSX.Element {
     const { experimentsConfig, experimentsConfigLoading } = useValues(experimentsConfigLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 

--- a/products/experiments/frontend/scenes/ExperimentsSharedMetricsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsSharedMetricsScene.tsx
@@ -19,24 +19,23 @@ import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/column
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { pluralize } from 'lib/utils/strings'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { MetricTypeTag } from 'scenes/experiments/MetricsView/shared/MetricTypeTag'
+import { InlineTagEditor } from 'scenes/experiments/SharedMetrics/InlineTagEditor'
+import { SharedMetric } from 'scenes/experiments/SharedMetrics/sharedMetricLogic'
+import { PAGE_SIZE, sharedMetricsLogic } from 'scenes/experiments/SharedMetrics/sharedMetricsLogic'
+import { isLegacySharedMetric } from 'scenes/experiments/utils'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { tagsModel } from '~/models/tagsModel'
 import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
 
-import { MetricTypeTag } from '../MetricsView/shared/MetricTypeTag'
-import { isLegacySharedMetric } from '../utils'
-import { InlineTagEditor } from './InlineTagEditor'
-import { SharedMetric } from './sharedMetricLogic'
-import { PAGE_SIZE, sharedMetricsLogic } from './sharedMetricsLogic'
-
 export const scene: SceneExport = {
-    component: SharedMetrics,
+    component: ExperimentsSharedMetricsScene,
     logic: sharedMetricsLogic,
 }
 
-export function SharedMetrics(): JSX.Element {
+export function ExperimentsSharedMetricsScene(): JSX.Element {
     const { sharedMetrics, sharedMetricsLoading, searchTerm, savingTagsMetricId, count, page } =
         useValues(sharedMetricsLogic)
     const { setSearchTerm, setPage, updateSharedMetricTags, deleteSharedMetric } = useActions(sharedMetricsLogic)
@@ -225,3 +224,5 @@ export function SharedMetrics(): JSX.Element {
         </div>
     )
 }
+
+export default ExperimentsSharedMetricsScene

--- a/products/experiments/manifest.tsx
+++ b/products/experiments/manifest.tsx
@@ -2,11 +2,22 @@ import { toParams } from 'lib/utils/url'
 import { urls } from 'scenes/urls'
 
 import { ExperimentMetric, ProductItemCategory, ProductKey } from '~/queries/schema/schema-general'
-
-import { FileSystemIconColor, ProductManifest } from '../../frontend/src/types'
+import { ActivityScope, FileSystemIconColor, ProductManifest } from '~/types'
 
 export const manifest: ProductManifest = {
     name: 'Experiments',
+    scenes: {
+        Experiments: {
+            import: () => import('./frontend/scenes/ExperimentsScene'),
+            projectBased: true,
+            name: 'Experiments',
+            activityScope: ActivityScope.EXPERIMENT,
+            description:
+                'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or due to chance.',
+            iconType: 'experiment',
+        },
+    },
+    routes: { '/experiments': ['Experiments', 'experiments'] },
     urls: {
         experiment: (
             id: string | number,

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -4,9 +4,11 @@
         "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short"
     },
     "dependencies": {
+        "@posthog/brand": "catalog:",
         "kea": "catalog:",
         "kea-loaders": "catalog:",
-        "kea-router": "catalog:"
+        "kea-router": "catalog:",
+        "ts-pattern": "catalog:"
     },
     "devDependencies": {
         "@storybook/react": "catalog:",


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Experiment's frontend files live under the `/frontend/src/scenes/experiments` folder, and as such, can't take advantage of CI/CD improvements in testing and releasing. Like the backend files before, they have to be migrated to the `/products/experiments` folder, incrementally to avoid disrupting existing work.

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This is the initial PR that moves to the `/products/experiments` folder the Experiments scene, including the sub-tabs. This is a mechanical change that doesn't modify code beyond renaming files or setting the scene routing.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

![cat-type-small](https://github.com/user-attachments/assets/ad6629f6-09d1-4019-a1e2-d8fcc5ef9a5d)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

No agent involved. Old-school, home-grown code.

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->