### PR TITLE
feat(replay-vision): open the scanner budget step at 20% and medium-plus activity

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7541,9 +7541,9 @@ snapshots:
     scenes-app-replay-vision--scanner-digests--light:
         hash: v1.k794b7964.7160d1eb03abff790b4ed77db80e5913c3359d80bca9d7f6863321575816e639.Qq99zfKOxqgP8Eu0DmH_s3K_ekEAOzo8VZe7TZVn67I
     scenes-app-replay-vision--scanner-editor-budget--dark:
-        hash: v1.k794b7964.42e4b220cdb14cc2459af06a332f598b81d0623af61d5b348b106353258d55b2.jCp1puvu6N0QmJmwh-EUu3TtKweZSCub1tKNSsDI4Yw
+        hash: v1.k794b7964.37379538a705b9cfdaae3992ffbb357d3f7277abc9b77000c37e5d65d2d9a182.tIr_lkCBHvvxOjUsNFJ_VwNzAkD_MY2q-fN7anGin90
     scenes-app-replay-vision--scanner-editor-budget--light:
-        hash: v1.k794b7964.f9c6c86d7d00060e501ebeb09ab6855d07c9f127e1931170252fd0ffd44fc693.3ey1j5pyzpuYLnVcWk0QPVODM0uPFGlqYp7-llGtmhs
+        hash: v1.k794b7964.092d0c888421a72264c4a608fe726353d7526f77b7ad1cfbef8de96f7c93cc82.AFcQ6LQbNB6EJWNAxAgptev4Tft57cam4gCwpGDFYx8
     scenes-app-replay-vision--scanner-editor-configure--dark:
         hash: v1.k794b7964.61f87066671bf857e14979e95550a61dc07ed7c2bfab99cb4d7360afade82066.mkuP-3M9s_-cH0lTCGcZLkQlBC7MZg5qULwH_jH8_Pk
     scenes-app-replay-vision--scanner-editor-configure--light:

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -46,6 +46,9 @@ const scanner = (overrides: Partial<ReplayScannerApi> = {}): ReplayScannerApi =>
         scanner_config: { prompt: 'Did the user struggle?' },
         query: null,
         sampling_rate: 1,
+        // The API always serializes this (non-null column with a default), so a fixture without it
+        // would render the editor's form default instead of the scanner's own coverage.
+        sampling_mode: 'comprehensive',
         provider: 'google',
         model: 'gemini-3.7-flash',
         enabled: true,

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerBudget.scss
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerBudget.scss
@@ -1,6 +1,6 @@
-// The three option labels total 389px and never wrap.
+// The three option labels total 572px and never wrap, so they stack below that.
 .ScannerSessionCoverage.LemonSegmentedButton {
-    @container (max-width: 400px) {
+    @container (max-width: 580px) {
         width: 100%;
 
         > ul {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -87,7 +87,8 @@ describe('replayScannerLogic', () => {
                 enabled: true,
                 scanner_type: 'monitor',
                 scanner_config: { prompt: '' },
-                sampling_rate: 1,
+                sampling_rate: 0.2,
+                sampling_mode: 'balanced',
             })
         })
 

--- a/products/replay_vision/frontend/replay_scanners/scannerTemplates.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerTemplates.test.ts
@@ -32,7 +32,9 @@ describe('newScanner', () => {
         expect(newScanner(null)).toMatchObject({
             id: 'new',
             enabled: true,
-            sampling_rate: 1,
+            // Narrow by default so the budget step's first estimate isn't a whole-project number.
+            sampling_rate: 0.2,
+            sampling_mode: 'balanced',
             description: '',
             tags: [],
         })

--- a/products/replay_vision/frontend/replay_scanners/scannerTemplates.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerTemplates.ts
@@ -125,8 +125,9 @@ export function newScanner(templateKey?: string | null, teamName?: string | null
         id: 'new',
         enabled: true,
         tags: [] as string[],
-        sampling_rate: 1,
-        sampling_mode: 'comprehensive' as const,
+        // Starts narrow: a wizard that opens on every recording at full rate quotes a scary first number.
+        sampling_rate: 0.2,
+        sampling_mode: 'balanced' as const,
         query: { kind: NodeKind.RecordingsQuery },
         provider: DEFAULT_PROVIDER,
         model: DEFAULT_MODEL,

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -383,21 +383,22 @@ export type ScannerConfig =
 
 export type SamplingMode = 'focused' | 'balanced' | 'comprehensive'
 
+// Ordered broadest to narrowest so the labels read as a ladder.
 export const SAMPLING_MODE_OPTIONS: { value: SamplingMode; label: string; description: string }[] = [
-    {
-        value: 'focused',
-        label: 'Highest activity only',
-        description: 'Only scans the recordings with the most going on.',
-    },
-    {
-        value: 'balanced',
-        label: 'Skip lowest activity',
-        description: 'Skips the lowest-activity recordings, scans everything else.',
-    },
     {
         value: 'comprehensive',
         label: 'All recordings',
-        description: 'Scans every recording that matches your filters, regardless of activity.',
+        description: 'Scans everything that matches your filters, whatever happens in the recording.',
+    },
+    {
+        value: 'balanced',
+        label: 'Medium and high activity recordings',
+        description: 'Skips recordings where almost nothing happens.',
+    },
+    {
+        value: 'focused',
+        label: 'High activity recordings only',
+        description: 'Scans just the busiest recordings. The fewest, and the most likely to be interesting.',
     },
 ]
 


### PR DESCRIPTION
## Problem

Someone creating a Replay Vision scanner lands on the budget step with sampling at 100% and coverage set to every recording. The estimated cost card then quotes what it costs to scan the whole project, which reads as alarming before anyone has tried the product.

The Session coverage labels made it worse. "Highest activity only" and "Skip lowest activity" describe the filter being applied rather than what actually gets scanned, so it wasn't obvious that the middle option is the sensible starting point.

## Changes

- A new scanner now opens the budget step at 20% sampling with medium-and-high activity coverage, so the first cost estimate is a fraction of what it was. Existing scanners are untouched.
- Session coverage now reads "All recordings" / "Medium and high activity recordings" / "High activity recordings only", ordered broadest to narrowest.
- Mechanical: the segmented control's stacking breakpoint moves from 400px to 580px, since the new labels are wider and would otherwise overflow instead of stacking.

Backend defaults are deliberately unchanged, so scanners created through the API or MCP behave exactly as before. No migration.

## How did you test this code?

Automated: updated the two default assertions (`scannerTemplates.test.ts`, `replayScannerLogic.test.ts`) to pin 20% and `balanced`. These catch a silent revert of the defaults, which is the whole point of the change and nothing else asserted.

Manual: rendered the budget step in Storybook (`Scenes-App/Replay Vision → ScannerEditorBudget`) at 1100px and 620px to confirm the longer labels fit on one row and stack cleanly below the new breakpoint. Screenshot upload was unavailable in this environment, so no images are attached.

Not checked: the live app against real recording volumes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills consulted: `/writing-user-facing-copy` for the label and description wording, `/writing-tests` for the assertion changes.

The work started wider. An earlier iteration also gated the Recordings step behind an explicit "scan every recording anyway" checkbox when no filters were set, wired through the kea-forms validator so the wizard refused to advance. That was cut back to defaults and copy only, to keep this shippable as a small change; the friction idea is still open as follow-up work.

One thing worth a reviewer's eye: 20% and `balanced` were chosen to make the first number unalarming, not from data on what coverage people end up settling at. If there's a better-grounded starting point, it's a two-line change in `newScanner()`.
