### PR TITLE
fix(data-warehouse): drop duplicate rows left by first-sync appends

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -265,6 +265,45 @@ async def _seed_cdc_companion_from_snapshot(
     )
 
 
+async def _repair_duplicate_primary_keys(
+    schema: ExternalDataSchema,
+    delta_table_ref: "DeltaTableRef",
+    resource: "Optional[SourceResponse]",
+    is_cdc_companion: bool,
+    logger: FilteringBoundLogger,
+) -> None:
+    """Collapse primary-key duplicates left behind when this run built the table through appends.
+
+    Only a first sync or a rebuild writes that way, so the probe is scoped to those runs instead
+    of charging a key scan to every sync. SCD2 companion tables are excluded because they keep
+    several rows per key by design, and non-merge sync types are excluded because repeated keys
+    there come from the source rather than from how the run wrote.
+
+    Best-effort: this run's rows are already durable, so a failure to deduplicate them must not
+    fail the sync. The duplicates stay visible in the log and can be repaired offline.
+    """
+    if is_cdc_companion or not delta_table_ref.is_first_sync:
+        return
+    if not (schema.is_incremental or schema.is_webhook or schema.is_xmin):
+        return
+
+    resource_keys = list(resource.primary_keys) if resource is not None and resource.primary_keys else []
+    primary_keys = schema.primary_key_columns or resource_keys
+    if not primary_keys:
+        return
+
+    from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.dedupe import (  # noqa: PLC0415 — keeps the heavy deltalake dep off this module's top-level import path
+        repair_duplicate_primary_keys,
+    )
+
+    try:
+        with POST_LOAD_DURATION_SECONDS.labels(operation="repair_duplicate_primary_keys").time():
+            await repair_duplicate_primary_keys(delta_table_ref, primary_keys, logger)
+    except Exception as e:
+        capture_exception(e)
+        logger.exception("Failed to repair duplicate primary keys", exc_info=e)
+
+
 async def _run_delta_maintenance(
     schema: ExternalDataSchema,
     delta_table_ref: "DeltaTableRef",
@@ -650,6 +689,10 @@ async def run_post_load_operations(
         await _finalize_sync_bookkeeping(job, schema, resource, last_incremental_field_value, logger)
         await _run_post_load_steps(job, schema, source, delta_table_ref, is_cdc_companion, logger)
         return None
+
+    # Ahead of maintenance so compaction folds the rewritten files, and ahead of the publish
+    # below so the queryable folder never serves a generation that still holds the duplicates.
+    await _repair_duplicate_primary_keys(schema, delta_table_ref, resource, is_cdc_companion, logger)
 
     await _run_delta_maintenance(schema, delta_table_ref, is_cdc_companion, logger)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -24,6 +24,7 @@ _LOAD_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelin
 _DB_RETRY_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.common.db_retry"
 _PIPELINE_SYNC_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync"
 _REPARTITION_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition_controller"
+_DEDUPE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.dedupe"
 _JOB_CREATED_AT = datetime(2026, 8, 19, 11, 0, tzinfo=UTC)
 
 
@@ -34,6 +35,7 @@ def _make_schema(
     partition_count: int | None = 7,
     cdc_table_mode: str = "consolidated",
     initial_sync_complete: bool = True,
+    primary_key_columns: list[str] | None = None,
 ) -> MagicMock:
     config = sync_type_config if sync_type_config is not None else {}
     schema = MagicMock()
@@ -47,13 +49,20 @@ def _make_schema(
     schema.partition_count = partition_count
     schema.cdc_table_mode = cdc_table_mode
     schema.initial_sync_complete = initial_sync_complete
+    schema.primary_key_columns = primary_key_columns
+    # Set explicitly so the duplicate-key gate reads real booleans rather than truthy mock
+    # attributes, which would make every schema look merge-keyed.
+    schema.is_incremental = not is_cdc
+    schema.is_webhook = False
+    schema.is_xmin = False
     return schema
 
 
-def _make_helper(*, file_uris: list[str] | None = None) -> MagicMock:
+def _make_helper(*, file_uris: list[str] | None = None, is_first_sync: bool = False) -> MagicMock:
     return MagicMock(
         get_delta_table=AsyncMock(return_value=MagicMock()),
         get_file_uris=AsyncMock(return_value=file_uris or []),
+        is_first_sync=is_first_sync,
     )
 
 
@@ -97,6 +106,76 @@ async def _run_post_load(
             cdc_write_mode=cdc_write_mode,
         )
     return run_scheduled, compact_table, prepare_s3
+
+
+class TestRunPostLoadDuplicatePrimaryKeys:
+    """Post-load only probes for duplicate primary keys on the runs that can create them; the
+    probe and repair themselves are covered in core/delta/test/test_dedupe.py."""
+
+    @staticmethod
+    async def _run(schema: MagicMock, helper: MagicMock, *, cdc_write_mode: str | None = None) -> AsyncMock:
+        repair = AsyncMock(return_value=0)
+        with patch(f"{_DEDUPE_MODULE}.repair_duplicate_primary_keys", repair):
+            await _run_post_load(schema, helper, cdc_write_mode=cdc_write_mode)
+        return repair
+
+    @pytest.mark.asyncio
+    async def test_first_sync_of_a_keyed_schema_is_repaired(self):
+        # A first sync writes chunk 0 with an overwrite and the rest with appends, which do no key
+        # matching, so a key spanning chunks lands once per chunk and nothing else ever removes it.
+        schema = _make_schema(is_cdc=False, primary_key_columns=["id"])
+
+        repair = await self._run(schema, _make_helper(is_first_sync=True))
+
+        repair.assert_awaited_once()
+        assert repair.await_args is not None
+        assert repair.await_args.args[1] == ["id"]
+
+    @parameterized.expand(
+        [
+            # Steady state never takes the append path, and a key scan on every sync would charge
+            # the whole fleet for a defect only first syncs and rebuilds can produce.
+            ("steady_state", {"is_first_sync": False}, {}, None),
+            # SCD2 companions keep several rows per key on purpose, so deduplicating them is data loss.
+            ("cdc_companion", {"is_first_sync": True}, {}, "scd2_append"),
+            # Without a key there is nothing to collapse on.
+            ("no_primary_keys", {"is_first_sync": True}, {"primary_key_columns": None}, None),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_runs_that_cannot_duplicate_are_not_scanned(
+        self, _name: str, helper_kwargs: dict, schema_kwargs: dict, cdc_write_mode: str | None
+    ) -> None:
+        schema = _make_schema(is_cdc=False, **{"primary_key_columns": ["id"], **schema_kwargs})
+
+        repair = await self._run(schema, _make_helper(**helper_kwargs), cdc_write_mode=cdc_write_mode)
+
+        repair.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_merge_sync_types_are_not_scanned(self):
+        # A full refresh legitimately appends every chunk, so repeated keys there come from the
+        # source and collapsing them would silently change what the customer asked to sync.
+        schema = _make_schema(is_cdc=False, primary_key_columns=["id"])
+        schema.is_incremental = False
+
+        repair = await self._run(schema, _make_helper(is_first_sync=True))
+
+        repair.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_repair_does_not_fail_the_sync(self):
+        # The run's rows are already durable at this point; duplicates can be repaired offline.
+        schema = _make_schema(is_cdc=False, primary_key_columns=["id"])
+        repair = AsyncMock(side_effect=RuntimeError("delta blew up"))
+
+        with (
+            patch(f"{_DEDUPE_MODULE}.repair_duplicate_primary_keys", repair),
+            patch(f"{_LOAD_MODULE}.capture_exception") as capture,
+        ):
+            await _run_post_load(schema, _make_helper(is_first_sync=True))
+
+        capture.assert_called_once()
 
 
 class TestRunPostLoadDeltaMaintenance:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/dedupe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/dedupe.py
@@ -1,0 +1,122 @@
+import asyncio
+from collections.abc import Sequence
+
+import pyarrow as pa
+import deltalake
+from structlog.types import FilteringBoundLogger
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    first_per_pk_table,
+    normalize_column_name,
+    pyarrow_schema_from_arrow_exportable,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.ops import (
+    execute_with_conflict_retry,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import DeltaTableRef
+
+
+def _distinct_key_count(keys: pa.Table, key_columns: list[str]) -> int:
+    """Number of distinct key tuples. Grouping handles composite keys, which
+    `pyarrow.compute.count_distinct` cannot express since it takes a single array."""
+    return keys.group_by(key_columns).aggregate([]).num_rows
+
+
+def _partition_values(delta_table: deltalake.DeltaTable) -> list[str]:
+    """Every partition value the table currently holds files for.
+
+    `get_add_actions` returns an arro3 table rather than a pyarrow one, so it has to be
+    adapted before pyarrow's accessors are available.
+    """
+    actions = pa.table(delta_table.get_add_actions(flatten=True))
+    column = f"partition.{PARTITION_KEY}"
+    if column not in actions.column_names:
+        return []
+    return sorted({value for value in actions.column(column).to_pylist() if value is not None})
+
+
+def _dedupe(data: pa.Table, key_columns: list[str]) -> tuple[pa.Table, int]:
+    deduped = first_per_pk_table(data, key_columns, keep="last")
+    return deduped, data.num_rows - deduped.num_rows
+
+
+async def _rewrite(
+    delta_table: deltalake.DeltaTable,
+    data: pa.Table,
+    predicate: str | None,
+    partitioned: bool,
+    logger: FilteringBoundLogger,
+) -> None:
+    def _write() -> None:
+        deltalake.write_deltalake(
+            table_or_uri=delta_table,
+            data=data,
+            partition_by=PARTITION_KEY if partitioned else None,
+            mode="overwrite",
+            predicate=predicate,
+        )
+
+    await execute_with_conflict_retry(delta_table, _write, "repair_duplicate_primary_keys", logger)
+
+
+async def repair_duplicate_primary_keys(
+    table_ref: DeltaTableRef,
+    primary_keys: Sequence[str],
+    logger: FilteringBoundLogger,
+) -> int:
+    """Collapse rows sharing a primary key down to one, returning how many rows were dropped.
+
+    A first sync or a rebuild writes its first chunk with an overwrite and every later chunk
+    with a plain append, because there is no table to merge against when the run starts.
+    Appends do no key matching, so a key the source emits in more than one chunk of that run
+    lands once per chunk. Nothing downstream repairs it: a later incremental merge matches
+    every copy of the key and updates them all together, which keeps the copies identical and
+    leaves the row count permanently inflated without ever failing a sync.
+
+    The probe reads only the key columns so that the common case, a table with no duplicates,
+    costs one narrow column scan. Repair rewrites a single partition at a time, so peak memory
+    follows the largest partition rather than the whole table.
+    """
+    delta_table = await table_ref.get_delta_table()
+    if delta_table is None:
+        return 0
+
+    available = set(pyarrow_schema_from_arrow_exportable(delta_table.schema()).names)
+    key_columns = [name for key in primary_keys if (name := normalize_column_name(key)) in available]
+    if not key_columns:
+        return 0
+
+    keys = await asyncio.to_thread(lambda: delta_table.to_pyarrow_dataset().to_table(columns=key_columns))
+    duplicate_rows = keys.num_rows - _distinct_key_count(keys, key_columns)
+    del keys
+    if duplicate_rows == 0:
+        return 0
+
+    await logger.awarning(
+        "repair_duplicate_primary_keys: found duplicate primary keys, rewriting",
+        duplicate_rows=duplicate_rows,
+        primary_keys=key_columns,
+    )
+
+    partition_columns = list(getattr(delta_table.metadata(), "partition_columns", None) or [])
+    partitioned = PARTITION_KEY in partition_columns
+
+    dropped = 0
+    if partitioned:
+        for value in _partition_values(delta_table):
+            data = await asyncio.to_thread(delta_table.to_pyarrow_table, partitions=[(PARTITION_KEY, "=", value)])
+            deduped, partition_dropped = _dedupe(data, key_columns)
+            if partition_dropped == 0:
+                continue
+            await _rewrite(delta_table, deduped, f"{PARTITION_KEY} = '{value}'", partitioned, logger)
+            dropped += partition_dropped
+    else:
+        data = await asyncio.to_thread(delta_table.to_pyarrow_table)
+        deduped, dropped = _dedupe(data, key_columns)
+        if dropped:
+            await _rewrite(delta_table, deduped, None, partitioned, logger)
+
+    await logger.ainfo("repair_duplicate_primary_keys: dropped duplicate rows", dropped_rows=dropped)
+
+    return dropped

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_dedupe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_dedupe.py
@@ -1,0 +1,156 @@
+import pytest
+
+import pyarrow as pa
+import deltalake
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.dedupe import (
+    repair_duplicate_primary_keys,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.test.helpers import (
+    make_local_table_ref,
+    make_logger,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.writer import DeltaWriter
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.partitioning import (
+    append_partition_key_to_table,
+)
+
+MAY = 1714521600
+JUNE = 1717200000
+
+
+def _rows(ids: list[str], created: list[int], *, region: list[str] | None = None) -> pa.Table:
+    columns: dict[str, pa.Array] = {
+        "id": pa.array(ids, pa.string()),
+        "created": pa.array(created, pa.int64()),
+        "balance": pa.array([1] * len(ids), pa.int64()),
+    }
+    if region is not None:
+        columns["region"] = pa.array(region, pa.string())
+    return pa.table(columns)
+
+
+def _with_partition_key(table: pa.Table) -> pa.Table:
+    result = append_partition_key_to_table(
+        table=table,
+        partition_count=1,
+        partition_size=1,
+        partition_keys=["created"],
+        partition_mode="datetime",
+        partition_format="month",
+        logger=make_logger(),
+    )
+    assert result is not None
+    return result.table
+
+
+async def _append_chunk(uri: str, data: pa.Table, *, primary_keys: list[str], overwrite: bool) -> None:
+    ref = make_local_table_ref(uri)
+    ref._is_first_sync = True
+    await DeltaWriter(ref).write(
+        data=data,
+        write_type="incremental",
+        should_overwrite_table=overwrite,
+        primary_keys=primary_keys,
+    )
+
+
+async def _build_table(
+    uri: str, chunks: list[pa.Table], *, primary_keys: list[str] | None = None, partitioned: bool = True
+) -> None:
+    keys = primary_keys or ["id"]
+    for index, chunk in enumerate(chunks):
+        data = _with_partition_key(chunk) if partitioned else chunk
+        await _append_chunk(uri, data, primary_keys=keys, overwrite=index == 0)
+
+
+def _counts(uri: str, key_columns: list[str]) -> tuple[int, int]:
+    table = deltalake.DeltaTable(uri).to_pyarrow_table()
+    distinct = table.group_by(key_columns).aggregate([]).num_rows
+    return table.num_rows, distinct
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("partitioned", [True, False])
+async def test_collapses_keys_duplicated_across_appended_chunks(tmp_path, partitioned):
+    uri = str(tmp_path / "t")
+    await _build_table(
+        uri,
+        [
+            _rows(["a", "busy"], [MAY, MAY]),
+            _rows(["b", "busy"], [JUNE, MAY]),
+            _rows(["c", "busy"], [MAY, MAY]),
+        ],
+        partitioned=partitioned,
+    )
+    assert _counts(uri, ["id"]) == (6, 4)
+
+    dropped = await repair_duplicate_primary_keys(make_local_table_ref(uri), ["id"], make_logger())
+
+    assert dropped == 2
+    assert _counts(uri, ["id"]) == (4, 4)
+
+
+@pytest.mark.asyncio
+async def test_keeps_every_column_of_the_surviving_row(tmp_path):
+    uri = str(tmp_path / "t")
+    await _build_table(uri, [_rows(["busy"], [MAY]), _rows(["busy"], [MAY])])
+
+    await repair_duplicate_primary_keys(make_local_table_ref(uri), ["id"], make_logger())
+
+    table = deltalake.DeltaTable(uri).to_pyarrow_table()
+    assert table.num_rows == 1
+    assert set(table.column_names) >= {"id", "created", "balance", PARTITION_KEY}
+    assert table.column("created").to_pylist() == [MAY]
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_table_without_duplicates_unwritten(tmp_path):
+    uri = str(tmp_path / "t")
+    await _build_table(uri, [_rows(["a"], [MAY]), _rows(["b"], [JUNE])])
+    version_before = deltalake.DeltaTable(uri).version()
+
+    dropped = await repair_duplicate_primary_keys(make_local_table_ref(uri), ["id"], make_logger())
+
+    assert dropped == 0
+    assert deltalake.DeltaTable(uri).version() == version_before
+
+
+@pytest.mark.asyncio
+async def test_collapses_on_the_full_composite_key(tmp_path):
+    uri = str(tmp_path / "t")
+    await _build_table(
+        uri,
+        [
+            _rows(["k", "k"], [MAY, MAY], region=["us", "eu"]),
+            _rows(["k"], [MAY], region=["us"]),
+        ],
+        primary_keys=["id", "region"],
+    )
+    assert _counts(uri, ["id", "region"]) == (3, 2)
+
+    dropped = await repair_duplicate_primary_keys(make_local_table_ref(uri), ["id", "region"], make_logger())
+
+    assert dropped == 1
+    assert _counts(uri, ["id", "region"]) == (2, 2)
+
+
+@pytest.mark.asyncio
+async def test_skips_a_key_that_is_not_a_column_of_the_table(tmp_path):
+    uri = str(tmp_path / "t")
+    await _build_table(uri, [_rows(["busy"], [MAY]), _rows(["busy"], [MAY])])
+
+    dropped = await repair_duplicate_primary_keys(make_local_table_ref(uri), ["no_such_column"], make_logger())
+
+    assert dropped == 0
+    assert _counts(uri, ["id"]) == (2, 1)
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_the_table_does_not_exist(tmp_path):
+    dropped = await repair_duplicate_primary_keys(
+        make_local_table_ref(str(tmp_path / "missing")), ["id"], make_logger()
+    )
+
+    assert dropped == 0

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -420,6 +420,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
             resource_name=export_signal.resource_name,
             job=job,
             logger=logger,
+            is_first_sync=export_signal.is_first_ever_sync,
         )
 
         delta_table = await delta_table_ref.get_delta_table()


### PR DESCRIPTION
## Problem

Queries against a synced warehouse table can return several identical rows for one primary key, so counts, joins and views over that table read high for everyone using it.

- A first sync or a rebuild writes its first chunk with an overwrite and every later chunk with a plain append, because there is no table to merge against when the run starts.
- Appends do no key matching, so a key the source emits in more than one chunk of that run lands once per chunk.
- Nothing repairs it afterwards. A later incremental merge matches every copy of the key and updates them all together, which keeps the copies identical and the row count inflated without any sync failing.

## Changes

- Post-load collapses duplicate primary keys after a first sync or a rebuild, so the table it publishes holds one row per key.
- The probe reads only the primary-key columns, so a table with no duplicates pays a single narrow column scan.
- Repair rewrites one partition at a time, so peak memory follows the largest partition rather than the whole table.
- The probe runs only for a run that took the append path on a merge-keyed schema. Steady-state syncs, full refresh, SCD2 companions and keyless tables are untouched.
- Repair runs before compaction and before the queryable folder is published, so a query never reads a generation that still holds duplicates.
- A repair failure is logged and captured, but does not fail the sync, because the run's rows are already durable by then.
- Converting the later chunks to merges was the obvious alternative. A local harness measured it at 80x slower on a 10-chunk sync, 0.2s against 16.7s, so the append path keeps its speed and the duplicates are collapsed once at the end instead.
- Mechanical: the v3 redelivered-final-batch path builds its `DeltaTableRef` with the run's first-sync flag, so both v3 post-load paths gate the same way.

Nothing changes in the UI. The visible effect is on the rows a warehouse table returns.

> [!NOTE]
> Tables that already hold duplicates are not repaired here, because they will not run another first sync. Those need a one-off offline pass.

## How did you test this code?

Automated tests only. No run against a real source, real S3, or any production table.

- `core/delta/test/test_dedupe.py` drives the real `DeltaWriter` down the append path and then repairs. The cases catch the repair not collapsing at all, missing the unpartitioned layout, and collapsing on only the first column of a composite key, which would delete distinct rows.
- One case asserts a table without duplicates leaves the Delta version unchanged, which catches a repair that rewrites every table and doubles post-load cost.
- Two cases cover a key that is not a column of the table and a table that does not exist, which catch a crash on a stale persisted key name.
- `common/test/test_load.py` covers the gate. Widening it would charge every steady-state sync a key scan, and would deduplicate SCD2 companion tables, which is data loss because they keep several rows per key by design.

`test_cdp_producer.py` errored twice during a local full-suite run with an `auth_permission` unique-constraint violation. It passes in isolation, so that is a local test-database collision rather than this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The session started as an investigation into duplicate primary keys in warehouse tables. The opening hypothesis, that the delta merge fails to match and re-inserts on every sync, was disproved: every copy of a duplicated key carries the same load id, so all copies come from a single run.
- The first fix proposed clearing the first-sync flag after chunk 0 so later chunks merge. A local harness measured that at 80x slower, and it was withdrawn in favour of the detect-and-repair design here.
- No customer data, ticket, or internal thread contributed to any file in this diff. The test fixtures use invented ids and fixed epoch timestamps.
