### PR TITLE
feat(desktop): open saved search matches in a split view

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -8,6 +8,7 @@ import { ChannelSidebar } from "@posthog/ui/features/canvas/components/ChannelSi
 import { ChannelsFab } from "@posthog/ui/features/canvas/components/ChannelsFab";
 import { ChannelsList } from "@posthog/ui/features/canvas/components/ChannelsList";
 import { useChannelsSidebarStore } from "@posthog/ui/features/canvas/components/channelsSidebarStore";
+import { TaskFeedPane } from "@posthog/ui/features/canvas/components/TaskFeedPane";
 import { useChannelPaneSwipe } from "@posthog/ui/features/canvas/hooks/useChannelPaneSwipe";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useCurrentChannel } from "@posthog/ui/features/canvas/hooks/useCurrentChannel";
@@ -47,6 +48,7 @@ import { ErrorBoundary } from "@posthog/ui/primitives/ErrorBoundary";
 import { useSidebarEdgeHoverPeek } from "@posthog/ui/primitives/hooks/useSidebarEdgeHoverPeek";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { navigateToArchived } from "@posthog/ui/router/navigationBridge";
+import { useParams } from "@tanstack/react-router";
 import { useDeferredValue, useEffect, useRef } from "react";
 
 /**
@@ -191,6 +193,7 @@ export function ChannelsSidebar() {
   // slide to there's only the list.
   const { showsActivityDetail } = useRailSurface();
   const selectedActivityId = useActivityDetailStore((s) => s.selected?.id);
+  const { feedId } = useParams({ strict: false });
   const pane = useChannelPaneStore((s) => s.pane);
   const showList = pane === "list" || currentChannelId == null;
 
@@ -237,6 +240,8 @@ export function ChannelsSidebar() {
                 selectedId={selectedActivityId}
                 onActivate={selectActivityItem}
               />
+            ) : feedId ? (
+              <TaskFeedPane feedId={feedId} className="min-h-0 flex-1" />
             ) : (
               <ChannelPanes
                 channelId={currentChannelId}

--- a/products/desktop/packages/ui/src/features/canvas/components/FeedQueryInput.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/FeedQueryInput.tsx
@@ -246,7 +246,7 @@ export function FeedQueryInput({
         />
       </div>
       {visible && (
-        <div className="absolute top-full right-0 left-0 z-50 mt-1.5 overflow-hidden rounded-lg border border-(--gray-a6) bg-(--color-panel-solid) shadow-lg">
+        <div className="absolute top-full right-0 left-0 z-50 mt-1.5 overflow-hidden rounded-lg border border-border bg-card shadow-lg">
           {group.heading !== "" && (
             <div className="px-3 pt-2 pb-1 font-medium text-(--gray-9) text-[11px] uppercase tracking-wider">
               {group.heading}

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedDetailPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedDetailPane.tsx
@@ -1,0 +1,52 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@posthog/quill";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useTaskFeedSelection } from "@posthog/ui/features/canvas/stores/taskFeedSelectionStore";
+import { TaskDetail } from "@posthog/ui/features/task-detail/components/TaskDetail";
+import { useResolvedTask } from "@posthog/ui/features/tasks/useResolvedTask";
+import { TaskDetailSkeleton } from "@posthog/ui/router/routeSkeletons";
+
+export function TaskFeedDetailPane({ feedId }: { feedId: string }) {
+  const selected = useTaskFeedSelection(feedId);
+  const task = useResolvedTask(selected?.taskId);
+  const { channels } = useChannels();
+
+  if (!selected) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Empty className="border-0">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <MagnifyingGlassIcon />
+            </EmptyMedia>
+            <EmptyTitle>Nothing selected</EmptyTitle>
+            <EmptyDescription>
+              Pick a task from the search to read it here.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    );
+  }
+
+  if (!task) return <TaskDetailSkeleton />;
+
+  const { channelId } = selected;
+  const channelName = channels.find((c) => c.id === channelId)?.name;
+
+  return (
+    <div className="h-full min-w-0">
+      <TaskDetail
+        task={task}
+        channelName={channelName ?? "Space"}
+        channelId={channelId ?? undefined}
+      />
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedDetailPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedDetailPane.tsx
@@ -37,15 +37,15 @@ export function TaskFeedDetailPane({ feedId }: { feedId: string }) {
 
   if (!task) return <TaskDetailSkeleton />;
 
-  const { channelId } = selected;
+  const channelId = task.channel ?? selected.channelId ?? undefined;
   const channelName = channels.find((c) => c.id === channelId)?.name;
 
   return (
     <div className="h-full min-w-0">
       <TaskDetail
         task={task}
-        channelName={channelName ?? "Space"}
-        channelId={channelId ?? undefined}
+        channelName={channelName}
+        channelId={channelName ? channelId : undefined}
       />
     </div>
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.test.tsx
@@ -14,6 +14,9 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
   useCurrentUser: () => ({ data: { uuid: "user-1" } }),
 }));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({ channels: [] }),
+}));
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskFeedResults", () => ({
   useFeedQueryPlan: () => ({ plan: undefined }),
   useTaskFeedResults: () => ({

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.tsx
@@ -12,12 +12,14 @@ import {
   Input,
   Spinner,
 } from "@posthog/quill";
+import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { FeedQueryInput } from "@posthog/ui/features/canvas/components/FeedQueryInput";
 import { unfinishedFilterKeys } from "@posthog/ui/features/canvas/components/feedQuerySuggestionUtils";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import {
   useFeedQueryPlan,
   useTaskFeedResults,
@@ -32,6 +34,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 const MAX_FEED_NAME_LENGTH = 80;
 const PREVIEW_DEBOUNCE_MS = 400;
+const PREVIEW_TASK_LIMIT = 4;
 
 export function TaskFeedModal({
   open,
@@ -53,6 +56,7 @@ export function TaskFeedModal({
   const projectId = useAuthStateValue((s) => s.currentProjectId);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
+  const { channels } = useChannels();
   const ownerId = currentUser?.uuid ?? null;
   const seedQuery = feed?.query ?? initialQuery ?? "";
   const [name, setName] = useState(
@@ -93,6 +97,15 @@ export function TaskFeedModal({
     return unfinishedFilterKeys(parsedText)[0];
   }, [trimmedQuery]);
   const counting = trimmedQuery !== "" && (isPending || preview.isLoading);
+  const hasPreview = trimmedQuery !== "" && previewQuery !== "";
+  const previewTasks = preview.tasks.slice(0, PREVIEW_TASK_LIMIT);
+  const previewOverflow = hasPreview
+    ? preview.tasks.length - previewTasks.length
+    : 0;
+  const channelNames = useMemo(
+    () => new Map(channels.map((channel) => [channel.id, channel.name])),
+    [channels],
+  );
 
   const submit = () => {
     if (!canSubmit) return;
@@ -125,7 +138,7 @@ export function TaskFeedModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-visible sm:max-w-lg">
+      <DialogContent className="overflow-visible sm:max-w-xl">
         <DialogHeader className="min-w-0">
           <DialogTitle>
             {feed ? "Edit saved search" : "Save search"}
@@ -135,36 +148,32 @@ export function TaskFeedModal({
             the command palette.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody className="flex min-w-0 flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-3">
-              <label htmlFor="task-feed-query" className="font-medium text-sm">
-                Query
-              </label>
-              <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground text-xs tabular-nums">
-                {counting ? (
-                  <Spinner className="size-3" />
-                ) : preview.error && preview.canRetry ? (
-                  <Button
-                    variant="link-muted"
-                    size="xs"
-                    loading={preview.isFetching}
-                    disabled={preview.isFetching}
-                    onClick={preview.refetch}
-                  >
-                    Try again
-                  </Button>
-                ) : preview.error ? null : (
-                  trimmedQuery !== "" &&
-                  previewQuery !== "" &&
-                  (preview.isComplete
-                    ? preview.tasks.length === 1
-                      ? "1 task matches"
-                      : `${preview.tasks.length} tasks match`
-                    : "Some matches may not be shown")
-                )}
-              </span>
-            </div>
+        <DialogBody className="flex min-w-0 flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="task-feed-name" className="font-medium text-sm">
+              Name
+            </label>
+            <Input
+              id="task-feed-name"
+              value={name}
+              placeholder="Name based on the query"
+              maxLength={MAX_FEED_NAME_LENGTH}
+              onChange={(event) => {
+                setName(event.target.value);
+                nameEdited.current = event.target.value.trim() !== "";
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  submit();
+                }
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="task-feed-query" className="font-medium text-sm">
+              Query
+            </label>
             <FeedQueryInput
               id="task-feed-query"
               autoFocus
@@ -195,26 +204,69 @@ export function TaskFeedModal({
                     : "Free text searches task titles. Repeat a filter to match either value. Use - to exclude a filter."))}
             </div>
           </div>
-          <div className="flex flex-col gap-2">
-            <label htmlFor="task-feed-name" className="font-medium text-sm">
-              Name
-            </label>
-            <Input
-              id="task-feed-name"
-              value={name}
-              placeholder="Name based on the query"
-              maxLength={MAX_FEED_NAME_LENGTH}
-              onChange={(event) => {
-                setName(event.target.value);
-                nameEdited.current = event.target.value.trim() !== "";
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  submit();
-                }
-              }}
-            />
+          <div className="flex min-h-40 flex-col overflow-hidden rounded-lg border border-border bg-muted/40">
+            <div className="flex h-8 shrink-0 items-center gap-2 border-border border-b px-3 text-muted-foreground text-xs">
+              <span className="font-medium">Matches</span>
+              <span className="ml-auto flex items-center gap-1.5 tabular-nums">
+                {counting ? (
+                  <Spinner className="size-3" />
+                ) : preview.error && preview.canRetry ? (
+                  <Button
+                    variant="link-muted"
+                    size="xs"
+                    loading={preview.isFetching}
+                    disabled={preview.isFetching}
+                    onClick={preview.refetch}
+                  >
+                    Try again
+                  </Button>
+                ) : preview.error ? null : (
+                  hasPreview &&
+                  (preview.isComplete
+                    ? preview.tasks.length === 1
+                      ? "1 task matches"
+                      : `${preview.tasks.length} tasks match`
+                    : "Some matches may not be shown")
+                )}
+              </span>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {!hasPreview || counting ? (
+                <p className="px-3 py-6 text-center text-muted-foreground text-xs">
+                  Matching tasks appear here as you type.
+                </p>
+              ) : previewTasks.length === 0 ? (
+                <p className="px-3 py-6 text-center text-muted-foreground text-xs">
+                  No tasks match this query yet.
+                </p>
+              ) : (
+                previewTasks.map((task) => (
+                  <div
+                    key={task.id}
+                    className="flex items-center gap-2 border-border/60 border-b px-3 py-1.5 text-xs last:border-b-0"
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {task.title}
+                    </span>
+                    {task.channel && channelNames.get(task.channel) && (
+                      <span className="shrink-0 text-muted-foreground">
+                        {channelNames.get(task.channel)}
+                      </span>
+                    )}
+                    <span className="w-8 shrink-0 text-right text-muted-foreground tabular-nums">
+                      {formatRelativeTimeShort(
+                        task.last_activity_at ?? task.updated_at,
+                      )}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+            {previewOverflow > 0 && (
+              <div className="shrink-0 border-border border-t px-3 py-1.5 text-muted-foreground text-xs">
+                and {previewOverflow} more
+              </div>
+            )}
           </div>
         </DialogBody>
         <DialogFooter className="min-w-0">

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedModal.tsx
@@ -148,7 +148,10 @@ export function TaskFeedModal({
             the command palette.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody className="flex min-w-0 flex-col gap-5">
+        <DialogBody
+          render={<div />}
+          className="flex min-w-0 flex-col gap-4 overflow-y-auto py-4"
+        >
           <div className="flex flex-col gap-1.5">
             <label htmlFor="task-feed-name" className="font-medium text-sm">
               Name
@@ -204,7 +207,7 @@ export function TaskFeedModal({
                     : "Free text searches task titles. Repeat a filter to match either value. Use - to exclude a filter."))}
             </div>
           </div>
-          <div className="flex min-h-40 flex-col overflow-hidden rounded-lg border border-border bg-muted/40">
+          <div className="flex min-h-24 flex-1 basis-40 flex-col overflow-hidden rounded-lg border border-border bg-muted/40">
             <div className="flex h-8 shrink-0 items-center gap-2 border-border border-b px-3 text-muted-foreground text-xs">
               <span className="font-medium">Matches</span>
               <span className="ml-auto flex items-center gap-1.5 tabular-nums">
@@ -222,6 +225,7 @@ export function TaskFeedModal({
                   </Button>
                 ) : preview.error ? null : (
                   hasPreview &&
+                  preview.tasks.length > 0 &&
                   (preview.isComplete
                     ? preview.tasks.length === 1
                       ? "1 task matches"

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.test.tsx
@@ -5,15 +5,48 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@posthog/ui/features/archive/useArchivedTaskIds", () => ({
+  useArchivedTaskIds: () => new Set<string>(),
+}));
+vi.mock("@posthog/ui/features/archive/useArchiveTask", () => ({
+  useArchiveTask: () => ({ archiveTask: vi.fn() }),
+}));
+vi.mock("@posthog/ui/features/sidebar/usePinnedTasks", () => ({
+  usePinnedTasks: () => ({
+    pinnedTaskIds: new Set<string>(),
+    togglePin: vi.fn(),
+    setPinnedMany: vi.fn(),
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelItems", () => ({
+  useChannelSessionFacts: () => ({
+    needsInputTaskIds: new Set<string>(),
+    viewedTimestamps: {},
+    workspaceByTaskId: new Map(),
+  }),
+}));
+vi.mock("@posthog/ui/features/command-center/commandCenterStore", () => ({
+  useCommandCenterStore: () => [] as string[],
+}));
+vi.mock("@posthog/ui/features/canvas/components/ChannelItemRow", () => ({
+  ChannelItemRow: ({
+    item,
+    actions,
+  }: {
+    item: { id: string; title: string };
+    actions: { open: (item: { id: string; title: string }) => void };
+  }) => (
+    <button type="button" onClick={() => actions.open(item)}>
+      {item.title}
+    </button>
+  ),
+}));
 vi.mock("@posthog/ui/features/canvas/components/FeedQueryInput", () => ({
   FeedQueryHighlight: ({ query }: { query: string }) => <span>{query}</span>,
 }));
 vi.mock("@posthog/ui/features/canvas/components/TaskFeedModal", () => ({
   TaskFeedModal: ({ open }: { open: boolean }) =>
     open ? <div>Edit saved search</div> : null,
-}));
-vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskStatus", () => ({
-  useTaskStatusInput: () => null,
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskFeedResults", () => ({
   useTaskFeedResults: () => ({
@@ -26,6 +59,7 @@ vi.mock("@posthog/ui/features/canvas/hooks/useTaskFeedResults", () => ({
         id: "task-1",
         title: "Invoice total rounds down",
         channel: "channel-1",
+        created_at: "2026-08-20T00:00:00Z",
         updated_at: "2026-08-21T00:00:00Z",
       } as Task,
     ],

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.test.tsx
@@ -1,0 +1,97 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { Theme } from "@radix-ui/themes";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@posthog/ui/features/canvas/components/FeedQueryInput", () => ({
+  FeedQueryHighlight: ({ query }: { query: string }) => <span>{query}</span>,
+}));
+vi.mock("@posthog/ui/features/canvas/components/TaskFeedModal", () => ({
+  TaskFeedModal: ({ open }: { open: boolean }) =>
+    open ? <div>Edit saved search</div> : null,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskStatus", () => ({
+  useTaskStatusInput: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskFeedResults", () => ({
+  useTaskFeedResults: () => ({
+    error: null,
+    errorMessage: null,
+    isComplete: true,
+    isLoading: false,
+    tasks: [
+      {
+        id: "task-1",
+        title: "Invoice total rounds down",
+        channel: "channel-1",
+        updated_at: "2026-08-21T00:00:00Z",
+      } as Task,
+    ],
+  }),
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+
+import { useTaskFeedSelectionStore } from "@posthog/ui/features/canvas/stores/taskFeedSelectionStore";
+import { useTaskFeedsStore } from "@posthog/ui/features/canvas/stores/taskFeedsStore";
+import { TaskFeedPane } from "./TaskFeedPane";
+
+vi.mock("@posthog/ui/features/canvas/hooks/useProjectTaskFeeds", () => ({
+  useProjectTaskFeed: (feedId: string) =>
+    useTaskFeedsStore.getState().feeds.find((feed) => feed.id === feedId),
+}));
+
+describe("TaskFeedPane", () => {
+  beforeEach(() => {
+    useTaskFeedSelectionStore.setState({ selected: null });
+    useTaskFeedsStore.setState({
+      feeds: [
+        {
+          id: "feed-1",
+          projectId: 1,
+          ownerId: "user-1",
+          name: "Billing work",
+          query: "billing",
+          createdAt: "2026-08-01T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  it("selects a match into the detail pane instead of navigating", async () => {
+    const user = userEvent.setup();
+    render(
+      <Theme>
+        <TaskFeedPane feedId="feed-1" />
+      </Theme>,
+    );
+
+    await user.click(screen.getByText("Invoice total rounds down"));
+
+    expect(useTaskFeedSelectionStore.getState().selected).toEqual({
+      feedId: "feed-1",
+      taskId: "task-1",
+      channelId: "channel-1",
+    });
+  });
+
+  it("drops the selection when the search is deleted", async () => {
+    const user = userEvent.setup();
+    useTaskFeedSelectionStore.setState({
+      selected: { feedId: "feed-1", taskId: "task-1", channelId: null },
+    });
+    render(
+      <Theme>
+        <TaskFeedPane feedId="feed-1" />
+      </Theme>,
+    );
+
+    await user.click(screen.getByLabelText("Delete saved search…"));
+    const dialog = screen.getByRole("alertdialog");
+    await user.click(within(dialog).getByText("Delete"));
+
+    expect(useTaskFeedsStore.getState().feeds).toEqual([]);
+    expect(useTaskFeedSelectionStore.getState().selected).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
@@ -4,6 +4,10 @@ import {
   TrashIcon,
 } from "@phosphor-icons/react";
 import {
+  buildChannelItems,
+  type ChannelItemModel,
+} from "@posthog/core/canvas/channelItems";
+import {
   AlertDialog,
   AlertDialogClose,
   AlertDialogContent,
@@ -21,12 +25,14 @@ import {
   Spinner,
   Text,
 } from "@posthog/quill";
-import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
-import type { Task } from "@posthog/shared/domain-types";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
+import type { ChannelItemActions } from "@posthog/ui/features/canvas/components/ChannelItemRow";
+import { ChannelItemRow } from "@posthog/ui/features/canvas/components/ChannelItemRow";
 import { FeedQueryHighlight } from "@posthog/ui/features/canvas/components/FeedQueryInput";
 import { TaskFeedModal } from "@posthog/ui/features/canvas/components/TaskFeedModal";
-import { useTaskStatusInput } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
+import { useChannelSessionFacts } from "@posthog/ui/features/canvas/hooks/useChannelItems";
 import { useProjectTaskFeed } from "@posthog/ui/features/canvas/hooks/useProjectTaskFeeds";
 import { useTaskFeedResults } from "@posthog/ui/features/canvas/hooks/useTaskFeedResults";
 import {
@@ -34,40 +40,13 @@ import {
   useTaskFeedSelectionStore,
 } from "@posthog/ui/features/canvas/stores/taskFeedSelectionStore";
 import { useTaskFeedsStore } from "@posthog/ui/features/canvas/stores/taskFeedsStore";
-import { TaskStatusDot } from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
-import { taskDot } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
-import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
+import { placeTaskInCommandCenter } from "@posthog/ui/features/command-center/placeTaskInCommandCenter";
+import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
-
-function TaskFeedRow({
-  task,
-  isActive,
-  onSelect,
-}: {
-  task: Task;
-  isActive: boolean;
-  onSelect: () => void;
-}) {
-  const status = useTaskStatusInput(task, { withPrStatus: false });
-
-  return (
-    <SidebarItem
-      depth={0}
-      icon={status ? <TaskStatusDot dot={taskDot(status)} /> : null}
-      label={task.title}
-      isActive={isActive}
-      onClick={onSelect}
-      endHint={
-        <span className="text-muted-foreground text-xs">
-          {formatRelativeTimeShort(task.last_activity_at ?? task.updated_at)}
-        </span>
-      }
-    />
-  );
-}
+import { useEffect, useMemo, useState } from "react";
 
 export function TaskFeedPane({
   feedId,
@@ -83,8 +62,51 @@ export function TaskFeedPane({
   const selected = useTaskFeedSelection(feedId);
   const { error, errorMessage, isComplete, isLoading, tasks } =
     useTaskFeedResults(feed?.query);
+  const archivedTaskIds = useArchivedTaskIds();
+  const { pinnedTaskIds, togglePin, setPinnedMany } = usePinnedTasks();
+  const { archiveTask } = useArchiveTask({ navigateSpace: "website" });
+  const sessionFacts = useChannelSessionFacts();
+  const commandCenterCells = useCommandCenterStore((state) => state.cells);
   const [editOpen, setEditOpen] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  const items = useMemo(
+    () =>
+      buildChannelItems({
+        dashboards: [],
+        feedTasks: tasks,
+        archivedTaskIds,
+        pinnedTaskIds,
+        ownedBy: null,
+        sessionFacts,
+      }),
+    [tasks, archivedTaskIds, pinnedTaskIds, sessionFacts],
+  );
+
+  const actions = useMemo<ChannelItemActions>(
+    () => ({
+      open: (item) =>
+        select({
+          feedId,
+          taskId: item.id,
+          channelId: item.task?.channel ?? null,
+        }),
+      togglePin: (item) => {
+        togglePin(item.id).catch(() => toast.error("Couldn't update pin"));
+      },
+      setPinned: (pinItems, pinned) => {
+        setPinnedMany(
+          pinItems.map((item) => item.id),
+          pinned,
+        ).catch(() => toast.error("Couldn't update pin"));
+      },
+      archive: (item) => {
+        void archiveTask({ taskId: item.id });
+      },
+      remove: () => undefined,
+    }),
+    [feedId, select, togglePin, setPinnedMany, archiveTask],
+  );
 
   useEffect(() => {
     track(ANALYTICS_EVENTS.TASK_FEED_ACTION, {
@@ -130,7 +152,7 @@ export function TaskFeedPane({
         <span className="truncate font-bold text-base">{feed.name}</span>
         {!isLoading && !error && (
           <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
-            {isComplete ? tasks.length : `${tasks.length}+`}
+            {isComplete ? items.length : `${items.length}+`}
           </span>
         )}
         <div className="ml-auto flex shrink-0 items-center gap-1">
@@ -164,7 +186,7 @@ export function TaskFeedPane({
       </Button>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
-        {isLoading && tasks.length === 0 ? (
+        {isLoading && items.length === 0 ? (
           <div className="flex justify-center py-10">
             <Spinner />
           </div>
@@ -172,7 +194,7 @@ export function TaskFeedPane({
           <Text className="block px-2 py-6 text-center text-(--red-11) text-xs">
             {errorMessage}
           </Text>
-        ) : tasks.length === 0 ? (
+        ) : items.length === 0 ? (
           <Empty className="border-0 py-8">
             <EmptyHeader>
               <EmptyMedia variant="icon">
@@ -186,17 +208,17 @@ export function TaskFeedPane({
           </Empty>
         ) : (
           <div className="flex flex-col gap-px">
-            {tasks.map((task) => (
-              <TaskFeedRow
-                key={task.id}
-                task={task}
-                isActive={selected?.taskId === task.id}
-                onSelect={() =>
-                  select({
-                    feedId,
-                    taskId: task.id,
-                    channelId: task.channel ?? null,
-                  })
+            {items.map((item: ChannelItemModel) => (
+              <ChannelItemRow
+                key={item.key}
+                item={item}
+                channelId={item.task?.channel ?? undefined}
+                isActive={selected?.taskId === item.id}
+                actions={actions}
+                onAddToCommandCenter={
+                  commandCenterCells.includes(item.id)
+                    ? undefined
+                    : () => placeTaskInCommandCenter(item.id, item.title)
                 }
               />
             ))}

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
@@ -1,0 +1,233 @@
+import {
+  MagnifyingGlassIcon,
+  PencilSimpleIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  cn,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Spinner,
+  Text,
+} from "@posthog/quill";
+import { formatRelativeTimeShort } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { Task } from "@posthog/shared/domain-types";
+import { FeedQueryHighlight } from "@posthog/ui/features/canvas/components/FeedQueryInput";
+import { TaskFeedModal } from "@posthog/ui/features/canvas/components/TaskFeedModal";
+import { useTaskStatusInput } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
+import { useProjectTaskFeed } from "@posthog/ui/features/canvas/hooks/useProjectTaskFeeds";
+import { useTaskFeedResults } from "@posthog/ui/features/canvas/hooks/useTaskFeedResults";
+import {
+  useTaskFeedSelection,
+  useTaskFeedSelectionStore,
+} from "@posthog/ui/features/canvas/stores/taskFeedSelectionStore";
+import { useTaskFeedsStore } from "@posthog/ui/features/canvas/stores/taskFeedsStore";
+import { TaskStatusDot } from "@posthog/ui/features/sidebar/components/items/TaskStatusDot";
+import { taskDot } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+function TaskFeedRow({
+  task,
+  isActive,
+  onSelect,
+}: {
+  task: Task;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  const status = useTaskStatusInput(task, { withPrStatus: false });
+
+  return (
+    <SidebarItem
+      depth={0}
+      icon={status ? <TaskStatusDot dot={taskDot(status)} /> : null}
+      label={task.title}
+      isActive={isActive}
+      onClick={onSelect}
+      endHint={
+        <span className="text-muted-foreground text-xs">
+          {formatRelativeTimeShort(task.last_activity_at ?? task.updated_at)}
+        </span>
+      }
+    />
+  );
+}
+
+export function TaskFeedPane({
+  feedId,
+  className,
+}: {
+  feedId: string;
+  className?: string;
+}) {
+  const navigate = useNavigate();
+  const feed = useProjectTaskFeed(feedId);
+  const removeFeed = useTaskFeedsStore((state) => state.removeFeed);
+  const select = useTaskFeedSelectionStore((state) => state.select);
+  const selected = useTaskFeedSelection(feedId);
+  const { error, errorMessage, isComplete, isLoading, tasks } =
+    useTaskFeedResults(feed?.query);
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    track(ANALYTICS_EVENTS.TASK_FEED_ACTION, {
+      action_type: "open",
+      surface: "feed_home",
+      feed_id: feedId,
+    });
+  }, [feedId]);
+
+  if (!feed) {
+    return (
+      <div className={cn("flex min-h-0 flex-col", className)}>
+        <Empty className="border-0 py-8">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <MagnifyingGlassIcon />
+            </EmptyMedia>
+            <EmptyTitle>Saved search not found</EmptyTitle>
+            <EmptyDescription>
+              Searches are saved per project on this device.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    );
+  }
+
+  const handleDelete = () => {
+    removeFeed(feed.id);
+    select(null);
+    track(ANALYTICS_EVENTS.TASK_FEED_ACTION, {
+      action_type: "delete",
+      surface: "feed_home",
+      feed_id: feed.id,
+    });
+    toast.success("Saved search deleted");
+    void navigate({ to: "/website" });
+  };
+
+  return (
+    <div className={cn("flex min-h-0 flex-col", className)}>
+      <div className="flex h-10 shrink-0 items-center gap-2 border-border border-b pr-2 pl-3">
+        <span className="truncate font-bold text-base">{feed.name}</span>
+        {!isLoading && !error && (
+          <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
+            {isComplete ? tasks.length : `${tasks.length}+`}
+          </span>
+        )}
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          <Button
+            variant="default"
+            size="icon-xs"
+            aria-label="Edit saved search"
+            onClick={() => setEditOpen(true)}
+          >
+            <PencilSimpleIcon size={14} />
+          </Button>
+          <Button
+            variant="default"
+            size="icon-xs"
+            aria-label="Delete saved search…"
+            onClick={() => setConfirmDeleteOpen(true)}
+          >
+            <TrashIcon size={14} />
+          </Button>
+        </div>
+      </div>
+
+      <Button
+        variant="default"
+        left
+        className="h-auto shrink-0 gap-2 rounded-none border-border border-b px-3 py-2"
+        onClick={() => setEditOpen(true)}
+      >
+        <MagnifyingGlassIcon size={12} className="shrink-0 text-(--gray-9)" />
+        <FeedQueryHighlight query={feed.query} className="min-w-0 truncate" />
+      </Button>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+        {isLoading && tasks.length === 0 ? (
+          <div className="flex justify-center py-10">
+            <Spinner />
+          </div>
+        ) : error ? (
+          <Text className="block px-2 py-6 text-center text-(--red-11) text-xs">
+            {errorMessage}
+          </Text>
+        ) : tasks.length === 0 ? (
+          <Empty className="border-0 py-8">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <MagnifyingGlassIcon />
+              </EmptyMedia>
+              <EmptyTitle>No tasks match</EmptyTitle>
+              <EmptyDescription>
+                Tasks appear here as they start matching the query.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="flex flex-col gap-px">
+            {tasks.map((task) => (
+              <TaskFeedRow
+                key={task.id}
+                task={task}
+                isActive={selected?.taskId === task.id}
+                onSelect={() =>
+                  select({
+                    feedId,
+                    taskId: task.id,
+                    channelId: task.channel ?? null,
+                  })
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <TaskFeedModal open={editOpen} onOpenChange={setEditOpen} feed={feed} />
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent className="max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete saved search?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete <span className="font-medium">{feed.name}</span>? You
+              cannot undo this action.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose
+              render={
+                <Button variant="outline" size="sm">
+                  Cancel
+                </Button>
+              }
+            />
+            <Button variant="destructive" size="sm" onClick={handleDelete}>
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -37,6 +37,37 @@ import { useMemo } from "react";
  * nothing — which keeps the personal-channel ownership filter from running
  * against an identity we haven't established yet.
  */
+export function useChannelSessionFacts(): ChannelSessionFacts {
+  const sessions = useSidebarSessionMap();
+  const { timestamps } = useTaskViewed();
+  const { data: workspaces } = useWorkspaces();
+
+  return useMemo<ChannelSessionFacts>(() => {
+    const needsInputTaskIds = new Set<string>();
+    for (const [taskId, session] of sessions) {
+      if ((session.pendingPermissions?.size ?? 0) > 0) {
+        needsInputTaskIds.add(taskId);
+      }
+    }
+    const workspaceByTaskId = new Map<string, ChannelWorkspaceFacts>();
+    for (const [taskId, workspace] of Object.entries(workspaces ?? {})) {
+      workspaceByTaskId.set(taskId, {
+        mode: workspace.mode,
+        folderPath: workspace.folderPath,
+        isScratch: workspace.isScratch,
+        // The linked branch wins: a worktree's own branch is where the work is
+        // only until it is linked to the branch the PR is on.
+        branch: workspace.linkedBranch ?? workspace.branchName ?? undefined,
+      });
+    }
+    return {
+      needsInputTaskIds,
+      viewedTimestamps: timestamps,
+      workspaceByTaskId,
+    };
+  }, [sessions, timestamps, workspaces]);
+}
+
 export function useChannelItems(channelId: string): {
   items: ChannelItemModel[];
   actions: ChannelItemActions;
@@ -75,34 +106,7 @@ export function useChannelItems(channelId: string): {
   // permission prompt, when you last looked, and where the workspace is. The
   // session map is the sidebar's own subscription, which ignores the streamed
   // events a turn fires and only wakes on the fields a row reads.
-  const sessions = useSidebarSessionMap();
-  const { timestamps } = useTaskViewed();
-  const { data: workspaces } = useWorkspaces();
-  const sessionFacts = useMemo<ChannelSessionFacts>(() => {
-    const needsInputTaskIds = new Set<string>();
-    for (const [taskId, session] of sessions) {
-      if ((session.pendingPermissions?.size ?? 0) > 0) {
-        needsInputTaskIds.add(taskId);
-      }
-    }
-    const workspaceByTaskId = new Map<string, ChannelWorkspaceFacts>();
-    for (const [taskId, workspace] of Object.entries(workspaces ?? {})) {
-      workspaceByTaskId.set(taskId, {
-        mode: workspace.mode,
-        folderPath: workspace.folderPath,
-        isScratch: workspace.isScratch,
-        // The linked branch wins: a worktree's own branch is where the work is
-        // only until it is linked to the branch the PR is on.
-        branch: workspace.linkedBranch ?? workspace.branchName ?? undefined,
-      });
-    }
-    return {
-      needsInputTaskIds,
-      viewedTimestamps: timestamps,
-      workspaceByTaskId,
-    };
-  }, [sessions, timestamps, workspaces]);
-
+  const sessionFacts = useChannelSessionFacts();
   const meUuid = currentUser?.uuid ?? null;
   const me = useMemo<ChannelItemOwner>(() => ({ uuid: meUuid }), [meUuid]);
   // Only a uuid establishes identity — ownership compares uuids, so a viewer

--- a/products/desktop/packages/ui/src/features/canvas/stores/taskFeedSelectionStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/taskFeedSelectionStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+export interface TaskFeedSelection {
+  feedId: string;
+  taskId: string;
+  channelId: string | null;
+}
+
+interface TaskFeedSelectionState {
+  selected: TaskFeedSelection | null;
+  select: (selection: TaskFeedSelection | null) => void;
+}
+
+export const useTaskFeedSelectionStore = create<TaskFeedSelectionState>()(
+  (set) => ({
+    selected: null,
+    select: (selected) => set({ selected }),
+  }),
+);
+
+export function useTaskFeedSelection(feedId: string): TaskFeedSelection | null {
+  const selected = useTaskFeedSelectionStore((state) => state.selected);
+  return selected?.feedId === feedId ? selected : null;
+}

--- a/products/desktop/packages/ui/src/features/navigation/useActiveSession.ts
+++ b/products/desktop/packages/ui/src/features/navigation/useActiveSession.ts
@@ -1,5 +1,6 @@
 import { useRailSurface } from "@posthog/ui/features/canvas/hooks/useRailSurface";
 import { useActivityDetailStore } from "@posthog/ui/features/canvas/stores/activityDetailStore";
+import { useTaskFeedSelectionStore } from "@posthog/ui/features/canvas/stores/taskFeedSelectionStore";
 import { useParams } from "@tanstack/react-router";
 
 export interface ActiveSession {
@@ -14,12 +15,19 @@ export interface ActiveSession {
 export function useActiveSession(): ActiveSession {
   const { showsActivityDetail } = useRailSurface();
   const selected = useActivityDetailStore((s) => s.selected);
+  const feedSelected = useTaskFeedSelectionStore((s) => s.selected);
   const params = useParams({ strict: false });
 
   if (showsActivityDetail) {
     return {
       taskId: selected?.taskId,
       channelId: selected?.channelId ?? undefined,
+    };
+  }
+  if (params.feedId && feedSelected?.feedId === params.feedId) {
+    return {
+      taskId: feedSelected.taskId,
+      channelId: feedSelected.channelId ?? undefined,
     };
   }
   return { taskId: params.taskId, channelId: params.channelId };

--- a/products/desktop/packages/ui/src/router/routes/website/feeds/$feedId.tsx
+++ b/products/desktop/packages/ui/src/router/routes/website/feeds/$feedId.tsx
@@ -1,4 +1,6 @@
+import { TaskFeedDetailPane } from "@posthog/ui/features/canvas/components/TaskFeedDetailPane";
 import { TaskFeedHome } from "@posthog/ui/features/canvas/components/TaskFeedHome";
+import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import {
   ChannelSkeleton,
   withRouteSkeleton,
@@ -12,5 +14,10 @@ export const Route = createFileRoute("/website/feeds/$feedId")({
 
 function TaskFeedRoute() {
   const { feedId } = Route.useParams();
-  return <TaskFeedHome feedId={feedId} />;
+  const channelsLayout = useChannelsLayout();
+  return channelsLayout ? (
+    <TaskFeedDetailPane feedId={feedId} />
+  ) : (
+    <TaskFeedHome feedId={feedId} />
+  );
 }


### PR DESCRIPTION
## Problem

Opening a match from a saved search takes you off the search. The saved search fills the whole screen with task cards, and picking one navigates to the task, so returning means reopening the search and finding your place again. Working through a list of matches costs a round trip per task.

Activity already solved this: its feed sits in the sidebar pane and the item you pick reads in the main pane.

## Changes

- A saved search now lists its matches in the sidebar pane, and the match you pick opens beside it. The list keeps its scroll and selection, so you can work down it.
- Matches render as `ChannelItemRow`, the same row a space's session list uses. Each one carries its status dot, metadata line, badges, hover card, and right-click menu.
- The right-click menu pins, archives, files to a space, and adds to the command center. Pin and archive run the shared mutations, so the row behaves as it does in a space.
- The task header names the space the task is filed in. It read "Space" before, and a task with no space now shows its title alone.
- Clicking the query, or the pencil, opens the edit modal. The modal is laid out again: name, then query, then a live panel naming the first four matches with their space and last activity.
- The query suggestion list is opaque. Its surface used a Radix Themes variable that is undefined inside the dialog portal, so the name field and the hint underneath showed through it. Suggestions now open over the match panel instead of over an input.
- The modal no longer scrolls as a whole. The match panel takes the leftover height and scrolls its own list, so the fields stay put. A window under about 450px tall still scrolls the body, which keeps the fields reachable.
- Deleting the search from the pane clears the open task and returns to the space.
- Selection lives in a store keyed by feed id, not in the URL. The route stays on the saved search while you read tasks, which is what keeps the pane on screen.
- `useActiveSession` resolves the selected task, so the header row and right panel follow it the way they follow an Activity selection.
- The old full-width feed stays for the layout without the channels sidebar, which has no pane to put the list in.

Mechanical: the session-facts memo moves out of `useChannelItems` into an exported `useChannelSessionFacts`, so the pane builds its items from the same facts. The route component picks between the two views by layout flag.

| Matches | Suggestions open | No matches | Short window, 1000×520 |
| --- | --- | --- | --- |
| ![light-many](https://raw.githubusercontent.com/PostHog/pr-assets/fd8ea81470fa4de95afd895a5c3067e92fb74f12/2026/08/891a4a81-ed77-4b07-9abc-e360e123eae7.png) | ![light-suggest](https://raw.githubusercontent.com/PostHog/pr-assets/dd42ab222c8e2e840154437de5422ee6a4f76a85/2026/08/79804553-4661-4365-96d7-6e1cdc13c42e.png) | ![light-none](https://raw.githubusercontent.com/PostHog/pr-assets/31e8f7d80574390172b083e364aa82140bc312e8/2026/08/48267852-2059-46f0-afb9-54e4cad4a02a.png) | ![light-many-short](https://raw.githubusercontent.com/PostHog/pr-assets/57bb49d0156ac8dadacc1fcaa5aef90a1499166f/2026/08/028b99fb-5ad6-43ca-bd25-adc021101de8.png) |

Rendered in Storybook with invented sample tasks.

## How did you test this code?

- Added `TaskFeedPane.test.tsx`. It catches two regressions no existing test covers: a match click that navigates instead of selecting, and a delete that leaves a stale task open in the main pane.
- Rendered the modal in Storybook across 9 states per theme: many, one, and no matches, long titles, suggestions open, and viewports from 1100×1100 down to 900×420. Asserted per state that the body does not scroll, the footer stays on screen, the suggestion popover is opaque, and it never covers a field. Only the 900×420 case scrolls the body, by design.
- Rendered the pane at 360×760 and 360×420, full and empty, and asserted no horizontal overflow and no clipped row text.
- Ran the `@posthog/ui` vitest suite and `tsc --noEmit` for that package, plus `hogli ci:preflight --fix`, which triggered Biome only, since the diff is desktop TypeScript.
- Not done: no manual run of the desktop app, so the hover card and context menu are verified by their wiring rather than by use.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with pi. The work started as an HTML mockup, reviewed and revised before any code: the first pass edited the query inline in the pane, which review replaced with a modal, and it had a back row to a saved-search list, which review removed, because the command palette is the only way into a saved search.

Later rounds shaped the rest. The first implementation drew its own compact row on `SidebarItem`, and review asked for the shared row, so rows moved to `ChannelItemRow` and picked up the hover card and context menu with it. Review then caught the transparent suggestion popover, the placeholder space name, and a scrollbar down the modal, each from a screenshot of the running app.

Skills invoked: `/writing-pr-descriptions`.

Component structure follows `ActivityFeedList` and `ActivityDetailPane` deliberately, so the two split-view destinations stay one pattern. Per the requester, the code carries no comments.
