### PR TITLE
fix(data-warehouse): tell users how to recover from a duplicate table name

### DIFF
--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -1286,7 +1286,7 @@ class DataWarehouseSavedQuerySerializer(
         # user-filtered, so also resolve the name team-wide using get_view_or_table_by_name.
         # Otherwise a user with denied table could create another one with colliding name.
         if self.context["database"].has_table(name) or get_view_or_table_by_name(self.context["team_id"], name):
-            raise serializers.ValidationError("A table with this name already exists.")
+            raise serializers.ValidationError("A table or view with this name already exists. Choose a different name.")
 
         return name
 

--- a/products/data_warehouse/backend/presentation/views/table.py
+++ b/products/data_warehouse/backend/presentation/views/table.py
@@ -351,7 +351,9 @@ class TableSerializer(UserAccessControlSerializerMixin, serializers.ModelSeriali
             # it's user-filtered, so also resolve the name team-wide using get_view_or_table_by_name.
             # Otherwise a user with denied table could create another one with colliding name.
             if self.context["database"].has_table(name) or get_view_or_table_by_name(self.context["team_id"], name):
-                raise serializers.ValidationError("A table with this name already exists.")
+                raise serializers.ValidationError(
+                    "A table or view with this name already exists. Choose a different name."
+                )
 
         return name
 
@@ -738,7 +740,8 @@ class TableViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.M
         database = Database.create_for(team_id=self.team_id, user=cast(User, request.user))
         if database.has_table(table_name) or get_view_or_table_by_name(self.team_id, table_name):
             return response.Response(
-                status=status.HTTP_400_BAD_REQUEST, data={"message": "A table with this name already exists."}
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "A table or view with this name already exists. Choose a different name."},
             )
 
         # Confirm the object is actually there before creating a table that would fail every query.

--- a/products/data_warehouse/backend/tests/api/test_saved_query.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query.py
@@ -1880,7 +1880,7 @@ class TestSavedQuery(APIBaseTest):
             },
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "A table with this name already exists."
+        assert response.json()["detail"] == "A table or view with this name already exists. Choose a different name."
 
     def test_update_saved_query_with_managed_viewset_fails(self):
         """Test that updating a saved query with managed viewset fails with correct error message"""

--- a/products/data_warehouse/backend/tests/api/test_table.py
+++ b/products/data_warehouse/backend/tests/api/test_table.py
@@ -688,7 +688,7 @@ class TestTable(APIBaseTest):
             },
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "A table with this name already exists."
+        assert response.json()["detail"] == "A table or view with this name already exists. Choose a different name."
 
     def test_update_table_name_to_existing_name(self):
         table = DataWarehouseTable.objects.create(
@@ -704,7 +704,7 @@ class TestTable(APIBaseTest):
             },
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "A table with this name already exists."
+        assert response.json()["detail"] == "A table or view with this name already exists. Choose a different name."
 
     def test_update_table_name_to_same_name(self):
         table = DataWarehouseTable.objects.create(


### PR DESCRIPTION
## Problem

Someone setting up a warehouse table who picks a name that is already taken sees "A table with this name already exists." and nothing else. In onboarding sessions this reads as a dead end: users delete the whole source and re-upload the file just to set a different name, when picking another name in place would have worked.

## Changes

- The duplicate-name error now says "A table or view with this name already exists. Choose a different name." so the next step is clear.
- The message covers both object kinds, because the collision check matches existing views as well as tables.
- Applied at the three places that raise it: creating a table from an upload, renaming a table, and creating a saved query. Validation behavior is unchanged; only the wording changed.

## How did you test this code?

Updated the three tests that assert this exact string. Not run: the DB-backed API suites, because this sandbox has no Postgres (the tests error with "connection refused" at setup). The change is a string swap with matching assertions, checked by grep to be identical across source and tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while reviewing anonymized data-warehouse onboarding session summaries for recurring friction. A table-naming theme recurred: users hit the duplicate-name error and restarted the whole upload. A subagent confirmed renaming is only a uniqueness check, not a block, so the fix is copy that points to the recovery path rather than a behavior change. Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*