### PR TITLE
fix(comments): stop doubling line spacing when comments post to Slack

### DIFF
--- a/posthog/comment/formatting.py
+++ b/posthog/comment/formatting.py
@@ -751,9 +751,24 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
         return None
 
     rich_text_elements: list[JSON] = []
-    # Empty paragraphs are blank lines the author typed. They carry to the next section that has
+    # Empty paragraphs are blank lines the author typed. They carry to the next element that has
     # content, so leading and trailing ones fall away — matching what rich_content_to_markdown strips.
     pending_blank_lines = 0
+
+    def open_next_element(starts_its_own_line: bool) -> None:
+        """Emit the line breaks owed before the next element, then clear the debt.
+
+        Sections run together, so one following another needs an explicit line ending on top of any
+        blank lines. A preformatted element is its own code box and already starts a line, so it
+        needs the blank lines alone.
+        """
+        nonlocal pending_blank_lines
+        newlines = pending_blank_lines if starts_its_own_line else pending_blank_lines + 1
+        if rich_text_elements and newlines:
+            rich_text_elements.append(
+                {"type": "rich_text_section", "elements": [{"type": "text", "text": "\n" * newlines}]}
+            )
+        pending_blank_lines = 0
 
     for node in rich_content.get("content", []):
         node_type = node.get("type")
@@ -777,19 +792,14 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
                     pending_blank_lines += 1
                 continue
 
-            if rich_text_elements:
-                separator = "\n" * (pending_blank_lines + 1)
-                rich_text_elements.append(
-                    {"type": "rich_text_section", "elements": [{"type": "text", "text": separator}]}
-                )
-            pending_blank_lines = 0
+            open_next_element(starts_its_own_line=False)
             rich_text_elements.append({"type": "rich_text_section", "elements": section_elements})
             continue
 
         if node_type == "codeBlock":
             code_text = "".join(child.get("text", "") for child in node.get("content", []))
             if code_text:
-                pending_blank_lines = 0
+                open_next_element(starts_its_own_line=True)
                 rich_text_elements.append(
                     {"type": "rich_text_preformatted", "elements": [{"type": "text", "text": code_text}]}
                 )
@@ -798,7 +808,7 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
         if node_type == "image" and include_images:
             src = node.get("attrs", {}).get("src")
             if src:
-                pending_blank_lines = 0
+                open_next_element(starts_its_own_line=False)
                 rich_text_elements.append(
                     {
                         "type": "rich_text_section",

--- a/posthog/comment/formatting.py
+++ b/posthog/comment/formatting.py
@@ -35,6 +35,9 @@ _RE_MD_ESCAPED_CHAR = re.compile(r"\\([\\`*_{}\[\]()#+\-.!|])")
 _RE_ALT_ESCAPE = re.compile(r"([\\\]])")
 _RE_SLACK_EMOJI = re.compile(r":([a-z0-9_+\-]+):")
 _RE_MRKDWN_BLOCKQUOTE_UNESCAPE = re.compile(r"^&gt;", re.MULTILINE)
+_RE_MD_FENCED_CODE = re.compile(r"(^```[^\n]*\n.*?^```)", re.MULTILINE | re.DOTALL)
+_RE_MD_TRAILING_LINE_SPACES = re.compile(r"[ \t]+\n")
+_RE_BLANK_LINE_RUN = re.compile(r"\n{2,}")
 
 
 def escape_slack_mrkdwn(text: str) -> str:
@@ -176,6 +179,24 @@ def strip_slack_user_mentions(text: str) -> str:
     return _RE_SLACK_USER_MENTION.sub("", text)
 
 
+def _markdown_breaks_to_mrkdwn(text: str) -> str:
+    """Translate markdown's vertical whitespace into mrkdwn's.
+
+    Markdown needs a blank line to end a paragraph and two trailing spaces to force a line
+    break, because a lone newline is only a soft wrap. mrkdwn has no soft wrap — every newline
+    already breaks the line — so passing markdown spacing through doubles every gap: a
+    paragraph break renders as a blank line, and a blank line the author typed renders as
+    three. Halving each run of newlines maps one convention onto the other. Fenced code keeps
+    its own spacing, where blank lines are content rather than structure.
+    """
+    parts = _RE_MD_FENCED_CODE.split(text)
+    # split() interleaves the fenced blocks at the odd indices; only the prose needs rewriting.
+    for index in range(0, len(parts), 2):
+        prose = _RE_MD_TRAILING_LINE_SPACES.sub("\n", parts[index])
+        parts[index] = _RE_BLANK_LINE_RUN.sub(lambda match: "\n" * (len(match.group()) // 2), prose)
+    return "".join(parts)
+
+
 def content_to_slack_mrkdwn(
     content: str,
     organization_id: str | UUID | None = None,
@@ -200,6 +221,7 @@ def content_to_slack_mrkdwn(
     if not content:
         return ""
 
+    content = _markdown_breaks_to_mrkdwn(content)
     # Escape mrkdwn control chars up front so user content can't inject links,
     # user mentions, or <!channel>-style broadcasts. The conversions below
     # generate their own <url|label> constructs on top of the escaped text.
@@ -729,6 +751,9 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
         return None
 
     rich_text_elements: list[JSON] = []
+    # Empty paragraphs are blank lines the author typed. They carry to the next section that has
+    # content, so leading and trailing ones fall away — matching what rich_content_to_markdown strips.
+    pending_blank_lines = 0
 
     for node in rich_content.get("content", []):
         node_type = node.get("type")
@@ -747,17 +772,24 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
                         alt = child.get("attrs", {}).get("alt", "image")
                         section_elements.append({"type": "link", "url": src, "text": alt})
 
-            if section_elements:
+            if not section_elements:
                 if rich_text_elements:
-                    rich_text_elements.append(
-                        {"type": "rich_text_section", "elements": [{"type": "text", "text": "\n"}]}
-                    )
-                rich_text_elements.append({"type": "rich_text_section", "elements": section_elements})
+                    pending_blank_lines += 1
+                continue
+
+            if rich_text_elements:
+                separator = "\n" * (pending_blank_lines + 1)
+                rich_text_elements.append(
+                    {"type": "rich_text_section", "elements": [{"type": "text", "text": separator}]}
+                )
+            pending_blank_lines = 0
+            rich_text_elements.append({"type": "rich_text_section", "elements": section_elements})
             continue
 
         if node_type == "codeBlock":
             code_text = "".join(child.get("text", "") for child in node.get("content", []))
             if code_text:
+                pending_blank_lines = 0
                 rich_text_elements.append(
                     {"type": "rich_text_preformatted", "elements": [{"type": "text", "text": code_text}]}
                 )
@@ -766,6 +798,7 @@ def rich_content_to_slack_blocks(rich_content: JSON | None, include_images: bool
         if node_type == "image" and include_images:
             src = node.get("attrs", {}).get("src")
             if src:
+                pending_blank_lines = 0
                 rich_text_elements.append(
                     {
                         "type": "rich_text_section",

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -334,6 +334,58 @@ class TestSlackFormatting(SimpleTestCase):
 
     @parameterized.expand(
         [
+            (
+                "paragraphs_break_once",
+                [_paragraph("one"), _paragraph("two")],
+                "one\ntwo",
+            ),
+            (
+                "authored_blank_line_stays_a_single_blank_line",
+                [_paragraph("one"), {"type": "paragraph"}, _paragraph("two")],
+                "one\n\ntwo",
+            ),
+            (
+                "hard_break_drops_its_markdown_trailing_spaces",
+                [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {"type": "text", "text": "one"},
+                            {"type": "hardBreak"},
+                            {"type": "text", "text": "two"},
+                        ],
+                    }
+                ],
+                "one\ntwo",
+            ),
+            (
+                "code_block_keeps_its_own_blank_lines",
+                [
+                    {"type": "codeBlock", "content": [{"type": "text", "text": "a = 1\n\nb = 2"}]},
+                    _paragraph("after"),
+                ],
+                "```\na = 1\n\nb = 2\n```\nafter",
+            ),
+        ]
+    )
+    def test_outbound_text_uses_mrkdwn_line_breaks_not_markdown_ones(
+        self, _name: str, content: list[dict], expected: str
+    ) -> None:
+        slack_text, _ = rich_content_to_slack_payload({"type": "doc", "content": content}, "")
+        assert slack_text == expected
+
+    def test_outbound_blocks_keep_an_authored_blank_line(self) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [_paragraph("one"), {"type": "paragraph"}, _paragraph("two")],
+        }
+
+        _, slack_blocks = rich_content_to_slack_payload(rich_content, "")
+        assert slack_blocks is not None
+        assert [el["elements"][0]["text"] for el in slack_blocks[0]["elements"]] == ["one", "\n\n", "two"]
+
+    @parameterized.expand(
+        [
             ("bold_stays_bold", "**bold**", "*bold*"),
             ("italic", "*italic*", "_italic_"),
             ("bold_italic", "***both***", "*_both_*"),
@@ -655,7 +707,7 @@ class TestRichContentBlockNodes(SimpleTestCase):
         }
         text, blocks = rich_content_to_slack_payload(doc, "fallback")
         assert blocks is None
-        assert text == "Two options (pick one):\n\n- Use query-time properties, e.g. person.email"
+        assert text == "Two options (pick one):\n- Use query-time properties, e.g. person.email"
 
     @parameterized.expand(
         [

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -374,15 +374,26 @@ class TestSlackFormatting(SimpleTestCase):
         slack_text, _ = rich_content_to_slack_payload({"type": "doc", "content": content}, "")
         assert slack_text == expected
 
-    def test_outbound_blocks_keep_an_authored_blank_line(self) -> None:
-        rich_content = {
-            "type": "doc",
-            "content": [_paragraph("one"), {"type": "paragraph"}, _paragraph("two")],
-        }
+    @parameterized.expand(
+        [
+            # A section runs on from the one before it, so it needs a line ending plus the blank line.
+            ("before_a_paragraph", _paragraph("two"), "\n\n"),
+            ("before_an_image", {"type": "image", "attrs": {"src": "https://e.com/a.png", "alt": "a"}}, "\n\n"),
+            # A preformatted element is its own code box, so the blank line is all it needs.
+            ("before_a_code_block", {"type": "codeBlock", "content": [{"type": "text", "text": "x = 1"}]}, "\n"),
+        ]
+    )
+    def test_outbound_blocks_keep_an_authored_blank_line(
+        self, _name: str, follower: dict, expected_separator: str
+    ) -> None:
+        rich_content = {"type": "doc", "content": [_paragraph("one"), {"type": "paragraph"}, follower]}
 
         _, slack_blocks = rich_content_to_slack_payload(rich_content, "")
         assert slack_blocks is not None
-        assert [el["elements"][0]["text"] for el in slack_blocks[0]["elements"]] == ["one", "\n\n", "two"]
+
+        elements = slack_blocks[0]["elements"]
+        assert len(elements) == 3
+        assert elements[1]["elements"][0]["text"] == expected_separator
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

A PostHog comment sent to Slack arrives with a blank line after every line, and three blank lines wherever the author typed one. Reported in [this Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1787335605987829).

The comment body is serialized to markdown, then handed to Slack as mrkdwn. Markdown needs a blank line to end a paragraph and two trailing spaces to force a line break, because a lone newline is only a soft wrap. mrkdwn has no soft wrap, so every gap arrives doubled.

This hits all three mirrors: discussion threads, task comment DMs, and support conversation replies. The thread root card is worst, because it prefixes `> ` to every line, so each spurious blank line becomes a blank quoted row.

## Changes

- A mirrored comment now spaces the way its author typed it.
- `content_to_slack_mrkdwn` halves each run of newlines and drops the trailing spaces of a markdown hard break.
- Fenced code keeps its own spacing, where a blank line is content rather than structure.
- A blank line the author typed now survives into a threaded reply. The Slack `rich_text` block path dropped empty paragraphs, so the thread root showed a gap the reply did not.
- One helper owns the separator between block elements, so the paragraph, code block, and image branches cannot drift apart again.
- An image now starts its own line. It used to run on from the preceding paragraph's text. No Slack caller sends images today, since all three pass `include_images=False`.

Halving the newline run is what maps one convention onto the other: a paragraph break becomes one line break, and a typed blank line stays one blank line. Collapsing every run to a single newline would have been simpler and would have deleted the author's blank lines instead.

Before, for a comment of four lines with one blank line in the middle:

```
> Hey team - quick update on the migration.
> 
> 
> 
> We shipped the backfill last night.
> 
> Numbers look good.
```

After:

```
> Hey team - quick update on the migration.
> 
> We shipped the backfill last night.
> Numbers look good.
```

## How did you test this code?

- Five cases added to `products/conversations/backend/api/tests/test_formatting.py`. They catch a paragraph break rendering as a blank line, a typed blank line tripling, a hard break leaking its two trailing spaces, a code fence losing its internal blank lines, and an empty paragraph vanishing from the block path. No existing test asserted outbound vertical spacing.
- One existing assertion changed: `test_slack_text_fallback_is_not_markdown_escaped` encoded the doubled gap between a lead-in and its list.
- `ruff` and repo-wide `mypy` pass locally.
- Not run: the Postgres-backed cases in that file and the two Slack sync suites. This sandbox has no database. Not verified against a live Slack workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack thread reporting the spacing. The Slack message itself was not readable from this session, so the diagnosis came from reproducing the conversion against a TipTap document shaped like the reported comment.

The first suspect was `_quote_mrkdwn` in the thread root card, since the report described the quoted block. It turned out to amplify the bug rather than cause it. Reproducing the conversion showed the doubling already present in `content_to_slack_mrkdwn`, upstream of all three call sites.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1787335671983419)*

