### PR TITLE
feat(loops): add disable_loops management command

### DIFF
--- a/products/tasks/backend/logic/services/loop_runs.py
+++ b/products/tasks/backend/logic/services/loop_runs.py
@@ -380,7 +380,7 @@ def _fire_loop_committed(
         # deactivation grabs the row lock first, the other either sees the disabled row (and skips)
         # or blocks until this fire commits, so deactivation's run-cancellation scan then sees the
         # new run instead of racing past it. A run must never start under a just-deactivated
-        # owner's credentials (see loop_lifecycle._pause_loop_and_cancel_runs).
+        # owner's credentials (see loop_lifecycle.pause_loop).
         # `for_team`: fire_loop runs outside request/team scope (Temporal workflow, webhook), so the
         # fail-closed default manager would raise without ambient team context.
         locked_loop = (

--- a/products/tasks/backend/loop_lifecycle.py
+++ b/products/tasks/backend/loop_lifecycle.py
@@ -29,6 +29,7 @@ DISABLED_REASON_OWNER_DEACTIVATED = "owner_deactivated"
 DISABLED_REASON_OWNER_REMOVED = "owner_removed_from_org"
 DISABLED_REASON_GITHUB_DISCONNECTED = "github_integration_disconnected"
 
+DEFAULT_PAUSE_MESSAGE = "This loop has been paused."
 _PAUSE_MESSAGES = {
     DISABLED_REASON_OWNER_DEACTIVATED: "This loop's owner was deactivated, so it has been paused.",
     DISABLED_REASON_OWNER_REMOVED: "This loop's owner was removed from the organization, so it has been paused.",
@@ -44,7 +45,7 @@ def pause_loops_for_deactivated_user(user_id: int) -> None:
     loops = list(Loop.objects.unscoped().filter(created_by_id=user_id, enabled=True, deleted=False))
     for loop in loops:
         try:
-            _pause_loop_and_cancel_runs(loop, DISABLED_REASON_OWNER_DEACTIVATED)
+            pause_loop(loop, DISABLED_REASON_OWNER_DEACTIVATED)
         except Exception:
             logger.exception("loop_lifecycle.owner_deactivation_pause_failed", extra={"loop_id": str(loop.id)})
 
@@ -73,7 +74,7 @@ def pause_loops_for_removed_member(user_id: int, organization_id: str) -> None:
     )
     for loop in loops:
         try:
-            _pause_loop_and_cancel_runs(loop, DISABLED_REASON_OWNER_REMOVED)
+            pause_loop(loop, DISABLED_REASON_OWNER_REMOVED)
         except Exception:
             logger.exception("loop_lifecycle.member_removal_pause_failed", extra={"loop_id": str(loop.id)})
 
@@ -106,12 +107,30 @@ def _cancel_loop_runs_authored_by(user_id: int, *, organization_id: str | None =
         signal_loop_run_cancelled(run.workflow_id)
 
 
-def _pause_loop_and_cancel_runs(loop: Loop, reason: str) -> None:
+def pause_loop(
+    loop: Loop, reason: str, *, message: str | None = None, cancel_runs: bool = True, notify: bool = True
+) -> int:
+    """Pause one loop and record why. Returns how many in-flight runs were cancelled."""
     loop.enabled = False
     loop.disabled_reason = reason
     loop.save(update_fields=["enabled", "disabled_reason", "updated_at"])
     pause_loop_schedules(loop)
 
+    cancelled = _cancel_loop_runs(loop) if cancel_runs else 0
+
+    if notify:
+        dispatch_loop_event(
+            loop,
+            "needs_attention",
+            {
+                "reason": reason,
+                "body": message or _PAUSE_MESSAGES.get(reason, DEFAULT_PAUSE_MESSAGE),
+            },
+        )
+    return cancelled
+
+
+def _cancel_loop_runs(loop: Loop) -> int:
     now = django_timezone.now()
     # Matches both the FK (`Task.loop`) and the pre-FK run-state snapshot (`TaskRun.state["loop_id"]`),
     # same transitional lookup as `facade/loops.py::list_loop_runs`.
@@ -122,24 +141,17 @@ def _pause_loop_and_cancel_runs(loop: Loop, reason: str) -> None:
             status__in=_NON_TERMINAL_TASK_RUN_STATUSES,
         )
     )
-    if runs:
-        TaskRun.objects.filter(id__in=[run.id for run in runs]).update(
-            status=TaskRun.Status.CANCELLED, completed_at=now, updated_at=now
-        )
-        # Cancelling the DB row isn't enough: signal each workflow so the live sandbox actually winds
-        # down instead of running to completion under the deactivated owner's freshly minted
-        # credentials. That's the entire point of the security response (see module docstring).
-        for run in runs:
-            signal_loop_run_cancelled(run.workflow_id)
-
-    dispatch_loop_event(
-        loop,
-        "needs_attention",
-        {
-            "reason": reason,
-            "body": _PAUSE_MESSAGES.get(reason, "This loop has been paused."),
-        },
+    if not runs:
+        return 0
+    TaskRun.objects.filter(id__in=[run.id for run in runs]).update(
+        status=TaskRun.Status.CANCELLED, completed_at=now, updated_at=now
     )
+    # Cancelling the DB row isn't enough: signal each workflow so the live sandbox actually winds
+    # down instead of running to completion under the deactivated owner's freshly minted
+    # credentials. That's the entire point of the security response (see module docstring).
+    for run in runs:
+        signal_loop_run_cancelled(run.workflow_id)
+    return len(runs)
 
 
 def pause_loops_referencing_integrations(integrations: list[Integration], installation_id: str) -> None:
@@ -205,6 +217,7 @@ def pause_loops_referencing_integrations(integrations: list[Integration], instal
 
 
 __all__ = [
+    "pause_loop",
     "pause_loops_for_deactivated_user",
     "pause_loops_for_removed_member",
     "pause_loops_referencing_integrations",

--- a/products/tasks/backend/management/commands/disable_loops.py
+++ b/products/tasks/backend/management/commands/disable_loops.py
@@ -1,0 +1,142 @@
+import re
+import sys
+import uuid
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.db.models import QuerySet
+
+from products.tasks.backend.loop_lifecycle import DEFAULT_PAUSE_MESSAGE, pause_loop
+from products.tasks.backend.models import Loop
+
+FILTER_OPTIONS = ("loop_id", "team_id", "organization_id")
+REASON_PATTERN = re.compile(r"^[a-z0-9_]{1,64}$")
+
+
+class Command(BaseCommand):
+    help = (
+        "Pause loops: set enabled=False with a disabled_reason, pause their Temporal schedules and notify "
+        "their owners. Loops that are already paused or deleted are left unchanged. "
+        "Pass at least one filter, or --all to pause every loop."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--reason",
+            required=True,
+            metavar="CODE",
+            help=(
+                "Stored on Loop.disabled_reason (lowercase letters, digits and underscores, max 64 chars). "
+                "The desktop app has dedicated copy for known codes such as usage_limited; other codes "
+                "render as auto-paused."
+            ),
+        )
+        parser.add_argument(
+            "--message",
+            metavar="TEXT",
+            help=f"Body of the needs-attention notification sent to each owner. Defaults to {DEFAULT_PAUSE_MESSAGE!r}",
+        )
+        parser.add_argument("--all", action="store_true", help="Pause every loop. Cannot be combined with filters.")
+        parser.add_argument("--loop-id", nargs="+", metavar="UUID", help="Only these loops")
+        parser.add_argument("--team-id", nargs="+", type=int, metavar="ID", help="Only loops in these teams")
+        parser.add_argument(
+            "--organization-id", nargs="+", metavar="UUID", help="Only loops in teams of these organizations"
+        )
+        parser.add_argument(
+            "--cancel-runs",
+            action="store_true",
+            help="Also cancel each loop's in-flight runs and signal their sandboxes to stop",
+        )
+        parser.add_argument("--no-notify", action="store_true", help="Skip the needs-attention notification")
+        parser.add_argument("--dry-run", action="store_true", help="List matching loops without changing anything")
+        parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        reason = options["reason"]
+        if not REASON_PATTERN.match(reason):
+            raise CommandError("--reason must be 1-64 characters of lowercase letters, digits and underscores")
+        has_filters = any(options[name] for name in FILTER_OPTIONS)
+        if options["all"] and has_filters:
+            raise CommandError("--all cannot be combined with filters")
+        if not options["all"] and not has_filters:
+            raise CommandError("Pass at least one filter (--loop-id, --team-id, --organization-id) or --all")
+
+        matched = self._apply_filters(Loop.objects.unscoped().filter(deleted=False), options)
+        to_pause = list(matched.filter(enabled=True).select_related("created_by").order_by("team_id", "created_at"))
+        already_paused = matched.count() - len(to_pause)
+
+        for loop in to_pause:
+            owner = loop.created_by.email if loop.created_by else "-"
+            self.stdout.write(f"{loop.id}  team {loop.team_id}  {loop.name}  owner {owner}")
+        self.stdout.write(f"{len(to_pause)} to pause, {already_paused} already paused (skipped)")
+
+        if not to_pause:
+            self.stdout.write(self.style.WARNING("No loops to pause."))
+            return
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING(f"Dry run: {len(to_pause)} loop(s) would be paused."))
+            return
+
+        self._confirm(
+            f"Pause {len(to_pause)} loop(s) with reason {reason!r}? Type 'yes' to continue: ", yes=options["yes"]
+        )
+
+        paused = 0
+        cancelled_runs = 0
+        failed: list[Loop] = []
+        for loop in to_pause:
+            try:
+                cancelled_runs += pause_loop(
+                    loop,
+                    reason,
+                    message=options["message"],
+                    cancel_runs=options["cancel_runs"],
+                    notify=not options["no_notify"],
+                )
+                paused += 1
+            except Exception as error:
+                failed.append(loop)
+                self.stderr.write(f"Failed to pause loop {loop.id}: {error!r}")
+
+        summary = f"Paused {paused} loop(s) with reason {reason!r}."
+        if options["cancel_runs"]:
+            summary += f" Cancelled {cancelled_runs} in-flight run(s)."
+        self.stdout.write(self.style.SUCCESS(summary))
+        if failed:
+            raise CommandError(
+                f"{len(failed)} loop(s) could not be paused: {', '.join(str(loop.id) for loop in failed)}"
+            )
+
+    def _apply_filters(self, queryset: QuerySet[Loop], options: dict[str, Any]) -> QuerySet[Loop]:
+        if options["loop_id"]:
+            loop_ids = self._parse_uuids(options["loop_id"], "--loop-id")
+            queryset = queryset.filter(id__in=loop_ids)
+            found = set(queryset.values_list("id", flat=True))
+            unknown = sorted(str(loop_id) for loop_id in loop_ids if loop_id not in found)
+            if unknown:
+                raise CommandError(f"Unknown loop ids: {', '.join(unknown)}")
+        if options["team_id"]:
+            queryset = queryset.filter(team_id__in=options["team_id"])
+        if options["organization_id"]:
+            organization_ids = self._parse_uuids(options["organization_id"], "--organization-id")
+            queryset = queryset.filter(team__organization_id__in=organization_ids)
+        return queryset
+
+    @staticmethod
+    def _parse_uuids(raw_values: list[str], flag: str) -> list[uuid.UUID]:
+        parsed: list[uuid.UUID] = []
+        for raw in raw_values:
+            try:
+                parsed.append(uuid.UUID(raw.strip()))
+            except ValueError:
+                raise CommandError(f"{flag} is not a valid UUID: {raw!r}")
+        return parsed
+
+    @staticmethod
+    def _confirm(prompt: str, *, yes: bool) -> None:
+        if yes:
+            return
+        if not sys.stdin.isatty():
+            raise CommandError("Refusing to pause loops non-interactively without --yes")
+        if input(prompt).strip() != "yes":
+            raise CommandError("Aborted.")

--- a/products/tasks/backend/management/commands/disable_loops.py
+++ b/products/tasks/backend/management/commands/disable_loops.py
@@ -61,7 +61,9 @@ class Command(BaseCommand):
         if not options["all"] and not has_filters:
             raise CommandError("Pass at least one filter (--loop-id, --team-id, --organization-id) or --all")
 
-        matched = self._apply_filters(Loop.objects.unscoped().filter(deleted=False), options)
+        # Validate --loop-id against deleted loops too, so a deleted loop's id is skipped rather than
+        # rejected as unknown; deleted loops are then excluded from the set we actually pause.
+        matched = self._apply_filters(Loop.objects.unscoped(), options).filter(deleted=False)
         to_pause = list(matched.filter(enabled=True).select_related("created_by").order_by("team_id", "created_at"))
         already_paused = matched.count() - len(to_pause)
 

--- a/products/tasks/backend/management/commands/disable_loops.py
+++ b/products/tasks/backend/management/commands/disable_loops.py
@@ -104,7 +104,8 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(summary))
         if failed:
             raise CommandError(
-                f"{len(failed)} loop(s) could not be paused: {', '.join(str(loop.id) for loop in failed)}"
+                f"{len(failed)} loop(s) failed part-way: {', '.join(str(loop.id) for loop in failed)}. "
+                "Re-running skips any that were already marked paused, so check their schedules and runs by hand."
             )
 
     def _apply_filters(self, queryset: QuerySet[Loop], options: dict[str, Any]) -> QuerySet[Loop]:

--- a/products/tasks/backend/management/commands/test/test_disable_loops.py
+++ b/products/tasks/backend/management/commands/test/test_disable_loops.py
@@ -1,0 +1,185 @@
+from io import StringIO
+
+from unittest.mock import patch
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from posthog.models import Organization, Team, User
+
+from products.tasks.backend.loop_lifecycle import DEFAULT_PAUSE_MESSAGE
+from products.tasks.backend.models import Loop, Task, TaskRun
+
+LIFECYCLE_MODULE = "products.tasks.backend.loop_lifecycle"
+ENABLED_LOOPS = ("a1", "a2", "b1")
+
+
+class TestDisableLoops(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_pause_schedules = patch(f"{LIFECYCLE_MODULE}.pause_loop_schedules").start()
+        self.mock_dispatch = patch(f"{LIFECYCLE_MODULE}.dispatch_loop_event").start()
+        self.mock_signal = patch(f"{LIFECYCLE_MODULE}.signal_loop_run_cancelled").start()
+        self.addCleanup(patch.stopall)
+
+        self.org_a = Organization.objects.create(name="Org A")
+        self.org_b = Organization.objects.create(name="Org B")
+        self.team_a1 = Team.objects.create(organization=self.org_a, name="A1")
+        self.team_a2 = Team.objects.create(organization=self.org_a, name="A2")
+        self.team_b1 = Team.objects.create(organization=self.org_b, name="B1")
+        self.user = User.objects.create_user(email="owner@example.com", first_name="Owner", password=None)
+        self.loops = {
+            "a1": self._loop(self.team_a1, "a1"),
+            "a1-paused": self._loop(self.team_a1, "a1-paused", enabled=False),
+            "a1-deleted": self._loop(self.team_a1, "a1-deleted", deleted=True),
+            "a2": self._loop(self.team_a2, "a2"),
+            "b1": self._loop(self.team_b1, "b1"),
+        }
+        self.placeholders = {
+            "team_a1": str(self.team_a1.id),
+            "team_a2": str(self.team_a2.id),
+            "org_a": str(self.org_a.id),
+            "org_b": str(self.org_b.id),
+            "loop_a2": str(self.loops["a2"].id),
+            "loop_b1": str(self.loops["b1"].id),
+        }
+
+    def _loop(self, team: Team, name: str, **overrides: object) -> Loop:
+        fields: dict[str, object] = {
+            "team": team,
+            "created_by": self.user,
+            "name": name,
+            "instructions": "Summarize",
+            "runtime_adapter": "claude",
+            "model": "claude-sonnet-5",
+            "enabled": True,
+        }
+        fields.update(overrides)
+        return Loop.objects.unscoped().create(**fields)
+
+    def _call(self, *args: str) -> str:
+        stdout = StringIO()
+        call_command("disable_loops", *[arg.format(**self.placeholders) for arg in args], stdout=stdout)
+        return stdout.getvalue()
+
+    def _state(self) -> dict[str, tuple[bool, str | None]]:
+        return {
+            loop.name: (loop.enabled, loop.disabled_reason)
+            for loop in Loop.objects.unscoped().filter(id__in=[loop.id for loop in self.loops.values()])
+        }
+
+    def _assert_untouched(self, names: tuple[str, ...] = ENABLED_LOOPS) -> None:
+        state = self._state()
+        assert all(state[name] == (True, None) for name in names)
+        assert state["a1-paused"] == (False, None)
+        assert state["a1-deleted"] == (True, None)
+
+    def _in_flight_run(self, loop: Loop) -> TaskRun:
+        task = Task.objects.create(
+            team=loop.team,
+            created_by=self.user,
+            title="Active",
+            description="d",
+            origin_product=Task.OriginProduct.LOOP,
+            internal=True,
+        )
+        run = task.create_run(mode="background", extra_state={"loop_id": str(loop.id)})
+        run.status = TaskRun.Status.IN_PROGRESS
+        run.save(update_fields=["status", "updated_at"])
+        return run
+
+    @parameterized.expand(
+        [
+            ("all", ["--all"], {"a1", "a2", "b1"}),
+            ("team", ["--team-id", "{team_a1}"], {"a1"}),
+            ("teams", ["--team-id", "{team_a1}", "{team_a2}"], {"a1", "a2"}),
+            ("organization", ["--organization-id", "{org_a}"], {"a1", "a2"}),
+            ("loop_ids", ["--loop-id", "{loop_a2}", "{loop_b1}"], {"a2", "b1"}),
+            ("team_and_organization_intersect", ["--team-id", "{team_a1}", "--organization-id", "{org_b}"], set()),
+        ]
+    )
+    def test_pauses_only_matching_enabled_loops(self, _name: str, args: list[str], expected: set[str]) -> None:
+        output = self._call(*args, "--reason", "maintenance", "--yes")
+
+        state = self._state()
+        assert {name for name in ENABLED_LOOPS if state[name] == (False, "maintenance")} == expected
+        self._assert_untouched(tuple(name for name in ENABLED_LOOPS if name not in expected))
+        assert {call.args[0].name for call in self.mock_pause_schedules.call_args_list} == expected
+        assert {call.args[0].name for call in self.mock_dispatch.call_args_list} == expected
+        if expected:
+            assert f"Paused {len(expected)} loop(s) with reason 'maintenance'." in output
+        else:
+            assert "No loops to pause." in output
+
+    def test_dry_run_changes_nothing(self) -> None:
+        output = self._call("--all", "--reason", "maintenance", "--dry-run")
+
+        assert "3 to pause, 1 already paused (skipped)" in output
+        assert "Dry run: 3 loop(s) would be paused." in output
+        self._assert_untouched()
+        self.mock_pause_schedules.assert_not_called()
+        self.mock_dispatch.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("default_message", [], DEFAULT_PAUSE_MESSAGE),
+            ("custom_message", ["--message", "Paused while we fix things."], "Paused while we fix things."),
+        ]
+    )
+    def test_notifies_owner_with_reason_and_message(self, _name: str, args: list[str], expected_body: str) -> None:
+        self._call("--loop-id", "{loop_a2}", "--reason", "maintenance", "--yes", *args)
+
+        self.mock_dispatch.assert_called_once()
+        loop, event, payload = self.mock_dispatch.call_args.args
+        assert (loop.id, event) == (self.loops["a2"].id, "needs_attention")
+        assert payload == {"reason": "maintenance", "body": expected_body}
+
+    def test_no_notify_skips_notification(self) -> None:
+        self._call("--loop-id", "{loop_a2}", "--reason", "maintenance", "--yes", "--no-notify")
+
+        assert self._state()["a2"] == (False, "maintenance")
+        self.mock_dispatch.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("keeps_runs_by_default", [], TaskRun.Status.IN_PROGRESS, 0),
+            ("cancels_runs_on_request", ["--cancel-runs"], TaskRun.Status.CANCELLED, 1),
+        ]
+    )
+    def test_cancel_runs_flag(self, _name: str, args: list[str], expected_status: str, expected_signals: int) -> None:
+        run = self._in_flight_run(self.loops["a2"])
+
+        output = self._call("--loop-id", "{loop_a2}", "--reason", "maintenance", "--yes", *args)
+
+        run.refresh_from_db()
+        assert run.status == expected_status
+        assert self.mock_signal.call_count == expected_signals
+        assert ("Cancelled 1 in-flight run(s)." in output) == bool(expected_signals)
+
+    @parameterized.expand(
+        [
+            ("no_filters", ["--reason", "maintenance"]),
+            ("all_with_filter", ["--all", "--team-id", "{team_a1}", "--reason", "maintenance"]),
+            ("reason_not_snake_case", ["--all", "--reason", "Billing Hold"]),
+            ("reason_too_long", ["--all", "--reason", "x" * 65]),
+            ("bad_loop_uuid", ["--loop-id", "not-a-uuid", "--reason", "maintenance"]),
+            ("unknown_loop", ["--loop-id", "00000000-0000-0000-0000-000000000000", "--reason", "maintenance"]),
+            ("bad_organization_uuid", ["--organization-id", "nope", "--reason", "maintenance"]),
+        ]
+    )
+    def test_rejects_invalid_arguments(self, _name: str, args: list[str]) -> None:
+        with self.assertRaises(CommandError):
+            self._call(*args, "--yes")
+
+        self._assert_untouched()
+        self.mock_pause_schedules.assert_not_called()
+
+    def test_refuses_without_yes_when_not_interactive(self) -> None:
+        with patch("sys.stdin") as stdin, self.assertRaises(CommandError):
+            stdin.isatty.return_value = False
+            self._call("--all", "--reason", "maintenance")
+
+        self._assert_untouched()
+        self.mock_pause_schedules.assert_not_called()

--- a/products/tasks/backend/management/commands/test/test_disable_loops.py
+++ b/products/tasks/backend/management/commands/test/test_disable_loops.py
@@ -44,6 +44,7 @@ class TestDisableLoops(TestCase):
             "org_b": str(self.org_b.id),
             "loop_a2": str(self.loops["a2"].id),
             "loop_b1": str(self.loops["b1"].id),
+            "loop_a1_deleted": str(self.loops["a1-deleted"].id),
         }
 
     def _loop(self, team: Team, name: str, **overrides: object) -> Loop:
@@ -97,6 +98,7 @@ class TestDisableLoops(TestCase):
             ("teams", ["--team-id", "{team_a1}", "{team_a2}"], {"a1", "a2"}),
             ("organization", ["--organization-id", "{org_a}"], {"a1", "a2"}),
             ("loop_ids", ["--loop-id", "{loop_a2}", "{loop_b1}"], {"a2", "b1"}),
+            ("loop_ids_skip_deleted", ["--loop-id", "{loop_a2}", "{loop_a1_deleted}"], {"a2"}),
             ("team_and_organization_intersect", ["--team-id", "{team_a1}", "--organization-id", "{org_b}"], set()),
         ]
     )


### PR DESCRIPTION
## Problem

Operators have no way to pause loops in bulk. A loop pauses today only through its owner, the billing kill switch, five failed runs in a row or the owner's account going away. Pausing every loop for an incident or a maintenance window means editing rows by hand.

## Changes

- A new management command, `disable_loops`, pauses any set of loops and records a reason of your choice.
- Select loops with `--all`, `--loop-id`, `--team-id` or `--organization-id`. Preview with `--dry-run`, confirm interactively or pass `--yes`.
- Owners get the same "needs attention" notification as an owner-deactivation pause. `--message` sets the body, `--no-notify` skips it.
- `--cancel-runs` also cancels in-flight runs and signals their sandboxes to stop. Off by default, since disabling normally means no new fires rather than killing live work.
- Loops that are already paused or deleted are skipped, so an owner's own pause keeps showing as "Paused" instead of "Auto-paused".
- Owners re-enable from the app as before, which clears the reason. A reason the desktop app does not know renders as "Auto-paused".
- Mechanical: the private lifecycle helper became the public `pause_loop` with `message`, `cancel_runs` and `notify` options. Existing callers keep their behavior.

```
python manage.py disable_loops --reason maintenance --all --dry-run
python manage.py disable_loops --reason maintenance --organization-id <uuid> --message "Paused while we fix things." --yes
```

## How did you test this code?

- New `test_disable_loops.py`: filter selection including the intersection and skipped-loop cases, dry run, notification body, `--cancel-runs`, argument validation and the non-interactive guard. No existing test covered a bulk pause.
- Existing `test_loop_lifecycle.py` covers the refactored `pause_loop` defaults.
- Not run against a live Temporal. Schedule pausing is mocked, as in the lifecycle tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, internal operator command.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) wrote the command, the refactor and the tests from a request for a manual way to disable all loops with a reason. Skills invoked: /writing-tests, /writing-pr-descriptions. The command reuses the owner-deactivation pause path so the app renders these loops the same way as other backend pauses.
