### PR TITLE
feat(desktop): lead report pages with a verdict banner

### DIFF
--- a/products/desktop/packages/core/src/inbox/reportVerdict.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportVerdict.test.ts
@@ -1,0 +1,82 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { describe, expect, it } from "vitest";
+
+import { deriveReportVerdict } from "./reportVerdict";
+
+function report(overrides: Partial<SignalReport>): SignalReport {
+  return {
+    id: "r",
+    title: "A report",
+    summary: null,
+    status: "ready",
+    total_weight: 1,
+    signal_count: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    artefact_count: 0,
+    ...overrides,
+  } as SignalReport;
+}
+
+describe("deriveReportVerdict", () => {
+  it.each([
+    // Non-ready lifecycle states speak for themselves, whatever the artefacts say.
+    [{ status: "resolved" }, false, "Resolved", "info"],
+    [{ status: "suppressed" }, false, "Archived", "info"],
+    [{ status: "deleted" }, false, "Archived", "info"],
+    [{ status: "failed" }, false, "Run failed", "danger"],
+    [{ status: "pending_input" }, false, "Waiting on you", "decision"],
+    [{ status: "potential" }, false, "Agent investigating", "progress"],
+    [{ status: "candidate" }, false, "Agent investigating", "progress"],
+    [{ status: "in_progress" }, false, "Agent investigating", "progress"],
+    // Ready: an existing PR outranks actionability, which outranks nothing.
+    [
+      { status: "ready", actionability: "immediately_actionable" },
+      true,
+      "Review the open PR",
+      "decision",
+    ],
+    [
+      { status: "ready", already_addressed: true },
+      false,
+      "Likely already fixed",
+      "info",
+    ],
+    [
+      { status: "ready", actionability: "immediately_actionable" },
+      false,
+      "Needs your decision",
+      "decision",
+    ],
+    [
+      { status: "ready", actionability: "requires_human_input" },
+      false,
+      "Needs your direction",
+      "decision",
+    ],
+    [
+      { status: "ready", actionability: "not_actionable" },
+      false,
+      "For your awareness",
+      "info",
+    ],
+    [{ status: "ready" }, false, "Ready for review", "decision"],
+  ] as const)(
+    "%j with hasExistingPr=%s reads %j",
+    (overrides, hasExistingPr, title, tone) => {
+      const verdict = deriveReportVerdict(
+        report(overrides as Partial<SignalReport>),
+        { hasExistingPr },
+      );
+      expect(verdict.title).toBe(title);
+      expect(verdict.tone).toBe(tone);
+    },
+  );
+
+  it("a PR on a non-ready report does not override the lifecycle state", () => {
+    const verdict = deriveReportVerdict(report({ status: "in_progress" }), {
+      hasExistingPr: true,
+    });
+    expect(verdict.title).toBe("Agent investigating");
+  });
+});

--- a/products/desktop/packages/core/src/inbox/reportVerdict.ts
+++ b/products/desktop/packages/core/src/inbox/reportVerdict.ts
@@ -1,0 +1,105 @@
+import type { SignalReport } from "@posthog/shared/types";
+
+/** Drives the banner's styling: what kind of moment the report is in. */
+export type ReportVerdictTone = "decision" | "progress" | "info" | "danger";
+
+export interface ReportVerdict {
+  tone: ReportVerdictTone;
+  /** The state line a reader scans first, e.g. "Needs your decision". */
+  title: string;
+  /** One or two sentences: why the report is in this state and what to do. */
+  body: string;
+}
+
+/**
+ * What a report is asking of its reader, stated before the prose. The detail
+ * page leads with this so the decision doesn't hide at the bottom of a long
+ * summary; the banner component adds the matching action buttons beside it.
+ *
+ * `hasExistingPr` folds in what the report row alone can't know: a linked
+ * implementation task may hold a live PR before `implementation_pr_url` is
+ * stamped (see findContinuableImplementationTask).
+ */
+export function deriveReportVerdict(
+  report: SignalReport,
+  { hasExistingPr }: { hasExistingPr: boolean },
+): ReportVerdict {
+  switch (report.status) {
+    case "resolved":
+      return {
+        tone: "info",
+        title: "Resolved",
+        body: "This report is resolved. Nothing left to do here.",
+      };
+    case "suppressed":
+    case "deleted":
+      return {
+        tone: "info",
+        title: "Archived",
+        body: "This report was archived and is kept for reference.",
+      };
+    case "failed":
+      return {
+        tone: "danger",
+        title: "Run failed",
+        body: "The agent couldn't finish this report. Archive it, or start a chat to dig into what happened.",
+      };
+    case "pending_input":
+      return {
+        tone: "decision",
+        title: "Waiting on you",
+        body: "The agent needs your input before it can continue.",
+      };
+    case "potential":
+    case "candidate":
+    case "in_progress":
+      return {
+        tone: "progress",
+        title: "Agent investigating",
+        body: "The agent is still gathering evidence. This report updates as findings land.",
+      };
+    case "ready":
+      break;
+  }
+
+  if (hasExistingPr) {
+    return {
+      tone: "decision",
+      title: "Review the open PR",
+      body: "Implementation is already in flight. Review the pull request, or continue the work on its branch.",
+    };
+  }
+  if (report.already_addressed) {
+    return {
+      tone: "info",
+      title: "Likely already fixed",
+      body: "The evidence suggests this was already addressed. Skim the summary and archive the report if you agree.",
+    };
+  }
+  switch (report.actionability) {
+    case "immediately_actionable":
+      return {
+        tone: "decision",
+        title: "Needs your decision",
+        body: "The agent can fix this with code. Start the pull request, or archive the report if it isn't worth fixing.",
+      };
+    case "requires_human_input":
+      return {
+        tone: "decision",
+        title: "Needs your direction",
+        body: "A fix needs your call first: business context, trade-offs, or a choice between approaches. Add direction when you start the PR, or ask about it in chat.",
+      };
+    case "not_actionable":
+      return {
+        tone: "info",
+        title: "For your awareness",
+        body: "No code change follows from this report. Read it, then archive it.",
+      };
+    default:
+      return {
+        tone: "decision",
+        title: "Ready for review",
+        body: "Read the summary and decide what happens next.",
+      };
+  }
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -57,6 +57,8 @@ interface InboxDetailFrameProps {
   metaSuffix?: ReactNode;
   /** Variant-specific primary action button (e.g. "Open in GitHub" or "Copy link"). */
   primaryAction?: ReactNode;
+  /** Rendered at the top of the main column, before the summary (the verdict banner). */
+  aboveSummary?: ReactNode;
   /** Summary section: icon + title (e.g. "Summary" / "What the agent looked at"). */
   summarySection: {
     Icon: ComponentType<IconProps>;
@@ -97,6 +99,7 @@ export function InboxDetailFrame({
   metaPrefix,
   metaSuffix,
   primaryAction,
+  aboveSummary,
   summarySection,
   belowSummary,
   evidenceSection,
@@ -238,6 +241,7 @@ export function InboxDetailFrame({
         ) : (
           <div className="grid @4xl:grid-cols-[minmax(0,80ch)_minmax(0,1fr)] grid-cols-1 gap-5">
             <div className="flex min-w-0 flex-col gap-5">
+              {aboveSummary}
               <DetailSection
                 Icon={SummaryIcon}
                 title={summarySection.title}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -3,8 +3,8 @@ import type { SignalReport } from "@posthog/shared/types";
 import { ReportFeedbackFooter } from "@posthog/ui/features/inbox/components/detail/ReportFeedbackFooter";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
-import { ReportDecisionSection } from "@posthog/ui/features/inbox/components/ReportDecisionSection";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
+import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
 
 interface ReportDetailProps {
   reportId: string;
@@ -44,9 +44,10 @@ export function ReportDetail({
 }
 
 /**
- * A report reads as: the story (summary + charts), then its one ask (the
- * decision block), then the evidence. Pipeline machinery (runs, activity
- * logs, reviewer reasoning) deliberately doesn't render.
+ * A report reads answer-first: the verdict (what state it's in and what it
+ * asks, with the action beside it), then the story (summary + charts), then
+ * the evidence. Pipeline machinery (runs, activity logs, reviewer reasoning)
+ * deliberately doesn't render.
  */
 function ReportDetailContent({
   report,
@@ -64,13 +65,9 @@ function ReportDetailContent({
       backLabel={backLabel}
       fallbackTitle="Untitled report"
       primaryAction={<ReportDetailActions report={report} />}
+      aboveSummary={<ReportVerdictBanner report={report} />}
       summarySection={{ Icon: FileTextIcon, title: "Summary" }}
-      belowSummary={
-        <>
-          <ReportDecisionSection report={report} />
-          <ReportFeedbackFooter report={report} />
-        </>
-      }
+      belowSummary={<ReportFeedbackFooter report={report} />}
       evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
     />
   );

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -42,8 +42,8 @@ const isMac =
 /**
  * The report header's action cluster: Discuss and Canvas stay visible, and
  * everything occasional (GitHub, copy link, refund) folds into an overflow
- * menu. Starting or continuing implementation work lives in the decision
- * block under the summary (ReportDecisionSection / PrDecisionBlock), not here.
+ * menu. Starting or continuing implementation work lives in the verdict
+ * banner above the summary (ReportVerdictBanner / PrDecisionBlock), not here.
  */
 export function ReportDetailActions({
   report,

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -1,0 +1,230 @@
+import { ArrowSquareOutIcon, GitPullRequestIcon } from "@phosphor-icons/react";
+import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
+import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
+import {
+  deriveReportVerdict,
+  type ReportVerdictTone,
+} from "@posthog/core/inbox/reportVerdict";
+import {
+  Button,
+  cn,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Spinner,
+  Textarea,
+} from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
+import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
+import {
+  findContinuableImplementationTask,
+  getTaskPrUrl,
+  useReportTasks,
+} from "@posthog/ui/features/inbox/hooks/useReportTasks";
+import { useOpenTask } from "@posthog/ui/router/useOpenTask";
+import { useCallback, useState } from "react";
+
+const isMac =
+  typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+
+// Same sizing as PrDecisionBlock: the decision is the page's one ask.
+const BIG_BUTTON = "h-9 gap-2 px-4 text-[13px]";
+
+const TONE_CLASS: Record<ReportVerdictTone, string> = {
+  decision: "border-(--amber-6) bg-(--amber-2)",
+  danger: "border-(--red-6) bg-(--red-2)",
+  progress: "border-(--gray-5) bg-(--gray-1)",
+  info: "border-(--gray-5) bg-(--gray-1)",
+};
+
+interface ReportVerdictBannerProps {
+  report: SignalReport;
+}
+
+/**
+ * The report's verdict, stated before the prose: what state it is in, what it
+ * asks of the reader, and the action that answers the ask (start the PR, or
+ * continue the one in flight). Replaces the old decision block that sat below
+ * the summary, where the ask arrived only after the wall of text.
+ */
+export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
+  const canCreatePr = canCreateImplementationPr(report);
+  const { data: artefactsResp } = useInboxReportArtefacts(report.id);
+  const cloudRepository = extractRepoSelectionRepository(
+    artefactsResp?.results,
+  );
+
+  // Structural dedupe guard: re-engaging a report that already has live
+  // implementation work (an open PR, or a run still in flight) should continue
+  // that task rather than spin up a duplicate PR. `report.implementation_pr_url`
+  // alone is unreliable here — it can be stale or not yet set — so we also look
+  // at the linked implementation task's own state.
+  const { data: reportTasks, isLoading: reportTasksLoading } = useReportTasks(
+    report.id,
+    report.status,
+  );
+  const continuableTask = findContinuableImplementationTask(reportTasks);
+  const existingPrUrl =
+    report.implementation_pr_url ??
+    (continuableTask ? getTaskPrUrl(continuableTask) : null);
+  const hasExistingPr = !!existingPrUrl || !!continuableTask;
+
+  const verdict = deriveReportVerdict(report, { hasExistingPr });
+
+  const fireAction = useReportActionTracker(report);
+  const openTask = useOpenTask();
+
+  const { createPrReport, isCreatingPr } = useCreatePrReport({
+    reportId: report.id,
+    reportTitle: report.title ?? null,
+    cloudRepository,
+  });
+
+  const [prOpen, setPrOpen] = useState(false);
+  const [prFeedback, setPrFeedback] = useState("");
+
+  const handleCreatePr = useCallback(() => {
+    const trimmed = prFeedback.trim();
+    fireAction("create_pr", {
+      has_feedback: trimmed.length > 0,
+      ...(trimmed ? { feedback_text: trimmed.slice(0, 500) } : {}),
+    });
+    setPrFeedback("");
+    setPrOpen(false);
+    void createPrReport(trimmed || undefined);
+  }, [createPrReport, fireAction, prFeedback]);
+
+  const handleContinuePr = useCallback(() => {
+    if (!continuableTask) return;
+    fireAction("open_pr");
+    void openTask(continuableTask);
+  }, [continuableTask, fireAction, openTask]);
+
+  // The banner carries the report's one action: create the PR, or continue the
+  // one in flight. Offer it whenever the report can start a PR (`canCreatePr`
+  // already restricts that to ready-actionable and pending-input reports) or
+  // already holds live implementation work — matching the old decision block.
+  // Terminal reports (merged/archived) get no action; their verdict says so.
+  const isTerminalReport =
+    report.status === "resolved" ||
+    report.status === "suppressed" ||
+    report.status === "deleted";
+  const showActions = !isTerminalReport && (canCreatePr || hasExistingPr);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-lg border p-4",
+        TONE_CLASS[verdict.tone],
+      )}
+    >
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2 font-semibold text-[14px] text-gray-12">
+          {verdict.tone === "progress" && <Spinner />}
+          {verdict.title}
+        </span>
+        <span className="text-[13px] text-gray-11">{verdict.body}</span>
+      </div>
+
+      {showActions && (
+        <div className="flex flex-wrap items-center gap-2.5">
+          {hasExistingPr ? (
+            <>
+              <Button
+                type="button"
+                variant="primary"
+                disabled={isCreatingPr || !continuableTask}
+                onClick={handleContinuePr}
+                className={BIG_BUTTON}
+              >
+                {reportTasksLoading && !continuableTask ? (
+                  <Spinner />
+                ) : (
+                  <GitPullRequestIcon size={15} />
+                )}
+                Continue existing PR
+              </Button>
+              {existingPrUrl && (
+                <a
+                  href={existingPrUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-(--accent-11) text-[12px] hover:underline"
+                >
+                  <ArrowSquareOutIcon size={12} />
+                  View PR on GitHub
+                </a>
+              )}
+            </>
+          ) : (
+            <Popover
+              open={prOpen}
+              onOpenChange={(next) => {
+                setPrOpen(next);
+                if (!next) setPrFeedback("");
+              }}
+            >
+              <PopoverTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="primary"
+                    disabled={isCreatingPr}
+                    className={BIG_BUTTON}
+                  >
+                    {isCreatingPr ? (
+                      <Spinner />
+                    ) : (
+                      <GitPullRequestIcon size={15} />
+                    )}
+                    Create PR
+                  </Button>
+                }
+              />
+              <PopoverContent
+                align="start"
+                side="bottom"
+                sideOffset={6}
+                className="flex w-[420px] flex-col gap-2 p-3"
+              >
+                <Textarea
+                  aria-label="Optional direction for the agent"
+                  autoFocus
+                  placeholder="Add direction for the agent (optional)…"
+                  rows={4}
+                  value={prFeedback}
+                  onChange={(event) => setPrFeedback(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (
+                      event.key === "Enter" &&
+                      (event.metaKey || event.ctrlKey)
+                    ) {
+                      event.preventDefault();
+                      handleCreatePr();
+                    }
+                  }}
+                />
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[11px] text-gray-10">
+                    {isMac ? "⌘↵" : "Ctrl+↵"} to create
+                  </span>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="sm"
+                    disabled={isCreatingPr}
+                    onClick={handleCreatePr}
+                  >
+                    Create PR
+                  </Button>
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

Reading a report meant scrolling a wall of prose before finding out what the report actually wants from you. The decision block (Create PR / Continue PR) sat *below* the summary, so the ask arrived last.

Part of the report-page rework agreed in the design feedback thread: make the report answer-first, then interactive. Stacked on #86780.

## Changes

- The report detail now opens with a **verdict banner**: one line naming the report's state, a sentence saying what to do, and the action that answers it, all before the summary.
  - "Needs your decision" / "Needs your direction" with the Create PR button (ready + actionable)
  - "Review the open PR" with Continue existing PR (implementation in flight)
  - "Agent investigating", "Waiting on you", "Likely already fixed", "For your awareness", "Run failed", "Resolved", "Archived" for the rest
- The old decision block below the summary is gone; its create/continue logic moved into the banner unchanged.
- `deriveReportVerdict` is a pure function in `@posthog/core` so the wording and state mapping are unit-tested, not baked into JSX.

## How did you test this code?

- New parameterized core test covering every status and the ready-state actionability fork, including "a PR on a non-ready report does not override the lifecycle state" (15 cases).
- Full inbox UI suite (90 tests) and both package typechecks pass.
- Not run locally: visual pass in the running app; the banner reuses the existing decision-block styling primitives and tokens.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Desktop surface behind the existing reports flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a PostHog Desktop session, implementing the "answer-first report page" work item scoped with the team after the launch-feedback thread. Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions. A generation-side structured summary schema is the agreed follow-up; this PR restructures presentation against today's data only.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*