### PR TITLE
fix(desktop): reduce PR attribution log noise

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -5031,9 +5031,9 @@ ${commonInstructions}
       baseBranch: this.config.baseBranch ?? null,
     });
     if (!owned) {
-      // Info, not debug: a wrongly rejected PR leaves the run with no PR until the
-      // webhook backstop binds it, and this line is the only trace of why.
-      this.logger.info(
+      // Keep the evidence available for diagnosing wrongly rejected PRs without
+      // surfacing every unrelated PR URL found in routine agent output.
+      this.logger.debug(
         "PR seen in output is not this run's, skipping attribution",
         {
           runId: payload.run_id,


### PR DESCRIPTION
## Problem

Desktop users see routine PR ownership rejections as repeated info logs during agent runs.

**Why:** These expected rejections obscure actionable information while the diagnostic evidence remains useful for troubleshooting.

## Changes

- Routine PR attribution rejections now appear only in debug logs.
- The ownership guard and its diagnostic fields remain unchanged.
- This change has no visual interface impact.

## How did you test this code?

- The agent package typecheck and Biome check pass.
- All PR attribution tests pass.
- The full agent suite has seven unrelated failures in environment-dependent tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this focused logging change using the /posthog-desktop, /writing-tests, /writing-code-comments, and /writing-pr-descriptions skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*