### PR TITLE
feat(replay): show scans that left no result below the player

### DIFF
--- a/products/replay_vision/frontend/components/ObservationsDock.tsx
+++ b/products/replay_vision/frontend/components/ObservationsDock.tsx
@@ -17,7 +17,7 @@ import type { ReplayScannerApi } from '../generated/api.schemas'
 import { observationsDockLogic } from '../logics/observationsDockLogic'
 import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { getReplayVisionEditDisabledReason } from '../utils/accessControl'
-import { isSummaryObservation } from '../utils/observation'
+import { dockObservations, isUnsuccessfulScan } from '../utils/observation'
 import { quotaUx } from '../utils/quotaProjection'
 import { VisionDocsLink, visionDocsUrl } from './DocsLink'
 import { ObservationDockCard } from './ObservationCard'
@@ -191,9 +191,11 @@ function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Elem
     }
     const { desiredSize, isResizeInProgress } = useValues(resizerLogic(resizerProps))
 
-    // Scanner observations live in the sidebar's Observations tab; the dock only surfaces summaries
-    const summaries = observations.filter(isSummaryObservation)
-    const hasContent = summaries.length > 0 || observationsLoading
+    const shown = dockObservations(observations)
+    // Collapsed, the dock is one bar with a caret, so a scan that left no result would sit behind it
+    // unseen. The count says there is something to open for; the card inside says which scan and why.
+    const unsuccessfulCount = shown.filter(isUnsuccessfulScan).length
+    const hasContent = shown.length > 0 || observationsLoading
     const expandedHeight = Math.max(
         MIN_EXPANDED_HEIGHT,
         Math.min(MAX_EXPANDED_HEIGHT, desiredSize ?? DEFAULT_EXPANDED_HEIGHT)
@@ -213,27 +215,33 @@ function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Elem
                 <SummarizeButton sessionId={sessionId} />
                 <SummarizeExplainer />
                 {hasContent && (
-                    <LemonButton
-                        className="ml-auto"
-                        size="small"
-                        icon={<IconChevronDown className={dockOpen ? 'rotate-180' : ''} />}
-                        onClick={() => setDockOpen(!dockOpen)}
-                        tooltip={dockOpen ? 'Collapse' : 'Expand'}
-                        aria-label={dockOpen ? 'Collapse summary' : 'Expand summary'}
-                        data-attr="vision-dock-toggle"
-                        // This click also sets the auto-expand preference, so which way it went is the
-                        // signal for whether people keep summaries open by default.
-                        data-ph-capture-attribute-dock-action={dockOpen ? 'collapse' : 'expand'}
-                    />
+                    <div className="ml-auto flex items-center gap-2 min-w-0">
+                        {!dockOpen && unsuccessfulCount > 0 && (
+                            <span className="text-muted text-xs truncate" data-attr="vision-dock-no-result-count">
+                                No result from {unsuccessfulCount} {unsuccessfulCount === 1 ? 'scan' : 'scans'}
+                            </span>
+                        )}
+                        <LemonButton
+                            size="small"
+                            icon={<IconChevronDown className={dockOpen ? 'rotate-180' : ''} />}
+                            onClick={() => setDockOpen(!dockOpen)}
+                            tooltip={dockOpen ? 'Collapse' : 'Expand'}
+                            aria-label={dockOpen ? 'Collapse summary' : 'Expand summary'}
+                            data-attr="vision-dock-toggle"
+                            // This click also sets the auto-expand preference, so which way it went is
+                            // the signal for whether people keep summaries open by default.
+                            data-ph-capture-attribute-dock-action={dockOpen ? 'collapse' : 'expand'}
+                        />
+                    </div>
                 )}
             </div>
             {dockOpen && (
                 <div className="flex-1 overflow-y-auto px-3 pb-3 space-y-2">
-                    {observationsLoading && summaries.length === 0 ? (
+                    {observationsLoading && shown.length === 0 ? (
                         <div className="flex items-center gap-2 text-muted py-4">
                             <Spinner /> Loading summaries…
                         </div>
-                    ) : summaries.length === 0 ? (
+                    ) : shown.length === 0 ? (
                         <div className="text-muted text-sm py-4">
                             No summary yet. Summarize this recording to generate one.{' '}
                             <VisionDocsLink page="observations" dataAttr="vision-empty-docs-link-dock">
@@ -241,7 +249,7 @@ function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Elem
                             </VisionDocsLink>
                         </div>
                     ) : (
-                        summaries.map((observation) => (
+                        shown.map((observation) => (
                             <ObservationDockCard
                                 key={observation.id}
                                 observation={observation}

--- a/products/replay_vision/frontend/logics/observationsDockLogic.ts
+++ b/products/replay_vision/frontend/logics/observationsDockLogic.ts
@@ -2,6 +2,7 @@ import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path,
 
 import { ApiError } from 'lib/api-error'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import type { ToastButton } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { metricCount } from 'lib/operationalMetrics'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -333,7 +334,13 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                     // is in hand before naming it, and leave a way to re-read when it stays hidden.
                     actions.summarizeFailure()
                     actions.setDockOpen(true)
-                    const tryAgain = { label: 'Try again', action: () => actions.loadObservations() }
+                    // Both retries re-read the same rows, but they follow different failures: a row the
+                    // reload could not see, and a reload that did not complete. Keep them apart.
+                    const tryAgain = (dataAttr: string): ToastButton => ({
+                        label: 'Try again',
+                        action: () => actions.loadObservations(),
+                        dataAttr,
+                    })
                     try {
                         const reloaded = await visionObservationsList(String(teamId), {
                             session_id: props.sessionId,
@@ -347,13 +354,15 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                         } else {
                             lemonToast.warning(
                                 'This recording was already summarized, but the result is not available here.',
-                                { button: tryAgain }
+                                { button: tryAgain('vision-summary-hidden-retry') }
                             )
                         }
                     } catch {
                         metricCount('replay_vision_frontend_observations_load_failures')
                         actions.loadObservationsFailure()
-                        lemonToast.warning("Couldn't load this recording's summary.", { button: tryAgain })
+                        lemonToast.warning("Couldn't load this recording's summary.", {
+                            button: tryAgain('vision-summary-reload-retry'),
+                        })
                     }
                     return
                 }

--- a/products/replay_vision/frontend/utils/observation.test.ts
+++ b/products/replay_vision/frontend/utils/observation.test.ts
@@ -1,5 +1,10 @@
 import type { ReplayObservationApi } from '../generated/api.schemas'
-import { ObservationSeekbarMark, observationClipboardText, observationSeekbarMarks } from './observation'
+import {
+    ObservationSeekbarMark,
+    dockObservations,
+    observationClipboardText,
+    observationSeekbarMarks,
+} from './observation'
 
 const summarizerEntry = { scannerName: 'Session summarizer', headline: null, snippet: 'Rage clicked pay' }
 const longSentence = 'x'.repeat(200)
@@ -148,6 +153,33 @@ describe('observation utils', () => {
             },
         ])('$name', ({ observations, expected }) => {
             expect(observationSeekbarMarks(observations)).toEqual(expected)
+        })
+    })
+
+    describe('dockObservations', () => {
+        const obs = (
+            id: string,
+            scannerType: string,
+            status: ReplayObservationApi['status']
+        ): ReplayObservationApi => ({ ...makeObservation(scannerType, null, status), id })
+
+        // The dock is the only vision surface under the player, and a scan that settled without a
+        // result is exactly what a person needs it for: nothing else there says why none arrived.
+        // Succeeded scanner runs stay in the sidebar, so the dock does not restate what it already has.
+        it.each<[string, ReplayObservationApi[], string[]]>([
+            ['a summary is shown', [obs('s1', 'summarizer', 'succeeded')], ['s1']],
+            ['a failed summary is shown once, not twice', [obs('s1', 'summarizer', 'failed')], ['s1']],
+            ['a failed scanner is shown', [obs('m1', 'monitor', 'failed')], ['m1']],
+            ['an ineligible scanner is shown', [obs('m1', 'monitor', 'ineligible')], ['m1']],
+            ['a succeeded scanner stays in the sidebar', [obs('m1', 'monitor', 'succeeded')], []],
+            ['a running scanner stays in the sidebar', [obs('m1', 'monitor', 'running')], []],
+            [
+                'summaries come before scans that left no result',
+                [obs('m1', 'monitor', 'failed'), obs('s1', 'summarizer', 'succeeded')],
+                ['s1', 'm1'],
+            ],
+        ])('%s', (_, observations, expectedIds) => {
+            expect(dockObservations(observations).map((o) => o.id)).toEqual(expectedIds)
         })
     })
 })

--- a/products/replay_vision/frontend/utils/observation.ts
+++ b/products/replay_vision/frontend/utils/observation.ts
@@ -30,9 +30,30 @@ export function readReasoning(obs: ReplayObservationApi): string | null {
     return typeof raw === 'string' && raw ? raw : null
 }
 
-/** The dock shows summaries only; observations from the team's own scanners live in the sidebar tab. */
+/** Summarizer output, which is the dock's primary content. */
 export function isSummaryObservation(obs: ReplayObservationApi): boolean {
     return obs.scanner_snapshot?.scanner_type === 'summarizer'
+}
+
+/** A scan that settled without a result: the scanner failed, or the recording did not qualify. */
+export function isUnsuccessfulScan(obs: ReplayObservationApi): boolean {
+    return obs.status === 'failed' || obs.status === 'ineligible'
+}
+
+/**
+ * What the dock shows below the player: every summary, plus any other scanner that left no result.
+ *
+ * A succeeded scanner observation stays in the sidebar tab, which is where the team reads its own
+ * scanners. One that failed or was ineligible is different: nothing below the player would otherwise
+ * say why no result arrived, so the run is only discoverable by opening the sidebar and looking.
+ */
+export function dockObservations(observations: ReplayObservationApi[]): ReplayObservationApi[] {
+    // A summarizer that failed is already carried by the first filter, so the second skips summaries
+    // rather than listing them twice.
+    return [
+        ...observations.filter(isSummaryObservation),
+        ...observations.filter((obs) => !isSummaryObservation(obs) && isUnsuccessfulScan(obs)),
+    ]
 }
 
 /** Summarizer output: the one-line headline. */


### PR DESCRIPTION
## Problem

A scanner that failed, or that found the recording ineligible, is only visible in the sidebar's Observations tab. Below the player there is nothing: a person reading the dock sees an empty summary area and no reason for it, and the run is only discoverable by opening the sidebar and looking for it.

## Changes

- The dock lists scans that settled without a result — failed or ineligible — alongside summaries.
- While collapsed, the bar names the count, so a failure is not hidden behind the caret. Expanding names the scanner and why it left nothing.
- Succeeded scanner runs stay in the sidebar, which already lists them. The dock does not restate what another surface owns.
- The "Try again" button on the summary toasts now reports a `data-attr`, and reports a different one per failure, since a row the reload could not see and a reload that did not complete have different causes.
- Mechanical: the selection rule moves into a pure `dockObservations`.

Collapsed, with two scans that left no result:

![Dock collapsed, the bar reading "No result from 2 scans" beside the expand caret](https://raw.githubusercontent.com/PostHog/pr-assets/dfc402e9db162e2ff91c5531df33e96fe6cff7fe/2026/08/711e5fc2-7c3e-48c8-9093-efc6b483bb1a.png)

Expanded, naming each one:

![Dock expanded, showing a failed summarizer with an AI provider unavailable message and a retry button, and an ineligible monitor marked too short](https://raw.githubusercontent.com/PostHog/pr-assets/fe19de3d64c27d45aafc3b32661abc8de20bb0d9/2026/08/697168af-b2c9-4e48-ac03-f2fe3d3302d3.png)

A failure does not auto-expand the dock; only a succeeded summary does. A scan failing on many recordings would otherwise force the panel open on each one, so the count is the affordance instead.

This covers `ineligible` and `failed` only. The `skipped_quota` and `skipped_limit` outcomes never create a row — the scan trigger returns them and nothing is stored — so there is no run to surface for those.

## How did you test this code?

`dockObservations` is a pure function with a case table over the selection rules: a summary shows whatever its status, a failed summary shows once rather than twice, a failed or ineligible scanner shows, and a succeeded or running scanner stays in the sidebar. One case pins the order.

Every rule was checked against a mutated source tree. Reverting to summaries-only, dropping the guard that keeps a failed summary from listing twice, widening the status set to include running, and dropping the status filter altogether each fail only the cases that target them.

The screenshots are the real component rendered in Storybook against mocked observations, with invented scanner names and failure text. Not done: no pass against a live team in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (PostHog Desktop), from a request to surface scans that were skipped or failed. The session driver clarified that "skipped" meant ineligible, which is what the model actually stores.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

This began as the top layer of a stack. #87359 and #87366 have since merged, so it was rebased onto master and now carries only its own two commits.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

