### PR TITLE
feat(ai-research): use global refs for fetched images

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
@@ -4,11 +4,9 @@ The [README](./README.md) is the normative specification. This file lists change
 
 ## Global URL refs
 
-The current URL ref has the form `imageurl:<pseudo-team>:<hash>`. The hash uses a key derived for one team. The crawl-history key also contains the team pseudonym.
+The mirror URL collector, Kafka parser, and crawl-history key now use the global URL ref from requirement 13.5. Inline image refs remain team-specific. Shared Rust and Node fixtures pin the key derivation and ref format.
 
-Change the URL collector, Kafka record parser, crawl-history key, image scrubber, S3 storage, and data-preparation lookup to use the global URL ref from requirement 13.5. Inline image refs can remain team-specific.
-
-Derive one URL HMAC key from the existing ML pseudonymization secret without a team input. Pin the derivation from requirement 13.5 and the resulting test vectors in the shared Rust and Node fixtures before changing either producer.
+Change the image scrubber, S3 storage, and data-preparation lookup to use the same global ref.
 
 ## Data-preparation ref attributes
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/collected-urls-record.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/collected-urls-record.test.ts
@@ -12,6 +12,31 @@ function body(fields: string): Buffer {
 
 describe('parseCollectedUrlsRecord', () => {
     it.each([
+        ['raw team name', 'team'],
+        ['uppercase value', 'A'.repeat(32)],
+        ['short value', 'a'.repeat(31)],
+        ['long value', 'a'.repeat(33)],
+        ['oversized value', 'a'.repeat(2048)],
+    ])('refuses a %s as the transport pseudonym for a global ref', (_name, pseudoTeam) => {
+        const value = Buffer.from(
+            JSON.stringify({
+                v: 1,
+                pseudoTeam,
+                capturedAtMs: 1700000000000,
+                urls: [
+                    {
+                        ref: `imageurl:${HASH}`,
+                        url: 'https://cdn.example.com/a.png',
+                        host: 'cdn.example.com',
+                    },
+                ],
+            })
+        )
+
+        expect(parseCollectedUrlsRecord(value, 'example.com')).toEqual({ ok: false, reason: 'malformed' })
+    })
+
+    it.each([
         ['a magnitude no double can hold', '"capturedAtMs":-1e400'],
         ['a positive one', '"capturedAtMs":1e400'],
     ])('refuses %s rather than passing a non-finite timestamp on', (_name, fields) => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/collected-urls-record.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/collected-urls-record.ts
@@ -13,6 +13,7 @@ const MAX_URL_LENGTH = 2048
  * request fan-out and the in-memory candidate set both scale with this value.
  */
 const MAX_URLS_PER_RECORD = 640
+const PSEUDO_TEAM_RE = /^[0-9a-f]{32}$/
 
 export interface FetchCandidate {
     ref: string
@@ -72,7 +73,12 @@ export function parseCollectedUrlsRecord(value: Buffer | null, key: string | nul
         return { ok: false, reason: 'unsupported_version' }
     }
     const { pseudoTeam, capturedAtMs, urls, hopsRemaining, notBeforeMs } = parsed
-    if (typeof pseudoTeam !== 'string' || !pseudoTeam || typeof capturedAtMs !== 'number' || !Array.isArray(urls)) {
+    if (
+        typeof pseudoTeam !== 'string' ||
+        !PSEUDO_TEAM_RE.test(pseudoTeam) ||
+        typeof capturedAtMs !== 'number' ||
+        !Array.isArray(urls)
+    ) {
         return { ok: false, reason: 'malformed' }
     }
     // Finite, not merely a number: JSON carries `-1e400`, which parses to -Infinity and would reach

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/collected-urls-record.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/collected-urls-record.ts
@@ -99,7 +99,7 @@ export function parseCollectedUrlsRecord(value: Buffer | null, key: string | nul
             continue
         }
         const ref = parseImageRef(entry.ref)
-        if (!ref || ref.source !== 'url' || ref.pseudoTeam !== pseudoTeam) {
+        if (!ref || ref.source !== 'url' || (ref.pseudoTeam && ref.pseudoTeam !== pseudoTeam)) {
             rejected.push({ reason: 'bad_ref' })
             continue
         }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/crawl-history.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/crawl-history.ts
@@ -1,7 +1,13 @@
+import { parseImageRef } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/content-ref'
+
 const CRAWL_HISTORY_PREFIX = 'imgfetch:seen'
 
-export function crawlHistoryKey(pseudoTeam: string, urlHash: string): string {
-    return `${CRAWL_HISTORY_PREFIX}:${pseudoTeam}:${urlHash}`
+export function crawlHistoryKey(ref: string): string {
+    const parsed = parseImageRef(ref)
+    if (parsed?.source === 'url' && parsed.pseudoTeam) {
+        return `${CRAWL_HISTORY_PREFIX}:${parsed.pseudoTeam}:${parsed.hash}`
+    }
+    return ref
 }
 
 export interface CrawlHistoryReadResult {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.test.ts
@@ -17,6 +17,10 @@ function ref(name: string, team: string = TEAM): string {
     return `imageurl:${team}:${hash(name)}`
 }
 
+function globalRef(name: string): string {
+    return `imageurl:${hash(name)}`
+}
+
 class FakeCrawlHistory implements CrawlHistoryStore {
     public readonly stored = new Map<string, number>()
     public readFailure: Error | null = null
@@ -153,20 +157,34 @@ describe('UrlFetchConsumer', () => {
     })
 
     it('does not re-record a URL another pod already reached', async () => {
-        crawlHistory.stored.set(crawlHistoryKey(TEAM, hash('a')), NOW - 1000)
+        crawlHistory.stored.set(crawlHistoryKey(ref('a')), NOW - 1000)
 
         await consumer.handleBatch([record([url('a'), url('b')])], NOW)
 
         // The earlier entry survives, so the store measures the hit rate rather than the rate of
         // first arrivals.
-        expect(crawlHistory.stored.get(crawlHistoryKey(TEAM, hash('a')))).toBe(NOW - 1000)
-        expect(crawlHistory.stored.get(crawlHistoryKey(TEAM, hash('b')))).toBe(NOW)
+        expect(crawlHistory.stored.get(crawlHistoryKey(ref('a')))).toBe(NOW - 1000)
+        expect(crawlHistory.stored.get(crawlHistoryKey(ref('b')))).toBe(NOW)
     })
 
     it('collapses a repeated URL inside one batch into a single ledger write', async () => {
         await consumer.handleBatch([record([url('a')]), record([url('a')]), record([url('a')])], NOW)
 
-        expect([...crawlHistory.stored.keys()]).toEqual([crawlHistoryKey(TEAM, hash('a'))])
+        expect([...crawlHistory.stored.keys()]).toEqual([crawlHistoryKey(ref('a'))])
+    })
+
+    it('deduplicates one global ref across teams after a pod restart', async () => {
+        const sharedUrl = {
+            ref: globalRef('shared'),
+            url: 'https://cdn.example.com/shared.png',
+            host: 'cdn.example.com',
+        }
+
+        await consumer.handleBatch([record([sharedUrl], { pseudoTeam: TEAM })], NOW)
+        consumer = build()
+        await consumer.handleBatch([record([sharedUrl], { pseudoTeam: OTHER_TEAM })], NOW + 1)
+
+        expect([...crawlHistory.stored.entries()]).toEqual([[sharedUrl.ref, NOW]])
     })
 
     it('does not consult the store for a URL this pod already handled', async () => {
@@ -280,7 +298,7 @@ describe('UrlFetchConsumer', () => {
     })
 
     it('does not mark the pod cache for a URL whose write failed', async () => {
-        crawlHistory.partialWriteFailures.add(crawlHistoryKey(TEAM, hash('a')))
+        crawlHistory.partialWriteFailures.add(crawlHistoryKey(ref('a')))
 
         await consumer.handleBatch([record([url('a')])], NOW)
         const readsAfterFirst = crawlHistory.reads
@@ -312,7 +330,7 @@ describe('UrlFetchConsumer', () => {
     it('holds back a URL whose dedup read failed, rather than treating it as new', async () => {
         // To count it as new would fetch it. A store outage would then make every batch send the
         // full un-deduped volume at customer sites, because our own store is down.
-        crawlHistory.partialReadFailures.add(crawlHistoryKey(TEAM, hash('a')))
+        crawlHistory.partialReadFailures.add(crawlHistoryKey(ref('a')))
 
         await expect(consumer.handleBatch([record([url('a'), url('b')])], NOW)).resolves.toBeUndefined()
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.ts
@@ -209,7 +209,7 @@ export class UrlFetchConsumer {
         if (candidates.length === 0) {
             return []
         }
-        const keys = candidates.map((candidate) => crawlHistoryKey(candidate.pseudoTeam, candidate.urlHash))
+        const keys = candidates.map((candidate) => crawlHistoryKey(candidate.ref))
         let result
         try {
             result = await this.crawlHistory.read(keys, nowMs)
@@ -273,7 +273,7 @@ export class UrlFetchConsumer {
      * from fetching.
      */
     private async recordFetched(candidates: FetchCandidate[], nowMs: number): Promise<void> {
-        const keys = candidates.map((candidate) => crawlHistoryKey(candidate.pseudoTeam, candidate.urlHash))
+        const keys = candidates.map((candidate) => crawlHistoryKey(candidate.ref))
         let failed: Set<number>
         try {
             failed = (await this.crawlHistory.record(keys, nowMs, this.options.seenTtlSeconds)).failed

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/content-ref.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/content-ref.ts
@@ -1,6 +1,6 @@
-// The shared ref format between the producer, this consumer, and training joins; pseudo_team is the
-// non-reversible HMAC team pseudonym from ml-mirror/pseudonymize.ts (keeps raw team ids out of the
-// ML bucket). The hash half is keyed (per-team HMAC, derived alongside the pseudonym) so the
+// The inline-image ref format shared by the producer, this consumer, and training joins.
+// pseudo_team is the non-reversible HMAC team pseudonym from ml-mirror/pseudonymize.ts. The hash
+// half is keyed with a per-team HMAC, derived alongside the pseudonym, so the
 // unencrypted bucket carries no unkeyed content digest — a plain sha256 would let a bucket reader
 // confirm whether specific known bytes appeared in a session, and correlate identical images across
 // teams. The consumer trusts the producer's ref (it is the only writer) and never recomputes the
@@ -17,7 +17,9 @@ const PREFIX = 'image'
  * silent mis-join rather than an error.
  */
 const URL_PREFIX = 'imageurl'
-const REF_RE = /^(image|imageurl):([0-9a-f]{32}):([A-Za-z0-9_-]{22})$/
+const CONTENT_REF_RE = /^image:([0-9a-f]{32}):([A-Za-z0-9_-]{22})$/
+const GLOBAL_URL_REF_RE = /^imageurl:([A-Za-z0-9_-]{22})$/
+const LEGACY_URL_REF_RE = /^imageurl:([0-9a-f]{32}):([A-Za-z0-9_-]{22})$/
 
 export function hashImageBytes(contentKey: string | Buffer, bytes: Buffer): string {
     return createHmac('sha256', contentKey).update(bytes).digest('base64url').slice(0, 22)
@@ -27,16 +29,26 @@ export function imageRef(pseudoTeam: string, hash: string): string {
     return `${PREFIX}:${pseudoTeam}:${hash}`
 }
 
-export function urlRef(pseudoTeam: string, hash: string): string {
-    return `${URL_PREFIX}:${pseudoTeam}:${hash}`
+export function urlRef(hash: string): string {
+    return `${URL_PREFIX}:${hash}`
 }
 
 export function isImageRef(s: string): boolean {
-    return REF_RE.test(s)
+    return CONTENT_REF_RE.test(s) || GLOBAL_URL_REF_RE.test(s) || LEGACY_URL_REF_RE.test(s)
 }
 
 /** Parses either kind of ref. `source` says which promise the hash carries. */
-export function parseImageRef(s: string): { pseudoTeam: string; hash: string; source: 'bytes' | 'url' } | null {
-    const m = REF_RE.exec(s)
-    return m ? { pseudoTeam: m[2], hash: m[3], source: m[1] === PREFIX ? 'bytes' : 'url' } : null
+export function parseImageRef(
+    s: string
+): { pseudoTeam: string; hash: string; source: 'bytes' } | { pseudoTeam?: string; hash: string; source: 'url' } | null {
+    const content = CONTENT_REF_RE.exec(s)
+    if (content) {
+        return { pseudoTeam: content[1], hash: content[2], source: 'bytes' }
+    }
+    const globalUrl = GLOBAL_URL_REF_RE.exec(s)
+    if (globalUrl) {
+        return { hash: globalUrl[1], source: 'url' }
+    }
+    const legacyUrl = LEGACY_URL_REF_RE.exec(s)
+    return legacyUrl ? { pseudoTeam: legacyUrl[1], hash: legacyUrl[2], source: 'url' } : null
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -49,7 +49,7 @@ export type MlMirrorConfig = {
      *
      * Enabling changes the mirrored JSONL shape a second time: a remote image keeps its grey
      * placeholder and a `data-anon-image-ref-<attribute>` sibling carries its
-     * `imageurl:<pseudoTeam>:<hash>` ref. The prefix differs from the image lane's `image:` on
+     * `imageurl:<hash>` ref. The prefix differs from the image lane's `image:` on
      * purpose, because this hash names the URL rather than the bytes behind it. Nothing fetches
      * those URLs yet, so every such ref is dangling. What this buys is the measurement of how many
      * URLs and how many distinct hosts real traffic carries.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -62,7 +62,8 @@ export type MlMirrorConfig = {
      * This flag is separate from the collection flag, because the two steps have different risks.
      * Collection changes only the mirrored data. A produce puts original, unscrubbed URLs onto a
      * Kafka topic, so the fetch topic is as sensitive as the raw replay topic. Turn this flag on
-     * only after the topic exists with the retention that section 2.5 of the plan gives it.
+     * only after the topic exists with the required retention and every fetch consumer accepts the
+     * current ref format. The disabled default lets consumer support deploy before producers change.
      *
      * The flag does nothing unless SESSION_RECORDING_ML_URL_COLLECTION_ENABLED is also on, because
      * the anonymizer collects no URLs until then.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
@@ -46,8 +46,7 @@ export interface MlMirrorUrlFetchProducer {
 }
 
 /**
- * Which collection lanes the anonymizer runs, and the key they derive their per-team ref prefix
- * from.
+ * Which collection lanes the anonymizer runs, and the key they derive their ref HMAC keys from.
  *
  * Separate from the two producer settings, because collecting and producing are separate
  * decisions. Collection alone measures. A produce puts original, unscrubbed URLs onto Kafka.
@@ -56,7 +55,7 @@ export interface MlMirrorUrlFetchProducer {
  * make that measurement impossible to take on its own.
  */
 export interface MlMirrorCollection {
-    /** The ML pseudonym HMAC key (also used by the block-metadata sink), for the per-team ref prefix. */
+    /** The ML pseudonym HMAC key, also used by the block-metadata sink. */
     pseudonymSecret: string | Buffer
     collectImages: boolean
     collectUrls: boolean

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.test.ts
@@ -23,7 +23,7 @@ describe('produceCollectedUrlsStep', () => {
     })
 
     function collected(hash: string, host: string, url: string, domain = host): CollectedUrl {
-        return { ref: `imageurl:${PSEUDO_TEAM}:${hash.padEnd(22, 'x')}`, url, host, domain }
+        return { ref: `imageurl:${hash.padEnd(22, 'x')}`, pseudoTeam: PSEUDO_TEAM, url, host, domain }
     }
 
     function decode(batch: { key: string; value: Buffer }[]) {
@@ -68,12 +68,12 @@ describe('produceCollectedUrlsStep', () => {
                         capturedAtMs: CAPTURED_AT,
                         urls: [
                             {
-                                ref: `imageurl:${PSEUDO_TEAM}:h1xxxxxxxxxxxxxxxxxxxx`,
+                                ref: `imageurl:h1xxxxxxxxxxxxxxxxxxxx`,
                                 url: 'https://cdn.example.com/a.jpg?sig=1',
                                 host: 'cdn.example.com',
                             },
                             {
-                                ref: `imageurl:${PSEUDO_TEAM}:h3xxxxxxxxxxxxxxxxxxxx`,
+                                ref: `imageurl:h3xxxxxxxxxxxxxxxxxxxx`,
                                 url: 'https://cdn.example.com/c.jpg',
                                 host: 'cdn.example.com',
                             },
@@ -88,7 +88,7 @@ describe('produceCollectedUrlsStep', () => {
                         capturedAtMs: CAPTURED_AT,
                         urls: [
                             {
-                                ref: `imageurl:${PSEUDO_TEAM}:h2xxxxxxxxxxxxxxxxxxxx`,
+                                ref: `imageurl:h2xxxxxxxxxxxxxxxxxxxx`,
                                 url: 'https://img.other.com/b.png',
                                 host: 'img.other.com',
                             },
@@ -134,18 +134,18 @@ describe('produceCollectedUrlsStep', () => {
         expect(queueMessages).toHaveBeenCalledTimes(2)
     })
 
-    it('refuses to produce a ref whose hash names bytes rather than a URL', async () => {
-        // A bytes ref comes from an image the page inlined, and its hash cannot be reproduced from
-        // any URL. Producing one would put a record on the fetch topic that the fetcher indexes
-        // under a hash nothing will ever match. Both prefixes parse, so only the source check
-        // separates them.
+    test.each([
+        ['inline image', `image:${PSEUDO_TEAM}:h1xxxxxxxxxxxxxxxxxxxx`],
+        ['legacy team-scoped URL', `imageurl:${PSEUDO_TEAM}:h1xxxxxxxxxxxxxxxxxxxx`],
+    ])('refuses to produce a %s ref', async (_name, ref) => {
         const step = createProduceCollectedUrlsStep(outputs, 100)
 
         await run(step, {
             message: { timestamp: CAPTURED_AT },
             collectedUrls: [
                 {
-                    ref: `image:${PSEUDO_TEAM}:h1xxxxxxxxxxxxxxxxxxxx`,
+                    ref,
+                    pseudoTeam: PSEUDO_TEAM,
                     url: 'https://img.example.com/a.png',
                     host: 'img.example.com',
                     domain: 'example.com',
@@ -166,6 +166,7 @@ describe('produceCollectedUrlsStep', () => {
                 collected('h1', 'img.example.com', 'https://img.example.com/a.png'),
                 {
                     ref: `image:${PSEUDO_TEAM}:h2xxxxxxxxxxxxxxxxxxxx`,
+                    pseudoTeam: PSEUDO_TEAM,
                     url: 'https://img.example.com/inlined.png',
                     host: 'img.example.com',
                     domain: 'example.com',
@@ -177,8 +178,8 @@ describe('produceCollectedUrlsStep', () => {
         const sent = decode(queued[0])
         expect(sent).toHaveLength(1)
         expect(sent[0].value.urls.map((u: { ref: string }) => u.ref)).toEqual([
-            `imageurl:${PSEUDO_TEAM}:h1xxxxxxxxxxxxxxxxxxxx`,
-            `imageurl:${PSEUDO_TEAM}:h3xxxxxxxxxxxxxxxxxxxx`,
+            `imageurl:h1xxxxxxxxxxxxxxxxxxxx`,
+            `imageurl:h3xxxxxxxxxxxxxxxxxxxx`,
         ])
     })
 
@@ -238,7 +239,8 @@ describe('produceCollectedUrlsStep', () => {
             collectedUrls: [
                 collected('h1', 'img.example.com', 'https://img.example.com/a.png'),
                 {
-                    ref: `imageurl:${otherTeam}:h2xxxxxxxxxxxxxxxxxxxx`,
+                    ref: `imageurl:h2xxxxxxxxxxxxxxxxxxxx`,
+                    pseudoTeam: otherTeam,
                     url: 'https://img.example.com/b.png',
                     host: 'img.example.com',
                     domain: 'img.example.com',

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.test.ts
@@ -4,7 +4,7 @@ import { PipelineResultType } from '~/ingestion/framework/results'
 import { CollectedUrl } from '~/ingestion/pipelines/sessionreplay/parse-and-anonymize-step'
 import { MlImageFetchOutput } from '~/ingestion/pipelines/sessionreplay/shared/outputs'
 
-import { createProduceCollectedUrlsStep } from './produce-collected-urls-step'
+import { RecordUrl, createProduceCollectedUrlsStep } from './produce-collected-urls-step'
 
 describe('produceCollectedUrlsStep', () => {
     const PSEUDO_TEAM = 'a'.repeat(32)
@@ -108,15 +108,15 @@ describe('produceCollectedUrlsStep', () => {
         expect(queueMessages).not.toHaveBeenCalled()
     })
 
-    it('dedups refs it already produced across messages', async () => {
+    it('dedups an identical transport URL but produces a new URL for the same ref', async () => {
         const step = createProduceCollectedUrlsStep(outputs)
-        const first = collected('h1', 'cdn.example.com', 'https://cdn.example.com/a.jpg')
-        const second = collected('h2', 'cdn.example.com', 'https://cdn.example.com/b.jpg')
+        const first = collected('h1', 'cdn.example.com', 'https://cdn.example.com/a.jpg?cb=old')
+        const replacement = collected('h1', 'cdn.example.com', 'https://cdn.example.com/a.jpg?cb=new')
         await run(step, { message: { timestamp: CAPTURED_AT }, collectedUrls: [first] })
-        await run(step, { message: { timestamp: CAPTURED_AT }, collectedUrls: [first, second] })
+        await run(step, { message: { timestamp: CAPTURED_AT }, collectedUrls: [first, replacement] })
         expect(
-            queued.map((batch) => decode(batch).map((m) => m.value.urls.map((u: { ref: string }) => u.ref)))
-        ).toEqual([[[first.ref]], [[second.ref]]])
+            queued.map((batch) => decode(batch).map((message) => message.value.urls.map((url: RecordUrl) => url.url)))
+        ).toEqual([[[first.url]], [[replacement.url]]])
     })
 
     it('swallows a failed produce and un-marks its refs so a later sighting produces again', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.ts
@@ -10,7 +10,7 @@ import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-de
 
 /**
  * The same trade as the image lane's cache, at a much lower cost per entry: a record here holds a
- * ref of approximately 60 bytes and no image bytes. A ref that this cache drops before its next
+ * ref of approximately 32 bytes and no image bytes. A ref that this cache drops before its next
  * arrival produces a second time, which costs topic volume and one more ledger read in the
  * fetcher, but never correctness. The fetcher dedupes on the same ref again.
  */
@@ -107,18 +107,22 @@ export function createProduceCollectedUrlsStep<
         // reaches the fetcher under a hash nothing will ever match. Both kinds parse, so only
         // `source` separates them, and checking one entry would let every later one through.
         //
-        // The pseudonym comes back out of the ref, because the ref is the only place the collector
-        // puts it. Every entry must agree on it: one replay message belongs to one team, and a
-        // record stamped with another team's pseudonym is a tenant-attribution error that nothing
-        // downstream can detect.
+        // Every entry must use the global URL-ref shape and carry the same transport pseudonym. One
+        // replay message belongs to one team, and a record stamped with another team's pseudonym is
+        // a tenant-attribution error that nothing downstream can detect.
         const usable: CollectedUrl[] = []
         let pseudoTeam: string | undefined
         for (const entry of fresh) {
             const parsed = parseImageRef(entry.ref)
-            if (!parsed || parsed.source !== 'url' || (pseudoTeam && parsed.pseudoTeam !== pseudoTeam)) {
+            if (
+                !parsed ||
+                parsed.source !== 'url' ||
+                parsed.pseudoTeam !== undefined ||
+                (pseudoTeam && entry.pseudoTeam !== pseudoTeam)
+            ) {
                 continue
             }
-            pseudoTeam ??= parsed.pseudoTeam
+            pseudoTeam ??= entry.pseudoTeam
             usable.push(entry)
         }
         const unusable = fresh.length - usable.length

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-urls-step.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { logger } from '~/common/utils/logger'
 import { ok } from '~/ingestion/framework/results'
@@ -10,9 +12,9 @@ import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-de
 
 /**
  * The same trade as the image lane's cache, at a much lower cost per entry: a record here holds a
- * ref of approximately 32 bytes and no image bytes. A ref that this cache drops before its next
- * arrival produces a second time, which costs topic volume and one more ledger read in the
- * fetcher, but never correctness. The fetcher dedupes on the same ref again.
+ * digest of the ref and transport URL, with no image bytes or original URL. An entry that this
+ * cache drops before its next arrival produces a second time, which costs topic volume and one
+ * more ledger read in the fetcher, but never correctness. The fetcher dedupes on the ref again.
  */
 const PRODUCED_REF_CACHE_MAX = 500_000
 
@@ -57,6 +59,10 @@ export interface CollectedUrlsMessage {
     urls: RecordUrl[]
 }
 
+function producedUrlCacheKey(entry: CollectedUrl): string {
+    return createHash('sha256').update(entry.ref).update('\0').update(entry.url).digest('base64url')
+}
+
 /**
  * Produce the collected URLs of remote images to the fetch topic, keyed by registrable domain.
  *
@@ -74,7 +80,8 @@ export interface CollectedUrlsMessage {
  * that batch. A buffer that spans messages would break that guarantee, because the pipeline could
  * commit the offset of a message while the URLs of that message were still in the buffer. A crash
  * would then lose them. The group-by-host step already removes most of the record count, `linger.ms`
- * makes the batches on the wire, and the ref cache stops a repeated image before it produces at all.
+ * makes the batches on the wire, and the cache stops an identical transport URL before it produces
+ * at all. A new transport URL for the same canonical ref still produces.
  *
  * Delivery is not awaited and never fails the message. The mirrored lines already carry the refs
  * in namespaced sibling attributes, while media sources keep their placeholders.
@@ -88,7 +95,7 @@ export function createProduceCollectedUrlsStep<
     outputs: IngestionOutputs<MlImageFetchOutput>,
     producedRefCacheMax: number = PRODUCED_REF_CACHE_MAX
 ): ProcessingStep<T, T> {
-    const producedRefs = new RefDedupCache('image_fetch_producer', producedRefCacheMax)
+    const producedTransportUrls = new RefDedupCache('image_fetch_producer', producedRefCacheMax)
 
     return function produceCollectedUrlsStep(input) {
         const collected = input.collectedUrls
@@ -96,7 +103,9 @@ export function createProduceCollectedUrlsStep<
             return Promise.resolve(ok(input))
         }
 
-        const fresh = collected.filter((entry) => !producedRefs.has(entry.ref))
+        const fresh = collected
+            .map((entry) => ({ entry, cacheKey: producedUrlCacheKey(entry) }))
+            .filter(({ cacheKey }) => !producedTransportUrls.has(cacheKey))
         SessionRecordingIngesterMetrics.incrementMlUrlsCollected('deduped', collected.length - fresh.length)
         if (fresh.length === 0) {
             return Promise.resolve(ok({ ...input, collectedUrls: undefined }))
@@ -110,9 +119,10 @@ export function createProduceCollectedUrlsStep<
         // Every entry must use the global URL-ref shape and carry the same transport pseudonym. One
         // replay message belongs to one team, and a record stamped with another team's pseudonym is
         // a tenant-attribution error that nothing downstream can detect.
-        const usable: CollectedUrl[] = []
+        const usable: typeof fresh = []
         let pseudoTeam: string | undefined
-        for (const entry of fresh) {
+        for (const candidate of fresh) {
+            const { entry } = candidate
             const parsed = parseImageRef(entry.ref)
             if (
                 !parsed ||
@@ -123,7 +133,7 @@ export function createProduceCollectedUrlsStep<
                 continue
             }
             pseudoTeam ??= entry.pseudoTeam
-            usable.push(entry)
+            usable.push(candidate)
         }
         const unusable = fresh.length - usable.length
         if (unusable > 0) {
@@ -137,8 +147,8 @@ export function createProduceCollectedUrlsStep<
         }
 
         const byDomain = new Map<string, RecordUrl[]>()
-        for (const entry of usable) {
-            producedRefs.add(entry.ref)
+        for (const { entry, cacheKey } of usable) {
+            producedTransportUrls.add(cacheKey)
             const group = byDomain.get(entry.domain)
             const record: RecordUrl = { ref: entry.ref, url: entry.url, host: entry.host }
             SessionRecordingIngesterMetrics.observeMlUrlBytes(Buffer.byteLength(entry.url))
@@ -170,29 +180,29 @@ export function createProduceCollectedUrlsStep<
             })
         )
 
-        // The failure handler captures only the refs, so that a produce which is not yet delivered
-        // does not hold the URL strings alive longer than the messages themselves.
-        const refs = usable.map((entry) => entry.ref)
+        // The failure handler captures only the cache keys, so that a produce which is not yet
+        // delivered does not hold the URL strings alive longer than the messages themselves.
+        const producedCacheKeys = usable.map(({ cacheKey }) => cacheKey)
         const produce = outputs
             .queueMessages(ML_IMAGE_FETCH_OUTPUT, messages)
             .then(() => {
                 // queueMessages resolves on the delivery acks, so `produced` counts what landed.
-                SessionRecordingIngesterMetrics.incrementMlUrlsCollected('produced', refs.length)
+                SessionRecordingIngesterMetrics.incrementMlUrlsCollected('produced', producedCacheKeys.length)
             })
             .catch((error) => {
                 // A dangling ref renders as a placeholder, so a failed produce is logged and never
-                // thrown back into the pipeline. Un-mark the refs: the same image in a later
+                // thrown back into the pipeline. Un-mark the cache entries: the same image in a later
                 // snapshot then produces again, one attempt for each recurrence and no retry loop.
                 // A duplicate costs the fetcher one ledger read, because the ledger is keyed by ref.
-                for (const ref of refs) {
-                    producedRefs.delete(ref)
+                for (const cacheKey of producedCacheKeys) {
+                    producedTransportUrls.delete(cacheKey)
                 }
                 logger.warn('🌐', 'ml_image_fetch_produce_failed', {
-                    count: refs.length,
+                    count: producedCacheKeys.length,
                     domains: byDomain.size,
                     error: String(error),
                 })
-                SessionRecordingIngesterMetrics.incrementMlUrlsCollected('produce_failed', refs.length)
+                SessionRecordingIngesterMetrics.incrementMlUrlsCollected('produce_failed', producedCacheKeys.length)
             })
         return Promise.resolve(ok({ ...input, collectedUrls: undefined }, [produce]))
     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/pseudonymize.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/pseudonymize.ts
@@ -15,12 +15,8 @@ export function pseudonymize(secret: string | Buffer, namespace: string, value: 
 export const PSEUDONYM_TEAM = 'team'
 /** Namespace for the per-team image content-HMAC key (see ml-mirror-image-scrub/content-ref.ts). */
 export const PSEUDONYM_IMAGE_CONTENT_KEY = 'image-content-key'
-/**
- * Namespace for the per-team URL-HMAC key, which hashes a remote image's URL rather than its bytes.
- *
- * Separate from the content key on purpose. Both produce a ref of the same shape, and each hashes
- * a different thing. A separate key keeps the two kinds of ref independent for one team.
- */
+/** Namespace for the global URL-HMAC key, which hashes a remote image's URL rather than its bytes. */
 export const PSEUDONYM_IMAGE_URL_KEY = 'image-url-key'
+export const PSEUDONYM_IMAGE_URL_GLOBAL_VALUE = 'global-v1'
 export const PSEUDONYM_SESSION = 'session'
 export const PSEUDONYM_DISTINCT_ID = 'distinct_id'

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/shared-fixtures.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/shared-fixtures.test.ts
@@ -9,7 +9,13 @@ import {
     imageRef,
     isImageRef,
     parseImageRef,
+    urlRef,
 } from '~/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/content-ref'
+import {
+    PSEUDONYM_IMAGE_URL_GLOBAL_VALUE,
+    PSEUDONYM_IMAGE_URL_KEY,
+    pseudonymize,
+} from '~/ingestion/pipelines/sessionreplay/ml-mirror/pseudonymize'
 
 // Shared fixtures pin the addon's behavior through the FFI; the pure-Rust side of the same
 // fixtures is covered by rust/replay-anonymizer/tests/parity.rs.
@@ -218,7 +224,7 @@ describeAddon('native rust addon matches the shared fixtures', () => {
     })
 })
 
-describe('image content hash matches the shared fixtures', () => {
+describe('image refs match the shared fixtures', () => {
     // Pins the keyed hashImageBytes to the Rust collector's HMAC (tests/parity.rs runs the same
     // fixture): the consumer trusts the producer, so this is the only cross-implementation check.
     interface HashCase {
@@ -230,6 +236,24 @@ describe('image content hash matches the shared fixtures', () => {
     test.each(load<HashCase>('image-hash.json').map((c) => [c.name, c] as const))('hash: %s', (_name, c) => {
         expect(hashImageBytes(c.keyAscii, Buffer.from(c.bytesBase64, 'base64'))).toBe(c.hash)
     })
+
+    interface UrlRefCase {
+        name: string
+        pseudonymSecret: string
+        globalUrlKey: string
+        hash: string
+        ref: string
+    }
+    test.each(load<UrlRefCase>('image-url-ref.json').map((c) => [c.name, c] as const))(
+        'global URL ref: %s',
+        (_name, c) => {
+            expect(pseudonymize(c.pseudonymSecret, PSEUDONYM_IMAGE_URL_KEY, PSEUDONYM_IMAGE_URL_GLOBAL_VALUE)).toBe(
+                c.globalUrlKey
+            )
+            expect(urlRef(c.hash)).toBe(c.ref)
+            expect(parseImageRef(c.ref)).toEqual({ hash: c.hash, source: 'url' })
+        }
+    )
 })
 
 describeAddon('native image collection', () => {
@@ -306,16 +330,14 @@ describeAddon('native image collection', () => {
         expect(result.lines!.toString()).not.toContain('image:')
     })
 
-    it('rejects a per-team key with no pseudonym to attribute it to', async () => {
-        // Each lane's ref embeds the pseudonym, so a key without one would mint refs that nothing
-        // can attribute to a team. That fails loudly rather than collecting under a blank prefix.
+    it('requires a pseudonym only for the inline image key', async () => {
         rustAddon!.initAnonymizer({ text: [], url: [] })
         await expect(
             rustAddon!.anonymizeKafkaPayload(imagePayload(), undefined, undefined, CONTENT_KEY)
-        ).rejects.toThrow('require pseudoTeam')
+        ).rejects.toThrow('contentKey requires pseudoTeam')
         await expect(
             rustAddon!.anonymizeKafkaPayload(imagePayload(), undefined, undefined, undefined, CONTENT_KEY)
-        ).rejects.toThrow('require pseudoTeam')
+        ).resolves.toMatchObject({ failed: false })
     })
 
     it('runs either collection lane without the other', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/parse-and-anonymize-step.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/parse-and-anonymize-step.test.ts
@@ -7,6 +7,7 @@ import { PipelineResultType } from '~/ingestion/framework/results'
 import { imageRef } from './ml-mirror-image-scrub/content-ref'
 import {
     PSEUDONYM_IMAGE_CONTENT_KEY,
+    PSEUDONYM_IMAGE_URL_GLOBAL_VALUE,
     PSEUDONYM_IMAGE_URL_KEY,
     PSEUDONYM_TEAM,
     pseudonymize,
@@ -295,7 +296,7 @@ describe('createParseAndAnonymizeMessageStep with image collection', () => {
 describe('createParseAndAnonymizeMessageStep with url collection', () => {
     const secret = 'test-pseudonym-secret'
     const pseudoTeam = pseudonymize(secret, PSEUDONYM_TEAM, '1')
-    const urlKey = pseudonymize(secret, PSEUDONYM_IMAGE_URL_KEY, '1')
+    const urlKey = pseudonymize(secret, PSEUDONYM_IMAGE_URL_KEY, PSEUDONYM_IMAGE_URL_GLOBAL_VALUE)
     const now = Date.now()
     const team = { teamId: 1, consoleLogIngestionEnabled: true, aiTrainingOptedIn: true }
     const headers: SessionReplayHeaders = {
@@ -331,7 +332,7 @@ describe('createParseAndAnonymizeMessageStep with url collection', () => {
 
     beforeEach(() => mockAnonymizeKafkaPayload.mockReset())
 
-    it('runs without the image lane, and forwards only the url key', async () => {
+    it('uses one global URL key and ref for every team', async () => {
         // The URL lane measures before any topic exists. Requiring the image lane to be on first
         // would make that measurement impossible to take on its own.
         mockAnonymizeKafkaPayload.mockResolvedValue({
@@ -347,15 +348,26 @@ describe('createParseAndAnonymizeMessageStep with url collection', () => {
         })
 
         const result: any = await step({ message: kafkaMessage(), headers, team } as any)
+        const otherTeam = { ...team, teamId: 2 }
+        const otherResult: any = await step({ message: kafkaMessage(), headers, team: otherTeam } as any)
 
         expect(mockAnonymizeKafkaPayload).toHaveBeenCalledWith(expect.anything(), null, pseudoTeam, undefined, urlKey)
         expect(result.value.collectedUrls).toEqual([
             {
-                ref: `imageurl:${pseudoTeam}:${'h'.repeat(22)}`,
+                ref: `imageurl:${'h'.repeat(22)}`,
+                pseudoTeam,
                 url: 'https://cdn.example.com/a.png',
                 host: 'cdn.example.com',
             },
         ])
+        expect(mockAnonymizeKafkaPayload).toHaveBeenLastCalledWith(
+            expect.anything(),
+            null,
+            pseudonymize(secret, PSEUDONYM_TEAM, '2'),
+            undefined,
+            urlKey
+        )
+        expect(otherResult.value.collectedUrls[0].ref).toBe(result.value.collectedUrls[0].ref)
         expect(result.value.collectedImages).toBeUndefined()
     })
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/parse-and-anonymize-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/parse-and-anonymize-step.ts
@@ -15,6 +15,7 @@ import { TeamForReplay } from '~/ingestion/pipelines/sessionreplay/teams/types'
 import { hashImageBytes, imageRef, isImageRef, urlRef } from './ml-mirror-image-scrub/content-ref'
 import {
     PSEUDONYM_IMAGE_CONTENT_KEY,
+    PSEUDONYM_IMAGE_URL_GLOBAL_VALUE,
     PSEUDONYM_IMAGE_URL_KEY,
     PSEUDONYM_TEAM,
     pseudonymize,
@@ -57,8 +58,10 @@ export interface CollectedImage {
  * label, or any destination outside the fetch topic.
  */
 export interface CollectedUrl {
-    /** `imageurl:<pseudoTeam>:<hash>` stored in the mirrored line's namespaced ref attribute. */
+    /** `imageurl:<hash>` stored in the mirrored line's namespaced ref attribute. */
     ref: string
+    /** The team pseudonym remains transport metadata until the fetch topic moves to its global schema. */
+    pseudoTeam: string
     url: string
     /** The host the request goes to. robots.txt and the connection limit are scoped to this. */
     host: string
@@ -99,13 +102,16 @@ export interface ImageCollectionConfig {
 export function createParseAndAnonymizeMessageStep<T extends ParseMessageStepInput & { team: TeamForReplay }>(
     imageCollection?: ImageCollectionConfig
 ): ProcessingStep<T, T & ParseAndAnonymizeStepOutput> {
-    // Both are per-team HMACs of the same secret (domain-separated) — cache them rather than
-    // re-deriving on every message. The content key keys the image hash so the unencrypted bucket
-    // carries no unkeyed content digest; it never crosses the FFI as the raw secret.
+    const globalUrlKey =
+        imageCollection?.collectUrls === true
+            ? pseudonymize(imageCollection.pseudonymSecret, PSEUDONYM_IMAGE_URL_KEY, PSEUDONYM_IMAGE_URL_GLOBAL_VALUE)
+            : undefined
+
+    // Cache the team values rather than re-deriving them for every message. The content key keys
+    // the inline image hash. The URL key is global and does not use this cache.
     interface TeamImageKeys {
         pseudoTeam: string
         contentKey?: string
-        urlKey?: string
     }
     const teamKeysCache = new Map<number, TeamImageKeys>()
     const teamKeysFor = (teamId: number): TeamImageKeys | undefined => {
@@ -131,9 +137,6 @@ export function createParseAndAnonymizeMessageStep<T extends ParseMessageStepInp
             keys = {
                 pseudoTeam,
                 contentKey: imageCollection.collectImages ? contentKey : undefined,
-                urlKey: imageCollection.collectUrls
-                    ? pseudonymize(imageCollection.pseudonymSecret, PSEUDONYM_IMAGE_URL_KEY, String(teamId))
-                    : undefined,
             }
             teamKeysCache.set(teamId, keys)
         }
@@ -164,7 +167,7 @@ export function createParseAndAnonymizeMessageStep<T extends ParseMessageStepInp
                 contentEncoding,
                 teamKeys?.pseudoTeam,
                 teamKeys?.contentKey,
-                teamKeys?.urlKey
+                globalUrlKey
             )
         } catch (error) {
             // A rejected promise (native panic, addon load failure) must fail closed.
@@ -273,7 +276,7 @@ export function createParseAndAnonymizeMessageStep<T extends ParseMessageStepInp
         const collectedImages = teamKeys?.contentKey
             ? unpackCollectedImages(teamKeys.pseudoTeam, meta, result.images)
             : undefined
-        const collectedUrls = teamKeys?.urlKey ? unpackCollectedUrls(teamKeys.pseudoTeam, meta) : undefined
+        const collectedUrls = globalUrlKey && teamKeys ? unpackCollectedUrls(teamKeys.pseudoTeam, meta) : undefined
         return ok({ ...input, parsedMessage, collectedImages, collectedUrls })
     }
 }
@@ -318,7 +321,8 @@ function unpackCollectedUrls(pseudoTeam: string, meta: AnonymizeMeta): Collected
     const domains = new Set<string>()
     for (const entry of meta.urls ?? []) {
         urls.push({
-            ref: urlRef(pseudoTeam, entry.hash),
+            ref: urlRef(entry.hash),
+            pseudoTeam,
             url: entry.url,
             host: entry.host,
             domain: entry.domain,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8976,7 +8976,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-replay-anonymizer"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8988,6 +8988,7 @@ dependencies = [
  "libdeflater",
  "lz4",
  "memchr",
+ "percent-encoding",
  "public-suffix",
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -183,8 +183,9 @@ once_cell = "1.21.4"
 opentelemetry = { version = "0.22.0", features = ["trace"] }
 opentelemetry-otlp = "0.15.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["trace", "rt-tokio"] }
-public-suffix = "0.1.2"
+percent-encoding = "2.3.1"
 prost = "0.13"
+public-suffix = "0.1.2"
 rand = "0.8.5"
 rdkafka = { version = "0.37.0", features = ["tracing", "ssl-vendored"] }
 reqwest = { version = "0.12.3", features = ["json", "stream"] }

--- a/rust/replay-anonymizer-node/src/index.ts
+++ b/rust/replay-anonymizer-node/src/index.ts
@@ -137,12 +137,11 @@ export function initAnonymizer(allow: AllowListsInput): void {
  * blur, and the original bytes come back in `images`/`meta.images` for the caller to produce to
  * the scrub topic.
  *
- * `urlKey` enables the URL-collection lane alongside it: a remote image's `src` keeps the media
- * placeholder, a namespaced sibling attribute carries its ref, and its original URL comes back in
- * `meta.urls` for the caller to hand to the fetch lane.
+ * `urlKey` enables the URL-collection lane independently. It is the global URL HMAC key. A remote
+ * image's `src` keeps the media placeholder, a namespaced sibling attribute carries its ref, and
+ * its original URL comes back in `meta.urls` for the caller to hand to the fetch lane.
  *
- * The two lanes are independent: either, both, or neither. Both need `pseudoTeam`, because the ref
- * embeds it, so a `contentKey` or a `urlKey` without one throws.
+ * The two lanes are independent: either, both, or neither. Only `contentKey` needs `pseudoTeam`.
  */
 export async function anonymizeKafkaPayload(
     payload: Buffer,

--- a/rust/replay-anonymizer-node/src/lib.rs
+++ b/rust/replay-anonymizer-node/src/lib.rs
@@ -100,13 +100,9 @@ fn anonymize_kafka_payload_ffi(mut cx: FunctionContext) -> JsResult<JsPromise> {
     };
     let pseudo_team = opt_string_arg(&mut cx, 2)?;
     let content_key = opt_string_arg(&mut cx, 3)?;
-    // The URL lane is enabled independently of the image lane, but it needs the same pseudonym, so
-    // a urlKey without a pseudoTeam is a mis-keyed ref rather than a partial opt-in.
     let url_key = opt_string_arg(&mut cx, 4)?;
-    // Each lane needs the pseudonym, because its ref embeds it, and its own per-team key. A key
-    // without the pseudonym would mint refs nothing can attribute, so it fails loudly instead.
-    if pseudo_team.is_none() && (content_key.is_some() || url_key.is_some()) {
-        return cx.throw_error("contentKey and urlKey each require pseudoTeam");
+    if pseudo_team.is_none() && content_key.is_some() {
+        return cx.throw_error("contentKey requires pseudoTeam");
     }
     let image_collection = match (pseudo_team.clone(), content_key) {
         (Some(pseudo_team), Some(content_key)) => Some(ImageCollection {
@@ -115,13 +111,7 @@ fn anonymize_kafka_payload_ffi(mut cx: FunctionContext) -> JsResult<JsPromise> {
         }),
         _ => None,
     };
-    let url_collection = match (pseudo_team, url_key) {
-        (Some(pseudo_team), Some(url_key)) => Some(UrlCollection {
-            pseudo_team,
-            url_key,
-        }),
-        _ => None,
-    };
+    let url_collection = url_key.map(|url_key| UrlCollection { url_key });
     // Created on the JS thread so every offset shares one monotonic origin: the task-start mark
     // becomes the threadpool queue wait, and no wall clock is involved.
     let timings = PhaseTimings::new();

--- a/rust/replay-anonymizer/Cargo.toml
+++ b/rust/replay-anonymizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-replay-anonymizer"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "PII scrubber for rrweb session-replay events: text/URL redaction, native image blur, and canvas/cv neutralization"
 license = "MIT"

--- a/rust/replay-anonymizer/Cargo.toml
+++ b/rust/replay-anonymizer/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 simd-json = { version = "0.15", features = ["serde_impl"] }
+percent-encoding = { workspace = true }
 public-suffix = { workspace = true }
 url = { workspace = true }
 zstd = { workspace = true }

--- a/rust/replay-anonymizer/src/assets.rs
+++ b/rust/replay-anonymizer/src/assets.rs
@@ -54,7 +54,7 @@ pub(crate) fn tag_src_is_image(tag: &str) -> bool {
 ///
 /// A subset of [`MEDIA_SRC_ATTRS`], because the rest do not name one fetchable image.
 ///
-/// `src` and `rr_src` need the tag as well as the name.
+/// `src` needs the tag as well as the name.
 ///
 /// Without the tag check, the lane collects the `src` of a `<video>`, an `<audio>` or a `<track>`.
 /// The mutation path is worse: rrweb sends attributes with no tag, so any `src` passes, including
@@ -64,18 +64,9 @@ pub(crate) fn tag_src_is_image(tag: &str) -> bool {
 /// a different workload and a different data-classification question. `tag_src_is_image` is false
 /// on the tagless mutation path, so that path declines rather than guesses.
 ///
-/// `poster` needs no tag check. It exists only on a video element and it always names a still
-/// image.
-///
-/// `srcset` holds several candidates with descriptors, so it needs a parse and a choice of which
-/// candidate to fetch. `href` and `xlink:href` on a media tag are as often a link or an SVG
-/// fragment reference as an image. Both can be added later without changing anything else here.
+/// The other media attributes remain out of scope until the fetcher specification includes them.
 pub(crate) fn is_fetchable_src_attr(name: &str, tag_src_is_image: bool) -> bool {
-    match name {
-        "poster" => true,
-        "src" | "rr_src" => tag_src_is_image,
-        _ => false,
-    }
+    name == "src" && tag_src_is_image
 }
 
 /// True if an attribute map contains any media-source attribute.

--- a/rust/replay-anonymizer/src/collect.rs
+++ b/rust/replay-anonymizer/src/collect.rs
@@ -43,8 +43,8 @@ pub fn image_ref(pseudo_team: &str, hash: &str) -> String {
 /// mis-join rather than an error.
 pub const URL_REF_PREFIX: &str = "imageurl";
 
-pub fn url_ref(pseudo_team: &str, hash: &str) -> String {
-    format!("{URL_REF_PREFIX}:{pseudo_team}:{hash}")
+pub fn url_ref(hash: &str) -> String {
+    format!("{URL_REF_PREFIX}:{hash}")
 }
 
 /// True for strings shaped like a content ref. The `image:` prefix cannot collide with a data URI,
@@ -57,27 +57,36 @@ pub fn is_image_ref(s: &str) -> bool {
     s.starts_with("image:")
 }
 
-/// True only for a fully well-formed ref: `image:` + 32 lowercase hex (the team pseudonym) + `:`
-/// + 22 base64url chars (the truncated HMAC).
+/// True only for a fully well-formed content ref or URL ref.
 ///
 /// The loose prefix check would let a captured page set a media attribute to `image:<anything>` and
 /// have it copied verbatim into anonymized output. This bounds what can survive to a fixed-width
 /// opaque token with no room for readable content.
 pub fn is_image_ref_strict(s: &str) -> bool {
-    let Some(rest) = s
-        .strip_prefix("image:")
-        .or_else(|| s.strip_prefix("imageurl:"))
-    else {
-        return false;
-    };
-    let Some((team, hash)) = rest.split_once(':') else {
-        return false;
-    };
+    if let Some(rest) = s.strip_prefix("image:") {
+        let Some((team, hash)) = rest.split_once(':') else {
+            return false;
+        };
+        return is_pseudo_team(team) && is_ref_hash(hash);
+    }
+    if let Some(rest) = s.strip_prefix("imageurl:") {
+        return is_ref_hash(rest)
+            || rest
+                .split_once(':')
+                .is_some_and(|(team, hash)| is_pseudo_team(team) && is_ref_hash(hash));
+    }
+    false
+}
+
+fn is_pseudo_team(team: &str) -> bool {
     team.len() == 32
         && team
             .bytes()
             .all(|b| b.is_ascii_digit() || b.is_ascii_lowercase() && b <= b'f')
-        && hash.len() == 22
+}
+
+fn is_ref_hash(hash: &str) -> bool {
+    hash.len() == 22
         && hash
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')

--- a/rust/replay-anonymizer/src/url_collect.rs
+++ b/rust/replay-anonymizer/src/url_collect.rs
@@ -19,12 +19,8 @@
 //! downstream. Removing the volatile parameters matters more for that than it does for
 //! the request count.
 //!
-//! The hash is a *keyed* HMAC, for the same reason as the image hash. The ML bucket is not
-//! encrypted. An unkeyed digest of a URL would let a reader of the bucket learn which sites the
-//! users of a team visited.
-//!
-//! The caller derives the per-team key from the same KMS-held secret as the team pseudonym.
-//! Neither the secret nor the key leaves the ingester.
+//! The hash is a *keyed* HMAC. The caller derives one global URL key from the KMS-held secret. The
+//! secret does not leave the ingester.
 
 use std::collections::{HashMap, HashSet};
 
@@ -55,11 +51,7 @@ pub const MAX_URLS_PER_MESSAGE: usize = 512;
 /// Enables URL collection for one anonymize call.
 #[derive(Debug, Clone)]
 pub struct UrlCollection {
-    /// The non-reversible HMAC team pseudonym (32 hex chars), computed by the caller. Embedded
-    /// verbatim in every emitted ref, exactly as on the image lane.
-    pub pseudo_team: String,
-    /// Per-team key for the URL HMAC. The caller derives it under its own domain separator, so a
-    /// URL ref and an image ref stay distinct for one team.
+    /// Global key for the URL HMAC. The caller derives it under a URL-specific domain separator.
     pub url_key: String,
 }
 
@@ -91,7 +83,6 @@ pub fn hash_url(url_key: &[u8], dedup_url: &str) -> String {
 
 /// Accumulates the remote image URLs of one message, deduplicated on the hash.
 pub struct UrlCollector {
-    pseudo_team: String,
     url_key: String,
     urls: Vec<CollectedUrl>,
     seen: HashSet<String>,
@@ -106,7 +97,6 @@ pub struct UrlCollector {
 impl UrlCollector {
     pub fn new(collection: UrlCollection) -> Self {
         Self {
-            pseudo_team: collection.pseudo_team,
             url_key: collection.url_key,
             urls: Vec::new(),
             seen: HashSet::new(),
@@ -156,7 +146,7 @@ impl UrlCollector {
         };
         let hash = hash_url(self.url_key.as_bytes(), &canonical.dedup);
         if self.seen.contains(&hash) {
-            return Some(crate::collect::url_ref(&self.pseudo_team, &hash));
+            return Some(crate::collect::url_ref(&hash));
         }
         self.seen.insert(hash.clone());
         self.urls.push(CollectedUrl {
@@ -165,7 +155,7 @@ impl UrlCollector {
             host: canonical.host,
             domain: canonical.domain,
         });
-        Some(crate::collect::url_ref(&self.pseudo_team, &hash))
+        Some(crate::collect::url_ref(&hash))
     }
 
     /// Counts by reason for the URLs this collector refused.
@@ -194,7 +184,6 @@ mod tests {
 
     fn collector() -> UrlCollector {
         UrlCollector::new(UrlCollection {
-            pseudo_team: "a".repeat(32),
             url_key: String::from_utf8(TEST_KEY.to_vec()).unwrap(),
         })
     }

--- a/rust/replay-anonymizer/src/url_collect.rs
+++ b/rust/replay-anonymizer/src/url_collect.rs
@@ -6,18 +6,17 @@
 //! sibling attribute carries the content ref. The message also carries the original URL back to
 //! the caller.
 //!
-//! **Two URLs come out of this module. Do not confuse them.**
+//! **Two forms of one URL come out of this module. Do not confuse them.**
 //!
 //! The *dedup* URL is canonical, and its volatile parameters are removed. It is the only input to
 //! the hash, so it sets the ref and the dedup key of the fetch lane.
 //!
-//! The *fetch* URL is canonical, and every parameter stays. The fetcher requests this one. A
-//! signed URL works only in this form, and it dedups only in the first form.
+//! The *fetch* URL is canonical, and every permitted parameter stays. The fetcher requests this
+//! one. URLs that carry credentials or signatures are refused before either form is created.
 //!
-//! That split is what makes the ref stable. A URL that carries a fresh signature on each page
-//! load would otherwise mint a new ref every time. A ref that appears once joins to nothing
-//! downstream. Removing the volatile parameters matters more for that than it does for
-//! the request count.
+//! That split is what makes the ref stable across non-credential cache busters. A ref that appears
+//! once joins to nothing downstream. Removing the volatile parameters matters more for that than
+//! it does for the request count.
 //!
 //! The hash is a *keyed* HMAC. The caller derives one global URL key from the KMS-held secret. The
 //! secret does not leave the ingester.
@@ -208,19 +207,13 @@ mod tests {
     }
 
     #[test]
-    fn two_signatures_of_one_image_share_a_ref() {
+    fn a_signed_url_produces_no_global_ref() {
         let mut c = collector();
-        let first = c
+        assert!(c
             .collect("https://cdn.example.com/a.png?X-Amz-Signature=aaa")
-            .unwrap();
-        let second = c
-            .collect("https://cdn.example.com/a.png?X-Amz-Signature=bbb")
-            .unwrap();
-        assert_eq!(first, second);
-        // One entry, and it keeps the URL of the first sighting, which is a URL that still works.
-        let urls = c.into_urls();
-        assert_eq!(urls.len(), 1);
-        assert!(urls[0].url.contains("X-Amz-Signature=aaa"));
+            .is_none());
+        assert_eq!(c.into_declines(), vec![("credential".to_string(), 1)]);
+        assert_eq!(c.into_urls(), Vec::new());
     }
 
     #[test]

--- a/rust/replay-anonymizer/src/url_policy.rs
+++ b/rust/replay-anonymizer/src/url_policy.rs
@@ -14,53 +14,52 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
 
+use percent_encoding::percent_decode_str;
 use public_suffix::{EffectiveTLDProvider, DEFAULT_PROVIDER};
 
 use url::Url;
 
-/// Query parameters that change on each page load without changing the image behind the URL.
-///
-/// **This is an allow list of names. It must stay one.**
-///
-/// Never add a rule about the *shape* of a value. "Looks random" and "is long" both describe real
-/// image parameters.
-///
-/// **Never add a name that also selects an image.** `w`, `h`, `q`, `fm`, `dpr`, `fit`, `auto`,
-/// `format`, `resize`, `crop` and `quality` all do. Collapsing those onto one ref would point one
-/// ref at several genuinely different images, and nothing downstream can detect it.
-///
-/// Only unambiguous names live here. A short name that one vendor uses for a signature and another
-/// uses for a size belongs in [`SCOPED_VOLATILE_PARAMS`], where a marker keeps it honest.
-///
-/// `s` is the name that forced the split. imgix signs with it. Gravatar sizes with it. Removing it
-/// everywhere made a 48-pixel avatar and a 200-pixel avatar the same image.
-const VOLATILE_PARAMS: &[&str] = &[
-    // AWS SigV4 presigned (S3, CloudFront). Long and vendor-prefixed, so unambiguous.
-    "x-amz-algorithm",
-    "x-amz-credential",
-    "x-amz-date",
-    "x-amz-expires",
-    "x-amz-signedheaders",
-    "x-amz-signature",
-    "x-amz-security-token",
-    // CloudFront canned policies. key-pair-id is vendor-specific enough to stand alone.
-    "key-pair-id",
-    // Google Cloud Storage V4.
-    "x-goog-algorithm",
-    "x-goog-credential",
-    "x-goog-date",
-    "x-goog-expires",
-    "x-goog-signedheaders",
-    "x-goog-signature",
-    // Akamai token auth.
-    "hdnts",
+const VOLATILE_PARAMS: &[&str] = &["cb", "rnd", "nocache"];
+
+const CREDENTIAL_PARAMS: &[&str] = &[
+    "__cld_token__",
+    "__token__",
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth_token",
+    "authorization",
+    "awsaccesskeyid",
+    "credential",
+    "googleaccessid",
     "hdnea",
     "hdntl",
-    "__token__",
-    // Cache busters whose names say so.
-    "cb",
-    "rnd",
-    "nocache",
+    "hdnts",
+    "id_token",
+    "ik-s",
+    "jsessionid",
+    "ossaccesskeyid",
+    "phpsessid",
+    "q-ak",
+    "q-signature",
+    "security-token",
+    "session_token",
+    "sessionid",
+    "sig",
+    "signature",
+    "signedheaders",
+    "token",
+    "x-amz-credential",
+    "x-amz-security-token",
+    "x-amz-signature",
+    "x-amz-signedheaders",
+    "x-cos-security-token",
+    "x-goog-credential",
+    "x-goog-signature",
+    "x-goog-signedheaders",
+    "x-oss-credential",
+    "x-oss-security-token",
+    "x-oss-signature",
 ];
 
 /// Volatile names that are only volatile in a known context.
@@ -68,23 +67,8 @@ const VOLATILE_PARAMS: &[&str] = &[
 /// Each entry is `(marker, names)`. The names are removed only when the query also carries the
 /// marker, which is a parameter the vendor always sends alongside them. Without the marker the
 /// names are left alone, because on another host they select an image.
-const SCOPED_VOLATILE_PARAMS: &[(&str, &[&str])] = &[
-    // Azure Blob shared access signatures always carry sig, and sv alongside the rest.
-    (
-        "sig",
-        &["sv", "st", "se", "sp", "sr", "sig", "spr", "skoid"],
-    ),
-    // Meta's CDN always carries _nc_ohc with the rest of its rotating set. stp encodes a crop, so
-    // it is only safe to drop when the whole set is present and the URL is therefore one of theirs.
-    ("_nc_ohc", &["_nc_ohc", "_nc_ht", "oh", "oe", "ccb", "stp"]),
-    // CloudFront canned policies pair Signature with Expires and Policy. Both are ordinary words
-    // elsewhere: `expires` is a real cache hint, and `policy=thumb` is a plausible image selector.
-    ("signature", &["signature", "expires", "policy"]),
-    ("key-pair-id", &["policy", "expires"]),
-];
-
-/// Hosts whose short signature parameter is safe to remove, because the vendor owns the host.
-const HOST_SCOPED_VOLATILE_PARAMS: &[(&str, &[&str])] = &[(".imgix.net", &["s", "expires"])];
+const SCOPED_VOLATILE_PARAMS: &[(&str, &[&str])] =
+    &[("_nc_ohc", &["_nc_ohc", "_nc_ht", "oh", "oe", "ccb", "stp"])];
 
 /// Longer than this and we neither collect nor fetch it. Well past what a real image URL needs,
 /// and it bounds what one message can pin in memory alongside the count cap.
@@ -135,18 +119,13 @@ pub struct CanonicalUrl {
 ///
 /// The name set is built once per URL. A scan of the parameter list made this quadratic in the
 /// parameter count, and a page controls both that count and the number of URLs.
-fn is_volatile(name: &str, host: &str, names_on_this_url: &HashSet<String>) -> bool {
+fn is_volatile(name: &str, names_on_this_url: &HashSet<String>) -> bool {
     if VOLATILE_PARAMS.iter().any(|p| p.eq_ignore_ascii_case(name)) {
         return true;
     }
     for (marker, names) in SCOPED_VOLATILE_PARAMS {
         if names.iter().any(|p| p.eq_ignore_ascii_case(name)) && names_on_this_url.contains(*marker)
         {
-            return true;
-        }
-    }
-    for (suffix, names) in HOST_SCOPED_VOLATILE_PARAMS {
-        if host.ends_with(suffix) && names.iter().any(|p| p.eq_ignore_ascii_case(name)) {
             return true;
         }
     }
@@ -289,6 +268,10 @@ pub enum Decline {
     NoHost,
     /// Loopback, private, link-local or an internal-only name. See [`is_public_host`].
     NonPublicHost,
+    /// A known URL credential, signature, token, signed-header list, or non-empty userinfo.
+    Credential,
+    /// A query parameter name could not be percent-decoded as UTF-8.
+    InvalidQuery,
 }
 
 impl Decline {
@@ -301,6 +284,8 @@ impl Decline {
             Decline::BadPort => "bad_port",
             Decline::NoHost => "no_host",
             Decline::NonPublicHost => "non_public_host",
+            Decline::Credential => "credential",
+            Decline::InvalidQuery => "invalid_query",
         }
     }
 }
@@ -331,6 +316,9 @@ pub fn try_canonicalize(raw: &str) -> Result<CanonicalUrl, Decline> {
     if url.port().is_some() {
         return Err(Decline::BadPort);
     }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(Decline::Credential);
+    }
     // `example.com.` and `example.com` name the same host, and the consumer compares the two as
     // strings in more than one place. The dot comes off the URL as well as off the host, so
     // everything downstream sees one spelling.
@@ -342,15 +330,18 @@ pub fn try_canonicalize(raw: &str) -> Result<CanonicalUrl, Decline> {
     if host != host_str {
         url.set_host(Some(&host)).map_err(|_| Decline::NoHost)?;
     }
+    if has_credential_query(&url)? || has_credential_path(&url, &host) {
+        return Err(Decline::Credential);
+    }
 
-    remove_credentials_and_fragment(&mut url);
+    url.set_fragment(None);
     let fetch = url.to_string();
     // Percent-encoding and IDNA can grow a URL, so the cap is re-checked on what we emit.
     if fetch.len() > MAX_URL_LEN {
         return Err(Decline::TooLong);
     }
 
-    remove_volatile_params(&mut url, &host);
+    remove_volatile_params(&mut url);
     let dedup = url.to_string();
 
     Ok(CanonicalUrl {
@@ -361,19 +352,89 @@ pub fn try_canonicalize(raw: &str) -> Result<CanonicalUrl, Decline> {
     })
 }
 
-fn remove_credentials_and_fragment(url: &mut Url) {
-    // The setters fail only on a cannot-be-a-base URL, which the http(s) check already excluded.
-    let _ = url.set_username("");
-    let _ = url.set_password(None);
-    url.set_fragment(None);
+fn has_credential_query(url: &Url) -> Result<bool, Decline> {
+    let Some(raw_query) = url.query() else {
+        return Ok(false);
+    };
+    for raw_pair in raw_query.split('&') {
+        let raw_name = raw_pair.split_once('=').map_or(raw_pair, |(name, _)| name);
+        if !has_valid_percent_encoding(raw_name) {
+            return Err(Decline::InvalidQuery);
+        }
+        let form_name = raw_name.replace('+', " ");
+        percent_decode_str(&form_name)
+            .decode_utf8()
+            .map_err(|_| Decline::InvalidQuery)?;
+    }
+    Ok(url.query_pairs().any(|(name, value)| {
+        CREDENTIAL_PARAMS
+            .iter()
+            .any(|credential| credential.eq_ignore_ascii_case(&name))
+            || (name.eq_ignore_ascii_case("s") && value.chars().count() == 32)
+    }))
+}
+
+fn has_valid_percent_encoding(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit()
+            {
+                return false;
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+    true
+}
+
+fn has_credential_path(url: &Url, host: &str) -> bool {
+    let path = url.path().to_ascii_lowercase();
+    let segments: Vec<&str> = path.split('/').collect();
+    let first_segment_has_bunny_token = segments
+        .get(1)
+        .and_then(|segment| segment.strip_prefix("bcdn_token="))
+        .and_then(|value| value.split('&').next())
+        .is_some_and(|token| !token.is_empty());
+    let has_oracle_token = host.starts_with("objectstorage.")
+        && host.ends_with(".oraclecloud.com")
+        && host.split('.').count() == 4
+        && segments.get(1) == Some(&"p")
+        && segments.get(2).is_some_and(|token| !token.is_empty())
+        && segments.get(3) == Some(&"n");
+    let has_cloudinary_signature = segments.iter().any(|segment| {
+        segment
+            .strip_prefix("s--")
+            .and_then(|value| value.strip_suffix("--"))
+            .is_some_and(|token| !token.is_empty())
+    });
+    let has_supabase_signature = path.contains("/storage/v1/object/sign/")
+        || path.contains("/storage/v1/render/image/sign/");
+    let has_session_token = segments.iter().any(|segment| {
+        segment
+            .split_once(";jsessionid=")
+            .and_then(|(_, value)| value.split(';').next())
+            .is_some_and(|token| !token.is_empty())
+    });
+
+    first_segment_has_bunny_token
+        || has_oracle_token
+        || has_cloudinary_signature
+        || has_supabase_signature
+        || has_session_token
 }
 
 /// Rewrites the query of every URL that has one, whether or not it removed anything.
 ///
 /// Rewriting only when something was removed made the result depend on an unrelated fact. Two
-/// encodings of one query then hashed the same when a signature was present and differently when
-/// it was absent, so one image could hold two refs.
-fn remove_volatile_params(url: &mut Url, host: &str) {
+/// encodings of one query then hashed differently when a cache buster was absent, so one image
+/// could hold two refs.
+fn remove_volatile_params(url: &mut Url) {
     if url.query().is_none() {
         return;
     }
@@ -385,7 +446,7 @@ fn remove_volatile_params(url: &mut Url, host: &str) {
         pairs.iter().map(|(k, _)| k.to_ascii_lowercase()).collect();
     let kept: Vec<&(String, String)> = pairs
         .iter()
-        .filter(|(k, _)| !is_volatile(k, host, &names_on_this_url))
+        .filter(|(k, _)| !is_volatile(k, &names_on_this_url))
         .collect();
 
     if kept.is_empty() {
@@ -403,9 +464,9 @@ fn remove_volatile_params(url: &mut Url, host: &str) {
 mod tests {
     use super::*;
 
-    fn volatile(name: &str, host: &str, others: &[&str]) -> bool {
+    fn volatile(name: &str, others: &[&str]) -> bool {
         let present: HashSet<String> = others.iter().map(|o| o.to_ascii_lowercase()).collect();
-        is_volatile(name, host, &present)
+        is_volatile(name, &present)
     }
     #[test]
     fn canonicalize_rejects_what_we_will_not_fetch() {
@@ -423,22 +484,72 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_normalizes_and_strips_credentials() {
-        let c = canonicalize("HTTPS://User:Pass@Example.COM:443/A.png#frag").unwrap();
+    fn canonicalize_normalizes_and_removes_the_fragment() {
+        let c = canonicalize("HTTPS://Example.COM:443/A.png#frag").unwrap();
         assert_eq!(c.fetch, "https://example.com/A.png");
         assert_eq!(c.host, "example.com");
-        assert!(!c.fetch.contains("User"));
-        assert!(!c.fetch.contains("Pass"));
     }
 
     #[test]
-    fn the_signature_stays_on_the_fetch_url_and_leaves_the_dedup_url() {
-        let signed = "https://cdn.example.com/a.png?w=200&X-Amz-Signature=deadbeef&X-Amz-Date=20260810T000000Z";
-        let c = canonicalize(signed).unwrap();
-        // The fetcher needs the signature, or the request 403s.
-        assert!(c.fetch.contains("X-Amz-Signature=deadbeef"));
-        // The ref must not move when the signature does.
-        assert_eq!(c.dedup, "https://cdn.example.com/a.png?w=200");
+    fn known_query_credentials_are_refused_case_insensitively() {
+        for name in CREDENTIAL_PARAMS {
+            let raw = format!(
+                "https://cdn.example.com/a.png?{}=",
+                name.to_ascii_uppercase()
+            );
+            assert_eq!(try_canonicalize(&raw), Err(Decline::Credential), "{name}");
+        }
+        assert_eq!(
+            try_canonicalize("https://cdn.example.com/a.png?X-Amz-%53ignature=value"),
+            Err(Decline::Credential)
+        );
+        assert_eq!(
+            try_canonicalize("https://cdn.example.com/a.png?safe=1&safe=2&TOKEN="),
+            Err(Decline::Credential)
+        );
+        assert_eq!(
+            try_canonicalize("https://cdn.example.com/a.png?s=0123456789abcdef0123456789abcdef"),
+            Err(Decline::Credential)
+        );
+        assert!(canonicalize("https://cdn.example.com/a.png?s=200").is_some());
+    }
+
+    #[test]
+    fn credential_path_patterns_are_refused_case_insensitively() {
+        for raw in [
+            "https://cdn.example.com/BCDN_TOKEN=value/image.png",
+            "https://objectstorage.region.oraclecloud.com/P/value/N/image.png",
+            "https://cdn.example.com/S--value--/image.png",
+            "https://cdn.example.com/STORAGE/V1/OBJECT/SIGN/value",
+            "https://cdn.example.com/storage/v1/render/image/sign/value",
+            "https://cdn.example.com/images;JSESSIONID=value/a.png",
+        ] {
+            assert_eq!(try_canonicalize(raw), Err(Decline::Credential), "{raw}");
+        }
+    }
+
+    #[test]
+    fn userinfo_and_invalid_query_names_are_refused() {
+        assert_eq!(
+            try_canonicalize("https://user:pass@cdn.example.com/a.png"),
+            Err(Decline::Credential)
+        );
+        assert_eq!(
+            try_canonicalize("https://cdn.example.com/a.png?bad%FF=value"),
+            Err(Decline::InvalidQuery)
+        );
+        assert_eq!(
+            try_canonicalize("https://cdn.example.com/a.png?bad%ZZ=value"),
+            Err(Decline::InvalidQuery)
+        );
+    }
+
+    #[test]
+    fn signing_metadata_without_a_credential_is_preserved() {
+        let raw = "https://cdn.example.com/a.png?X-Amz-Algorithm=v4&X-Amz-Date=20260810T000000Z&X-Amz-Expires=60";
+        let canonical = canonicalize(raw).unwrap();
+        assert!(canonical.fetch.contains("X-Amz-Algorithm=v4"));
+        assert!(canonical.dedup.contains("X-Amz-Algorithm=v4"));
     }
 
     #[test]
@@ -448,13 +559,10 @@ mod tests {
     }
 
     #[test]
-    fn a_generic_word_is_only_volatile_beside_its_vendor_marker() {
-        // `policy=thumb` and `policy=full` are plausible image selectors on an ordinary host.
+    fn a_generic_word_is_not_volatile() {
         let thumb = canonicalize("https://cdn.example.com/a.png?policy=thumb").unwrap();
         let full = canonicalize("https://cdn.example.com/a.png?policy=full").unwrap();
         assert_ne!(thumb.dedup, full.dedup);
-        // Beside CloudFront's signature it is part of the signing set.
-        assert!(volatile("policy", "cdn.example.com", &["signature"]));
     }
 
     #[test]
@@ -472,24 +580,16 @@ mod tests {
             "w", "h", "q", "fm", "dpr", "fit", "auto", "format", "resize", "crop", "quality",
         ] {
             assert!(
-                !volatile(name, "cdn.example.com", &[]),
+                !volatile(name, &[]),
                 "{name} changes the image and must be kept"
             );
         }
     }
 
     #[test]
-    fn a_short_name_is_only_volatile_where_the_vendor_owns_it() {
-        // `s` sizes a Gravatar avatar and signs an imgix URL. Stripping it everywhere made a
-        // 48-pixel avatar and a 200-pixel avatar the same image.
-        assert!(!volatile("s", "www.gravatar.com", &[]));
-        assert!(volatile("s", "images.imgix.net", &[]));
-        // The Azure SAS names are volatile only when the signature of that set is also present.
-        assert!(!volatile("sp", "cdn.example.com", &["w"]));
-        assert!(volatile("sp", "acct.blob.core.windows.net", &["sig", "sv"]));
-        // `expires` is a real cache hint until CloudFront's `signature` appears beside it.
-        assert!(!volatile("expires", "cdn.example.com", &[]));
-        assert!(volatile("expires", "cdn.example.com", &["signature"]));
+    fn meta_cache_fields_are_volatile_only_with_their_marker() {
+        assert!(!volatile("stp", &[]));
+        assert!(volatile("stp", &["_nc_ohc"]));
     }
 
     #[test]
@@ -616,12 +716,10 @@ mod tests {
     }
 
     #[test]
-    fn the_dedup_url_does_not_depend_on_whether_a_signature_rode_along() {
-        // The query used to be re-encoded only when something was stripped, so one image could
-        // hold two refs depending on an unrelated condition.
-        let plain = canonicalize("https://cdn.example.com/a.png?a=1&b=2").unwrap();
-        let signed =
-            canonicalize("https://cdn.example.com/a.png?a=1&b=2&X-Amz-Signature=zz").unwrap();
-        assert_eq!(plain.dedup, signed.dedup);
+    fn query_encoding_is_stable_without_a_cache_buster() {
+        let plain = canonicalize("https://cdn.example.com/a.png?a=hello%20world&b=2").unwrap();
+        let cache_busted =
+            canonicalize("https://cdn.example.com/a.png?a=hello%20world&b=2&cb=zz").unwrap();
+        assert_eq!(plain.dedup, cache_busted.dedup);
     }
 }

--- a/rust/replay-anonymizer/tests/fixtures/image-url-ref.json
+++ b/rust/replay-anonymizer/tests/fixtures/image-url-ref.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "hero",
+        "pseudonymSecret": "test-pseudonym-secret",
+        "canonicalUrl": "https://cdn.example.com/hero.png?w=200",
+        "globalUrlKey": "46debdbcad6c0b245d92ed38ac325eac",
+        "hash": "7WmDiXph-36Tg6OgJyWa8U",
+        "ref": "imageurl:7WmDiXph-36Tg6OgJyWa8U"
+    },
+    {
+        "name": "root",
+        "pseudonymSecret": "0123456789abcdef0123456789abcdef",
+        "canonicalUrl": "https://example.com/",
+        "globalUrlKey": "588b95940ea105e7ecc5f1e9b8ae4f50",
+        "hash": "XSZWrG3WXXBn46zmq_k7RS",
+        "ref": "imageurl:XSZWrG3WXXBn46zmq_k7RS"
+    }
+]

--- a/rust/replay-anonymizer/tests/parity.rs
+++ b/rust/replay-anonymizer/tests/parity.rs
@@ -7,8 +7,13 @@ use std::time::Instant;
 use base64::Engine;
 use posthog_replay_anonymizer::allow_lists::AllowLists;
 use posthog_replay_anonymizer::{
-    anonymize_event_str, anonymize_message, collect::hash_image_bytes, context::Ctx,
-    text::scrub_text, url::scrub_url, url::URL_SCHEME_ALLOWLIST,
+    anonymize_event_str, anonymize_message,
+    collect::{hash_image_bytes, url_ref},
+    context::Ctx,
+    text::scrub_text,
+    url::scrub_url,
+    url::URL_SCHEME_ALLOWLIST,
+    url_collect::hash_url,
 };
 use serde_json::Value;
 
@@ -49,6 +54,27 @@ fn image_hash_fixtures() {
             hash_image_bytes(key.as_bytes(), &bytes),
             case["hash"].as_str().unwrap(),
             "image hash case: {}",
+            case["name"]
+        );
+    }
+}
+
+#[test]
+fn image_url_ref_fixtures() {
+    for case in fixtures("image-url-ref.json") {
+        let global_url_key = case["globalUrlKey"].as_str().unwrap();
+        let canonical_url = case["canonicalUrl"].as_str().unwrap();
+        let hash = hash_url(global_url_key.as_bytes(), canonical_url);
+        assert_eq!(
+            hash,
+            case["hash"].as_str().unwrap(),
+            "case: {}",
+            case["name"]
+        );
+        assert_eq!(
+            url_ref(&hash),
+            case["ref"].as_str().unwrap(),
+            "case: {}",
             case["name"]
         );
     }

--- a/rust/replay-anonymizer/tests/ref_idempotence.rs
+++ b/rust/replay-anonymizer/tests/ref_idempotence.rs
@@ -3,7 +3,7 @@
 //!
 //! The mirror replaces each inlined image with an `image:<pseudo_team>:<hash>` ref and ships the
 //! bytes out of band, so that ref is the only join key back to them. Remote images keep a media
-//! placeholder and carry an `imageurl:<pseudo_team>:<hash>` ref in a namespaced sibling attribute.
+//! placeholder and carry an `imageurl:<hash>` ref in a namespaced sibling attribute.
 //! Scrubbing mirrored output a second time must not destroy either join key.
 //!
 //! The ref format is not a secret, though, so preserving anything `image:`-shaped found in a
@@ -19,7 +19,8 @@ use serde_json::{json, Value};
 
 const TS0: f64 = 1_700_000_000_000.0;
 const REF: &str = "image:0123456789abcdef0123456789abcdef:AAAAAAAAAAAAAAAAAAAAAA";
-const URL_REF: &str = "imageurl:0123456789abcdef0123456789abcdef:AAAAAAAAAAAAAAAAAAAAAA";
+const URL_REF: &str = "imageurl:AAAAAAAAAAAAAAAAAAAAAA";
+const LEGACY_URL_REF: &str = "imageurl:0123456789abcdef0123456789abcdef:AAAAAAAAAAAAAAAAAAAAAA";
 
 fn img_line(value: &str, attr: &str) -> Value {
     json!(["w", { "type": 3, "timestamp": TS0, "data": {
@@ -104,14 +105,16 @@ fn a_ref_survives_a_trusted_rescrub() {
 
 #[test]
 fn a_namespaced_url_ref_survives_only_a_trusted_rescrub() {
-    let line = img_line(URL_REF, "data-anon-image-ref-src");
-    assert!(scrub_trusted(&line).contains(URL_REF));
-    assert!(!scrub_default(&line).contains("data-anon-image-ref-src"));
-    for byte_walk in [true, false] {
-        assert!(
-            !scrub_ingestion(&line, byte_walk).contains("data-anon-image-ref-src"),
-            "a captured internal ref attribute survived ingestion (byte_walk={byte_walk})"
-        );
+    for url_ref in [URL_REF, LEGACY_URL_REF] {
+        let line = img_line(url_ref, "data-anon-image-ref-src");
+        assert!(scrub_trusted(&line).contains(url_ref));
+        assert!(!scrub_default(&line).contains("data-anon-image-ref-src"));
+        for byte_walk in [true, false] {
+            assert!(
+                !scrub_ingestion(&line, byte_walk).contains("data-anon-image-ref-src"),
+                "a captured internal ref attribute survived ingestion (byte_walk={byte_walk})"
+            );
+        }
     }
 }
 

--- a/rust/replay-anonymizer/tests/url_collection.rs
+++ b/rust/replay-anonymizer/tests/url_collection.rs
@@ -11,7 +11,6 @@ use posthog_replay_anonymizer::{
 use serde_json::{json, Value};
 
 const TS0: f64 = 1_700_000_000_000.0;
-const PSEUDO_TEAM: &str = "0123456789abcdef0123456789abcdef";
 const URL_KEY: &str = "0123456789abcdef0123456789abcdef";
 
 fn payload_tagged(tag: &str, attrs: Value) -> Vec<u8> {
@@ -54,7 +53,6 @@ fn collect_urls_of(tag: &str, attrs: Value) -> Vec<String> {
             None,
             None,
             Some(UrlCollection {
-                pseudo_team: PSEUDO_TEAM.to_string(),
                 url_key: URL_KEY.to_string(),
             }),
         )
@@ -85,15 +83,19 @@ fn only_an_image_bearing_tag_has_its_src_collected() {
 }
 
 #[test]
-fn a_video_poster_is_still_collected() {
-    // poster only exists on a video and always names a still image.
-    assert_eq!(
-        collect_urls_of(
+fn attributes_other_than_src_are_not_collected() {
+    for (tag, attrs) in [
+        ("img", json!({ "rr_src": "https://cdn.example.com/a.png" })),
+        (
             "video",
-            json!({ "poster": "https://cdn.example.com/poster.jpg" })
+            json!({ "poster": "https://cdn.example.com/poster.jpg" }),
         ),
-        vec!["byte_walk=true:1", "byte_walk=false:1"]
-    );
+    ] {
+        assert_eq!(
+            collect_urls_of(tag, attrs),
+            vec!["byte_walk=true:0", "byte_walk=false:0"]
+        );
+    }
 }
 
 fn payload(attrs: Value) -> Vec<u8> {
@@ -129,7 +131,6 @@ fn run(attrs: Value, collect: bool) -> Vec<(String, Value)> {
     for byte_walk in [true, false] {
         let mut bytes = payload(attrs.clone());
         let collection = collect.then(|| UrlCollection {
-            pseudo_team: PSEUDO_TEAM.to_string(),
             url_key: URL_KEY.to_string(),
         });
         let msg = anonymize_kafka_payload_collecting(
@@ -176,18 +177,19 @@ fn a_remote_src_keeps_its_placeholder_and_stashes_the_ref() {
         let url_ref = attrs_of(line)["data-anon-image-ref-src"]
             .as_str()
             .expect("the URL ref is stashed");
-        assert!(
-            url_ref.starts_with(&format!("imageurl:{PSEUDO_TEAM}:")),
-            "{engine}: expected a URL ref, got {url_ref}"
-        );
+        assert!(url_ref.starts_with("imageurl:"), "{engine}: got {url_ref}");
 
         let urls = meta["urls"].as_array().expect("meta.urls present");
         assert_eq!(urls.len(), 1, "{engine}");
         assert_eq!(urls[0]["url"], "https://cdn.example.com/hero.png?w=200");
         assert_eq!(urls[0]["host"], "cdn.example.com");
         assert!(
-            url_ref.ends_with(urls[0]["hash"].as_str().expect("hash is a string")),
-            "{engine}: the ref must carry the hash meta reports"
+            url_ref
+                == format!(
+                    "imageurl:{}",
+                    urls[0]["hash"].as_str().expect("hash is a string")
+                ),
+            "{engine}: the ref must equal the hash meta reports"
         );
 
         assert!(
@@ -302,7 +304,6 @@ fn one_url_under_two_signatures_collects_once() {
         None,
         None,
         Some(UrlCollection {
-            pseudo_team: PSEUDO_TEAM.to_string(),
             url_key: URL_KEY.to_string(),
         }),
     )
@@ -316,18 +317,14 @@ fn one_url_under_two_signatures_collects_once() {
 }
 
 #[test]
-fn every_refusal_is_counted_with_a_reason() {
+fn a_refusal_is_counted_with_a_reason() {
     // A silent decline makes the lane look like the traffic carries fewer images than it does,
     // which is exactly the number the measurement phase exists to produce.
     let allow = AllowLists::default();
     let mut bytes = payload_tagged(
         "img",
         json!({
-            // https, so this refusal counts as an address refusal. The scheme check runs first, so
-            // over http it would count as a scheme refusal instead.
-            "src": "https://169.254.169.254/meta.png",
-            "rr_src": "ftp://files.example.com/a.png",
-            "poster": "/relative/a.png"
+            "src": "https://169.254.169.254/meta.png"
         }),
     );
     let msg = anonymize_kafka_payload_collecting(
@@ -337,7 +334,6 @@ fn every_refusal_is_counted_with_a_reason() {
         None,
         None,
         Some(UrlCollection {
-            pseudo_team: PSEUDO_TEAM.to_string(),
             url_key: URL_KEY.to_string(),
         }),
     )
@@ -351,6 +347,4 @@ fn every_refusal_is_counted_with_a_reason() {
         .map(|d| d.reason.as_str())
         .collect();
     assert!(reasons.contains(&"non_public_host"), "{reasons:?}");
-    assert!(reasons.contains(&"bad_scheme"), "{reasons:?}");
-    assert!(reasons.contains(&"not_absolute"), "{reasons:?}");
 }

--- a/rust/replay-anonymizer/tests/url_collection.rs
+++ b/rust/replay-anonymizer/tests/url_collection.rs
@@ -273,47 +273,20 @@ fn srcset_stays_out_of_scope_and_keeps_the_placeholder() {
 }
 
 #[test]
-fn one_url_under_two_signatures_collects_once() {
-    // The whole reason canonicalization splits the dedup URL from the fetch URL.
-    let allow = AllowLists::default();
-    let mut bytes = json!({
-        "distinct_id": "d",
-        "data": json!({
-            "event": "$snapshot_items",
-            "properties": {
-                "$session_id": "s",
-                "$window_id": "w",
-                "$snapshot_items": [
-                    {"type": 3, "timestamp": TS0, "data": {"source": 0, "adds": [
-                        {"parentId": 1, "nextId": null, "node": {"type": 2, "tagName": "img", "id": 1,
-                          "attributes": {"src": "https://cdn.example.com/a.png?X-Amz-Signature=aaa"}, "childNodes": []}},
-                        {"parentId": 1, "nextId": null, "node": {"type": 2, "tagName": "img", "id": 2,
-                          "attributes": {"src": "https://cdn.example.com/a.png?X-Amz-Signature=bbb"}, "childNodes": []}}
-                    ]}}
-                ]
-            }
-        }).to_string()
-    })
-    .to_string()
-    .into_bytes();
-
-    let msg = anonymize_kafka_payload_collecting(
-        &allow,
-        &mut bytes,
-        AnonymizeOpts::default(),
-        None,
-        None,
-        Some(UrlCollection {
-            url_key: URL_KEY.to_string(),
-        }),
-    )
-    .expect("anonymize should succeed");
-
-    assert_eq!(
-        msg.meta.urls.len(),
-        1,
-        "two signatures of one image are one URL to fetch"
-    );
+fn signed_urls_produce_no_ref_or_fetch_candidate() {
+    for (engine, result) in run(
+        json!({ "src": "https://cdn.example.com/a.png?X-Amz-Signature=aaa" }),
+        true,
+    ) {
+        let (line, meta) = (&result[0], &result[1]);
+        assert!(
+            attrs_of(line).get("data-anon-image-ref-src").is_none(),
+            "{engine}: signed URLs must not produce a global ref"
+        );
+        assert!(meta.get("urls").is_none(), "{engine}");
+        assert_eq!(meta["urlDeclines"][0]["reason"], "credential", "{engine}");
+        assert_eq!(meta["urlDeclines"][0]["count"], 1, "{engine}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

ML mirror image fetches cannot use one stable ref for the same source URL across teams.

The mirror emits team-scoped URL refs, but the fetcher specification requires a global URL ref.

## Changes

- Remote `src` images now use `imageurl:<hash>` with a global HMAC key.

Before:

```mermaid
flowchart LR
    A["Image src URL"] --> B["Team URL key"]
    B --> C["imageurl:<team>:<hash>"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phBlue;
    class C phGray;
```

After:

```mermaid
flowchart LR
    A["Image src URL"] --> B["Global URL key"]
    B --> C["imageurl:<hash>"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phBlue;
    class C phGray;
```

- Inline images keep their team-scoped `image:<team>:<hash>` refs.
- URL collection reads only `src`, so `rr_src`, `poster`, and inline content stay outside this path.
- Global refs use the exact ref as their durable crawl-history key.
- Legacy refs remain readable and keep their existing crawl-history keys.
- The record parser validates the transport team pseudonym independently.
- URL production defaults to disabled and requires a consumer-first rollout.
- Shared fixtures keep the TypeScript and Rust formats consistent.
- This change is internal to replay processing.

## How did you test this code?

Local automated checks have no public run link:

- `hogli test --changed` verifies source selection, inline exclusion, legacy reads, parser validation, durable deduplication, and cross-language parity.
- `cargo test --manifest-path=rust/Cargo.toml -p posthog-replay-anonymizer` verifies the full Rust crate.
- `pnpm --filter=@posthog/nodejs typescript:check` verifies the Node.js types.
- `hogli ci:preflight --strict` verifies the branch against current master.
- Not run: manual browser testing, because this change has no browser surface.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The [fetcher specification](https://github.com/PostHog/posthog/pull/86640) defines the global format. This PR updates the implementation notes for the completed mirror work.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Agent:** Codex desktop
- **Tools:** GitHub, Git, hogli, Jest, TypeScript, and Cargo
- **Skills:** /github, /qa-team, /source-command-conventions, /writing-tests, /writing-pr-descriptions, and Simplified Technical English
- The QA review found rollout, durable deduplication, and validation gaps. The fix pass closed each gap, and the follow-up review reported no actionable findings.
