### PR TITLE
feat(tasks): hogland sandbox provider and golden snapshot bake

### DIFF
--- a/products/tasks/backend/logic/services/hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/hogland_sandbox.py
@@ -1,0 +1,441 @@
+"""Hogland-backed sandbox provider.
+
+Hogland is PostHog's Firecracker microVM service. A hogbox boots from a golden
+snapshot (alias ``posthog-tasks-default``) baked from the same layout as the Modal
+base image, so the shared ``AgentServerLaunchMixin`` drives it unchanged: repo
+clone, agent-server launch, and health checks are all bash over ``execute``.
+
+Transport differences from Modal, handled by the callers that read
+``TaskRun.state``:
+- the agent-server is reached through hogplane's authenticated proxy
+  (``/v1/hogboxes/<id>/proxy/8080``), authenticated with the backend's hogland
+  bearer as a ``?token=`` query param — never a per-sandbox token, so
+  ``get_connect_credentials`` deliberately returns ``token=None`` and nothing
+  secret lands in ``TaskRun.state``;
+- resume snapshots are not supported yet — every run cold-boots from the golden
+  snapshot.
+"""
+
+from __future__ import annotations
+
+import uuid
+import shlex
+import logging
+from collections.abc import Iterable
+from functools import lru_cache
+from pathlib import Path
+
+from django.conf import settings
+
+import httpx
+from hogland import APIError, ExecEvent, Hogbox, Hogland, NotFoundError
+
+from products.tasks.backend.exceptions import (
+    SandboxCleanupError,
+    SandboxExecutionError,
+    SandboxNotFoundError,
+    SandboxNotRunningError,
+    SandboxProvisionError,
+    SandboxTimeoutError,
+    SnapshotCreationError,
+)
+from products.tasks.backend.logic.services.agent_server_launcher import AGENT_SERVER_PORT, AgentServerLaunchMixin
+from products.tasks.backend.logic.services.agentsh import AGENTSH_DAEMON_PORT
+from products.tasks.backend.logic.services.sandbox import redact_sandbox_command
+
+from .sandbox import AgentServerResult, ExecutionResult, ExecutionStream, SandboxConfig, SandboxStatus, SandboxTemplate
+
+logger = logging.getLogger(__name__)
+
+# "agent" is a registered hogland kind (1h idle-TTL default) for API-driven
+# LLM sandbox runs — exactly this workload. Using it rather than an unregistered
+# kind means a call site that ever omits ttl_seconds inherits a safe default
+# instead of minting an immortal box.
+HOGLAND_TASKS_BOX_KIND = "agent"
+
+# Every template hogland supports maps to a global snapshot alias baked in CI
+# (the tasks golden-snapshot workflow). Only the plain default-template run is routed
+# to hogland; anything else stays on Modal (see get_task_processing_context).
+TEMPLATE_TO_SNAPSHOT_ALIAS: dict[SandboxTemplate, str] = {
+    SandboxTemplate.DEFAULT_BASE: "alias:posthog-tasks-default",
+}
+
+# The golden snapshot (baked in CI) pins this machine shape. A hogland
+# restore must inherit-or-match it, so per-task overrides are ignored and the provisioned
+# box is always this size. Keep in sync with the shape the CI golden bake boots at.
+HOGLAND_GOLDEN_CPU_CORES = 4.0
+HOGLAND_GOLDEN_MEMORY_GB = 16.0
+HOGLAND_GOLDEN_DISK_GB = 64.0
+
+# `create()` blocks until the box is running; a cold boot on a fresh Karpenter node
+# can take minutes, and `exec` calls legitimately run up to the caller's
+# timeout_seconds (default 10 minutes). One generous read timeout covers both —
+# the server enforces the real per-call budgets.
+_HTTP_TIMEOUT = httpx.Timeout(30 * 60, connect=15)
+
+# Static container env the Modal image carries as Dockerfile ENVs. The golden image
+# bakes them into /etc/environment too; passing them per-box keeps a restore that
+# predates a bake change consistent with this backend.
+_STATIC_BOX_ENV = {
+    "IS_SANDBOX": "1",
+    "GH_TELEMETRY": "false",
+    "PYTHONPATH": "/tmp/workspace",
+    "AGENTSH_SERVER": f"http://127.0.0.1:{AGENTSH_DAEMON_PORT}",
+    # Guards in /opt/posthog/bin must shadow the real git/gh.
+    "PATH": "/opt/posthog/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+}
+
+
+@lru_cache(maxsize=4)
+def _cached_client(base_url: str, token: str) -> Hogland:
+    return Hogland(token=token, base_url=base_url, timeout=_HTTP_TIMEOUT)
+
+
+def _read_token_file() -> str | None:
+    path = settings.HOGLAND_API_TOKEN_FILE
+    if not path:
+        return None
+    try:
+        token = Path(path).read_text().strip()
+    except OSError:
+        logger.warning(
+            "Hogland token file is set but unreadable; falling back to the static token", extra={"path": path}
+        )
+        return None
+    return token or None
+
+
+def get_hogland_api_token() -> str | None:
+    """Current control-plane bearer, preferring the projected ServiceAccount token file.
+
+    The file carries a rotating JWT, so it is re-read on every call; the static
+    HOGLAND_API_TOKEN is the local-dev/bake fallback.
+    """
+    return _read_token_file() or settings.HOGLAND_API_TOKEN
+
+
+def get_hogland_client() -> Hogland:
+    base_url = settings.HOGLAND_API_URL
+    file_token = _read_token_file()
+    if base_url and file_token:
+        # SDK 0.3.x binds the token at construction, so a cached client would keep a
+        # rotated-out JWT and 401. Build a fresh client per call until the SDK ships
+        # Hogland.from_token_file with per-request re-reads; then this collapses to a
+        # cached Hogland.from_token_file(...) client.
+        return Hogland(token=file_token, base_url=base_url, timeout=_HTTP_TIMEOUT)
+    token = settings.HOGLAND_API_TOKEN
+    if not base_url or not token:
+        raise SandboxProvisionError(
+            "Hogland sandbox backend is not configured",
+            {"missing": "HOGLAND_API_URL/HOGLAND_API_TOKEN_FILE/HOGLAND_API_TOKEN"},
+            cause=RuntimeError("HOGLAND_API_URL and a hogland token (file or static) must both be set"),
+        )
+    return _cached_client(base_url, token)
+
+
+class _HogboxExecutionStream:
+    """Adapts the SDK's SSE exec stream to the ExecutionStream protocol."""
+
+    def __init__(self, events: Iterable[ExecEvent]):
+        self._events = iter(events)
+        self._stdout_chunks: list[str] = []
+        self._stderr_chunks: list[str] = []
+        self._exit_code: int | None = None
+
+    def _consume(self, event: ExecEvent) -> str | None:
+        if event.kind == "stdout":
+            self._stdout_chunks.append(event.data)
+            return event.data
+        if event.kind == "stderr":
+            self._stderr_chunks.append(event.data)
+        elif event.kind == "exit":
+            self._exit_code = event.exit_code
+        return None
+
+    def iter_stdout(self) -> Iterable[str]:
+        for event in self._events:
+            chunk = self._consume(event)
+            if chunk is not None:
+                yield chunk
+
+    def wait(self) -> ExecutionResult:
+        for event in self._events:
+            self._consume(event)
+        return ExecutionResult(
+            stdout="".join(self._stdout_chunks),
+            stderr="".join(self._stderr_chunks),
+            # -1 mirrors the server's "killed before reporting" sentinel for a
+            # stream that ended without an exit frame.
+            exit_code=self._exit_code if self._exit_code is not None else -1,
+            error=None,
+        )
+
+
+class HoglandSandbox(AgentServerLaunchMixin):
+    """Firecracker sandbox on hogland. A box on our own metal."""
+
+    id: str
+    config: SandboxConfig
+    _box: Hogbox
+    _sandbox_url: str | None
+
+    def __init__(self, box: Hogbox, config: SandboxConfig, sandbox_url: str | None = None):
+        self.id = box.id
+        self.config = config
+        self._box = box
+        self._sandbox_url = sandbox_url
+
+    @property
+    def sandbox_url(self) -> str | None:
+        return self._sandbox_url
+
+    @classmethod
+    def create(cls, config: SandboxConfig) -> HoglandSandbox:
+        snapshot_alias = TEMPLATE_TO_SNAPSHOT_ALIAS.get(config.template)
+        if snapshot_alias is None:
+            raise SandboxProvisionError(
+                "Template is not supported on the hogland backend",
+                {"config_name": config.name, "template": config.template.value},
+                cause=RuntimeError(f"no hogland golden snapshot for template {config.template.value}"),
+            )
+        if config.snapshot_id or config.snapshot_external_id:
+            # Backend resolution forces resume snapshots off for hogland runs; if an id
+            # slips through anyway, cold-boot loudly rather than restoring the wrong thing.
+            logger.warning(
+                "Hogland backend ignores resume snapshot; cold-booting from the golden image",
+                extra={"snapshot_id": config.snapshot_id, "snapshot_external_id": config.snapshot_external_id},
+            )
+        config.snapshot_restored = False
+        config.image_fallback = None
+
+        env = {**_STATIC_BOX_ENV, **(config.environment_variables or {})}
+        tags = [f"{key}={value}" for key, value in (config.metadata or {}).items()]
+
+        try:
+            client = get_hogland_client()
+            box = client.create(
+                # cpus/memory_mib/disk_gib deliberately omitted: a snapshot restore must
+                # inherit the golden snapshot's machine config (a mismatch is a 400).
+                # Per-task resource overrides are therefore unsupported on hogland.
+                snapshot_id=snapshot_alias,
+                # Explicit and defensive: a restore inherits the snapshot's access_type,
+                # and the key-less golden bake is stamped "none", so task boxes already
+                # restore as "none". Passing it here just pins that intent. Note "none"
+                # still allocates a port + DNAT, so it does not remove ingress; the box is
+                # driven via exec / files / proxy regardless.
+                access_type="none",
+                # Non-empty names must be unique per owner; suffix like the Modal backend.
+                name=f"{config.name}-{uuid.uuid4().hex[:6]}"[:64],
+                kind=HOGLAND_TASKS_BOX_KIND,
+                # Always explicit: an unregistered kind carries no server-side TTL
+                # default, and an omitted value would make the box immortal.
+                ttl_seconds=config.ttl_seconds,
+                env=env,
+                tags=tags or None,
+            )
+        except APIError as e:
+            raise SandboxProvisionError(
+                "Failed to create hogland sandbox",
+                {"config_name": config.name, "status_code": str(e.status_code), "error": str(e)},
+                cause=e,
+            )
+        except SandboxProvisionError:
+            raise
+        except Exception as e:
+            raise SandboxProvisionError(
+                "Failed to create hogland sandbox", {"config_name": config.name, "error": str(e)}, cause=e
+            )
+
+        if (config.cpu_cores, config.memory_gb, config.disk_size_gb) != (
+            HOGLAND_GOLDEN_CPU_CORES,
+            HOGLAND_GOLDEN_MEMORY_GB,
+            HOGLAND_GOLDEN_DISK_GB,
+        ):
+            logger.info(
+                "Hogland sandbox ignores per-task resource overrides; using the golden snapshot's machine config",
+                extra={"sandbox_id": box.id, "cpu_cores": config.cpu_cores, "memory_gb": config.memory_gb},
+            )
+        # Price the usage ledger on the shape the box actually delivered, read back from
+        # the box spec, not the requested golden constants. A restored box always reports a
+        # concrete machine shape (snapshot defaults + inheritance), so a golden snapshot
+        # rebaked at a different shape flows through here instead of desyncing every ledger
+        # row against a pinned constant.
+        spec = box.view.spec
+        if spec.cpus is None or spec.memory_mib is None or spec.disk_gib is None:
+            raise SandboxProvisionError(
+                "Hogland box spec is missing a machine dimension",
+                {"config_name": config.name, "sandbox_id": box.id},
+                cause=RuntimeError(f"incomplete box spec for {box.id}"),
+            )
+        config.cpu_cores = spec.cpus
+        config.memory_gb = spec.memory_mib / 1024
+        config.disk_size_gb = float(spec.disk_gib)
+
+        logger.info(f"Created hogland sandbox {box.id} for {config.name}")
+        return cls(box=box, config=config)
+
+    @staticmethod
+    def get_by_id(sandbox_id: str) -> HoglandSandbox:
+        try:
+            box = get_hogland_client().get(sandbox_id)
+        except NotFoundError as e:
+            raise SandboxNotFoundError(
+                f"Sandbox {sandbox_id} not found", {"sandbox_id": sandbox_id, "error": str(e)}, cause=e
+            )
+        except Exception as e:
+            logger.exception(f"Failed to retrieve hogland sandbox {sandbox_id}: {e}")
+            raise SandboxNotFoundError(
+                f"Sandbox {sandbox_id} not found", {"sandbox_id": sandbox_id, "error": str(e)}, cause=e
+            )
+        config = SandboxConfig(name=box.view.spec.name or f"sandbox-{sandbox_id}")
+        return HoglandSandbox(box=box, config=config)
+
+    def get_status(self) -> SandboxStatus:
+        try:
+            self._box.refresh()
+        except NotFoundError:
+            return SandboxStatus.SHUTDOWN
+        return SandboxStatus.RUNNING if self._box.status == "running" else SandboxStatus.SHUTDOWN
+
+    def is_running(self) -> bool:
+        return self.get_status() == SandboxStatus.RUNNING
+
+    def execute(
+        self, command: str, timeout_seconds: int | None = None, env: dict[str, str] | None = None
+    ) -> ExecutionResult:
+        if not self.is_running():
+            raise SandboxNotRunningError(
+                "Sandbox not in running state.",
+                {"sandbox_id": self.id},
+                cause=RuntimeError(f"Sandbox {self.id} is not running"),
+            )
+
+        if timeout_seconds is None:
+            timeout_seconds = self.config.default_execution_timeout_seconds
+
+        redacted_command = redact_sandbox_command(command)
+        try:
+            result = self._box.exec(["bash", "-c", command], timeout_seconds=timeout_seconds, env=env)
+        except Exception as e:
+            redacted_error = redact_sandbox_command(str(e))
+            # Provider exceptions can echo the shell command, so avoid exc_info here.
+            logger.error(  # noqa: TRY400
+                "Failed to execute command", extra={"sandbox_id": self.id, "redacted_error": redacted_error}
+            )
+            raise SandboxExecutionError(
+                "Failed to execute command",
+                {"sandbox_id": self.id, "command": redacted_command, "error": redacted_error},
+                cause=RuntimeError(redacted_error),
+            )
+
+        if result.timed_out:
+            raise SandboxTimeoutError(
+                f"Execution timed out after {timeout_seconds} seconds",
+                {"sandbox_id": self.id, "timeout_seconds": timeout_seconds},
+                cause=RuntimeError(f"exec timed out after {timeout_seconds}s"),
+            )
+
+        return ExecutionResult(stdout=result.stdout, stderr=result.stderr, exit_code=result.exit_code, error=None)
+
+    def execute_stream(self, command: str, timeout_seconds: int | None = None) -> ExecutionStream:
+        if not self.is_running():
+            raise SandboxNotRunningError(
+                "Sandbox not in running state.",
+                {"sandbox_id": self.id},
+                cause=RuntimeError(f"Sandbox {self.id} is not running"),
+            )
+
+        if timeout_seconds is None:
+            timeout_seconds = self.config.default_execution_timeout_seconds
+
+        events = self._box.exec_stream(["bash", "-c", command], timeout_seconds=timeout_seconds)
+        return _HogboxExecutionStream(events)
+
+    def write_file(self, path: str, payload: bytes) -> ExecutionResult:
+        if not self.is_running():
+            raise SandboxNotRunningError(
+                "Sandbox not in running state.",
+                {"sandbox_id": self.id},
+                cause=RuntimeError(f"Sandbox {self.id} is not running"),
+            )
+        try:
+            # The server writes via tmp + rename, so this matches the Modal
+            # backend's temp-file + mv atomicity.
+            self._box.write_file(path, payload, mkdir=True)
+        except Exception as e:
+            logger.exception(f"Failed to write file to sandbox: {e}")
+            raise SandboxExecutionError(
+                "Failed to write file",
+                {"sandbox_id": self.id, "path": path, "error": str(e)},
+                cause=e,
+            )
+        return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+
+    def get_connect_credentials(self) -> AgentServerResult:
+        """URL of the agent-server behind hogplane's box proxy.
+
+        There is no per-sandbox token: the proxy authenticates with the backend's
+        hogland bearer, which callers attach at request time (never persisted in
+        ``TaskRun.state``) — see ``agent_command.sandbox_transport_token``.
+        """
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
+
+        self._sandbox_url = self._box.proxy_url(AGENT_SERVER_PORT).rstrip("/")
+        logger.info(f"Got connect credentials for sandbox {self.id}: {self._sandbox_url}")
+        return AgentServerResult(url=self._sandbox_url, token=None)
+
+    def setup_repository(self, repository: str) -> ExecutionResult:
+        """No-op: repository setup is handled by agent-server."""
+        return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+
+    def is_git_clean(self, repository: str) -> tuple[bool, str]:
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
+
+        org, repo = repository.lower().split("/")
+        repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+
+        result = self.execute(f"cd {shlex.quote(repo_path)} && git status --porcelain")
+        return not result.stdout.strip(), result.stdout
+
+    def execute_task(
+        self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
+    ) -> ExecutionResult:
+        """No-op: task execution is handled by agent-server."""
+        return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+
+    def create_snapshot(self, *, timeout_seconds: int | None = None) -> str:
+        raise SnapshotCreationError(
+            "Resume snapshots are not supported on the hogland backend yet",
+            {"sandbox_id": self.id},
+            cause=NotImplementedError("hogland resume snapshots"),
+        )
+
+    def create_directory_snapshot(self, path: str) -> str:
+        raise SnapshotCreationError(
+            "Resume snapshots are not supported on the hogland backend yet",
+            {"sandbox_id": self.id, "path": path},
+            cause=NotImplementedError("hogland resume snapshots"),
+        )
+
+    def prune_snapshot_heavy_dirs(self, path: str) -> None:
+        """No-op: hogland snapshots are block-level and have no file-count cap."""
+
+    @staticmethod
+    def delete_snapshot(external_id: str) -> None:
+        logger.info(f"Ignoring delete for hogland snapshot {external_id}; hogland snapshots are unreachable in MVP")
+
+    def destroy(self) -> None:
+        try:
+            self._box.delete()
+            logger.info(f"Destroyed hogland sandbox {self.id}")
+        except Exception as e:
+            logger.exception(f"Failed to destroy sandbox: {e}")
+            raise SandboxCleanupError(
+                f"Failed to destroy sandbox: {e}", {"sandbox_id": self.id, "error": str(e)}, cause=e
+            )
+
+    @property
+    def name(self) -> str:
+        return self.config.name

--- a/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
@@ -1,0 +1,273 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from hogland import ExecEvent, ExecResult, NotFoundError
+from parameterized import parameterized
+
+from products.tasks.backend.exceptions import (
+    SandboxExecutionError,
+    SandboxNotFoundError,
+    SandboxProvisionError,
+    SandboxTimeoutError,
+    SnapshotCreationError,
+)
+from products.tasks.backend.logic.services.hogland_sandbox import (
+    _STATIC_BOX_ENV,
+    HoglandSandbox,
+    get_hogland_api_token,
+    get_hogland_client,
+)
+from products.tasks.backend.logic.services.sandbox import (
+    SandboxConfig,
+    SandboxStatus,
+    SandboxTemplate,
+    get_sandbox_class_for_sandbox_id,
+)
+
+
+def _exec_result(**overrides) -> ExecResult:
+    payload = {"stdout": "", "stderr": "", "exit_code": 0, "timed_out": False, "duration_ms": 1}
+    payload.update(overrides)
+    return ExecResult.model_validate(payload)
+
+
+def _mock_box(
+    box_id: str = "box-abc123def456",
+    status: str = "running",
+    *,
+    cpus: float = 4.0,
+    memory_mib: int = 16384,
+    disk_gib: int = 64,
+) -> MagicMock:
+    box = MagicMock()
+    box.id = box_id
+    box.status = status
+    box.view.spec.cpus = cpus
+    box.view.spec.memory_mib = memory_mib
+    box.view.spec.disk_gib = disk_gib
+    box.refresh.return_value = box
+    return box
+
+
+def _running_sandbox(box: MagicMock | None = None) -> HoglandSandbox:
+    box = box if box is not None else _mock_box()
+    return HoglandSandbox(box=box, config=SandboxConfig(name="test-sandbox"))
+
+
+class TestHoglandSandboxCreate:
+    def _create(self, config: SandboxConfig, box: MagicMock | None = None) -> tuple[HoglandSandbox, MagicMock]:
+        client = MagicMock()
+        client.create.return_value = box if box is not None else _mock_box()
+        with patch("products.tasks.backend.logic.services.hogland_sandbox.get_hogland_client", return_value=client):
+            sandbox = HoglandSandbox.create(config)
+        return sandbox, client
+
+    def test_create_maps_config_onto_the_golden_snapshot_restore(self):
+        config = SandboxConfig(
+            name="sandbox-task-1",
+            environment_variables={"GITHUB_TOKEN": "tok", "IS_SANDBOX": "override"},
+            metadata={"task_id": "t1", "run_id": "r1"},
+        )
+        sandbox, client = self._create(config)
+
+        kwargs = client.create.call_args.kwargs
+        assert kwargs["snapshot_id"] == "alias:posthog-tasks-default"
+        # An omitted ttl on an unregistered kind means an immortal box.
+        assert kwargs["ttl_seconds"] == config.ttl_seconds
+        # Restores must inherit the golden snapshot's machine config.
+        for sizing_key in ("cpus", "memory_mib", "disk_gib"):
+            assert sizing_key not in kwargs
+        # Explicit and defensive; a restore inherits the snapshot's "none" access_type anyway.
+        assert kwargs["access_type"] == "none"
+        assert kwargs["kind"] == "agent"
+        assert kwargs["name"].startswith("sandbox-task-1-")
+        assert sorted(kwargs["tags"]) == ["run_id=r1", "task_id=t1"]
+        assert kwargs["env"]["GITHUB_TOKEN"] == "tok"
+        assert kwargs["env"]["PATH"] == _STATIC_BOX_ENV["PATH"]
+        # Per-run values win over the static baseline.
+        assert kwargs["env"]["IS_SANDBOX"] == "override"
+        assert sandbox.id == "box-abc123def456"
+        assert config.snapshot_restored is False
+
+    def test_create_records_the_read_back_box_shape_for_the_ledger(self):
+        # The box ignores per-task overrides, so the ledger must reflect the shape the box
+        # actually delivered, read back from box.view.spec — not the requested override and
+        # not a pinned constant that a rebaked golden snapshot would silently desync.
+        config = SandboxConfig(name="oversized", cpu_cores=16, memory_gb=64, disk_size_gb=100)
+        box = _mock_box(cpus=8.0, memory_mib=32768, disk_gib=128)
+        _sandbox, _client = self._create(config, box=box)
+        assert (config.cpu_cores, config.memory_gb, config.disk_size_gb) == (8.0, 32.0, 128.0)
+
+    def test_create_rejects_a_box_spec_missing_a_machine_dimension(self):
+        # The read-back has no golden-constant fallback, so an incomplete spec must fail
+        # loudly rather than price the ledger against a stale pinned shape.
+        box = _mock_box()
+        box.view.spec.memory_mib = None
+        with pytest.raises(SandboxProvisionError):
+            self._create(SandboxConfig(name="incomplete"), box=box)
+
+    @parameterized.expand([(template,) for template in SandboxTemplate if template != SandboxTemplate.DEFAULT_BASE])
+    def test_create_rejects_templates_without_a_golden_snapshot(self, template: SandboxTemplate):
+        with pytest.raises(SandboxProvisionError):
+            HoglandSandbox.create(SandboxConfig(name="t", template=template))
+
+
+class TestHoglandSandboxExecution:
+    def test_execute_returns_execution_result(self):
+        box = _mock_box()
+        box.exec.return_value = _exec_result(stdout="out", stderr="err", exit_code=3)
+        sandbox = _running_sandbox(box)
+
+        result = sandbox.execute("echo hi", timeout_seconds=5)
+
+        assert (result.stdout, result.stderr, result.exit_code) == ("out", "err", 3)
+        assert box.exec.call_args.args[0] == ["bash", "-c", "echo hi"]
+        assert box.exec.call_args.kwargs["timeout_seconds"] == 5
+        # No per-call env forwards as None, so the box keeps its baked/create env.
+        assert box.exec.call_args.kwargs["env"] is None
+
+    def test_execute_forwards_per_call_env_to_the_sdk(self):
+        box = _mock_box()
+        box.exec.return_value = _exec_result(stdout="out")
+        sandbox = _running_sandbox(box)
+
+        per_call_env = {"POSTHOG_TASK_RUN_SESSION_TOKEN": "fresh"}
+        sandbox.execute("run", timeout_seconds=5, env=per_call_env)
+
+        assert box.exec.call_args.kwargs["env"] == per_call_env
+
+    def test_execute_timeout_raises_sandbox_timeout_error(self):
+        box = _mock_box()
+        box.exec.return_value = _exec_result(exit_code=-1, timed_out=True)
+        sandbox = _running_sandbox(box)
+
+        with pytest.raises(SandboxTimeoutError):
+            sandbox.execute("sleep 100", timeout_seconds=1)
+
+    def test_execute_wraps_transport_errors_and_redacts_the_command(self):
+        box = _mock_box()
+        box.exec.side_effect = RuntimeError("POSTHOG_TASK_RUN_SESSION_TOKEN='secret' boom")
+        sandbox = _running_sandbox(box)
+
+        with pytest.raises(SandboxExecutionError) as err:
+            sandbox.execute("env POSTHOG_TASK_RUN_SESSION_TOKEN='secret' run", timeout_seconds=1)
+
+        assert "secret" not in str(err.value.context)
+
+    def test_execute_stream_buffers_output_and_defaults_missing_exit_to_minus_one(self):
+        box = _mock_box()
+        events = [
+            {"kind": "stdout", "data": "a"},
+            {"kind": "stderr", "data": "warn"},
+            {"kind": "stdout", "data": "b"},
+        ]
+        box.exec_stream.return_value = iter([ExecEvent.model_validate(e) for e in events])
+        sandbox = _running_sandbox(box)
+
+        stream = sandbox.execute_stream("cmd")
+        assert list(stream.iter_stdout()) == ["a", "b"]
+        result = stream.wait()
+        assert (result.stdout, result.stderr, result.exit_code) == ("ab", "warn", -1)
+
+
+class TestHoglandSandboxLifecycle:
+    def test_get_by_id_maps_not_found(self):
+        client = MagicMock()
+        client.get.side_effect = NotFoundError(status_code=404, body=None, request_id=None, message="nope")
+        with patch("products.tasks.backend.logic.services.hogland_sandbox.get_hogland_client", return_value=client):
+            with pytest.raises(SandboxNotFoundError):
+                HoglandSandbox.get_by_id("box-000000000000")
+
+    @parameterized.expand(
+        [
+            ("running", SandboxStatus.RUNNING),
+            ("paused", SandboxStatus.SHUTDOWN),
+            ("stopped", SandboxStatus.SHUTDOWN),
+            ("failed", SandboxStatus.SHUTDOWN),
+        ]
+    )
+    def test_get_status_maps_box_status(self, box_status: str, expected: SandboxStatus):
+        sandbox = _running_sandbox(_mock_box(status=box_status))
+        assert sandbox.get_status() == expected
+
+    def test_get_status_of_deleted_box_is_shutdown(self):
+        box = _mock_box()
+        box.refresh.side_effect = NotFoundError(status_code=404, body=None, request_id=None, message="gone")
+        sandbox = _running_sandbox(box)
+        assert sandbox.get_status() == SandboxStatus.SHUTDOWN
+
+    def test_connect_credentials_carry_no_token(self):
+        box = _mock_box()
+        box.proxy_url.return_value = "https://hogland.example/v1/hogboxes/hb-abc123/proxy/8080/"
+        sandbox = _running_sandbox(box)
+
+        credentials = sandbox.get_connect_credentials()
+
+        # The hogland account bearer must never land in TaskRun.state; callers
+        # attach it at request time instead.
+        assert credentials.token is None
+        assert credentials.url == "https://hogland.example/v1/hogboxes/hb-abc123/proxy/8080"
+        assert sandbox.sandbox_url == credentials.url
+
+    def test_snapshots_are_rejected(self):
+        sandbox = _running_sandbox()
+        with pytest.raises(SnapshotCreationError):
+            sandbox.create_snapshot()
+        with pytest.raises(SnapshotCreationError):
+            sandbox.create_directory_snapshot("/tmp/workspace")
+
+
+class TestSandboxIdPrefixDispatch:
+    @parameterized.expand([("box-b99582fcb238", True), ("sb-abc123", False), ("sandbox-legacy", False)])
+    def test_get_by_id_routes_on_id_prefix(self, sandbox_id: str, expect_hogland: bool):
+        resolved = get_sandbox_class_for_sandbox_id(sandbox_id)
+        assert (resolved is HoglandSandbox) == expect_hogland
+
+
+class TestHoglandAuthPrecedence:
+    def test_file_mode_builds_an_uncached_client_from_the_current_file_contents(self, tmp_path):
+        token_path = tmp_path / "token"
+        token_path.write_text("tok-before\n")
+        with override_settings(
+            HOGLAND_API_URL="https://hogland.example",
+            HOGLAND_API_TOKEN="static-tok",
+            HOGLAND_API_TOKEN_FILE=str(token_path),
+        ):
+            with patch("products.tasks.backend.logic.services.hogland_sandbox.Hogland") as client_cls:
+                get_hogland_client()
+                # The projected SA token rotates on disk; the next call must pick
+                # the new value up instead of reusing a cached client.
+                token_path.write_text("tok-after\n")
+                get_hogland_client()
+
+        assert [call.kwargs["token"] for call in client_cls.call_args_list] == ["tok-before", "tok-after"]
+
+    @pytest.mark.parametrize(
+        "file_state,static_token,expected",
+        [
+            ("readable", "static-tok", "file-tok"),
+            ("unset", "static-tok", "static-tok"),
+            ("missing", "static-tok", "static-tok"),
+            ("unset", None, None),
+        ],
+        ids=[
+            "file_wins_over_static",
+            "static_when_file_env_unset",
+            "static_when_file_missing",
+            "none_when_nothing_configured",
+        ],
+    )
+    def test_api_token_precedence(self, file_state: str, static_token: str | None, expected: str | None, tmp_path):
+        if file_state == "readable":
+            token_path = tmp_path / "token"
+            token_path.write_text("file-tok\n")
+            file_setting: str | None = str(token_path)
+        elif file_state == "missing":
+            file_setting = str(tmp_path / "does-not-exist")
+        else:
+            file_setting = None
+
+        with override_settings(HOGLAND_API_TOKEN_FILE=file_setting, HOGLAND_API_TOKEN=static_token):
+            assert get_hogland_api_token() == expected


### PR DESCRIPTION
## Problem

- Layer 2 of the stack on #87250: the provider seam exists, but nothing can boot a task sandbox on hogland, and no golden image exists for one to boot from.

## Changes

- `HoglandSandbox` boots a Firecracker hogbox by restoring the global snapshot alias `posthog-tasks-default`; the shared launch mixin then runs the repo clone and agent-server unchanged.
- Every box gets an explicit 6-hour TTL. Hogland treats an omitted TTL on an unregistered kind as immortal, so this is load-bearing.
- Sizing (`cpus`/`memory_mib`/`disk_gib`) is omitted on create: a snapshot restore must inherit the golden image's machine shape (4 CPU / 16 GiB / 64 GiB), so per-task resource overrides log and no-op on hogland.
- `get_hogland_client()` prefers `HOGLAND_API_TOKEN_FILE`: it re-reads the file on every call and builds a fresh, un-cached client. SDK 0.3.1 binds the token at construction, so a cached client would keep a rotated-out JWT and 401. This collapses to a cached `Hogland.from_token_file` client once PostHog/hogland#403 ships.
- `get_hogland_api_token()` exposes the same precedence (fresh file read, else the static token) for the transport layer in #87253. `manage.py bake_hogland_snapshot` keeps its own `--token`/static path; it runs from a laptop.
- `get_connect_credentials()` returns `token=None` on purpose: hogland has no per-sandbox token, and the account bearer must never land in `TaskRun.state`. Layer 3 attaches it at request time instead.
- Resume snapshots raise; layer 3 forces them off for hogland runs.
- `manage.py bake_hogland_snapshot` replays `Dockerfile.sandbox-base` over exec/write_file into a box, snapshots it, and re-points the alias. The Dockerfile stays the source of truth; the command mirrors its pins.
- The bake installs a systemd drop-in on the in-box exec daemon (`EnvironmentFile=/etc/hogbox-env`) so per-box env from `create(env=...)` reaches exec processes the way Modal's container env does.

## How did you test this code?

- Unit tests with a mocked SDK client, one per regression: a dropped `ttl_seconds` mints immortal boxes; explicit sizing turns every restore into a 400; an SDK `NotFoundError` leaking past `get_by_id` crashes the reaper; a token in the credentials would persist the bearer to the DB; `hb-`/`sb-` prefix dispatch.
- Auth tests: two client calls straddling a token-file rewrite carry the two different tokens (a cached client would 401 after rotation); the file wins over the static token; the static token serves when the file env is unset or the file is missing.
- Not run: the bake against a live cluster, and no live box was booted. That is the first ops step before the layer-3 flag turns on.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the backend is unreachable until the layer-3 flag exists.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a session directed by Tom Owers. Skills invoked across the stack: /writing-tests, /improving-drf-endpoints, /writing-pr-descriptions, /stacking-prs. The adapter deliberately reuses the launch mixin from #87250 instead of the hogland repo's example adapter, whose launch layout does not match this repo's agent-server contract.

