### PR TITLE
perf(replay_vision): always correlate, dropping the candidate-count gate

### DIFF
--- a/products/replay_vision/backend/queries/scanner_candidate_query.py
+++ b/products/replay_vision/backend/queries/scanner_candidate_query.py
@@ -67,12 +67,9 @@ SAMPLE_RATE_PRECISION = 10_000
 # Smallest non-zero rate the modulo bucketing can express (one bucket); the API rejects non-zero rates below it.
 MIN_SAMPLING_RATE = 1 / SAMPLE_RATE_PRECISION
 DEFAULT_CANDIDATE_LIMIT = 5_000
-# Correlating only pays while the id list stays short. A bloom filter answers "might this granule
-# hold any of these values", so with N probes a granule survives with probability ~1-(1-p)^N and
-# pruning decays exponentially. Measured against a production 4h window: 1 id prunes 98.5% of
-# granules, 20 prunes 49%, 50 prunes 24%, and 300 prunes 0.2%. Past this many candidates the second
-# query reads what the single query would have read, on top of it, so the tick takes the plain path.
-CORRELATION_MAX_SESSIONS = 100
+# How many sessions one tick pulls into the correlated pass. Phase one is a keyset page over the
+# replay table and costs a few MiB, so a page that turns out not to prune is nearly free.
+CANDIDATE_SCAN_LIMIT = 2_000
 DEFAULT_MAX_EXECUTION_SECONDS = 180
 
 # Emitted by `emit_observation_event_activity` once an observation succeeds.
@@ -341,30 +338,20 @@ def run_correlated_batch(
     prune the scan, which is where the saving comes from.
     """
 
-    def single_query() -> CandidateBatch:
-        plain = build()
-        plain.limit = ast.Constant(value=dispatch_limit)
-        rows = execute(plain, match_query_type)
-        return build_candidate_batch(rows, rows, dispatch_limit, dispatch_limit)
-
     query = build()
     predicates = session_in_predicates(query)
     if not predicates:
         # No events subquery to correlate against, so splitting would only cost a second round trip.
-        return single_query()
+        query.limit = ast.Constant(value=dispatch_limit)
+        considered = execute(query, match_query_type)
+        return build_candidate_batch(considered, considered, dispatch_limit, dispatch_limit)
 
     for predicate in predicates:
         _drop_event_filter(predicate)
-    # One over the ceiling, so a window that holds too many to correlate is recognised without
-    # reading the rest of them.
-    query.limit = ast.Constant(value=CORRELATION_MAX_SESSIONS + 1)
+    query.limit = ast.Constant(value=CANDIDATE_SCAN_LIMIT)
     considered = execute(query, scan_query_type)
     if not considered:
         return CandidateBatch(matched=[])
-    if len(considered) > CORRELATION_MAX_SESSIONS:
-        # Too many ids for the bloom filter to prune on, so correlating would read the whole window
-        # again. The scan above is the only cost of finding that out.
-        return single_query()
 
     matching = build()
     session_ids = [c.session_id for c in considered]
@@ -374,9 +361,9 @@ def run_correlated_batch(
     # through a non-event branch, which the subquery restriction never sees; without this the match
     # set could run past the page the keyset is computed from.
     _restrict_outer_to_sessions(matching, session_ids)
-    matching.limit = ast.Constant(value=CORRELATION_MAX_SESSIONS)
+    matching.limit = ast.Constant(value=CANDIDATE_SCAN_LIMIT)
     matched = execute(matching, match_query_type)
-    return build_candidate_batch(considered, matched, dispatch_limit, CORRELATION_MAX_SESSIONS + 1)
+    return build_candidate_batch(considered, matched, dispatch_limit, CANDIDATE_SCAN_LIMIT)
 
 
 def session_in_predicates(query: ast.SelectQuery) -> list[ast.CompareOperation]:

--- a/products/replay_vision/backend/tests/test_candidate_batch.py
+++ b/products/replay_vision/backend/tests/test_candidate_batch.py
@@ -14,7 +14,6 @@ from posthog.models import Organization, Team
 
 from products.replay_vision.backend.models.replay_scanner import SETTLE_INTERVAL
 from products.replay_vision.backend.queries.scanner_candidate_query import (
-    CORRELATION_MAX_SESSIONS,
     CandidateSession,
     ScannerCandidateQuery,
     build_candidate_batch,
@@ -171,30 +170,6 @@ class TestSessionInPredicates:
         predicates = session_in_predicates(self._query(filter_test_accounts=True, with_event_filter=True).get_query())
 
         assert len(predicates) == 2
-
-    def test_a_window_with_too_many_sessions_falls_back_to_one_query(self) -> None:
-        # A bloom filter cannot prune on a long id list, so past the ceiling the second query would
-        # read the whole window again on top of the first. One plain query is cheaper.
-        candidate_query = self._query(filter_test_accounts=False, with_event_filter=True)
-        executed: list[str] = []
-
-        def execute(query: ast.SelectQuery, query_type: str) -> list[CandidateSession]:
-            executed.append(query_type)
-            if len(executed) == 1:
-                return [
-                    CandidateSession(session_id=f"s-{i}", session_end=_T0) for i in range(CORRELATION_MAX_SESSIONS + 1)
-                ]
-            return []
-
-        run_correlated_batch(
-            build=candidate_query.get_query,
-            execute=execute,
-            scan_query_type="scan",
-            match_query_type="match",
-            dispatch_limit=10,
-        )
-
-        assert executed == ["scan", "match"]
 
     def test_an_or_filter_still_bounds_the_match_query_to_the_scanned_page(self) -> None:
         # With operand OR a session can match through a non-event branch, which the subquery


### PR DESCRIPTION
## Problem

Several Replay Vision scanners started reading five to seven times more per sweep tick after #87207 shipped. The candidate-count gate added there stops correlating once a window holds more than 100 sessions, and those scanners sit above that line while still pruning well.

- The gate's threshold came from one team's pruning curve, where correlation genuinely stopped paying above about 100 session ids.
- That curve does not generalise. On other teams correlation still pays five to seven times far above the threshold.
- The gate also guards against very little. Phase one is a keyset page over the replay table, measured in production at 4.93 MiB on average and 7.53 MiB at p95 across 51,215 queries.
- So the gate trades a few megabytes of insurance for hundreds of gigabytes of lost pruning.

## Changes

- Affected scanners return to their pre-#87207 read volume, which is five to seven times lower per tick.
- The sweep always takes the correlated path when a scanner has an events subquery to correlate against.
- `CORRELATION_MAX_SESSIONS` and the single-query fallback are gone, and the page limit returns to `CANDIDATE_SCAN_LIMIT`.
- The comment now records why gating is wrong rather than restating the pruning curve, so the threshold does not get reintroduced.
- The rest of #87207, resolving group filters to group keys, is untouched and keeps working.

## How did you test this code?

Production query logs identify the gate as the cause: an affected scanner emits a 0.03 GiB phase-one scan and then a several-hundred GiB candidate query, which is the gate tripping and falling back. Before #87207 the same scanner averaged roughly a seventh of that.

The phase-one cost above is measured over the same logs, and is what makes the gate a bad trade in both directions.

Deleted the test that pinned the gate's fallback, since the behavior it described is gone. No new tests: this restores a path that ran in production for weeks and still has its existing coverage, and the failure mode is a cost regression that no unit test would have caught. The remaining suite for this module and the group key resolver passes.

Not checked: post-merge read volume, which needs a deploy and a few ticks to confirm.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this. Skills invoked: `/writing-pr-descriptions`, `/shepherd-pr`.

The gate was added in #87207 by the same session, on a pruning curve measured against a single team. Post-deploy verification across the top 25 scanners by read volume showed the regression, which is what prompted this revert. Skipped `/simplify` and a second bot review pass: the diff only deletes code added earlier today that already went through both.

No customer conversation, ticket, or log fed this change.
