### PR TITLE
fix(dashboards): preserve widget flag evaluation context

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -6,6 +6,7 @@ from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest, snapshot
 from unittest import mock
 from unittest.mock import ANY, MagicMock, call, patch
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 from django.utils.timezone import now
@@ -674,8 +675,11 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             Dashboard.objects.get(id=copied_id).customization, {"show_legend": False, "tile_spacing": "wide"}
         )
 
-    @patch("products.dashboards.backend.feature_flags.posthoganalytics.feature_enabled", return_value=True)
-    def test_dashboard_customization_uses_shared_flag_evaluation(self, mock_feature_enabled: MagicMock) -> None:
+    @patch(
+        "products.dashboards.backend.feature_flags.get_flags_from_service",
+        return_value={"flags": {"dashboard-customization": {"enabled": True}}},
+    )
+    def test_dashboard_customization_uses_remote_flag_evaluation(self, mock_get_flags: MagicMock) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
 
         _, updated = self.dashboard_api.update_dashboard(
@@ -688,18 +692,30 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             {"tile_spacing": "condensed", "layout_compaction": "horizontal"},
         )
         expected_flag_call = call(
-            "dashboard-customization",
+            self.team.api_token,
             self.user.distinct_id,
             groups={"organization": str(self.team.organization_id), "project": str(self.team.id)},
-            group_properties={
-                "organization": {"id": str(self.team.organization_id)},
-                "project": {"id": str(self.team.id)},
-            },
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
+            flag_keys=["dashboard-customization"],
+            internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
+            evaluation_runtime="all",
         )
-        self.assertGreater(len(mock_feature_enabled.call_args_list), 0)
-        self.assertTrue(all(flag_call == expected_flag_call for flag_call in mock_feature_enabled.call_args_list))
+        self.assertGreater(len(mock_get_flags.call_args_list), 0)
+        self.assertTrue(all(flag_call == expected_flag_call for flag_call in mock_get_flags.call_args_list))
+
+    @patch("products.dashboards.backend.feature_flags.get_flags_from_service", side_effect=ConnectionError)
+    def test_dashboard_customization_fails_closed_when_remote_evaluation_fails(
+        self, _mock_get_flags: MagicMock
+    ) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        _, response = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"grid_spacing": "condensed"},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertEqual(response["attr"], "grid_spacing")
+        self.assertEqual(response["detail"], "Tile density isn't available.")
 
     @parameterized.expand([("horizontal",), ("stable",)])
     @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -6,7 +6,6 @@ from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest, snapshot
 from unittest import mock
 from unittest.mock import ANY, MagicMock, call, patch
 
-from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 from django.utils.timezone import now
@@ -675,11 +674,8 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             Dashboard.objects.get(id=copied_id).customization, {"show_legend": False, "tile_spacing": "wide"}
         )
 
-    @patch(
-        "products.dashboards.backend.feature_flags.get_flags_from_service",
-        return_value={"flags": {"dashboard-customization": {"enabled": True}}},
-    )
-    def test_dashboard_customization_uses_remote_flag_evaluation(self, _mock_get_flags: MagicMock) -> None:
+    @patch("products.dashboards.backend.feature_flags.posthoganalytics.feature_enabled", return_value=True)
+    def test_dashboard_customization_uses_shared_flag_evaluation(self, mock_feature_enabled: MagicMock) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
 
         _, updated = self.dashboard_api.update_dashboard(
@@ -692,33 +688,18 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             {"tile_spacing": "condensed", "layout_compaction": "horizontal"},
         )
         expected_flag_call = call(
-            self.team.api_token,
+            "dashboard-customization",
             self.user.distinct_id,
             groups={"organization": str(self.team.organization_id), "project": str(self.team.id)},
-            flag_keys=["dashboard-customization"],
-            internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
-            evaluation_runtime="all",
+            group_properties={
+                "organization": {"id": str(self.team.organization_id)},
+                "project": {"id": str(self.team.id)},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
         )
-        self.assertGreater(len(_mock_get_flags.call_args_list), 0)
-        self.assertTrue(all(flag_call == expected_flag_call for flag_call in _mock_get_flags.call_args_list))
-
-    @patch(
-        "products.dashboards.backend.feature_flags.get_flags_from_service",
-        side_effect=ConnectionError,
-    )
-    def test_dashboard_customization_fails_closed_when_remote_evaluation_fails(
-        self, _mock_get_flags: MagicMock
-    ) -> None:
-        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
-
-        _, response = self.dashboard_api.update_dashboard(
-            dashboard_id,
-            {"grid_spacing": "condensed"},
-            expected_status=status.HTTP_400_BAD_REQUEST,
-        )
-
-        self.assertEqual(response["attr"], "grid_spacing")
-        self.assertEqual(response["detail"], "Tile density isn't available.")
+        self.assertGreater(len(mock_feature_enabled.call_args_list), 0)
+        self.assertTrue(all(flag_call == expected_flag_call for flag_call in mock_feature_enabled.call_args_list))
 
     @parameterized.expand([("horizontal",), ("stable",)])
     @patch("products.dashboards.backend.api.dashboard.dashboard_customization_enabled", return_value=True)

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.conf import settings
+
 import posthoganalytics
 
+from posthog.api.services.flags_service import get_flags_from_service
 from posthog.permissions import _FORCE_ENABLED_FLAGS
 
 if TYPE_CHECKING:
@@ -15,7 +18,7 @@ DASHBOARD_CUSTOMIZATION_FLAG = "dashboard-customization"
 
 
 def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> bool:
-    """Match in-app flag evaluation: user distinct_id plus project/org groups."""
+    """Match the existing in-app widget flag evaluation."""
     if flag in _FORCE_ENABLED_FLAGS:
         return True
 
@@ -35,9 +38,32 @@ def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> b
     )
 
 
+def _remote_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> bool:
+    """Evaluate flags whose rollout depends on cohort membership."""
+    if flag in _FORCE_ENABLED_FLAGS:
+        return True
+
+    distinct_id = (user.distinct_id or str(user.uuid)) if user is not None else str(team.uuid)
+    organization_id = str(team.organization_id)
+    project_id = str(team.id)
+
+    try:
+        result = get_flags_from_service(
+            team.api_token,
+            distinct_id,
+            groups={"organization": organization_id, "project": project_id},
+            flag_keys=[flag],
+            internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
+            evaluation_runtime="all",
+        )
+    except Exception:
+        return False
+    return bool(result.get("flags", {}).get(flag, {}).get("enabled"))
+
+
 def dashboard_widgets_enabled(*, team: Team, user: User | None = None) -> bool:
     return widget_flag_enabled(DASHBOARD_WIDGETS_FLAG, team=team, user=user)
 
 
 def dashboard_customization_enabled(*, team: Team, user: User | None = None) -> bool:
-    return widget_flag_enabled(DASHBOARD_CUSTOMIZATION_FLAG, team=team, user=user)
+    return _remote_flag_enabled(DASHBOARD_CUSTOMIZATION_FLAG, team=team, user=user)

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from django.conf import settings
+import posthoganalytics
 
-from posthog.api.services.flags_service import get_flags_from_service
 from posthog.permissions import _FORCE_ENABLED_FLAGS
 
 if TYPE_CHECKING:
@@ -24,19 +23,16 @@ def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> b
     organization_id = str(team.organization_id)
     project_id = str(team.id)
 
-    try:
-        # Cohort targeting needs the remote evaluator; process-local definitions do not include membership.
-        result = get_flags_from_service(
-            team.api_token,
+    return bool(
+        posthoganalytics.feature_enabled(
+            flag,
             distinct_id,
             groups={"organization": organization_id, "project": project_id},
-            flag_keys=[flag],
-            internal_request_token=settings.INTERNAL_REQUEST_TOKEN,
-            evaluation_runtime="all",
+            group_properties={"organization": {"id": organization_id}, "project": {"id": project_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
         )
-    except Exception:
-        return False
-    return bool(result.get("flags", {}).get(flag, {}).get("enabled"))
+    )
 
 
 def dashboard_widgets_enabled(*, team: Team, user: User | None = None) -> bool:


### PR DESCRIPTION
## Problem

Dashboard customization flag evaluation changed the shared dashboard flag helper, causing widget saves to use a different evaluation context than the path that had been working.

## Changes

- Restore the existing `posthoganalytics` evaluator for dashboard feature flags.
- Make dashboard customization continue through the same shared path as dashboard widgets.
- Update regression coverage to assert the evaluator arguments.

## Why

Preserving the established widget evaluation context prevents the frontend from showing widget controls while the backend rejects the save.

## How did you test this code?

- `python3 -m compileall` passed for the changed Python files.
- `ruff check --fix` and `ruff format --check` passed.
- The focused Django test could not start because no local PostgreSQL service was available.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change was directed from the Slack thread and committed with PostHog Desktop.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BPULZFS84/p1787350225233569?thread_ts=1787350225.233569&cid=C0BPULZFS84)*