### PR TITLE
feat(warehouse-sources): find connectors by their former names in search

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/twitter/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/twitter/source.py
@@ -26,6 +26,8 @@ class TwitterSource(SimpleSource[TwitterSourceConfig]):
             name=SchemaExternalDataSourceType.TWITTER,
             category=DataWarehouseSourceCategory.COMMUNICATION,
             label="Twitter",
+            # Twitter was rebranded to X; match the terms users now search by.
+            keywords=["x", "x.com"],
             iconPath="/static/services/twitter.png",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk_sell/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk_sell/source.py
@@ -58,6 +58,8 @@ class ZendeskSellSource(ResumableSource[ZendeskSellSourceConfig, ZendeskSellResu
             name=SchemaExternalDataSourceType.ZENDESK_SELL,
             category=DataWarehouseSourceCategory.CRM,
             label="Zendesk Sell",
+            # Zendesk Sell was formerly Base CRM; long-time users still search by the old name.
+            keywords=["base crm", "base"],
             releaseStatus=ReleaseStatus.ALPHA,
             caption="""Enter your Zendesk Sell access token to pull your Sell (formerly Base CRM) data into the PostHog Data warehouse.
 


### PR DESCRIPTION
## Problem

Someone adding a data warehouse source who searches the connector catalog by a product's former name gets no result, because search only matches the current label, name, and keywords. Zendesk Sell and Twitter both changed names, so users who know the old name miss the connector that is actually there.

## Changes

- Searching "Base CRM" (or "Base") now surfaces the Zendesk Sell connector. Zendesk Sell was formerly Base CRM, and the connector's own caption already notes the rename.
- Searching "X" (or "x.com") now surfaces the Twitter connector. Twitter was rebranded to X; the twitter_ads connector already lists "x ads", so this brings the base Twitter connector in line.
- Both changes add search keywords to the source config only. No connection, sync, or schema behavior changes.

The catalog search already indexes a connector's `keywords`, so no other wiring changes.

## How did you test this code?

No automated test covers the catalog keyword list; this change adds entries to the same `keywords` field many connectors already use, indexed by the existing Fuse search over `['label', 'name', 'keywords', 'category']`. Not run: the app was not started to search the catalog by hand.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while reviewing anonymized data-warehouse onboarding session summaries for recurring friction. One theme was users failing to find a connector by an alternate name. A subagent audited the catalog for high-confidence former-name gaps; Zendesk Sell (Base CRM) and Twitter (X) were the two unambiguous rebrands found. Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*