### PR TITLE
feat(desktop): file canvases to other spaces

### DIFF
--- a/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
@@ -145,6 +145,11 @@ export const renameDashboardInput = z.object({
   name: z.string().min(1),
 });
 
+export const fileDashboardInput = z.object({
+  id: z.string().min(1),
+  channelId: z.string().min(1),
+});
+
 // Set (or clear, when taskId is null) the canvas's generation-task association.
 export const setGenerationTaskInput = z.object({
   id: z.string().min(1),

--- a/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
@@ -104,3 +104,20 @@ describe("DashboardsService.getBuilds", () => {
     expect(lifecycle.builds[0].buildStatus).toBe("ready");
   });
 });
+
+describe("DashboardsService.file", () => {
+  it("patches the canvas channel", async () => {
+    const { api, calls } = fakeApi({
+      "canvases/c1/": apiCanvas({ channel: "chan-2" }),
+    });
+    const service = new DashboardsService(api);
+
+    const canvas = await service.file({ id: "c1", channelId: "chan-2" });
+
+    expect(canvas.channelId).toBe("chan-2");
+    expect(calls[0]).toMatchObject({ path: "canvases/c1/" });
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      channel_id: "chan-2",
+    });
+  });
+});

--- a/products/desktop/packages/core/src/canvas/dashboardsService.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.ts
@@ -331,6 +331,14 @@ export class DashboardsService {
     return this.patch(input.id, { pinned: input.pinned }, "set pin");
   }
 
+  file(input: { id: string; channelId: string }): Promise<DashboardRecord> {
+    return this.patch(
+      input.id,
+      { channel_id: input.channelId },
+      "file canvas to space",
+    );
+  }
+
   // File a rendering error in the canvas's authoring-task thread (the server
   // dedupes per build and error type). Best-effort: a report must never affect
   // the render, and backends without the endpoint just refuse it, so every

--- a/products/desktop/packages/core/src/canvas/services.ts
+++ b/products/desktop/packages/core/src/canvas/services.ts
@@ -75,6 +75,7 @@ export interface IDashboardsService {
     taskId: string | null;
   }): Promise<DashboardRecord>;
   setPinned(input: { id: string; pinned: boolean }): Promise<DashboardRecord>;
+  file(input: { id: string; channelId: string }): Promise<DashboardRecord>;
   // File a rendering error against the build that threw it (best-effort).
   reportError(input: {
     id: string;

--- a/products/desktop/packages/host-router/src/routers/dashboards.router.ts
+++ b/products/desktop/packages/host-router/src/routers/dashboards.router.ts
@@ -18,6 +18,7 @@ import {
   createDashboardInput,
   dashboardIdInput,
   dashboardRecordSchema,
+  fileDashboardInput,
   listComponentsInput,
   listDashboardsInput,
   promoteCanvasInput,
@@ -179,6 +180,12 @@ export const dashboardsRouter = router({
       ctx.container
         .get<IDashboardsService>(DASHBOARDS_SERVICE)
         .setPinned(input),
+    ),
+  file: publicProcedure
+    .input(fileDashboardInput)
+    .output(dashboardRecordSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.container.get<IDashboardsService>(DASHBOARDS_SERVICE).file(input),
     ),
   reportError: publicProcedure
     .input(reportCanvasErrorInput)

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -514,6 +514,7 @@ describe("ChannelItemRow", () => {
       kind: "canvas",
       id: "c1",
       title: "Web analytics overview",
+      authorUser: { id: 999, uuid: "u-1", email: "owner@example.com" },
     });
     renderInList(
       <ChannelItemRow
@@ -535,6 +536,26 @@ describe("ChannelItemRow", () => {
     ).not.toBeNull();
     expect(screen.getByRole("button", { name: "File to…" })).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Archive" })).toBeNull();
+  });
+
+  it("does not offer filing for another user's canvas", async () => {
+    const canvas = item({
+      key: "canvas:c1",
+      kind: "canvas",
+      id: "c1",
+      title: "Web analytics overview",
+      authorUser: { id: 7, uuid: "u-2", email: "creator@example.com" },
+    });
+    renderInList(
+      <ChannelItemRow actions={actions} isActive={false} item={canvas} />,
+    );
+
+    await userEvent.hover(screen.getByText("Web analytics overview"));
+
+    expect(
+      await screen.findByRole("button", { name: "Pin" }, { timeout: 2000 }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "File to…" })).toBeNull();
   });
 
   it("confirms before deleting a canvas — it goes for the whole space", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -68,6 +68,7 @@ const actions = {
   setPinned: () => {},
   archive: () => {},
   remove: () => {},
+  fileCanvas: () => {},
 };
 
 function item(overrides: Partial<ChannelItemModel> = {}): ChannelItemModel {
@@ -507,7 +508,7 @@ describe("ChannelItemRow", () => {
     expect(screen.queryByRole("img", { name: "All caught up" })).toBeNull();
   });
 
-  it("gives a canvas the actions it has: pin and delete, not archive or filing", async () => {
+  it("lets a canvas be filed to another space", async () => {
     const canvas = item({
       key: "canvas:c1",
       kind: "canvas",
@@ -532,10 +533,8 @@ describe("ChannelItemRow", () => {
     expect(
       screen.getByRole("button", { name: "Add to Command Center…" }),
     ).not.toBeNull();
-    // A canvas can't be archived or filed to another space.
-    for (const absent of ["Archive", "File to…"]) {
-      expect(screen.queryByRole("button", { name: absent })).toBeNull();
-    }
+    expect(screen.getByRole("button", { name: "File to…" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Archive" })).toBeNull();
   });
 
   it("confirms before deleting a canvas — it goes for the whole space", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -302,6 +302,10 @@ export function ChannelItemRow({
     item.task != null &&
     item.authorUser?.id != null &&
     currentUser.data?.id === item.authorUser.id;
+  const canFileCanvas =
+    item.kind === "canvas" &&
+    item.authorUser?.id != null &&
+    currentUser.data?.id === item.authorUser.id;
   const handleDragStart = useCallback(
     (event: DragEvent) => {
       if (item.kind === "canvas") {
@@ -334,8 +338,12 @@ export function ChannelItemRow({
             title: item.title,
             isPinned: item.pinned,
             channelId,
-            onFile: (targetChannelId) =>
-              actions.fileCanvas(item, targetChannelId),
+            ...(canFileCanvas
+              ? {
+                  onFile: (targetChannelId: string) =>
+                    actions.fileCanvas(item, targetChannelId),
+                }
+              : {}),
             onTogglePin: () => actions.togglePin(item),
             onAddToCommandCenter,
             // Confirm first, like the canvas menus in the artifacts grid and
@@ -357,7 +365,15 @@ export function ChannelItemRow({
           },
     // canHandoff rides on the currentUser query, so it belongs in deps for a
     // sign-in refresh to re-evaluate.
-    [item, channelId, actions, onAddToCommandCenter, onRename, canHandoff],
+    [
+      item,
+      channelId,
+      actions,
+      onAddToCommandCenter,
+      onRename,
+      canHandoff,
+      canFileCanvas,
+    ],
   );
 
   if (isEditing) {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -64,6 +64,7 @@ export interface ChannelItemActions {
   archive: (item: ChannelItemModel) => void;
   /** Canvases only — a task is archived, not deleted. */
   remove: (item: ChannelItemModel) => void;
+  fileCanvas: (item: ChannelItemModel, channelId: string) => void;
 }
 
 // The channel sidebar's own chrome. Deliberately not shared with the Code
@@ -320,7 +321,7 @@ export function ChannelItemRow({
   );
 
   // A canvas gets the same menu with the items it actually has: command-centre
-  // placement, pin, and delete instead of archive. Filing remains task-only.
+  // placement, pin, filing, and delete instead of archive.
   //
   // Memoized because it travels to the shared preview card as the trigger's
   // payload, which is written to the card's store whenever its identity changes.
@@ -332,6 +333,9 @@ export function ChannelItemRow({
             id: item.id,
             title: item.title,
             isPinned: item.pinned,
+            channelId,
+            onFile: (targetChannelId) =>
+              actions.fileCanvas(item, targetChannelId),
             onTogglePin: () => actions.togglePin(item),
             onAddToCommandCenter,
             // Confirm first, like the canvas menus in the artifacts grid and

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedPane.tsx
@@ -104,6 +104,7 @@ export function TaskFeedPane({
         void archiveTask({ taskId: item.id });
       },
       remove: () => undefined,
+      fileCanvas: () => undefined,
     }),
     [feedId, select, togglePin, setPinnedMany, archiveTask],
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -185,7 +185,7 @@ function TaskRowMenuItems({
         <SquaresFourIcon size={14} />
         Add to Command Center…
       </Item>
-      {channelItems.length > 0 && (
+      {channelItems.length > 0 && (isTask || menu.onFile) && (
         <Sub>
           <SubTrigger>
             <FolderSimpleIcon size={14} />

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -54,8 +54,8 @@ import {
  * which needs the channel list and a mutation — belongs to the menu.
  *
  * Canvases share this menu but not all of it: they can be added to the command
- * centre, pinned, and deleted, but they can't be filed to another space.
- * `kind` decides which remaining actions apply.
+ * centre, pinned, filed, and deleted. `kind` decides which remaining actions
+ * apply.
  */
 export interface TaskRowMenuProps {
   kind: "task" | "canvas";
@@ -63,7 +63,7 @@ export interface TaskRowMenuProps {
   title: string;
   isPinned: boolean;
   task?: Task;
-  /** The channel this task is already filed to, ticked in "File to…". */
+  /** The channel this item is already filed to, ticked in "File to…". */
   channelId?: string;
   /** Absent when the command centre is full, which disables the item. */
   onAddToCommandCenter?: () => void;
@@ -71,6 +71,8 @@ export interface TaskRowMenuProps {
   onRename?: () => void;
   onStop?: () => void;
   onTogglePin: () => void;
+  /** Canvases supply their own filing mutation; task filing is shared here. */
+  onFile?: (channelId: string) => void;
   /** Tasks are archived; canvases are deleted (with an undo window). */
   onArchive?: () => void;
   onDelete?: () => void;
@@ -143,7 +145,7 @@ function TaskRowMenuItems({
   );
   const isTask = menu.kind === "task";
   const analysisTask = isTask && menu.task?.latest_run ? menu.task : null;
-  const { channels } = useChannels({ enabled: bluebirdEnabled && isTask });
+  const { channels } = useChannels({ enabled: bluebirdEnabled });
   const fileToChannel = useFileTaskToChannel();
 
   const channelItems: MenuFlyoutItem[] = channels.map((channel) => ({
@@ -183,7 +185,7 @@ function TaskRowMenuItems({
         <SquaresFourIcon size={14} />
         Add to Command Center…
       </Item>
-      {isTask && channelItems.length > 0 && (
+      {channelItems.length > 0 && (
         <Sub>
           <SubTrigger>
             <FolderSimpleIcon size={14} />
@@ -195,7 +197,9 @@ function TaskRowMenuItems({
               placeholder="Search spaces…"
               emptyLabel="No spaces"
               onSelect={(channelId) =>
-                fileToChannel(channelId, menu.id, menu.title)
+                menu.kind === "canvas"
+                  ? menu.onFile?.(channelId)
+                  : fileToChannel(channelId, menu.id, menu.title)
               }
             />
           </MenuSubFlyout>

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -94,9 +94,12 @@ export function useChannelItems(channelId: string): {
   });
   const archivedTaskIds = useArchivedTaskIds();
   const { pinnedTaskIds, togglePin, setPinnedMany } = usePinnedTasks();
-  const { archiveTask } = useArchiveTask();
-  const { setPinned: setCanvasPinned, invalidateDashboards } =
-    useDashboardMutations();
+  const { archiveTask } = useArchiveTask({ navigateUnscoped: true });
+  const {
+    setPinned: setCanvasPinned,
+    fileDashboard,
+    invalidateDashboards,
+  } = useDashboardMutations();
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser, isLoading: viewerLoading } = useCurrentUser({
     client,
@@ -214,6 +217,23 @@ export function useChannelItems(channelId: string): {
       archive: (item) => {
         void archiveTask({ taskId: item.id });
       },
+      fileCanvas: (item, targetChannelId) => {
+        fileDashboard(item.id, targetChannelId)
+          .then(() => {
+            const targetName = channels.find(
+              (candidate) => candidate.id === targetChannelId,
+            )?.name;
+            toast.success(
+              targetName ? `Filed to ${targetName}` : "Canvas filed",
+            );
+          })
+          .catch((error) => {
+            toast.error("Couldn't file canvas", {
+              description:
+                error instanceof Error ? error.message : String(error),
+            });
+          });
+      },
       // Canvases only, and through the shared undo window: the row disappears at
       // once and the host isn't told until the toast expires, so an accidental
       // delete costs nothing.
@@ -235,6 +255,8 @@ export function useChannelItems(channelId: string): {
       togglePin,
       setPinnedMany,
       archiveTask,
+      fileDashboard,
+      channels,
       invalidateDashboards,
     ],
   );

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -217,22 +217,18 @@ export function useChannelItems(channelId: string): {
       archive: (item) => {
         void archiveTask({ taskId: item.id });
       },
-      fileCanvas: (item, targetChannelId) => {
-        fileDashboard(item.id, targetChannelId)
-          .then(() => {
-            const targetName = channels.find(
-              (candidate) => candidate.id === targetChannelId,
-            )?.name;
-            toast.success(
-              targetName ? `Filed to ${targetName}` : "Canvas filed",
-            );
-          })
-          .catch((error) => {
-            toast.error("Couldn't file canvas", {
-              description:
-                error instanceof Error ? error.message : String(error),
-            });
+      fileCanvas: async (item, targetChannelId) => {
+        try {
+          await fileDashboard(item.id, targetChannelId);
+          const targetName = channels.find(
+            (candidate) => candidate.id === targetChannelId,
+          )?.name;
+          toast.success(targetName ? `Filed to ${targetName}` : "Canvas filed");
+        } catch (error) {
+          toast.error("Couldn't file canvas", {
+            description: error instanceof Error ? error.message : String(error),
           });
+        }
       },
       // Canvases only, and through the shared undo window: the row disappears at
       // once and the host isn't told until the toast expires, so an accidental

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -196,6 +196,9 @@ export function useDashboardMutations() {
   const setPinned = useMutation(
     trpc.dashboards.setPinned.mutationOptions({ onSuccess: invalidate }),
   );
+  const file = useMutation(
+    trpc.dashboards.file.mutationOptions({ onSuccess: invalidate }),
+  );
 
   return {
     // Refresh the canvas queries after a mutation that didn't go through this
@@ -232,6 +235,8 @@ export function useDashboardMutations() {
     // shows in the channel's Pinned menu for every member.
     setPinned: (id: string, pinned: boolean) =>
       setPinned.mutateAsync({ id, pinned }),
+    fileDashboard: (id: string, channelId: string) =>
+      file.mutateAsync({ id, channelId }),
     isCreating: create.isPending,
     isDeleting: remove.isPending,
     isSavingContext: saveContext.isPending,


### PR DESCRIPTION
## Problem

Canvas users can file sessions to another space, but canvas rows do not offer the same action.

This layer builds on [#86844](https://github.com/PostHog/posthog/pull/86844), which adds the protected canvas move API.

## Changes

- Canvas rows now offer the existing searchable “File to…” space picker.
- Filing moves the canvas itself and refreshes the source and destination feeds.
- The service and router additions connect the picker to the canvas API.
- Screenshot not captured because the menu requires an authenticated workspace with multiple spaces.

## How did you test this code?

- Core tests cover the canvas filing request.
- UI tests cover the filing action on canvas rows.
- The desktop package suites, full typecheck, and core boundary lint pass locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. The existing filing interaction now applies to canvases.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex restored the deferred desktop layer after the backend and frontend changes were split for independent deployment.

Skills invoked: `posthog-desktop`, `stacking-prs`, and `writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*