### PR TITLE
fix(comments): tell people when the discussion failed to load

### DIFF
--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -137,7 +137,7 @@ const CommentBottomRow = ({ comment }: { comment: CommentType }): JSX.Element | 
 }
 
 const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element => {
-    const { editingComment, commentsLoading, editingCommentRichContentEditor, isEditingCommentEmpty } =
+    const { editingComment, isSavingEditedComment, editingCommentRichContentEditor, isEditingCommentEmpty } =
         useValues(commentsLogic)
     const {
         setEditingComment,
@@ -163,7 +163,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                     }
                 }}
                 onPressCmdEnter={persistEditedComment}
-                disabled={commentsLoading}
+                disabled={isSavingEditedComment}
             />
             <div className="flex justify-end items-center gap-2">
                 <LemonButton
@@ -173,7 +173,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                         setEditingComment(null)
                         setEditingCommentRichContentEditor(null)
                     }}
-                    disabled={commentsLoading}
+                    disabled={isSavingEditedComment}
                 >
                     Cancel
                 </LemonButton>
@@ -181,7 +181,7 @@ const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element 
                     type="primary"
                     size="small"
                     onClick={persistEditedComment}
-                    disabledReason={isEditingCommentEmpty ? 'No message' : commentsLoading ? 'Saving...' : null}
+                    disabledReason={isEditingCommentEmpty ? 'No message' : isSavingEditedComment ? 'Saving...' : null}
                     sideIcon={<KeyboardShortcut command enter />}
                 >
                     Save

--- a/frontend/src/scenes/comments/CommentsList.test.tsx
+++ b/frontend/src/scenes/comments/CommentsList.test.tsx
@@ -12,6 +12,13 @@ import { commentsLogic } from './commentsLogic'
 
 const PROPS = { scope: ActivityScope.TICKET, item_id: 'ticket-1' }
 
+const FAILING_LOAD = {
+    get: {
+        '/api/projects/:team_id/comments': () => [500, { detail: 'nope' }],
+        '/api/organizations/@current/members/': { results: [] },
+    },
+}
+
 afterEach(cleanup)
 
 describe('CommentsList', () => {
@@ -60,5 +67,47 @@ describe('CommentsList', () => {
 
         // Let the refresh land, so its request doesn't settle after teardown
         await waitFor(() => expect(logic.values.commentsLoading).toBe(false))
+    })
+
+    const mountAndRender = (): ReturnType<typeof commentsLogic.build> => {
+        const logic = commentsLogic(PROPS)
+        logic.mount()
+
+        render(
+            <Provider>
+                <CommentsList {...PROPS} />
+            </Provider>
+        )
+
+        return logic
+    }
+
+    it('shows an error state when the first load fails', async () => {
+        initKeaTests()
+        useMocks(FAILING_LOAD)
+        const logic = mountAndRender()
+
+        await waitFor(() => expect(screen.getByText("Couldn't load the discussion.")).toBeInTheDocument())
+        // A thread nobody has posted in and a thread that never answered read the same otherwise, so
+        // the reader is invited to start a discussion that may already be underway
+        expect(screen.queryByText('Start the discussion!')).not.toBeInTheDocument()
+        expect(logic.values.comments).toBe(null)
+    })
+
+    it('keeps the error state through a background refresh', async () => {
+        initKeaTests()
+        useMocks(FAILING_LOAD)
+        const logic = mountAndRender()
+
+        await waitFor(() => expect(screen.getByText("Couldn't load the discussion.")).toBeInTheDocument())
+
+        act(() => {
+            logic.actions.refreshComments()
+        })
+        expect(logic.values.commentsLoading).toBe(true)
+        expect(screen.getByText("Couldn't load the discussion.")).toBeInTheDocument()
+
+        await waitFor(() => expect(logic.values.commentsLoading).toBe(false))
+        expect(screen.getByText("Couldn't load the discussion.")).toBeInTheDocument()
     })
 })

--- a/frontend/src/scenes/comments/CommentsList.test.tsx
+++ b/frontend/src/scenes/comments/CommentsList.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { ActivityScope } from '~/types'
+
+import { CommentsList } from './CommentsList'
+import { commentsLogic } from './commentsLogic'
+
+const PROPS = { scope: ActivityScope.TICKET, item_id: 'ticket-1' }
+
+afterEach(cleanup)
+
+describe('CommentsList', () => {
+    // Loading, empty, and loaded are three different screens, and a thread that has already answered
+    // is never the first of them again. Branching the skeleton on `commentsLoading` broke that: the
+    // ticket page polls `refreshComments` every 20 seconds, that shares the loader's flag with the
+    // first fetch, so an open panel dropped its empty state and jumped the composer up the panel
+    // every 20 seconds while someone was typing into it.
+    it('shows the empty state once loaded and keeps it through a background refresh', async () => {
+        initKeaTests()
+
+        let answerFirstLoad: () => void = () => {}
+        const firstLoadReached = new Promise<void>((resolve) => {
+            answerFirstLoad = resolve
+        })
+        useMocks({
+            get: {
+                '/api/projects/:team_id/comments': async () => {
+                    await firstLoadReached
+                    return [200, { results: [] }]
+                },
+                '/api/organizations/@current/members/': { results: [] },
+            },
+        })
+
+        const logic = commentsLogic(PROPS)
+        logic.mount()
+
+        render(
+            <Provider>
+                <CommentsList {...PROPS} />
+            </Provider>
+        )
+
+        // Nothing has answered yet, so there is no empty thread to claim
+        expect(screen.queryByText('Start the discussion!')).not.toBeInTheDocument()
+
+        await act(async () => {
+            answerFirstLoad()
+        })
+        await waitFor(() => expect(screen.getByText('Start the discussion!')).toBeInTheDocument())
+
+        act(() => {
+            logic.actions.refreshComments()
+        })
+        expect(logic.values.commentsLoading).toBe(true)
+        expect(screen.getByText('Start the discussion!')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/comments/CommentsList.test.tsx
+++ b/frontend/src/scenes/comments/CommentsList.test.tsx
@@ -16,10 +16,8 @@ afterEach(cleanup)
 
 describe('CommentsList', () => {
     // Loading, empty, and loaded are three different screens, and a thread that has already answered
-    // is never the first of them again. Branching the skeleton on `commentsLoading` broke that: the
-    // ticket page polls `refreshComments` every 20 seconds, that shares the loader's flag with the
-    // first fetch, so an open panel dropped its empty state and jumped the composer up the panel
-    // every 20 seconds while someone was typing into it.
+    // is never the first of them again. The ticket page refreshes this one every 20 seconds, and
+    // every handler on the `comments` loader shares one loading flag with the first fetch.
     it('shows the empty state once loaded and keeps it through a background refresh', async () => {
         initKeaTests()
 
@@ -59,5 +57,8 @@ describe('CommentsList', () => {
         })
         expect(logic.values.commentsLoading).toBe(true)
         expect(screen.getByText('Start the discussion!')).toBeInTheDocument()
+
+        // Let the refresh land, so its request doesn't settle after teardown
+        await waitFor(() => expect(logic.values.commentsLoading).toBe(false))
     })
 })

--- a/frontend/src/scenes/comments/CommentsList.tsx
+++ b/frontend/src/scenes/comments/CommentsList.tsx
@@ -17,7 +17,7 @@ export interface CommentsListProps extends CommentsLogicProps {
 }
 
 export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JSX.Element => {
-    const { key, commentsWithReplies, commentsLoading } = useValues(commentsLogic(props))
+    const { key, commentsWithReplies, commentsInitialLoading } = useValues(commentsLogic(props))
     const { loadComments, setReplyingComment, clearRichContentEditor } = useActions(commentsLogic(props))
 
     // If the comment list focus changes we should load the comments
@@ -38,7 +38,7 @@ export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JS
     return (
         <BindLogic logic={commentsLogic} props={props}>
             <div className="flex flex-col">
-                {!commentsWithReplies?.length && commentsLoading ? (
+                {!commentsWithReplies?.length && commentsInitialLoading ? (
                     <div className="deprecated-space-y-2">
                         <LemonSkeleton className="h-10 w-full" />
                     </div>

--- a/frontend/src/scenes/comments/CommentsList.tsx
+++ b/frontend/src/scenes/comments/CommentsList.tsx
@@ -38,7 +38,7 @@ export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JS
     return (
         <BindLogic logic={commentsLogic} props={props}>
             <div className="flex flex-col">
-                {!commentsWithReplies?.length && commentsInitialLoading ? (
+                {commentsInitialLoading ? (
                     <div className="deprecated-space-y-2">
                         <LemonSkeleton className="h-10 w-full" />
                     </div>

--- a/frontend/src/scenes/comments/CommentsList.tsx
+++ b/frontend/src/scenes/comments/CommentsList.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import * as phoneCall from '@posthog/brand/hoggies/png/phone-call'
-import { LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { pngHoggie } from 'lib/brand/hoggies'
 
@@ -17,7 +17,9 @@ export interface CommentsListProps extends CommentsLogicProps {
 }
 
 export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JSX.Element => {
-    const { key, commentsWithReplies, commentsInitialLoading } = useValues(commentsLogic(props))
+    const { key, commentsWithReplies, commentsInitialLoading, commentsInitialLoadFailed } = useValues(
+        commentsLogic(props)
+    )
     const { loadComments, setReplyingComment, clearRichContentEditor } = useActions(commentsLogic(props))
 
     // If the comment list focus changes we should load the comments
@@ -38,7 +40,24 @@ export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JS
     return (
         <BindLogic logic={commentsLogic} props={props}>
             <div className="flex flex-col">
-                {commentsInitialLoading ? (
+                {/* Failure before loading, rather than the usual loading-then-error order: the poll
+                    retries a thread that never loaded, so both are true at once every 20 seconds, and
+                    checking loading first would swap the error for a skeleton and back each time.
+                    Retrying clears the failure, so the button still gets its skeleton. */}
+                {commentsInitialLoadFailed ? (
+                    <div className="p-2">
+                        <LemonBanner
+                            type="error"
+                            action={{
+                                children: 'Try again',
+                                onClick: () => loadComments(),
+                                'data-attr': 'comments-load-retry',
+                            }}
+                        >
+                            Couldn't load the discussion.
+                        </LemonBanner>
+                    </div>
+                ) : commentsInitialLoading ? (
                     <div className="deprecated-space-y-2">
                         <LemonSkeleton className="h-10 w-full" />
                     </div>

--- a/frontend/src/scenes/comments/Discussions.stories.tsx
+++ b/frontend/src/scenes/comments/Discussions.stories.tsx
@@ -57,3 +57,13 @@ export const Threads: Story = {}
 export const ReplyingToThread: Story = {
     args: { replyingTo: 'thread-0001' },
 }
+
+export const LoadFailed: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/comments': () => [500, { detail: 'nope' }],
+            },
+        }),
+    ],
+}

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -68,7 +68,9 @@ export interface commentsLogicValues {
     user: UserType | null // userLogic
     commentContexts: Record<string, string>
     comments: CommentType[] | null
+    commentsInitialLoadFailed: boolean
     commentsInitialLoading: boolean
+    commentsLoadFailed: boolean
     commentsLoading: boolean
     commentsWithReplies: CommentWithRepliesType[]
     composerDrafts: Record<string, JSONContent | null>
@@ -360,6 +362,7 @@ export interface commentsLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         key: (arg: any) => string
         commentsInitialLoading: (comments: CommentType[] | null, commentsLoading: boolean) => boolean
+        commentsInitialLoadFailed: (comments: CommentType[] | null, commentsLoadFailed: boolean) => boolean
         sortedComments: (comments: CommentType[] | null) => CommentType[]
         commentsWithReplies: (sortedComments: CommentType[]) => CommentWithRepliesType[]
         emojiReactionsByComment: (sortedComments: CommentType[]) => Record<string, Record<string, CommentType[]>>
@@ -555,6 +558,19 @@ export const commentsLogic = kea<commentsLogicType>([
                 persistEditedComment: () => true,
                 persistEditedCommentSuccess: () => false,
                 persistEditedCommentFailure: () => false,
+            },
+        ],
+        commentsLoadFailed: [
+            false,
+            {
+                // Deliberately not reset when `refreshComments` starts: the background poll runs every
+                // 20 seconds, so clearing it on the way out would take an error state off screen and
+                // put it back each time the poll came round. It clears when a fetch actually answers.
+                loadComments: () => false,
+                loadCommentsSuccess: () => false,
+                loadCommentsFailure: () => true,
+                refreshCommentsSuccess: () => false,
+                refreshCommentsFailure: () => true,
             },
         ],
     }),
@@ -892,6 +908,14 @@ export const commentsLogic = kea<commentsLogicType>([
         commentsInitialLoading: [
             (s) => [s.comments, s.commentsLoading],
             (comments: CommentType[] | null, commentsLoading: boolean): boolean => !comments && commentsLoading,
+        ],
+
+        // A failed poll over a thread that is already on screen is not worth interrupting anyone for,
+        // so this stays false while there is something to read. It reports only the case where the
+        // reader would otherwise be looking at an empty thread that was never actually fetched.
+        commentsInitialLoadFailed: [
+            (s) => [s.comments, s.commentsLoadFailed],
+            (comments: CommentType[] | null, commentsLoadFailed: boolean): boolean => !comments && commentsLoadFailed,
         ],
 
         sortedComments: [

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -68,6 +68,7 @@ export interface commentsLogicValues {
     user: UserType | null // userLogic
     commentContexts: Record<string, string>
     comments: CommentType[] | null
+    commentsInitialLoading: boolean
     commentsLoading: boolean
     commentsWithReplies: CommentWithRepliesType[]
     composerDrafts: Record<string, JSONContent | null>
@@ -84,6 +85,7 @@ export interface commentsLogicValues {
     isEditingCommentEmpty: boolean
     isEmpty: boolean
     isMyComment: (comment: CommentType) => boolean
+    isSavingEditedComment: boolean
     isSendingComment: boolean
     itemContext: CommentContext | null
     key: string
@@ -357,6 +359,7 @@ export interface commentsLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
         key: (arg: any) => string
+        commentsInitialLoading: (comments: CommentType[] | null, commentsLoading: boolean) => boolean
         sortedComments: (comments: CommentType[] | null) => CommentType[]
         commentsWithReplies: (sortedComments: CommentType[]) => CommentWithRepliesType[]
         emojiReactionsByComment: (sortedComments: CommentType[]) => Record<string, Record<string, CommentType[]>>
@@ -544,6 +547,14 @@ export const commentsLogic = kea<commentsLogicType>([
             {
                 onEditingCommentRichContentEditorUpdate: (_, { isEmpty }) => isEmpty,
                 persistEditedCommentSuccess: () => false,
+            },
+        ],
+        isSavingEditedComment: [
+            false,
+            {
+                persistEditedComment: () => true,
+                persistEditedCommentSuccess: () => false,
+                persistEditedCommentFailure: () => false,
             },
         ],
     }),
@@ -873,6 +884,16 @@ export const commentsLogic = kea<commentsLogicType>([
 
     selectors({
         key: [() => [(_, props) => props], (props): string => `${props.scope}-${props.item_id || ''}`],
+
+        // Every handler on the `comments` loader shares `commentsLoading`, including the background
+        // poll's `refreshComments` and the local writes. Only the very first load has nothing to put
+        // on screen; once `comments` is an array the thread is renderable, empty or not, so a
+        // surface that swaps in a skeleton on `commentsLoading` would flash it away on every poll.
+        commentsInitialLoading: [
+            (s) => [s.comments, s.commentsLoading],
+            (comments: CommentType[] | null, commentsLoading: boolean): boolean => !comments && commentsLoading,
+        ],
+
         sortedComments: [
             (s) => [s.comments],
             (comments: CommentType[] | null) => {


### PR DESCRIPTION
## Problem

Someone opening a discussion panel while the comments API is failing sees "Start the discussion!", the screen an empty thread shows. They can post a reply into a thread that already has replies they cannot see.

- A failed first fetch leaves `comments` at null, and nothing records that it was ever asked.
- `CommentsList` reads "no threads to render" as empty, so a failure and an empty thread reach the same branch.
- The panel has no error branch at all.

Follow-up to #87239, which fixed a flicker in the same ternary and left this untouched.

## Changes

- The panel shows "Couldn't load the discussion." and a "Try again" button when the first fetch fails.
- "Try again" refetches. A background poll that succeeds also clears the error on its own.
- A failed poll over a thread that is already on screen changes nothing the reader sees.
- `commentsLoadFailed` records the failure. `commentsInitialLoadFailed` gates it on having nothing to show.
- The failure branch sits ahead of the loading branch, against the usual loading-then-error order.
- That order is deliberate: the ticket page retries every 20 seconds, so both states are true at once, and checking loading first would swap the error for a skeleton on every poll.
- A `LoadFailed` story renders the state in Storybook.

<img width="1280" height="800" alt="shot-p2" src="https://github.com/user-attachments/assets/8ebd40f0-ace2-4f0b-9dfb-a6e62e33dca4" />



> [!NOTE]
> The screenshot is not attached. `hogli pr:upload-image` was blocked by a local permission rule in the authoring session. The rendered state is a `LemonBanner type="error"` reading "Couldn't load the discussion." above a full-width "Try again" button, in place of the hedgehog empty state. `LemonBanner` stacks that button below the text at panel widths under 448px, which is its own responsive behavior and matches every other banner with an action.

## How did you test this code?

Two tests in `CommentsList.test.tsx`:

- "shows an error state when the first load fails" catches a failed load rendering as the empty state. No existing test rendered `CommentsList` against a failing API.
- "keeps the error state through a background refresh" catches the error flickering on the 20 second poll. It fails if the reducer resets on `refreshComments`, or if the ternary checks loading first.

Each test was checked against the mutation it is meant to catch. Removing the error branch fails both. Resetting the flag when the poll starts fails only the second. Swapping the branch order fails only the second.

Rendered the new `LoadFailed` story in a local Storybook through headless Chromium, which is how the full-width button was found. Building the nested `@posthog/quill` workspace first was needed to make Storybook resolve.

Not run: no check against a real API, and no test of the "Try again" click path, which is a one line action call.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No API, setting, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code. This started as a review of #87239, where the missing error state came up as out of scope for that PR. This is that follow-up, stacked on it because both edit the same ternary.

The first version checked loading before failure, following the documented resolution order in `/writing-ui-components`. Rendering it showed that order reintroduces the flicker #87239 fixed, since the retry poll makes loading and failure true together. The order is inverted here for that reason, and a comment at the branch records it.

The banner padding started at `p-4` and moved to `p-2` after the Storybook render.

Skills invoked: `/stacking-prs`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-ui-components`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
