### PR TITLE
feat(warehouse-sources): sync zendesk ticket comments incrementally

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
@@ -93,7 +93,7 @@ def build_dependent_resource(
     db_incremental_field_last_value: Any,
     should_use_incremental_field: bool = False,
     incremental_field: str | None = None,
-    incremental_config_factory: Callable[[str], IncrementalConfig] | None = None,
+    incremental_config_factory: Callable[[str], IncrementalConfig | None] | None = None,
     parent_endpoint_extra: Endpoint | None = None,
     child_endpoint_extra: Endpoint | None = None,
     child_params_extra: dict[str, Any] | None = None,
@@ -220,9 +220,12 @@ def build_dependent_resource(
     if use_merge:
         if incremental_config_factory is None:
             raise ValueError("incremental_config_factory is required for incremental fan-out resources")
-        child_endpoint_config["incremental"] = incremental_config_factory(
-            incremental_field or child_config.default_incremental_field or "id"
-        )
+        incremental = incremental_config_factory(incremental_field or child_config.default_incremental_field or "id")
+        # A factory returns None for a child endpoint that has no server-side time filter to bind
+        # the cursor to. Such a child still merges on its primary key, which is what lets a caller
+        # bound the request set through the fan-out parent instead of through a request window.
+        if incremental is not None:
+            child_endpoint_config["incremental"] = incremental
 
     child_resource: EndpointResource = {
         "name": child_endpoint,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
@@ -156,6 +156,36 @@ def test_build_dependent_resource_backwards_compatible_defaults(mock_rest_api_re
 
 
 @patch("products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources")
+def test_child_without_a_request_window_merges_and_sends_no_incremental(mock_rest_api_resources) -> None:
+    mock_rest_api_resources.return_value = [_stub_child_resource()]
+    endpoint_configs = _build_endpoint_configs()
+    endpoint_configs["children"].incremental_fields = [{"field": "created_at"}]
+    endpoint_configs["children"].default_incremental_field = "created_at"
+
+    build_dependent_resource(
+        endpoint_configs=endpoint_configs,
+        child_endpoint="children",
+        fanout=DependentEndpointConfig(
+            parent_name="parents",
+            resolve_param="parent_id",
+            resolve_field="id",
+            include_from_parent=["id"],
+        ),
+        client_config={"base_url": "https://example.com"},
+        path_format_values={},
+        team_id=1,
+        job_id="job-1",
+        db_incremental_field_last_value="2026-01-01T00:00:00Z",
+        should_use_incremental_field=True,
+        incremental_config_factory=lambda _cursor_path: None,
+    )
+
+    child_resource = mock_rest_api_resources.call_args.args[0]["resources"][1]
+    assert child_resource["write_disposition"] == {"disposition": "merge", "strategy": "upsert"}
+    assert "incremental" not in child_resource["endpoint"]
+
+
+@patch("products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources")
 def test_build_dependent_resource_merges_fanout_child_params(mock_rest_api_resources) -> None:
     mock_rest_api_resources.return_value = [_stub_child_resource()]
     build_dependent_resource(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/settings.py
@@ -210,6 +210,12 @@ ZENDESK_ENDPOINTS: dict[str, ZendeskEndpointConfig] = {
         # across the whole table.
         primary_key=["ticket_id", "id"],
         partition_key="created_at",
+        # No `incremental_start_param`: `/tickets/{id}/comments` takes no time filter, unlike the
+        # plain list endpoints. The cursor exists so the table merges on its primary key instead of
+        # being replaced, which is what lets the fan-out over tickets be bounded without dropping
+        # the comments that fall outside the bound.
+        incremental_fields=[_datetime_incremental_field("created_at")],
+        default_incremental_field="created_at",
         fanout=DependentEndpointConfig(
             parent_name=TICKET_COMMENTS_PARENT_NAME,
             resolve_param="ticket_id",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -548,7 +548,7 @@ class _FakeResource:
 
 
 class TestZendeskTicketCommentsFanout:
-    def _build(self) -> tuple[_FakeResource, list[Any]]:
+    def _build(self, should_use_incremental_field: bool = False) -> tuple[_FakeResource, list[Any]]:
         child = _FakeResource("ticket_comments")
 
         with patch(
@@ -562,7 +562,8 @@ class TestZendeskTicketCommentsFanout:
                 endpoint="ticket_comments",
                 team_id=1,
                 job_id="job-1",
-                db_incremental_field_last_value=None,
+                db_incremental_field_last_value="2026-01-01T00:00:00Z" if should_use_incremental_field else None,
+                should_use_incremental_field=should_use_incremental_field,
             )
 
         return child, mock_resources.call_args[0]
@@ -581,6 +582,20 @@ class TestZendeskTicketCommentsFanout:
             "field": "id",
         }
         assert child["include_from_parent"] == ["id"]
+
+    def test_replaces_the_table_when_the_schema_is_not_incremental(self) -> None:
+        _, args = self._build()
+        _, child = args[0]["resources"]
+
+        assert child["write_disposition"] == "replace"
+
+    def test_incremental_merges_but_sends_no_request_window(self) -> None:
+        _, args = self._build(should_use_incremental_field=True)
+        _, child = args[0]["resources"]
+
+        assert child["write_disposition"] == {"disposition": "merge", "strategy": "upsert"}
+        assert "incremental" not in child["endpoint"]
+        assert "since" not in child["endpoint"]["params"]
 
     def test_comment_rows_carry_the_parent_ticket_id(self) -> None:
         # Without this rename a comment row has no ticket_id, so the (ticket_id, id) primary key
@@ -606,12 +621,16 @@ class TestZendeskSchemas:
         # The endpoints that shipped first must keep being offered.
         assert {"tickets", "users", "organizations", "brands", "groups", "sla_policies"}.issubset(names)
 
-    def test_only_endpoints_with_a_server_side_filter_advertise_incremental(self) -> None:
+    def test_incremental_is_advertised_only_where_it_can_be_honored(self) -> None:
         schemas = self._schemas()
         incremental = {name for name in ZENDESK_ENDPOINTS if schemas[name].supports_incremental}
 
-        assert incremental == {"activities"}
+        assert incremental == {"activities", "ticket_comments"}
         assert schemas["activities"].incremental_fields[0]["field"] == "created_at"
+        assert schemas["ticket_comments"].incremental_fields[0]["field"] == "created_at"
+        for name in incremental:
+            config = ZENDESK_ENDPOINTS[name]
+            assert config.incremental_start_param is not None or config.fanout is not None
 
     def test_canonical_descriptions_cover_every_new_table(self) -> None:
         descriptions = ZendeskSource().get_canonical_descriptions()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
@@ -1,5 +1,6 @@
 import re
 import base64
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Optional, cast
 
@@ -63,6 +64,22 @@ def zendesk_incremental_window(start_param: str, cursor_path: str) -> Incrementa
         "initial_value": ZENDESK_EPOCH_START,
         "convert": to_zendesk_iso8601,
     }
+
+
+def _fanout_incremental_config(config: ZendeskEndpointConfig) -> Callable[[str], IncrementalConfig | None]:
+    """Build the child's request window, or report that the endpoint has none.
+
+    A plain list endpoint without a start param is a config error (`get_declarative_resource`
+    raises). A fan-out child is different: the parent bounds which rows it requests, so a child
+    endpoint that takes no time filter still merges rather than replaces.
+    """
+
+    def _factory(cursor_path: str) -> IncrementalConfig | None:
+        if config.incremental_start_param is None:
+            return None
+        return zendesk_incremental_window(config.incremental_start_param, cursor_path)
+
+    return _factory
 
 
 def paginator_for(config: ZendeskEndpointConfig) -> BasePaginator:
@@ -504,6 +521,7 @@ def zendesk_fanout_source(
             db_incremental_field_last_value=db_incremental_field_last_value,
             should_use_incremental_field=should_use_incremental_field,
             incremental_field=incremental_field_name,
+            incremental_config_factory=_fanout_incremental_config(config),
             page_size_param="page[size]",
             parent_endpoint_extra={
                 "paginator": JSONLinkPaginator(next_url_path="links.next"),


### PR DESCRIPTION
## Problem

A Zendesk user syncing `ticket_comments` can only run it as a full refresh, so every sync replaces the whole table.

- The sync fans out over every ticket in the account to re-fetch comments it already holds. On a large account that is roughly an hour per run.
- Narrowing that walk is the fix, and `replace` blocks it: any bound on which tickets get visited would delete the comments left outside the bound.
- Comments carry no modification timestamp, so nothing here can key off the comment. Only the write disposition can change.

This PR does not make the sync faster. It removes the reason a later change cannot.

## Changes

- `ticket_comments` now offers incremental sync. An incremental schema merges on `(ticket_id, id)`; a full-refresh schema still replaces, unchanged.
- No request window reaches `/tickets/{id}/comments`, which accepts none. The cursor exists only to select the merge.
- The fan-out builder now accepts a child endpoint that has no server-side time filter. This is the only shared change and is mechanical: a factory returning `None` means "no request window", and merge no longer depends on having one.

## How did you test this code?

- `test_child_without_a_request_window_merges_and_sends_no_incremental` — catches a revert of the guard, which would put `"incremental": None` on the child endpoint and make `setup_incremental_object` index a `start_param` that does not exist.
- `test_incremental_merges_but_sends_no_request_window` — catches `ticket_comments` gaining an `incremental_start_param`, which would send `since=` to an endpoint that ignores it, and catches the write disposition regressing to `replace`.
- `test_replaces_the_table_when_the_schema_is_not_incremental` — pins that existing full-refresh schemas are untouched.
- `test_only_endpoints_with_a_server_side_filter_advertise_incremental` is renamed to `test_incremental_is_advertised_only_where_it_can_be_honored`. The old name asserted the rule this PR changes. The new one holds that a schema advertises incremental only when it has a start param or is a fan-out child, so a plain endpoint gaining a cursor without a filter still fails.
- Both new tests were confirmed to fail with the guard removed.
- Ran locally: the Zendesk, shared fan-out, Sentry, and Typeform suites, and `uv run mypy --cache-fine-grained .` repo-wide.
- Not run: anything against a real Zendesk account.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` describes per-schema sync types for Zendesk.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Opus 5 in Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Layer 1 of three. Layer 2 remaps the fan-out onto the synced `tickets` table with a row filter on the ticket's `updated_at`; layer 3 probes a real account and rolls out. Splitting it this way keeps the write-disposition change reviewable on its own, and it is the layer the other two depend on.
- Two live schemas run `ticket_comments` today, both on full refresh. Neither changes behavior until someone switches them, which is deliberate.
