### PR TITLE
feat(wizard): mint scoped gateway tokens per run

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -47,6 +47,7 @@ from posthog.rate_limit import (
     SetupWizardCloudRunSustainedRateThrottle,
     SetupWizardGatewayTokenRateThrottle,
     SetupWizardQueryRateThrottle,
+    refund_wizard_mint,
     reserve_wizard_mint,
 )
 from posthog.storage.gateway_credential_cache import (
@@ -180,8 +181,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
         return []
 
     def throttled(self, request: Request, wait: float) -> NoReturn:
-        # 429s never reach the action body, so without this the kickoff counter is blind to
-        # rate-limited users and throttle pressure is invisible in dashboards.
+        # A rejection from DRF's own throttle check returns before the action body, so
+        # it counts here. A reservation that raises inside a body counts there instead.
         if self.action == "cloud_run":
             WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="throttled").inc()
         if self.action == "gateway_token":
@@ -427,12 +428,18 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise exceptions.NotFound("Wizard gateway tokens are not available.")
 
         authenticator = OAuthAccessTokenAuthentication()
-        result = authenticator.authenticate(request)
-        if not result:
-            raise AuthenticationFailed("Invalid access token.")
-        user, _ = result
-        if not user:
-            raise AuthenticationFailed("Invalid access token.")
+        # authenticate() raises its own AuthenticationFailed (expired, disabled user,
+        # no application), so the count wraps the call, not just the checks.
+        try:
+            result = authenticator.authenticate(request)
+            if not result:
+                raise AuthenticationFailed("Invalid access token.")
+            user, _ = result
+            if not user:
+                raise AuthenticationFailed("Invalid access token.")
+        except AuthenticationFailed:
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="invalid_token").inc()
+            raise
 
         access_token = authenticator.access_token
         # llm_gateway:read is on every sandbox and agent token, so the scope alone
@@ -455,7 +462,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
-            # 404 means "not rolled out" to the CLI, which downgrades to legacy.
+            # Deliberately 403: a 404 would read as "not rolled out" and downgrade
+            # the run to legacy, but a vanished team is an authorization failure.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_missing").inc()
             raise exceptions.PermissionDenied(ERROR_PROJECT_NOT_FOUND)
 
@@ -479,16 +487,26 @@ class SetupWizardViewSet(viewsets.ViewSet):
         # Refusing keeps every pinned node one that carries a budget.
         product = wizard_product_node(request.data.get("program") if isinstance(request.data, dict) else None)
         if product is None:
-            # The CLI falls back only on 404, so an unlisted program keeps running
-            # on legacy instead of dying. It still cannot mint.
+            # 404 and not 400: the CLI falls back only on 404, so an unlisted
+            # program keeps running on legacy instead of dying. It still cannot mint.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
             raise exceptions.NotFound("Unrecognized wizard program.")
         # After every gate and before the mint: a refused request spends nothing,
         # and the reservation is atomic so parallel requests cannot share a slot.
-        reserve_wizard_mint(request, self)
+        try:
+            reserved = reserve_wizard_mint(request, self)
+        except exceptions.Throttled:
+            # The reservation raises after check_throttles ran, so the throttled()
+            # hook never sees it.
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="throttled").inc()
+            raise
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
         except WizardGatewayMintError as e:
+            # Only a failure that proves no token was issued returns the slot; an
+            # ambiguous one keeps it rather than risk exceeding the daily ceiling.
+            if not e.token_may_exist:
+                refund_wizard_mint(reserved)
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="mint_failed").inc()
             capture_exception(e, {"ai_product": "wizard", "team_id": team.id})
             return Response({"error": "Gateway token mint failed."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -435,8 +435,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise AuthenticationFailed("Invalid access token.")
 
         access_token = authenticator.access_token
-        # llm_gateway:read is an internal scope stamped on every sandbox and agent
-        # token, so only the wizard's own OAuth application may mint.
+        # llm_gateway:read is on every sandbox and agent token, so the scope alone
+        # cannot identify the wizard.
         application = getattr(access_token, "application", None)
         client_id = getattr(application, "client_id", None)
         if not client_id or client_id not in settings.WIZARD_GATEWAY_CLIENT_IDS:
@@ -455,14 +455,11 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
-            # Not 404: the CLI reads that as "not rolled out" and downgrades to
-            # the legacy posture. A team that vanished is an authorization
-            # failure, not a rollout state.
+            # 404 means "not rolled out" to the CLI, which downgrades to legacy.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_missing").inc()
             raise exceptions.PermissionDenied(ERROR_PROJECT_NOT_FOUND)
 
-        # scoped_teams is frozen at consent, so re-check what it cannot see: the user
-        # is still active, still a member, and still has project access.
+        # scoped_teams is frozen at consent, so re-check what it cannot see.
         if not oauth_credential_authorized(access_token, team):
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unauthorized").inc()
             raise exceptions.PermissionDenied("Access token is no longer authorized for this project.")
@@ -479,18 +476,15 @@ class SetupWizardViewSet(viewsets.ViewSet):
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_rolled_out").inc()
             raise exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization.")
 
-        # The caller names its program; the configured set decides whether it may be
-        # pinned. Refusing keeps every pinned node one that carries a budget.
+        # Refusing keeps every pinned node one that carries a budget.
         product = wizard_product_node(request.data.get("program") if isinstance(request.data, dict) else None)
         if product is None:
-            # 404, not 400: the CLI falls back only on 404, and a program this
-            # deploy has not been told about should keep running on the legacy
-            # gateway rather than failing. It still cannot mint.
+            # The CLI falls back only on 404, so an unlisted program keeps running
+            # on legacy instead of dying. It still cannot mint.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
             raise exceptions.NotFound("Unrecognized wizard program.")
-        # Immediately before the mint, after every gate above: a refused request
-        # spends nothing, and the reservation is atomic so parallel requests
-        # cannot all pass the same free slot.
+        # After every gate and before the mint: a refused request spends nothing,
+        # and the reservation is atomic so parallel requests cannot share a slot.
         reserve_wizard_mint(request, self)
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
@@ -506,8 +500,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
                 "expires_at": minted["expires_at"],
                 "cap_usd": minted.get("cap_usd"),
                 "gateway_url": wizard_gateway_base_url(),
-                # Rides the CLI's run-metadata blob so dashboards keep a team
-                # breakdown next to the org-level obo attribution.
+                # Keeps a team breakdown beside the org-level obo attribution.
                 "team_id": team.id,
             },
             status=status.HTTP_201_CREATED,

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -47,6 +47,7 @@ from posthog.rate_limit import (
     SetupWizardCloudRunSustainedRateThrottle,
     SetupWizardGatewayTokenRateThrottle,
     SetupWizardQueryRateThrottle,
+    reserve_wizard_mint,
 )
 from posthog.storage.gateway_credential_cache import (
     GATEWAY_CREDENTIAL_REQUIRED_SCOPE as RequiredGatewayScope,
@@ -487,6 +488,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # gateway rather than failing. It still cannot mint.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
             raise exceptions.NotFound("Unrecognized wizard program.")
+        # Immediately before the mint, after every gate above: a refused request
+        # spends nothing, and the reservation is atomic so parallel requests
+        # cannot all pass the same free slot.
+        reserve_wizard_mint(request, self)
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
         except WizardGatewayMintError as e:
@@ -494,10 +499,6 @@ class SetupWizardViewSet(viewsets.ViewSet):
             capture_exception(e, {"ai_product": "wizard", "team_id": team.id})
             return Response({"error": "Gateway token mint failed."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
-        # Charged here rather than on arrival: every gate above answers 404 or a
-        # refusal without minting, and a request that issues no token must not
-        # spend a run's quota.
-        SetupWizardGatewayTokenRateThrottle().record(request, self)
         WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="minted").inc()
         return Response(
             {

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -76,7 +76,8 @@ WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP = 15
 WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_gateway_token_requests_total",
     "Wizard gateway-token mint requests, by outcome (minted/unconfigured/not_wizard_app/"
-    "scope_missing/team_ambiguous/team_missing/unauthorized/not_rolled_out/mint_failed)",
+    "scope_missing/team_ambiguous/team_missing/unauthorized/program_unknown/not_rolled_out/"
+    "mint_failed)",
     labelnames=["outcome"],
 )
 
@@ -474,9 +475,12 @@ class SetupWizardViewSet(viewsets.ViewSet):
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_rolled_out").inc()
             raise exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization.")
 
-        # The caller names its program; the resolver decides what gets pinned, so a
-        # program outside the configured set spends under the parent node.
+        # The caller names its program; the configured set decides whether it may be
+        # pinned. Refusing keeps every pinned node one that carries a budget.
         product = wizard_product_node(request.data.get("program") if isinstance(request.data, dict) else None)
+        if product is None:
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
+            raise exceptions.ValidationError("Unrecognized wizard program.")
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
         except WizardGatewayMintError as e:

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -418,8 +418,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
         The CLI uses the returned phe_ (pinned product=wizard / obo=<customer org>,
         capped, expiring) as its gateway bearer and re-calls near expiry. It treats
-        any non-200 as "stay on the legacy gateway", so rollout is controlled here
-        rather than by a CLI release.
+        a 404 as "stay on the legacy gateway", so rollout is controlled here rather
+        than by a CLI release. Every other failure fails the run.
         """
         if not wizard_gateway_configured():
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unconfigured").inc()
@@ -454,8 +454,11 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
+            # Not 404: the CLI reads that as "not rolled out" and downgrades to
+            # the legacy posture. A team that vanished is an authorization
+            # failure, not a rollout state.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_missing").inc()
-            raise exceptions.NotFound(ERROR_PROJECT_NOT_FOUND)
+            raise exceptions.PermissionDenied(ERROR_PROJECT_NOT_FOUND)
 
         # scoped_teams is frozen at consent, so re-check what it cannot see: the user
         # is still active, still a member, and still has project access.
@@ -479,8 +482,11 @@ class SetupWizardViewSet(viewsets.ViewSet):
         # pinned. Refusing keeps every pinned node one that carries a budget.
         product = wizard_product_node(request.data.get("program") if isinstance(request.data, dict) else None)
         if product is None:
+            # 404, not 400: the CLI falls back only on 404, and a program this
+            # deploy has not been told about should keep running on the legacy
+            # gateway rather than failing. It still cannot mint.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
-            raise exceptions.ValidationError("Unrecognized wizard program.")
+            raise exceptions.NotFound("Unrecognized wizard program.")
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
         except WizardGatewayMintError as e:
@@ -488,6 +494,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
             capture_exception(e, {"ai_product": "wizard", "team_id": team.id})
             return Response({"error": "Gateway token mint failed."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
+        # Charged here rather than on arrival: every gate above answers 404 or a
+        # refusal without minting, and a request that issues no token must not
+        # spend a run's quota.
+        SetupWizardGatewayTokenRateThrottle().record(request, self)
         WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="minted").inc()
         return Response(
             {

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -36,6 +36,7 @@ from posthog.llm.wizard_gateway_token import (
     mint_wizard_gateway_token,
     wizard_gateway_base_url,
     wizard_gateway_configured,
+    wizard_product_node,
 )
 from posthog.models import Team, User
 from posthog.models.project import Project
@@ -473,8 +474,11 @@ class SetupWizardViewSet(viewsets.ViewSet):
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_rolled_out").inc()
             raise exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization.")
 
+        # The caller names its program; the resolver decides what gets pinned, so a
+        # program outside the configured set spends under the parent node.
+        product = wizard_product_node(request.data.get("program") if isinstance(request.data, dict) else None)
         try:
-            minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id)
+            minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
         except WizardGatewayMintError as e:
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="mint_failed").inc()
             capture_exception(e, {"ai_product": "wizard", "team_id": team.id})

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -428,8 +428,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise exceptions.NotFound("Wizard gateway tokens are not available.")
 
         authenticator = OAuthAccessTokenAuthentication()
-        # authenticate() raises its own AuthenticationFailed (expired, disabled user,
-        # no application), so the count wraps the call, not just the checks.
+        # authenticate() raises its own AuthenticationFailed, so the count wraps the
+        # call rather than only the two checks below.
         try:
             result = authenticator.authenticate(request)
             if not result:
@@ -491,8 +491,6 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # program keeps running on legacy instead of dying. It still cannot mint.
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="program_unknown").inc()
             raise exceptions.NotFound("Unrecognized wizard program.")
-        # After every gate and before the mint: a refused request spends nothing,
-        # and the reservation is atomic so parallel requests cannot share a slot.
         try:
             reserved = reserve_wizard_mint(request, self)
         except exceptions.Throttled:
@@ -503,8 +501,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id, product=product)
         except WizardGatewayMintError as e:
-            # Only a failure that proves no token was issued returns the slot; an
-            # ambiguous one keeps it rather than risk exceeding the daily ceiling.
+            # An ambiguous failure keeps the slot rather than risk the ceiling.
             if not e.token_may_exist:
                 refund_wizard_mint(reserved)
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="mint_failed").inc()

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -34,6 +34,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.llm.wizard_gateway_token import (
     WizardGatewayMintError,
     mint_wizard_gateway_token,
+    wizard_gateway_base_url,
     wizard_gateway_configured,
 )
 from posthog.models import Team, User
@@ -43,7 +44,12 @@ from posthog.rate_limit import (
     SetupWizardAuthenticationRateThrottle,
     SetupWizardCloudRunBurstRateThrottle,
     SetupWizardCloudRunSustainedRateThrottle,
+    SetupWizardGatewayTokenRateThrottle,
     SetupWizardQueryRateThrottle,
+)
+from posthog.storage.gateway_credential_cache import (
+    GATEWAY_CREDENTIAL_REQUIRED_SCOPE as RequiredGatewayScope,
+    oauth_credential_authorized,
 )
 from posthog.user_permissions import UserPermissions
 
@@ -394,7 +400,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         methods=["POST"],
         detail=False,
         url_path="gateway_token",
-        throttle_classes=[SetupWizardQueryRateThrottle],
+        throttle_classes=[SetupWizardGatewayTokenRateThrottle],
     )
     def gateway_token(self, request: Request) -> Response:
         """Mint a scoped gateway token for a wizard run against the Go ai-gateway.
@@ -417,19 +423,35 @@ class SetupWizardViewSet(viewsets.ViewSet):
         if not user:
             raise AuthenticationFailed("Invalid access token.")
 
-        # Literal scope check, mirroring the gateway ("*" must not subsume it).
-        # llm_gateway:read is a privileged scope that only reaches a token
-        # through an explicit app scope ceiling (the wizard's own OAuth app),
-        # so this doubles as the application check.
-        if "llm_gateway:read" not in (authenticator.access_token.scopes or []):
+        access_token = authenticator.access_token
+        # The wizard's own OAuth application, by client id. llm_gateway:read is an
+        # internal scope stamped on every sandbox and agent token, so the scope
+        # alone does not say the caller is the wizard, and those tokens run
+        # customer repository content.
+        application = getattr(access_token, "application", None)
+        client_id = getattr(application, "client_id", None)
+        if not client_id or client_id not in settings.WIZARD_GATEWAY_CLIENT_IDS:
+            raise AuthenticationFailed("Access token was not issued to the wizard.")
+
+        # The token's own scope text, matching credential_has_gateway_scope. The
+        # `scopes` property filters through OAUTH2_PROVIDER["SCOPES"], so a
+        # narrowing of that map would silently drop the scope.
+        if RequiredGatewayScope not in (access_token.scope or "").split():
             raise AuthenticationFailed("Access token lacks the gateway scope.")
 
-        scoped_team_ids = authenticator.access_token.scoped_teams or []
+        scoped_team_ids = access_token.scoped_teams or []
         if len(scoped_team_ids) != 1:
             raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
             raise exceptions.NotFound(ERROR_PROJECT_NOT_FOUND)
+
+        # scoped_teams is frozen at consent, so re-check what it cannot see:
+        # the user is still active, still a member, and still has project
+        # access. The credential projection runs the same check for the same
+        # token class.
+        if not oauth_credential_authorized(access_token, team):
+            raise exceptions.PermissionDenied("Access token is no longer authorized for this project.")
 
         distinct_id = str(user.distinct_id)
         if not posthoganalytics.feature_enabled(
@@ -453,7 +475,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
                 "token": minted["token"],
                 "expires_at": minted["expires_at"],
                 "cap_usd": minted.get("cap_usd"),
-                "gateway_url": settings.WIZARD_GATEWAY_URL,
+                "gateway_url": wizard_gateway_base_url(),
                 # For the CLI's run-metadata blob, so dashboards keep a team
                 # breakdown next to the org-level obo attribution.
                 "team_id": team.id,

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -72,6 +72,13 @@ OPENAI_SUPPORTED_MODELS = {"o4-mini", "gpt-5-mini", "gpt-5-nano", "gpt-5"}
 # loop lands on. Only requests that reach creation consume it.
 WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP = 15
 
+WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL = Counter(
+    "posthog_wizard_gateway_token_requests_total",
+    "Wizard gateway-token mint requests, by outcome (minted/unconfigured/not_wizard_app/"
+    "scope_missing/team_ambiguous/team_missing/unauthorized/not_rolled_out/mint_failed)",
+    labelnames=["outcome"],
+)
+
 WIZARD_CLOUD_RUN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_cloud_run_requests_total",
     "Cloud-run wizard kickoff requests, by outcome (created/unavailable/invalid/permission_denied/throttled)",
@@ -174,6 +181,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
         # rate-limited users and throttle pressure is invisible in dashboards.
         if self.action == "cloud_run":
             WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="throttled").inc()
+        if self.action == "gateway_token":
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="throttled").inc()
         super().throttled(request, wait)
 
     @action(methods=["POST"], detail=False, url_path="initialize")
@@ -413,6 +422,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         release.
         """
         if not wizard_gateway_configured():
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unconfigured").inc()
             raise exceptions.NotFound("Wizard gateway tokens are not available.")
 
         authenticator = OAuthAccessTokenAuthentication()
@@ -431,26 +441,34 @@ class SetupWizardViewSet(viewsets.ViewSet):
         application = getattr(access_token, "application", None)
         client_id = getattr(application, "client_id", None)
         if not client_id or client_id not in settings.WIZARD_GATEWAY_CLIENT_IDS:
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_wizard_app").inc()
             raise AuthenticationFailed("Access token was not issued to the wizard.")
 
         # The token's own scope text, matching credential_has_gateway_scope. The
         # `scopes` property filters through OAUTH2_PROVIDER["SCOPES"], so a
         # narrowing of that map would silently drop the scope.
         if RequiredGatewayScope not in (access_token.scope or "").split():
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="scope_missing").inc()
             raise AuthenticationFailed("Access token lacks the gateway scope.")
 
         scoped_team_ids = access_token.scoped_teams or []
         if len(scoped_team_ids) != 1:
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_ambiguous").inc()
             raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
         team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
         if team is None:
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_missing").inc()
             raise exceptions.NotFound(ERROR_PROJECT_NOT_FOUND)
 
         # scoped_teams is frozen at consent, so re-check what it cannot see:
         # the user is still active, still a member, and still has project
         # access. The credential projection runs the same check for the same
-        # token class.
+        # token class, though it passes the organization's root team while this
+        # passes the scoped team itself, so the scoped-teams containment branch
+        # is a tautology here and the membership and RBAC branches are the ones
+        # doing work.
         if not oauth_credential_authorized(access_token, team):
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unauthorized").inc()
             raise exceptions.PermissionDenied("Access token is no longer authorized for this project.")
 
         distinct_id = str(user.distinct_id)
@@ -462,14 +480,17 @@ class SetupWizardViewSet(viewsets.ViewSet):
             only_evaluate_locally=False,
             send_feature_flag_events=False,
         ):
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_rolled_out").inc()
             raise exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization.")
 
         try:
             minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id)
         except WizardGatewayMintError as e:
+            WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="mint_failed").inc()
             capture_exception(e, {"ai_product": "wizard", "team_id": team.id})
             return Response({"error": "Gateway token mint failed."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
+        WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="minted").inc()
         return Response(
             {
                 "token": minted["token"],

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -412,14 +412,12 @@ class SetupWizardViewSet(viewsets.ViewSet):
         throttle_classes=[SetupWizardGatewayTokenRateThrottle],
     )
     def gateway_token(self, request: Request) -> Response:
-        """Mint a scoped gateway token for a wizard run against the Go ai-gateway.
+        """Mint a scoped gateway token for a wizard run.
 
-        The CLI calls this after OAuth and uses the returned phe_ (pinned
-        product=wizard / obo=<customer org>, capped, expiring) as its gateway
-        bearer, re-calling near expiry. 404 when unconfigured or the rollout
-        flag is off for this org — the CLI treats any non-200 as "stay on the
-        legacy gateway", so rollout percentage is controlled here without a CLI
-        release.
+        The CLI uses the returned phe_ (pinned product=wizard / obo=<customer org>,
+        capped, expiring) as its gateway bearer and re-calls near expiry. It treats
+        any non-200 as "stay on the legacy gateway", so rollout is controlled here
+        rather than by a CLI release.
         """
         if not wizard_gateway_configured():
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unconfigured").inc()
@@ -434,19 +432,16 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise AuthenticationFailed("Invalid access token.")
 
         access_token = authenticator.access_token
-        # The wizard's own OAuth application, by client id. llm_gateway:read is an
-        # internal scope stamped on every sandbox and agent token, so the scope
-        # alone does not say the caller is the wizard, and those tokens run
-        # customer repository content.
+        # llm_gateway:read is an internal scope stamped on every sandbox and agent
+        # token, so only the wizard's own OAuth application may mint.
         application = getattr(access_token, "application", None)
         client_id = getattr(application, "client_id", None)
         if not client_id or client_id not in settings.WIZARD_GATEWAY_CLIENT_IDS:
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="not_wizard_app").inc()
             raise AuthenticationFailed("Access token was not issued to the wizard.")
 
-        # The token's own scope text, matching credential_has_gateway_scope. The
-        # `scopes` property filters through OAUTH2_PROVIDER["SCOPES"], so a
-        # narrowing of that map would silently drop the scope.
+        # The token's own scope text: the `scopes` property filters through
+        # OAUTH2_PROVIDER["SCOPES"], where a narrowing would silently drop the scope.
         if RequiredGatewayScope not in (access_token.scope or "").split():
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="scope_missing").inc()
             raise AuthenticationFailed("Access token lacks the gateway scope.")
@@ -460,13 +455,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="team_missing").inc()
             raise exceptions.NotFound(ERROR_PROJECT_NOT_FOUND)
 
-        # scoped_teams is frozen at consent, so re-check what it cannot see:
-        # the user is still active, still a member, and still has project
-        # access. The credential projection runs the same check for the same
-        # token class, though it passes the organization's root team while this
-        # passes the scoped team itself, so the scoped-teams containment branch
-        # is a tautology here and the membership and RBAC branches are the ones
-        # doing work.
+        # scoped_teams is frozen at consent, so re-check what it cannot see: the user
+        # is still active, still a member, and still has project access.
         if not oauth_credential_authorized(access_token, team):
             WIZARD_GATEWAY_TOKEN_REQUESTS_TOTAL.labels(outcome="unauthorized").inc()
             raise exceptions.PermissionDenied("Access token is no longer authorized for this project.")
@@ -497,7 +487,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
                 "expires_at": minted["expires_at"],
                 "cap_usd": minted.get("cap_usd"),
                 "gateway_url": wizard_gateway_base_url(),
-                # For the CLI's run-metadata blob, so dashboards keep a team
+                # Rides the CLI's run-metadata blob so dashboards keep a team
                 # breakdown next to the org-level obo attribution.
                 "team_id": team.id,
             },

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -20,7 +20,7 @@ from openai.types.chat import (
 from posthoganalytics.ai.gemini import genai
 from posthoganalytics.ai.openai import OpenAI
 from prometheus_client import Counter
-from rest_framework import exceptions, response, serializers, viewsets
+from rest_framework import exceptions, response, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
@@ -31,7 +31,12 @@ from posthog.api.wizard.utils import json_schema_to_gemini_schema
 from posthog.auth import OAuthAccessTokenAuthentication, SessionAuthentication
 from posthog.cloud_utils import get_api_host
 from posthog.exceptions_capture import capture_exception
-from posthog.models import User
+from posthog.llm.wizard_gateway_token import (
+    WizardGatewayMintError,
+    mint_wizard_gateway_token,
+    wizard_gateway_configured,
+)
+from posthog.models import Team, User
 from posthog.models.project import Project
 from posthog.permissions import APIScopePermission
 from posthog.rate_limit import (
@@ -384,6 +389,77 @@ class SetupWizardViewSet(viewsets.ViewSet):
             raise exceptions.ValidationError(f"Model '{model}' is not supported.")
 
         return Response({"data": response_data})
+
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path="gateway_token",
+        throttle_classes=[SetupWizardQueryRateThrottle],
+    )
+    def gateway_token(self, request: Request) -> Response:
+        """Mint a scoped gateway token for a wizard run against the Go ai-gateway.
+
+        The CLI calls this after OAuth and uses the returned phe_ (pinned
+        product=wizard / obo=<customer org>, capped, expiring) as its gateway
+        bearer, re-calling near expiry. 404 when unconfigured or the rollout
+        flag is off for this org — the CLI treats any non-200 as "stay on the
+        legacy gateway", so rollout percentage is controlled here without a CLI
+        release.
+        """
+        if not wizard_gateway_configured():
+            raise exceptions.NotFound("Wizard gateway tokens are not available.")
+
+        authenticator = OAuthAccessTokenAuthentication()
+        result = authenticator.authenticate(request)
+        if not result:
+            raise AuthenticationFailed("Invalid access token.")
+        user, _ = result
+        if not user:
+            raise AuthenticationFailed("Invalid access token.")
+
+        # Literal scope check, mirroring the gateway ("*" must not subsume it).
+        # llm_gateway:read is a privileged scope that only reaches a token
+        # through an explicit app scope ceiling (the wizard's own OAuth app),
+        # so this doubles as the application check.
+        if "llm_gateway:read" not in (authenticator.access_token.scopes or []):
+            raise AuthenticationFailed("Access token lacks the gateway scope.")
+
+        scoped_team_ids = authenticator.access_token.scoped_teams or []
+        if len(scoped_team_ids) != 1:
+            raise exceptions.ValidationError("Access token must be scoped to exactly one team.")
+        team = Team.objects.select_related("organization").filter(id=scoped_team_ids[0]).first()
+        if team is None:
+            raise exceptions.NotFound(ERROR_PROJECT_NOT_FOUND)
+
+        distinct_id = str(user.distinct_id)
+        if not posthoganalytics.feature_enabled(
+            "wizard-gateway-v2",
+            distinct_id,
+            groups={"organization": str(team.organization_id), "project": str(team.id)},
+            group_properties={"organization": {"id": str(team.organization_id)}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        ):
+            raise exceptions.NotFound("Wizard gateway tokens are not rolled out for this organization.")
+
+        try:
+            minted = mint_wizard_gateway_token(obo=str(team.organization_id), user=distinct_id)
+        except WizardGatewayMintError as e:
+            capture_exception(e, {"ai_product": "wizard", "team_id": team.id})
+            return Response({"error": "Gateway token mint failed."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+        return Response(
+            {
+                "token": minted["token"],
+                "expires_at": minted["expires_at"],
+                "cap_usd": minted.get("cap_usd"),
+                "gateway_url": settings.WIZARD_GATEWAY_URL,
+                # For the CLI's run-metadata blob, so dashboards keep a team
+                # breakdown next to the org-level obo attribution.
+                "team_id": team.id,
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
     @action(
         methods=["POST"],

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -10,6 +10,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from prometheus_client import REGISTRY
 from rest_framework import status
 from rest_framework.exceptions import Throttled
 from rest_framework.request import Request
@@ -20,7 +21,7 @@ from posthog.cloud_utils import get_api_host
 from posthog.llm.wizard_gateway_token import WizardGatewayMintError
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
-from posthog.rate_limit import SetupWizardGatewayTokenRateThrottle, reserve_wizard_mint
+from posthog.rate_limit import SetupWizardGatewayTokenRateThrottle, refund_wizard_mint, reserve_wizard_mint
 
 
 class SetupWizardTests(APIBaseTest):
@@ -775,6 +776,59 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         )
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
+    def _reserved_counter_value(self, key="refund-test-key"):
+        """The live value of the reservation counter for a pinned cache key."""
+        import time
+
+        from django.core.cache import cache as django_cache
+
+        from posthog.rate_limit import SetupWizardGatewayTokenRateThrottle
+
+        window = int(time.time()) // SetupWizardGatewayTokenRateThrottle().duration
+        return django_cache.get(f"{key}:{window}")
+
+    @patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="refund-test-key")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_a_failure_that_issued_no_token_returns_the_slot(
+        self, mock_authentication, mock_flag, mock_authorized, mock_key
+    ):
+        # The refund only runs through the view's exception handler, so nothing
+        # below the helper's own unit tests covers deleting or inverting it.
+        self._mock_oauth(mock_authentication)
+        with patch(
+            "posthog.api.wizard.http.mint_wizard_gateway_token",
+            side_effect=WizardGatewayMintError("refused", token_may_exist=False),
+        ):
+            response = self.client.post(
+                self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            )
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert self._reserved_counter_value() == 0
+
+    @patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="refund-test-key")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_a_failure_that_may_have_issued_a_token_keeps_the_slot(
+        self, mock_authentication, mock_flag, mock_authorized, mock_key
+    ):
+        # The paired negative: refunding here would return a slot for a token the
+        # gateway may hold, which is what the guard exists to prevent.
+        self._mock_oauth(mock_authentication)
+        with patch(
+            "posthog.api.wizard.http.mint_wizard_gateway_token",
+            side_effect=WizardGatewayMintError("unreadable", token_may_exist=True),
+        ):
+            response = self.client.post(
+                self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            )
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert self._reserved_counter_value() == 1
+
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
@@ -816,6 +870,45 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_mint.assert_not_called()
 
+    @override_settings(DEBUG=False)
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_a_throttled_mint_is_counted(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
+        # The reservation raises inside the action body, after DRF's own throttle
+        # check admitted the request, so the throttled() hook never sees this one.
+        self._mock_oauth(mock_authentication)
+        before = _gateway_token_outcome("throttled")
+
+        for _ in range(5):
+            self.client.post(
+                self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            )
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert _gateway_token_outcome("throttled") == before + 1
+
+    def test_an_unresolvable_bearer_is_counted(self):
+        # The authenticator raises on its own, before any gate that counts, so a
+        # rejected bearer would otherwise leave no sample at all.
+        before = _gateway_token_outcome("invalid_token")
+
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_unknown"}
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert _gateway_token_outcome("invalid_token") == before + 1
+
+
+def _gateway_token_outcome(outcome: str) -> float:
+    """Current value of one outcome counter. An unrecorded label reads as zero."""
+    return REGISTRY.get_sample_value("posthog_wizard_gateway_token_requests_total", {"outcome": outcome}) or 0.0
+
 
 class TestReserveWizardMint:
     """The ceiling is atomic and sits on the mint, not on arrival."""
@@ -839,6 +932,53 @@ class TestReserveWizardMint:
                 reserve_wizard_mint(req, None)
             with pytest.raises(Throttled):
                 reserve_wizard_mint(req, None)
+
+    def test_the_reservation_returns_the_counter_it_charged(self):
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()
+        req = self._request()
+        with patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="k"):
+            counter = reserve_wizard_mint(req, None)
+        assert counter is not None
+        assert counter.startswith("k:")
+        assert django_cache.get(counter) == 1
+
+    def test_a_refund_returns_the_slot_to_that_counter(self):
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()
+        req = self._request()
+        with patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="k"):
+            counter = reserve_wizard_mint(req, None)
+            refund_wizard_mint(counter)
+            # The refunded slot is spendable again rather than merely not charged.
+            for _ in range(5):
+                reserve_wizard_mint(req, None)
+            with pytest.raises(Throttled):
+                reserve_wizard_mint(req, None)
+
+    def test_a_vanished_key_is_re_established_so_its_counter_is_refundable(self):
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()
+        req = self._request()
+        with patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="k"):
+            # incr raises when the key expired between add and incr. The branch has
+            # to persist the charge, or it hands back a counter whose decr would
+            # debit whatever a concurrent request charged next.
+            with patch("posthog.rate_limit.cache.incr", side_effect=ValueError("no key")):
+                counter = reserve_wizard_mint(req, None)
+
+        assert counter is not None
+        assert django_cache.get(counter) == 1
+        refund_wizard_mint(counter)
+        assert django_cache.get(counter) == 0
+
+    def test_a_refund_without_a_counter_is_a_no_op(self):
+        # reserve returns None when it charged nothing, and the caller refunds
+        # unconditionally on an unambiguous failure.
+        refund_wizard_mint(None)
 
     def test_a_cache_failure_fails_open(self):
         # Load-shedding posture: the per-token cap and the wallet also bound this,

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -787,7 +787,9 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         response = self.client.post(
             self.GATEWAY_TOKEN_URL, {"program": "invented"}, headers={"authorization": "Bearer pha_test"}
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # 404, not 400: the CLI falls back only on 404, so an unlisted program keeps
+        # running on the legacy gateway instead of having its run killed.
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_mint.assert_not_called()
 
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
@@ -798,5 +800,24 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         # A CLI that names no program cannot mint: there is no node to pin it to.
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_mint.assert_not_called()
+
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_a_non_string_program_is_refused_not_a_500(
+        self, mock_authentication, mock_flag, mock_authorized, mock_mint
+    ):
+        # The value is caller JSON: an unhashable one would raise on the set
+        # membership, from inside a throttle that runs before authentication.
+        self._mock_oauth(mock_authentication)
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL,
+            data=json.dumps({"program": ["integration"]}),
+            content_type="application/json",
+            headers={"authorization": "Bearer pha_test"},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_mint.assert_not_called()

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -659,6 +659,7 @@ class SetupWizardGatewayTokenThrottleTests(APIBaseTest):
     WIZARD_GATEWAY_MINT_KEY="phs_wizard_mint",
     WIZARD_GATEWAY_URL="https://ai-gateway.us.posthog.com",
     WIZARD_GATEWAY_CLIENT_IDS=["wizard-client-id"],
+    WIZARD_GATEWAY_PROGRAM_IDS=["integration"],
 )
 class SetupWizardGatewayTokenTests(APIBaseTest):
     GATEWAY_TOKEN_URL = "/api/wizard/gateway_token"
@@ -691,7 +692,9 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_mints_for_scoped_oauth_token(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
         self._mock_oauth(mock_authentication)
 
-        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
 
         assert response.status_code == status.HTTP_201_CREATED, response.content
         body = response.json()
@@ -699,10 +702,12 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert body["expires_at"] == self.MINTED["expires_at"]
         assert body["gateway_url"] == "https://ai-gateway.us.posthog.com"
         assert body["team_id"] == self.team.id
-        # The mint pins obo to the org and user to the acting identity.
+        # The mint pins obo to the org, user to the acting identity, and the product
+        # to the run's program.
         assert mock_mint.call_args.kwargs == {
             "obo": str(self.team.organization_id),
             "user": str(self.user.distinct_id),
+            "product": "wizard:integration",
         }
 
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
@@ -766,5 +771,32 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_mint_failure_is_503(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
         self._mock_oauth(mock_authentication)
-        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+        )
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_unlisted_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
+        # The allowlist is authoritative. Folding an unlisted program into a generic
+        # node would bill it as plain wizard spend and leave it unbudgeted.
+        self._mock_oauth(mock_authentication)
+        response = self.client.post(
+            self.GATEWAY_TOKEN_URL, {"program": "invented"}, headers={"authorization": "Bearer pha_test"}
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_mint.assert_not_called()
+
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_missing_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
+        # A CLI that names no program cannot mint: there is no node to pin it to.
+        self._mock_oauth(mock_authentication)
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_mint.assert_not_called()

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timedelta
 
+import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from rest_framework import status
+from rest_framework.exceptions import Throttled
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
@@ -18,6 +20,7 @@ from posthog.cloud_utils import get_api_host
 from posthog.llm.wizard_gateway_token import WizardGatewayMintError
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+from posthog.rate_limit import SetupWizardGatewayTokenRateThrottle, reserve_wizard_mint
 
 
 class SetupWizardTests(APIBaseTest):
@@ -821,3 +824,34 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_mint.assert_not_called()
+
+
+class TestReserveWizardMint:
+    """The ceiling is atomic and sits on the mint, not on arrival."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):
+        with override_settings(WIZARD_GATEWAY_PROGRAM_IDS=["integration"], DEBUG=False):
+            yield
+
+    def _request(self):
+        factory = APIRequestFactory()
+        return Request(factory.post("/api/wizard/gateway_token", {"program": "integration"}))
+
+    def test_the_sixth_reservation_in_a_window_is_refused(self):
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()
+        req = self._request()
+        with patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="k"):
+            for _ in range(5):
+                reserve_wizard_mint(req, None)
+            with pytest.raises(Throttled):
+                reserve_wizard_mint(req, None)
+
+    def test_a_cache_failure_fails_open(self):
+        # Load-shedding posture: the per-token cap and the wallet also bound this,
+        # and a Redis blip must not turn a minted token into a 500.
+        req = self._request()
+        with patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", side_effect=RuntimeError("redis down")):
+            reserve_wizard_mint(req, None)

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -705,8 +705,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert body["expires_at"] == self.MINTED["expires_at"]
         assert body["gateway_url"] == "https://ai-gateway.us.posthog.com"
         assert body["team_id"] == self.team.id
-        # The mint pins obo to the org, user to the acting identity, and the product
-        # to the run's program.
         assert mock_mint.call_args.kwargs == {
             "obo": str(self.team.organization_id),
             "user": str(self.user.distinct_id),
@@ -731,8 +729,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_token_from_another_application_is_401(self, mock_authentication, mock_authorized):
-        # llm_gateway:read is an internal scope carried by every sandbox and agent
-        # token, so the scope alone must not admit a mint.
+        # llm_gateway:read is on every sandbox and agent token.
         self._mock_oauth(mock_authentication, client_id="sandbox-client-id")
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -741,8 +738,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_revoked_project_access_is_403(self, mock_authentication, mock_flag, mock_authorized):
-        # scoped_teams is frozen at consent; losing membership or project access
-        # must stop the mint.
+        # scoped_teams is frozen at consent.
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -784,14 +780,10 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_unlisted_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
-        # The allowlist is authoritative. Folding an unlisted program into a generic
-        # node would bill it as plain wizard spend and leave it unbudgeted.
         self._mock_oauth(mock_authentication)
         response = self.client.post(
             self.GATEWAY_TOKEN_URL, {"program": "invented"}, headers={"authorization": "Bearer pha_test"}
         )
-        # 404, not 400: the CLI falls back only on 404, so an unlisted program keeps
-        # running on the legacy gateway instead of having its run killed.
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_mint.assert_not_called()
 
@@ -800,7 +792,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_missing_program_is_refused(self, mock_authentication, mock_flag, mock_authorized, mock_mint):
-        # A CLI that names no program cannot mint: there is no node to pin it to.
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -813,8 +804,8 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_a_non_string_program_is_refused_not_a_500(
         self, mock_authentication, mock_flag, mock_authorized, mock_mint
     ):
-        # The value is caller JSON: an unhashable one would raise on the set
-        # membership, from inside a throttle that runs before authentication.
+        # An unhashable value raises on the set membership, inside a throttle that
+        # runs before authentication.
         self._mock_oauth(mock_authentication)
         response = self.client.post(
             self.GATEWAY_TOKEN_URL,

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -803,6 +803,49 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
         assert self._reserved_counter_value() == 0
 
+    @override_settings(DEBUG=False)
+    @patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="refund-test-key")
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_induced_failures_cannot_buy_extra_tokens(self, mock_authentication, mock_flag, mock_authorized, mock_key):
+        """The counter must equal the tokens actually issued, however many failures ran.
+
+        The refund exists so an outage does not burn a user's quota, which invites
+        the mirror question: induce failures on purpose and keep the slot each time.
+        That is only safe while a refund is impossible on any path that hands back a
+        token, so the ceiling has to bind on issued tokens rather than on attempts.
+        """
+        self._mock_oauth(mock_authentication)
+
+        with patch(
+            "posthog.api.wizard.http.mint_wizard_gateway_token",
+            side_effect=WizardGatewayMintError("unreachable", token_may_exist=False),
+        ):
+            for _ in range(20):
+                failed = self.client.post(
+                    self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+                )
+                assert failed.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+        assert self._reserved_counter_value() == 0
+
+        with patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=self.MINTED) as mock_mint:
+            for _ in range(5):
+                ok = self.client.post(
+                    self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+                )
+                assert ok.status_code == status.HTTP_201_CREATED
+            # The ceiling counts issued tokens, so the 20 refunded failures bought
+            # nothing: the sixth mint is refused even though 25 requests preceded it.
+            refused = self.client.post(
+                self.GATEWAY_TOKEN_URL, {"program": "integration"}, headers={"authorization": "Bearer pha_test"}
+            )
+
+        assert refused.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert mock_mint.call_count == 5
+        assert self._reserved_counter_value() == 6
+
     @patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="refund-test-key")
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -677,8 +677,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def _mock_oauth(self, mock_authentication, scope=None, scoped_teams=None, client_id="wizard-client-id"):
         mock_authenticator = mock_authentication.return_value
         mock_authenticator.authenticate.return_value = (self.user, None)
-        # `scope` is the token's own space-separated text, which is what the
-        # endpoint reads (not DOT's registry-filtered `scopes` dict).
         mock_authenticator.access_token.scope = "llm_gateway:read" if scope is None else scope
         mock_authenticator.access_token.scoped_teams = scoped_teams if scoped_teams is not None else [self.team.id]
         mock_authenticator.access_token.application.client_id = client_id
@@ -730,7 +728,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_token_from_another_application_is_401(self, mock_authentication, mock_authorized):
-        # llm_gateway:read is on every sandbox and agent token.
         self._mock_oauth(mock_authentication, client_id="sandbox-client-id")
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -739,7 +736,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_revoked_project_access_is_403(self, mock_authentication, mock_flag, mock_authorized):
-        # scoped_teams is frozen at consent.
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -794,8 +790,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_a_failure_that_issued_no_token_returns_the_slot(
         self, mock_authentication, mock_flag, mock_authorized, mock_key
     ):
-        # The refund only runs through the view's exception handler, so nothing
-        # below the helper's own unit tests covers deleting or inverting it.
+        # Nothing below the helper's unit tests covers deleting or inverting this.
         self._mock_oauth(mock_authentication)
         with patch(
             "posthog.api.wizard.http.mint_wizard_gateway_token",
@@ -815,8 +810,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     def test_a_failure_that_may_have_issued_a_token_keeps_the_slot(
         self, mock_authentication, mock_flag, mock_authorized, mock_key
     ):
-        # The paired negative: refunding here would return a slot for a token the
-        # gateway may hold, which is what the guard exists to prevent.
+        # The paired negative: the gateway may hold this token.
         self._mock_oauth(mock_authentication)
         with patch(
             "posthog.api.wizard.http.mint_wizard_gateway_token",
@@ -876,8 +870,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_a_throttled_mint_is_counted(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
-        # The reservation raises inside the action body, after DRF's own throttle
-        # check admitted the request, so the throttled() hook never sees this one.
         self._mock_oauth(mock_authentication)
         before = _gateway_token_outcome("throttled")
 
@@ -893,8 +885,6 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         assert _gateway_token_outcome("throttled") == before + 1
 
     def test_an_unresolvable_bearer_is_counted(self):
-        # The authenticator raises on its own, before any gate that counts, so a
-        # rejected bearer would otherwise leave no sample at all.
         before = _gateway_token_outcome("invalid_token")
 
         response = self.client.post(
@@ -964,9 +954,6 @@ class TestReserveWizardMint:
         django_cache.clear()
         req = self._request()
         with patch.object(SetupWizardGatewayTokenRateThrottle, "get_cache_key", return_value="k"):
-            # incr raises when the key expired between add and incr. The branch has
-            # to persist the charge, or it hands back a counter whose decr would
-            # debit whatever a concurrent request charged next.
             with patch("posthog.rate_limit.cache.incr", side_effect=ValueError("no key")):
                 counter = reserve_wizard_mint(req, None)
 
@@ -976,8 +963,6 @@ class TestReserveWizardMint:
         assert django_cache.get(counter) == 0
 
     def test_a_refund_without_a_counter_is_a_no_op(self):
-        # reserve returns None when it charged nothing, and the caller refunds
-        # unconditionally on an unambiguous failure.
         refund_wizard_mint(None)
 
     def test_a_cache_failure_fails_open(self):

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -13,6 +13,7 @@ from rest_framework import status
 
 from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
 from posthog.cloud_utils import get_api_host
+from posthog.llm.wizard_gateway_token import WizardGatewayMintError
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
@@ -617,3 +618,79 @@ class SetupWizardCloudRunTests(APIBaseTest):
     def tearDown(self):
         super().tearDown()
         cache.clear()  # Clears out all DRF throttle data
+
+
+@override_settings(
+    WIZARD_GATEWAY_MINT_KEY="phs_wizard_mint",
+    WIZARD_GATEWAY_URL="https://gateway.us.posthog.com",
+)
+class SetupWizardGatewayTokenTests(APIBaseTest):
+    GATEWAY_TOKEN_URL = "/api/wizard/gateway_token"
+
+    MINTED = {"token": "phe_test_token", "expires_at": "2026-08-22T00:00:00Z", "cap_usd": "50"}
+
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()  # Clears out all DRF throttle data
+
+    def _mock_oauth(self, mock_authentication, scopes=None, scoped_teams=None):
+        mock_authenticator = mock_authentication.return_value
+        mock_authenticator.authenticate.return_value = (self.user, None)
+        mock_authenticator.access_token.scopes = scopes if scopes is not None else ["llm_gateway:read"]
+        mock_authenticator.access_token.scoped_teams = scoped_teams if scoped_teams is not None else [self.team.id]
+        return mock_authenticator
+
+    @override_settings(WIZARD_GATEWAY_MINT_KEY="")
+    def test_unconfigured_is_404(self):
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_mints_for_scoped_oauth_token(self, mock_authentication, mock_flag, mock_mint):
+        self._mock_oauth(mock_authentication)
+
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        body = response.json()
+        assert body["token"] == "phe_test_token"
+        assert body["expires_at"] == self.MINTED["expires_at"]
+        assert body["gateway_url"] == "https://gateway.us.posthog.com"
+        assert body["team_id"] == self.team.id
+        # The mint pins obo to the org and user to the acting identity.
+        assert mock_mint.call_args.kwargs == {
+            "obo": str(self.team.organization_id),
+            "user": str(self.user.distinct_id),
+        }
+
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=False)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_flag_off_is_404(self, mock_authentication, mock_flag):
+        self._mock_oauth(mock_authentication)
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_missing_gateway_scope_is_401(self, mock_authentication):
+        self._mock_oauth(mock_authentication, scopes=["*"])
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_multi_team_scope_is_400(self, mock_authentication):
+        self._mock_oauth(mock_authentication, scoped_teams=[self.team.id, self.team.id + 1])
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch(
+        "posthog.api.wizard.http.mint_wizard_gateway_token",
+        side_effect=WizardGatewayMintError("refused"),
+    )
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_mint_failure_is_503(self, mock_authentication, mock_flag, mock_mint):
+        self._mock_oauth(mock_authentication)
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -622,7 +622,8 @@ class SetupWizardCloudRunTests(APIBaseTest):
 
 @override_settings(
     WIZARD_GATEWAY_MINT_KEY="phs_wizard_mint",
-    WIZARD_GATEWAY_URL="https://gateway.us.posthog.com",
+    WIZARD_GATEWAY_URL="https://ai-gateway.us.posthog.com",
+    WIZARD_GATEWAY_CLIENT_IDS=["wizard-client-id"],
 )
 class SetupWizardGatewayTokenTests(APIBaseTest):
     GATEWAY_TOKEN_URL = "/api/wizard/gateway_token"
@@ -633,11 +634,14 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         super().tearDown()
         cache.clear()  # Clears out all DRF throttle data
 
-    def _mock_oauth(self, mock_authentication, scopes=None, scoped_teams=None):
+    def _mock_oauth(self, mock_authentication, scope=None, scoped_teams=None, client_id="wizard-client-id"):
         mock_authenticator = mock_authentication.return_value
         mock_authenticator.authenticate.return_value = (self.user, None)
-        mock_authenticator.access_token.scopes = scopes if scopes is not None else ["llm_gateway:read"]
+        # `scope` is the token's own space-separated text, which is what the
+        # endpoint reads (not DOT's registry-filtered `scopes` dict).
+        mock_authenticator.access_token.scope = "llm_gateway:read" if scope is None else scope
         mock_authenticator.access_token.scoped_teams = scoped_teams if scoped_teams is not None else [self.team.id]
+        mock_authenticator.access_token.application.client_id = client_id
         return mock_authenticator
 
     @override_settings(WIZARD_GATEWAY_MINT_KEY="")
@@ -645,10 +649,11 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.mint_wizard_gateway_token", return_value=MINTED)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
-    def test_mints_for_scoped_oauth_token(self, mock_authentication, mock_flag, mock_mint):
+    def test_mints_for_scoped_oauth_token(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
         self._mock_oauth(mock_authentication)
 
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
@@ -657,7 +662,7 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         body = response.json()
         assert body["token"] == "phe_test_token"
         assert body["expires_at"] == self.MINTED["expires_at"]
-        assert body["gateway_url"] == "https://gateway.us.posthog.com"
+        assert body["gateway_url"] == "https://ai-gateway.us.posthog.com"
         assert body["team_id"] == self.team.id
         # The mint pins obo to the org and user to the acting identity.
         assert mock_mint.call_args.kwargs == {
@@ -665,17 +670,50 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
             "user": str(self.user.distinct_id),
         }
 
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=False)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
-    def test_flag_off_is_404(self, mock_authentication, mock_flag):
+    def test_flag_off_is_404(self, mock_authentication, mock_flag, mock_authorized):
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
     def test_missing_gateway_scope_is_401(self, mock_authentication):
-        self._mock_oauth(mock_authentication, scopes=["*"])
+        # "*" must not subsume the privileged scope.
+        self._mock_oauth(mock_authentication, scope="*")
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_token_from_another_application_is_401(self, mock_authentication, mock_authorized):
+        # llm_gateway:read is an internal scope carried by every sandbox and agent
+        # token, so the scope alone must not admit a mint.
+        self._mock_oauth(mock_authentication, client_id="sandbox-client-id")
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=False)
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
+    def test_revoked_project_access_is_403(self, mock_authentication, mock_flag, mock_authorized):
+        # scoped_teams is frozen at consent; losing membership or project access
+        # must stop the mint.
+        self._mock_oauth(mock_authentication)
+        response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_unauthenticated_request_is_rejected(self):
+        # No authenticator mock: the real one must refuse a request with no
+        # bearer, on a viewset whose permission_classes is empty.
+        self.client.logout()
+        response = self.client.post(self.GATEWAY_TOKEN_URL)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_session_cookie_alone_is_rejected(self):
+        # APIBaseTest leaves a logged-in session; it must not authorize a mint.
+        response = self.client.post(self.GATEWAY_TOKEN_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
@@ -688,9 +726,10 @@ class SetupWizardGatewayTokenTests(APIBaseTest):
         "posthog.api.wizard.http.mint_wizard_gateway_token",
         side_effect=WizardGatewayMintError("refused"),
     )
+    @patch("posthog.api.wizard.http.oauth_credential_authorized", return_value=True)
     @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.api.wizard.http.OAuthAccessTokenAuthentication")
-    def test_mint_failure_is_503(self, mock_authentication, mock_flag, mock_mint):
+    def test_mint_failure_is_503(self, mock_authentication, mock_flag, mock_mint, mock_authorized):
         self._mock_oauth(mock_authentication)
         response = self.client.post(self.GATEWAY_TOKEN_URL, headers={"authorization": "Bearer pha_test"})
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -623,13 +623,6 @@ class SetupWizardCloudRunTests(APIBaseTest):
 
 
 class SetupWizardGatewayTokenThrottleTests(APIBaseTest):
-    """The mint throttle must not key on anything the caller chooses.
-
-    request.user is anonymous at throttle time (this viewset carries only
-    session auth and the action authenticates in its own body), so the throttle
-    resolves the bearer itself and falls back to the trusted proxy chain.
-    """
-
     def tearDown(self):
         super().tearDown()
         cache.clear()

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -10,6 +10,8 @@ from django.urls import reverse
 from django.utils import timezone
 
 from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
 from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
 from posthog.cloud_utils import get_api_host
@@ -618,6 +620,46 @@ class SetupWizardCloudRunTests(APIBaseTest):
     def tearDown(self):
         super().tearDown()
         cache.clear()  # Clears out all DRF throttle data
+
+
+class SetupWizardGatewayTokenThrottleTests(APIBaseTest):
+    """The mint throttle must not key on anything the caller chooses.
+
+    request.user is anonymous at throttle time (this viewset carries only
+    session auth and the action authenticates in its own body), so the throttle
+    resolves the bearer itself and falls back to the trusted proxy chain.
+    """
+
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()
+
+    def test_key_ignores_a_caller_supplied_forwarded_for(self):
+        from posthog.rate_limit import SetupWizardGatewayTokenRateThrottle
+
+        throttle = SetupWizardGatewayTokenRateThrottle()
+        factory = APIRequestFactory()
+
+        first = factory.post("/api/wizard/gateway_token", HTTP_X_FORWARDED_FOR="1.2.3.4")
+        second = factory.post("/api/wizard/gateway_token", HTTP_X_FORWARDED_FOR="5.6.7.8, 9.9.9.9")
+
+        # Same untrusted origin, two different forwarded headers: the bucket
+        # must not move, or the cap is bypassed by rotating the header.
+        assert throttle.get_cache_key(Request(first), None) == throttle.get_cache_key(Request(second), None)
+
+    @patch("posthog.rate_limit.OAuthAccessTokenAuthentication")
+    def test_key_follows_the_authenticated_user(self, mock_authentication):
+        from posthog.rate_limit import SetupWizardGatewayTokenRateThrottle
+
+        throttle = SetupWizardGatewayTokenRateThrottle()
+        factory = APIRequestFactory()
+        mock_authentication.return_value.authenticate.return_value = (self.user, None)
+
+        keyed = throttle.get_cache_key(Request(factory.post("/api/wizard/gateway_token")), None)
+        mock_authentication.return_value.authenticate.return_value = None
+        anonymous = throttle.get_cache_key(Request(factory.post("/api/wizard/gateway_token")), None)
+
+        assert keyed != anonymous
 
 
 @override_settings(

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -156,6 +156,42 @@ class TestMintWizardGatewayToken:
                 mint_wizard_gateway_token(obo="org_1", user="user_1")
         assert post.call_args.kwargs["json"]["cap_usd"] == "20.000000"
 
+    @pytest.mark.parametrize(
+        "raised,token_may_exist",
+        [
+            # Never reached the gateway, so nothing was issued.
+            (requests.exceptions.ConnectionError("refused"), False),
+            (requests.exceptions.ConnectTimeout("connect timed out"), False),
+            # The request may have landed; the gateway could hold a token.
+            (requests.exceptions.ReadTimeout("read timed out"), True),
+        ],
+    )
+    def test_transport_failures_report_whether_a_token_may_exist(self, raised, token_may_exist):
+        with patch("posthog.llm.wizard_gateway_token.requests.post", side_effect=raised):
+            with pytest.raises(WizardGatewayMintError) as excinfo:
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert excinfo.value.token_may_exist is token_may_exist
+
+    def test_a_refusal_reports_that_no_token_exists(self):
+        with patch(
+            "posthog.llm.wizard_gateway_token.requests.post",
+            return_value=_Response(400, {"error": "bad request"}),
+        ):
+            with pytest.raises(WizardGatewayMintError) as excinfo:
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert excinfo.value.token_may_exist is False
+
+    def test_an_unreadable_201_reports_that_a_token_may_exist(self):
+        # The gateway said it minted; we just could not read it back. Refunding the
+        # slot here would let the ceiling be exceeded by a token that is live.
+        with patch(
+            "posthog.llm.wizard_gateway_token.requests.post",
+            return_value=_Response(201, {"not": "a token"}),
+        ):
+            with pytest.raises(WizardGatewayMintError) as excinfo:
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert excinfo.value.token_may_exist is True
+
     @override_settings(WIZARD_GATEWAY_TOKEN_CAP_USD="12.5")
     def test_in_contract_cap_is_sent_as_fixed_point(self):
         minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -138,6 +138,13 @@ class TestMintWizardGatewayToken:
             "0",
             "-5",
             "20000",
+            # Reaches the quantize guard: the result needs more digits than the
+            # decimal context allows, so quantize raises rather than returning.
+            "1e100000",
+            # Parse as Decimals but are not finite, so the is_finite branch is the
+            # only thing between them and the gateway.
+            "NaN",
+            "Infinity",
             "",
             # Positive but under a microdollar: it quantizes to 0.000000, which
             # the gateway rejects as non-positive.

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -17,8 +17,8 @@ MINT_SETTINGS = {
     "WIZARD_GATEWAY_URL": "https://ai-gateway.us.posthog.com",
     "WIZARD_GATEWAY_MINT_KEY": "phs_wizard_secret",
     "WIZARD_GATEWAY_CLIENT_IDS": ["wizard-client-id"],
-    # Deliberately not _DEFAULT_CAP_USD: equal values would make the
-    # honored-setting and fell-back-to-default assertions indistinguishable.
+    # Not _DEFAULT_CAP_USD: equal values make the honored-setting and fell-back
+    # assertions indistinguishable.
     "WIZARD_GATEWAY_TOKEN_CAP_USD": "25",
     "WIZARD_GATEWAY_TOKEN_TTL_SECONDS": 86400,
     "WIZARD_GATEWAY_PROGRAM_IDS": ["integration"],
@@ -72,8 +72,6 @@ class TestMintWizardGatewayToken:
 
     @override_settings(WIZARD_GATEWAY_TOKEN_TTL_SECONDS=172800)
     def test_ttl_clamped_to_gateway_ceiling(self):
-        # The gateway 400s a TTL over 24h; an over-set knob must not make every
-        # mint fail.
         minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
         with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
             mint_wizard_gateway_token(obo="org_1", user="user_1")
@@ -81,9 +79,6 @@ class TestMintWizardGatewayToken:
 
     @override_settings(WIZARD_GATEWAY_TOKEN_TTL_SECONDS=5)
     def test_ttl_clamped_to_a_ttl_that_outlives_a_run(self):
-        # Not the gateway's own 60s floor: a run's holders capture the bearer once
-        # and cannot re-resolve, so a token clamped to the gateway minimum would
-        # 401 mid-run rather than falling back.
         minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
         with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
             mint_wizard_gateway_token(obo="org_1", user="user_1")
@@ -152,8 +147,6 @@ class TestMintWizardGatewayToken:
         ],
     )
     def test_out_of_contract_cap_falls_back_to_the_default(self, configured):
-        # The gateway 400s any of these, and a 400 becomes a 503 for every
-        # wizard run, so a bad knob must not reach it.
         minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
         with override_settings(WIZARD_GATEWAY_TOKEN_CAP_USD=configured):
             with patch(
@@ -212,8 +205,6 @@ class TestWizardProductNode:
 
     @override_settings(WIZARD_GATEWAY_PROGRAM_IDS=["integration"])
     def test_an_unknown_program_is_refused(self):
-        # No fold to a generic node: that would bill a new program as plain wizard
-        # spend and leave the program with no budget of its own, silently.
         assert wizard_product_node("../../etc") is None
         assert wizard_product_node("not-a-program") is None
         assert wizard_product_node("") is None

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -10,6 +10,7 @@ from posthog.llm.wizard_gateway_token import (
     mint_wizard_gateway_token,
     wizard_gateway_base_url,
     wizard_gateway_configured,
+    wizard_product_node,
 )
 
 MINT_SETTINGS = {
@@ -149,7 +150,7 @@ class TestMintWizardGatewayToken:
                 return_value=_Response(201, minted),
             ) as post:
                 mint_wizard_gateway_token(obo="org_1", user="user_1")
-        assert post.call_args.kwargs["json"]["cap_usd"] == "10.000000"
+        assert post.call_args.kwargs["json"]["cap_usd"] == "20.000000"
 
     @override_settings(WIZARD_GATEWAY_TOKEN_CAP_USD="12.5")
     def test_in_contract_cap_is_sent_as_fixed_point(self):
@@ -181,3 +182,22 @@ class TestWizardGatewayConfigured:
         blank: dict = {**MINT_SETTINGS, missing: [] if missing == "WIZARD_GATEWAY_CLIENT_IDS" else ""}
         with override_settings(**blank):
             assert wizard_gateway_configured() is False
+
+
+class TestWizardProductNode:
+    @override_settings(WIZARD_GATEWAY_PROGRAM_IDS=["integration", "audit"])
+    def test_a_configured_program_gets_its_own_node(self):
+        assert wizard_product_node("audit") == "wizard:audit"
+
+    @override_settings(WIZARD_GATEWAY_PROGRAM_IDS=["integration"])
+    def test_an_unknown_program_degrades_to_the_parent(self):
+        # Not rejected: the parent node carries a budget, an invented one would
+        # carry none, and gateway budgets skip a node with no budget row.
+        assert wizard_product_node("../../etc") == "wizard"
+        assert wizard_product_node("not-a-program") == "wizard"
+        assert wizard_product_node("") == "wizard"
+        assert wizard_product_node(None) == "wizard"
+
+    @override_settings(WIZARD_GATEWAY_PROGRAM_IDS=[])
+    def test_no_configured_programs_pins_the_parent(self):
+        assert wizard_product_node("audit") == "wizard"

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -21,6 +21,7 @@ MINT_SETTINGS = {
     # honored-setting and fell-back-to-default assertions indistinguishable.
     "WIZARD_GATEWAY_TOKEN_CAP_USD": "25",
     "WIZARD_GATEWAY_TOKEN_TTL_SECONDS": 86400,
+    "WIZARD_GATEWAY_PROGRAM_IDS": ["integration"],
 }
 
 
@@ -79,11 +80,14 @@ class TestMintWizardGatewayToken:
         assert post.call_args.kwargs["json"]["ttl_seconds"] == 86400
 
     @override_settings(WIZARD_GATEWAY_TOKEN_TTL_SECONDS=5)
-    def test_ttl_clamped_to_gateway_floor(self):
+    def test_ttl_clamped_to_a_ttl_that_outlives_a_run(self):
+        # Not the gateway's own 60s floor: a run's holders capture the bearer once
+        # and cannot re-resolve, so a token clamped to the gateway minimum would
+        # 401 mid-run rather than falling back.
         minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
         with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
             mint_wizard_gateway_token(obo="org_1", user="user_1")
-        assert post.call_args.kwargs["json"]["ttl_seconds"] == 60
+        assert post.call_args.kwargs["json"]["ttl_seconds"] == 3600
 
     @pytest.mark.parametrize(
         "response",
@@ -170,16 +174,26 @@ class TestMintWizardGatewayToken:
 
 
 class TestWizardGatewayConfigured:
-    def test_all_three_present(self):
+    def test_all_four_present(self):
         with override_settings(**MINT_SETTINGS):
             assert wizard_gateway_configured() is True
 
     @pytest.mark.parametrize(
         "missing",
-        ["WIZARD_GATEWAY_URL", "WIZARD_GATEWAY_MINT_KEY", "WIZARD_GATEWAY_CLIENT_IDS"],
+        [
+            "WIZARD_GATEWAY_URL",
+            "WIZARD_GATEWAY_MINT_KEY",
+            "WIZARD_GATEWAY_CLIENT_IDS",
+            # An empty program list refuses every program, so leaving it out is an
+            # unconfigured deploy, not a fleet of callers sending bad names.
+            "WIZARD_GATEWAY_PROGRAM_IDS",
+        ],
     )
     def test_any_missing_piece_disables(self, missing):
-        blank: dict = {**MINT_SETTINGS, missing: [] if missing == "WIZARD_GATEWAY_CLIENT_IDS" else ""}
+        blank: dict = {
+            **MINT_SETTINGS,
+            missing: [] if missing in ("WIZARD_GATEWAY_CLIENT_IDS", "WIZARD_GATEWAY_PROGRAM_IDS") else "",
+        }
         with override_settings(**blank):
             assert wizard_gateway_configured() is False
 

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -190,14 +190,14 @@ class TestWizardProductNode:
         assert wizard_product_node("audit") == "wizard:audit"
 
     @override_settings(WIZARD_GATEWAY_PROGRAM_IDS=["integration"])
-    def test_an_unknown_program_degrades_to_the_parent(self):
-        # Not rejected: the parent node carries a budget, an invented one would
-        # carry none, and gateway budgets skip a node with no budget row.
-        assert wizard_product_node("../../etc") == "wizard"
-        assert wizard_product_node("not-a-program") == "wizard"
-        assert wizard_product_node("") == "wizard"
-        assert wizard_product_node(None) == "wizard"
+    def test_an_unknown_program_is_refused(self):
+        # No fold to a generic node: that would bill a new program as plain wizard
+        # spend and leave the program with no budget of its own, silently.
+        assert wizard_product_node("../../etc") is None
+        assert wizard_product_node("not-a-program") is None
+        assert wizard_product_node("") is None
+        assert wizard_product_node(None) is None
 
     @override_settings(WIZARD_GATEWAY_PROGRAM_IDS=[])
-    def test_no_configured_programs_pins_the_parent(self):
-        assert wizard_product_node("audit") == "wizard"
+    def test_no_configured_programs_refuses_every_program(self):
+        assert wizard_product_node("audit") is None

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -1,0 +1,150 @@
+import pytest
+from unittest.mock import patch
+
+from django.test import override_settings
+
+import requests
+
+from posthog.llm.wizard_gateway_token import (
+    WizardGatewayMintError,
+    mint_wizard_gateway_token,
+    wizard_gateway_base_url,
+    wizard_gateway_configured,
+)
+
+MINT_SETTINGS = {
+    "WIZARD_GATEWAY_URL": "https://ai-gateway.us.posthog.com",
+    "WIZARD_GATEWAY_MINT_KEY": "phs_wizard_secret",
+    "WIZARD_GATEWAY_CLIENT_IDS": ["wizard-client-id"],
+    "WIZARD_GATEWAY_TOKEN_CAP_USD": "50",
+    "WIZARD_GATEWAY_TOKEN_TTL_SECONDS": 86400,
+}
+
+
+class _Response:
+    def __init__(self, status_code: int, payload=None, raise_on_json=False):
+        self.status_code = status_code
+        self._payload = payload
+        self._raise_on_json = raise_on_json
+        self.text = "body"
+
+    def json(self):
+        if self._raise_on_json:
+            raise ValueError("not json")
+        return self._payload
+
+
+class TestMintWizardGatewayToken:
+    """Covers the request this module builds and each failure branch. The endpoint
+    tests mock this function out, so without these the product pin, the bearer,
+    and the four error paths are never executed."""
+
+    @pytest.fixture(autouse=True)
+    def _mint_settings(self):
+        with override_settings(**MINT_SETTINGS):
+            yield
+
+    def test_posts_pinned_attribution_and_bearer(self):
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z", "cap_usd": "50"}
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
+            assert mint_wizard_gateway_token(obo="org_1", user="user_1") == minted
+
+        assert post.call_args[0][0] == "https://ai-gateway.us.posthog.com/v1/tokens"
+        assert post.call_args.kwargs["json"] == {
+            "cap_usd": "50",
+            "ttl_seconds": 86400,
+            "product": "wizard",
+            "obo": "org_1",
+            "user": "user_1",
+        }
+        assert post.call_args.kwargs["headers"] == {"Authorization": "Bearer phs_wizard_secret"}
+        assert post.call_args.kwargs["timeout"] > 0
+
+    @override_settings(WIZARD_GATEWAY_URL="https://ai-gateway.us.posthog.com/v1/")
+    def test_version_suffixed_setting_does_not_double_up(self):
+        # The setting may carry /v1; both the mint path and the base handed to the
+        # CLI must come out the same regardless.
+        assert wizard_gateway_base_url() == "https://ai-gateway.us.posthog.com"
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
+            mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert post.call_args[0][0] == "https://ai-gateway.us.posthog.com/v1/tokens"
+
+    @override_settings(WIZARD_GATEWAY_TOKEN_TTL_SECONDS=172800)
+    def test_ttl_clamped_to_gateway_ceiling(self):
+        # The gateway 400s a TTL over 24h; an over-set knob must not make every
+        # mint fail.
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
+            mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert post.call_args.kwargs["json"]["ttl_seconds"] == 86400
+
+    @override_settings(WIZARD_GATEWAY_TOKEN_TTL_SECONDS=5)
+    def test_ttl_clamped_to_gateway_floor(self):
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
+            mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert post.call_args.kwargs["json"]["ttl_seconds"] == 60
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            _Response(429),
+            _Response(500),
+            _Response(200, {"token": "phe_x", "expires_at": "z"}),  # only 201 is a mint
+        ],
+    )
+    def test_non_201_raises(self, response):
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=response):
+            with pytest.raises(WizardGatewayMintError):
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+
+    def test_transport_failure_raises(self):
+        with patch(
+            "posthog.llm.wizard_gateway_token.requests.post",
+            side_effect=requests.RequestException("connection reset"),
+        ):
+            with pytest.raises(WizardGatewayMintError):
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+
+    def test_non_json_body_raises(self):
+        with patch(
+            "posthog.llm.wizard_gateway_token.requests.post",
+            return_value=_Response(201, raise_on_json=True),
+        ):
+            with pytest.raises(WizardGatewayMintError):
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"expires_at": "2026-08-22T00:00:00Z"},  # no token
+            {"token": "phe_x"},  # no expiry, so the CLI cannot refresh
+            [],  # not an object
+        ],
+    )
+    def test_incomplete_payload_raises(self, payload):
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, payload)):
+            with pytest.raises(WizardGatewayMintError):
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+
+    def test_secret_never_appears_in_the_error(self):
+        with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(403)):
+            with pytest.raises(WizardGatewayMintError) as raised:
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert "phs_wizard_secret" not in str(raised.value)
+
+
+class TestWizardGatewayConfigured:
+    def test_all_three_present(self):
+        with override_settings(**MINT_SETTINGS):
+            assert wizard_gateway_configured() is True
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["WIZARD_GATEWAY_URL", "WIZARD_GATEWAY_MINT_KEY", "WIZARD_GATEWAY_CLIENT_IDS"],
+    )
+    def test_any_missing_piece_disables(self, missing):
+        blank: dict = {**MINT_SETTINGS, missing: [] if missing == "WIZARD_GATEWAY_CLIENT_IDS" else ""}
+        with override_settings(**blank):
+            assert wizard_gateway_configured() is False

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -51,7 +51,7 @@ class TestMintWizardGatewayToken:
 
         assert post.call_args[0][0] == "https://ai-gateway.us.posthog.com/v1/tokens"
         assert post.call_args.kwargs["json"] == {
-            "cap_usd": "50",
+            "cap_usd": "50.000000",
             "ttl_seconds": 86400,
             "product": "wizard",
             "obo": "org_1",
@@ -127,6 +127,32 @@ class TestMintWizardGatewayToken:
         with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, payload)):
             with pytest.raises(WizardGatewayMintError):
                 mint_wizard_gateway_token(obo="org_1", user="user_1")
+
+    @pytest.mark.parametrize(
+        "configured",
+        ["not a number", "0", "-5", "20000", ""],
+    )
+    def test_out_of_contract_cap_falls_back_to_the_default(self, configured):
+        # The gateway 400s any of these, and a 400 becomes a 503 for every
+        # wizard run, so a bad knob must not reach it.
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
+        with override_settings(WIZARD_GATEWAY_TOKEN_CAP_USD=configured):
+            with patch(
+                "posthog.llm.wizard_gateway_token.requests.post",
+                return_value=_Response(201, minted),
+            ) as post:
+                mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert post.call_args.kwargs["json"]["cap_usd"] == "50.000000"
+
+    @override_settings(WIZARD_GATEWAY_TOKEN_CAP_USD="12.5")
+    def test_in_contract_cap_is_sent_as_fixed_point(self):
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z"}
+        with patch(
+            "posthog.llm.wizard_gateway_token.requests.post",
+            return_value=_Response(201, minted),
+        ) as post:
+            mint_wizard_gateway_token(obo="org_1", user="user_1")
+        assert post.call_args.kwargs["json"]["cap_usd"] == "12.500000"
 
     def test_secret_never_appears_in_the_error(self):
         with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(403)):

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -35,10 +35,6 @@ class _Response:
 
 
 class TestMintWizardGatewayToken:
-    """Covers the request this module builds and each failure branch. The endpoint
-    tests mock this function out, so without these the product pin, the bearer,
-    and the four error paths are never executed."""
-
     @pytest.fixture(autouse=True)
     def _mint_settings(self):
         with override_settings(**MINT_SETTINGS):

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -130,7 +130,16 @@ class TestMintWizardGatewayToken:
 
     @pytest.mark.parametrize(
         "configured",
-        ["not a number", "0", "-5", "20000", ""],
+        [
+            "not a number",
+            "0",
+            "-5",
+            "20000",
+            "",
+            # Positive but under a microdollar: it quantizes to 0.000000, which
+            # the gateway rejects as non-positive.
+            "0.0000001",
+        ],
     )
     def test_out_of_contract_cap_falls_back_to_the_default(self, configured):
         # The gateway 400s any of these, and a 400 becomes a 503 for every

--- a/posthog/llm/test_wizard_gateway_token.py
+++ b/posthog/llm/test_wizard_gateway_token.py
@@ -16,7 +16,9 @@ MINT_SETTINGS = {
     "WIZARD_GATEWAY_URL": "https://ai-gateway.us.posthog.com",
     "WIZARD_GATEWAY_MINT_KEY": "phs_wizard_secret",
     "WIZARD_GATEWAY_CLIENT_IDS": ["wizard-client-id"],
-    "WIZARD_GATEWAY_TOKEN_CAP_USD": "50",
+    # Deliberately not _DEFAULT_CAP_USD: equal values would make the
+    # honored-setting and fell-back-to-default assertions indistinguishable.
+    "WIZARD_GATEWAY_TOKEN_CAP_USD": "25",
     "WIZARD_GATEWAY_TOKEN_TTL_SECONDS": 86400,
 }
 
@@ -41,13 +43,13 @@ class TestMintWizardGatewayToken:
             yield
 
     def test_posts_pinned_attribution_and_bearer(self):
-        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z", "cap_usd": "50"}
+        minted = {"token": "phe_x", "expires_at": "2026-08-22T00:00:00Z", "cap_usd": "25"}
         with patch("posthog.llm.wizard_gateway_token.requests.post", return_value=_Response(201, minted)) as post:
             assert mint_wizard_gateway_token(obo="org_1", user="user_1") == minted
 
         assert post.call_args[0][0] == "https://ai-gateway.us.posthog.com/v1/tokens"
         assert post.call_args.kwargs["json"] == {
-            "cap_usd": "50.000000",
+            "cap_usd": "25.000000",
             "ttl_seconds": 86400,
             "product": "wizard",
             "obo": "org_1",
@@ -147,7 +149,7 @@ class TestMintWizardGatewayToken:
                 return_value=_Response(201, minted),
             ) as post:
                 mint_wizard_gateway_token(obo="org_1", user="user_1")
-        assert post.call_args.kwargs["json"]["cap_usd"] == "50.000000"
+        assert post.call_args.kwargs["json"]["cap_usd"] == "10.000000"
 
     @override_settings(WIZARD_GATEWAY_TOKEN_CAP_USD="12.5")
     def test_in_contract_cap_is_sent_as_fixed_point(self):

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -26,7 +26,8 @@ _MINT_TIMEOUT_SECONDS = 10
 # The gateway refuses a TTL outside these bounds with a 400, so clamp locally: a
 # misconfigured setting should not turn every mint into a 503.
 # Far above the gateway's own 60s floor: a run's holders capture the bearer once
-# and cannot re-resolve, so a token must outlive the whole run.
+# and cannot re-resolve, so a token must outlive the whole run. Clamping to that
+# floor would turn a misconfigured knob into mid-run 401s.
 _MIN_TTL_SECONDS = 3600
 _MAX_TTL_SECONDS = 86400
 
@@ -46,7 +47,7 @@ def wizard_product_node(program: str | None) -> str | None:
     The setting is authoritative: an unrecognized program is refused rather than
     folded into a generic node. Gateway budgets match a node value exactly, so
     folding would report a new program's spend as plain wizard spend and leave the
-    program itself with no budget of its own, and the drift would be silent. A
+    program itself with no budget of its own, and the drift would be silent.
     A refusal is visible in the mint outcome counter, and the endpoint answers it
     with a 404, the one status the CLI falls back on: a program this deploy has
     not been told about keeps running on the legacy gateway rather than having
@@ -68,7 +69,16 @@ WIZARD_GATEWAY_MINTS = Counter(
 
 
 class WizardGatewayMintError(Exception):
-    """The gateway refused or failed the mint; the caller answers 503."""
+    """The gateway refused or failed the mint; the caller answers 503.
+
+    token_may_exist is False only when the failure proves no token was issued,
+    so the caller can return the daily mint slot. It defaults True: refunding a
+    slot for a token the gateway did mint would let the ceiling be exceeded.
+    """
+
+    def __init__(self, message: str, *, token_may_exist: bool = True) -> None:
+        super().__init__(message)
+        self.token_may_exist = token_may_exist
 
 
 def wizard_gateway_configured() -> bool:
@@ -115,12 +125,32 @@ def mint_wizard_gateway_token(*, obo: str, user: str, product: str = WIZARD_PROD
     except requests.RequestException as e:
         WIZARD_GATEWAY_MINTS.labels(outcome="unreachable").inc()
         logger.warning("wizard_gateway_token: mint transport failure", error=str(e))
-        raise WizardGatewayMintError("gateway unreachable") from e
+        # Only a failure after the request was transmitted can leave a token behind.
+        # URL and schema errors raise before any byte is sent, and a connect-level
+        # failure never established the session; ConnectTimeout subclasses
+        # ConnectionError, while a ReadTimeout's request may have landed.
+        #
+        # Not a clean split: requests re-raises a body-phase read timeout as
+        # ConnectionError, so that case refunds despite the request landing. The
+        # token it may leave behind is never delivered, and a cap is a ceiling
+        # rather than a reservation, so an unheld token spends nothing.
+        never_sent = isinstance(
+            e,
+            (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.URLRequired,
+                requests.exceptions.MissingSchema,
+                requests.exceptions.InvalidSchema,
+                requests.exceptions.InvalidURL,
+            ),
+        )
+        raise WizardGatewayMintError("gateway unreachable", token_may_exist=not never_sent) from e
 
     if response.status_code != 201:
         WIZARD_GATEWAY_MINTS.labels(outcome="refused").inc()
         logger.warning("wizard_gateway_token: mint refused", status=response.status_code)
-        raise WizardGatewayMintError(f"mint refused with HTTP {response.status_code}")
+        # The gateway answered and refused, so no token was issued.
+        raise WizardGatewayMintError(f"mint refused with HTTP {response.status_code}", token_may_exist=False)
     try:
         minted = response.json()
     except ValueError as e:

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -50,9 +50,10 @@ def wizard_product_node(program: str | None) -> str | None:
     folded into a generic node. Gateway budgets match a node value exactly, so
     folding would report a new program's spend as plain wizard spend and leave the
     program itself with no budget of its own, and the drift would be silent. A
-    refusal is visible in the mint outcome counter. The CLI stays on the legacy
-    gateway only for a 404, so an unlisted program fails its run rather than
-    silently spending unattributed.
+    A refusal is visible in the mint outcome counter, and the endpoint answers it
+    with a 404, the one status the CLI falls back on: a program this deploy has
+    not been told about keeps running on the legacy gateway rather than having
+    its run killed, while still being unable to mint.
     """
     # isinstance first: the value is caller JSON, and an unhashable one (a list
     # or object) raises on the set membership below, inside a throttle that runs

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -25,7 +25,12 @@ _MINT_TIMEOUT_SECONDS = 10
 
 # The gateway refuses a TTL outside these bounds with a 400, so clamp locally: a
 # misconfigured setting should not turn every mint into a 503.
-_MIN_TTL_SECONDS = 60
+# Deliberately far above the gateway's own 60s floor. A run's holders capture the
+# bearer once (the agent subprocess at spawn, the triage provider at boot) and
+# cannot re-resolve, so a token must outlive the whole run, and the CLI refuses
+# anything under two minutes outright. Clamping to the gateway's floor would turn
+# a misconfigured knob into mid-run 401s instead of the fallback the clamp is for.
+_MIN_TTL_SECONDS = 3600
 _MAX_TTL_SECONDS = 86400
 
 # The gateway 400s a cap that is non-positive, over 6dp, or above its top-up
@@ -45,10 +50,14 @@ def wizard_product_node(program: str | None) -> str | None:
     folded into a generic node. Gateway budgets match a node value exactly, so
     folding would report a new program's spend as plain wizard spend and leave the
     program itself with no budget of its own, and the drift would be silent. A
-    refusal is visible in the mint outcome counter, and the CLI reads any non-200
-    as "stay on the legacy gateway", so runs continue while the list is updated.
+    refusal is visible in the mint outcome counter. The CLI stays on the legacy
+    gateway only for a 404, so an unlisted program fails its run rather than
+    silently spending unattributed.
     """
-    if program and program in set(settings.WIZARD_GATEWAY_PROGRAM_IDS):
+    # isinstance first: the value is caller JSON, and an unhashable one (a list
+    # or object) raises on the set membership below, inside a throttle that runs
+    # before authentication.
+    if isinstance(program, str) and program in set(settings.WIZARD_GATEWAY_PROGRAM_IDS):
         return f"{WIZARD_PRODUCT}:{program}"
     return None
 
@@ -65,8 +74,18 @@ class WizardGatewayMintError(Exception):
 
 
 def wizard_gateway_configured() -> bool:
-    """Every one of the three is required; any missing piece answers 404."""
-    return bool(settings.WIZARD_GATEWAY_MINT_KEY and settings.WIZARD_GATEWAY_URL and settings.WIZARD_GATEWAY_CLIENT_IDS)
+    """Every one of the four is required; any missing piece answers 404.
+
+    The program list is a hard requirement, not a refinement: an empty one
+    refuses every program, so without it the deploy would report itself
+    configured and 400 every request as though the callers were at fault.
+    """
+    return bool(
+        settings.WIZARD_GATEWAY_MINT_KEY
+        and settings.WIZARD_GATEWAY_URL
+        and settings.WIZARD_GATEWAY_CLIENT_IDS
+        and settings.WIZARD_GATEWAY_PROGRAM_IDS
+    )
 
 
 def wizard_gateway_base_url() -> str:
@@ -137,9 +156,15 @@ def _cap_usd() -> str:
         logger.warning("wizard_gateway_token: cap_usd is not a decimal, using the default", cap=raw)
         cap = _DEFAULT_CAP_USD
     # Quantize before the range check: a positive value below a microdollar
-    # rounds to 0.000000, which the gateway rejects as non-positive.
+    # rounds to 0.000000, which the gateway rejects as non-positive. Guarded
+    # because quantize raises once the result needs more digits than the decimal
+    # context allows, and this function's contract is to fall back, never raise.
     if cap.is_finite():
-        cap = cap.quantize(_CAP_QUANTUM)
+        try:
+            cap = cap.quantize(_CAP_QUANTUM)
+        except InvalidOperation:
+            logger.warning("wizard_gateway_token: cap_usd is out of representable range, using the default", cap=raw)
+            cap = _DEFAULT_CAP_USD.quantize(_CAP_QUANTUM)
     if not cap.is_finite() or cap <= 0 or cap > _MAX_CAP_USD:
         logger.warning("wizard_gateway_token: cap_usd out of range, using the default", cap=raw)
         cap = _DEFAULT_CAP_USD.quantize(_CAP_QUANTUM)

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -25,11 +25,8 @@ _MINT_TIMEOUT_SECONDS = 10
 
 # The gateway refuses a TTL outside these bounds with a 400, so clamp locally: a
 # misconfigured setting should not turn every mint into a 503.
-# Deliberately far above the gateway's own 60s floor. A run's holders capture the
-# bearer once (the agent subprocess at spawn, the triage provider at boot) and
-# cannot re-resolve, so a token must outlive the whole run, and the CLI refuses
-# anything under two minutes outright. Clamping to the gateway's floor would turn
-# a misconfigured knob into mid-run 401s instead of the fallback the clamp is for.
+# Far above the gateway's own 60s floor: a run's holders capture the bearer once
+# and cannot re-resolve, so a token must outlive the whole run.
 _MIN_TTL_SECONDS = 3600
 _MAX_TTL_SECONDS = 86400
 

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -37,18 +37,20 @@ _CAP_QUANTUM = Decimal("0.000001")
 WIZARD_PRODUCT = "wizard"
 
 
-def wizard_product_node(program: str | None) -> str:
-    """The product node to pin for a run: `wizard:<program>`, or bare `wizard`.
+def wizard_product_node(program: str | None) -> str | None:
+    """The product node to pin for a run, or None when this is not a program
+    Django knows.
 
-    An unrecognized program degrades to the parent instead of being pinned as
-    sent. Gateway budgets match a node value exactly and skip a value with no
-    budget row, so pinning a caller-supplied program would let a caller name an
-    unbudgeted node and spend without a ceiling. Degrading also keeps a program
-    the CLI ships before this list knows it running, under the parent's budget.
+    The setting is authoritative: an unrecognized program is refused rather than
+    folded into a generic node. Gateway budgets match a node value exactly, so
+    folding would report a new program's spend as plain wizard spend and leave the
+    program itself with no budget of its own, and the drift would be silent. A
+    refusal is visible in the mint outcome counter, and the CLI reads any non-200
+    as "stay on the legacy gateway", so runs continue while the list is updated.
     """
     if program and program in set(settings.WIZARD_GATEWAY_PROGRAM_IDS):
         return f"{WIZARD_PRODUCT}:{program}"
-    return WIZARD_PRODUCT
+    return None
 
 
 WIZARD_GATEWAY_MINTS = Counter(

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -30,9 +30,26 @@ _MAX_TTL_SECONDS = 86400
 
 # The gateway 400s a cap that is non-positive, over 6dp, or above its top-up
 # ceiling, so a bad knob falls back locally instead of 503ing every mint.
-_DEFAULT_CAP_USD = Decimal("10")
+_DEFAULT_CAP_USD = Decimal("20")
 _MAX_CAP_USD = Decimal("10000")
 _CAP_QUANTUM = Decimal("0.000001")
+
+WIZARD_PRODUCT = "wizard"
+
+
+def wizard_product_node(program: str | None) -> str:
+    """The product node to pin for a run: `wizard:<program>`, or bare `wizard`.
+
+    An unrecognized program degrades to the parent instead of being pinned as
+    sent. Gateway budgets match a node value exactly and skip a value with no
+    budget row, so pinning a caller-supplied program would let a caller name an
+    unbudgeted node and spend without a ceiling. Degrading also keeps a program
+    the CLI ships before this list knows it running, under the parent's budget.
+    """
+    if program and program in set(settings.WIZARD_GATEWAY_PROGRAM_IDS):
+        return f"{WIZARD_PRODUCT}:{program}"
+    return WIZARD_PRODUCT
+
 
 WIZARD_GATEWAY_MINTS = Counter(
     "posthog_wizard_gateway_token_mints_total",
@@ -56,7 +73,7 @@ def wizard_gateway_base_url() -> str:
     return settings.WIZARD_GATEWAY_URL.rstrip("/").removesuffix("/v1")
 
 
-def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
+def mint_wizard_gateway_token(*, obo: str, user: str, product: str = WIZARD_PRODUCT) -> dict[str, Any]:
     """Mint one run's token; returns {token, expires_at, cap_usd}. Raises
     WizardGatewayMintError on any refusal or transport failure; the bearer never
     appears in logs or exception text.
@@ -65,7 +82,7 @@ def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
     body = {
         "cap_usd": _cap_usd(),
         "ttl_seconds": _ttl_seconds(),
-        "product": "wizard",
+        "product": product,
         "obo": obo,
         "user": user,
     }

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -1,0 +1,75 @@
+"""Mint a wizard-run scoped gateway token.
+
+The wizard CLI's v2 auth: instead of sending the user's OAuth token to the
+gateway, Django mints a `phe_` scoped token off the PostHog-owned wizard team's
+`phs_` (WIZARD_GATEWAY_MINT_KEY). The mint pins the attribution the caller must
+not control: product=wizard, obo=the customer organization the run is for, and
+the acting user — plus a per-run spend cap and an expiry. The customer's own
+wallet is never involved; the debit lands on the wizard team.
+
+Sibling of products/tasks' sandbox mint (ai_gateway_token.py); separate because
+the wizard needs `expires_at` back for CLI-side refresh and runs on its own
+settings, and interactive mints answer one attempt fast instead of retrying
+into the CLI's timeout.
+"""
+
+from typing import Any
+
+from django.conf import settings
+
+import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_MINT_TIMEOUT_SECONDS = 10
+
+
+class WizardGatewayMintError(Exception):
+    """The gateway refused or failed the mint; the caller answers 503 and the
+    CLI falls back to the legacy gateway posture."""
+
+
+def wizard_gateway_configured() -> bool:
+    return bool(settings.WIZARD_GATEWAY_MINT_KEY and settings.WIZARD_GATEWAY_URL)
+
+
+def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
+    """Mint one run's token; returns {token, expires_at, cap_usd}.
+
+    Raises WizardGatewayMintError on any refusal or transport failure. The
+    bearer never appears in logs or exception text.
+    """
+    base_url = settings.WIZARD_GATEWAY_URL.rstrip("/").removesuffix("/v1")
+    body = {
+        "cap_usd": str(settings.WIZARD_GATEWAY_TOKEN_CAP_USD),
+        "ttl_seconds": int(settings.WIZARD_GATEWAY_TOKEN_TTL_SECONDS),
+        "product": "wizard",
+        "obo": obo,
+        "user": user,
+    }
+    try:
+        response = requests.post(
+            f"{base_url}/v1/tokens",
+            json=body,
+            headers={"Authorization": f"Bearer {settings.WIZARD_GATEWAY_MINT_KEY}"},
+            timeout=_MINT_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as e:
+        logger.warning("wizard_gateway_token: mint transport failure", error=str(e))
+        raise WizardGatewayMintError("gateway unreachable") from e
+
+    if response.status_code != 201:
+        logger.warning("wizard_gateway_token: mint refused", status=response.status_code)
+        raise WizardGatewayMintError(f"mint refused with HTTP {response.status_code}")
+    try:
+        minted = response.json()
+    except ValueError as e:
+        raise WizardGatewayMintError("mint response was not JSON") from e
+    if not isinstance(minted, dict) or not minted.get("token") or not minted.get("expires_at"):
+        raise WizardGatewayMintError("mint response missing token or expires_at")
+    return {
+        "token": minted["token"],
+        "expires_at": minted["expires_at"],
+        "cap_usd": minted.get("cap_usd"),
+    }

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -13,6 +13,7 @@ settings, and interactive mints answer one attempt fast instead of retrying
 into the CLI's timeout.
 """
 
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from django.conf import settings
@@ -29,6 +30,12 @@ _MINT_TIMEOUT_SECONDS = 10
 # misconfigured setting should not turn every mint into a 503.
 _MIN_TTL_SECONDS = 60
 _MAX_TTL_SECONDS = 86400
+
+# The gateway parses the cap as a decimal and 400s anything non-positive, over
+# 6dp, or above its top-up ceiling. A bad knob should be a local default rather
+# than a 503 for every wizard run.
+_DEFAULT_CAP_USD = Decimal("50")
+_MAX_CAP_USD = Decimal("10000")
 
 WIZARD_GATEWAY_MINTS = Counter(
     "posthog_wizard_gateway_token_mints_total",
@@ -61,7 +68,7 @@ def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
     """
     base_url = wizard_gateway_base_url()
     body = {
-        "cap_usd": str(settings.WIZARD_GATEWAY_TOKEN_CAP_USD),
+        "cap_usd": _cap_usd(),
         "ttl_seconds": _ttl_seconds(),
         "product": "wizard",
         "obo": obo,
@@ -102,3 +109,21 @@ def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
 def _ttl_seconds() -> int:
     """The requested token lifetime, clamped to the gateway's mint bounds."""
     return max(_MIN_TTL_SECONDS, min(int(settings.WIZARD_GATEWAY_TOKEN_TTL_SECONDS), _MAX_TTL_SECONDS))
+
+
+def _cap_usd() -> str:
+    """The per-token cap as a fixed-point string the gateway will accept.
+
+    An unparseable, non-positive, or over-ceiling setting falls back to the
+    default rather than making every mint a 503.
+    """
+    raw = str(settings.WIZARD_GATEWAY_TOKEN_CAP_USD)
+    try:
+        cap = Decimal(raw)
+    except (InvalidOperation, ValueError):
+        logger.warning("wizard_gateway_token: cap_usd is not a decimal, using the default", cap=raw)
+        cap = _DEFAULT_CAP_USD
+    if not cap.is_finite() or cap <= 0 or cap > _MAX_CAP_USD:
+        logger.warning("wizard_gateway_token: cap_usd out of range, using the default", cap=raw)
+        cap = _DEFAULT_CAP_USD
+    return f"{cap.quantize(Decimal('0.000001')):f}"

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -36,6 +36,7 @@ _MAX_TTL_SECONDS = 86400
 # than a 503 for every wizard run.
 _DEFAULT_CAP_USD = Decimal("50")
 _MAX_CAP_USD = Decimal("10000")
+_CAP_QUANTUM = Decimal("0.000001")
 
 WIZARD_GATEWAY_MINTS = Counter(
     "posthog_wizard_gateway_token_mints_total",
@@ -123,7 +124,12 @@ def _cap_usd() -> str:
     except (InvalidOperation, ValueError):
         logger.warning("wizard_gateway_token: cap_usd is not a decimal, using the default", cap=raw)
         cap = _DEFAULT_CAP_USD
+    # Quantize first, then range-check: a positive value below a microdollar
+    # rounds to 0.000000, which the gateway rejects as non-positive — the 503
+    # this clamp exists to avoid.
+    if cap.is_finite():
+        cap = cap.quantize(_CAP_QUANTUM)
     if not cap.is_finite() or cap <= 0 or cap > _MAX_CAP_USD:
         logger.warning("wizard_gateway_token: cap_usd out of range, using the default", cap=raw)
-        cap = _DEFAULT_CAP_USD
-    return f"{cap.quantize(Decimal('0.000001')):f}"
+        cap = _DEFAULT_CAP_USD.quantize(_CAP_QUANTUM)
+    return f"{cap:f}"

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -30,7 +30,7 @@ _MAX_TTL_SECONDS = 86400
 
 # The gateway 400s a cap that is non-positive, over 6dp, or above its top-up
 # ceiling, so a bad knob falls back locally instead of 503ing every mint.
-_DEFAULT_CAP_USD = Decimal("50")
+_DEFAULT_CAP_USD = Decimal("10")
 _MAX_CAP_USD = Decimal("10000")
 _CAP_QUANTUM = Decimal("0.000001")
 

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -19,10 +19,22 @@ from django.conf import settings
 
 import requests
 import structlog
+from prometheus_client import Counter
 
 logger = structlog.get_logger(__name__)
 
 _MINT_TIMEOUT_SECONDS = 10
+
+# The gateway refuses a TTL outside these bounds with a 400, so clamp locally: a
+# misconfigured setting should not turn every mint into a 503.
+_MIN_TTL_SECONDS = 60
+_MAX_TTL_SECONDS = 86400
+
+WIZARD_GATEWAY_MINTS = Counter(
+    "posthog_wizard_gateway_token_mints_total",
+    "Wizard gateway token mints, by outcome (ok/refused/unreachable/malformed)",
+    labelnames=["outcome"],
+)
 
 
 class WizardGatewayMintError(Exception):
@@ -31,7 +43,14 @@ class WizardGatewayMintError(Exception):
 
 
 def wizard_gateway_configured() -> bool:
-    return bool(settings.WIZARD_GATEWAY_MINT_KEY and settings.WIZARD_GATEWAY_URL)
+    """Every one of the three is required; any missing piece answers 404."""
+    return bool(settings.WIZARD_GATEWAY_MINT_KEY and settings.WIZARD_GATEWAY_URL and settings.WIZARD_GATEWAY_CLIENT_IDS)
+
+
+def wizard_gateway_base_url() -> str:
+    """The gateway base the mint posts to, without the version segment. Handed to
+    the CLI as well, so both sides read one normalization of the setting."""
+    return settings.WIZARD_GATEWAY_URL.rstrip("/").removesuffix("/v1")
 
 
 def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
@@ -40,10 +59,10 @@ def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
     Raises WizardGatewayMintError on any refusal or transport failure. The
     bearer never appears in logs or exception text.
     """
-    base_url = settings.WIZARD_GATEWAY_URL.rstrip("/").removesuffix("/v1")
+    base_url = wizard_gateway_base_url()
     body = {
         "cap_usd": str(settings.WIZARD_GATEWAY_TOKEN_CAP_USD),
-        "ttl_seconds": int(settings.WIZARD_GATEWAY_TOKEN_TTL_SECONDS),
+        "ttl_seconds": _ttl_seconds(),
         "product": "wizard",
         "obo": obo,
         "user": user,
@@ -56,20 +75,30 @@ def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
             timeout=_MINT_TIMEOUT_SECONDS,
         )
     except requests.RequestException as e:
+        WIZARD_GATEWAY_MINTS.labels(outcome="unreachable").inc()
         logger.warning("wizard_gateway_token: mint transport failure", error=str(e))
         raise WizardGatewayMintError("gateway unreachable") from e
 
     if response.status_code != 201:
+        WIZARD_GATEWAY_MINTS.labels(outcome="refused").inc()
         logger.warning("wizard_gateway_token: mint refused", status=response.status_code)
         raise WizardGatewayMintError(f"mint refused with HTTP {response.status_code}")
     try:
         minted = response.json()
     except ValueError as e:
+        WIZARD_GATEWAY_MINTS.labels(outcome="malformed").inc()
         raise WizardGatewayMintError("mint response was not JSON") from e
     if not isinstance(minted, dict) or not minted.get("token") or not minted.get("expires_at"):
+        WIZARD_GATEWAY_MINTS.labels(outcome="malformed").inc()
         raise WizardGatewayMintError("mint response missing token or expires_at")
+    WIZARD_GATEWAY_MINTS.labels(outcome="ok").inc()
     return {
         "token": minted["token"],
         "expires_at": minted["expires_at"],
         "cap_usd": minted.get("cap_usd"),
     }
+
+
+def _ttl_seconds() -> int:
+    """The requested token lifetime, clamped to the gateway's mint bounds."""
+    return max(_MIN_TTL_SECONDS, min(int(settings.WIZARD_GATEWAY_TOKEN_TTL_SECONDS), _MAX_TTL_SECONDS))

--- a/posthog/llm/wizard_gateway_token.py
+++ b/posthog/llm/wizard_gateway_token.py
@@ -1,16 +1,13 @@
 """Mint a wizard-run scoped gateway token.
 
-The wizard CLI's v2 auth: instead of sending the user's OAuth token to the
-gateway, Django mints a `phe_` scoped token off the PostHog-owned wizard team's
-`phs_` (WIZARD_GATEWAY_MINT_KEY). The mint pins the attribution the caller must
-not control: product=wizard, obo=the customer organization the run is for, and
-the acting user — plus a per-run spend cap and an expiry. The customer's own
-wallet is never involved; the debit lands on the wizard team.
-
-Sibling of products/tasks' sandbox mint (ai_gateway_token.py); separate because
-the wizard needs `expires_at` back for CLI-side refresh and runs on its own
-settings, and interactive mints answer one attempt fast instead of retrying
-into the CLI's timeout.
+Django mints a `phe_` off the PostHog-owned wizard team's `phs_`
+(WIZARD_GATEWAY_MINT_KEY) rather than sending the user's OAuth token to the
+gateway. The mint pins what the caller must not control (product=wizard, obo=the
+customer organization, the acting user) plus a per-run cap and an expiry, and the
+debit lands on the wizard team, never the customer's wallet. Kept separate from
+products/tasks' sandbox mint (ai_gateway_token.py): the wizard needs
+`expires_at` back for CLI-side refresh, and an interactive mint answers one
+attempt fast instead of retrying into the CLI's timeout.
 """
 
 from decimal import Decimal, InvalidOperation
@@ -31,9 +28,8 @@ _MINT_TIMEOUT_SECONDS = 10
 _MIN_TTL_SECONDS = 60
 _MAX_TTL_SECONDS = 86400
 
-# The gateway parses the cap as a decimal and 400s anything non-positive, over
-# 6dp, or above its top-up ceiling. A bad knob should be a local default rather
-# than a 503 for every wizard run.
+# The gateway 400s a cap that is non-positive, over 6dp, or above its top-up
+# ceiling, so a bad knob falls back locally instead of 503ing every mint.
 _DEFAULT_CAP_USD = Decimal("50")
 _MAX_CAP_USD = Decimal("10000")
 _CAP_QUANTUM = Decimal("0.000001")
@@ -46,8 +42,7 @@ WIZARD_GATEWAY_MINTS = Counter(
 
 
 class WizardGatewayMintError(Exception):
-    """The gateway refused or failed the mint; the caller answers 503 and the
-    CLI falls back to the legacy gateway posture."""
+    """The gateway refused or failed the mint; the caller answers 503."""
 
 
 def wizard_gateway_configured() -> bool:
@@ -56,16 +51,15 @@ def wizard_gateway_configured() -> bool:
 
 
 def wizard_gateway_base_url() -> str:
-    """The gateway base the mint posts to, without the version segment. Handed to
-    the CLI as well, so both sides read one normalization of the setting."""
+    """The gateway base without the version segment. The CLI gets the same string,
+    so both sides read one normalization of the setting."""
     return settings.WIZARD_GATEWAY_URL.rstrip("/").removesuffix("/v1")
 
 
 def mint_wizard_gateway_token(*, obo: str, user: str) -> dict[str, Any]:
-    """Mint one run's token; returns {token, expires_at, cap_usd}.
-
-    Raises WizardGatewayMintError on any refusal or transport failure. The
-    bearer never appears in logs or exception text.
+    """Mint one run's token; returns {token, expires_at, cap_usd}. Raises
+    WizardGatewayMintError on any refusal or transport failure; the bearer never
+    appears in logs or exception text.
     """
     base_url = wizard_gateway_base_url()
     body = {
@@ -113,10 +107,9 @@ def _ttl_seconds() -> int:
 
 
 def _cap_usd() -> str:
-    """The per-token cap as a fixed-point string the gateway will accept.
-
-    An unparseable, non-positive, or over-ceiling setting falls back to the
-    default rather than making every mint a 503.
+    """The per-token cap as a fixed-point string the gateway accepts. An
+    unparseable, non-positive, or over-ceiling setting falls back to the default
+    rather than making every mint a 503.
     """
     raw = str(settings.WIZARD_GATEWAY_TOKEN_CAP_USD)
     try:
@@ -124,9 +117,8 @@ def _cap_usd() -> str:
     except (InvalidOperation, ValueError):
         logger.warning("wizard_gateway_token: cap_usd is not a decimal, using the default", cap=raw)
         cap = _DEFAULT_CAP_USD
-    # Quantize first, then range-check: a positive value below a microdollar
-    # rounds to 0.000000, which the gateway rejects as non-positive — the 503
-    # this clamp exists to avoid.
+    # Quantize before the range check: a positive value below a microdollar
+    # rounds to 0.000000, which the gateway rejects as non-positive.
     if cap.is_finite():
         cap = cap.quantize(_CAP_QUANTUM)
     if not cap.is_finite() or cap <= 0 or cap > _MAX_CAP_USD:

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1098,37 +1098,66 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
         return f"throttle_wizard_gateway_token_{hashlib.sha256(ident.encode()).hexdigest()}"
 
 
-def reserve_wizard_mint(request, view) -> None:
+def reserve_wizard_mint(request, view) -> str | None:
     """Atomically consume one of this user's daily mints for this program, or raise.
 
-    Called immediately before the mint, after every gate, so a request that never
-    mints spends nothing, while parallel requests cannot all slip under the
-    ceiling the way a read-then-charge throttle lets them. Same shape as the
-    sibling cloud-run attempt reservation.
+    Called immediately before the mint, after every gate, so a request refused by a
+    gate spends nothing, while parallel requests cannot all slip under the ceiling
+    the way a read-then-charge throttle lets them. A mint that then fails keeps its
+    slot unless the failure proves no token was issued; see refund_wizard_mint.
+
+    Returns the counter it charged so the refund targets that exact key. Recomputing
+    the window at refund time would decrement the next day's counter for a request
+    spanning 00:00 UTC, handing out a free slot.
 
     Fails open on a cache error: this bounds spend that the per-token cap and the
     wallet also bound, and a Redis blip must not turn a minted token into a 500.
     """
     throttle = SetupWizardGatewayTokenRateThrottle()
     if throttle.rate is None:
-        return
+        return None
     try:
         key = throttle.get_cache_key(request, view)
         if key is None:
-            return
+            return None
         window = int(time.time()) // throttle.duration
         counter = f"{key}:{window}"
         cache.add(counter, 0, timeout=throttle.duration)
         try:
             count = cache.incr(counter)
         except ValueError:
-            # Expired between add and incr; this request is the window's first.
+            # The key vanished between add and incr, so the incr wrote nothing.
+            # Persist the charge as the window's first rather than leaving it
+            # implicit: the counter this returns is refundable, and a handle for a
+            # charge that was never stored would debit a concurrent request's slot.
+            cache.set(counter, 1, timeout=throttle.duration)
             count = 1
     except Exception as e:
         capture_exception(e)
-        return
+        return None
     if count > throttle.num_requests:
         raise exceptions.Throttled(detail="This wizard program has used its daily run limit. Try again tomorrow.")
+    return counter
+
+
+def refund_wizard_mint(counter: str | None) -> None:
+    """Return a reserved mint slot after a failure that issued no token.
+
+    Only for failures that prove the gateway holds nothing: refunding one it did
+    mint would let a user exceed the daily ceiling. Swallows cache errors so a
+    refund can never turn the 503 the caller is already answering into a 500.
+    """
+    if counter is None:
+        return
+    try:
+        cache.decr(counter)
+    except ValueError:
+        # The window that owned the charge is gone, so there is nothing to return.
+        pass
+    except Exception as e:
+        # A lost refund costs the user a slot until the window rolls, and looks
+        # identical to a moot one; the sibling reserve reports its errors the same way.
+        capture_exception(e)
 
 
 class SetupWizardCloudRunOutcomeAwareThrottle(UserRateThrottle):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1074,7 +1074,9 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
             program = request.data.get("program") if isinstance(request.data, dict) else None
         except Exception:
             program = None
-        ident = f"{ident}|{wizard_product_node(program)}"
+        # One shared bucket for anything unrecognized: a per-name bucket would hand
+        # out a fresh quota for every invented program, even though each is refused.
+        ident = f"{ident}|{wizard_product_node(program) or 'unknown-program'}"
         # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
         return f"throttle_wizard_gateway_token_{hashlib.sha256(ident.encode()).hexdigest()}"
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1039,10 +1039,24 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
 
 
 class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
-    """Mint throttle for the wizard's gateway token. Its own namespace, so a mint
-    never spends the wizard query allowance and a gateway flap cannot exhaust the
-    budget the legacy fallback depends on.
+    """Counts a user's gateway-token MINTS per program, not requests.
+
+    Its own namespace, so a mint never spends the wizard query allowance and a
+    gateway flap cannot exhaust the budget the legacy fallback depends on.
+
+    DRF evaluates throttles in `initial()`, before the view body, so charging on
+    arrival would spend a run's quota on requests that never mint: the feature
+    unconfigured, the org not rolled out, or a program this deploy has not been
+    told about. Each answers 404, which the CLI is meant to treat as an invisible
+    "stay on the legacy gateway" and will retry; at 5/day the sixth such retry
+    would return a run-killing 429 for a rollout state the user cannot see. The
+    same reasoning as the sibling cloud-run throttle, which counts runs rather
+    than requests for exactly this reason.
     """
+
+    # Assigned by SimpleRateThrottle.__init__ from the parsed rate.
+    num_requests: int
+    duration: int
 
     scope = "wizard_gateway_token"
 
@@ -1050,6 +1064,33 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
         if settings.DEBUG:
             return "1000/day"
         return "5/day"
+
+    def allow_request(self, request, view):
+        """Read the bucket without consuming it; `record` charges a real mint."""
+        if self.rate is None:
+            return True
+        self.key = self.get_cache_key(request, view)
+        if self.key is None:
+            return True
+        self.history = self.cache.get(self.key, [])
+        self.now = self.timer()
+        while self.history and self.history[-1] <= self.now - self.duration:
+            self.history.pop()
+        return len(self.history) < self.num_requests
+
+    def record(self, request, view) -> None:
+        """Charge one mint. Called by the view only once a token was issued."""
+        if self.rate is None:
+            return
+        key = self.get_cache_key(request, view)
+        if key is None:
+            return
+        now = self.timer()
+        history = self.cache.get(key, [])
+        while history and history[-1] <= now - self.duration:
+            history.pop()
+        history.insert(0, now)
+        self.cache.set(key, history, self.duration)
 
     def get_cache_key(self, request, view):
         # request.user is anonymous here: the viewset authenticates sessions only and

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -8,10 +8,12 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.core.cache import cache
 from django.urls import resolve
 from django.utils import timezone
 
 from prometheus_client import Counter
+from rest_framework import exceptions
 from rest_framework.throttling import SimpleRateThrottle, UserRateThrottle
 from statshog.defaults.django import statsd
 
@@ -1066,33 +1068,17 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
         return "5/day"
 
     def allow_request(self, request, view):
-        """Read the bucket without consuming it; `record` charges a real mint."""
-        if self.rate is None:
-            return True
-        self.key = self.get_cache_key(request, view)
-        if self.key is None:
-            return True
-        self.history = self.cache.get(self.key, [])
-        self.now = self.timer()
-        while self.history and self.history[-1] <= self.now - self.duration:
-            self.history.pop()
-        return len(self.history) < self.num_requests
+        """Always admit; the ceiling is the view's atomic reservation.
 
-    def record(self, request, view) -> None:
-        """Charge one mint. Called by the view only once a token was issued."""
-        if self.rate is None:
-            return
-        key = self.get_cache_key(request, view)
-        if key is None:
-            return
-        now = self.timer()
-        history = self.cache.get(key, [])
-        while history and history[-1] <= now - self.duration:
-            history.pop()
-        history.insert(0, now)
-        self.cache.set(key, history, self.duration)
+        A read here and a charge after the mint would sit a whole mint round trip
+        apart, so parallel requests would all see the same free slot. This class
+        now only derives the identity, and `reserve_wizard_mint` owns the count.
+        Errors are swallowed: this is a load-shedding gate, and it must fail open.
+        """
+        return True
 
     def get_cache_key(self, request, view):
+        """The per-user, per-program bucket identity. Read by the view's reservation."""
         # request.user is anonymous here: the viewset authenticates sessions only and
         # the bearer is checked in the action body, after throttling. get_ident would
         # then key on the caller-chosen X-Forwarded-For, so resolve the token and fall
@@ -1120,6 +1106,39 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
         ident = f"{ident}|{wizard_product_node(program) or 'unknown-program'}"
         # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
         return f"throttle_wizard_gateway_token_{hashlib.sha256(ident.encode()).hexdigest()}"
+
+
+def reserve_wizard_mint(request, view) -> None:
+    """Atomically consume one of this user's daily mints for this program, or raise.
+
+    Called immediately before the mint, after every gate, so a request that never
+    mints spends nothing, while parallel requests cannot all slip under the
+    ceiling the way a read-then-charge throttle lets them. Same shape as the
+    sibling cloud-run attempt reservation.
+
+    Fails open on a cache error: this bounds spend that the per-token cap and the
+    wallet also bound, and a Redis blip must not turn a minted token into a 500.
+    """
+    throttle = SetupWizardGatewayTokenRateThrottle()
+    if throttle.rate is None:
+        return
+    try:
+        key = throttle.get_cache_key(request, view)
+        if key is None:
+            return
+        window = int(time.time()) // throttle.duration
+        counter = f"{key}:{window}"
+        cache.add(counter, 0, timeout=throttle.duration)
+        try:
+            count = cache.incr(counter)
+        except ValueError:
+            # Expired between add and incr; this request is the window's first.
+            count = 1
+    except Exception as e:
+        capture_exception(e)
+        return
+    if count > throttle.num_requests:
+        raise exceptions.Throttled(detail="This wizard program has used its daily run limit. Try again tomorrow.")
 
 
 class SetupWizardCloudRunOutcomeAwareThrottle(UserRateThrottle):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication
 from posthog.event_usage import report_user_action
 from posthog.exceptions_capture import capture_exception
+from posthog.llm.wizard_gateway_token import wizard_product_node
 from posthog.metrics import LABEL_PATH, LABEL_ROUTE, LABEL_TEAM_ID
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.team.team import Team
@@ -1048,7 +1049,7 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
     def get_rate(self):
         if settings.DEBUG:
             return "1000/day"
-        return "120/day"
+        return "5/day"
 
     def get_cache_key(self, request, view):
         # request.user is anonymous here: the viewset authenticates sessions only and
@@ -1067,6 +1068,13 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
                 ident = f"user:{user.pk}"
         if ident is None:
             ident = f"ip:{get_trusted_client_ip(request) or 'unknown'}"
+        # Bucket per program, on the resolved node rather than the raw field: keying
+        # on what the caller sent would hand out a fresh quota per invented name.
+        try:
+            program = request.data.get("program") if isinstance(request.data, dict) else None
+        except Exception:
+            program = None
+        ident = f"{ident}|{wizard_product_node(program)}"
         # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
         return f"throttle_wizard_gateway_token_{hashlib.sha256(ident.encode()).hexdigest()}"
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1041,19 +1041,9 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
 
 
 class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
-    """Counts a user's gateway-token MINTS per program, not requests.
+    """Derives the per-user, per-program mint bucket. `reserve_wizard_mint` counts it.
 
-    Its own namespace, so a mint never spends the wizard query allowance and a
-    gateway flap cannot exhaust the budget the legacy fallback depends on.
-
-    DRF evaluates throttles in `initial()`, before the view body, so charging on
-    arrival would spend a run's quota on requests that never mint: the feature
-    unconfigured, the org not rolled out, or a program this deploy has not been
-    told about. Each answers 404, which the CLI is meant to treat as an invisible
-    "stay on the legacy gateway" and will retry; at 5/day the sixth such retry
-    would return a run-killing 429 for a rollout state the user cannot see. The
-    same reasoning as the sibling cloud-run throttle, which counts runs rather
-    than requests for exactly this reason.
+    Its own namespace, so a mint never spends the wizard query allowance.
     """
 
     # Assigned by SimpleRateThrottle.__init__ from the parsed rate.

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from rest_framework.request import Request
     from rest_framework.views import APIView
 
-from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication
 from posthog.event_usage import report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.metrics import LABEL_PATH, LABEL_ROUTE, LABEL_TEAM_ID
@@ -29,7 +29,7 @@ from posthog.models.instance_setting import get_instance_setting
 from posthog.models.team.team import Team
 from posthog.models.utils import hash_key_value
 from posthog.settings.utils import get_list
-from posthog.utils import patchable
+from posthog.utils import get_trusted_client_ip, patchable
 
 RATE_LIMIT_EXCEEDED_COUNTER = Counter(
     "rate_limit_exceeded_total",
@@ -1055,8 +1055,25 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
         return "120/day"
 
     def get_cache_key(self, request, view):
-        user = getattr(request, "user", None)
-        ident = str(user.pk) if user is not None and user.is_authenticated else self.get_ident(request)
+        # DRF resolves request.user from this viewset's authenticators, which are
+        # the project defaults (session only) — the bearer is authenticated in the
+        # action body, after throttling. So request.user is anonymous here and
+        # get_ident would fall back to the raw X-Forwarded-For header, which the
+        # caller chooses. Resolve the token instead, and key on the trusted proxy
+        # chain's client IP when there isn't one.
+        ident = None
+        try:
+            result = OAuthAccessTokenAuthentication().authenticate(request)
+        except Exception:
+            # Throttling must not turn a bad bearer into a 500; the action
+            # rejects it a moment later with the right status.
+            result = None
+        if result is not None:
+            user, _ = result
+            if user is not None:
+                ident = f"user:{user.pk}"
+        if ident is None:
+            ident = f"ip:{get_trusted_client_ip(request) or 'unknown'}"
         # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
         return f"throttle_wizard_gateway_token_{hashlib.sha256(ident.encode()).hexdigest()}"
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1037,6 +1037,30 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
         return f"throttle_wizard_query_{sha_hash}"
 
 
+class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
+    """Mint throttle for the wizard's gateway token.
+
+    Its own namespace, so a mint never spends the wizard query allowance and a
+    gateway flap cannot exhaust the budget the legacy fallback depends on. Keyed
+    on the authenticated user rather than the bearer: OAuth access tokens rotate
+    hourly, and a per-bearer key resets with them while the mint ceiling it
+    protects is shared by every wizard user behind one credential.
+    """
+
+    scope = "wizard_gateway_token"
+
+    def get_rate(self):
+        if settings.DEBUG:
+            return "1000/day"
+        return "120/day"
+
+    def get_cache_key(self, request, view):
+        user = getattr(request, "user", None)
+        ident = str(user.pk) if user is not None and user.is_authenticated else self.get_ident(request)
+        # nosemgrep: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+        return f"throttle_wizard_gateway_token_{hashlib.sha256(ident.encode()).hexdigest()}"
+
+
 class SetupWizardCloudRunOutcomeAwareThrottle(UserRateThrottle):
     """Counts a user's recent wizard cloud RUNS (not requests), excluding failed and cancelled ones.
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1038,13 +1038,9 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
 
 
 class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
-    """Mint throttle for the wizard's gateway token.
-
-    Its own namespace, so a mint never spends the wizard query allowance and a
-    gateway flap cannot exhaust the budget the legacy fallback depends on. Keyed
-    on the authenticated user rather than the bearer: OAuth access tokens rotate
-    hourly, and a per-bearer key resets with them while the mint ceiling it
-    protects is shared by every wizard user behind one credential.
+    """Mint throttle for the wizard's gateway token. Its own namespace, so a mint
+    never spends the wizard query allowance and a gateway flap cannot exhaust the
+    budget the legacy fallback depends on.
     """
 
     scope = "wizard_gateway_token"
@@ -1055,18 +1051,15 @@ class SetupWizardGatewayTokenRateThrottle(SimpleRateThrottle):
         return "120/day"
 
     def get_cache_key(self, request, view):
-        # DRF resolves request.user from this viewset's authenticators, which are
-        # the project defaults (session only) — the bearer is authenticated in the
-        # action body, after throttling. So request.user is anonymous here and
-        # get_ident would fall back to the raw X-Forwarded-For header, which the
-        # caller chooses. Resolve the token instead, and key on the trusted proxy
-        # chain's client IP when there isn't one.
+        # request.user is anonymous here: the viewset authenticates sessions only and
+        # the bearer is checked in the action body, after throttling. get_ident would
+        # then key on the caller-chosen X-Forwarded-For, so resolve the token and fall
+        # back to the trusted proxy chain's client IP.
         ident = None
         try:
             result = OAuthAccessTokenAuthentication().authenticate(request)
         except Exception:
-            # Throttling must not turn a bad bearer into a 500; the action
-            # rejects it a moment later with the right status.
+            # A bad bearer must not become a 500; the action rejects it a moment later.
             result = None
         if result is not None:
             user, _ = result

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1330,7 +1330,12 @@ WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
 WIZARD_GATEWAY_CLIENT_IDS = [
     client_id for client_id in get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", "")) if client_id
 ]
-WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "10")
+WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "20")
+# Wizard programs that get their own pinned product node (and so their own
+# per-program budget and mint quota). A program absent here still runs: it
+# degrades to the bare `wizard` node, which is budgeted, rather than to an
+# unbudgeted one. Mirrors the CLI's PROGRAM_REGISTRY.
+WIZARD_GATEWAY_PROGRAM_IDS = get_list(get_from_env("WIZARD_GATEWAY_PROGRAM_IDS", ""))
 WIZARD_GATEWAY_TOKEN_TTL_SECONDS = get_from_env("WIZARD_GATEWAY_TOKEN_TTL_SECONDS", 86400, type_cast=int)
 
 # Sharing configuration settings

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1315,7 +1315,13 @@ AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
 
 # Projected into gateway_credential.json: a JSON team_id -> tier map
 # ("free"/"pro"/"enterprise") for the gateway's rate-limit bucket.
-AI_GATEWAY_TEAM_TIER_OVERRIDES = get_from_env("AI_GATEWAY_TEAM_TIER_OVERRIDES", {}, type_cast=json.loads)
+# Parsed defensively rather than with type_cast=json.loads: that runs at settings
+# import, so a malformed value takes every process down at boot, while the
+# consumer is written to degrade to no overrides.
+try:
+    AI_GATEWAY_TEAM_TIER_OVERRIDES = json.loads(get_from_env("AI_GATEWAY_TEAM_TIER_OVERRIDES", "{}"))
+except ValueError:
+    AI_GATEWAY_TEAM_TIER_OVERRIDES = {}
 
 # Wizard gateway-token mint. WIZARD_GATEWAY_MINT_KEY unset disables the endpoint
 # (404), which the CLI treats as "stay on the legacy gateway".
@@ -1329,10 +1335,10 @@ WIZARD_GATEWAY_CLIENT_IDS = [
     client_id for client_id in get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", "")) if client_id
 ]
 WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "20")
-# Wizard programs that get their own pinned product node (and so their own
-# per-program budget and mint quota). A program absent here still runs: it
-# degrades to the bare `wizard` node, which is budgeted, rather than to an
-# unbudgeted one. Mirrors the CLI's PROGRAM_REGISTRY.
+# Wizard programs that may mint, each getting its own pinned product node and so
+# its own per-program budget and mint quota. The list is authoritative: a program
+# absent here is refused, not folded into a generic node, so listing a new program
+# is required rather than optional. Mirrors the CLI's PROGRAM_REGISTRY.
 WIZARD_GATEWAY_PROGRAM_IDS = get_list(get_from_env("WIZARD_GATEWAY_PROGRAM_IDS", ""))
 WIZARD_GATEWAY_TOKEN_TTL_SECONDS = get_from_env("WIZARD_GATEWAY_TOKEN_TTL_SECONDS", 86400, type_cast=int)
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1313,10 +1313,8 @@ AI_GATEWAY_INTERNAL_TOKEN = get_from_env("AI_GATEWAY_INTERNAL_TOKEN", "")
 AI_GATEWAY_URL = get_from_env("AI_GATEWAY_URL", "")
 AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
 
-# Internal-product posture projected into gateway_credential.json: team ids whose
-# spend is PostHog-funded (the gateway stamps $ai_billable=false), and a JSON
-# team_id -> tier map ("free"/"pro"/"enterprise") for its rate-limit bucket.
-AI_GATEWAY_NON_BILLABLE_TEAM_IDS = get_list(get_from_env("AI_GATEWAY_NON_BILLABLE_TEAM_IDS", ""))
+# Projected into gateway_credential.json: a JSON team_id -> tier map
+# ("free"/"pro"/"enterprise") for the gateway's rate-limit bucket.
 AI_GATEWAY_TEAM_TIER_OVERRIDES = get_from_env("AI_GATEWAY_TEAM_TIER_OVERRIDES", {}, type_cast=json.loads)
 
 # Wizard gateway-token mint. WIZARD_GATEWAY_MINT_KEY unset disables the endpoint

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1326,6 +1326,10 @@ AI_GATEWAY_TEAM_TIER_OVERRIDES = get_from_env("AI_GATEWAY_TEAM_TIER_OVERRIDES", 
 # which the CLI treats as "stay on the legacy gateway".
 WIZARD_GATEWAY_URL = get_from_env("WIZARD_GATEWAY_URL", "")
 WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
+# OAuth application client ids allowed to mint. Required: llm_gateway:read is an
+# internal scope stamped on every sandbox and agent token, so the scope alone does
+# not identify the wizard. Empty refuses every mint.
+WIZARD_GATEWAY_CLIENT_IDS = get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", ""))
 WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "50")
 WIZARD_GATEWAY_TOKEN_TTL_SECONDS = get_from_env("WIZARD_GATEWAY_TOKEN_TTL_SECONDS", 86400, type_cast=int)
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1313,24 +1313,20 @@ AI_GATEWAY_INTERNAL_TOKEN = get_from_env("AI_GATEWAY_INTERNAL_TOKEN", "")
 AI_GATEWAY_URL = get_from_env("AI_GATEWAY_URL", "")
 AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
 
-# Internal-product posture projected into gateway_credential.json blobs.
-# NON_BILLABLE: comma-separated team ids whose gateway spend is PostHog-funded
-# (the gateway stamps $ai_billable=false). TIER_OVERRIDES: JSON map of team id
-# (string) -> tier ("free"/"pro"/"enterprise") for the gateway rate-limit bucket.
+# Internal-product posture projected into gateway_credential.json: team ids whose
+# spend is PostHog-funded (the gateway stamps $ai_billable=false), and a JSON
+# team_id -> tier map ("free"/"pro"/"enterprise") for its rate-limit bucket.
 AI_GATEWAY_NON_BILLABLE_TEAM_IDS = get_list(get_from_env("AI_GATEWAY_NON_BILLABLE_TEAM_IDS", ""))
 AI_GATEWAY_TEAM_TIER_OVERRIDES = get_from_env("AI_GATEWAY_TEAM_TIER_OVERRIDES", {}, type_cast=json.loads)
 
-# Wizard gateway-token mint (the wizard CLI's v2 auth): the wizard team's phs_
-# used as the mint bearer, the gateway base URL handed to the CLI, and the
-# per-run bounds. WIZARD_GATEWAY_MINT_KEY unset disables the endpoint (404),
-# which the CLI treats as "stay on the legacy gateway".
+# Wizard gateway-token mint. WIZARD_GATEWAY_MINT_KEY unset disables the endpoint
+# (404), which the CLI treats as "stay on the legacy gateway".
 WIZARD_GATEWAY_URL = get_from_env("WIZARD_GATEWAY_URL", "")
 WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
-# OAuth application client ids allowed to mint. Required: llm_gateway:read is an
-# internal scope stamped on every sandbox and agent token, so the scope alone does
-# not identify the wizard. Empty refuses every mint.
-# Blank entries filtered: get_list keeps them, and a list of empty strings is
-# truthy, which would read as configured while matching no client id.
+# OAuth application client ids allowed to mint: llm_gateway:read is an internal
+# scope on every sandbox and agent token, so the scope alone does not identify the
+# wizard. Empty refuses every mint, and blanks are filtered because a list of
+# empty strings is truthy and would read as configured.
 WIZARD_GATEWAY_CLIENT_IDS = [
     client_id for client_id in get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", "")) if client_id
 ]

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1330,7 +1330,7 @@ WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
 WIZARD_GATEWAY_CLIENT_IDS = [
     client_id for client_id in get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", "")) if client_id
 ]
-WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "50")
+WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "10")
 WIZARD_GATEWAY_TOKEN_TTL_SECONDS = get_from_env("WIZARD_GATEWAY_TOKEN_TTL_SECONDS", 86400, type_cast=int)
 
 # Sharing configuration settings

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1,5 +1,6 @@
 # Web app specific settings/middleware/apps setup
 import os
+import json
 from datetime import timedelta
 
 import structlog
@@ -1311,6 +1312,22 @@ AI_GATEWAY_INTERNAL_TOKEN = get_from_env("AI_GATEWAY_INTERNAL_TOKEN", "")
 # secret for routing LLM calls through the gateway. Unset = direct to the provider.
 AI_GATEWAY_URL = get_from_env("AI_GATEWAY_URL", "")
 AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
+
+# Internal-product posture projected into gateway_credential.json blobs.
+# NON_BILLABLE: comma-separated team ids whose gateway spend is PostHog-funded
+# (the gateway stamps $ai_billable=false). TIER_OVERRIDES: JSON map of team id
+# (string) -> tier ("free"/"pro"/"enterprise") for the gateway rate-limit bucket.
+AI_GATEWAY_NON_BILLABLE_TEAM_IDS = get_list(get_from_env("AI_GATEWAY_NON_BILLABLE_TEAM_IDS", ""))
+AI_GATEWAY_TEAM_TIER_OVERRIDES = get_from_env("AI_GATEWAY_TEAM_TIER_OVERRIDES", {}, type_cast=json.loads)
+
+# Wizard gateway-token mint (the wizard CLI's v2 auth): the wizard team's phs_
+# used as the mint bearer, the gateway base URL handed to the CLI, and the
+# per-run bounds. WIZARD_GATEWAY_MINT_KEY unset disables the endpoint (404),
+# which the CLI treats as "stay on the legacy gateway".
+WIZARD_GATEWAY_URL = get_from_env("WIZARD_GATEWAY_URL", "")
+WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
+WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "50")
+WIZARD_GATEWAY_TOKEN_TTL_SECONDS = get_from_env("WIZARD_GATEWAY_TOKEN_TTL_SECONDS", 86400, type_cast=int)
 
 # Sharing configuration settings
 SHARING_TOKEN_GRACE_PERIOD_SECONDS = 60 * 5  # 5 minutes

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1329,7 +1329,11 @@ WIZARD_GATEWAY_MINT_KEY = get_from_env("WIZARD_GATEWAY_MINT_KEY", "")
 # OAuth application client ids allowed to mint. Required: llm_gateway:read is an
 # internal scope stamped on every sandbox and agent token, so the scope alone does
 # not identify the wizard. Empty refuses every mint.
-WIZARD_GATEWAY_CLIENT_IDS = get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", ""))
+# Blank entries filtered: get_list keeps them, and a list of empty strings is
+# truthy, which would read as configured while matching no client id.
+WIZARD_GATEWAY_CLIENT_IDS = [
+    client_id for client_id in get_list(get_from_env("WIZARD_GATEWAY_CLIENT_IDS", "")) if client_id
+]
 WIZARD_GATEWAY_TOKEN_CAP_USD = get_from_env("WIZARD_GATEWAY_TOKEN_CAP_USD", "50")
 WIZARD_GATEWAY_TOKEN_TTL_SECONDS = get_from_env("WIZARD_GATEWAY_TOKEN_TTL_SECONDS", 86400, type_cast=int)
 

--- a/posthog/storage/gateway_credential_cache.py
+++ b/posthog/storage/gateway_credential_cache.py
@@ -6,7 +6,7 @@ so the secret never sits in a Redis key. Public phc_ project tokens can't dispat
 
     Key: cache/team_tokens_hashed/<sha256$hex>/team_metadata/gateway_credential.json
     Body: {team_id, project_token, scopes, billing_mode, revoked_at,
-           overspend_allowance_usd?, billable?, tier?}
+           overspend_allowance_usd?, tier?}
 
 The hash matches Django's hash_key_value(token, mode="sha256") = "sha256$"+hex, which the
 gateway derives identically. A credential holding llm_gateway:read attributes to its team
@@ -69,11 +69,10 @@ GATEWAY_CREDENTIAL_FIELDS = [
     "revoked_at",
 ]
 
-# Internal-product posture (gateway-defined, internal/auth/gateway_credential.go):
-# billable:false marks PostHog-funded spend, tier feeds the rate-limit/shed bucket.
-# Settings-driven rather than Team columns: a handful of internal teams, and a
-# settings change lands on the hourly reprojection with no signal wiring.
-BILLABLE_KEY = "billable"
+# Tier (gateway-defined, internal/auth/gateway_credential.go) feeds the
+# rate-limit/shed bucket. Settings-driven rather than a Team column: a handful of
+# internal teams, and a settings change lands on the hourly reprojection with no
+# signal wiring.
 TIER_KEY = "tier"
 GATEWAY_KNOWN_TIERS = {"free", "pro", "enterprise"}
 
@@ -298,10 +297,8 @@ def _policy_for_credential(
     if allowance is not None:
         policy[OVERSPEND_ALLOWANCE_KEY] = format_overspend_allowance_usd(allowance)
 
-    # Absent means billable / tier-unknown on the gateway, so ordinary teams' blobs
-    # stay byte-identical.
-    if team.id in _non_billable_team_ids():
-        policy[BILLABLE_KEY] = False
+    # Absent means tier-unknown on the gateway, so ordinary teams' blobs stay
+    # byte-identical.
     tier = _team_tier_overrides().get(str(team.id))
     if tier is not None:
         # isinstance first: an unhashable value from the JSON setting would raise on
@@ -313,20 +310,6 @@ def _policy_for_credential(
             logger.warning("gateway_credential: unrecognized tier override, not projecting", team_id=team.id, tier=tier)
 
     return policy
-
-
-def _non_billable_team_ids() -> set[int]:
-    """Teams whose gateway spend is PostHog-funded (never customer-billable). A
-    non-numeric entry is skipped rather than raised: this runs inside every
-    credential projection, and an aborted refresh expires the whole cache.
-    """
-    ids: set[int] = set()
-    for team_id in getattr(settings, "AI_GATEWAY_NON_BILLABLE_TEAM_IDS", []) or []:
-        try:
-            ids.add(int(team_id))
-        except (TypeError, ValueError):
-            logger.warning("gateway_credential: non-numeric non-billable team id, skipping", team_id=team_id)
-    return ids
 
 
 def _team_tier_overrides() -> dict[str, str]:

--- a/posthog/storage/gateway_credential_cache.py
+++ b/posthog/storage/gateway_credential_cache.py
@@ -70,11 +70,9 @@ GATEWAY_CREDENTIAL_FIELDS = [
 ]
 
 # Internal-product posture (gateway-defined, internal/auth/gateway_credential.go):
-# billable:false marks spend the gateway stamps $ai_billable=false (PostHog-funded
-# products like the setup wizard); tier feeds the gateway's rate-limit/shed bucket.
-# Both are settings-driven maps rather than Team columns: they apply to a handful
-# of internal teams, and a settings change takes effect on the hourly full
-# reprojection without signal wiring.
+# billable:false marks PostHog-funded spend, tier feeds the rate-limit/shed bucket.
+# Settings-driven rather than Team columns: a handful of internal teams, and a
+# settings change lands on the hourly reprojection with no signal wiring.
 BILLABLE_KEY = "billable"
 TIER_KEY = "tier"
 GATEWAY_KNOWN_TIERS = {"free", "pro", "enterprise"}
@@ -300,32 +298,27 @@ def _policy_for_credential(
     if allowance is not None:
         policy[OVERSPEND_ALLOWANCE_KEY] = format_overspend_allowance_usd(allowance)
 
-    # Omit both posture fields unless set: absent means billable / tier-unknown
-    # on the gateway side, so blobs for ordinary teams stay byte-identical.
+    # Absent means billable / tier-unknown on the gateway, so ordinary teams' blobs
+    # stay byte-identical.
     if team.id in _non_billable_team_ids():
         policy[BILLABLE_KEY] = False
     tier = _team_tier_overrides().get(str(team.id))
     if tier is not None:
-        # isinstance first: an unhashable value (a list or dict from the JSON
-        # setting) would raise on the set membership below, inside a projection
-        # whose failure expires every credential blob.
+        # isinstance first: an unhashable value from the JSON setting would raise on
+        # the membership test, inside a projection whose failure expires every blob.
         if isinstance(tier, str) and tier in GATEWAY_KNOWN_TIERS:
             policy[TIER_KEY] = tier
         else:
-            # Dropping it silently would also suppress the gateway's own
-            # unrecognized-tier warning, leaving a typo with no signal anywhere.
+            # The gateway never sees the value, so this is the only signal a typo gets.
             logger.warning("gateway_credential: unrecognized tier override, not projecting", team_id=team.id, tier=tier)
 
     return policy
 
 
 def _non_billable_team_ids() -> set[int]:
-    """Teams whose gateway spend is PostHog-funded (never customer-billable).
-
-    Read per call so tests can override_settings without cache poking. A
+    """Teams whose gateway spend is PostHog-funded (never customer-billable). A
     non-numeric entry is skipped rather than raised: this runs inside every
-    credential projection, so one malformed entry must not stop the others
-    (an aborted refresh expires the whole credential cache).
+    credential projection, and an aborted refresh expires the whole cache.
     """
     ids: set[int] = set()
     for team_id in getattr(settings, "AI_GATEWAY_NON_BILLABLE_TEAM_IDS", []) or []:
@@ -337,9 +330,8 @@ def _non_billable_team_ids() -> set[int]:
 
 
 def _team_tier_overrides() -> dict[str, str]:
-    """Explicit team_id (string) -> tier map for the gateway's rate-limit bucket.
-
-    A non-mapping value degrades to no overrides for the same reason as above.
+    """Explicit team_id (string) -> tier map for the gateway's rate-limit bucket. A
+    non-mapping value degrades to no overrides rather than failing the projection.
     """
     raw = getattr(settings, "AI_GATEWAY_TEAM_TIER_OVERRIDES", {}) or {}
     if not isinstance(raw, dict):
@@ -349,11 +341,9 @@ def _team_tier_overrides() -> dict[str, str]:
 
 
 def oauth_credential_authorized(credential: OAuthAccessToken, team: Any) -> bool:
-    """Whether an OAuth credential is still authorized for team right now.
-
-    Public entry point for callers outside the projection (the wizard mint
-    endpoint) that must re-check what a token's frozen scoped_teams cannot see:
-    the user is active, a member, and still has project access.
+    """Whether an OAuth credential is still authorized for team right now: the user
+    is active, a member, and still has project access. Callers outside the
+    projection need it because a token's scoped_teams is frozen at consent.
     """
     return _oauth_authorization_ok(credential, team, team.id, None)
 

--- a/posthog/storage/gateway_credential_cache.py
+++ b/posthog/storage/gateway_credential_cache.py
@@ -5,7 +5,8 @@ One blob per phs_ project secret key / pha_ OAuth token, keyed by the credential
 so the secret never sits in a Redis key. Public phc_ project tokens can't dispatch.
 
     Key: cache/team_tokens_hashed/<sha256$hex>/team_metadata/gateway_credential.json
-    Body: {team_id, project_token, scopes, billing_mode, revoked_at, overspend_allowance_usd?}
+    Body: {team_id, project_token, scopes, billing_mode, revoked_at,
+           overspend_allowance_usd?, billable?, tier?}
 
 The hash matches Django's hash_key_value(token, mode="sha256") = "sha256$"+hex, which the
 gateway derives identically. A credential holding llm_gateway:read attributes to its team
@@ -304,22 +305,54 @@ def _policy_for_credential(
     if team.id in _non_billable_team_ids():
         policy[BILLABLE_KEY] = False
     tier = _team_tier_overrides().get(str(team.id))
-    if tier in GATEWAY_KNOWN_TIERS:
-        policy[TIER_KEY] = tier
+    if tier is not None:
+        if tier in GATEWAY_KNOWN_TIERS:
+            policy[TIER_KEY] = tier
+        else:
+            # Dropping it silently would also suppress the gateway's own
+            # unrecognized-tier warning, leaving a typo with no signal anywhere.
+            logger.warning("gateway_credential: unrecognized tier override, not projecting", team_id=team.id, tier=tier)
 
     return policy
 
 
 def _non_billable_team_ids() -> set[int]:
     """Teams whose gateway spend is PostHog-funded (never customer-billable).
-    Read per call so tests can override_settings without cache poking."""
-    raw = getattr(settings, "AI_GATEWAY_NON_BILLABLE_TEAM_IDS", []) or []
-    return {int(team_id) for team_id in raw}
+
+    Read per call so tests can override_settings without cache poking. A
+    non-numeric entry is skipped rather than raised: this runs inside every
+    credential projection, so one malformed entry must not stop the others
+    (an aborted refresh expires the whole credential cache).
+    """
+    ids: set[int] = set()
+    for team_id in getattr(settings, "AI_GATEWAY_NON_BILLABLE_TEAM_IDS", []) or []:
+        try:
+            ids.add(int(team_id))
+        except (TypeError, ValueError):
+            logger.warning("gateway_credential: non-numeric non-billable team id, skipping", team_id=team_id)
+    return ids
 
 
 def _team_tier_overrides() -> dict[str, str]:
-    """Explicit team_id (string) -> tier map for the gateway's rate-limit bucket."""
-    return getattr(settings, "AI_GATEWAY_TEAM_TIER_OVERRIDES", {}) or {}
+    """Explicit team_id (string) -> tier map for the gateway's rate-limit bucket.
+
+    A non-mapping value degrades to no overrides for the same reason as above.
+    """
+    raw = getattr(settings, "AI_GATEWAY_TEAM_TIER_OVERRIDES", {}) or {}
+    if not isinstance(raw, dict):
+        logger.warning("gateway_credential: tier overrides setting is not a mapping, ignoring")
+        return {}
+    return raw
+
+
+def oauth_credential_authorized(credential: OAuthAccessToken, team: Any) -> bool:
+    """Whether an OAuth credential is still authorized for team right now.
+
+    Public entry point for callers outside the projection (the wizard mint
+    endpoint) that must re-check what a token's frozen scoped_teams cannot see:
+    the user is active, a member, and still has project access.
+    """
+    return _oauth_authorization_ok(credential, team, team.id, None)
 
 
 def _resolve_credential(hash_key: str) -> Credential | None:

--- a/posthog/storage/gateway_credential_cache.py
+++ b/posthog/storage/gateway_credential_cache.py
@@ -306,7 +306,10 @@ def _policy_for_credential(
         policy[BILLABLE_KEY] = False
     tier = _team_tier_overrides().get(str(team.id))
     if tier is not None:
-        if tier in GATEWAY_KNOWN_TIERS:
+        # isinstance first: an unhashable value (a list or dict from the JSON
+        # setting) would raise on the set membership below, inside a projection
+        # whose failure expires every credential blob.
+        if isinstance(tier, str) and tier in GATEWAY_KNOWN_TIERS:
             policy[TIER_KEY] = tier
         else:
             # Dropping it silently would also suppress the gateway's own

--- a/posthog/storage/gateway_credential_cache.py
+++ b/posthog/storage/gateway_credential_cache.py
@@ -68,6 +68,16 @@ GATEWAY_CREDENTIAL_FIELDS = [
     "revoked_at",
 ]
 
+# Internal-product posture (gateway-defined, internal/auth/gateway_credential.go):
+# billable:false marks spend the gateway stamps $ai_billable=false (PostHog-funded
+# products like the setup wizard); tier feeds the gateway's rate-limit/shed bucket.
+# Both are settings-driven maps rather than Team columns: they apply to a handful
+# of internal teams, and a settings change takes effect on the hourly full
+# reprojection without signal wiring.
+BILLABLE_KEY = "billable"
+TIER_KEY = "tier"
+GATEWAY_KNOWN_TIERS = {"free", "pro", "enterprise"}
+
 # Overspend allowance wire contract (gateway-defined, internal/auth/gateway_credential.go):
 # fixed-point USD string, 6dp, present only when set. Out-of-range/malformed clamps to 0 there,
 # so we validate at the write surfaces instead of relying on the clamp.
@@ -289,7 +299,27 @@ def _policy_for_credential(
     if allowance is not None:
         policy[OVERSPEND_ALLOWANCE_KEY] = format_overspend_allowance_usd(allowance)
 
+    # Omit both posture fields unless set: absent means billable / tier-unknown
+    # on the gateway side, so blobs for ordinary teams stay byte-identical.
+    if team.id in _non_billable_team_ids():
+        policy[BILLABLE_KEY] = False
+    tier = _team_tier_overrides().get(str(team.id))
+    if tier in GATEWAY_KNOWN_TIERS:
+        policy[TIER_KEY] = tier
+
     return policy
+
+
+def _non_billable_team_ids() -> set[int]:
+    """Teams whose gateway spend is PostHog-funded (never customer-billable).
+    Read per call so tests can override_settings without cache poking."""
+    raw = getattr(settings, "AI_GATEWAY_NON_BILLABLE_TEAM_IDS", []) or []
+    return {int(team_id) for team_id in raw}
+
+
+def _team_tier_overrides() -> dict[str, str]:
+    """Explicit team_id (string) -> tier map for the gateway's rate-limit bucket."""
+    return getattr(settings, "AI_GATEWAY_TEAM_TIER_OVERRIDES", {}) or {}
 
 
 def _resolve_credential(hash_key: str) -> Credential | None:

--- a/posthog/storage/test/test_gateway_credential_cache.py
+++ b/posthog/storage/test/test_gateway_credential_cache.py
@@ -26,6 +26,7 @@ from posthog.storage.gateway_credential_cache import (
     GATEWAY_CREDENTIAL_FIELDS,
     GATEWAY_CREDENTIAL_LAST_USED_KEY,
     GATEWAY_CREDENTIAL_SECRET_KEY_CACHE_TTL,
+    GATEWAY_KNOWN_TIERS,
     OVERSPEND_ALLOWANCE_KEY,
     TIER_KEY,
     clear_gateway_credential,
@@ -225,6 +226,19 @@ class TestGatewayCredentialWireShape(GatewayCredentialTestMixin):
         blob = self._read_blob(credential_hash(credential))
         assert blob is not None
         self.assertNotIn(TIER_KEY, blob)
+
+    def test_the_writable_tiers_are_the_gateway_vocabulary_minus_the_sentinel(self):
+        # The gateway owns this vocabulary in internal/principal/tiers.go and
+        # holds free/pro/enterprise/unknown. "unknown" is its sentinel for a tier
+        # it could not resolve, so projecting it would assert a value rather than
+        # leave the field absent; the writable set is the rest.
+        #
+        # Nothing can import across the repositories, so this pins the literal and
+        # catches this set drifting on its own. A gateway-side change shows up as
+        # gateway.auth.tier_unrecognized.total going nonzero for credential blobs,
+        # but not for a tier already stamped into a live scoped-token structure,
+        # which degrades to unknown with no signal.
+        self.assertEqual(GATEWAY_KNOWN_TIERS, {"free", "pro", "enterprise"})
 
 
 class TestOverspendAllowanceFormatting(BaseTest):

--- a/posthog/storage/test/test_gateway_credential_cache.py
+++ b/posthog/storage/test/test_gateway_credential_cache.py
@@ -23,7 +23,6 @@ from posthog.models.utils import SHA256_HASH_PREFIX, generate_random_token, gene
 from posthog.redis import get_client
 from posthog.settings.utils import generate_rsa_private_key_pem
 from posthog.storage.gateway_credential_cache import (
-    BILLABLE_KEY,
     GATEWAY_CREDENTIAL_FIELDS,
     GATEWAY_CREDENTIAL_LAST_USED_KEY,
     GATEWAY_CREDENTIAL_SECRET_KEY_CACHE_TTL,
@@ -198,26 +197,23 @@ class TestGatewayCredentialWireShape(GatewayCredentialTestMixin):
         self.assertEqual(blob[OVERSPEND_ALLOWANCE_KEY], expected)
         self.assertIsInstance(blob[OVERSPEND_ALLOWANCE_KEY], str)
 
-    def test_posture_fields_omitted_by_default(self):
-        # Absent means billable / tier-unknown on the gateway; ordinary teams'
-        # blobs must stay byte-identical to the pre-posture shape.
+    def test_tier_omitted_by_default(self):
+        # Absent means tier-unknown on the gateway; ordinary teams' blobs must
+        # stay byte-identical to the pre-tier shape.
         credential, _ = self._make_secret_key([GATEWAY_SCOPE])
         project_gateway_credential(credential)
         blob = self._read_blob(credential_hash(credential))
         assert blob is not None
-        self.assertNotIn(BILLABLE_KEY, blob)
         self.assertNotIn(TIER_KEY, blob)
 
-    def test_posture_fields_projected_for_configured_team(self):
+    def test_tier_projected_for_configured_team(self):
         credential, _ = self._make_secret_key([GATEWAY_SCOPE])
         with override_settings(
-            AI_GATEWAY_NON_BILLABLE_TEAM_IDS=[str(self.team.id)],
             AI_GATEWAY_TEAM_TIER_OVERRIDES={str(self.team.id): "enterprise"},
         ):
             project_gateway_credential(credential)
         blob = self._read_blob(credential_hash(credential))
         assert blob is not None
-        self.assertIs(blob[BILLABLE_KEY], False)
         self.assertEqual(blob[TIER_KEY], "enterprise")
 
     def test_unknown_tier_override_not_projected(self):

--- a/posthog/storage/test/test_gateway_credential_cache.py
+++ b/posthog/storage/test/test_gateway_credential_cache.py
@@ -23,10 +23,12 @@ from posthog.models.utils import SHA256_HASH_PREFIX, generate_random_token, gene
 from posthog.redis import get_client
 from posthog.settings.utils import generate_rsa_private_key_pem
 from posthog.storage.gateway_credential_cache import (
+    BILLABLE_KEY,
     GATEWAY_CREDENTIAL_FIELDS,
     GATEWAY_CREDENTIAL_LAST_USED_KEY,
     GATEWAY_CREDENTIAL_SECRET_KEY_CACHE_TTL,
     OVERSPEND_ALLOWANCE_KEY,
+    TIER_KEY,
     clear_gateway_credential,
     credential_hash,
     drain_gateway_credential_last_used,
@@ -195,6 +197,38 @@ class TestGatewayCredentialWireShape(GatewayCredentialTestMixin):
         # Pin the literal wire value, not a serializer round-trip.
         self.assertEqual(blob[OVERSPEND_ALLOWANCE_KEY], expected)
         self.assertIsInstance(blob[OVERSPEND_ALLOWANCE_KEY], str)
+
+    def test_posture_fields_omitted_by_default(self):
+        # Absent means billable / tier-unknown on the gateway; ordinary teams'
+        # blobs must stay byte-identical to the pre-posture shape.
+        credential, _ = self._make_secret_key([GATEWAY_SCOPE])
+        project_gateway_credential(credential)
+        blob = self._read_blob(credential_hash(credential))
+        assert blob is not None
+        self.assertNotIn(BILLABLE_KEY, blob)
+        self.assertNotIn(TIER_KEY, blob)
+
+    def test_posture_fields_projected_for_configured_team(self):
+        credential, _ = self._make_secret_key([GATEWAY_SCOPE])
+        with override_settings(
+            AI_GATEWAY_NON_BILLABLE_TEAM_IDS=[str(self.team.id)],
+            AI_GATEWAY_TEAM_TIER_OVERRIDES={str(self.team.id): "enterprise"},
+        ):
+            project_gateway_credential(credential)
+        blob = self._read_blob(credential_hash(credential))
+        assert blob is not None
+        self.assertIs(blob[BILLABLE_KEY], False)
+        self.assertEqual(blob[TIER_KEY], "enterprise")
+
+    def test_unknown_tier_override_not_projected(self):
+        # A typo'd tier must not reach the wire; the gateway would degrade it to
+        # unknown anyway, but the blob should stay clean.
+        credential, _ = self._make_secret_key([GATEWAY_SCOPE])
+        with override_settings(AI_GATEWAY_TEAM_TIER_OVERRIDES={str(self.team.id): "platinum"}):
+            project_gateway_credential(credential)
+        blob = self._read_blob(credential_hash(credential))
+        assert blob is not None
+        self.assertNotIn(TIER_KEY, blob)
 
 
 class TestOverspendAllowanceFormatting(BaseTest):


### PR DESCRIPTION
## Problem

The setup wizard sends the end user's own OAuth token to the LLM gateway, so gateway spend authenticates as the customer's team. On the Go ai-gateway that inverts: PostHog funds the spend, and each run stays attributable to the customer it ran for. Nothing enforces that today, because whoever holds the credential can change a header-asserted attribution value.

## Changes

Adds a mint endpoint the wizard CLI calls after OAuth, returning a short-lived `phe_` scoped token with **product, customer organization and acting user pinned at mint** so the caller cannot move its own spend.

- The product node is **per program** (`wizard:<program>`), so budgets and mint quotas are per program. An **authoritative allowlist** decides which may be pinned; an unlisted program is refused rather than folded into a generic node that would bill it as plain wizard spend.
- Refusal answers **404**, the one status the CLI falls back on, so an unknown program keeps running on legacy instead of having its run killed.
- Admission is the wizard's **own OAuth application**, by client id. `llm_gateway:read` is on every sandbox and agent token, so scope alone would let those mint PostHog-funded credentials.
- **5 mints/day per user per program**, reserved atomically just before the mint. A failed mint returns the slot only when the failure proves no token was issued.
- Every terminal exit increments the outcome counter. Three did not, so a user hitting their daily limit produced a 429 no dashboard could see.
- Mechanical: `gateway_credential.json` gains `tier` from a settings-driven team map.

**Order:** inert on merge, since the endpoint 404s until the charts settings land. Requires PostHog/wizard#1130, which sends the program id.

## How did you test this code?

Automated, plus a local run against a real gateway and a real OAuth token.

`test_wizard_gateway_token.py` covers the outbound request, the program resolver, and each knob's fallback, including caps that reach the quantize guard rather than stopping at the range check. `test_http.py -k GatewayToken` covers a foreign-application token, revoked project access, a non-string program, and both branches of the refund decision.

Locally I drove all six terminal outcomes and confirmed each counter moved by exactly one, and that a minted token carries the pinned product, the customer organization id, and the inherited tier. I could not run the endpoint-level tests: every test in that class errors on a stale local ClickHouse schema, so CI is the only place they execute.

**Deploy order:** the mint key must exist in `posthog-django-shared-secrets` before the charts change referencing it. That reference is not optional, so a missing property stops new pods starting, not just the sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5); requires human review.
