### PR TITLE
fix(persons): restore persons_dedup log output in production

### DIFF
--- a/posthog/management/commands/persons_dedup.py
+++ b/posthog/management/commands/persons_dedup.py
@@ -106,6 +106,7 @@ from __future__ import annotations
 import os
 import json
 import time
+import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime
@@ -123,6 +124,9 @@ from posthog.dataclasses import frozen
 from posthog.persons_db import persons_db_connection, persons_db_url
 
 logger = structlog.get_logger(__name__)
+# The posthoganalytics SDK claims the "posthog" logger name and clamps it to WARNING at
+# client init, so every INFO record this command emits is dropped and a run leaves no log.
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 VICTIMS_TABLE = "pg_temp.persons_dedup_victims"
 

--- a/posthog/management/commands/test/test_persons_dedup.py
+++ b/posthog/management/commands/test/test_persons_dedup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import json
 import uuid as uuid_mod
+import logging
 from contextlib import contextmanager
 from typing import Any
 
@@ -804,6 +805,35 @@ class TestPersonsDedupTargetGuard:
         assert len(target) == 1, "every run must say which database it targets"
         assert target[0]["dbname"]
         assert "password" not in str(target[0]), "the log line must not carry credentials"
+
+
+class TestPersonsDedupLogVisibility:
+    def test_info_records_survive_the_posthog_logger_clamp(self):
+        # posthoganalytics calls logging.getLogger("posthog").setLevel(WARNING) at client init,
+        # which happens during django.setup(). Without an explicit level on this module's logger
+        # every INFO record is dropped, and three production runs of this command left no record
+        # of what they did. structlog's capture_logs() replaces the processor chain, so it cannot
+        # see this -- the assertion has to go through a real stdlib handler.
+        parent = logging.getLogger("posthog")
+        module_logger = logging.getLogger(persons_dedup_command.__name__)
+        captured: list[logging.LogRecord] = []
+
+        class _Collector(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        handler = _Collector()
+        original_level = parent.level
+        parent.setLevel(logging.WARNING)
+        module_logger.addHandler(handler)
+        try:
+            persons_dedup_command.logger.info("persons_dedup.log_visibility_probe", team_id=1)
+        finally:
+            module_logger.removeHandler(handler)
+            parent.setLevel(original_level)
+
+        assert captured, "INFO records are dropped, so a production run would leave no log"
+        assert captured[0].levelno == logging.INFO
 
 
 class TestPersonsDedupPrivilegePreflight:


### PR DESCRIPTION
## Problem

An operator running `persons_dedup` against production sees no output from it at all. The command completes, exits 0, and the log it was told to capture contains only Django startup noise. There is no record of which database it targeted, how many duplicate groups it found, how many rows it deleted, or whether a batch hit lock contention.

`posthoganalytics` calls `logging.getLogger("posthog").setLevel(logging.WARNING)` at client init ([client.py:984](https://github.com/PostHog/posthog-python/blob/master/posthoganalytics/client.py)), and that runs during `django.setup()`. Every logger under `posthog.*` inherits it unless it declares its own level, so all 20 of this command's `logger.info` events were dropped on a deployed pod. `DJANGO_LOG_LEVEL=INFO` does not help, because the clamp is applied at runtime after `dictConfig`.

This is not new: the repo already documents the same trap at [`posthog/settings/logs.py:176`](https://github.com/PostHog/posthog/blob/master/posthog/settings/logs.py#L176), where another logger needed an explicit level for exactly this reason. It went unnoticed here because the command had never been run on a production pod before this week.

The dedup's audit trail is the only record of a destructive, one-way repair, so a mute run is the difference between a documented change and an unexplained one.

## Changes

- The operator now gets the command's log back: target database and role, per-step timings, staged and deleted counts, per-batch progress, and contention warnings. One `setLevel` on this module's logger restores all of it.
- The level is set on `__name__`, not on `"posthog"`. A later SDK re-init re-clamps the parent, and a child with its own explicit level is unaffected by that.
- Mechanical: the `logging` import that the line needs.

The fix stays local to this command on purpose. A `loggers` entry in `posthog/settings/logs.py` would have worked too, but it changes handler routing for every process in every deployment, and 36 management commands share this clamp — that is a fleet-wide log-volume decision, not a fix for one command. Worth raising separately that those 36 are silently mute at INFO in production.

## How did you test this code?

Verified against production, on a prod-US toolbox pod, by applying the same two lines to the deployed copy and re-running:

- Before: `--mode classify` exits 0 emitting nothing.
- After: `classify`, `delete-unreferenced` and `repair` all emit their events, through the operator's `tee`-based wrapper and into the log file. Endpoint routing confirmed correct in the restored output — reads to the reader replica, writes to the writer.
- A real `--apply` run on one team then produced the full expected record: `staged`, `checkpoint`, `batch_done`, `done` with the backup path, followed by a clean `verify` and `classify`.

Automated:

- One new test, `TestPersonsDedupLogVisibility`. The regression it catches: someone removes the explicit level and the command goes silent in production again while every existing test still passes. No existing test could catch it, because they all assert through `structlog.testing.capture_logs()`, which replaces the processor chain and never consults stdlib logging levels. This one clamps `logging.getLogger("posthog")` to WARNING and asserts an INFO record still reaches a real stdlib handler.
- Confirmed the test discriminates rather than passing vacuously: with the explicit level the record is captured, without it the record is dropped.
- `hogli ci:preflight --strict`: 0 failures.

Not checked: repo-wide mypy, on the grounds that adding an import and a `setLevel` call is not type-risky. CI runs it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, during a production repair session for the persons `(team_id, uuid)` uniqueness cleanup. The bug surfaced when the operator's first dry runs against prod produced a log file with no command output in it; diagnosis started from the logging config and settled on the SDK clamp after confirming the effective level was `WARNING` on the pod.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two alternatives were considered and rejected, both recorded above: a `posthog/settings/logs.py` entry (too broad), and setting the level on the `"posthog"` logger itself (undone by a later SDK re-init).

The production verification described above was done by patching the deployed pod copy directly, so it is evidence about these exact lines rather than about a rebuilt image. Nothing in this PR carries material from the session that is not already public — the diff is two files and the description names no customer, team, or internal system.
