### PR TITLE
feat(web-analytics): use livestream-cleaned pathnames in the live view

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.test.ts
@@ -71,6 +71,17 @@ describe('liveWebAnalyticsMetricsLogic', () => {
         expect(logic.values.topPaths).toEqual([{ path: '/classes/:id', views: 2 }])
     })
 
+    it('prefers the livestream-cleaned pathname over the client-side mirror', () => {
+        const event = pageview('/classes/928q3hr9paw8hfe', 'user-1')
+        // Server-side RE2 cleaning can diverge from the JS mirror (e.g. re2-only
+        // syntax the mirror skips), so its value must win verbatim.
+        event.properties.$virt_cleaned_pathname = '/classes/:server_id'
+
+        logic.actions.addEvents([event], new Date(Date.now() - 60_000), logic.values.pathCleaningFilters)
+
+        expect(logic.values.topPaths).toEqual([{ path: '/classes/:server_id', views: 1 }])
+    })
+
     it('leaves streamed paths untouched once path cleaning is switched off', () => {
         webAnalyticsLogic.actions.setIsPathCleaningEnabled(false)
 

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -368,13 +368,17 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                         const newerThanTs = newerThan.getTime() / 1000
 
                         if (eventTs > newerThanTs) {
-                            // Streamed events arrive raw, so the same cleaning the backfill query
-                            // does server-side has to happen here for both to land on one key.
+                            // Prefer the livestream service's RE2-cleaned pathname — it matches the
+                            // backfill query exactly. The client-side mirror stays as a fallback for
+                            // livestream deploys that don't send it yet.
                             const rawPathname = event.properties?.$pathname
+                            const serverCleanedPathname = event.properties?.$virt_cleaned_pathname
                             const pathname =
-                                typeof rawPathname === 'string'
-                                    ? applyPathCleaning(rawPathname, pathCleaningFilters)
-                                    : rawPathname
+                                typeof serverCleanedPathname === 'string'
+                                    ? serverCleanedPathname
+                                    : typeof rawPathname === 'string'
+                                      ? applyPathCleaning(rawPathname, pathCleaningFilters)
+                                      : rawPathname
                             const deviceType = event.properties?.$device_type
                             const deviceId = event.properties?.$device_id
                             const browser = event.properties?.$browser
@@ -863,6 +867,11 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             const recordingColumn = values.currentTeam?.session_recording_opt_in ? ',$session_id' : ''
             url.searchParams.append('columns', `${baseColumns}${cityColumns}${recordingColumn}`)
             appendFilterParams(url, values.streamFilters)
+            if (values.pathCleaningFilters.length > 0) {
+                // The livestream service cleans server-side with RE2 (the engine the backfill
+                // query uses) and returns $virt_cleaned_pathname alongside the raw value.
+                url.searchParams.append('pathCleaning', JSON.stringify(values.pathCleaningFilters))
+            }
 
             cache.batch = cache.batch ?? ([] as LiveEvent[])
 


### PR DESCRIPTION
## Problem

Top layer of the live path cleaning stack, on [#87294](https://github.com/PostHog/posthog/pull/87294). The live top pages panel still cleans streamed pathnames with the client-side JS mirror from [#87140](https://github.com/PostHog/posthog/pull/87140), while the livestream service can now compute the same value with RE2, the engine the backfill query uses.

## Changes

- The live tab sends the team's path cleaning rules on the SSE connection and keys streamed pageviews on the returned `$virt_cleaned_pathname`, so streamed and backfilled paths land on the same row by construction.
- The client-side mirror stays as a fallback for events arriving without the property, so this deploys safely against livestream instances that predate the param.

Top pages rows look the same as with #87140; only where the cleaning runs changes, so no screenshot.

## How did you test this code?

Added one Jest case: an event carrying `$virt_cleaned_pathname` must use it verbatim, even when client rules would produce a different value. That catches the regression where the precedence is dropped and the JS mirror re-cleans the raw path, which diverges for rules the mirror cannot compile. The existing cases cover the fallback path.

Ran the `LiveMetricsDashboard` Jest suites locally. Not verified against a running livestream instance; the Go side's behavior is covered by the tests in #87294.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code), same session as the two PRs below it in the stack. Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0APW95TSTV/p1787317818611559?thread_ts=1787317818.611559&cid=C0APW95TSTV)*
