### PR TITLE
fix(warehouse_sources): treat exhausted intercom scroll lock as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
@@ -67,7 +67,17 @@ class IntercomSource(SimpleSource[IntercomSourceConfig], OAuthMixin):
         # then 404s (see `_is_scroll_expired`). `companies` is full-refresh, so a fresh
         # Temporal attempt opens a new scroll and restarts cleanly — transient and
         # self-recovering, not a real bug.
-        return {"Not Found for url: https://api.intercom.io/companies/scroll"}
+        #
+        # Opening a fresh scroll can also 400 with `scroll_exists` when another scroll is
+        # still open for the workspace (see `_is_scroll_exists`). `_open_companies_scroll`
+        # already backs off and retries that inline, but a lock held longer than the retry
+        # budget exhausts it and the raw error propagates — a fresh Temporal attempt opens
+        # cleanly once the stale scroll has expired, so this is the same self-recovering
+        # case as the 404 above, just surfaced later.
+        return {
+            "Not Found for url: https://api.intercom.io/companies/scroll",
+            "Bad Request for url: https://api.intercom.io/companies/scroll",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
@@ -105,6 +105,21 @@ class TestIntercomSource:
         retryable_errors = self.source.get_retryable_errors()
         assert any(key in error_msg for key in retryable_errors)
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "400 Client Error: Bad Request for url: https://api.intercom.io/companies/scroll",
+        ],
+    )
+    def test_companies_scroll_exists_exhaustion_is_retryable(self, error_msg):
+        # Opening a companies scroll retries a `scroll_exists` lock inline (see
+        # `_open_companies_scroll`), but a lock held longer than that budget exhausts it and
+        # the raw error propagates. A fresh Temporal attempt opens cleanly once the stale
+        # scroll expires, so this should stay out of error tracking the same way the 404
+        # scroll-expiry case above does.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in error_msg for key in retryable_errors)
+
     def test_get_schemas_covers_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
 


### PR DESCRIPTION
## Problem

The Intercom `companies` sync surfaces to error tracking as an unhandled crash when opening a fresh companies scroll fails with `HTTPError: 400 Client Error: Bad Request for url: https://api.intercom.io/companies/scroll` — [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a026c5-3cc4-7ee3-9e70-81f446074075).

This happens when another scroll is still open for the workspace. `_open_companies_scroll` already retries that `scroll_exists` lock inline for up to two minutes, but a lock held longer than that budget exhausts the retry and the raw error propagates unclassified.

## Changes

- `IntercomSource.get_retryable_errors()` now also matches this 400, alongside the existing 404 scroll-expiry entry it already covers for the same endpoint.
- `companies` syncs full-refresh, so a fresh Temporal attempt opens a clean scroll once the stale lock expires — the same self-recovering case as the 404, just surfaced later. This only quiets error tracking noise; it does not change retry behavior, which Temporal's activity policy already governs.

## How did you test this code?

Added `test_companies_scroll_exists_exhaustion_is_retryable` to `TestIntercomSource`, alongside the existing 404 case — catches a regression where this message stops being recognized as retryable and starts flooding error tracking again.

Ran locally: full `intercom` test suite (179 passed), `ruff check`/`ruff format`, and `mypy` on the changed files — all clean. Not run: a live sync against Intercom, since this only affects error-tracking classification.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled event with stack trace) to confirm the failure originates in `intercom.py`'s `_open_companies_scroll` path, then read the existing `scroll_exists`/`scroll_expired` handling and tests to establish that this 400 is the same lock-exhaustion case already handled for its 404 sibling. No skills were needed beyond `/writing-tests` and `/writing-pr-descriptions`.