### PR TITLE
feat(desktop): triage mode behind its own flag

### DIFF
--- a/products/desktop/packages/core/src/inbox/dailyReportLimit.ts
+++ b/products/desktop/packages/core/src/inbox/dailyReportLimit.ts
@@ -69,7 +69,8 @@ export function describeDailyReportLimit(
       limit,
       today: 0,
       reached: false,
-      usageText: "No daily limit. Reports reach the inbox as they are found.",
+      usageText:
+        "No daily limit. Reports reach Self-driving as they are found.",
       reachedText: null,
     };
   }

--- a/products/desktop/packages/core/src/inbox/reportVerdict.ts
+++ b/products/desktop/packages/core/src/inbox/reportVerdict.ts
@@ -81,7 +81,7 @@ export function deriveReportVerdict(
       return {
         tone: "decision",
         title: "Needs your decision",
-        body: "The agent can fix this with code. Start the pull request, or archive the report if it isn't worth fixing.",
+        body: "The agent can fix this with code and open a pull request. The report keeps watching its signals and reopens if the problem comes back.",
       };
     case "requires_human_input":
       return {

--- a/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
@@ -46,6 +46,21 @@ function makeSession(
 }
 
 describe("deriveSessionViewState", () => {
+  it("uses a live cloud session when task run metadata is unavailable", () => {
+    const task = makeTask("in_progress");
+    task.latest_run = undefined;
+
+    const state = deriveSessionViewState(
+      makeSession("in_progress"),
+      task,
+      null,
+      false,
+    );
+
+    expect(state.isCloud).toBe(true);
+    expect(state.isCloudRunNotTerminal).toBe(true);
+  });
+
   it("uses terminal task status over stale same-run session status", () => {
     const state = deriveSessionViewState(
       makeSession("in_progress"),

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -76,6 +76,13 @@ export const CHANNEL_REPORTS_FLAG = "posthog-desktop-channel-reports";
 export const REPORTS_INBOX_FLAG = "posthog-desktop-reports-inbox";
 
 /**
+ * One-report-at-a-time keyboard triage inside the reports inbox. On by
+ * default in dev builds for iteration (see useTriageFocusEnabled); off in
+ * production until it stabilizes.
+ */
+export const TRIAGE_FOCUS_FLAG = "posthog-desktop-triage-focus";
+
+/**
  * Serves a session's Claude traffic from Bedrock instead of Anthropic. The
  * `test` variant sends `x-posthog-provider: bedrock`, which the gateway routes
  * to its Bedrock backend; `control` sends nothing and the gateway keeps its

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.stories.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.stories.tsx
@@ -15,7 +15,7 @@ function bannerAnnouncement(
     kind: "announcement",
     id: "storybook-banner",
     title: "Loops are here",
-    body: "Schedule **recurring agent jobs** and route results to your [inbox](posthog-code://inbox/demo).\nBanners render only this first line.",
+    body: "Schedule **recurring agent jobs** and route results to [Self-driving](posthog-code://inbox/demo).\nBanners render only this first line.",
     cta: { label: "Try loops", url: "posthog-code://loop/storybook" },
     ...overrides,
   });

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.stories.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.stories.tsx
@@ -11,7 +11,7 @@ const MARKDOWN_BODY = [
   "PostHog Desktop now runs **recurring agent jobs** straight from your project.",
   "",
   "- Schedule a prompt on any cadence",
-  "- Route the results to your inbox or a channel",
+  "- Route the results to Self-driving or a channel",
   "- Pause or rewire a loop without a release",
   "",
   "Read the [docs](https://posthog.com/docs) for the full tour.",

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
@@ -159,7 +159,7 @@ describe("NavRail", () => {
   it.each([
     ["/", "Home"],
     ["/activity", "Activity"],
-    ["/inbox/pulls/$reportId", "Inbox"],
+    ["/inbox/pulls/$reportId", "Self-driving"],
     ["/command-center", "Command Center"],
     ["/spaces", "Spaces"],
     ["/spaces/$channelId/loops", "Spaces"],
@@ -179,7 +179,7 @@ describe("NavRail", () => {
     it("opens a destination in a new tab on Cmd-click", () => {
       render(<NavRail />);
 
-      fireEvent.click(screen.getByLabelText("Inbox"), { metaKey: true });
+      fireEvent.click(screen.getByLabelText("Self-driving"), { metaKey: true });
 
       expect(mocks.openBrowserTab).toHaveBeenCalledWith("/inbox");
       expect(mocks.navigateToInbox).not.toHaveBeenCalled();
@@ -327,7 +327,7 @@ describe("NavRail", () => {
       });
       render(<NavRail />);
 
-      await user.click(screen.getByLabelText("Inbox"));
+      await user.click(screen.getByLabelText("Self-driving"));
 
       expect(mocks.navigate).toHaveBeenCalledWith({ href: "/inbox/pulls/42" });
       expect(mocks.navigateToInbox).not.toHaveBeenCalled();
@@ -359,7 +359,7 @@ describe("NavRail", () => {
       rememberVisits({ inbox: { href: "/inbox/pulls/42" } });
       render(<NavRail />);
 
-      await user.click(screen.getByLabelText("Inbox"));
+      await user.click(screen.getByLabelText("Self-driving"));
 
       expect(mocks.navigateToInbox).toHaveBeenCalledOnce();
       expect(mocks.navigate).not.toHaveBeenCalled();
@@ -395,7 +395,7 @@ describe("NavRail", () => {
     render(<NavRail />);
 
     expect(screen.queryByLabelText("Command Center")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Inbox")).toBeInTheDocument();
+    expect(screen.getByLabelText("Self-driving")).toBeInTheDocument();
   });
 
   it("keeps the column's own destinations when everything else is hidden", () => {
@@ -430,7 +430,7 @@ describe("NavRail", () => {
       "Home",
       "Spaces",
       "Command Center",
-      "Inbox",
+      "Self-driving",
       "Activity",
     ]);
   });

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedHome.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedHome.test.tsx
@@ -1,4 +1,3 @@
-import type { SignalReport } from "@posthog/shared/types";
 import { Theme } from "@radix-ui/themes";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -6,8 +5,6 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let taskResultsError: Error | null = null;
-let taskResultsMode: "tasks" | "reports" = "tasks";
-let taskResultsReports: SignalReport[] = [];
 const refetch = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
@@ -44,14 +41,9 @@ vi.mock("@posthog/ui/features/canvas/hooks/useTaskFeedResults", () => ({
     isFetching: false,
     isLoading: false,
     issues: [],
-    mode: taskResultsMode,
     refetch,
-    reports: taskResultsReports,
     tasks: [],
   }),
-}));
-vi.mock("@posthog/ui/features/inbox/hooks/useOpenInboxReport", () => ({
-  useOpenInboxReport: () => vi.fn(),
 }));
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 
@@ -61,8 +53,6 @@ import { TaskFeedHome } from "./TaskFeedHome";
 describe("TaskFeedHome", () => {
   beforeEach(() => {
     taskResultsError = null;
-    taskResultsMode = "tasks";
-    taskResultsReports = [];
     refetch.mockClear();
     useTaskFeedsStore.setState({
       feeds: [
@@ -95,44 +85,6 @@ describe("TaskFeedHome", () => {
     ).not.toBeInTheDocument();
     await user.click(screen.getByText("Try again"));
     expect(refetch).toHaveBeenCalledOnce();
-  });
-
-  it("counts reports and hides the task empty state in a report feed", () => {
-    taskResultsMode = "reports";
-    taskResultsReports = [
-      { id: "r1" },
-      { id: "r2" },
-    ] as unknown as SignalReport[];
-    render(
-      <Theme>
-        <TaskFeedHome feedId="feed-1" />
-      </Theme>,
-    );
-
-    expect(screen.getByText("2 reports")).toBeInTheDocument();
-    expect(
-      screen.queryByText("No tasks match this saved search"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("No reports match this saved search"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("uses report wording for an empty report feed", () => {
-    taskResultsMode = "reports";
-    taskResultsReports = [];
-    render(
-      <Theme>
-        <TaskFeedHome feedId="feed-1" />
-      </Theme>,
-    );
-
-    expect(
-      screen.getByText("No reports match this saved search"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText("No tasks match this saved search"),
-    ).not.toBeInTheDocument();
   });
 
   it("requires confirmation before deleting a saved search", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskFeedHome.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskFeedHome.tsx
@@ -26,7 +26,6 @@ import { useProjectTaskFeed } from "@posthog/ui/features/canvas/hooks/useProject
 import { useTaskFeedResults } from "@posthog/ui/features/canvas/hooks/useTaskFeedResults";
 import { useTaskFeedsStore } from "@posthog/ui/features/canvas/stores/taskFeedsStore";
 import type { ThreadPanelTab } from "@posthog/ui/features/canvas/stores/threadPanelStore";
-import { useOpenInboxReport } from "@posthog/ui/features/inbox/hooks/useOpenInboxReport";
 import { openRightPanelSide } from "@posthog/ui/features/navigation/rightPanelSide";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { toast } from "@posthog/ui/primitives/toast";
@@ -47,12 +46,9 @@ export function TaskFeedHome({ feedId }: { feedId: string }) {
     isFetching,
     isLoading,
     issues,
-    mode,
     refetch,
-    reports,
     tasks,
   } = useTaskFeedResults(feed?.query);
-  const openReport = useOpenInboxReport();
   const [editOpen, setEditOpen] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
@@ -110,11 +106,7 @@ export function TaskFeedHome({ feedId }: { feedId: string }) {
     );
   }
 
-  // Report feeds carry reports, task feeds carry tasks; the status text reads
-  // from whichever list this feed's mode actually populates.
-  const reportsMode = mode === "reports";
-  const resultCount = reportsMode ? reports.length : tasks.length;
-  const resultNoun = reportsMode ? "report" : "task";
+  const resultCount = tasks.length;
 
   const queryBar = (
     <div className="mb-2 flex w-full items-center gap-2 rounded-xl border border-(--gray-4) bg-(--gray-2) px-4 py-3">
@@ -139,7 +131,7 @@ export function TaskFeedHome({ feedId }: { feedId: string }) {
           ) : (
             <span className="shrink-0 text-muted-foreground text-xs">
               {isComplete
-                ? `${resultCount} ${resultCount === 1 ? resultNoun : `${resultNoun}s`}`
+                ? `${resultCount} ${resultCount === 1 ? "task" : "tasks"}`
                 : "Partial results"}
             </span>
           )}
@@ -150,7 +142,7 @@ export function TaskFeedHome({ feedId }: { feedId: string }) {
           !isLoading &&
           !isComplete && (
             <span className="text-muted-foreground text-xs">
-              {`Some matching ${resultNoun}s may not be shown.`}
+              Some matching tasks may not be shown.
             </span>
           )
         )}
@@ -193,13 +185,9 @@ export function TaskFeedHome({ feedId }: { feedId: string }) {
       {queryBar}
       {!isLoading && !error && isComplete && resultCount === 0 && (
         <div className="flex flex-col items-center gap-1 px-4 py-16 text-center">
-          <Text className="font-medium">
-            {`No ${resultNoun}s match this saved search`}
-          </Text>
+          <Text className="font-medium">No tasks match this saved search</Text>
           <Text className="text-muted-foreground text-sm">
-            {reportsMode
-              ? "Reports appear here when they match the query."
-              : "Tasks appear here when they match the query."}
+            Tasks appear here when they match the query.
           </Text>
         </div>
       )}
@@ -212,9 +200,6 @@ export function TaskFeedHome({ feedId }: { feedId: string }) {
         <ChannelFeedView
           channelId={feed.id}
           tasks={tasks}
-          reports={mode === "reports" ? reports : undefined}
-          onOpenReport={openReport}
-          showKindFilter={false}
           isLoading={isLoading}
           intro={intro}
           onOpenTask={handleOpenTask}

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
@@ -1,5 +1,5 @@
 import { Theme } from "@radix-ui/themes";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 if (typeof globalThis.ResizeObserver === "undefined") {
@@ -59,19 +59,6 @@ vi.mock("@posthog/ui/hooks/useSetHeaderContent", () => ({
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => false,
 }));
-vi.mock("@posthog/ui/features/canvas/hooks/useChannelReports", () => ({
-  EMPTY_CHANNEL_REPORTS_FILTERS: {},
-  DEFAULT_CHANNEL_REPORTS_FILTERS: {
-    search: "",
-    relevantToMeOnly: true,
-    priorities: [],
-    status: "all",
-  },
-  useChannelReports: () => ({ reports: [] }),
-}));
-vi.mock("@posthog/ui/features/inbox/hooks/useOpenInboxReport", () => ({
-  useOpenInboxReport: () => vi.fn(),
-}));
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({ setQueryData: vi.fn(), invalidateQueries: vi.fn() }),
@@ -81,24 +68,7 @@ vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
 // ThreadSidebar is the task dock under test; the rest of the channel chrome
 // (feed rows, composer, intro) plays no part in the feed/sidebar exclusion.
 vi.mock("@posthog/ui/features/canvas/components/ChannelFeedView", () => ({
-  ChannelFeedView: ({
-    reportFilters,
-    onReportFiltersChange,
-  }: {
-    reportFilters?: { status?: string };
-    onReportFiltersChange?: (filters: { status?: string }) => void;
-  }) => (
-    <div data-testid="feed">
-      <span data-testid="report-status">{reportFilters?.status ?? "none"}</span>
-      <button
-        type="button"
-        data-testid="set-archived"
-        onClick={() =>
-          onReportFiltersChange?.({ ...reportFilters, status: "archived" })
-        }
-      />
-    </div>
-  ),
+  ChannelFeedView: () => <div data-testid="feed" />,
 }));
 vi.mock("@posthog/ui/features/canvas/components/ChannelHomeComposer", () => ({
   ChannelHomeComposer: () => null,
@@ -124,26 +94,6 @@ describe("WebsiteChannelHome", () => {
       collapsed: false,
       width: 360,
     });
-  });
-
-  it("resets report filters when the space changes", () => {
-    const { rerender } = render(
-      <Theme>
-        <WebsiteChannelHome channelId="chan-1" />
-      </Theme>,
-    );
-    expect(screen.getByTestId("report-status").textContent).toBe("all");
-
-    fireEvent.click(screen.getByTestId("set-archived"));
-    expect(screen.getByTestId("report-status").textContent).toBe("archived");
-
-    // A different space must not inherit the previous space's narrowing.
-    rerender(
-      <Theme>
-        <WebsiteChannelHome channelId="chan-2" />
-      </Theme>,
-    );
-    expect(screen.getByTestId("report-status").textContent).toBe("all");
   });
 
   it("drops a stale open thread so the feed can't show a task sidebar", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -1,11 +1,4 @@
-import {
-  isGeneralChannel,
-  isPersonalChannel,
-} from "@posthog/core/canvas/channelName";
-import {
-  channelReportView,
-  generalReportView,
-} from "@posthog/core/inbox/reportChannelScope";
+import { isPersonalChannel } from "@posthog/core/canvas/channelName";
 import { insertTaskDedup } from "@posthog/core/tasks/taskDelete";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
@@ -32,11 +25,6 @@ import {
   useChannelFeed,
 } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
 import { useChannelFeedMessages } from "@posthog/ui/features/canvas/hooks/useChannelFeedMessages";
-import {
-  type ChannelReportsFilters,
-  DEFAULT_CHANNEL_REPORTS_FILTERS,
-  useChannelReports,
-} from "@posthog/ui/features/canvas/hooks/useChannelReports";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
@@ -46,8 +34,6 @@ import {
   type ThreadPanelTab,
   useThreadPanelStore,
 } from "@posthog/ui/features/canvas/stores/threadPanelStore";
-import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/useChannelReportsEnabled";
-import { useOpenInboxReport } from "@posthog/ui/features/inbox/hooks/useOpenInboxReport";
 import { openRightPanelSide } from "@posthog/ui/features/navigation/rightPanelSide";
 import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
@@ -92,39 +78,6 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const { messages: systemMessages, isLoading: isLoadingMessages } =
     useChannelFeedMessages(channelId);
   const isLoading = isLoadingChannels || isLoadingFeed || isLoadingMessages;
-
-  // Reports interleave into the feed as compact cards: the general space shows
-  // every report, any other space only its own. Their load doesn't gate the
-  // feed — report cards land when their (slower) poll resolves.
-  const reportsEnabled = useChannelReportsEnabled();
-  const reportView = useMemo(
-    () =>
-      channel && !isGeneralChannel(channel)
-        ? channelReportView(channelId)
-        : generalReportView(),
-    [channel, channelId],
-  );
-  // Reset per space so a filter chosen in one space doesn't silently narrow
-  // another: the route reuses this component across a channelId change, so the
-  // filter state is reconciled against it (mirrors the feed's kind filter).
-  const [reportFilters, setReportFilters] = useState<{
-    channelId: string;
-    value: ChannelReportsFilters;
-  }>({ channelId, value: DEFAULT_CHANNEL_REPORTS_FILTERS });
-  const activeReportFilters =
-    reportFilters.channelId === channelId
-      ? reportFilters.value
-      : DEFAULT_CHANNEL_REPORTS_FILTERS;
-  const setActiveReportFilters = useCallback(
-    (next: ChannelReportsFilters) => {
-      setReportFilters({ channelId, value: next });
-    },
-    [channelId],
-  );
-  const { reports } = useChannelReports(reportView, activeReportFilters, {
-    enabled: reportsEnabled,
-  });
-  const openReport = useOpenInboxReport();
 
   useSetHeaderContent(
     useMemo(
@@ -348,10 +301,6 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           tasks={tasks}
           pending={visiblePending}
           systemMessages={systemMessages}
-          reports={reportsEnabled ? reports : undefined}
-          onOpenReport={openReport}
-          reportFilters={activeReportFilters}
-          onReportFiltersChange={setActiveReportFilters}
           isLoading={isLoading}
           emptyState={emptyState}
           intro={intro}

--- a/products/desktop/packages/ui/src/features/canvas/components/railDestinations.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/railDestinations.ts
@@ -173,7 +173,7 @@ export const RAIL_DESTINATIONS: readonly RailDestination[] = [
   {
     pane: "inbox",
     customizableId: "inbox",
-    label: "Inbox",
+    label: "Self-driving",
     analyticsId: "inbox",
     Icon: EnvelopeSimple,
     href: "/inbox",

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskFeedResults.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskFeedResults.test.ts
@@ -27,9 +27,6 @@ vi.mock("@posthog/ui/features/canvas/hooks/useOrgMembers", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({ channels: [], isLoading: false }),
 }));
-vi.mock("@posthog/ui/features/feature-flags/useChannelReportsEnabled", () => ({
-  useChannelReportsEnabled: () => true,
-}));
 vi.mock("@posthog/ui/hooks/useAuthenticatedQuery", () => ({
   useAuthenticatedQuery: () => ({
     data: undefined,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskFeedResults.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskFeedResults.ts
@@ -10,7 +10,6 @@ import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authCl
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
-import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/useChannelReportsEnabled";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useMemo } from "react";
 import {
@@ -71,7 +70,6 @@ export function useFeedQueryPlan(query: string | undefined): {
     refetch: refetchMembers,
   } = useOrgMembers({ enabled: needsMembers });
   const { channels, isLoading: channelsLoading } = useChannels();
-  const reportsEnabled = useChannelReportsEnabled();
 
   const memberLookupFailed = needsMembers && membersError !== null;
   const memberLookupIncomplete = needsMembers && !membersComplete;
@@ -93,7 +91,7 @@ export function useFeedQueryPlan(query: string | undefined): {
       members,
       spaces: channels.map((c) => ({ id: c.id, name: c.name })),
       me: me ?? null,
-      reportsEnabled,
+      reportsEnabled: false,
     });
   }, [
     normalized,
@@ -104,7 +102,6 @@ export function useFeedQueryPlan(query: string | undefined): {
     members,
     channels,
     me,
-    reportsEnabled,
   ]);
 
   return {

--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -360,7 +360,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         : [
             {
               id: "inbox",
-              label: "Inbox",
+              label: "Self-driving",
               keywords: "reports pull requests agents notifications",
               icon: <EnvelopeSimple size={12} className="text-gray-11" />,
               action: "open-inbox",

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -139,7 +139,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   {
     id: "inbox",
     keys: SHORTCUTS.INBOX,
-    description: "Open inbox",
+    description: "Open Self-driving",
     category: "navigation",
   },
   {

--- a/products/desktop/packages/ui/src/features/feature-flags/useTriageFocusEnabled.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/useTriageFocusEnabled.ts
@@ -1,0 +1,10 @@
+import { TRIAGE_FOCUS_FLAG } from "@posthog/shared";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+
+/**
+ * On by default in dev builds so focus mode can be iterated on locally;
+ * production stays flag-gated until it stabilizes.
+ */
+export function useTriageFocusEnabled(): boolean {
+  return useFeatureFlag(TRIAGE_FOCUS_FLAG, import.meta.env.DEV);
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -143,7 +143,7 @@ export function ConfigureAgentsSection() {
         description={
           <>
             Scheduled agents that sweep this project on a cadence and emit
-            signals to your inbox.{" "}
+            signals to Self-driving.{" "}
             {/* Placeholder docs link until a dedicated scouts page exists. */}
             <a
               href="https://posthog.com/blog/self-driving-product"

--- a/products/desktop/packages/ui/src/features/inbox/components/DetailSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DetailSection.tsx
@@ -36,7 +36,7 @@ export function DetailSection({
   const titleCluster = (
     <>
       <Icon size={14} weight="bold" className="shrink-0 text-gray-11" />
-      <span className="truncate font-semibold text-[13px] text-gray-12 tracking-[-0.01em]">
+      <span className="truncate font-semibold text-[14px] text-gray-12 tracking-[-0.01em]">
         {title}
       </span>
     </>

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
@@ -122,8 +122,8 @@ function DismissReportDialogBody({
       </Dialog.Title>
       <Dialog.Description className="text-gray-10 text-sm">
         {selectedCount > 1
-          ? "These reports will be removed from your inbox. Your feedback is saved on each report and helps the agent."
-          : "This report will be removed from your inbox. Your feedback is saved on the report and helps the agent."}
+          ? "These reports will be removed from Self-driving. Your feedback is saved on each report and helps the agent."
+          : "This report will be removed from Self-driving. Your feedback is saved on the report and helps the agent."}
       </Dialog.Description>
 
       <Flex direction="column" gap="4" mt="4">

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
@@ -110,7 +110,7 @@ function RestoreReportButton({ report }: { report: SignalReport }) {
       size="sm"
       disabled={restore.isPending}
       className="gap-1"
-      title="Restore this report to the inbox"
+      title="Restore this report to Self-driving"
       onClick={() =>
         restore.mutate(report.id, {
           onSuccess: () => navigate({ to: "/inbox/dismissed" }),

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -1,4 +1,11 @@
-import type { IconProps } from "@phosphor-icons/react";
+import {
+  ChartLineUpIcon,
+  type IconProps,
+  LightbulbIcon,
+  TargetIcon,
+  WarningCircleIcon,
+  WrenchIcon,
+} from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
 import { splitReportSummary } from "@posthog/core/inbox/reportPresentation";
@@ -56,7 +63,7 @@ interface InboxDetailFrameProps {
   metaPrefix?: ReactNode;
   /** Meta items appended after the timestamp + source (e.g. PR diff stats). */
   metaSuffix?: ReactNode;
-  /** Variant-specific primary action button (e.g. "Open in GitHub" or "Copy link"). */
+  /** Variant-specific primary action button (e.g. "Open PR in GitHub" or "Copy link"). */
   primaryAction?: ReactNode;
   /** Rendered at the top of the main column, before the summary (the verdict banner). */
   aboveSummary?: ReactNode;
@@ -67,6 +74,8 @@ interface InboxDetailFrameProps {
   };
   /** Sections rendered in the main column under the summary (e.g. PR comments). */
   belowSummary?: ReactNode;
+  /** Content that closes the overview after both responsive columns. */
+  footer?: ReactNode;
   /** Optional "Evidence" section icon + title; null hides it. */
   evidenceSection: {
     Icon: ComponentType<IconProps>;
@@ -103,6 +112,7 @@ export function InboxDetailFrame({
   aboveSummary,
   summarySection,
   belowSummary,
+  footer,
   evidenceSection,
   aboveEvidence,
   secondaryTab,
@@ -164,7 +174,7 @@ export function InboxDetailFrame({
             )}
             <RelativeTimestamp
               timestamp={report.updated_at ?? report.created_at}
-              className="text-[12px]"
+              className="text-[13px]"
             />
             {hasSource && (
               <>
@@ -213,10 +223,10 @@ export function InboxDetailFrame({
           <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList variant="line" className="h-auto gap-0.5">
               <TabsTrigger value="overview" className="gap-1.5 px-2.5 py-2">
-                <span className="font-medium text-[13px]">Overview</span>
+                <span className="font-medium text-[14px]">Overview</span>
               </TabsTrigger>
               <TabsTrigger value="secondary" className="gap-1.5 px-2.5 py-2">
-                <span className="flex items-center gap-1.5 font-medium text-[13px]">
+                <span className="flex items-center gap-1.5 font-medium text-[14px]">
                   {secondaryTab.label}
                 </span>
               </TabsTrigger>
@@ -228,13 +238,13 @@ export function InboxDetailFrame({
       {/*
          The detail body is a container-query grid:
            - Left column caps at 80ch – matches the prose width inside, because
-             we set the same 13px font context that the prose uses so `ch` here
+             we set the same 14px font context that the prose uses so `ch` here
              resolves to the same width as inside the markdown.
            - Right column grows beyond the prose to use the leftover space, but
              the grid container is capped so the right column never exceeds 50%
              of total width. Wider viewports just get larger side gutters.
         */}
-      <div className="@container mx-auto w-full max-w-[calc(160ch+5rem)] px-6 py-5 text-[13px]">
+      <div className="@container mx-auto w-full max-w-[calc(160ch+5rem)] px-6 py-5 text-[14px]">
         {secondaryTab && activeTab === "secondary" ? (
           <div className="flex min-w-0 flex-col gap-5">
             {secondaryTab.content}
@@ -259,7 +269,7 @@ export function InboxDetailFrame({
                   title={evidenceSection.title}
                   collapsible
                   rightSlot={
-                    <span className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+                    <span className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
                       {evidenceCount} signal
                       {evidenceCount === 1 ? "" : "s"}
                     </span>
@@ -275,6 +285,9 @@ export function InboxDetailFrame({
               {children}
             </div>
           </div>
+        )}
+        {(!secondaryTab || activeTab === "overview") && footer && (
+          <div className="mt-5">{footer}</div>
         )}
         {showDismiss && dismissDialog}
       </div>
@@ -309,6 +322,25 @@ function ReportSummarySlots({
     </div>
   );
 
+  const sectionIcon = (title: string): ComponentType<IconProps> => {
+    const normalizedTitle = title.toLowerCase();
+    if (normalizedTitle.includes("problem")) return WarningCircleIcon;
+    if (normalizedTitle.includes("impact")) return ChartLineUpIcon;
+    if (
+      normalizedTitle.includes("solution") ||
+      normalizedTitle.includes("recommend")
+    ) {
+      return LightbulbIcon;
+    }
+    if (
+      normalizedTitle.includes("implementation") ||
+      normalizedTitle.includes("fix")
+    ) {
+      return WrenchIcon;
+    }
+    return TargetIcon;
+  };
+
   if (split.sections.length === 0) {
     return (
       <DetailSection Icon={Icon} title={fallbackTitle} collapsible>
@@ -340,7 +372,7 @@ function ReportSummarySlots({
       {split.sections.map((section, index) => (
         <DetailSection
           key={`${section.title}-${index}`}
-          Icon={Icon}
+          Icon={sectionIcon(section.title)}
           title={section.title}
           collapsible
           defaultCollapsed={index > 0}
@@ -357,7 +389,7 @@ function ReportSummarySlots({
       {/* Charts stay outside the collapsibles: in-prose chart links jump to
           these anchors, and a jump into a folded section lands nowhere. */}
       {report.charts && report.charts.length > 0 && (
-        <DetailSection Icon={Icon} title="Charts">
+        <DetailSection Icon={ChartLineUpIcon} title="Charts">
           <ReportChartsSection reportId={report.id} charts={report.charts} />
         </DetailSection>
       )}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailPageHeader.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailPageHeader.tsx
@@ -46,19 +46,21 @@ export function InboxDetailPageHeader({
   const hasBottomRow = !!badges || !!meta || !!actions;
 
   return (
-    <div className="flex shrink-0 flex-col gap-3 border-(--gray-5) border-b px-6 pt-5 pb-4">
-      <div className="flex items-center gap-2 text-[12.5px] text-gray-11">
+    // Sticky within the detail page's scroll: the title and action verbs stay
+    // reachable however deep the reader is in the document.
+    <div className="sticky top-0 z-20 flex shrink-0 flex-col gap-3 border-(--gray-5) border-b bg-gray-1 px-6 pt-5 pb-4">
+      <div className="flex items-center gap-2 text-[13.5px] text-gray-11">
         <DetailBackLink to={backTo} label={backLabel} />
         {breadcrumb}
       </div>
 
-      <h1 className="min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
+      <h1 className="min-w-0 font-bold text-[25px] text-gray-12 leading-tight tracking-tight">
         {displayTitle}
       </h1>
 
       {hasBottomRow && (
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-[12px] text-gray-11">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-[13px] text-gray-11">
             {badges}
             {meta && <InboxMetaRow>{meta}</InboxMetaRow>}
           </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxMetaRow.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxMetaRow.tsx
@@ -3,7 +3,7 @@ import { Flex } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 const META_ROW_CLASS =
-  "cursor-default select-none text-[12px] text-gray-10 leading-none";
+  "cursor-default select-none text-[13px] text-gray-10 leading-none";
 
 interface InboxMetaRowProps {
   children: ReactNode;
@@ -26,7 +26,7 @@ export function InboxMetaRow({ children, className }: InboxMetaRowProps) {
 export function InboxMetaSeparator() {
   return (
     <span
-      className="shrink-0 select-none px-0.5 text-(--gray-9) text-[13px] leading-none"
+      className="shrink-0 select-none px-0.5 text-(--gray-9) text-[14px] leading-none"
       aria-hidden
     >
       ·

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxPageHeader.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxPageHeader.tsx
@@ -59,7 +59,7 @@ export function InboxPageHeader({ counts }: InboxPageHeaderProps) {
     <PageHeader>
       <PageHeaderHeading>
         <PageHeaderTitleRow>
-          <PageHeaderTitle>Inbox</PageHeaderTitle>
+          <PageHeaderTitle>Self-driving</PageHeaderTitle>
           <PageHeaderActions>
             <ConfigureAgentsButton />
           </PageHeaderActions>
@@ -86,7 +86,7 @@ function LegacyInboxPageHeader({ counts }: InboxPageHeaderProps) {
       <div className="flex items-start justify-between gap-3">
         <div className="flex cursor-default select-none flex-col gap-0.5">
           <span className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">
-            Inbox
+            Self-driving
           </span>
           <span className="max-w-3xl text-[12.5px] text-gray-11 leading-snug">
             Work done by your agents – pull requests, reports, and live runs.

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxScopeSelect.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxScopeSelect.tsx
@@ -101,7 +101,7 @@ export function InboxScopeSelect() {
           value={segmentValue}
           size="1"
           onValueChange={handleSegmentValueChange}
-          aria-label="Inbox scope"
+          aria-label="Self-driving scope"
         >
           <SegmentedControl.Item value="for-you">For you</SegmentedControl.Item>
           <SegmentedControl.Item

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
@@ -4,6 +4,7 @@ import {
   CheckIcon,
   CrosshairSimpleIcon,
   FlagIcon,
+  GitPullRequestIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import {
@@ -20,13 +21,21 @@ import { type ReactNode, useId, useMemo } from "react";
 
 interface InboxSearchFilterBarProps {
   searchPlaceholder?: string;
+  /** The sectioned inbox filters by PR state; the legacy tabs already are one. */
+  showPrFilter?: boolean;
 }
 
+const PR_FILTER_OPTIONS = [
+  { value: "with_pr", label: "Has a PR" },
+  { value: "without_pr", label: "No PR yet" },
+] as const;
+
 const FILTER_ITEM_CLASS =
-  "flex w-full items-center justify-between rounded-sm px-1.5 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none";
+  "flex w-full items-center justify-between rounded-sm px-1.5 py-1 text-left text-[14px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none";
 
 export function InboxSearchFilterBar({
   searchPlaceholder = "Search by title or description…",
+  showPrFilter = false,
 }: InboxSearchFilterBarProps) {
   const inputId = useId();
   const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
@@ -48,6 +57,8 @@ export function InboxSearchFilterBar({
   const setPriorityFilter = useInboxSignalsFilterStore(
     (s) => s.setPriorityFilter,
   );
+  const prFilter = useInboxSignalsFilterStore((s) => s.prFilter);
+  const setPrFilter = useInboxSignalsFilterStore((s) => s.setPrFilter);
 
   const sourceOptions = useInboxSourceFilterOptions(sourceProductFilter);
   const selectedSources = useMemo(
@@ -74,7 +85,7 @@ export function InboxSearchFilterBar({
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder={searchPlaceholder}
-          className="min-w-0 flex-1 bg-transparent text-[12.5px] text-gray-12 outline-none placeholder:text-(--gray-9)"
+          className="min-w-0 flex-1 bg-transparent text-[13.5px] text-gray-12 outline-none placeholder:text-(--gray-9)"
         />
       </label>
 
@@ -110,6 +121,40 @@ export function InboxSearchFilterBar({
           })}
         </Flex>
       </InboxFilterPopover>
+
+      {showPrFilter && (
+        <InboxFilterPopover
+          label="Pull request"
+          value={
+            PR_FILTER_OPTIONS.find((option) => option.value === prFilter)
+              ?.label ?? "All reports"
+          }
+          icon={<GitPullRequestIcon size={13} className="text-gray-10" />}
+          active={prFilter !== "all"}
+        >
+          <div className="flex flex-col">
+            <InboxFilterAnyItem
+              active={prFilter === "all"}
+              onClick={() => setPrFilter("all")}
+            />
+            {PR_FILTER_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={FILTER_ITEM_CLASS}
+                onClick={() =>
+                  setPrFilter(prFilter === option.value ? "all" : option.value)
+                }
+              >
+                <span className="truncate">{option.label}</span>
+                {prFilter === option.value ? (
+                  <CheckIcon size={12} className="shrink-0 text-gray-12" />
+                ) : null}
+              </button>
+            ))}
+          </div>
+        </InboxFilterPopover>
+      )}
 
       <InboxFilterPopover
         label="Sort"
@@ -219,7 +264,7 @@ function InboxFilterPopover({
           className="flex h-8 shrink-0 items-center gap-1.5 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-2.5 transition-colors hover:border-(--gray-6) hover:bg-(--gray-2) focus-visible:outline-none"
         >
           {icon}
-          <span className="max-w-[150px] truncate text-[12.5px] text-gray-12">
+          <span className="max-w-[150px] truncate text-[13.5px] text-gray-12">
             {value}
           </span>
           {active ? (

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxView.tsx
@@ -24,9 +24,9 @@ export function InboxView() {
         <EnvelopeSimpleIcon size={12} className="shrink-0 text-gray-10" />
         <Text
           className="truncate whitespace-nowrap font-medium text-[13px]"
-          title="Inbox"
+          title="Self-driving"
         >
-          Inbox
+          Self-driving
         </Text>
       </Flex>
     ),
@@ -54,13 +54,9 @@ export function InboxView() {
   const reportsInboxEnabled = useReportsInboxEnabled();
 
   if (reportsInboxEnabled && !isDetailView) {
-    return (
-      <Flex direction="column" className="h-full min-h-0">
-        <div className="min-h-0 flex-1 overflow-auto">
-          <ReportsInboxView />
-        </div>
-      </Flex>
-    );
+    // The view owns its height so its page header stays pinned while the
+    // sections scroll — the same shape ActivityView has.
+    return <ReportsInboxView />;
   }
 
   // With channel reports on, spaces replace the inbox as the home for reports.

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -57,7 +57,7 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
         prRef ? (
           <>
             <span className="text-(--gray-8)">/</span>
-            <span className="font-mono text-[12px] text-gray-11">
+            <span className="font-mono text-[13px] text-gray-11">
               {prRef.repoSlug}#{prRef.number}
             </span>
           </>
@@ -87,16 +87,14 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
           : undefined
       }
       belowSummary={
-        <>
-          {prUrl && (
-            <>
-              <PrDecisionBlock prUrl={prUrl} />
-              <PrCommentsSection prUrl={prUrl} />
-            </>
-          )}
-          <ReportFeedbackFooter report={report} />
-        </>
+        prUrl && (
+          <>
+            <PrDecisionBlock prUrl={prUrl} />
+            <PrCommentsSection prUrl={prUrl} />
+          </>
+        )
       }
+      footer={<ReportFeedbackFooter report={report} />}
       evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
     />
   );

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -230,8 +230,8 @@ export function ReportCardView(props: ReportCardViewProps) {
         variant="soft"
         color="gray"
         size="1"
-        aria-label="Restore this report to the inbox"
-        tooltipContent="Restore to inbox"
+        aria-label="Restore this report to Self-driving"
+        tooltipContent="Restore to Self-driving"
         loading={props.isRestorePending}
         disabled={props.isRestorePending}
         onClick={(event) => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -1,4 +1,10 @@
-import { ChatCircleIcon, XIcon } from "@phosphor-icons/react";
+import {
+  ArrowsOutSimpleIcon,
+  ChatCircleIcon,
+  GitPullRequestIcon,
+  ShapesIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import {
   isContentEmpty,
   textToContent,
@@ -9,6 +15,7 @@ import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChanne
 import { useDiscussReport } from "@posthog/ui/features/inbox/hooks/useDiscussReport";
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 import {
+  findContinuableImplementationTask,
   findLatestDiscussionTask,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
@@ -17,6 +24,7 @@ import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import { EmbeddedSessionView } from "@posthog/ui/features/sessions/components/EmbeddedSessionView";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
+import { useOpenTask } from "@posthog/ui/router/useOpenTask";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 
@@ -30,9 +38,11 @@ interface ReportChatSidebarProps {
 /**
  * The report's conversation, docked beside the report so reading and asking
  * happen on one screen (navigating away to a task page made people lose the
- * report they were asking about). One persistent discussion per report:
- * opening the panel resumes the report's existing discussion task, and only
- * the first question creates one.
+ * report they were asking about). One conversation per report: the dock binds
+ * to the report's live implementation task when one exists (continuing the
+ * fix IS chatting with the report), then to a task started this session, then
+ * to the existing discussion; only the first question on a task-less report
+ * creates one. The full task page stays one click away in the header.
  */
 export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
   const width = useReportChatPanelStore((s) => s.width);
@@ -44,13 +54,24 @@ export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
   const [isResizing, setIsResizing] = useState(false);
 
   // The durable association arrives via the report's task_run artefacts; a
-  // discussion started seconds ago is bridged by the store until it does.
-  const { data: reportTasks, isLoading: isLoadingTasks } = useReportTasks(
+  // task started seconds ago is bridged by the store until it does. The session
+  // bridge wins so a newly started canvas, fix, or discussion takes the dock
+  // over immediately.
+  const { data: reportTasks, isLoading: tasksLoading } = useReportTasks(
     report.id,
     report.status,
   );
-  const discussionTask = findLatestDiscussionTask(reportTasks);
-  const taskId = discussionTask?.id ?? startedTaskId;
+  const taskId =
+    startedTaskId ??
+    findContinuableImplementationTask(reportTasks)?.id ??
+    findLatestDiscussionTask(reportTasks)?.id ??
+    null;
+  const openTask = useOpenTask();
+  // Same query the conversation issues; react-query dedupes them.
+  const { data: boundTask } = useQuery({
+    ...taskDetailQuery(taskId ?? ""),
+    enabled: !!taskId,
+  });
 
   return (
     <ResizableSidebar
@@ -63,26 +84,38 @@ export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
     >
       <div className="flex h-full min-w-0 flex-col border-border border-l bg-gray-1">
         <div className="flex h-10 shrink-0 items-center justify-between border-b bg-chrome pr-2 pl-3">
-          <span className="flex items-center gap-1.5 font-medium text-[13px] text-gray-12">
+          <span className="flex items-center gap-1.5 font-medium text-[14px] text-gray-12">
             <ChatCircleIcon size={14} />
             Chat
           </span>
-          <Button
-            size="icon-sm"
-            variant="default"
-            aria-label="Close chat"
-            onClick={() => setOpen(false)}
-          >
-            <XIcon size={14} />
-          </Button>
+          <span className="flex items-center gap-1">
+            {boundTask && (
+              <Button
+                size="icon-sm"
+                variant="default"
+                aria-label="Open the full task"
+                title="Open the full task"
+                onClick={() => void openTask(boundTask)}
+              >
+                <ArrowsOutSimpleIcon size={14} />
+              </Button>
+            )}
+            <Button
+              size="icon-sm"
+              variant="default"
+              aria-label="Close chat"
+              onClick={() => setOpen(false)}
+            >
+              <XIcon size={14} />
+            </Button>
+          </span>
         </div>
         <div className="min-h-0 flex-1">
           {taskId ? (
-            <ReportChatConversation reportId={report.id} taskId={taskId} />
-          ) : isLoadingTasks ? (
-            // Until the report's tasks load we can't tell whether a discussion
-            // already exists; showing the starter here would let a fast submit
-            // open a second discussion for a report that already has one.
+            <ReportChatConversation report={report} taskId={taskId} />
+          ) : tasksLoading ? (
+            // Offering the starter before the task lookup resolves invites a
+            // duplicate conversation on a report that already has one.
             <div className="flex h-full items-center justify-center">
               <Spinner />
             </div>
@@ -99,20 +132,43 @@ export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
 // the same embedded view the canvas dock uses, so steering, queueing, and
 // follow-ups on a finished run all behave like they do elsewhere.
 function ReportChatConversation({
-  reportId,
+  report,
   taskId,
 }: {
-  reportId: string;
+  report: SignalReport;
   taskId: string;
 }) {
+  const reportId = report.id;
   const { data: task } = useQuery(taskDetailQuery(taskId));
 
   const pendingQuote = useReportChatPanelStore(
     (s) => s.pendingQuoteByReport[reportId] ?? null,
   );
-  const clearPendingQuote = useReportChatPanelStore((s) => s.clearPendingQuote);
+  const takePendingQuote = useReportChatPanelStore((s) => s.takePendingQuote);
   const { insertPendingContent, getDraft, requestFocus } = useDraftStore(
     (s) => s.actions,
+  );
+  const [sendingPrompt, setSendingPrompt] = useState<string | null>(null);
+  const workPrompt = report.implementation_pr_url
+    ? "Continue working on this report. Take the next concrete step toward resolving it."
+    : "Fix the issue in this report and monitor the result.";
+  const workLabel = report.implementation_pr_url
+    ? "Continue the task"
+    : "Fix and monitor";
+  const canvasPrompt =
+    "Create a canvas that visualizes this report using its evidence and relevant live data.";
+
+  const sendSuggestedPrompt = useCallback(
+    async (prompt: string, sendPrompt: (text: string) => Promise<boolean>) => {
+      if (sendingPrompt) return;
+      setSendingPrompt(prompt);
+      try {
+        await sendPrompt(prompt);
+      } finally {
+        setSendingPrompt(null);
+      }
+    },
+    [sendingPrompt],
   );
 
   // A highlighted passage is appended into the session composer, after anything
@@ -121,9 +177,10 @@ function ReportChatConversation({
   // the live editor even when it already holds text.
   useEffect(() => {
     if (!pendingQuote || !task) return;
+    const quote = takePendingQuote(reportId);
+    if (!quote) return;
     const separator = isContentEmpty(getDraft(taskId)) ? "" : "\n\n";
-    insertPendingContent(taskId, textToContent(`${separator}${pendingQuote}`));
-    clearPendingQuote(reportId);
+    insertPendingContent(taskId, textToContent(`${separator}${quote}`));
     requestFocus(taskId);
   }, [
     pendingQuote,
@@ -132,7 +189,7 @@ function ReportChatConversation({
     reportId,
     getDraft,
     insertPendingContent,
-    clearPendingQuote,
+    takePendingQuote,
     requestFocus,
   ]);
 
@@ -144,7 +201,37 @@ function ReportChatConversation({
     );
   }
 
-  return <EmbeddedSessionView task={task} />;
+  return (
+    <EmbeddedSessionView
+      task={task}
+      threadActions={({ sendPrompt, isPromptPending }) => (
+        <div className="flex flex-wrap items-center gap-1.5 border-border border-t px-3 py-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="h-7 rounded-full px-3 text-[12px]"
+            loading={sendingPrompt === workPrompt}
+            disabled={isPromptPending || sendingPrompt !== null}
+            onClick={() => void sendSuggestedPrompt(workPrompt, sendPrompt)}
+          >
+            <GitPullRequestIcon size={13} />
+            {workLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-7 rounded-full px-3 text-[12px]"
+            loading={sendingPrompt === canvasPrompt}
+            disabled={isPromptPending || sendingPrompt !== null}
+            onClick={() => void sendSuggestedPrompt(canvasPrompt, sendPrompt)}
+          >
+            <ShapesIcon size={13} />
+            Visualize on a canvas
+          </Button>
+        </div>
+      )}
+    />
+  );
 }
 
 // The report has no conversation yet: one question starts it, with the full
@@ -158,7 +245,7 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
   const pendingQuote = useReportChatPanelStore(
     (s) => s.pendingQuoteByReport[report.id] ?? null,
   );
-  const clearPendingQuote = useReportChatPanelStore((s) => s.clearPendingQuote);
+  const takePendingQuote = useReportChatPanelStore((s) => s.takePendingQuote);
   const starterDraft = useReportChatPanelStore(
     (s) => s.starterDraftByReport[report.id] ?? "",
   );
@@ -168,14 +255,15 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
   // Taken atomically so a double-fired effect can't paste the quote twice.
   useEffect(() => {
     if (!pendingQuote) return;
+    const quote = takePendingQuote(report.id);
+    if (!quote) return;
     const current =
       useReportChatPanelStore.getState().starterDraftByReport[report.id] ?? "";
     setStarterDraft(
       report.id,
-      current.trim() ? `${current.trimEnd()}\n\n${pendingQuote}` : pendingQuote,
+      current.trim() ? `${current.trimEnd()}\n\n${quote}` : quote,
     );
-    clearPendingQuote(report.id);
-  }, [pendingQuote, clearPendingQuote, setStarterDraft, report.id]);
+  }, [pendingQuote, takePendingQuote, setStarterDraft, report.id]);
 
   // Discussions file into the report's space, or #general when it has none —
   // a task without a channel shows in no space's sidebar at all.
@@ -228,10 +316,10 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
   return (
     <div className="flex h-full flex-col justify-between gap-3 p-3">
       <div className="flex flex-col gap-1 pt-1">
-        <span className="font-medium text-[13px] text-gray-12">
+        <span className="font-medium text-[14px] text-gray-12">
           Chat about this report
         </span>
-        <span className="text-[12px] text-gray-11">
+        <span className="text-[13px] text-gray-11">
           The agent joins with the full report and its evidence already in
           context. Highlight any part of the report to quote it here.
         </span>
@@ -279,7 +367,7 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
           }}
         />
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[11px] text-gray-10">
+          <span className="text-[12px] text-gray-10">
             {isMac ? "⌘↵" : "Ctrl+↵"} to send
           </span>
           <Button

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { inboxReportDetailGate } = vi.hoisted(() => ({
+  inboxReportDetailGate: vi.fn(() => null),
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/InboxReportDetailGate", () => ({
+  InboxReportDetailGate: inboxReportDetailGate,
+}));
+
+import { ReportDetail } from "@posthog/ui/features/inbox/components/ReportDetail";
+
+describe("ReportDetail", () => {
+  beforeEach(() => inboxReportDetailGate.mockClear());
+
+  it("returns to the reports list by default", () => {
+    render(<ReportDetail reportId="report-1" />);
+
+    expect(inboxReportDetailGate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backTo: "/inbox/reports",
+        backLabel: "Back to reports",
+      }),
+      undefined,
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -9,9 +9,8 @@ import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDet
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
-import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 interface ReportDetailProps {
   reportId: string;
@@ -26,7 +25,7 @@ interface ReportDetailProps {
 export function ReportDetail({
   reportId,
   cachedReport = null,
-  backTo = "/code/inbox/reports",
+  backTo = "/inbox/reports",
   backLabel = "Back to reports",
   statusRedirect = true,
 }: ReportDetailProps) {
@@ -51,9 +50,9 @@ export function ReportDetail({
 }
 
 /**
- * A report reads answer-first: the verdict (what state it's in and what it
- * asks, with the action beside it), then the story (summary + charts), then
- * the evidence. Pipeline machinery (runs, activity logs, reviewer reasoning)
+ * A report reads story-first: the summary and charts, then the evidence.
+ * The document stays pure content while its conversation owns follow-up
+ * actions. Pipeline machinery (runs, activity logs, reviewer reasoning)
  * deliberately doesn't render.
  *
  * The report owns its own scroll so the chat dock can sit full-height beside
@@ -74,6 +73,10 @@ function ReportDetailContent({
   const setPendingQuote = useReportChatPanelStore((s) => s.setPendingQuote);
   const contentRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    setChatOpen(true);
+  }, [setChatOpen]);
+
   const handleAsk = useCallback(
     (text: string) => {
       setPendingQuote(report.id, quoteSelection(text));
@@ -90,10 +93,11 @@ function ReportDetailContent({
           backTo={backTo}
           backLabel={backLabel}
           fallbackTitle="Untitled report"
-          primaryAction={<ReportDetailActions report={report} />}
-          aboveSummary={<ReportVerdictBanner report={report} />}
+          primaryAction={
+            <ReportDetailActions report={report} placement="header" />
+          }
           summarySection={{ Icon: FileTextIcon, title: "Summary" }}
-          belowSummary={<ReportFeedbackFooter report={report} />}
+          footer={<ReportFeedbackFooter report={report} />}
           evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
         />
       </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowSquareOutIcon,
   ChatCircleIcon,
+  ClockIcon,
   CopyIcon,
   DotsThreeIcon,
   ReceiptIcon,
@@ -18,50 +19,51 @@ import {
   PopoverTrigger,
   Spinner,
   Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/useChannelReportsEnabled";
 import { RefundReportDialog } from "@posthog/ui/features/inbox/components/RefundReportDialog";
 import { useCreateCanvasReport } from "@posthog/ui/features/inbox/hooks/useCreateCanvasReport";
+import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useRefundReport } from "@posthog/ui/features/inbox/hooks/useRefundReport";
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
-import { useCallback, useState } from "react";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { useCallback, useMemo, useState } from "react";
 
 interface ReportDetailActionsProps {
   report: SignalReport;
-  /** Implementation PR URL, when there is one; enables "Open in GitHub". */
+  /** Explicit PR URL (the PR-tab detail passes its own); falls back to the report's. */
   prUrl?: string | null;
+  placement?: "standalone" | "header";
 }
 
 const isMac =
   typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+const HEADER_ACTION_CLASS = "h-7 gap-1.5 px-2.5 text-[12px]";
 
-/**
- * The report header's action cluster: Discuss and Canvas stay visible, and
- * everything occasional (GitHub, copy link, refund) folds into an overflow
- * menu. Discuss opens the report's chat dock rather than navigating away;
- * starting or continuing implementation work lives in the verdict banner
- * above the summary (ReportVerdictBanner / PrDecisionBlock), not here.
- */
+/** Report actions split between page-level housekeeping and conversation work. */
 export function ReportDetailActions({
   report,
-  prUrl,
+  prUrl: prUrlProp,
+  placement = "standalone",
 }: ReportDetailActionsProps) {
+  // The report's own PR (open or merged) backs the GitHub item, so a merged
+  // fix stays reachable from the page even after the banner demotes it to
+  // history.
+  const prUrl = prUrlProp ?? report.implementation_pr_url ?? null;
   // Resolved reports are terminal (their PR already merged), so the work actions
   // drop out; only the read-only overflow menu (copy link, PR link) stays.
   const isResolved = report.status === "resolved";
 
   const fireAction = useReportActionTracker(report);
-  const chatOpen = useReportChatPanelStore((s) => s.open);
   const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
-
-  const handleToggleChat = useCallback(() => {
-    if (!chatOpen) fireAction("discuss", { has_question: false });
-    setChatOpen(!chatOpen);
-  }, [chatOpen, setChatOpen, fireAction]);
+  const chatOpen = useReportChatPanelStore((s) => s.open);
 
   // Canvases started from a report file into the report's space, or #general
   // when the report has none — a task without a channel shows in no space's
@@ -73,11 +75,22 @@ export function ReportDetailActions({
   const awaitingChannel = taskChannelId === null && channelsLoading;
 
   const canvasActionEnabled = useChannelReportsEnabled();
+  const rememberStartedTask = useReportChatPanelStore(
+    (s) => s.rememberStartedTask,
+  );
+  const handleCanvasTaskCreated = useCallback(
+    (task: { id: string }) => {
+      rememberStartedTask(report.id, task.id);
+      setChatOpen(true);
+    },
+    [rememberStartedTask, report.id, setChatOpen],
+  );
   const { createCanvasReport, isCreatingCanvas } = useCreateCanvasReport({
     reportId: report.id,
     reportTitle: report.title ?? null,
     channelId: taskChannelId,
     cloudRepository: null,
+    onTaskCreated: handleCanvasTaskCreated,
   });
 
   // implementation_pr_url comes from raw task-run output; only a verified
@@ -85,6 +98,16 @@ export function ReportDetailActions({
   const safePrUrl = prUrl && parsePrUrl(prUrl) ? prUrl : null;
   const refund = useRefundReport(report);
   const [refundOpen, setRefundOpen] = useState(false);
+  const reportsForBulk = useMemo(() => [report], [report]);
+  const bulkActions = useInboxBulkActions(
+    reportsForBulk,
+    report.id,
+    "detail_pane",
+  );
+  const canDefer =
+    report.status === "ready" ||
+    report.status === "failed" ||
+    report.status === "pending_input";
 
   const [canvasOpen, setCanvasOpen] = useState(false);
   const [canvasDirection, setCanvasDirection] = useState("");
@@ -115,12 +138,16 @@ export function ReportDetailActions({
         }
       />
       <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-        {safePrUrl && (
+        {canDefer && (
           <DropdownMenuItem
-            onClick={() => window.open(safePrUrl, "_blank", "noopener")}
+            disabled={
+              bulkActions.snoozeDisabledReason !== null ||
+              bulkActions.isSnoozing
+            }
+            onClick={() => void bulkActions.snoozeSelected()}
           >
-            <ArrowSquareOutIcon size={13} />
-            Open in GitHub
+            <ClockIcon size={13} />
+            Defer
           </DropdownMenuItem>
         )}
         <DropdownMenuItem onClick={() => copyInboxReportLink(report)}>
@@ -139,26 +166,150 @@ export function ReportDetailActions({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+  const githubButton = safePrUrl ? (
+    placement === "header" ? (
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        className={HEADER_ACTION_CLASS}
+        onClick={() => openExternalUrl(safePrUrl)}
+      >
+        <ArrowSquareOutIcon size={14} />
+        Open PR in GitHub
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        className={HEADER_ACTION_CLASS}
+        onClick={() => openExternalUrl(safePrUrl)}
+      >
+        <ArrowSquareOutIcon size={16} />
+        Open PR in GitHub
+      </Button>
+    )
+  ) : null;
 
-  // A terminal report keeps only the read-only overflow menu.
+  if (placement === "header") {
+    return (
+      <>
+        {githubButton}
+        {!chatOpen && (
+          <Button
+            type="button"
+            variant="primary"
+            size="xs"
+            className={HEADER_ACTION_CLASS}
+            onClick={() => setChatOpen(true)}
+          >
+            <ChatCircleIcon size={14} />
+            Chat with this report
+          </Button>
+        )}
+        {canDefer && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  className="h-7 w-7"
+                  aria-label="Defer"
+                  loading={bulkActions.isSnoozing}
+                  disabled={bulkActions.snoozeDisabledReason !== null}
+                  onClick={() => void bulkActions.snoozeSelected()}
+                />
+              }
+            >
+              <ClockIcon size={13} />
+            </TooltipTrigger>
+            <TooltipContent>
+              {bulkActions.snoozeDisabledReason ?? "Defer"}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-xs"
+                className="h-7 w-7"
+                aria-label="Copy link"
+                onClick={() => copyInboxReportLink(report)}
+              />
+            }
+          >
+            <CopyIcon size={13} />
+          </TooltipTrigger>
+          <TooltipContent>Copy link</TooltipContent>
+        </Tooltip>
+        {refund.canRefund && (
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon-xs"
+                        aria-label="More report actions"
+                      >
+                        <DotsThreeIcon size={13} weight="bold" />
+                      </Button>
+                    }
+                  />
+                }
+              />
+              <TooltipContent>More report actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
+              <DropdownMenuItem
+                disabled={refund.disabledReason !== null}
+                onClick={() => setRefundOpen(true)}
+              >
+                <ReceiptIcon size={13} />
+                Refund…
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        {refund.canRefund && (
+          <RefundReportDialog
+            open={refundOpen}
+            onOpenChange={setRefundOpen}
+            report={report}
+            isSubmitting={refund.mutation.isPending}
+            onConfirm={(input) =>
+              refund.mutation.mutate(input, {
+                onSuccess: () => setRefundOpen(false),
+              })
+            }
+          />
+        )}
+      </>
+    );
+  }
+
+  // A terminal report keeps its read-only GitHub and overflow actions.
   if (isResolved) {
-    return overflowMenu;
+    return (
+      <>
+        {githubButton}
+        {overflowMenu}
+      </>
+    );
   }
 
   return (
     <>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        aria-pressed={chatOpen}
-        className="gap-1"
-        onClick={handleToggleChat}
-        title="Chat with the agent about this report"
-      >
-        <ChatCircleIcon size={12} />
-        Chat with this report
-      </Button>
+      {githubButton}
 
       {canvasActionEnabled && (
         <Popover
@@ -173,13 +324,13 @@ export function ReportDetailActions({
               <Button
                 type="button"
                 variant="outline"
-                size="sm"
+                size="xs"
                 disabled={isCreatingCanvas || awaitingChannel}
-                className="gap-1"
+                className={HEADER_ACTION_CLASS}
                 title="Have the agent build a canvas from this report"
               >
-                {isCreatingCanvas ? <Spinner /> : <ShapesIcon size={12} />}
-                Create canvas…
+                {isCreatingCanvas ? <Spinner /> : <ShapesIcon size={16} />}
+                Visualize on a canvas
               </Button>
             }
           />
@@ -189,7 +340,7 @@ export function ReportDetailActions({
             sideOffset={6}
             className="flex w-[420px] flex-col gap-2 p-3"
           >
-            <span className="text-[12px] text-gray-11">
+            <span className="text-[13px] text-gray-11">
               What should the canvas focus on? The agent builds it from this
               report's evidence and live data.
             </span>
@@ -208,7 +359,7 @@ export function ReportDetailActions({
               }}
             />
             <div className="flex items-center justify-between gap-2">
-              <span className="text-[11px] text-gray-10">
+              <span className="text-[12px] text-gray-10">
                 {isMac ? "⌘↵" : "Ctrl+↵"} to create
               </span>
               <Button
@@ -225,24 +376,9 @@ export function ReportDetailActions({
         </Popover>
       )}
 
-      {/* An overflow menu earns its click only with something to hide; when
-          Copy link is the lone occasional action, it shows directly. */}
-      {!prUrl && !refund.canRefund ? (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          aria-label="Copy link to this report"
-          title="Copy link to this report"
-          onClick={() => copyInboxReportLink(report)}
-        >
-          <CopyIcon size={13} />
-        </Button>
-      ) : (
-        overflowMenu
-      )}
+      {placement === "standalone" && overflowMenu}
 
-      {refund.canRefund && (
+      {placement === "standalone" && refund.canRefund && (
         <RefundReportDialog
           open={refundOpen}
           onOpenChange={setRefundOpen}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportReviewersHeader.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportReviewersHeader.tsx
@@ -171,7 +171,7 @@ export function ReportReviewersHeader({ report }: { report: SignalReport }) {
               placeholder="Filter users…"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              className="min-w-0 flex-1 bg-transparent text-[12px] text-gray-12 outline-none placeholder:text-(--gray-9)"
+              className="min-w-0 flex-1 bg-transparent text-[13px] text-gray-12 outline-none placeholder:text-(--gray-9)"
             />
           </div>
           <div className="max-h-[280px] overflow-y-auto">
@@ -180,7 +180,7 @@ export function ReportReviewersHeader({ report }: { report: SignalReport }) {
                 <Spinner />
               </div>
             ) : options.length === 0 ? (
-              <span className="block px-1 py-2 text-[12px] text-gray-10">
+              <span className="block px-1 py-2 text-[13px] text-gray-10">
                 No users found.
               </span>
             ) : (
@@ -194,7 +194,7 @@ export function ReportReviewersHeader({ report }: { report: SignalReport }) {
                       key={option.uuid}
                       type="button"
                       disabled={isPending}
-                      className="flex w-full items-center justify-between gap-2 rounded-(--radius-1) px-1 py-1 text-left text-[12px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none disabled:opacity-60"
+                      className="flex w-full items-center justify-between gap-2 rounded-(--radius-1) px-1 py-1 text-left text-[13px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none disabled:opacity-60"
                       onClick={() => toggleReviewer(option)}
                     >
                       <span className="flex min-w-0 items-center gap-2">
@@ -209,7 +209,7 @@ export function ReportReviewersHeader({ report }: { report: SignalReport }) {
                             {getSuggestedReviewerDisplayName(option)}
                           </span>
                           {option.email ? (
-                            <span className="truncate text-[11px] text-gray-10">
+                            <span className="truncate text-[12px] text-gray-10">
                               {option.email}
                             </span>
                           ) : null}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isInteractiveTarget } from "./ReportTriageFocus";
+
+describe("isInteractiveTarget", () => {
+  function firstEl(html: string): HTMLElement {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    return container.firstElementChild as HTMLElement;
+  }
+
+  // Guards the triage Enter shortcut: any control the card renders (Next, Exit,
+  // a section toggle, a verdict button, the merged-PR link) must own Enter, or
+  // Tab-then-Enter exits triage instead of activating the control.
+  it.each<[string, boolean]>([
+    ["<button>Exit</button>", true],
+    ['<a href="https://x">PR</a>', true],
+    ["<a>no href</a>", false],
+    ['<div role="button">toggle</div>', true],
+    ["<div>plain</div>", false],
+  ])("classifies %s as interactive=%s", (html, expected) => {
+    expect(isInteractiveTarget(firstEl(html))).toBe(expected);
+  });
+
+  it("resolves a nested child up to its interactive ancestor", () => {
+    const button = firstEl("<button><span>icon</span></button>");
+    expect(isInteractiveTarget(button.firstElementChild)).toBe(true);
+  });
+
+  it("returns false for null or a non-element target", () => {
+    expect(isInteractiveTarget(null)).toBe(false);
+    expect(isInteractiveTarget(document)).toBe(false);
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -1,0 +1,344 @@
+import {
+  CaretLeftIcon,
+  CaretRightIcon,
+  FileTextIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import {
+  humanizeReportTitle,
+  splitReportSummary,
+} from "@posthog/core/inbox/reportPresentation";
+import { Button } from "@posthog/quill";
+import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
+import type { SignalReport } from "@posthog/shared/types";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import {
+  DismissReportDialog,
+  type DismissReportDialogResult,
+} from "@posthog/ui/features/inbox/components/DismissReportDialog";
+import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
+import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
+import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
+import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { navigateToInboxReportDetail } from "@posthog/ui/router/navigationBridge";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+/** A keyboard hint chip; quill has no kbd primitive, so plain HTML carries it. */
+export function KeyCap({ children }: { children: string }) {
+  return (
+    <kbd className="rounded border border-(--gray-6) bg-(--gray-2) px-1 font-mono text-[11.5px] text-gray-11">
+      {children}
+    </kbd>
+  );
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  );
+}
+
+/**
+ * A focused button or link owns Enter/Space activation. The global Enter
+ * shortcut must yield to it, or Tab-then-Enter on any control in the card
+ * (Next, Exit, a section toggle, a verdict button) exits triage instead of
+ * doing what the control says.
+ */
+export function isInteractiveTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("button, a[href], [role='button']") !== null
+  );
+}
+
+/**
+ * One report at a time, keyboard-driven: the fast way through a pile of
+ * decisions. Walks the needs-a-decision queue in the list's order — j/k (or
+ * arrows) move, e opens archive, enter opens the full report, esc leaves.
+ * Archiving auto-advances: the archived report drops out of the queue and the
+ * next one takes its place under the same index.
+ */
+export function ReportTriageFocus({
+  reports,
+  allReports,
+  onExit,
+}: {
+  /** The decision queue, in the list's current sort order. */
+  reports: SignalReport[];
+  /** Superset backing archive eligibility (mirrors the list shells). */
+  allReports: SignalReport[];
+  onExit: () => void;
+}) {
+  const [index, setIndex] = useState(0);
+  const [dismissOpen, setDismissOpen] = useState(false);
+
+  // The queue shrinks under us when a report is archived; clamping (rather
+  // than resetting) is what makes archive-and-advance work.
+  const clamped = Math.min(index, Math.max(0, reports.length - 1));
+  const report = reports[clamped];
+  const summarySplit = useMemo(
+    () => splitReportSummary(report?.summary),
+    [report?.summary],
+  );
+
+  const bulkActions = useInboxBulkActions(
+    allReports,
+    report?.id ?? null,
+    "list_row",
+  );
+  const dismissPending = bulkActions.isSuppressing || bulkActions.isSnoozing;
+
+  const handleDismissConfirm = useCallback(
+    async (result: DismissReportDialogResult) => {
+      const ok = isDismissalReasonSnooze(result.reason)
+        ? await bulkActions.snoozeSelected()
+        : await bulkActions.suppressSelected(result);
+      if (ok) setDismissOpen(false);
+    },
+    [bulkActions],
+  );
+
+  // Defer = snooze without a dialog: one keystroke, the report re-promotes
+  // itself when enough new evidence lands. Auto-advances like archive.
+  const deferReport = useCallback(async () => {
+    if (bulkActions.snoozeDisabledReason !== null) return;
+    await bulkActions.snoozeSelected();
+  }, [bulkActions]);
+
+  const goNext = useCallback(
+    () => setIndex((i) => Math.min(i + 1, reports.length - 1)),
+    [reports.length],
+  );
+  const goPrev = useCallback(() => setIndex((i) => Math.max(i - 1, 0)), []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // The dialog owns the keyboard while open; typing surfaces always do.
+      if (dismissOpen || isTypingTarget(event.target)) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      switch (event.key) {
+        case "k":
+        case "ArrowDown":
+        case "ArrowRight":
+          event.preventDefault();
+          goNext();
+          break;
+        case "j":
+        case "ArrowUp":
+        case "ArrowLeft":
+          event.preventDefault();
+          goPrev();
+          break;
+        case "e":
+          event.preventDefault();
+          if (report) setDismissOpen(true);
+          break;
+        case "d":
+          event.preventDefault();
+          if (report && !dismissPending) void deferReport();
+          break;
+        case "Enter":
+          // A focused control (button, link) owns Enter — let the browser
+          // activate it instead of hijacking the key to exit triage.
+          if (isInteractiveTarget(event.target)) break;
+          event.preventDefault();
+          if (report) {
+            onExit();
+            navigateToInboxReportDetail(report.id);
+          }
+          break;
+        case "Escape":
+          event.preventDefault();
+          onExit();
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    dismissOpen,
+    report,
+    dismissPending,
+    deferReport,
+    goNext,
+    goPrev,
+    onExit,
+  ]);
+
+  if (!report) {
+    // The queue ran dry mid-session — every decision is made.
+    return (
+      <div className="flex flex-col items-center gap-3 py-16">
+        <span className="font-medium text-[15px] text-gray-12">
+          All decisions made
+        </span>
+        <span className="text-[14px] text-gray-11">
+          Nothing left in the queue.
+        </span>
+        <Button type="button" variant="outline" size="sm" onClick={onExit}>
+          Back to the list
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              aria-label="Previous report"
+              disabled={clamped === 0}
+              onClick={goPrev}
+            >
+              <CaretLeftIcon size={14} />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              aria-label="Next report"
+              disabled={clamped >= reports.length - 1}
+              onClick={goNext}
+            >
+              <CaretRightIcon size={14} />
+            </Button>
+            <span className="text-[13px] text-gray-10 tabular-nums">
+              {clamped + 1} of {reports.length}
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onExit}
+            className="gap-1"
+          >
+            <XIcon size={12} />
+            Exit triage
+          </Button>
+        </div>
+
+        <div className="flex flex-col gap-3 rounded-lg border border-border bg-(--color-panel-solid) p-5">
+          <div className="flex flex-col gap-1.5">
+            <h2 className="font-semibold text-[17px] text-gray-12 leading-snug">
+              {humanizeReportTitle(report.title, "Untitled report")}
+            </h2>
+            <div className="flex items-center gap-2 text-[13px] text-gray-10">
+              <SignalReportPriorityBadge priority={report.priority} />
+              <span className="tabular-nums">
+                {report.signal_count} signal
+                {report.signal_count === 1 ? "" : "s"}
+              </span>
+              <RelativeTimestamp
+                timestamp={report.updated_at ?? report.created_at}
+                className="text-[13px]"
+              />
+            </div>
+          </div>
+
+          {/* The proof stays sorted and folded — the same labeled slots as
+              the detail page. The lede (the summary's own tl;dr) shows since
+              it's triage-sized; each section opens on demand. Triage reads
+              the verdict; research opens the full report. */}
+          {summarySplit.sections.length === 0 ? (
+            <DetailSection
+              Icon={FileTextIcon}
+              title="How we know"
+              collapsible
+              defaultCollapsed
+            >
+              <SignalReportSummaryMarkdown
+                content={report.summary}
+                fallback="No summary yet. The agent is still investigating."
+                variant="detail"
+                pending={report.status === "in_progress"}
+              />
+            </DetailSection>
+          ) : (
+            <>
+              {summarySplit.lede && (
+                <SignalReportSummaryMarkdown
+                  content={summarySplit.lede}
+                  fallback=""
+                  variant="detail"
+                  pending={report.status === "in_progress"}
+                />
+              )}
+              {summarySplit.sections.map((section, sectionIndex) => (
+                <DetailSection
+                  key={`${section.title}-${sectionIndex}`}
+                  Icon={FileTextIcon}
+                  title={section.title}
+                  collapsible
+                  defaultCollapsed
+                >
+                  <SignalReportSummaryMarkdown
+                    content={section.body}
+                    fallback=""
+                    variant="detail"
+                    pending={false}
+                  />
+                </DetailSection>
+              ))}
+            </>
+          )}
+
+          {/* The decision closes the card: read first, then accept. */}
+          <ReportVerdictBanner
+            report={report}
+            actionHotkey={dismissOpen ? undefined : "f"}
+            // The triage card hosts no dock: engaging opens the report page,
+            // where the dock (already flagged open) shows the conversation.
+            onEngaged={() => {
+              onExit();
+              navigateToInboxReportDetail(report.id);
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-center gap-4 text-[13px] text-gray-10">
+          <span className="flex items-center gap-1">
+            <KeyCap>j</KeyCap>
+            <KeyCap>k</KeyCap> move
+          </span>
+          <span className="flex items-center gap-1">
+            <KeyCap>f</KeyCap> fix
+          </span>
+          <span className="flex items-center gap-1">
+            <KeyCap>d</KeyCap> defer
+          </span>
+          <span className="flex items-center gap-1">
+            <KeyCap>e</KeyCap> dismiss
+          </span>
+          <span className="flex items-center gap-1">
+            <KeyCap>↵</KeyCap> open
+          </span>
+          <span className="flex items-center gap-1">
+            <KeyCap>esc</KeyCap> exit
+          </span>
+        </div>
+      </div>
+
+      {dismissOpen && (
+        <DismissReportDialog
+          open
+          onOpenChange={setDismissOpen}
+          report={report}
+          isSubmitting={dismissPending}
+          snoozeDisabledReason={bulkActions.snoozeDisabledReason}
+          onConfirm={handleDismissConfirm}
+        />
+      )}
+    </>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -1,10 +1,12 @@
 import {
   ArchiveIcon,
   ArrowSquareOutIcon,
+  ClockIcon,
   GitPullRequestIcon,
 } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
+import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import {
   deriveReportVerdict,
   type ReportVerdictTone,
@@ -17,9 +19,13 @@ import {
   PopoverTrigger,
   Spinner,
   Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
+import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
@@ -28,14 +34,15 @@ import {
   getTaskPrUrl,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
-import { useOpenTask } from "@posthog/ui/router/useOpenTask";
-import { useCallback, useState } from "react";
+import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const isMac =
   typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
 // Same sizing as PrDecisionBlock: the decision is the page's one ask.
-const BIG_BUTTON = "h-9 gap-2 px-4 text-[13px]";
+const BIG_BUTTON = "h-9 gap-2 px-4 text-[14px]";
 
 const TONE_CLASS: Record<ReportVerdictTone, string> = {
   decision: "border-(--amber-6) bg-(--amber-2)",
@@ -44,17 +51,38 @@ const TONE_CLASS: Record<ReportVerdictTone, string> = {
   info: "border-(--gray-5) bg-(--gray-1)",
 };
 
+type ReportVerdictBannerVariant = "full" | "header-actions";
+
 interface ReportVerdictBannerProps {
   report: SignalReport;
+  /**
+   * full: status box + action row (the triage card). header-actions: the
+   * compact action row alone (the detail page's sticky top bar owns the
+   * verbs, and the page shows no status box).
+   */
+  variant?: ReportVerdictBannerVariant;
+  /** Key that fires the primary action (triage mode passes "f"). */
+  actionHotkey?: string;
+  /**
+   * Called after an action opens the report's conversation dock. Surfaces
+   * without a dock (the triage card) navigate to the report here.
+   */
+  onEngaged?: () => void;
 }
 
 /**
- * The report's verdict, stated before the prose: what state it is in, what it
- * asks of the reader, and the action that answers the ask (start the PR, or
- * continue the one in flight). Replaces the old decision block that sat below
- * the summary, where the ask arrived only after the wall of text.
+ * The report's decision bar, closing the document: what state the report is
+ * in, what it asks of the reader, and every action that answers the ask -
+ * start the fix (or continue the one in flight), defer, or archive.
  */
-export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
+export function ReportVerdictBanner({
+  report,
+  variant = "full",
+  actionHotkey,
+  onEngaged,
+}: ReportVerdictBannerProps) {
+  const compact = variant === "header-actions";
+  const buttonClass = BIG_BUTTON;
   const canCreatePr = canCreateImplementationPr(report);
   const { data: artefactsResp } = useInboxReportArtefacts(report.id);
   const cloudRepository = extractRepoSelectionRepository(
@@ -77,6 +105,12 @@ export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
   const livePrUrl = report.implementation_pr_merged
     ? null
     : report.implementation_pr_url;
+  // The merged PR is history, not live work, but history the reader needs
+  // visible: it explains why an already-fixed issue is asking for a decision.
+  const mergedPr =
+    report.implementation_pr_merged && report.implementation_pr_url
+      ? parsePrUrl(report.implementation_pr_url)
+      : null;
   const existingPrUrl =
     livePrUrl ?? (continuableTask ? getTaskPrUrl(continuableTask) : null);
   const hasExistingPr = !!existingPrUrl || !!continuableTask;
@@ -84,24 +118,45 @@ export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
   const verdict = deriveReportVerdict(report, { hasExistingPr });
 
   const fireAction = useReportActionTracker(report);
-  const openTask = useOpenTask();
+
+  const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
+  const rememberStartedTask = useReportChatPanelStore(
+    (s) => s.rememberStartedTask,
+  );
 
   const { createPrReport, isCreatingPr } = useCreatePrReport({
     reportId: report.id,
     reportTitle: report.title ?? null,
     cloudRepository,
+    // The dock binds to the new task the moment it exists — and only then does
+    // the view advance. A failed create (offline, missing repo/integration/
+    // model, API error) never reaches here, so the report and its actions stay
+    // put instead of opening an empty dock or, in triage, navigating away.
+    onTaskCreated: (task) => {
+      rememberStartedTask(report.id, task.id);
+      setChatOpen(true);
+      onEngaged?.();
+    },
   });
 
   const [prOpen, setPrOpen] = useState(false);
   const [prFeedback, setPrFeedback] = useState("");
 
-  // Archive is the "no" beside Create PR's "yes" — a decision, so it lives in
+  // Archive is the "no" beside Fix & monitor's "yes" — a decision, so it lives in
   // the decision row. Offered wherever the report is waiting on a person
   // (several verdict bodies tell the reader to archive; the button should be
   // right there). Running reports keep it out of the banner — the header's
   // Dismiss covers that rare case.
   const { dialog: dismissDialog, openDialog: openDismissDialog } =
     useInboxReportDismissAction(report);
+  // Defer = snooze: the report re-promotes itself when enough new evidence
+  // lands. Same mechanism the triage card's d key uses.
+  const reportsForBulk = useMemo(() => [report], [report]);
+  const bulkActions = useInboxBulkActions(
+    reportsForBulk,
+    report.id,
+    "detail_pane",
+  );
   const canArchiveHere =
     report.status === "ready" ||
     report.status === "failed" ||
@@ -115,14 +170,19 @@ export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
     });
     setPrFeedback("");
     setPrOpen(false);
+    // The view advances from onTaskCreated once the task exists, not here — a
+    // failed create leaves the report and its actions in place.
     void createPrReport(trimmed || undefined);
   }, [createPrReport, fireAction, prFeedback]);
 
   const handleContinuePr = useCallback(() => {
     if (!continuableTask) return;
     fireAction("open_pr");
-    void openTask(continuableTask);
-  }, [continuableTask, fireAction, openTask]);
+    // The conversation opens docked beside the report — the full task page
+    // stays one click away in the dock header.
+    setChatOpen(true);
+    onEngaged?.();
+  }, [continuableTask, fireAction, setChatOpen, onEngaged]);
 
   // The banner carries the report's one action: create the PR, or continue the
   // one in flight. Offer it whenever the report can start a PR (`canCreatePr`
@@ -135,6 +195,181 @@ export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
     report.status === "deleted";
   const showActions = !isTerminalReport && (canCreatePr || hasExistingPr);
 
+  // One key fires the primary action (triage mode passes "f"): continue the
+  // task when a PR exists, otherwise start the fix with no extra direction.
+  useEffect(() => {
+    if (!actionHotkey) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== actionHotkey) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName))
+      ) {
+        return;
+      }
+      // An open dialog owns the keyboard: its buttons aren't typing targets,
+      // but f must not start a PR underneath the archive dialog.
+      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) {
+        return;
+      }
+      event.preventDefault();
+      if (report.status !== "ready" || isCreatingPr) return;
+      if (hasExistingPr) {
+        if (continuableTask) handleContinuePr();
+      } else if (canCreatePr) {
+        handleCreatePr();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    actionHotkey,
+    report.status,
+    isCreatingPr,
+    hasExistingPr,
+    continuableTask,
+    canCreatePr,
+    handleContinuePr,
+    handleCreatePr,
+  ]);
+
+  const actionsRow = showActions ? (
+    <div className="flex flex-wrap items-center gap-2.5">
+      {report.status === "ready" && hasExistingPr ? (
+        <>
+          <Button
+            type="button"
+            variant="primary"
+            disabled={isCreatingPr || !continuableTask}
+            onClick={handleContinuePr}
+            className={buttonClass}
+          >
+            {reportTasksLoading && !continuableTask ? (
+              <Spinner />
+            ) : (
+              <GitPullRequestIcon size={15} />
+            )}
+            Continue the task
+          </Button>
+          {existingPrUrl && !compact && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (existingPrUrl) openExternalUrl(existingPrUrl);
+              }}
+              className={buttonClass}
+            >
+              <ArrowSquareOutIcon size={16} />
+              View PR on GitHub
+            </Button>
+          )}
+        </>
+      ) : report.status === "ready" && canCreatePr ? (
+        <Popover
+          open={prOpen}
+          onOpenChange={(next) => {
+            setPrOpen(next);
+            if (!next) setPrFeedback("");
+          }}
+        >
+          <PopoverTrigger
+            render={
+              <Button
+                type="button"
+                variant="primary"
+                disabled={isCreatingPr}
+                className={buttonClass}
+              >
+                {isCreatingPr ? <Spinner /> : <GitPullRequestIcon size={15} />}
+                Fix & monitor
+              </Button>
+            }
+          />
+          <PopoverContent
+            align="start"
+            side="bottom"
+            sideOffset={6}
+            className="flex w-[420px] flex-col gap-2 p-3"
+          >
+            <Textarea
+              aria-label="Optional direction for the agent"
+              autoFocus
+              placeholder="Add direction for the agent (optional)…"
+              rows={4}
+              value={prFeedback}
+              onChange={(event) => setPrFeedback(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  handleCreatePr();
+                }
+              }}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[12px] text-gray-10">
+                {isMac ? "⌘↵" : "Ctrl+↵"} to start
+              </span>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                disabled={isCreatingPr}
+                onClick={handleCreatePr}
+              >
+                Fix & monitor
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+      ) : null}
+      {canArchiveHere && !compact && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                disabled={
+                  bulkActions.snoozeDisabledReason !== null ||
+                  bulkActions.isSnoozing
+                }
+                onClick={() => void bulkActions.snoozeSelected()}
+                className={buttonClass}
+              >
+                {bulkActions.isSnoozing ? <Spinner /> : <ClockIcon size={16} />}
+                Defer
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom">
+            {bulkActions.snoozeDisabledReason ??
+              "Snooze until enough new evidence arrives"}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {canArchiveHere && !compact && (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={openDismissDialog}
+          className={buttonClass}
+        >
+          <ArchiveIcon size={15} />
+          Archive…
+        </Button>
+      )}
+    </div>
+  ) : null;
+
+  if (variant === "header-actions") {
+    if (!actionsRow) return null;
+    return actionsRow;
+  }
+
   return (
     <div
       className={cn(
@@ -143,121 +378,26 @@ export function ReportVerdictBanner({ report }: ReportVerdictBannerProps) {
       )}
     >
       <div className="flex flex-col gap-1">
-        <span className="flex items-center gap-2 font-semibold text-[14px] text-gray-12">
+        <span className="flex items-center gap-2 font-semibold text-[15px] text-gray-12">
           {verdict.tone === "progress" && <Spinner />}
           {verdict.title}
         </span>
-        <span className="text-[13px] text-gray-11">{verdict.body}</span>
+        <span className="text-[14px] text-gray-11">{verdict.body}</span>
+        {mergedPr && report.implementation_pr_url && (
+          <a
+            href={report.implementation_pr_url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-[13px] text-gray-10 hover:underline"
+          >
+            <GitPullRequestIcon size={12} />
+            An earlier fix (#{mergedPr.number}) merged, but evidence kept
+            arriving afterwards
+          </a>
+        )}
       </div>
 
-      {showActions && (
-        <div className="flex flex-wrap items-center gap-2.5">
-          {report.status === "ready" && hasExistingPr ? (
-            <>
-              <Button
-                type="button"
-                variant="primary"
-                disabled={isCreatingPr || !continuableTask}
-                onClick={handleContinuePr}
-                className={BIG_BUTTON}
-              >
-                {reportTasksLoading && !continuableTask ? (
-                  <Spinner />
-                ) : (
-                  <GitPullRequestIcon size={15} />
-                )}
-                Continue the task
-              </Button>
-              {existingPrUrl && (
-                <a
-                  href={existingPrUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-(--accent-11) text-[12px] hover:underline"
-                >
-                  <ArrowSquareOutIcon size={12} />
-                  View PR on GitHub
-                </a>
-              )}
-            </>
-          ) : report.status === "ready" && canCreatePr ? (
-            <Popover
-              open={prOpen}
-              onOpenChange={(next) => {
-                setPrOpen(next);
-                if (!next) setPrFeedback("");
-              }}
-            >
-              <PopoverTrigger
-                render={
-                  <Button
-                    type="button"
-                    variant="primary"
-                    disabled={isCreatingPr}
-                    className={BIG_BUTTON}
-                  >
-                    {isCreatingPr ? (
-                      <Spinner />
-                    ) : (
-                      <GitPullRequestIcon size={15} />
-                    )}
-                    Create PR
-                  </Button>
-                }
-              />
-              <PopoverContent
-                align="start"
-                side="bottom"
-                sideOffset={6}
-                className="flex w-[420px] flex-col gap-2 p-3"
-              >
-                <Textarea
-                  aria-label="Optional direction for the agent"
-                  autoFocus
-                  placeholder="Add direction for the agent (optional)…"
-                  rows={4}
-                  value={prFeedback}
-                  onChange={(event) => setPrFeedback(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (
-                      event.key === "Enter" &&
-                      (event.metaKey || event.ctrlKey)
-                    ) {
-                      event.preventDefault();
-                      handleCreatePr();
-                    }
-                  }}
-                />
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-[11px] text-gray-10">
-                    {isMac ? "⌘↵" : "Ctrl+↵"} to create
-                  </span>
-                  <Button
-                    type="button"
-                    variant="primary"
-                    size="sm"
-                    disabled={isCreatingPr}
-                    onClick={handleCreatePr}
-                  >
-                    Create PR
-                  </Button>
-                </div>
-              </PopoverContent>
-            </Popover>
-          ) : null}
-          {canArchiveHere && (
-            <Button
-              type="button"
-              variant="outline"
-              onClick={openDismissDialog}
-              className={BIG_BUTTON}
-            >
-              <ArchiveIcon size={15} />
-              Archive…
-            </Button>
-          )}
-        </div>
-      )}
+      {actionsRow}
       {dismissDialog}
     </div>
   );

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -1,7 +1,11 @@
 import {
+  ArchiveIcon,
   CaretDownIcon,
+  CheckCircleIcon,
   EnvelopeSimpleIcon,
+  GitMergeIcon,
   GitPullRequestIcon,
+  ListChecksIcon,
 } from "@phosphor-icons/react";
 import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
 import {
@@ -23,16 +27,32 @@ import {
   EmptyTitle,
   Skeleton,
   Spinner,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
+import { useTriageFocusEnabled } from "@posthog/ui/features/feature-flags/useTriageFocusEnabled";
 import { InboxScopeSelect } from "@posthog/ui/features/inbox/components/InboxScopeSelect";
 import { InboxSearchFilterBar } from "@posthog/ui/features/inbox/components/InboxSearchFilterBar";
+import { ReportRestoreButton } from "@posthog/ui/features/inbox/components/ReportRestoreButton";
+import { ReportTriageFocus } from "@posthog/ui/features/inbox/components/ReportTriageFocus";
 import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
 import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useInboxSectionCounts } from "@posthog/ui/features/inbox/hooks/useInboxSectionCounts";
+import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderChip,
+  PageHeaderDescription,
+  PageHeaderHeading,
+  PageHeaderTitle,
+  PageHeaderTitleRow,
+} from "@posthog/ui/primitives/PageHeader";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import {
   navigateToAgents,
@@ -40,6 +60,16 @@ import {
 } from "@posthog/ui/router/navigationBridge";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useEffect, useMemo, useState } from "react";
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  );
+}
 
 /** Rows shown per section before "Show more" — a scan, not a scroll. */
 const SECTION_PREVIEW_LIMIT = 5;
@@ -66,7 +96,12 @@ export function ReportsInboxView() {
     isFetchingNextPage,
     fetchNextPage,
     searchQuery,
-  } = useInboxAllReports({ statusFilter: REPORTS_INBOX_STATUS_FILTER });
+  } = useInboxAllReports({
+    statusFilter: REPORTS_INBOX_STATUS_FILTER,
+    applyPrFilter: true,
+  });
+  const triageFocusEnabled = useTriageFocusEnabled();
+  const [focusMode, setFocusMode] = useState(false);
 
   const sections = useMemo(
     () => partitionInboxReports(scopedReports),
@@ -77,6 +112,7 @@ export function ReportsInboxView() {
   // Search is the one exception: it's a client-side title match, so a
   // searching page counts its matching rows instead.
   const serverCounts = useInboxSectionCounts();
+  const prFilter = useInboxSignalsFilterStore((s) => s.prFilter);
   const searchActive = searchQuery.trim().length > 0;
   const decisionCount = searchActive
     ? sections.decision.length
@@ -107,6 +143,33 @@ export function ReportsInboxView() {
     fetchNextPage,
   ]);
 
+  // Triage mode from anywhere on the page, matching the button's advertised key.
+  useEffect(() => {
+    if (!triageFocusEnabled || focusMode) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isTypingTarget(event.target)) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.key === "t" && sections.decision.length > 0) {
+        event.preventDefault();
+        setFocusMode(true);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [triageFocusEnabled, focusMode, sections.decision.length]);
+
+  if (triageFocusEnabled && focusMode) {
+    return (
+      <div className="h-full min-h-0 overflow-y-auto">
+        <ReportTriageFocus
+          reports={sections.decision}
+          allReports={allReports}
+          onExit={() => setFocusMode(false)}
+        />
+      </div>
+    );
+  }
+
   const isEmpty = searchActive
     ? sections.decision.length === 0 && sections.monitoring.length === 0
     : !serverCounts.isLoading &&
@@ -114,78 +177,132 @@ export function ReportsInboxView() {
       serverCounts.monitoring === 0;
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-0.5">
-          <h1 className="font-semibold text-[15px] text-gray-12">Inbox</h1>
-          <p className="text-[12.5px] text-gray-11">
+    <div className="flex h-full min-h-0 flex-col bg-gray-1">
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitleRow>
+            <PageHeaderTitle>Self-driving</PageHeaderTitle>
+            {serverCounts.decision > 0 && (
+              <PageHeaderChip
+                icon={<EnvelopeSimpleIcon size={12} weight="fill" />}
+              >
+                {serverCounts.decision} need
+                {serverCounts.decision === 1 ? "s" : ""} a decision
+              </PageHeaderChip>
+            )}
+            <PageHeaderActions>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => navigateToAgents()}
+              >
+                Configure agents
+              </Button>
+            </PageHeaderActions>
+          </PageHeaderTitleRow>
+          <PageHeaderDescription>
             Issues and opportunities found in your product, ready to review
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => navigateToAgents()}
-        >
-          Configure agents
-        </Button>
-      </div>
-
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <div className="flex items-center gap-2">
+          </PageHeaderDescription>
+        </PageHeaderHeading>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {triageFocusEnabled && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="gap-2"
+                    disabled={sections.decision.length === 0}
+                    onClick={() => setFocusMode(true)}
+                  >
+                    <ListChecksIcon size={16} />
+                    Triage mode
+                    <kbd className="rounded bg-(--gray-4) px-1.5 font-mono text-[12px] text-gray-11">
+                      T
+                    </kbd>
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">
+                Step through reports that need a decision, one at a time. Fix,
+                defer, or archive each with a single key.
+              </TooltipContent>
+            </Tooltip>
+          )}
           <InboxScopeSelect />
         </div>
+      </PageHeader>
+
+      {/* The filter bar stays pinned with the header; only the sections
+          scroll. */}
+      <div className="shrink-0 border-(--gray-5) border-b">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-2.5 px-6 py-3">
+          <InboxSearchFilterBar
+            searchPlaceholder="Search reports…"
+            showPrFilter
+          />
+        </div>
       </div>
 
-      <InboxSearchFilterBar searchPlaceholder="Search reports…" />
-
-      {isLoading && scopedReports.length === 0 ? (
-        <div aria-hidden className="flex flex-col gap-2 pt-2">
-          {[70, 55, 80, 60].map((width) => (
-            <div key={width} className="flex items-center gap-3 py-2">
-              <Skeleton className="h-4" style={{ width: `${width}%` }} />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-4">
+          {isLoading && scopedReports.length === 0 ? (
+            <div aria-hidden className="flex flex-col gap-2 pt-2">
+              {[70, 55, 80, 60].map((width) => (
+                <div key={width} className="flex items-center gap-3 py-2">
+                  <Skeleton className="h-4" style={{ width: `${width}%` }} />
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      ) : isEmpty ? (
-        <Empty className="mx-auto max-w-md py-16">
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <EnvelopeSimpleIcon size={24} />
-            </EmptyMedia>
-            <EmptyTitle>Nothing to review</EmptyTitle>
-            <EmptyDescription>
-              Reports show up here as your agents find things worth acting on.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : (
-        <>
-          <InboxSection
-            title="Needs a decision"
-            reports={sections.decision}
-            count={decisionCount}
-            caption={
-              !searchActive && serverCounts.decisionPr > 0
-                ? `${serverCounts.decisionPr} with a PR to review`
-                : undefined
-            }
-            emptyNote="Nothing waiting on you."
-          />
-          <InboxSection
-            title="Monitoring"
-            reports={sections.monitoring}
-            count={monitoringCount}
-          />
-          <ResolvedSection />
-          {isFetchingNextPage && (
-            <div className="flex justify-center py-2">
-              <Spinner />
-            </div>
+          ) : (
+            <>
+              {isEmpty ? (
+                <Empty className="mx-auto max-w-md py-16">
+                  <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                      <EnvelopeSimpleIcon size={24} />
+                    </EmptyMedia>
+                    <EmptyTitle>Nothing to review</EmptyTitle>
+                    <EmptyDescription>
+                      Reports show up here as your agents find things worth
+                      acting on.
+                    </EmptyDescription>
+                  </EmptyHeader>
+                </Empty>
+              ) : (
+                <>
+                  <InboxSection
+                    title="Needs a decision"
+                    reports={sections.decision}
+                    count={decisionCount}
+                    caption={
+                      !searchActive &&
+                      prFilter === "all" &&
+                      serverCounts.decisionPr > 0
+                        ? `${serverCounts.decisionPr} with a PR to review`
+                        : undefined
+                    }
+                    emptyNote="Nothing waiting on you."
+                  />
+                  <InboxSection
+                    title="Monitoring"
+                    reports={sections.monitoring}
+                    count={monitoringCount}
+                  />
+                  {isFetchingNextPage && (
+                    <div className="flex justify-center py-2">
+                      <Spinner />
+                    </div>
+                  )}
+                </>
+              )}
+              <ResolvedSection />
+            </>
           )}
-        </>
-      )}
+        </div>
+      </div>
     </div>
   );
 }
@@ -215,7 +332,7 @@ function InboxSection({
   const hidden = reports.length - visible.length;
   return (
     <section className="flex flex-col gap-1.5">
-      <h2 className="flex items-baseline gap-2 border-(--gray-5) border-b pb-1 font-medium text-[11px] text-gray-10 uppercase tracking-wide">
+      <h2 className="flex items-baseline gap-2 border-(--gray-5) border-b pb-1 font-medium text-[12px] text-gray-10 uppercase tracking-wide">
         {title}
         <span className="tabular-nums">({count})</span>
         {caption && (
@@ -225,7 +342,7 @@ function InboxSection({
         )}
       </h2>
       {count === 0 && reports.length === 0 ? (
-        <p className="px-1 py-2 text-[12.5px] text-gray-10">{emptyNote}</p>
+        <p className="px-1 py-2 text-[13.5px] text-gray-10">{emptyNote}</p>
       ) : (
         <div className="flex flex-col gap-1">
           {visible.map((report) => (
@@ -282,27 +399,51 @@ function InboxReportRow({ report }: { report: SignalReport }) {
       >
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="flex items-center gap-1.5">
-            <span className="truncate font-medium text-[13px] text-gray-12">
+            <span className="truncate font-medium text-[14px] text-gray-12">
               {humanizeReportTitle(report.title, "Untitled report")}
             </span>
           </span>
           {headline && (
-            <span className="line-clamp-1 text-[12px] text-gray-11">
+            <span className="line-clamp-2 text-[13px] text-gray-11">
               {headline}
             </span>
           )}
-          <span className="flex items-center gap-1.5 text-[11.5px] text-gray-10">
+          <span className="flex items-center gap-1.5 text-[12.5px] text-gray-10">
             {products && <span className="truncate">{products}</span>}
             <RelativeTimestamp
               timestamp={report.created_at}
-              className="shrink-0 text-[11.5px]"
+              className="shrink-0 text-[12.5px]"
             />
           </span>
         </div>
         <span className="flex shrink-0 items-center gap-2">
+          {/* Terminal rows share one section, so each wears its end state:
+              resolved closed itself when the fix shipped; archived was a
+              person's call and carries their reason. */}
+          {report.status === "resolved" && (
+            <span
+              title="The fix shipped and this report closed"
+              className="flex items-center gap-1 rounded border border-(--green-6) bg-(--green-2) px-1.5 py-0.5 text-[12px] text-green-11"
+            >
+              <CheckCircleIcon size={11} />
+              Shipped
+            </span>
+          )}
+          {report.status === "suppressed" && (
+            <span
+              title={report.dismissal_note ?? undefined}
+              className="flex items-center gap-1 rounded border border-(--gray-6) bg-(--gray-2) px-1.5 py-0.5 text-[12px] text-gray-11"
+            >
+              <ArchiveIcon size={11} />
+              Archived
+              {report.dismissal_reason
+                ? ` · ${humanizeIdentifier(report.dismissal_reason)}`
+                : ""}
+            </span>
+          )}
           <SuggestedReviewerAvatarStack report={report} />
           <SignalReportPriorityBadge priority={report.priority} />
-          <span className="font-mono text-[12px] text-gray-11 tabular-nums">
+          <span className="font-mono text-[13px] text-gray-11 tabular-nums">
             {report.signal_count} signal{report.signal_count === 1 ? "" : "s"}
           </span>
           {/* Acting on a row must not also open it. */}
@@ -325,9 +466,18 @@ function InboxReportRow({ report }: { report: SignalReport }) {
                     ? "This report's earlier PR merged, but evidence kept arriving"
                     : "Open the pull request on GitHub"
                 }
-                className="flex items-center gap-1 rounded border border-(--gray-6) px-1.5 py-0.5 font-mono text-[11px] text-gray-11 hover:bg-(--gray-3) hover:text-gray-12"
+                className={
+                  report.implementation_pr_merged
+                    ? "flex items-center gap-1 rounded border border-(--gray-6) px-1.5 py-0.5 font-mono text-[12px] text-gray-11 hover:bg-(--gray-3) hover:text-gray-12"
+                    : "flex items-center gap-1 rounded border border-(--accent-7) bg-(--accent-2) px-1.5 py-0.5 font-mono text-(--accent-11) text-[12px] hover:bg-(--accent-3)"
+                }
               >
-                <GitPullRequestIcon size={11} />#{pr.number}
+                {report.implementation_pr_merged ? (
+                  <GitMergeIcon size={11} />
+                ) : (
+                  <GitPullRequestIcon size={11} />
+                )}
+                #{pr.number}
                 {report.implementation_pr_merged ? " merged" : ""}
               </button>
             )}
@@ -342,9 +492,12 @@ function InboxReportRow({ report }: { report: SignalReport }) {
                   Review
                 </Button>
               )}
-            <span className="opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-              {archiveButton}
-            </span>
+            <ReportRestoreButton report={report} />
+            {report.status !== "suppressed" && (
+              <span className="opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                {archiveButton}
+              </span>
+            )}
           </span>
         </span>
       </div>
@@ -372,9 +525,9 @@ function ResolvedSection() {
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-baseline gap-2 border-(--gray-5) border-b pb-1 text-left font-medium text-[11px] text-gray-10 uppercase tracking-wide"
+        className="flex items-baseline gap-2 border-(--gray-5) border-b pb-1 text-left font-medium text-[12px] text-gray-10 uppercase tracking-wide"
       >
-        Resolved
+        Resolved & archived
         <CaretDownIcon
           size={11}
           className={expanded ? "rotate-180 self-center" : "self-center"}
@@ -386,8 +539,8 @@ function ResolvedSection() {
             <Spinner />
           </div>
         ) : allReports.length === 0 ? (
-          <p className="px-1 py-2 text-[12.5px] text-gray-10">
-            Nothing resolved yet.
+          <p className="px-1 py-2 text-[13.5px] text-gray-10">
+            Nothing resolved or archived yet.
           </p>
         ) : (
           <div className="flex flex-col gap-1">

--- a/products/desktop/packages/ui/src/features/inbox/components/SignalsList.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SignalsList.tsx
@@ -54,7 +54,7 @@ function SignalSourceGroupSection({ group }: { group: SignalSourceGroup }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-1.5 text-[12px] text-gray-11">
+      <div className="flex items-center gap-1.5 text-[13px] text-gray-11">
         {Icon && <Icon size={13} className="shrink-0 text-gray-10" />}
         <span className="font-medium">{label}</span>
         <span className="text-gray-10 tabular-nums">
@@ -68,7 +68,7 @@ function SignalSourceGroupSection({ group }: { group: SignalSourceGroup }) {
         <button
           type="button"
           onClick={() => setExpanded((open) => !open)}
-          className="self-start text-[12px] text-gray-10 underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-12"
+          className="self-start text-[13px] text-gray-10 underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-12"
         >
           {expanded ? "Show fewer" : `Show all ${group.signals.length}`}
         </button>

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -3,7 +3,7 @@ import type {
   SignalReportArtefactsResponse,
   SuggestedReviewer,
 } from "@posthog/shared/types";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -55,6 +55,13 @@ function reviewer(login: string, uuid: string): SuggestedReviewer {
 }
 
 const me = reviewer("alice", "user-me");
+me.relevant_commits = [
+  {
+    sha: "abc123",
+    url: "https://github.com/example/repo/commit/abc123",
+    reason: "Recently changed the affected request parser.",
+  },
+];
 const teammate = reviewer("bob", "user-bob");
 const report = {
   id: "report-1",
@@ -104,16 +111,22 @@ describe("SuggestedReviewerAvatarStack", () => {
   it.each([
     ["the current user is assigned", "user-me", true],
     ["the current user is not assigned", "user-other", false],
-  ])("is clickable when %s", (_case, currentUserUuid, isClickable) => {
+  ])("offers removal when %s", async (_case, currentUserUuid, canRemove) => {
+    const user = userEvent.setup();
     mocks.currentUserUuid = currentUserUuid;
     render(
       <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />,
     );
 
-    const button = screen.queryByRole("button", {
-      name: "remove me from reviewers",
+    await user.click(
+      screen.getByRole("button", {
+        name: "View suggested reviewer rationale",
+      }),
+    );
+    const removeButton = screen.queryByRole("button", {
+      name: "Remove me from reviewers",
     });
-    expect(!!button).toBe(isClickable);
+    expect(!!removeButton).toBe(canRemove);
     expect(screen.getByText("2 suggested reviewers")).toBeTruthy();
   });
 
@@ -125,13 +138,19 @@ describe("SuggestedReviewerAvatarStack", () => {
       <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />,
     );
 
-    const button = screen.getByRole("button", {
-      name: "remove me from reviewers",
+    await user.click(
+      screen.getByRole("button", {
+        name: "View suggested reviewer rationale",
+      }),
+    );
+    const button = await screen.findByRole("button", {
+      name: "Remove me from reviewers",
     });
-    await user.hover(button);
-    expect(await screen.findByText("remove me from reviewers")).toBeTruthy();
+    expect(
+      screen.getByText("Recently changed the affected request parser."),
+    ).toBeTruthy();
 
-    fireEvent.click(button);
+    await user.click(button);
 
     expect(onCardClick).not.toHaveBeenCalled();
     expect(mocks.mutate).toHaveBeenCalledWith({

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -4,11 +4,14 @@ import {
 } from "@posthog/core/inbox/artefacts";
 import { selectSuggestedReviewersArtefact } from "@posthog/core/inbox/reportArtefacts";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Button,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
 } from "@posthog/quill";
 import type { InboxReportActionSurface } from "@posthog/shared";
 import type {
@@ -27,7 +30,7 @@ import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useRepo
 const MAX_VISIBLE = 4;
 // Keep this stable because autocapture insights and UI tests can depend on it.
 const REMOVE_SELF_DATA_ATTR = "inbox-remove-self-from-reviewers";
-const REMOVE_SELF_TOOLTIP = "remove me from reviewers";
+const REMOVE_SELF_LABEL = "Remove me from reviewers";
 
 interface SuggestedReviewerAvatarStackProps {
   report: SignalReport;
@@ -69,7 +72,6 @@ export function SuggestedReviewerAvatarStack({
   const visible = reviewers.slice(0, MAX_VISIBLE);
   const overflow = reviewers.length - visible.length;
   const reviewerCountLabel = `${reviewers.length} suggested reviewer${reviewers.length === 1 ? "" : "s"}`;
-
   const avatarStack = (
     <span className="-space-x-1.5 flex items-center">
       <span className="sr-only">{reviewerCountLabel}</span>
@@ -89,23 +91,8 @@ export function SuggestedReviewerAvatarStack({
     </span>
   );
 
-  if (!currentReviewer || !reviewerArtefact) {
-    const reviewerNames = visible
-      .map((reviewer) => suggestedReviewerDisplayName(reviewer))
-      .join(", ");
-    return (
-      <TooltipProvider delay={300}>
-        <Tooltip>
-          <TooltipTrigger render={<span className="shrink-0" />}>
-            {avatarStack}
-          </TooltipTrigger>
-          <TooltipContent>{reviewerNames}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-
   const removeSelf = () => {
+    if (!currentReviewer || !reviewerArtefact) return;
     const nextReviewers = reviewerArtefact.content.filter(
       (reviewer) => reviewer.user?.uuid !== currentUser?.uuid,
     );
@@ -121,16 +108,67 @@ export function SuggestedReviewerAvatarStack({
   };
 
   return (
-    <TooltipProvider delay={300}>
-      <Tooltip>
-        <TooltipTrigger
-          render={
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="link-muted"
+            size="xs"
+            className="h-auto p-0 no-underline hover:no-underline"
+            aria-label="View suggested reviewer rationale"
+            onClick={(event) => event.stopPropagation()}
+          />
+        }
+      >
+        {avatarStack}
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        sideOffset={8}
+        className="flex w-96 flex-col gap-0 overflow-hidden p-0"
+      >
+        <div className="border-(--gray-6) border-b px-3 py-2 font-medium text-[13px]">
+          Suggested reviewers
+        </div>
+        <div className="max-h-80 overflow-y-auto overscroll-contain p-2">
+          <Accordion
+            multiple
+            defaultValue={
+              reviewers[0]?.github_login ? [reviewers[0].github_login] : []
+            }
+          >
+            {reviewers.map((reviewer) => (
+              <AccordionItem
+                key={reviewer.github_login}
+                value={reviewer.github_login}
+              >
+                <AccordionTrigger>
+                  {suggestedReviewerDisplayName(reviewer)}
+                </AccordionTrigger>
+                <AccordionContent>
+                  <div className="flex flex-col gap-2 pb-2 text-[12px] text-gray-11 leading-relaxed">
+                    {reviewer.relevant_commits.length > 0 ? (
+                      reviewer.relevant_commits.map((commit) => (
+                        <p key={commit.sha}>{commit.reason}</p>
+                      ))
+                    ) : (
+                      <p>Suggested by the agent</p>
+                    )}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+        {currentReviewer && reviewerArtefact ? (
+          <div className="border-(--gray-6) border-t p-2">
             <Button
               type="button"
-              variant="link-muted"
+              variant="outline"
               size="xs"
-              className="h-auto p-0 no-underline hover:no-underline"
-              aria-label={REMOVE_SELF_TOOLTIP}
+              className="w-full"
               data-attr={REMOVE_SELF_DATA_ATTR}
               loading={isPending}
               onClick={(event) => {
@@ -138,13 +176,12 @@ export function SuggestedReviewerAvatarStack({
                 event.stopPropagation();
                 removeSelf();
               }}
-            />
-          }
-        >
-          {avatarStack}
-        </TooltipTrigger>
-        <TooltipContent>{REMOVE_SELF_TOOLTIP}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+            >
+              {REMOVE_SELF_LABEL}
+            </Button>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -104,7 +104,7 @@ function CodeRefBlock({ code, language }: { code: string; language: string }) {
 
 function RelevanceNote({ note }: { note: string }) {
   if (!note.trim()) return null;
-  return <Text className="block text-(--gray-11) text-[12px]">{note}</Text>;
+  return <Text className="block text-(--gray-11) text-[13px]">{note}</Text>;
 }
 
 /** Judgment explanations are often paragraphs — collapsed by default behind a toggle. */
@@ -117,7 +117,7 @@ function CollapsibleReasoning({ text }: { text: string }) {
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="-mx-1 flex items-center gap-1 rounded-md px-1 py-0.5 text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
+        className="-mx-1 flex items-center gap-1 rounded-md px-1 py-0.5 text-(--gray-11) text-[13px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
       >
         {expanded ? (
           <CaretDownIcon size={12} className="shrink-0" />
@@ -127,7 +127,7 @@ function CollapsibleReasoning({ text }: { text: string }) {
         {expanded ? "Hide reasoning" : "Show reasoning"}
       </button>
       {expanded ? (
-        <Text className="block text-(--gray-11) text-[12px]">{text}</Text>
+        <Text className="block text-(--gray-11) text-[13px]">{text}</Text>
       ) : null}
     </Box>
   );
@@ -155,7 +155,7 @@ function CollapsibleNote({
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="-mx-1 flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-left text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
+        className="-mx-1 flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-left text-(--gray-11) text-[13px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
       >
         {expanded ? (
           <CaretDownIcon size={12} className="shrink-0" />
@@ -169,10 +169,10 @@ function CollapsibleNote({
         )}
       </button>
       {expanded ? (
-        <Box className="text-[12px]">
+        <Box className="text-[13px]">
           <MarkdownRenderer content={note} />
           {author ? (
-            <Text className="block text-(--gray-10) text-[11px]">
+            <Text className="block text-(--gray-10) text-[12px]">
               — {author}
             </Text>
           ) : null}
@@ -185,7 +185,7 @@ function CollapsibleNote({
 function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
   if (reviewers.length === 0) {
     return (
-      <Text className="block text-(--gray-10) text-[12px]">
+      <Text className="block text-(--gray-10) text-[13px]">
         No reviewers assigned.
       </Text>
     );
@@ -207,7 +207,7 @@ function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
               onLoad={(e) => e.currentTarget.classList.add("loaded")}
             />
           ) : null}
-          <Text className="text-[12px]">
+          <Text className="text-[13px]">
             {reviewer.user?.first_name ??
               reviewer.github_name ??
               reviewer.github_login}
@@ -217,7 +217,7 @@ function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
               href={`https://github.com/${reviewer.github_login}`}
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-0.5 text-[11px] text-gray-9 hover:text-gray-11"
+              className="inline-flex items-center gap-0.5 text-[12px] text-gray-9 hover:text-gray-11"
             >
               @{reviewer.github_login}
               <ArrowSquareOutIcon size={10} />
@@ -244,7 +244,7 @@ function ArtefactBody({
     const text = (artefact.content as SignalReportArtefactContent | null)
       ?.content;
     return (
-      <Text className="block text-(--gray-10) text-[12px]">
+      <Text className="block text-(--gray-10) text-[13px]">
         {text || "No preview available."}
       </Text>
     );
@@ -334,7 +334,7 @@ function ArtefactBody({
       return (
         <Flex direction="column" gap="1">
           <Flex align="center" gap="2" wrap="wrap">
-            <Text className="font-mono text-(--gray-10) text-[11px]">
+            <Text className="font-mono text-(--gray-10) text-[12px]">
               {c.signal_id}
             </Text>
             <Badge color={c.verified ? "green" : "gray"} variant="soft">
@@ -346,7 +346,7 @@ function ArtefactBody({
               {c.relevant_code_paths.map((path) => (
                 <Text
                   key={path}
-                  className="truncate font-mono text-(--gray-11) text-[11px]"
+                  className="truncate font-mono text-(--gray-11) text-[12px]"
                 >
                   {path}
                 </Text>
@@ -375,7 +375,7 @@ function ArtefactBody({
       const c = artefact.content as SignalReportArtefactContent | null;
       const text = typeof c?.content === "string" ? c.content : "";
       return (
-        <Text className="block text-(--gray-10) text-[12px]">
+        <Text className="block text-(--gray-10) text-[13px]">
           {text || "No preview available."}
         </Text>
       );
@@ -400,18 +400,18 @@ function ArtefactRow({
     <Box className="rounded-lg border border-gray-6 bg-gray-1 p-3">
       <Flex align="center" justify="between" gap="2" className="mb-1.5">
         <Flex align="center" gap="2" className="min-w-0">
-          <Text className="shrink-0 font-medium text-[12px]">
+          <Text className="shrink-0 font-medium text-[13px]">
             {typeLabel(artefact.type)}
           </Text>
           {location ? (
-            <Text className="truncate font-mono text-(--gray-10) text-[11px]">
+            <Text className="truncate font-mono text-(--gray-10) text-[12px]">
               {location}
             </Text>
           ) : null}
         </Flex>
         <Flex align="center" gap="2" className="shrink-0">
           {attribution ? (
-            <Text className="text-(--gray-10) text-[11px]">
+            <Text className="text-(--gray-10) text-[12px]">
               by {attribution}
             </Text>
           ) : null}
@@ -422,7 +422,7 @@ function ArtefactRow({
               onClick={() => setShowRaw((v) => !v)}
               title="View raw JSON (dev only)"
               aria-pressed={showRaw}
-              className={`rounded-sm px-1 font-mono text-[11px] transition-colors hover:bg-(--gray-3) ${
+              className={`rounded-sm px-1 font-mono text-[12px] transition-colors hover:bg-(--gray-3) ${
                 showRaw ? "text-(--gray-12)" : "text-(--gray-9)"
               }`}
             >
@@ -438,7 +438,7 @@ function ArtefactRow({
         hideCommitDiffs={hideCommitDiffs}
       />
       {showRaw ? (
-        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap rounded-md border border-(--gray-6) bg-(--gray-2) p-2 font-mono text-(--gray-11) text-[11px]">
+        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap rounded-md border border-(--gray-6) bg-(--gray-2) p-2 font-mono text-(--gray-11) text-[12px]">
           {JSON.stringify(artefact, null, 2)}
         </pre>
       ) : null}

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
@@ -36,7 +36,7 @@ export function ReportActivitySection({
       collapsible
       defaultCollapsed
       rightSlot={
-        <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+        <Text className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
           {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
         </Text>
       }

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportChartCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportChartCard.tsx
@@ -88,7 +88,7 @@ function ChartTableBody({
 }) {
   return (
     <div className="min-h-0 overflow-auto">
-      <table className="w-full border-collapse text-[12px]">
+      <table className="w-full border-collapse text-[13px]">
         <thead>
           <tr>
             {data.columns.map((column) => (
@@ -133,7 +133,7 @@ function ChartMessageBody({
 }) {
   return (
     <div className="flex flex-col items-center justify-center gap-2 py-6 text-center">
-      <span className="text-[12px] text-gray-10">{message}</span>
+      <span className="text-[13px] text-gray-10">{message}</span>
       {openTarget && (
         <Button
           type="button"
@@ -230,7 +230,7 @@ export function ReportChartCardView({
       data-testid="report-chart"
     >
       <div className="flex items-start justify-between gap-2">
-        <span className="min-w-0 break-words font-semibold text-[13px] text-gray-12">
+        <span className="min-w-0 break-words font-semibold text-[14px] text-gray-12">
           {title}
         </span>
         {stat && (
@@ -238,7 +238,7 @@ export function ReportChartCardView({
             className="flex shrink-0 items-baseline gap-1.5"
             data-testid="chart-headline-stat"
           >
-            <span className="font-semibold text-[17px] text-gray-12 tabular-nums leading-none">
+            <span className="font-semibold text-[18px] text-gray-12 tabular-nums leading-none">
               {stat.value}
             </span>
             {stat.delta && (
@@ -246,7 +246,7 @@ export function ReportChartCardView({
               // necessarily good (errors, latency, cost all land in these
               // cards). Stay neutral and let the arrow convey direction alone,
               // matching how the main app leaves an unlabelled change uncolored.
-              <span className="font-medium text-(--gray-11) text-[11px] tabular-nums">
+              <span className="font-medium text-(--gray-11) text-[12px] tabular-nums">
                 {stat.delta.direction === "up" ? "▲" : "▼"}
                 {stat.delta.label}
               </span>
@@ -278,7 +278,7 @@ export function ReportChartCardView({
         {body}
       </div>
       {caption && (
-        <figcaption className="m-0 text-[11px] text-gray-10">
+        <figcaption className="m-0 text-[12px] text-gray-10">
           {caption}
         </figcaption>
       )}

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -259,7 +259,7 @@ function VerificationBadge() {
     <Flex
       align="center"
       gap="1"
-      className="shrink-0 text-(--green-9) text-[11px]"
+      className="shrink-0 text-(--green-9) text-[12px]"
       title="Verified by code or data evidence"
     >
       <CheckCircleIcon size={12} weight="fill" />
@@ -289,7 +289,7 @@ function SignalCardHeader({
           <span className="inline-block h-2.5 w-2.5 rounded-full bg-(--gray-9)" />
         )}
       </span>
-      <Text className="font-medium text-[13px] text-gray-10">
+      <Text className="font-medium text-[14px] text-gray-10">
         {signalCardSourceLine({ ...signal, extra: parseExtra(signal.extra) })}
       </Text>
       <span className="flex-1" />
@@ -312,7 +312,7 @@ function CollapsibleBody({ body }: { body: string }) {
 
   return (
     <Box>
-      <Box className="text-pretty break-words text-[13px] text-gray-11 leading-relaxed [&_code]:text-[11px] [&_p:last-child]:mb-0 [&_p]:mb-1 [&_pre]:text-[11px]">
+      <Box className="text-pretty break-words text-[14px] text-gray-11 leading-relaxed [&_code]:text-[12px] [&_p:last-child]:mb-0 [&_p]:mb-1 [&_pre]:text-[12px]">
         <MarkdownRenderer content={displayBody} />
       </Box>
       {isLong && (
@@ -327,7 +327,7 @@ function CollapsibleBody({ body }: { body: string }) {
               return next;
             });
           }}
-          className="mt-1.5 flex items-center gap-1 rounded px-1 py-0.5 font-medium text-[12px] text-accent-11 hover:bg-accent-3 hover:text-accent-12"
+          className="mt-1.5 flex items-center gap-1 rounded px-1 py-0.5 font-medium text-[13px] text-accent-11 hover:bg-accent-3 hover:text-accent-12"
         >
           {expanded ? (
             <CaretDownIcon size={12} />
@@ -368,13 +368,13 @@ function GitHubIssueSignalCard({
         gap="2"
         wrap="wrap"
         mt="2"
-        className="text-[11px] text-gray-10"
+        className="text-[12px] text-gray-10"
       >
-        <Text className="font-medium text-[11px]">#{extra.number}</Text>
+        <Text className="font-medium text-[12px]">#{extra.number}</Text>
         {labels.map((label) => (
           <span
             key={label.name}
-            className="inline-flex items-center rounded-full px-1.5 py-0.5 font-medium text-[11px]"
+            className="inline-flex items-center rounded-full px-1.5 py-0.5 font-medium text-[12px]"
             style={
               label.color
                 ? {
@@ -399,7 +399,7 @@ function GitHubIssueSignalCard({
             href={issueUrl}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1 text-[11px] text-gray-10 hover:text-gray-12"
+            className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
           >
             View on GitHub
             <ArrowSquareOutIcon size={12} />
@@ -407,7 +407,7 @@ function GitHubIssueSignalCard({
         )}
       </Flex>
       {extra.created_at && (
-        <Text className="mt-1 block text-[11px] text-gray-10">
+        <Text className="mt-1 block text-[12px] text-gray-10">
           Opened: {new Date(extra.created_at).toLocaleString()}
         </Text>
       )}
@@ -439,15 +439,15 @@ function ZendeskTicketSignalCard({
         gap="2"
         wrap="wrap"
         mt="2"
-        className="text-[11px] text-gray-10"
+        className="text-[12px] text-gray-10"
       >
         {extra.priority && (
-          <Badge variant="soft" color="gray" size="1" className="text-[11px]">
+          <Badge variant="soft" color="gray" size="1" className="text-[12px]">
             Priority: {extra.priority}
           </Badge>
         )}
         {extra.status && (
-          <Badge variant="soft" color="gray" size="1" className="text-[11px]">
+          <Badge variant="soft" color="gray" size="1" className="text-[12px]">
             Status: {extra.status}
           </Badge>
         )}
@@ -457,7 +457,7 @@ function ZendeskTicketSignalCard({
             variant="soft"
             color="gray"
             size="1"
-            className="text-[11px]"
+            className="text-[12px]"
           >
             {tag}
           </Badge>
@@ -468,7 +468,7 @@ function ZendeskTicketSignalCard({
             href={zendeskWebUrl(extra.url)}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1 text-[11px] text-gray-10 hover:text-gray-12"
+            className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
           >
             Open
             <ArrowSquareOutIcon size={12} />
@@ -498,13 +498,13 @@ function LlmEvalSignalCard({
     <Box className="min-w-0 overflow-hidden rounded-(--radius-2) border border-(--gray-6) bg-gray-1 p-3">
       <SignalCardHeader signal={signal} verified={verified} />
       <CollapsibleBody body={signal.content} />
-      <Flex align="center" gap="2" mt="2" className="text-[11px] text-gray-10">
+      <Flex align="center" gap="2" mt="2" className="text-[12px] text-gray-10">
         {extra.model && <span>Model: {extra.model}</span>}
         {extra.model && extra.provider && <span>·</span>}
         {extra.provider && <span>Provider: {extra.provider}</span>}
       </Flex>
       {extra.trace_id && (
-        <Text className="mt-1 block text-[11px] text-gray-10">
+        <Text className="mt-1 block text-[12px] text-gray-10">
           Trace:{" "}
           <span className="font-mono">{extra.trace_id.slice(0, 12)}...</span>
         </Text>
@@ -560,7 +560,7 @@ function SessionProblemSignalCard({
     <Box className="min-w-0 overflow-hidden rounded-(--radius-2) border border-(--gray-6) bg-gray-1 p-3">
       <SignalCardHeader signal={signal} verified={verified} />
       {extra.segment_title && (
-        <Text mt="1" className="font-medium text-[13px] text-gray-11" as="p">
+        <Text mt="1" className="font-medium text-[14px] text-gray-11" as="p">
           {extra.segment_title}
         </Text>
       )}
@@ -578,20 +578,20 @@ function SessionProblemSignalCard({
         gap="2"
         wrap="wrap"
         mt="2"
-        className="text-[11px] text-gray-10"
+        className="text-[12px] text-gray-10"
       >
         {problemInfo && (
           <Badge
             variant="soft"
             color={problemInfo.color}
             size="1"
-            className="text-[11px]"
+            className="text-[12px]"
           >
             {problemInfo.label}
           </Badge>
         )}
         {extra.distinct_id && (
-          <Text className="font-mono text-[11px]">
+          <Text className="font-mono text-[12px]">
             {extra.distinct_id.slice(0, 10)}…
           </Text>
         )}
@@ -663,7 +663,7 @@ function SessionRecordingVideo({
     return (
       <Box
         mt="2"
-        className="flex h-24 items-center justify-center rounded bg-gray-3 text-[11px] text-gray-9"
+        className="flex h-24 items-center justify-center rounded bg-gray-3 text-[12px] text-gray-9"
       >
         Loading recording…
       </Box>
@@ -721,13 +721,13 @@ function ErrorTrackingSignalCard({
           align="center"
           justify="end"
           mt="2"
-          className="text-[11px] text-gray-10"
+          className="text-[12px] text-gray-10"
         >
           <a
             href={issueUrl}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1 text-[11px] text-gray-10 hover:text-gray-12"
+            className="inline-flex items-center gap-1 text-[12px] text-gray-10 hover:text-gray-12"
           >
             View issue
             <ArrowSquareOutIcon size={12} />
@@ -783,7 +783,7 @@ function CodePathsCollapsible({ paths }: { paths: string[] }) {
             return next;
           });
         }}
-        className="flex items-center gap-1 rounded px-1 py-0.5 font-medium text-[12px] text-gray-10 hover:bg-gray-3 hover:text-gray-12"
+        className="flex items-center gap-1 rounded px-1 py-0.5 font-medium text-[13px] text-gray-10 hover:bg-gray-3 hover:text-gray-12"
       >
         {expanded ? <CaretDownIcon size={12} /> : <CaretRightIcon size={12} />}
         Relevant code ({paths.length})
@@ -797,7 +797,7 @@ function CodePathsCollapsible({ paths }: { paths: string[] }) {
               parenIdx >= 0 ? trimmed.slice(0, parenIdx) : trimmed;
             const comment = parenIdx >= 0 ? trimmed.slice(parenIdx + 1) : null;
             return (
-              <Text key={raw} className="text-[11px]">
+              <Text key={raw} className="text-[12px]">
                 <span className="font-mono text-gray-12">{filePath}</span>
                 {comment && (
                   <span className="ml-1 text-(--gray-9)">{comment}</span>
@@ -833,7 +833,7 @@ function DataQueriedCollapsible({ text }: { text: string }) {
             return next;
           });
         }}
-        className="flex items-center gap-1 rounded px-1 py-0.5 font-medium text-[12px] text-gray-10 hover:bg-gray-3 hover:text-gray-12"
+        className="flex items-center gap-1 rounded px-1 py-0.5 font-medium text-[13px] text-gray-10 hover:bg-gray-3 hover:text-gray-12"
       >
         {expanded ? <CaretDownIcon size={12} /> : <CaretRightIcon size={12} />}
         Data queried
@@ -841,7 +841,7 @@ function DataQueriedCollapsible({ text }: { text: string }) {
       {expanded && (
         <Text
           color="gray"
-          className="mt-1 block whitespace-pre-wrap text-pretty pl-[18px] text-[11px] leading-relaxed"
+          className="mt-1 block whitespace-pre-wrap text-pretty pl-[18px] text-[12px] leading-relaxed"
         >
           {text}
         </Text>

--- a/products/desktop/packages/ui/src/features/inbox/components/utils/ExplainedDismissOptionLabels.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/utils/ExplainedDismissOptionLabels.tsx
@@ -4,10 +4,10 @@ import { RadioGroup, Tooltip } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 const PAUSE_OPTION_TOOLTIP =
-  "Snoozes this report: it briefly leaves your inbox while more context is gathered, and it can come back if new signals match.";
+  "Snoozes this report: it briefly leaves Self-driving while more context is gathered, and it can come back if new signals match.";
 
 const SUPPRESS_OPTION_TOOLTIP =
-  "Archives permanently: the report leaves your inbox and matching signals will not surface it again. Your reason is saved with the report.";
+  "Archives permanently: the report leaves Self-driving and matching signals will not surface it again. Your reason is saved with the report.";
 
 function dismissReasonOptionDomId(value: DismissalReasonOptionValue): string {
   return `dismiss-report-dialog-reason-${value}`;

--- a/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportStatusBadge.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportStatusBadge.tsx
@@ -13,7 +13,7 @@ const STATUS_TOOLTIPS: Record<string, string> = {
   potential:
     "Gathering signals. The report will be queued once enough evidence accumulates.",
   failed: "Research failed. The report may be retried automatically.",
-  suppressed: "This report has been suppressed and is out of your inbox.",
+  suppressed: "This report has been suppressed and is out of Self-driving.",
   deleted: "This report has been deleted.",
 };
 

--- a/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportSummaryMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportSummaryMarkdown.tsx
@@ -98,7 +98,7 @@ export function SignalReportSummaryMarkdown({
   if (variant === "list") {
     return (
       <div
-        className={`line-clamp-3 min-w-0 overflow-hidden text-pretty text-left text-[12px] text-gray-11 [&_.rt-Text]:mb-0! [&_a]:pointer-events-auto [&_li]:mb-0 [&_p]:mb-0! [&_ul]:mb-0! ${pendingClass}`}
+        className={`line-clamp-3 min-w-0 overflow-hidden text-pretty text-left text-[13px] text-gray-11 [&_.rt-Text]:mb-0! [&_a]:pointer-events-auto [&_li]:mb-0 [&_p]:mb-0! [&_ul]:mb-0! ${pendingClass}`}
       >
         <MarkdownRenderer
           content={listMarkdown}
@@ -114,7 +114,7 @@ export function SignalReportSummaryMarkdown({
   // the cap with the container.
   return (
     <div
-      className={`min-w-0 max-w-[80ch] text-pretty break-words text-[13px] text-gray-11 [&_*]:leading-relaxed [&_.rt-Text]:mb-2 [&_a]:pointer-events-auto [&_li]:mb-1 [&_p:last-child]:mb-0 ${pendingClass}`}
+      className={`min-w-0 max-w-[80ch] text-pretty break-words text-[14px] text-gray-11 [&_*]:leading-relaxed [&_.rt-Text]:mb-2 [&_a]:pointer-events-auto [&_li]:mb-1 [&_p:last-child]:mb-0 ${pendingClass}`}
     >
       <MarkdownRenderer content={raw} componentsOverride={detailComponents} />
     </div>

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useCreateCanvasReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useCreateCanvasReport.ts
@@ -1,6 +1,7 @@
 import { buildCreateCanvasReportPrompt } from "@posthog/core/inbox/reportActions";
 import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
 import type { TaskCreationInput } from "@posthog/core/task-detail/taskService";
+import type { Task } from "@posthog/shared/types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
   type InboxCloudTaskInputContext,
@@ -14,6 +15,8 @@ interface UseCreateCanvasReportOptions {
   /** The space that owns the report, when assigned; the agent falls back to #general. */
   channelId: string | null;
   cloudRepository: string | null;
+  /** Fires once the canvas task exists so the report can open it in the dock. */
+  onTaskCreated?: (task: Task) => void;
 }
 
 interface UseCreateCanvasReportReturn {
@@ -33,6 +36,7 @@ export function useCreateCanvasReport({
   reportTitle,
   channelId,
   cloudRepository,
+  onTaskCreated,
 }: UseCreateCanvasReportOptions): UseCreateCanvasReportReturn {
   const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
   const projectId = useAuthStateValue((s) => s.currentProjectId);
@@ -98,6 +102,7 @@ export function useCreateCanvasReport({
     buildInput,
     analyticsExtras: { has_branch: false },
     redirectOnSuccess: false,
+    onTaskCreated,
   });
 
   const createCanvasReport = useCallback(

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -1,6 +1,7 @@
 import { buildCreatePrReportPrompt } from "@posthog/core/inbox/reportActions";
 import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
 import type { TaskCreationInput } from "@posthog/core/task-detail/taskService";
+import type { Task } from "@posthog/shared/types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
   type InboxCloudTaskInputContext,
@@ -13,6 +14,8 @@ interface UseCreatePrReportOptions {
   reportId: string;
   reportTitle: string | null;
   cloudRepository: string | null;
+  /** Fires once the implementation task exists (the chat dock binds to it). */
+  onTaskCreated?: (task: Task) => void;
 }
 
 interface UseCreatePrReportReturn {
@@ -44,6 +47,7 @@ export function useCreatePrReport({
   reportId,
   reportTitle,
   cloudRepository,
+  onTaskCreated,
 }: UseCreatePrReportOptions): UseCreatePrReportReturn {
   const { data: teamConfig } = useSignalTeamConfig();
   const baseBranchOverrides = teamConfig?.autostart_base_branches ?? null;
@@ -126,6 +130,7 @@ export function useCreatePrReport({
     buildInput,
     analyticsExtras,
     redirectOnSuccess: false,
+    onTaskCreated,
   });
 
   const createPrReport = useCallback(

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -53,9 +53,18 @@ export function useInboxAllReports(options?: {
    * Callers sharing one dataset must pass the same value.
    */
   statusFilter?: string;
+  /**
+   * Apply the persisted `prFilter` (with-PR / without-PR) to the query. Only
+   * the sectioned inbox renders the control that sets it, so only it opts in —
+   * otherwise a stored value would silently filter surfaces with no way to
+   * clear it (e.g. empty the legacy Reports tab, which then drops PR-backed
+   * reports itself).
+   */
+  applyPrFilter?: boolean;
 }) {
   const ignoreScope = options?.ignoreScope ?? false;
   const ignoreFilters = options?.ignoreFilters ?? false;
+  const applyPrFilter = options?.applyPrFilter ?? false;
   const refetchIntervalMs =
     options?.refetchIntervalMs ?? INBOX_REFETCH_INTERVAL_MS;
   // The Pull requests tab fetches a server-filtered list (reports that have a
@@ -80,6 +89,9 @@ export function useInboxAllReports(options?: {
   const priorityFilter = useInboxSignalsFilterStore((s) =>
     ignoreFilters ? EMPTY_FILTER_ARRAY : s.priorityFilter,
   );
+  const prFilter = useInboxSignalsFilterStore((s) =>
+    ignoreFilters || !applyPrFilter ? "all" : s.prFilter,
+  );
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
 
@@ -98,7 +110,13 @@ export function useInboxAllReports(options?: {
       status: pullRequestsOnly
         ? INBOX_PULL_REQUEST_STATUS_FILTER
         : (options?.statusFilter ?? INBOX_PIPELINE_STATUS_FILTER),
-      has_implementation_pr: pullRequestsOnly ? true : undefined,
+      has_implementation_pr: pullRequestsOnly
+        ? true
+        : prFilter === "with_pr"
+          ? true
+          : prFilter === "without_pr"
+            ? false
+            : undefined,
       ordering: buildSignalReportListOrdering(sortField, sortDirection),
       source_product:
         sourceProductFilter.length > 0

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
@@ -1,5 +1,11 @@
 import { ArchiveIcon } from "@phosphor-icons/react";
-import { Button } from "@posthog/quill";
+import {
+  Button,
+  Spinner,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
 import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
 import {
@@ -7,7 +13,6 @@ import {
   type DismissReportDialogResult,
 } from "@posthog/ui/features/inbox/components/DismissReportDialog";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
-import { Spinner, Tooltip } from "@radix-ui/themes";
 import { type ReactElement, useCallback, useMemo, useState } from "react";
 
 const EMPTY_REPORTS: SignalReport[] = [];
@@ -47,17 +52,23 @@ export function useInboxReportDismissAction(report: SignalReport): {
   );
 
   const actionButton = (
-    <Tooltip content="Archive this report">
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        aria-label="Archive this report"
-        disabled={isPending}
-        onClick={() => setOpen(true)}
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-xs"
+            className="h-7 w-7"
+            aria-label="Archive this report"
+            disabled={isPending}
+            onClick={() => setOpen(true)}
+          />
+        }
       >
-        {isPending ? <Spinner size="1" /> : <ArchiveIcon size={12} />}
-      </Button>
+        {isPending ? <Spinner /> : <ArchiveIcon size={12} />}
+      </TooltipTrigger>
+      <TooltipContent>Archive</TooltipContent>
     </Tooltip>
   );
 

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxSectionCounts.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxSectionCounts.ts
@@ -46,6 +46,7 @@ export function useInboxSectionCounts(): InboxSectionCounts {
     (s) => s.sourceProductFilter,
   );
   const priorityFilter = useInboxSignalsFilterStore((s) => s.priorityFilter);
+  const prFilter = useInboxSignalsFilterStore((s) => s.prFilter);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
 
@@ -60,6 +61,13 @@ export function useInboxSectionCounts(): InboxSectionCounts {
         ? sourceProductFilter.join(",")
         : undefined,
     priority: buildPriorityFilterParam(priorityFilter),
+    // The decision-PR caption query overrides this with `true` via spread.
+    has_implementation_pr:
+      prFilter === "with_pr"
+        ? true
+        : prFilter === "without_pr"
+          ? false
+          : undefined,
     suggested_reviewers: reviewerUuid
       ? buildSuggestedReviewerFilterParam([reviewerUuid])
       : undefined,

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
@@ -32,7 +32,9 @@ function makeTask(
         status: run.status ?? "in_progress",
         log_url: "",
         error_message: null,
-        output,
+        output: run.prUrl
+          ? { pr_url: run.prUrl, ...(run.prMerged ? { pr_merged: true } : {}) }
+          : null,
         state: {},
         created_at: "2026-06-24T10:00:00Z",
         updated_at: "2026-06-24T10:00:00Z",
@@ -117,31 +119,28 @@ describe("findContinuableImplementationTask", () => {
     ).toBe(running);
   });
 
-  it.each<[string, { prMerged?: boolean; prState?: string }]>([
-    ["pr_state merged", { prState: "merged" }],
-    ["legacy pr_merged flag", { prMerged: true }],
-  ])(
-    "treats a task whose PR already merged (%s) as not continuable",
-    (_label, merge) => {
-      const merged = makeTask("impl", {
-        status: "completed",
-        prUrl: "https://gh/pr/9",
-        ...merge,
-      });
-      expect(findContinuableImplementationTask([entry(merged)])).toBeNull();
-    },
-  );
-
-  it("prefers a still-running task over one whose PR already merged", () => {
+  it("treats a merged PR as history, not continuable work", () => {
     const merged = makeTask("merged", {
       status: "completed",
       prUrl: "https://gh/pr/9",
-      prState: "merged",
+      prMerged: true,
     });
-    const running = makeTask("running", { status: "in_progress" });
+    expect(findContinuableImplementationTask([entry(merged)])).toBeNull();
+  });
+
+  it("continues a still-open PR and skips a merged one", () => {
+    const merged = makeTask("merged", {
+      status: "completed",
+      prUrl: "https://gh/pr/1",
+      prMerged: true,
+    });
+    const open = makeTask("open", {
+      status: "completed",
+      prUrl: "https://gh/pr/2",
+    });
     expect(
-      findContinuableImplementationTask([entry(merged), entry(running)]),
-    ).toBe(running);
+      findContinuableImplementationTask([entry(merged), entry(open)]),
+    ).toBe(open);
   });
 });
 

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -127,9 +127,9 @@ export function getTaskPrUrl(task: Task): string | null {
 }
 
 /**
- * Whether a task's latest run reports its PR as merged. Newer runs carry
- * `pr_state: "merged"`; runs merged before `pr_state` existed only carry the
- * legacy `pr_merged` flag, so honor both (matches feedQuery's `prStateOf`).
+ * Has the task's PR merged? A merged PR is history, not live work. `pr_state` is
+ * the current signal; runs merged before it existed carry only the legacy
+ * `pr_merged` flag (see feedQuery), so honor both.
  */
 export function isTaskPrMerged(task: Task): boolean {
   const output = task.latest_run?.output;
@@ -141,11 +141,11 @@ export function isTaskPrMerged(task: Task): boolean {
  * Find an implementation task linked to the report whose work is still live, so
  * re-engaging the report should resume it rather than spin up a duplicate PR. A
  * task is continuable when its latest run already produced a PR that is still
- * open (the report's `implementation_pr_url` may be stale or not yet set, but
- * the task knows) or is still running. A merged PR is history, not live work —
- * its branch is closed, so the report reads by its own state and a fresh
- * attempt starts a new PR. A failed/cancelled run with no PR is *not*
- * continuable either — the user can legitimately start a fresh attempt there.
+ * open (the report's `implementation_pr_url` may be stale or not yet set, but the
+ * task knows) or is still running. A failed/cancelled run with no PR is *not*
+ * continuable, and neither is a *merged* PR — a report that outlived its merged
+ * fix (evidence kept arriving) legitimately gets a fresh attempt, not a
+ * "continue" of the closed one.
  *
  * Prefers a task with a PR over a merely-running one; `reportTasks` is already
  * implementation-first ordered, so the first match wins among equals.

--- a/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -15,6 +15,9 @@ type SignalSortField = Extract<
 
 type SignalSortDirection = "asc" | "desc";
 
+/** Whether to show every report, only PR-backed ones, or only PR-less ones. */
+export type InboxPrFilter = "all" | "with_pr" | "without_pr";
+
 interface InboxSignalsFilterState {
   sortField: SignalSortField;
   sortDirection: SignalSortDirection;
@@ -23,6 +26,7 @@ interface InboxSignalsFilterState {
   sourceProductFilter: SourceProduct[];
   /** Empty array means "all priorities" (no filter). */
   priorityFilter: SignalReportPriority[];
+  prFilter: InboxPrFilter;
 }
 
 interface InboxSignalsFilterActions {
@@ -31,6 +35,7 @@ interface InboxSignalsFilterActions {
   toggleSourceProduct: (source: SourceProduct) => void;
   togglePriority: (priority: SignalReportPriority) => void;
   setPriorityFilter: (priorities: SignalReportPriority[]) => void;
+  setPrFilter: (prFilter: InboxPrFilter) => void;
   /** Clear the source filter back to "Any" (empty = all sources). */
   clearSourceProductFilter: () => void;
   /** Reset all filters when a deep link arrives so the linked report isn't hidden. */
@@ -54,6 +59,7 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
       searchQuery: "",
       sourceProductFilter: [],
       priorityFilter: [],
+      prFilter: "all",
       setSort: (sortField, sortDirection) => set({ sortField, sortDirection }),
       setSearchQuery: (searchQuery) => set({ searchQuery }),
       toggleSourceProduct: (source) =>
@@ -76,12 +82,14 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
         set({
           priorityFilter: Array.from(new Set(priorities)),
         }),
+      setPrFilter: (prFilter) => set({ prFilter }),
       clearSourceProductFilter: () => set({ sourceProductFilter: [] }),
       resetFilters: () =>
         set({
           searchQuery: "",
           sourceProductFilter: [],
           priorityFilter: [],
+          prFilter: "all",
         }),
     }),
     {
@@ -104,6 +112,7 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
         sortDirection: state.sortDirection,
         sourceProductFilter: state.sourceProductFilter,
         priorityFilter: state.priorityFilter,
+        prFilter: state.prFilter,
       }),
     },
   ),

--- a/products/desktop/packages/ui/src/features/inbox/stores/reportChatPanelStore.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/stores/reportChatPanelStore.test.ts
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useReportChatPanelStore } from "./reportChatPanelStore";
+
+describe("reportChatPanelStore", () => {
+  beforeEach(() => {
+    useReportChatPanelStore.setState({ pendingQuoteByReport: {} });
+  });
+
+  it("hands a pending quote to only one consumer", () => {
+    const store = useReportChatPanelStore.getState();
+    store.setPendingQuote("report-1", "> selected text");
+
+    expect(store.takePendingQuote("report-1")).toBe("> selected text");
+    expect(store.takePendingQuote("report-1")).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/stores/reportChatPanelStore.ts
+++ b/products/desktop/packages/ui/src/features/inbox/stores/reportChatPanelStore.ts
@@ -26,50 +26,55 @@ interface ReportChatPanelState {
   setWidth: (width: number) => void;
   rememberStartedTask: (reportId: string, taskId: string) => void;
   setPendingQuote: (reportId: string, quote: string) => void;
-  clearPendingQuote: (reportId: string) => void;
+  takePendingQuote: (reportId: string) => string | null;
   setStarterDraft: (reportId: string, text: string) => void;
   clearStarterDraft: (reportId: string) => void;
 }
 
-export const useReportChatPanelStore = create<ReportChatPanelState>((set) => ({
-  open: false,
-  width: 420,
-  startedTaskIdByReport: {},
-  pendingQuoteByReport: {},
-  starterDraftByReport: {},
-  setOpen: (open) => set({ open }),
-  setWidth: (width) => set({ width }),
-  rememberStartedTask: (reportId, taskId) =>
-    set((state) => ({
-      startedTaskIdByReport: {
-        ...state.startedTaskIdByReport,
-        [reportId]: taskId,
-      },
-    })),
-  setPendingQuote: (reportId, quote) =>
-    set((state) => ({
-      pendingQuoteByReport: {
-        ...state.pendingQuoteByReport,
-        [reportId]: quote,
-      },
-    })),
-  clearPendingQuote: (reportId) =>
-    set((state) => {
-      if (!(reportId in state.pendingQuoteByReport)) return state;
-      const { [reportId]: _, ...rest } = state.pendingQuoteByReport;
-      return { pendingQuoteByReport: rest };
-    }),
-  setStarterDraft: (reportId, text) =>
-    set((state) => ({
-      starterDraftByReport: {
-        ...state.starterDraftByReport,
-        [reportId]: text,
-      },
-    })),
-  clearStarterDraft: (reportId) =>
-    set((state) => {
-      if (!(reportId in state.starterDraftByReport)) return state;
-      const { [reportId]: _, ...rest } = state.starterDraftByReport;
-      return { starterDraftByReport: rest };
-    }),
-}));
+export const useReportChatPanelStore = create<ReportChatPanelState>(
+  (set, get) => ({
+    open: false,
+    width: 420,
+    startedTaskIdByReport: {},
+    pendingQuoteByReport: {},
+    starterDraftByReport: {},
+    setOpen: (open) => set({ open }),
+    setWidth: (width) => set({ width }),
+    rememberStartedTask: (reportId, taskId) =>
+      set((state) => ({
+        startedTaskIdByReport: {
+          ...state.startedTaskIdByReport,
+          [reportId]: taskId,
+        },
+      })),
+    setPendingQuote: (reportId, quote) =>
+      set((state) => ({
+        pendingQuoteByReport: {
+          ...state.pendingQuoteByReport,
+          [reportId]: quote,
+        },
+      })),
+    takePendingQuote: (reportId) => {
+      const quote = get().pendingQuoteByReport[reportId];
+      if (!quote) return null;
+      set((state) => {
+        const { [reportId]: _, ...rest } = state.pendingQuoteByReport;
+        return { pendingQuoteByReport: rest };
+      });
+      return quote;
+    },
+    setStarterDraft: (reportId, text) =>
+      set((state) => ({
+        starterDraftByReport: {
+          ...state.starterDraftByReport,
+          [reportId]: text,
+        },
+      })),
+    clearStarterDraft: (reportId) =>
+      set((state) => {
+        if (!(reportId in state.starterDraftByReport)) return state;
+        const { [reportId]: _, ...rest } = state.starterDraftByReport;
+        return { starterDraftByReport: rest };
+      }),
+  }),
+);

--- a/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.stories.tsx
+++ b/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.stories.tsx
@@ -11,14 +11,16 @@ function FakeAppBehind() {
   return (
     <div className="fixed inset-0 flex bg-(--gray-2)">
       <div className="w-64 shrink-0 border-(--gray-6) border-r bg-(--gray-1) p-3">
-        {["Inbox", "Tasks", "Channels", "Loops", "Settings"].map((item) => (
-          <div
-            key={item}
-            className="mb-1 rounded-(--radius-2) px-2 py-1.5 text-(--gray-11) text-sm"
-          >
-            {item}
-          </div>
-        ))}
+        {["Self-driving", "Tasks", "Channels", "Loops", "Settings"].map(
+          (item) => (
+            <div
+              key={item}
+              className="mb-1 rounded-(--radius-2) px-2 py-1.5 text-(--gray-11) text-sm"
+            >
+              {item}
+            </div>
+          ),
+        )}
       </div>
       <div className="flex-1 space-y-3 p-6">
         {RAGGED_LINE_WIDTHS.map((width) => (

--- a/products/desktop/packages/ui/src/features/scouts/components/ScoutBadges.tsx
+++ b/products/desktop/packages/ui/src/features/scouts/components/ScoutBadges.tsx
@@ -27,7 +27,7 @@ export function ScoutOriginBadge({ config }: { config: ScoutConfig }) {
 export function DryRunBadge({ config }: { config: ScoutConfig }) {
   if (config.emit) return null;
   return (
-    <Tooltip content="Runs on schedule but signals are not emitted to the Signals inbox">
+    <Tooltip content="Runs on schedule but signals are not emitted to Self-driving">
       <Badge
         variant="soft"
         color="amber"

--- a/products/desktop/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
+++ b/products/desktop/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
@@ -121,7 +121,7 @@ export function ScoutFindingsView() {
         <Text className="max-w-2xl text-pretty text-[12.5px] text-gray-11 leading-relaxed">
           Every signal your scouts have emitted recently, in one place — newest
           first. See what&apos;s been surfaced across the whole troop, which
-          scout found it, and the inbox report it fed into.
+          scout found it, and the Self-driving report it fed into.
         </Text>
         <Flex
           align="center"
@@ -150,7 +150,7 @@ export function ScoutFindingsView() {
         </Flex>
         <Text className="text-[12px] text-gray-9">
           Covers signals from the most recent {SCOUT_RUNS_WINDOW_SPAN} of troop
-          runs. Older signals live on in the inbox reports they produced.
+          runs. Older signals live on in the Self-driving reports they produced.
         </Text>
       </Flex>
 

--- a/products/desktop/packages/ui/src/features/sessions/components/EmbeddedSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/EmbeddedSessionView.tsx
@@ -1,6 +1,6 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { Flex } from "@radix-ui/themes";
-import { useEffect } from "react";
+import { type ReactNode, useEffect } from "react";
 import { useDraftStore } from "../../message-editor/draftStore";
 import { useSessionCallbacks } from "../hooks/useSessionCallbacks";
 import { useSessionConnection } from "../hooks/useSessionConnection";
@@ -15,9 +15,14 @@ import { SessionView } from "./SessionView";
 export function EmbeddedSessionView({
   task,
   isActiveSession,
+  threadActions,
 }: {
   task: Task;
   isActiveSession?: boolean;
+  threadActions?: (context: {
+    sendPrompt: (prompt: string) => Promise<boolean>;
+    isPromptPending: boolean;
+  }) => ReactNode;
 }) {
   const taskId = task.id;
   const { requestFocus } = useDraftStore((s) => s.actions);
@@ -78,6 +83,10 @@ export function EmbeddedSessionView({
         cloudStatus={cloudStatus}
         compact
         isActiveSession={isActiveSession}
+        threadActions={threadActions?.({
+          sendPrompt: handleSendPrompt,
+          isPromptPending: Boolean(isPromptPending),
+        })}
       />
     </Flex>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -79,7 +79,14 @@ import {
   usePendingTaskPrompt,
 } from "@posthog/ui/shell/pendingTaskPromptStore";
 import { Box, Button, ContextMenu, Flex, Text } from "@radix-ui/themes";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 export function getNewAttachments(
   previousIds: ReadonlySet<string>,
@@ -118,6 +125,8 @@ interface SessionViewProps {
   isActiveSession?: boolean;
   /** Hide the message input and permission UI — log-only view. */
   hideInput?: boolean;
+  /** Contextual actions shown between the thread and its composer. */
+  threadActions?: ReactNode;
 }
 
 const DEFAULT_ERROR_MESSAGE =
@@ -152,6 +161,7 @@ export function SessionView({
   compact = false,
   isActiveSession = true,
   hideInput = false,
+  threadActions,
 }: SessionViewProps) {
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   useSessionEventsResidency(taskId);
@@ -663,6 +673,8 @@ export function SessionView({
                 />
 
                 <PlanStatusBar plan={latestPlan} />
+
+                {threadActions}
 
                 {hasError && !showInlineBanner ? (
                   <Flex

--- a/products/desktop/packages/ui/src/features/settings/sections/AutostartBaseBranchesSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/AutostartBaseBranchesSettings.tsx
@@ -73,8 +73,9 @@ export function AutostartBaseBranchesSettings({
           Base branch for auto-PRs
         </Text>
         <Text className="text-(--gray-11) text-[13px]">
-          Point auto-started inbox PRs at a specific branch per repository.
-          Repositories without an override target their default branch.
+          Point auto-started Self-driving PRs at a specific branch per
+          repository. Repositories without an override target their default
+          branch.
         </Text>
       </Flex>
 

--- a/products/desktop/packages/ui/src/features/settings/sections/DailyReportLimitSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/DailyReportLimitSettings.tsx
@@ -79,7 +79,7 @@ export function DailyReportLimitSettings({
           Daily report limit
         </Text>
         <Text className="text-(--gray-11) text-[13px]">
-          Cap how many new reports reach the inbox each day. Leave the field
+          Cap how many new reports reach Self-driving each day. Leave the field
           empty for no limit.
         </Text>
       </div>

--- a/products/desktop/packages/ui/src/features/settings/sections/GitHubIntegrationSection.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/GitHubIntegrationSection.tsx
@@ -145,7 +145,7 @@ export function GitHubIntegrationSection({
         ? describeGithubConnectError(connectError)
         : timedOut
           ? GITHUB_CONNECT_TIMEOUT_MESSAGE
-          : "Required for the Inbox pipeline to work"}
+          : "Required for Self-driving to work"}
     </Text>
   );
 

--- a/products/desktop/packages/ui/src/features/settings/sections/SignalSourcesSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SignalSourcesSettings.tsx
@@ -117,7 +117,8 @@ export function SignalSourcesSettings({
               Slack notifications
             </Text>
             <Text className="text-(--gray-11) text-[13px]">
-              Choose where ready inbox reports are posted and who gets pinged.
+              Choose where ready Self-driving reports are posted and who gets
+              pinged.
             </Text>
           </Flex>
           <button

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackInboxNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackInboxNotificationsSettings.tsx
@@ -72,13 +72,13 @@ export function SlackInboxNotificationsSettings({
               <SlackLogoIcon size={16} />
             </span>
             <span className="font-medium text-(--gray-12) text-sm">
-              Inbox notifications
+              Self-driving notifications
             </span>
           </div>
           <p className="m-0 text-(--gray-11) text-[13px]">
-            New inbox reports are posted to Slack with the suggested reviewers
-            @mentioned. PostHog must be in the channel, so invite it with{" "}
-            <code className="text-[13px]">/invite @PostHog</code>.
+            New Self-driving reports are posted to Slack with the suggested
+            reviewers @mentioned. PostHog must be in the channel, so invite it
+            with <code className="text-[13px]">/invite @PostHog</code>.
           </p>
         </div>
       ) : null}

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackSettings.tsx
@@ -71,12 +71,12 @@ export function SlackSettings() {
 
       {hasSlackIntegration ? (
         <SettingsSection
-          label="Inbox notifications"
+          label="Self-driving notifications"
           description={
             <>
-              New inbox reports are posted to Slack with the suggested reviewers
-              @mentioned. PostHog must be in the channel, so invite it with{" "}
-              <code className="text-[12px]">/invite @PostHog</code>.
+              New Self-driving reports are posted to Slack with the suggested
+              reviewers @mentioned. PostHog must be in the channel, so invite it
+              with <code className="text-[12px]">/invite @PostHog</code>.
             </>
           }
         >

--- a/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
@@ -141,7 +141,7 @@ describe("CustomizeSidebarSettings", () => {
     useSidebarStore.setState({ navItemOverrides: { inbox: false } });
     renderSettings();
 
-    await user.click(screen.getByRole("checkbox", { name: "Inbox" }));
+    await user.click(screen.getByRole("checkbox", { name: "Self-driving" }));
 
     expect(useSidebarStore.getState().navItemOverrides.inbox).toBe(true);
     expect(track).toHaveBeenCalledWith(ANALYTICS_EVENTS.SIDEBAR_CUSTOMIZED, {
@@ -154,7 +154,7 @@ describe("CustomizeSidebarSettings", () => {
     useSidebarStore.setState({ navItemOrder: ["configure", "inbox"] });
     renderSettings();
 
-    expect(rowLabels().slice(0, 2)).toEqual(["Settings", "Inbox"]);
+    expect(rowLabels().slice(0, 2)).toEqual(["Settings", "Self-driving"]);
   });
 
   it("previews on dragover and persists only on drop", () => {
@@ -204,7 +204,7 @@ describe("CustomizeSidebarSettings", () => {
     dragOver("loops", "inbox");
     dragEnd("loops", { cancel: true });
 
-    expect(rowLabels()[0]).toBe("Inbox");
+    expect(rowLabels()[0]).toBe("Self-driving");
     expect(useSidebarStore.getState().navItemOrder).toEqual([]);
     expect(track).not.toHaveBeenCalled();
   });
@@ -227,6 +227,6 @@ describe("CustomizeSidebarSettings", () => {
     await user.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(useSidebarStore.getState().navItemOrder).toEqual([]);
-    expect(rowLabels()[0]).toBe("Inbox");
+    expect(rowLabels()[0]).toBe("Self-driving");
   });
 });

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarNavSection.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarNavSection.test.tsx
@@ -52,6 +52,12 @@ vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
         ? reportsInboxFlag
         : true,
 }));
+vi.mock("@posthog/ui/features/feature-flags/useChannelReportsEnabled", () => ({
+  useChannelReportsEnabled: () => channelReportsFlag,
+}));
+vi.mock("@posthog/ui/features/feature-flags/useReportsInboxEnabled", () => ({
+  useReportsInboxEnabled: () => reportsInboxFlag,
+}));
 // These tests pin the legacy layout (flag off), where the "Enable channels"
 // toggle row is present.
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelsLayout", () => ({
@@ -135,7 +141,7 @@ describe("SidebarNavSection", () => {
   });
 
   it.each([
-    ["inbox", "Inbox"],
+    ["inbox", "Self-driving"],
     ["command-center", "Command Center"],
     ["activity", "Activity"],
     ["configure", "Settings"],
@@ -156,16 +162,16 @@ describe("SidebarNavSection", () => {
     const position = (label: string) =>
       labels.findIndex((text) => text.includes(label));
 
-    expect(position("Inbox")).toBeLessThan(position("Activity"));
+    expect(position("Self-driving")).toBeLessThan(position("Activity"));
     expect(position("Activity")).toBeLessThan(position("Loops"));
-    expect(position("Inbox")).toBeLessThan(position("Loops"));
+    expect(position("Self-driving")).toBeLessThan(position("Loops"));
   });
 
   it("tracks top-level clicks with in_more false", async () => {
     const user = userEvent.setup();
     renderNav();
 
-    await user.click(screen.getByRole("button", { name: /Inbox/ }));
+    await user.click(screen.getByRole("button", { name: /Self-driving/ }));
 
     expect(navigateToInbox).toHaveBeenCalledTimes(1);
     // `layout` separates these from the nav rail's identically-named clicks.
@@ -178,7 +184,7 @@ describe("SidebarNavSection", () => {
   it("opens a destination in a new tab on Cmd-click", () => {
     renderNav();
 
-    fireEvent.click(screen.getByRole("button", { name: /Inbox/ }), {
+    fireEvent.click(screen.getByRole("button", { name: /Self-driving/ }), {
       metaKey: true,
     });
 
@@ -202,7 +208,7 @@ describe("SidebarNavSection", () => {
     try {
       renderNav();
       expect(
-        screen.queryByRole("button", { name: /Inbox/ }),
+        screen.queryByRole("button", { name: /Self-driving/ }),
       ).not.toBeInTheDocument();
     } finally {
       channelReportsFlag = false;
@@ -214,7 +220,9 @@ describe("SidebarNavSection", () => {
     reportsInboxFlag = true;
     try {
       renderNav();
-      expect(screen.getByRole("button", { name: /Inbox/ })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Self-driving/ }),
+      ).toBeInTheDocument();
     } finally {
       channelReportsFlag = false;
       reportsInboxFlag = false;

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
@@ -37,7 +37,7 @@ export function InboxItem({
           }
           label={
             <>
-              Inbox
+              Self-driving
               <SidebarCountBadge
                 count={decisionCount}
                 title={`${decisionCount} report${decisionCount === 1 ? " needs" : "s need"} a decision`}

--- a/products/desktop/packages/ui/src/features/sidebar/constants.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/constants.ts
@@ -15,7 +15,12 @@ export const CHANNELS_SIDEBAR_MIN_WIDTH = 272;
 export const NAV_RAIL_WIDTH = 44;
 
 export const CUSTOMIZABLE_NAV_ITEMS = [
-  { id: "inbox", label: "Inbox", analyticsId: "inbox", defaultVisible: true },
+  {
+    id: "inbox",
+    label: "Self-driving",
+    analyticsId: "inbox",
+    defaultVisible: true,
+  },
   {
     id: "activity",
     label: "Activity",

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1627,11 +1627,11 @@ export function TaskInput({
                         {activeReportAssociation.title || "Untitled report"}
                       </button>
                     </span>
-                    <Tooltip content="Exit Inbox mode">
+                    <Tooltip content="Exit Self-driving mode">
                       <button
                         type="button"
                         onClick={handleDismissReportAssociation}
-                        aria-label="Exit Inbox mode"
+                        aria-label="Exit Self-driving mode"
                         className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-blue-10 hover:bg-blue-4 hover:text-blue-12"
                       >
                         <X size={12} />

--- a/products/desktop/packages/ui/src/primitives/PageHeader.stories.tsx
+++ b/products/desktop/packages/ui/src/primitives/PageHeader.stories.tsx
@@ -34,7 +34,7 @@ export const WithTabsAndFilters: Story = {
       <>
         <PageHeaderHeading>
           <PageHeaderTitleRow>
-            <PageHeaderTitle>Inbox</PageHeaderTitle>
+            <PageHeaderTitle>Self-driving</PageHeaderTitle>
           </PageHeaderTitleRow>
           <PageHeaderDescription>
             Work done by your agents – pull requests, reports, and live runs.

--- a/products/desktop/packages/ui/src/router/navigationBridge.ts
+++ b/products/desktop/packages/ui/src/router/navigationBridge.ts
@@ -150,7 +150,7 @@ export function navigateToChannelReportDetail(
   reportId: string,
 ): void {
   void getRouterOrNull()?.navigate({
-    to: "/website/$channelId/reports/$reportId",
+    to: "/spaces/$channelId/reports/$reportId",
     params: { channelId, reportId },
   });
 }

--- a/products/desktop/packages/ui/src/router/routeTree.gen.ts
+++ b/products/desktop/packages/ui/src/router/routeTree.gen.ts
@@ -61,7 +61,6 @@ import { Route as ShellSpacesContextRouteImport } from './routes/_shell/spaces/c
 import { Route as ShellFeedsFeedIdRouteImport } from './routes/_shell/feeds/$feedId'
 import { Route as AgentsScoutsSkillNameIndexRouteImport } from './routes/agents/scouts.$skillName.index'
 import { Route as ShellSpacesChannelIdIndexRouteImport } from './routes/_shell/spaces/$channelId/index'
-import { Route as WebsiteChannelIdReportsReportIdRouteImport } from './routes/website/$channelId/reports/$reportId'
 import { Route as ShellSpacesChannelIdNewRouteImport } from './routes/_shell/spaces/$channelId/new'
 import { Route as ShellSpacesChannelIdLoopsRouteImport } from './routes/_shell/spaces/$channelId/loops'
 import { Route as ShellSpacesChannelIdHistoryRouteImport } from './routes/_shell/spaces/$channelId/history'
@@ -69,6 +68,7 @@ import { Route as ShellSpacesChannelIdContextRouteImport } from './routes/_shell
 import { Route as ShellSpacesChannelIdCanvasesRouteImport } from './routes/_shell/spaces/$channelId/canvases'
 import { Route as ShellSpacesChannelIdArtifactsRouteImport } from './routes/_shell/spaces/$channelId/artifacts'
 import { Route as ShellSpacesChannelIdTasksTaskIdRouteImport } from './routes/_shell/spaces/$channelId/tasks/$taskId'
+import { Route as ShellSpacesChannelIdReportsReportIdRouteImport } from './routes/_shell/spaces/$channelId/reports/$reportId'
 import { Route as ShellSpacesChannelIdDashboardsDashboardIdRouteImport } from './routes/_shell/spaces/$channelId/dashboards/$dashboardId'
 
 const UsageRoute = UsageRouteImport.update({
@@ -332,12 +332,6 @@ const ShellSpacesChannelIdIndexRoute =
     path: '/spaces/$channelId/',
     getParentRoute: () => ShellRoute,
   } as any)
-const WebsiteChannelIdReportsReportIdRoute =
-  WebsiteChannelIdReportsReportIdRouteImport.update({
-    id: '/website/$channelId/reports/$reportId',
-    path: '/website/$channelId/reports/$reportId',
-    getParentRoute: () => rootRouteImport,
-  } as any)
 const ShellSpacesChannelIdNewRoute = ShellSpacesChannelIdNewRouteImport.update({
   id: '/spaces/$channelId/new',
   path: '/spaces/$channelId/new',
@@ -377,6 +371,12 @@ const ShellSpacesChannelIdTasksTaskIdRoute =
   ShellSpacesChannelIdTasksTaskIdRouteImport.update({
     id: '/spaces/$channelId/tasks/$taskId',
     path: '/spaces/$channelId/tasks/$taskId',
+    getParentRoute: () => ShellRoute,
+  } as any)
+const ShellSpacesChannelIdReportsReportIdRoute =
+  ShellSpacesChannelIdReportsReportIdRouteImport.update({
+    id: '/spaces/$channelId/reports/$reportId',
+    path: '/spaces/$channelId/reports/$reportId',
     getParentRoute: () => ShellRoute,
   } as any)
 const ShellSpacesChannelIdDashboardsDashboardIdRoute =
@@ -442,10 +442,10 @@ export interface FileRoutesByFullPath {
   '/spaces/$channelId/history': typeof ShellSpacesChannelIdHistoryRoute
   '/spaces/$channelId/loops': typeof ShellSpacesChannelIdLoopsRoute
   '/spaces/$channelId/new': typeof ShellSpacesChannelIdNewRoute
-  '/website/$channelId/reports/$reportId': typeof WebsiteChannelIdReportsReportIdRoute
   '/spaces/$channelId/': typeof ShellSpacesChannelIdIndexRoute
   '/agents/scouts/$skillName/': typeof AgentsScoutsSkillNameIndexRoute
   '/spaces/$channelId/dashboards/$dashboardId': typeof ShellSpacesChannelIdDashboardsDashboardIdRoute
+  '/spaces/$channelId/reports/$reportId': typeof ShellSpacesChannelIdReportsReportIdRoute
   '/spaces/$channelId/tasks/$taskId': typeof ShellSpacesChannelIdTasksTaskIdRoute
 }
 export interface FileRoutesByTo {
@@ -495,10 +495,10 @@ export interface FileRoutesByTo {
   '/spaces/$channelId/history': typeof ShellSpacesChannelIdHistoryRoute
   '/spaces/$channelId/loops': typeof ShellSpacesChannelIdLoopsRoute
   '/spaces/$channelId/new': typeof ShellSpacesChannelIdNewRoute
-  '/website/$channelId/reports/$reportId': typeof WebsiteChannelIdReportsReportIdRoute
   '/spaces/$channelId': typeof ShellSpacesChannelIdIndexRoute
   '/agents/scouts/$skillName': typeof AgentsScoutsSkillNameIndexRoute
   '/spaces/$channelId/dashboards/$dashboardId': typeof ShellSpacesChannelIdDashboardsDashboardIdRoute
+  '/spaces/$channelId/reports/$reportId': typeof ShellSpacesChannelIdReportsReportIdRoute
   '/spaces/$channelId/tasks/$taskId': typeof ShellSpacesChannelIdTasksTaskIdRoute
 }
 export interface FileRoutesById {
@@ -559,10 +559,10 @@ export interface FileRoutesById {
   '/_shell/spaces/$channelId/history': typeof ShellSpacesChannelIdHistoryRoute
   '/_shell/spaces/$channelId/loops': typeof ShellSpacesChannelIdLoopsRoute
   '/_shell/spaces/$channelId/new': typeof ShellSpacesChannelIdNewRoute
-  '/website/$channelId/reports/$reportId': typeof WebsiteChannelIdReportsReportIdRoute
   '/_shell/spaces/$channelId/': typeof ShellSpacesChannelIdIndexRoute
   '/agents/scouts/$skillName/': typeof AgentsScoutsSkillNameIndexRoute
   '/_shell/spaces/$channelId/dashboards/$dashboardId': typeof ShellSpacesChannelIdDashboardsDashboardIdRoute
+  '/_shell/spaces/$channelId/reports/$reportId': typeof ShellSpacesChannelIdReportsReportIdRoute
   '/_shell/spaces/$channelId/tasks/$taskId': typeof ShellSpacesChannelIdTasksTaskIdRoute
 }
 export interface FileRouteTypes {
@@ -623,10 +623,10 @@ export interface FileRouteTypes {
     | '/spaces/$channelId/history'
     | '/spaces/$channelId/loops'
     | '/spaces/$channelId/new'
-    | '/website/$channelId/reports/$reportId'
     | '/spaces/$channelId/'
     | '/agents/scouts/$skillName/'
     | '/spaces/$channelId/dashboards/$dashboardId'
+    | '/spaces/$channelId/reports/$reportId'
     | '/spaces/$channelId/tasks/$taskId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -676,10 +676,10 @@ export interface FileRouteTypes {
     | '/spaces/$channelId/history'
     | '/spaces/$channelId/loops'
     | '/spaces/$channelId/new'
-    | '/website/$channelId/reports/$reportId'
     | '/spaces/$channelId'
     | '/agents/scouts/$skillName'
     | '/spaces/$channelId/dashboards/$dashboardId'
+    | '/spaces/$channelId/reports/$reportId'
     | '/spaces/$channelId/tasks/$taskId'
   id:
     | '__root__'
@@ -739,10 +739,10 @@ export interface FileRouteTypes {
     | '/_shell/spaces/$channelId/history'
     | '/_shell/spaces/$channelId/loops'
     | '/_shell/spaces/$channelId/new'
-    | '/website/$channelId/reports/$reportId'
     | '/_shell/spaces/$channelId/'
     | '/agents/scouts/$skillName/'
     | '/_shell/spaces/$channelId/dashboards/$dashboardId'
+    | '/_shell/spaces/$channelId/reports/$reportId'
     | '/_shell/spaces/$channelId/tasks/$taskId'
   fileRoutesById: FileRoutesById
 }
@@ -766,7 +766,6 @@ export interface RootRouteChildren {
   SettingsIndexRoute: typeof SettingsIndexRoute
   WebsiteIndexRoute: typeof WebsiteIndexRoute
   TasksPendingKeyRoute: typeof TasksPendingKeyRoute
-  WebsiteChannelIdReportsReportIdRoute: typeof WebsiteChannelIdReportsReportIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1135,13 +1134,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellSpacesChannelIdIndexRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/website/$channelId/reports/$reportId': {
-      id: '/website/$channelId/reports/$reportId'
-      path: '/website/$channelId/reports/$reportId'
-      fullPath: '/website/$channelId/reports/$reportId'
-      preLoaderRoute: typeof WebsiteChannelIdReportsReportIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/_shell/spaces/$channelId/new': {
       id: '/_shell/spaces/$channelId/new'
       path: '/spaces/$channelId/new'
@@ -1191,6 +1183,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellSpacesChannelIdTasksTaskIdRouteImport
       parentRoute: typeof ShellRoute
     }
+    '/_shell/spaces/$channelId/reports/$reportId': {
+      id: '/_shell/spaces/$channelId/reports/$reportId'
+      path: '/spaces/$channelId/reports/$reportId'
+      fullPath: '/spaces/$channelId/reports/$reportId'
+      preLoaderRoute: typeof ShellSpacesChannelIdReportsReportIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
     '/_shell/spaces/$channelId/dashboards/$dashboardId': {
       id: '/_shell/spaces/$channelId/dashboards/$dashboardId'
       path: '/spaces/$channelId/dashboards/$dashboardId'
@@ -1219,6 +1218,7 @@ interface ShellRouteChildren {
   ShellSpacesChannelIdNewRoute: typeof ShellSpacesChannelIdNewRoute
   ShellSpacesChannelIdIndexRoute: typeof ShellSpacesChannelIdIndexRoute
   ShellSpacesChannelIdDashboardsDashboardIdRoute: typeof ShellSpacesChannelIdDashboardsDashboardIdRoute
+  ShellSpacesChannelIdReportsReportIdRoute: typeof ShellSpacesChannelIdReportsReportIdRoute
   ShellSpacesChannelIdTasksTaskIdRoute: typeof ShellSpacesChannelIdTasksTaskIdRoute
 }
 
@@ -1241,6 +1241,8 @@ const ShellRouteChildren: ShellRouteChildren = {
   ShellSpacesChannelIdIndexRoute: ShellSpacesChannelIdIndexRoute,
   ShellSpacesChannelIdDashboardsDashboardIdRoute:
     ShellSpacesChannelIdDashboardsDashboardIdRoute,
+  ShellSpacesChannelIdReportsReportIdRoute:
+    ShellSpacesChannelIdReportsReportIdRoute,
   ShellSpacesChannelIdTasksTaskIdRoute: ShellSpacesChannelIdTasksTaskIdRoute,
 }
 
@@ -1400,7 +1402,6 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsIndexRoute: SettingsIndexRoute,
   WebsiteIndexRoute: WebsiteIndexRoute,
   TasksPendingKeyRoute: TasksPendingKeyRoute,
-  WebsiteChannelIdReportsReportIdRoute: WebsiteChannelIdReportsReportIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/products/desktop/packages/ui/src/router/routes/_shell/spaces/$channelId/reports/$reportId.tsx
+++ b/products/desktop/packages/ui/src/router/routes/_shell/spaces/$channelId/reports/$reportId.tsx
@@ -4,10 +4,9 @@ import { ReportDetail } from "@posthog/ui/features/inbox/components/ReportDetail
 import { getCachedInboxReportDetail } from "@posthog/ui/features/inbox/inboxQueries";
 import { createFileRoute } from "@tanstack/react-router";
 
-// The in-space report detail: same body as the inbox detail, hosted inside the
-// channels world so the space sidebar keeps its context. One route serves every
-// report status, so the inbox's status↔route redirect is off.
-export const Route = createFileRoute("/website/$channelId/reports/$reportId")({
+export const Route = createFileRoute(
+  "/_shell/spaces/$channelId/reports/$reportId",
+)({
   component: ChannelReportDetailRoute,
   pendingComponent: () => null,
   loader: ({ params }): SignalReport | null =>
@@ -18,15 +17,16 @@ function ChannelReportDetailRoute() {
   const { channelId, reportId } = Route.useParams();
   const cachedReport = Route.useLoaderData();
   const { channels } = useChannels();
-  const channelName = channels.find((c) => c.id === channelId)?.name;
+  const channelName = channels.find(
+    (channel) => channel.id === channelId,
+  )?.name;
+
   return (
-    // ReportDetail owns its scroll (its chat dock sits beside the scrolling
-    // report); this wrapper only hands it WebsiteLayout's outlet height.
     <div className="h-full min-h-0">
       <ReportDetail
         reportId={reportId}
         cachedReport={cachedReport}
-        backTo={`/website/${channelId}`}
+        backTo={`/spaces/${channelId}`}
         backLabel={channelName ? `Back to #${channelName}` : "Back to space"}
         statusRedirect={false}
       />


### PR DESCRIPTION
## Problem

Triage mode is promising but still experimental, so it should not ship as part of the reports inbox release.

This PR keeps the keyboard-driven workflow isolated behind its own feature flag.

## Changes

- Triage mode steps through reports that need a decision, one at a time.
- Keyboard actions cover navigation, fixing, deferring, archiving, opening a report, and exiting.
- The verdict banner keeps Fix and monitor, Defer, and Archive available within the triage card.
- The summary uses labeled collapsible sections, and archiving advances to the next report.
- The Triage mode control now sits beside the For you / Entire project scope control.
- Report breadcrumbs return to the current space through the active `/spaces` route.
- Canvas creation opens the new task in the report sidebar instead of navigating away.
- Reports stay in their dedicated Reports tab and never render in space or saved feeds.
- Desktop labels now call the reports inbox Self-driving while preserving existing routes and analytics identifiers.
- The `posthog-desktop-triage-focus` flag enables the button, shortcut, and view.
- Development builds enable the flag by default. Production keeps it off.

## How did you test this code?

The focused inbox, channel-home, and saved-feed coverage passes. Desktop typecheck and quality checks pass.

Live dogfooding remains necessary before enabling the flag in production.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is a flag-gated experiment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR isolates triage mode from the reports inbox release and incorporates direct review feedback.

Skills used: writing-ui-components, writing-user-facing-copy, writing-tests, posthog-desktop, quill-code, writing-pr-descriptions, debugging-ci-failures.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
