### PR TITLE
fix(data-imports): stop redis errors masking non-retryable import failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 import pyarrow as pa
 import posthoganalytics
+from redis import exceptions as redis_exceptions
 from structlog.typing import FilteringBoundLogger
 from temporalio import activity
 
@@ -237,10 +238,19 @@ async def handle_non_retryable_error(
             raise NonRetryableException() from error
 
         retry_key = build_non_retryable_errors_redis_key(team_id, source_id, run_id)
-        attempts = await redis_client.incr(retry_key)
+        try:
+            attempts = await redis_client.incr(retry_key)
+            if attempts <= NON_RETRYABLE_ERROR_RETRY_LIMIT:
+                await redis_client.expire(retry_key, 86400)  # Expire after 24 hours
+        except redis_exceptions.RedisError as e:
+            # A successful ping doesn't guarantee later commands still have a Redis to talk to -
+            # treat that the same as a `None` client instead of letting it surface unwrapped and
+            # mask the already-classified `error` behind an ordinary retryable activity failure.
+            capture_exception(e)
+            await logger.adebug(f"Redis became unreachable tracking a non-retryable error. error={error_msg}")
+            raise NonRetryableException() from error
 
         if attempts <= NON_RETRYABLE_ERROR_RETRY_LIMIT:
-            await redis_client.expire(retry_key, 86400)  # Expire after 24 hours
             await logger.adebug(
                 f"Non-retryable error attempt {attempts}/{NON_RETRYABLE_ERROR_RETRY_LIMIT}, retrying. error={error_msg}"
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
+from redis import exceptions as redis_exceptions
 
 from posthog.temporal.common.errors import NonReportableError
 
@@ -742,3 +743,30 @@ class TestHandleNonRetryableError:
 
         assert isinstance(exc_info.value, NonReportableError)
         assert exc_info.value.__cause__ is original_error
+
+    def test_redis_error_after_successful_ping_fails_fast(self):
+        # A successful ping doesn't guarantee `.incr()` still reaches Redis - if it raises, this
+        # must take the same fast-fail path as a `None` client instead of surfacing unwrapped and
+        # masking the already-classified `error` behind an ordinary retryable activity failure.
+        original_error = ValueError("Ad account owner has NOT granted ads_read permission")
+        redis_client = MagicMock(
+            incr=AsyncMock(side_effect=redis_exceptions.ConnectionError("Connect call failed")),
+            expire=AsyncMock(),
+        )
+
+        @asynccontextmanager
+        async def fake_get_redis():
+            yield redis_client
+
+        with (
+            patch(f"{_EXTRACT_MODULE}._get_redis", fake_get_redis),
+            patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture,
+        ):
+            with pytest.raises(NonRetryableException) as exc_info:
+                async_to_sync(handle_non_retryable_error)(
+                    1, "source-1", "run-1", str(original_error), MagicMock(adebug=AsyncMock()), original_error
+                )
+
+        assert isinstance(exc_info.value, NonRetryableException)
+        assert exc_info.value.__cause__ is original_error
+        mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

A data import whose non-retryable error handling reaches for Redis can lose the original error to an unrelated Redis connection failure, so Temporal retries a condition that should have stopped immediately. This surfaced as a [ConnectionError issue](https://us.posthog.com/project/2/error_tracking/01a027db-824e-7830-b31a-b12f275dc594) in error tracking, 28 occurrences across 28 users within about a minute, with a Postgres source's SSL-configuration error as the underlying cause.

`_get_redis()` already resets its client to `None` when the initial ping fails ([#84210](https://github.com/PostHog/posthog/pull/84210)), but `handle_non_retryable_error` still calls `.incr()`/`.expire()` on the client afterward with no guard. A Redis blip between the ping and those calls reproduces the same masking bug that PR fixed.

## Changes

- `handle_non_retryable_error` wraps its `.incr()`/`.expire()` calls in a `try`/`except redis.exceptions.RedisError`.
- A Redis error there now takes the same fast-fail path as a `None` client: capture the exception and raise `NonRetryableException` from the original error, instead of letting the raw connection error propagate and hide it.

## How did you test this code?

- Added `test_redis_error_after_successful_ping_fails_fast`, which fails without the fix (the raw `ConnectionError` propagates uncaught) and passes with it.
- Ran `ruff check --fix`, `ruff format`, and `uv run mypy --cache-fine-grained .` on the full repo — clean.
- Not run: the DB-backed tests elsewhere in the same file (heartbeat/reset/corrupted-log suites) — they need a live Postgres this sandbox doesn't provide, and are unaffected by this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline reliability fix, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error tracking issue via Claude Code. Skills invoked: `investigating-error-issue`, `writing-tests`, `writing-pr-descriptions`.

The stack trace's outermost exception was a Redis `ConnectionError`, but the chained `__cause__` showed the real, already-classified failure was a Postgres SSL requirement mismatch. Comparing `handle_non_retryable_error` against the fast-fail guard added in #84210 showed that fix only covered the initial ping, not the commands issued after it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
