### PR TITLE
feat(session-replay): support fetched image transport

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/IMPLEMENTATION_NOTES.md
@@ -22,17 +22,15 @@ Resolve the URL ref before rendering and tokenization. Use the sibling attribute
 
 ## Fetcher-to-scrubber record
 
-The mirror currently sends an image to the scrub topic with the ref as the Kafka key and the raw image bytes as the Kafka value. It sends no JSON envelope. The scrubber accepts `image:` refs and rejects `imageurl:` refs.
+The mirror currently sends an image to the scrub topic with the ref as the Kafka key and the raw image bytes as the Kafka value. It sends no JSON envelope. The scrubber accepts the current team-specific `imageurl:` refs but does not accept the global ref format.
 
 The fetcher does not publish images yet. The server enforces dry-run mode.
 
 Publish the fetched response body in the Kafka value and add the headers from section 17. The current fetcher requests `identity` and refuses another content coding. Change it to accept the codings it advertises and pass the encoded response body to Kafka.
 
-Change the scrubber to accept a global `imageurl:` ref. Decode its `content-encoding` with an uncompressed-size limit, then check its bytes against `content-type` before scrubbing it.
+Change the scrubber to accept a global `imageurl:` ref. The scrubber already decodes the current ref's `content-encoding` with an uncompressed-size limit. It checks the result against `content-type` before scrubbing it.
 
 The current scrubber writes every image into a binary shard and writes its location to a time-partitioned Parquet index. Store a URL-backed image at the deterministic object key from requirements 17.11 to 17.13 instead. Keep the shard and index path for inline images.
-
-The current dead-letter sink rebuilds the headers from diagnostic data, and its replay keeps only the replay counter. Change both paths to preserve `content-type` and `content-encoding`.
 
 The image-fetch producer currently uses the default Kafka message limit because its configuration has no `message.max.bytes` setting. Raise the configured response limit to 20 MiB and size the producer and both topics for that limit plus the maximum record overhead.
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/README.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/README.md
@@ -501,7 +501,6 @@ the userinfo of a URL, cookies, and known credential query parameters
 | `image/jpeg`   | JPEG   |
 | `image/gif`    | GIF    |
 | `image/webp`   | WebP   |
-| `image/bmp`    | BMP    |
 | `image/avif`   | AVIF   |
 
 **14.11** This lane does not check that the downloaded bytes match the expected media type. It is expected that the image scrubber will do this.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.test.ts
@@ -78,6 +78,7 @@ describe('HttpImageFetcher', () => {
     it.each([
         ['a type that is not an image', 'text/html', PNG],
         ['a type outside the raster set', 'image/svg+xml', PNG],
+        ['the unsupported BMP format', 'image/bmp', Buffer.from('BM')],
         ['a payload that is not the declared format', 'image/gif', PNG],
         ['a payload of the wrong raster format', 'image/png', GIF],
     ])('refuses %s', async (_name, contentType, bytes) => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/image-fetcher.ts
@@ -3,13 +3,12 @@ import { InvalidRequestError, ResolutionError, SecureRequestError, fetchStreamed
 import { WebBotAuthRequestSigner } from './web-bot-auth'
 
 /**
- * The raster set the anonymizer keeps on a collected ref, so a fetched image and an inline one reach
- * the scrub lane as the same kind of thing.
+ * The raster formats that the fetch lane and image scrubber accept.
  *
  * SVG is absent on purpose. It is a text format that can carry the page's own data, so its redaction
  * belongs on the inline path rather than on an image model.
  */
-const ALLOWED_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/avif'] as const
+const ALLOWED_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/avif'] as const
 
 export type ImageContentType = (typeof ALLOWED_CONTENT_TYPES)[number]
 
@@ -328,8 +327,6 @@ export function magicBytesMatch(bytes: Buffer, contentType: ImageContentType): b
             return asciiAt(bytes, 0, 'GIF87a') || asciiAt(bytes, 0, 'GIF89a')
         case 'image/webp':
             return asciiAt(bytes, 0, 'RIFF') && asciiAt(bytes, 8, 'WEBP')
-        case 'image/bmp':
-            return asciiAt(bytes, 0, 'BM')
         case 'image/avif':
             // An ISO base media file names its brand after the `ftyp` box header, and AVIF still
             // ships under the `mif1` and `msf1` brands that came before the AVIF ones.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/README.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/README.md
@@ -86,14 +86,15 @@ That matters because the consumer's per-request timeout is an inactivity timeout
 
 Given an image, `advancedScrub` (`src/scrub.ts`):
 
-1. **Plan the sizes**: `planScales` (`src/scale-plan.ts`) decides every resize from the source dimensions alone, before a pixel is read — the decoded frame, what each detector sees, and what gets stored.
+1. **Apply the image policy**: reject an image when its XMP `plus:DataMining` value prohibits AI training.
+2. **Plan the sizes**: `planScales` (`src/scale-plan.ts`) decides every resize from the source dimensions alone, before a pixel is read — the decoded frame, what each detector sees, and what gets stored.
    An area budget rather than a long-side cap, so tall pages keep legible native resolution instead of being squashed.
    Faces are detected on a letterboxed (never squashed) 640×640 input; frames beyond 3:1 aspect are tiled along their long axis (overlapping windows) so a face on a tall page stays above the detector's minimum size instead of shrinking past it.
-2. **NSFW/gore gate**: if the image is explicit or gory (NSFL + NSFW probability over `NSFW_THRESHOLD`), it collapses to a 1x1 blank.
-3. **Face redaction**: every detected face (YuNet) is filled with its **mean colour**.
-4. **Text redaction**: every detected text region (DBNet) gets the same fill, with a margin scaled to the box height (= font size).
+3. **NSFW/gore gate**: if the image is explicit or gory (NSFL + NSFW probability over `NSFW_THRESHOLD`), it collapses to a 1x1 blank.
+4. **Face redaction**: every detected face (YuNet) is filled with its **mean colour**.
+5. **Text redaction**: every detected text region (DBNet) gets the same fill, with a margin scaled to the box height (= font size).
    We detect _where_ text is and never read it.
-5. **Code redaction**: every decodable QR/barcode (zxing) gets the same fill — a TOTP provisioning QR or ticket barcode is machine-readable PII that the face/text detectors can't see.
+6. **Code redaction**: every decodable QR/barcode (zxing) gets the same fill — a TOTP provisioning QR or ticket barcode is machine-readable PII that the face/text detectors can't see.
 
 The goal is to protect data labellers and reduce PII exposure.
 It does not need to be perfect; the self-verifying test (below) keeps it honest.
@@ -146,6 +147,8 @@ src/  (production — ships)
   smoke.ts        image-build-time smoke test: models load + one scrub, with networking disabled
   env.ts          validated numeric env knobs — invalid values refuse to start (never fail open)
   metrics.ts      Prometheus registry: HTTP outcomes + scrub outcome signals
+  image-input.ts  accepted image decoders, pixel limits, and embedded metadata policy
+  xmp.ts          PLUS Data Mining metadata parser
 
 dev/  (non-production)
   scrub-eval.ts   OCR + face-redaction eval over downloaded images (npm run eval)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/package.json
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/package.json
@@ -20,7 +20,6 @@
         "smoke": "tsx src/smoke.ts"
     },
     "dependencies": {
-        "bmp-ts": "^1.0.9",
         "express": "^4.21.1",
         "onnxruntime-node": "^1.27.0",
         "prom-client": "^15.1.3",

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/package.json
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/package.json
@@ -20,9 +20,11 @@
         "smoke": "tsx src/smoke.ts"
     },
     "dependencies": {
+        "bmp-ts": "^1.0.9",
         "express": "^4.21.1",
         "onnxruntime-node": "^1.27.0",
         "prom-client": "^15.1.3",
+        "saxes": "^6.0.0",
         "sharp": "^0.35.3",
         "tsx": "^4.19.2",
         "zxing-wasm": "^2.2.0"

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/pnpm-lock.yaml
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      bmp-ts:
+        specifier: ^1.0.9
+        version: 1.0.9
       express:
         specifier: ^4.21.1
         version: 4.22.2
@@ -17,6 +20,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      saxes:
+        specifier: ^6.0.0
+        version: 6.0.0
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@24.13.2)
@@ -1494,6 +1500,9 @@ packages:
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
+  bmp-ts@1.0.9:
+    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
+
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2384,6 +2393,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2641,6 +2654,9 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4159,6 +4175,8 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
+  bmp-ts@1.0.9: {}
+
   body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
@@ -5240,6 +5258,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   semver@6.3.1: {}
 
   semver@7.8.5: {}
@@ -5522,6 +5544,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/pnpm-lock.yaml
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      bmp-ts:
-        specifier: ^1.0.9
-        version: 1.0.9
       express:
         specifier: ^4.21.1
         version: 4.22.2
@@ -1499,9 +1496,6 @@ packages:
 
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
-
-  bmp-ts@1.0.9:
-    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
@@ -4174,8 +4168,6 @@ snapshots:
   bintrees@1.0.2: {}
 
   bmp-js@0.1.0: {}
-
-  bmp-ts@1.0.9: {}
 
   body-parser@1.20.5:
     dependencies:

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.test.ts
@@ -44,6 +44,13 @@ describe('blur', () => {
         await expect(blurOnly(malicious)).rejects.toBeInstanceOf(UndecodableImageError)
     })
 
+    it.each([1, 2, 0xffff_ffff])('rejects BMP compression mode %s', async (compression) => {
+        const compressed = Buffer.from(bmpSwatch())
+        compressed.writeUInt32LE(compression, 30)
+
+        await expect(blurOnly(compressed)).rejects.toBeInstanceOf(UndecodableImageError)
+    })
+
     it('rejects TIFF input because it is not an accepted fetcher format', async () => {
         const bytes = await swatch().tiff().toBuffer()
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.test.ts
@@ -1,35 +1,52 @@
+import { encode as encodeBmp } from 'bmp-ts'
 import sharp, { type FormatEnum, type Sharp } from 'sharp'
 
 import { UndecodableImageError, blurOnly } from './blur.ts'
 
 describe('blur', () => {
     const swatch = (): Sharp => sharp({ create: { width: 8, height: 8, channels: 3, background: '#0af' } })
+    const bmpSwatch = (): Buffer =>
+        encodeBmp({
+            width: 8,
+            height: 8,
+            bitPP: 24,
+            data: Buffer.from(Array.from({ length: 8 * 8 }, () => [0, 255, 0, 0]).flat()),
+        }).data
 
     // A capture can name a data URI `image/png` and put any bytes after the comma, and libvips
     // dispatches on magic bytes rather than that name, so the loader set is what actually bounds
-    // which decoders user content can reach. TIFF is blocked in blur.ts; GIF is deliberately not,
-    // because pages really do inline GIFs and blocking it would send every one of them to the
-    // dead-letter topic.
+    // which decoders user content can reach. TIFF is blocked; the fetcher formats stay reachable.
     //
-    // The native VIPS format (`VipsForeignLoadVips`, also blocked in blur.ts) has no row here: a
+    // The native VIPS format (`VipsForeignLoadVips`, also blocked in image-input.ts) has no row here: a
     // real `.v`/`.vips` buffer, built with the `vips` CLI, fails to decode with the identical
     // "unsupported image format" error whether or not the block is applied, so there is no buffer
     // that can exercise that branch either way. Blocking it only guards a call path that loads
     // from a file path, which nothing in this sidecar does today.
-    it.each([
-        ['tiff', true],
-        ['gif', false],
-        ['png', false],
-        ['jpeg', false],
-    ])('%s input is rejected: %s', async (format, blocked) => {
+    it.each(['gif', 'png', 'jpeg', 'webp', 'avif'])('decodes %s input', async (format) => {
         const bytes = await swatch()
             .toFormat(format as keyof FormatEnum)
             .toBuffer()
-        const decode = blurOnly(bytes)
-        if (blocked) {
-            await expect(decode).rejects.toBeInstanceOf(UndecodableImageError)
-        } else {
-            await expect(decode).resolves.toBeInstanceOf(Buffer)
-        }
+
+        await expect(blurOnly(bytes)).resolves.toBeInstanceOf(Buffer)
+    })
+
+    it('decodes BMP input through the bounded BMP decoder', async () => {
+        const output = await blurOnly(bmpSwatch())
+        const pixel = await sharp(output).removeAlpha().raw().toBuffer()
+
+        expect([...pixel]).toEqual([0, 0, 255])
+    })
+
+    it('rejects a BMP palette that would allocate beyond the file', async () => {
+        const malicious = Buffer.from(bmpSwatch())
+        malicious.writeUInt32LE(0xffff_ffff, 46)
+
+        await expect(blurOnly(malicious)).rejects.toBeInstanceOf(UndecodableImageError)
+    })
+
+    it('rejects TIFF input because it is not an accepted fetcher format', async () => {
+        const bytes = await swatch().tiff().toBuffer()
+
+        await expect(blurOnly(bytes)).rejects.toBeInstanceOf(UndecodableImageError)
     })
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.test.ts
@@ -1,17 +1,9 @@
-import { encode as encodeBmp } from 'bmp-ts'
 import sharp, { type FormatEnum, type Sharp } from 'sharp'
 
 import { UndecodableImageError, blurOnly } from './blur.ts'
 
 describe('blur', () => {
     const swatch = (): Sharp => sharp({ create: { width: 8, height: 8, channels: 3, background: '#0af' } })
-    const bmpSwatch = (): Buffer =>
-        encodeBmp({
-            width: 8,
-            height: 8,
-            bitPP: 24,
-            data: Buffer.from(Array.from({ length: 8 * 8 }, () => [0, 255, 0, 0]).flat()),
-        }).data
 
     // A capture can name a data URI `image/png` and put any bytes after the comma, and libvips
     // dispatches on magic bytes rather than that name, so the loader set is what actually bounds
@@ -28,27 +20,6 @@ describe('blur', () => {
             .toBuffer()
 
         await expect(blurOnly(bytes)).resolves.toBeInstanceOf(Buffer)
-    })
-
-    it('decodes BMP input through the bounded BMP decoder', async () => {
-        const output = await blurOnly(bmpSwatch())
-        const pixel = await sharp(output).removeAlpha().raw().toBuffer()
-
-        expect([...pixel]).toEqual([0, 0, 255])
-    })
-
-    it('rejects a BMP palette that would allocate beyond the file', async () => {
-        const malicious = Buffer.from(bmpSwatch())
-        malicious.writeUInt32LE(0xffff_ffff, 46)
-
-        await expect(blurOnly(malicious)).rejects.toBeInstanceOf(UndecodableImageError)
-    })
-
-    it.each([1, 2, 0xffff_ffff])('rejects BMP compression mode %s', async (compression) => {
-        const compressed = Buffer.from(bmpSwatch())
-        compressed.writeUInt32LE(compression, 30)
-
-        await expect(blurOnly(compressed)).rejects.toBeInstanceOf(UndecodableImageError)
     })
 
     it('rejects TIFF input because it is not an accepted fetcher format', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.ts
@@ -23,7 +23,7 @@ export async function blurOnly(input: Buffer): Promise<Buffer> {
     try {
         const description = await inspectImage(input)
         const [tw, th] = targetDims(description.width, description.height)
-        return await sharpForImage(input, description).resize(tw, th, { fit: 'fill' }).blur(BLUR_SIGMA).png().toBuffer()
+        return await sharpForImage(input).resize(tw, th, { fit: 'fill' }).blur(BLUR_SIGMA).png().toBuffer()
     } catch (e) {
         throw e instanceof PermanentImageError ? e : new UndecodableImageError(String(e))
     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/blur.ts
@@ -1,34 +1,16 @@
 // These params must stay in sync with rust/replay-anonymizer/src/blur.rs, or the mirror diverges from the inline anonymizer.
-import sharp from 'sharp'
+import { PermanentImageError, UndecodableImageError, inspectImage, sharpForImage } from './image-input.ts'
 
-// One libvips thread per op and no cross-request cache, so N concurrent scrubs cost ~N threads (not N x CPU)
-// and no shared cache: bounds sidecar CPU/RSS under the concurrency ceiling.
-sharp.concurrency(1)
-sharp.cache(false)
-
-// The producer decides an image is collectable from the MIME type written in its data URI, but libvips
-// picks a decoder by sniffing magic bytes, so `data:image/png;base64,<anything>` reaches whichever loader
-// the bytes actually match. Narrow that to the formats a browser can inline: no page emits TIFF or the
-// native VIPS format, so anything arriving as one is already anomalous and belongs on the dead-letter
-// topic rather than in a decoder. Blocked loaders make the whole class of libvips decoder CVEs in these
-// two formats unreachable, independent of the pinned version. GIF is deliberately absent: pages do inline
-// GIFs, and blocking it would dead-letter every one of them.
-sharp.block({ operation: ['VipsForeignLoadTiff', 'VipsForeignLoadVips'] })
+export { LIMIT_INPUT_PIXELS, UndecodableImageError } from './image-input.ts'
 
 const DOWNSAMPLE_RATIO = 0.12
 const BLUR_SIGMA = 2.34
 const MAX_LONG_SIDE = 96
-// Cap decoded pixels: compressed bytes expand many-fold in libvips, so this guards RSS, not input size.
-// Every sharp() decode of raw request bytes (here and in the ML path's src-image.ts) must pass this.
-export const LIMIT_INPUT_PIXELS = 50_000_000
-
 // 1x1 transparent PNG: the output substituted for an image the NSFW/gore gate rejects (see advancedScrub).
 export const BLANK_PNG = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
     'base64'
 )
-
-export class UndecodableImageError extends Error {}
 
 function targetDims(w: number, h: number): [number, number] {
     const scale = Math.min(DOWNSAMPLE_RATIO, MAX_LONG_SIDE / Math.max(w, h))
@@ -39,22 +21,10 @@ export async function blurOnly(input: Buffer): Promise<Buffer> {
     // Any libvips failure — bad header OR a corrupt/truncated body that fails mid-decode — is permanent for
     // these bytes, so map it all to UndecodableImageError (422/skip). A 500 here would poison the partition.
     try {
-        const meta = await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS }).metadata()
-        if (!meta.width || !meta.height) {
-            throw new UndecodableImageError('image has invalid dimensions')
-        }
-        // Reject oversized images from the cheap header read, before the full-resolution decode allocates
-        // ~4 bytes/pixel. (The decode enforces the same cap, but only after starting to allocate.)
-        if (meta.width * meta.height > LIMIT_INPUT_PIXELS) {
-            throw new UndecodableImageError('image exceeds the pixel limit')
-        }
-        const [tw, th] = targetDims(meta.width, meta.height)
-        return await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS })
-            .resize(tw, th, { fit: 'fill' })
-            .blur(BLUR_SIGMA)
-            .png()
-            .toBuffer()
+        const description = await inspectImage(input)
+        const [tw, th] = targetDims(description.width, description.height)
+        return await sharpForImage(input, description).resize(tw, th, { fit: 'fill' }).blur(BLUR_SIGMA).png().toBuffer()
     } catch (e) {
-        throw e instanceof UndecodableImageError ? e : new UndecodableImageError(String(e))
+        throw e instanceof PermanentImageError ? e : new UndecodableImageError(String(e))
     }
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
@@ -30,7 +30,11 @@ parentPort.on('message', async (job) => {
         return
     }
     if (kind === 'undecodable') {
-        parentPort.postMessage({ id: job.id, failure: { message: 'bad bytes', undecodable: true } })
+        parentPort.postMessage({ id: job.id, failure: { message: 'bad bytes', kind: 'undecodable' } })
+        return
+    }
+    if (kind === 'opt-out') {
+        parentPort.postMessage({ id: job.id, failure: { message: 'training prohibited', kind: 'opt-out' } })
         return
     }
     // Reports its own interval so the test can assert overlap directly rather than inferring

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/image-input.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/image-input.ts
@@ -1,4 +1,3 @@
-import { decode as decodeBmp } from 'bmp-ts'
 import sharp, { type Sharp } from 'sharp'
 
 import { imageMetadataProhibitsAiTraining } from './xmp.ts'
@@ -22,51 +21,7 @@ export interface ImageDescription {
     format: string
 }
 
-function isBmp(input: Buffer): boolean {
-    return input.toString('ascii', 0, 2) === 'BM'
-}
-
-function inspectBmp(input: Buffer): ImageDescription {
-    if (input.length < 54) {
-        throw new UndecodableImageError('BMP header is truncated')
-    }
-    const headerSize = input.readUInt32LE(14)
-    if (headerSize < 40) {
-        throw new UndecodableImageError(`unsupported BMP header size ${headerSize}`)
-    }
-    const pixelOffset = input.readUInt32LE(10)
-    if (14 + headerSize > input.length || pixelOffset < 14 + headerSize || pixelOffset > input.length) {
-        throw new UndecodableImageError('BMP has invalid header bounds')
-    }
-    const compression = input.readUInt32LE(30)
-    if (compression !== 0) {
-        throw new UndecodableImageError(`unsupported BMP compression ${compression}`)
-    }
-    const width = input.readInt32LE(18)
-    const signedHeight = input.readInt32LE(22)
-    const height = Math.abs(signedHeight)
-    if (width <= 0 || height === 0) {
-        throw new UndecodableImageError('BMP has invalid dimensions')
-    }
-    if (!Number.isSafeInteger(width * height) || width * height > LIMIT_INPUT_PIXELS) {
-        throw new UndecodableImageError('image exceeds the pixel limit')
-    }
-    const planes = input.readUInt16LE(26)
-    const bitsPerPixel = input.readUInt16LE(28)
-    if (planes !== 1 || ![1, 4, 8, 16, 24, 32].includes(bitsPerPixel)) {
-        throw new UndecodableImageError('BMP has an unsupported pixel layout')
-    }
-    const paletteEntries = input.readUInt32LE(46) || (bitsPerPixel <= 8 ? 2 ** bitsPerPixel : 0)
-    if (paletteEntries > 256 || paletteEntries * 4 > pixelOffset - (14 + headerSize)) {
-        throw new UndecodableImageError('BMP has invalid palette bounds')
-    }
-    return { width, height, format: 'bmp' }
-}
-
 export async function inspectImage(input: Buffer): Promise<ImageDescription> {
-    if (isBmp(input)) {
-        return inspectBmp(input)
-    }
     const metadata = await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS }).metadata()
     if (!metadata.width || !metadata.height) {
         throw new UndecodableImageError('image has invalid dimensions')
@@ -84,25 +39,6 @@ export async function inspectImage(input: Buffer): Promise<ImageDescription> {
     }
 }
 
-export function sharpForImage(input: Buffer, description: ImageDescription): Sharp {
-    if (description.format !== 'bmp') {
-        return sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS })
-    }
-    const decoded = decodeBmp(input, { toRGBA: true })
-    if (
-        decoded.width !== description.width ||
-        decoded.height !== description.height ||
-        decoded.data.length !== description.width * description.height * 4
-    ) {
-        throw new UndecodableImageError('decoded BMP dimensions do not match its header')
-    }
-    if (decoded.bitPP < 32) {
-        // bmp-ts emits zero alpha for BMP depths that have no alpha channel, which would flatten every pixel to white.
-        for (let alphaOffset = 3; alphaOffset < decoded.data.length; alphaOffset += 4) {
-            decoded.data[alphaOffset] = 0xff
-        }
-    }
-    return sharp(decoded.data, {
-        raw: { width: description.width, height: description.height, channels: 4 },
-    })
+export function sharpForImage(input: Buffer): Sharp {
+    return sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS })
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/image-input.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/image-input.ts
@@ -1,0 +1,104 @@
+import { decode as decodeBmp } from 'bmp-ts'
+import sharp, { type Sharp } from 'sharp'
+
+import { imageMetadataProhibitsAiTraining } from './xmp.ts'
+
+// One libvips thread per operation and no shared cache bound CPU and memory to the request concurrency limit.
+sharp.concurrency(1)
+sharp.cache(false)
+// The accepted image types do not need TIFF or native VIPS loaders, so blocking them removes unnecessary decoder paths.
+sharp.block({ operation: ['VipsForeignLoadTiff', 'VipsForeignLoadVips'] })
+
+// Compressed image bytes can expand many times in memory, so every decoder applies this pixel limit before allocation.
+export const LIMIT_INPUT_PIXELS = 50_000_000
+
+export class PermanentImageError extends Error {}
+export class UndecodableImageError extends PermanentImageError {}
+export class ImageOptOutError extends PermanentImageError {}
+
+export interface ImageDescription {
+    width: number
+    height: number
+    format: string
+}
+
+function isBmp(input: Buffer): boolean {
+    return input.toString('ascii', 0, 2) === 'BM'
+}
+
+function inspectBmp(input: Buffer): ImageDescription {
+    if (input.length < 54) {
+        throw new UndecodableImageError('BMP header is truncated')
+    }
+    const headerSize = input.readUInt32LE(14)
+    if (headerSize < 40) {
+        throw new UndecodableImageError(`unsupported BMP header size ${headerSize}`)
+    }
+    const pixelOffset = input.readUInt32LE(10)
+    if (14 + headerSize > input.length || pixelOffset < 14 + headerSize || pixelOffset > input.length) {
+        throw new UndecodableImageError('BMP has invalid header bounds')
+    }
+    const width = input.readInt32LE(18)
+    const signedHeight = input.readInt32LE(22)
+    const height = Math.abs(signedHeight)
+    if (width <= 0 || height === 0) {
+        throw new UndecodableImageError('BMP has invalid dimensions')
+    }
+    if (!Number.isSafeInteger(width * height) || width * height > LIMIT_INPUT_PIXELS) {
+        throw new UndecodableImageError('image exceeds the pixel limit')
+    }
+    const planes = input.readUInt16LE(26)
+    const bitsPerPixel = input.readUInt16LE(28)
+    if (planes !== 1 || ![1, 4, 8, 16, 24, 32].includes(bitsPerPixel)) {
+        throw new UndecodableImageError('BMP has an unsupported pixel layout')
+    }
+    const paletteEntries = input.readUInt32LE(46) || (bitsPerPixel <= 8 ? 2 ** bitsPerPixel : 0)
+    if (paletteEntries > 256 || paletteEntries * 4 > pixelOffset - (14 + headerSize)) {
+        throw new UndecodableImageError('BMP has invalid palette bounds')
+    }
+    return { width, height, format: 'bmp' }
+}
+
+export async function inspectImage(input: Buffer): Promise<ImageDescription> {
+    if (isBmp(input)) {
+        return inspectBmp(input)
+    }
+    const metadata = await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS }).metadata()
+    if (!metadata.width || !metadata.height) {
+        throw new UndecodableImageError('image has invalid dimensions')
+    }
+    if (metadata.width * metadata.height > LIMIT_INPUT_PIXELS) {
+        throw new UndecodableImageError('image exceeds the pixel limit')
+    }
+    if (imageMetadataProhibitsAiTraining(input, metadata.xmp)) {
+        throw new ImageOptOutError('image metadata prohibits AI training')
+    }
+    return {
+        width: metadata.width,
+        height: metadata.height,
+        format: metadata.format === 'heif' ? 'avif' : (metadata.format ?? 'unknown'),
+    }
+}
+
+export function sharpForImage(input: Buffer, description: ImageDescription): Sharp {
+    if (description.format !== 'bmp') {
+        return sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS })
+    }
+    const decoded = decodeBmp(input, { toRGBA: true })
+    if (
+        decoded.width !== description.width ||
+        decoded.height !== description.height ||
+        decoded.data.length !== description.width * description.height * 4
+    ) {
+        throw new UndecodableImageError('decoded BMP dimensions do not match its header')
+    }
+    if (decoded.bitPP < 32) {
+        // bmp-ts emits zero alpha for BMP depths that have no alpha channel, which would flatten every pixel to white.
+        for (let alphaOffset = 3; alphaOffset < decoded.data.length; alphaOffset += 4) {
+            decoded.data[alphaOffset] = 0xff
+        }
+    }
+    return sharp(decoded.data, {
+        raw: { width: description.width, height: description.height, channels: 4 },
+    })
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/image-input.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/image-input.ts
@@ -38,6 +38,10 @@ function inspectBmp(input: Buffer): ImageDescription {
     if (14 + headerSize > input.length || pixelOffset < 14 + headerSize || pixelOffset > input.length) {
         throw new UndecodableImageError('BMP has invalid header bounds')
     }
+    const compression = input.readUInt32LE(30)
+    if (compression !== 0) {
+        throw new UndecodableImageError(`unsupported BMP compression ${compression}`)
+    }
     const width = input.readInt32LE(18)
     const signedHeight = input.readInt32LE(22)
     const height = Math.abs(signedHeight)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/metrics.ts
@@ -19,6 +19,11 @@ const undecodable = new Counter({
     help: 'Inputs sharp could not decode (422) — permanently skipped, never retried',
     registers: [register],
 })
+const optedOut = new Counter({
+    name: 'ml_mirror_image_scrub_opted_out_total',
+    help: 'Images skipped because embedded PLUS metadata prohibits AI training',
+    registers: [register],
+})
 const rejected = new Counter({
     name: 'ml_mirror_image_scrub_rejected_total',
     help: 'Requests shed for concurrency (503)',
@@ -182,6 +187,7 @@ export const ScrubMetrics = {
     incScrubbed: () => scrubbed.inc(),
     incFailed: () => failed.inc(),
     incUndecodable: () => undecodable.inc(),
+    incOptedOut: () => optedOut.inc(),
     incRejected: () => rejected.inc(),
     incTooLarge: () => tooLarge.inc(),
     incAborted: () => aborted.inc(),

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import { UndecodableImageError } from './blur.ts'
+import { ImageOptOutError } from './image-input.ts'
 import { ScrubAbandonedError, type ScrubPool, type ScrubResult, startPool } from './pool.ts'
 
 // cwd-relative rather than import.meta, which jest's CJS transform cannot load (see qr.ts).
@@ -106,6 +107,12 @@ describe('startPool', () => {
         pool = await startPool(1, FAKE_WORKER)
 
         await expect(pool.scrub(Buffer.from('undecodable'))).rejects.toBeInstanceOf(UndecodableImageError)
+    })
+
+    it('rebuilds an ImageOptOutError from the wire', async () => {
+        pool = await startPool(1, FAKE_WORKER)
+
+        await expect(pool.scrub(Buffer.from('opt-out'))).rejects.toBeInstanceOf(ImageOptOutError)
     })
 
     it('drops a queued job whose caller has hung up, without occupying a worker', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
@@ -3,6 +3,7 @@ import { Worker } from 'node:worker_threads'
 
 import { UndecodableImageError } from './blur.ts'
 import { WORKER_HEAP_MB } from './cores.ts'
+import { ImageOptOutError } from './image-input.ts'
 import { ScrubMetrics } from './metrics.ts'
 import { type StageTimings } from './scrub.ts'
 import { type ScrubReply } from './worker-protocol.ts'
@@ -194,9 +195,12 @@ export async function startPool(
                 restartFailures[index] = 0
             }
             if ('failure' in msg) {
-                const error = msg.failure.undecodable
-                    ? new UndecodableImageError(msg.failure.message)
-                    : new Error(msg.failure.message)
+                const error =
+                    msg.failure.kind === 'undecodable'
+                        ? new UndecodableImageError(msg.failure.message)
+                        : msg.failure.kind === 'opt-out'
+                          ? new ImageOptOutError(msg.failure.message)
+                          : new Error(msg.failure.message)
                 pending.reject(error)
             } else {
                 pending.resolve({

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub-worker.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub-worker.ts
@@ -8,6 +8,7 @@
 import { parentPort } from 'node:worker_threads'
 
 import { UndecodableImageError } from './blur.ts'
+import { ImageOptOutError } from './image-input.ts'
 import { advancedScrub, loadModels } from './scrub.ts'
 import { type ScrubJob, type ScrubReply } from './worker-protocol.ts'
 
@@ -41,7 +42,12 @@ port.on('message', (job: ScrubJob) => {
                 id: job.id,
                 failure: {
                     message: error instanceof Error ? error.message : String(error),
-                    undecodable: error instanceof UndecodableImageError,
+                    kind:
+                        error instanceof ImageOptOutError
+                            ? 'opt-out'
+                            : error instanceof UndecodableImageError
+                              ? 'undecodable'
+                              : 'failed',
                 },
             } satisfies ScrubReply)
         })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub.ts
@@ -16,6 +16,7 @@ import { BLANK_PNG, LIMIT_INPUT_PIXELS, UndecodableImageError, blurOnly } from '
 import { type DbnetModel, detectTextDbnet, loadDbnet } from './dbnet.ts'
 import { numFromEnv } from './env.ts'
 import { type Box } from './geometry.ts'
+import { PermanentImageError } from './image-input.ts'
 import { detectCodes } from './qr.ts'
 import { type SafetyModel, classifySafety, loadSafety } from './safety.ts'
 import { type Dims, type ScalePlan, limitsFromEnv, planScales } from './scale-plan.ts'
@@ -146,7 +147,7 @@ export async function advancedScrub(
         plan = planScales(meta, limitsFromEnv())
         src = await decodeSrc(input, plan.frame)
     } catch (e) {
-        throw e instanceof UndecodableImageError ? e : new UndecodableImageError(String(e))
+        throw e instanceof PermanentImageError ? e : new UndecodableImageError(String(e))
     }
     const { W, H } = src
     timings.decodeMs = performance.now() - tDec

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/server.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/server.test.ts
@@ -1,5 +1,6 @@
 import { once } from 'node:events'
 import type { AddressInfo } from 'node:net'
+import sharp from 'sharp'
 
 import { blurOnly } from './blur.ts'
 import { startServer } from './server.ts'
@@ -56,6 +57,25 @@ describe('image-scrub sidecar server', () => {
     it('422s a truncated image (fails mid-decode, not just at the header)', async () => {
         const res = await fetch(`${base}/scrub`, { method: 'POST', body: PNG.subarray(0, 40) })
         expect(res.status).toBe(422)
+    })
+
+    it('422s an image whose PLUS metadata prohibits AI training', async () => {
+        const optedOut = await sharp(PNG)
+            .withXmp(
+                `
+                <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                         xmlns:plus="http://ns.useplus.org/ldf/xmp/1.0/">
+                    <rdf:Description plus:DataMining="http://ns.useplus.org/ldf/vocab/DMI-PROHIBITED-AIMLTRAINING" />
+                </rdf:RDF>
+            `
+            )
+            .png()
+            .toBuffer()
+
+        const res = await fetch(`${base}/scrub`, { method: 'POST', body: optedOut })
+
+        expect(res.status).toBe(422)
+        expect(await res.text()).toBe('image metadata prohibits AI training')
     })
 
     it('serves health + metrics on the metrics listener, not the scrub listener', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/server.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/server.ts
@@ -3,6 +3,7 @@ import express, { type NextFunction, type Request, type Response } from 'express
 import { type Server } from 'node:http'
 
 import { UndecodableImageError } from './blur.ts'
+import { ImageOptOutError } from './image-input.ts'
 import { ScrubMetrics, register } from './metrics.ts'
 import { ScrubAbandonedError } from './pool.ts'
 
@@ -124,6 +125,11 @@ export function startServer(
         if (err instanceof UndecodableImageError) {
             ScrubMetrics.incUndecodable()
             res.status(422).send('undecodable image')
+            return
+        }
+        if (err instanceof ImageOptOutError) {
+            ScrubMetrics.incOptedOut()
+            res.status(422).send('image metadata prohibits AI training')
             return
         }
         ScrubMetrics.incFailed()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/src-image.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/src-image.ts
@@ -35,7 +35,7 @@ export async function decodeSrc(input: Buffer, frame?: Dims): Promise<Src> {
     // flatten, NOT removeAlpha: removeAlpha discards the alpha channel but keeps the RGB underneath,
     // so content hidden under fully transparent pixels (invisible in the replay) would surface in
     // the scrubbed output. Flatten composites over a background, destroying hidden RGB.
-    const { data, info } = await sharpForImage(input, description)
+    const { data, info } = await sharpForImage(input)
         .resize(targetW, targetH, { fit: 'fill' })
         .flatten({ background: '#fff' })
         .raw()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/src-image.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/src-image.ts
@@ -2,7 +2,7 @@
  *  Decoding a multi-megapixel PNG is tens of ms; the pipeline touches the source 4-5 times. */
 import sharp, { type Sharp } from 'sharp'
 
-import { LIMIT_INPUT_PIXELS } from './blur.ts'
+import { inspectImage, sharpForImage } from './image-input.ts'
 import { type Dims, limitsFromEnv, planScales } from './scale-plan.ts'
 
 export interface Src {
@@ -16,11 +16,8 @@ export interface Src {
 
 /** Source dimensions from the header alone, so the plan can be made before any pixel is decoded. */
 export async function probeDims(input: Buffer): Promise<Dims> {
-    const meta = await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS }).metadata()
-    if (!meta.width || !meta.height) {
-        throw new Error('image has invalid dimensions')
-    }
-    return { width: meta.width, height: meta.height }
+    const description = await inspectImage(input)
+    return { width: description.width, height: description.height }
 }
 
 /**
@@ -31,17 +28,14 @@ export async function probeDims(input: Buffer): Promise<Dims> {
  * modules that happen to apply it.
  */
 export async function decodeSrc(input: Buffer, frame?: Dims): Promise<Src> {
-    const meta = await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS }).metadata()
-    if (!meta.width || !meta.height) {
-        throw new Error('image has invalid dimensions')
-    }
-    const target = frame ?? planScales({ width: meta.width, height: meta.height }, limitsFromEnv()).frame
+    const description = await inspectImage(input)
+    const target = frame ?? planScales(description, limitsFromEnv()).frame
     const targetW = target.width
     const targetH = target.height
     // flatten, NOT removeAlpha: removeAlpha discards the alpha channel but keeps the RGB underneath,
     // so content hidden under fully transparent pixels (invisible in the replay) would surface in
     // the scrubbed output. Flatten composites over a background, destroying hidden RGB.
-    const { data, info } = await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS })
+    const { data, info } = await sharpForImage(input, description)
         .resize(targetW, targetH, { fit: 'fill' })
         .flatten({ background: '#fff' })
         .raw()
@@ -50,8 +44,8 @@ export async function decodeSrc(input: Buffer, frame?: Dims): Promise<Src> {
         data,
         W: info.width,
         H: info.height,
-        format: meta.format ?? 'unknown',
-        inputPixels: meta.width * meta.height,
+        format: description.format,
+        inputPixels: description.width * description.height,
     }
 }
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/worker-protocol.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/worker-protocol.ts
@@ -9,4 +9,4 @@ export interface ScrubJob {
 export type ScrubReply =
     | { ready: true }
     | { id: number; out: Uint8Array; timings: StageTimings }
-    | { id: number; failure: { message: string; undecodable: boolean } }
+    | { id: number; failure: { message: string; kind: 'undecodable' | 'opt-out' | 'failed' } }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/xmp.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/xmp.test.ts
@@ -1,0 +1,64 @@
+import { imageMetadataProhibitsAiTraining, xmpProhibitsAiTraining } from './xmp.ts'
+
+const packet = (description: string): Buffer =>
+    Buffer.from(`
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description xmlns:rights="http://ns.useplus.org/ldf/xmp/1.0/" ${description} />
+            </rdf:RDF>
+        </x:xmpmeta>
+    `)
+
+describe('PLUS Data Mining metadata', () => {
+    it.each([
+        'DMI-PROHIBITED',
+        'DMI-PROHIBITED-AIMLTRAINING',
+        'DMI-PROHIBITED-EXCEPTSEARCHENGINEINDEXING',
+        'DMI-PROHIBITED-GENAIMLTRAINING',
+        'DMI-PROHIBITED-SEECONSTRAINT',
+        'DMI-PROHIBITED-SEEEMBEDDEDRIGHTSEXPR',
+        'DMI-PROHIBITED-SEELINKEDRIGHTSEXPR',
+    ])('recognizes %s in an attribute with any valid namespace prefix', (value) => {
+        expect(xmpProhibitsAiTraining(packet(`rights:DataMining="http://ns.useplus.org/ldf/vocab/${value}"`))).toBe(
+            true
+        )
+    })
+
+    it('recognizes the RDF resource form', () => {
+        expect(
+            xmpProhibitsAiTraining(
+                Buffer.from(`
+                    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                             xmlns:plus="http://ns.useplus.org/ldf/xmp/1.0/">
+                        <rdf:Description>
+                            <plus:DataMining rdf:resource="http://ns.useplus.org/ldf/vocab/DMI-PROHIBITED" />
+                        </rdf:Description>
+                    </rdf:RDF>
+                `)
+            )
+        ).toBe(true)
+    })
+
+    it('does not reject an allowed value or the same property name in another namespace', () => {
+        expect(xmpProhibitsAiTraining(packet('rights:DataMining="http://ns.useplus.org/ldf/vocab/DMI-ALLOWED"'))).toBe(
+            false
+        )
+        expect(
+            xmpProhibitsAiTraining(Buffer.from('<DataMining xmlns="https://example.com/">DMI-PROHIBITED</DataMining>'))
+        ).toBe(false)
+    })
+
+    it('recognizes an XMP packet in a GIF application extension', () => {
+        const xmp = packet('rights:DataMining="http://ns.useplus.org/ldf/vocab/DMI-PROHIBITED"')
+        const trailer = Buffer.from([0x01, ...Array.from({ length: 255 }, (_, index) => 0xff - index), 0x00, 0x00])
+        const gif = Buffer.concat([
+            Buffer.from('GIF89a', 'ascii'),
+            Buffer.from([0x21, 0xff, 0x0b]),
+            Buffer.from('XMP DataXMP', 'ascii'),
+            xmp,
+            trailer,
+        ])
+
+        expect(imageMetadataProhibitsAiTraining(gif, undefined)).toBe(true)
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/xmp.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/xmp.ts
@@ -1,0 +1,103 @@
+import { type SaxesAttributeNS, SaxesParser, type SaxesTagNS } from 'saxes'
+
+const PLUS_NAMESPACE = 'http://ns.useplus.org/ldf/xmp/1.0/'
+const RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+const GIF_XMP_MARKER = Buffer.concat([Buffer.from([0x21, 0xff, 0x0b]), Buffer.from('XMP DataXMP', 'ascii')])
+const GIF_XMP_TRAILER = Buffer.from([0x01, ...Array.from({ length: 255 }, (_, index) => 0xff - index), 0x00, 0x00])
+const PROHIBITED_DATA_MINING_VALUES = new Set([
+    'DMI-PROHIBITED',
+    'DMI-PROHIBITED-AIMLTRAINING',
+    'DMI-PROHIBITED-EXCEPTSEARCHENGINEINDEXING',
+    'DMI-PROHIBITED-GENAIMLTRAINING',
+    'DMI-PROHIBITED-SEECONSTRAINT',
+    'DMI-PROHIBITED-SEEEMBEDDEDRIGHTSEXPR',
+    'DMI-PROHIBITED-SEELINKEDRIGHTSEXPR',
+])
+
+function isProhibitedDataMiningValue(value: string): boolean {
+    const identifier = value.trim().split('/').at(-1)
+    return identifier !== undefined && PROHIBITED_DATA_MINING_VALUES.has(identifier)
+}
+
+function isDataMiningProperty(value: { uri: string; local: string }): boolean {
+    return value.uri === PLUS_NAMESPACE && value.local === 'DataMining'
+}
+
+function resourceValue(tag: SaxesTagNS): string | undefined {
+    return Object.values(tag.attributes).find(
+        (attribute: SaxesAttributeNS) => attribute.uri === RDF_NAMESPACE && attribute.local === 'resource'
+    )?.value
+}
+
+export function xmpProhibitsAiTraining(xmp: Buffer): boolean {
+    const parser = new SaxesParser({ xmlns: true })
+    let prohibited = false
+    let dataMiningDepth = 0
+    let dataMiningText = ''
+
+    parser.on('opentag', (tag) => {
+        for (const attribute of Object.values(tag.attributes)) {
+            if (isDataMiningProperty(attribute) && isProhibitedDataMiningValue(attribute.value)) {
+                prohibited = true
+            }
+        }
+        if (dataMiningDepth > 0) {
+            dataMiningDepth += 1
+            return
+        }
+        if (isDataMiningProperty(tag)) {
+            dataMiningDepth = 1
+            dataMiningText = ''
+            const resource = resourceValue(tag)
+            if (resource && isProhibitedDataMiningValue(resource)) {
+                prohibited = true
+            }
+        }
+    })
+    const collectText = (text: string): void => {
+        if (dataMiningDepth > 0) {
+            dataMiningText += text
+        }
+    }
+    parser.on('text', collectText)
+    parser.on('cdata', collectText)
+    parser.on('closetag', () => {
+        if (dataMiningDepth === 0) {
+            return
+        }
+        dataMiningDepth -= 1
+        if (dataMiningDepth === 0 && isProhibitedDataMiningValue(dataMiningText)) {
+            prohibited = true
+        }
+    })
+    parser.write(xmp.toString('utf8')).close()
+    return prohibited
+}
+
+function gifXmpPackets(input: Buffer): Buffer[] {
+    if (input.toString('ascii', 0, 6) !== 'GIF89a') {
+        return []
+    }
+    const packets: Buffer[] = []
+    let searchFrom = 0
+    for (;;) {
+        const markerOffset = input.indexOf(GIF_XMP_MARKER, searchFrom)
+        if (markerOffset === -1) {
+            return packets
+        }
+        const packetOffset = markerOffset + GIF_XMP_MARKER.length
+        const trailerOffset = input.indexOf(GIF_XMP_TRAILER, packetOffset)
+        if (trailerOffset === -1) {
+            throw new Error('GIF XMP extension has no valid trailer')
+        }
+        packets.push(input.subarray(packetOffset, trailerOffset))
+        searchFrom = trailerOffset + GIF_XMP_TRAILER.length
+    }
+}
+
+export function imageMetadataProhibitsAiTraining(input: Buffer, decodedXmp: Buffer | undefined): boolean {
+    if (decodedXmp && xmpProhibitsAiTraining(decodedXmp)) {
+        return true
+    }
+    return gifXmpPackets(input).some(xmpProhibitsAiTraining)
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dead-letter-sink.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dead-letter-sink.test.ts
@@ -1,0 +1,30 @@
+import { KafkaProducerWrapper } from '~/common/kafka/producer'
+
+import { KafkaDeadLetterSink } from './dead-letter-sink'
+
+describe('KafkaDeadLetterSink', () => {
+    it('keeps transport headers beside the diagnostic headers', async () => {
+        const produced: { headers?: Record<string, string> }[] = []
+        const producer = {
+            produce: (message: { headers?: Record<string, string> }) => {
+                produced.push(message)
+                return Promise.resolve()
+            },
+        } as unknown as KafkaProducerWrapper
+        const sink = new KafkaDeadLetterSink(producer, 'image-scrub-dlq')
+
+        await sink.park({
+            ref: 'imageurl:team:hash',
+            bytes: Buffer.from('compressed'),
+            headers: { 'content-type': 'image/png', 'content-encoding': 'gzip' },
+            detail: { reason: 'rejected', replayCount: 1 },
+        })
+
+        expect(produced[0].headers).toEqual({
+            'content-type': 'image/png',
+            'content-encoding': 'gzip',
+            reason: 'rejected',
+            replayCount: '1',
+        })
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dead-letter-sink.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dead-letter-sink.ts
@@ -19,12 +19,20 @@ export class KafkaDeadLetterSink implements DeadLetterSink {
         private readonly topic: string
     ) {}
 
-    public async park(image: { ref: string; bytes: Buffer; detail: Record<string, unknown> }): Promise<void> {
+    public async park(image: {
+        ref: string
+        bytes: Buffer
+        headers: Record<string, string>
+        detail: Record<string, unknown>
+    }): Promise<void> {
         await this.producer.produce({
             topic: this.topic,
             key: Buffer.from(image.ref),
             value: image.bytes,
-            headers: Object.fromEntries(Object.entries(image.detail).map(([k, v]) => [k, String(v)])),
+            headers: {
+                ...image.headers,
+                ...Object.fromEntries(Object.entries(image.detail).map(([k, v]) => [k, String(v)])),
+            },
         })
     }
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dlq-replay.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dlq-replay.test.ts
@@ -5,7 +5,12 @@ import { KafkaProducerWrapper } from '~/common/kafka/producer'
 import { MAX_REPLAYS, replayBatch } from './dlq-replay'
 import { REPLAY_COUNT_HEADER } from './image-batcher'
 
-function parked(ref: string, bytes: string, replayCount?: number): Message {
+function parked(
+    ref: string,
+    bytes: string,
+    replayCount?: number,
+    transportHeaders: Record<string, string> = {}
+): Message {
     return {
         topic: 'session_replay_image_scrub_dlq',
         partition: 0,
@@ -13,6 +18,7 @@ function parked(ref: string, bytes: string, replayCount?: number): Message {
         key: Buffer.from(ref),
         value: Buffer.from(bytes),
         headers: [
+            ...Object.entries(transportHeaders).map(([key, value]) => ({ [key]: Buffer.from(value) })),
             { reason: Buffer.from('rejected') },
             ...(replayCount === undefined ? [] : [{ [REPLAY_COUNT_HEADER]: Buffer.from(String(replayCount)) }]),
         ],
@@ -48,7 +54,7 @@ describe('replayBatch', () => {
                 key: 'ref-1',
                 value: 'original-image',
                 // The park's diagnostic headers describe an old failure and must not travel with a
-                // fresh attempt; only the count that bounds the round trips survives.
+                // fresh attempt. This inline image has no transport headers, so only the count survives.
                 headers: { [REPLAY_COUNT_HEADER]: '1' },
             },
         ])
@@ -73,5 +79,24 @@ describe('replayBatch', () => {
         await replayBatch([parked('ref-1', 'image', 1)], producer, 'session_replay_image_scrub')
 
         expect(produced[0].headers).toEqual({ [REPLAY_COUNT_HEADER]: '2' })
+    })
+
+    it('preserves the content headers needed to decode a replayed URL image', async () => {
+        await replayBatch(
+            [
+                parked('ref-1', 'compressed-image', undefined, {
+                    'content-type': 'image/png',
+                    'content-encoding': 'gzip',
+                }),
+            ],
+            producer,
+            'session_replay_image_scrub'
+        )
+
+        expect(produced[0].headers).toEqual({
+            'content-type': 'image/png',
+            'content-encoding': 'gzip',
+            [REPLAY_COUNT_HEADER]: '1',
+        })
     })
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dlq-replay.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/dlq-replay.ts
@@ -5,6 +5,7 @@ import { KafkaProducerWrapper } from '~/common/kafka/producer'
 import { logger } from '~/common/utils/logger'
 
 import { REPLAY_COUNT_HEADER } from './image-batcher'
+import { CONTENT_ENCODING_HEADER, CONTENT_TYPE_HEADER } from './image-transport'
 import { ImageScrubConsumerMetrics } from './metrics'
 
 /**
@@ -29,10 +30,9 @@ export interface ReplayOutcome {
  * exercise is to put it through a fixed sidecar exactly as it arrived the first time. The key is the
  * ref, so it lands on the partition the rest of that image's copies hash to.
  *
- * Diagnostic headers from the park are deliberately dropped: they describe the failure that put the
- * image here, and carrying them onto a topic where every other message has none would leave the
- * scrub consumer reading stale reasons on a fresh attempt. Only the replay count survives, because
- * it is what stops an image circling between the two topics.
+ * Diagnostic headers from the park are deliberately dropped because they describe an old failure.
+ * The content headers survive because the consumer needs them to decode and validate fetched images.
+ * The replay count also survives because it stops an image circling between the two topics.
  */
 export async function replayBatch(
     messages: Message[],
@@ -59,7 +59,13 @@ export async function replayBatch(
             topic: sourceTopic,
             key: Buffer.from(ref),
             value: message.value,
-            headers: { [REPLAY_COUNT_HEADER]: String(replayCount + 1) },
+            headers: {
+                ...(headers[CONTENT_TYPE_HEADER] ? { [CONTENT_TYPE_HEADER]: headers[CONTENT_TYPE_HEADER] } : {}),
+                ...(headers[CONTENT_ENCODING_HEADER]
+                    ? { [CONTENT_ENCODING_HEADER]: headers[CONTENT_ENCODING_HEADER] }
+                    : {}),
+                [REPLAY_COUNT_HEADER]: String(replayCount + 1),
+            },
         })
         outcome.replayed += 1
         ImageScrubConsumerMetrics.incReplayed()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -1,6 +1,7 @@
-import { Message, TopicPartitionOffset } from 'node-rdkafka'
+import { Message, MessageHeader, TopicPartitionOffset } from 'node-rdkafka'
+import { gzipSync } from 'node:zlib'
 
-import { hashImageBytes, imageRef } from './content-ref'
+import { hashImageBytes, imageRef, urlRef } from './content-ref'
 import { ImageBatcher, OffsetStore } from './image-batcher'
 import { ImageShardStore, ScrubbedImage } from './image-shard-store'
 import { ScrubClient, ScrubPoisoned } from './scrub-client'
@@ -8,7 +9,14 @@ import { ScrubClient, ScrubPoisoned } from './scrub-client'
 const pt = (n: number): string => String(n).padStart(32, '0')
 const CONTENT_KEY = 'fedcba9876543210fedcba9876543210'
 
-function msg(partition: number, offset: number, pseudoTeam: string, bytes: Buffer, keyOverride?: string): Message {
+function msg(
+    partition: number,
+    offset: number,
+    pseudoTeam: string,
+    bytes: Buffer,
+    keyOverride?: string,
+    headers?: MessageHeader[]
+): Message {
     const ref = keyOverride ?? imageRef(pseudoTeam, hashImageBytes(CONTENT_KEY, bytes))
     return {
         topic: 'session_replay_image_scrub',
@@ -16,6 +24,7 @@ function msg(partition: number, offset: number, pseudoTeam: string, bytes: Buffe
         offset,
         key: Buffer.from(ref),
         value: bytes,
+        headers,
     } as unknown as Message
 }
 
@@ -83,6 +92,63 @@ describe('ImageBatcher', () => {
 
         expect(store.writes).toHaveLength(1)
         expect(store.writes[0][0].hash).toBe(ref.split(':')[2])
+    })
+
+    it('decodes and validates a URL image from its Kafka transport headers before scrubbing it', async () => {
+        const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+        const received: Buffer[] = []
+        const capturingClient = {
+            scrub: (bytes: Buffer) => {
+                received.push(bytes)
+                return Promise.resolve(bytes)
+            },
+        } as unknown as ScrubClient
+        const store = new FakeStore()
+        const batcher = new ImageBatcher(
+            store as unknown as ImageShardStore,
+            new FakeOffsets(),
+            capturingClient,
+            options,
+            0
+        )
+        const ref = urlRef(pt(1), hashImageBytes(CONTENT_KEY, Buffer.from('https://example.com/image.png')))
+
+        await batcher.handleBatch(
+            [
+                msg(0, 0, pt(1), gzipSync(png), ref, [
+                    { 'content-type': Buffer.from('image/png') },
+                    { 'content-encoding': Buffer.from('gzip') },
+                ]),
+            ],
+            1
+        )
+
+        expect(received).toEqual([png])
+        expect(store.writes.flat()).toHaveLength(1)
+    })
+
+    it('drops a URL image whose bytes do not match its Kafka content-type', async () => {
+        let scrubCalls = 0
+        const batcher = new ImageBatcher(
+            new FakeStore() as unknown as ImageShardStore,
+            new FakeOffsets(),
+            {
+                scrub: () => {
+                    scrubCalls += 1
+                    return Promise.resolve(Buffer.from('scrubbed'))
+                },
+            } as unknown as ScrubClient,
+            options,
+            0
+        )
+        const ref = urlRef(pt(1), hashImageBytes(CONTENT_KEY, Buffer.from('https://example.com/image.png')))
+
+        await batcher.handleBatch(
+            [msg(0, 0, pt(1), Buffer.from([0xff, 0xd8, 0xff]), ref, [{ 'content-type': Buffer.from('image/png') }])],
+            1
+        )
+
+        expect(scrubCalls).toBe(0)
     })
 
     it('does not store offsets when the shard write fails (at-least-once replay)', async () => {
@@ -541,6 +607,51 @@ describe('ImageBatcher', () => {
         await batcher.handleBatch([replayed], 1)
 
         expect(parked[0].replayCount).toBe(1)
+    })
+
+    it('preserves URL transport headers when it parks the original compressed bytes', async () => {
+        const parked: { headers: Record<string, string>; bytes: Buffer }[] = []
+        const poisonClient = {
+            scrub: () =>
+                Promise.reject(
+                    new ScrubPoisoned('cannot process', {
+                        reason: 'rejected',
+                        lastError: 'sidecar responded 500',
+                        attempts: 12,
+                        waitedMs: 60_000,
+                    })
+                ),
+        } as unknown as ScrubClient
+        const batcher = new ImageBatcher(
+            new FakeStore() as unknown as ImageShardStore,
+            new FakeOffsets(),
+            poisonClient,
+            options,
+            0,
+            {
+                park: (image) => Promise.resolve(void parked.push({ headers: image.headers, bytes: image.bytes })),
+            }
+        )
+        const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+        const compressed = gzipSync(png)
+        const ref = urlRef(pt(1), hashImageBytes(CONTENT_KEY, Buffer.from('https://example.com/poison.png')))
+
+        await batcher.handleBatch(
+            [
+                msg(0, 0, pt(1), compressed, ref, [
+                    { 'content-type': Buffer.from('image/png') },
+                    { 'content-encoding': Buffer.from('gzip') },
+                ]),
+            ],
+            1
+        )
+
+        expect(parked).toEqual([
+            {
+                bytes: compressed,
+                headers: { 'content-type': 'image/png', 'content-encoding': 'gzip' },
+            },
+        ])
     })
 
     it('refuses to start when concurrency is too low for dead-lettering to be reachable', () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
@@ -7,6 +7,12 @@ import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-de
 
 import { parseImageRef } from './content-ref'
 import { ImageShardStore, ScrubbedImage } from './image-shard-store'
+import {
+    CONTENT_ENCODING_HEADER,
+    CONTENT_TYPE_HEADER,
+    InvalidImageTransportError,
+    prepareFetchedImage,
+} from './image-transport'
 import { ImageScrubConsumerMetrics } from './metrics'
 import { POISON_MIN_OTHER_SUCCESSES, ScrubAborted, ScrubClient, ScrubPoisoned } from './scrub-client'
 
@@ -22,7 +28,12 @@ export interface OffsetStore {
  * the sidecar bug behind it unreproducible. Parking it keeps both properties.
  */
 export interface DeadLetterSink {
-    park(image: { ref: string; bytes: Buffer; detail: Record<string, unknown> }): Promise<void>
+    park(image: {
+        ref: string
+        bytes: Buffer
+        headers: Record<string, string>
+        detail: Record<string, unknown>
+    }): Promise<void>
 }
 
 /**
@@ -56,7 +67,9 @@ interface PlannedScrub {
     ref: string
     pseudoTeam: string
     hash: string
+    source: 'bytes' | 'url'
     value: Buffer
+    transportHeaders: Record<string, string>
     /** Where this image came from, carried only so a parked one can be traced back to its source. */
     sourceTopic: string
     sourcePartition: number
@@ -336,11 +349,7 @@ export class ImageBatcher {
             // The ref's hash is a producer-side per-team HMAC; this consumer doesn't hold the key and
             // trusts the producer (the topic's only writer) that the key names these bytes.
             const parsed = ref ? parseImageRef(ref) : null
-            // A URL ref names a URL, not these bytes. The shard store indexes by (pseudoTeam, hash)
-            // with the prefix dropped, so accepting one here would file URL-sourced bytes in the
-            // same slot as content-addressed ones. That is the silent mis-join the prefix exists
-            // to prevent, so it counts as an invalid key rather than being stored.
-            if (!ref || !parsed || parsed.source !== 'bytes' || !m.value) {
+            if (!ref || !parsed || !m.value) {
                 ImageScrubConsumerMetrics.incInvalidKey()
                 continue
             }
@@ -353,16 +362,27 @@ export class ImageBatcher {
                 ImageScrubConsumerMetrics.incDeduped('pod')
                 continue
             }
+            const headers = parseKafkaHeaders(m.headers)
+            const transportHeaders =
+                parsed.source === 'url'
+                    ? Object.fromEntries(
+                          [CONTENT_TYPE_HEADER, CONTENT_ENCODING_HEADER]
+                              .filter((header) => headers[header] !== undefined)
+                              .map((header) => [header, headers[header]])
+                      )
+                    : {}
             planned.push({
                 index,
                 ref,
                 pseudoTeam: parsed.pseudoTeam,
                 hash: parsed.hash,
+                source: parsed.source,
                 value: m.value,
+                transportHeaders,
                 sourceTopic: m.topic,
                 sourcePartition: m.partition,
                 sourceOffset: m.offset,
-                replayCount: Number(parseKafkaHeaders(m.headers)[REPLAY_COUNT_HEADER] ?? 0) || 0,
+                replayCount: Number(headers[REPLAY_COUNT_HEADER] ?? 0) || 0,
             })
         }
         return planned
@@ -400,9 +420,27 @@ export class ImageBatcher {
     }
 
     private async scrubOne(planned: PlannedScrub, signal: AbortSignal): Promise<ScrubbedImage | null> {
+        let input = planned.value
+        if (planned.source === 'url') {
+            try {
+                input = await prepareFetchedImage(
+                    input,
+                    planned.transportHeaders[CONTENT_TYPE_HEADER],
+                    planned.transportHeaders[CONTENT_ENCODING_HEADER]
+                )
+            } catch (error) {
+                if (!(error instanceof InvalidImageTransportError)) {
+                    throw error
+                }
+                this.seenRefs.add(planned.ref)
+                ImageScrubConsumerMetrics.incSkipped()
+                return null
+            }
+        }
+
         let bytes: Buffer | null
         try {
-            bytes = await this.scrubClient.scrub(planned.value, signal, planned.ref)
+            bytes = await this.scrubClient.scrub(input, signal, planned.ref)
         } catch (error) {
             if (!(error instanceof ScrubPoisoned) || !this.deadLetters) {
                 throw error
@@ -451,6 +489,7 @@ export class ImageBatcher {
                 await this.deadLetters!.park({
                     ref: planned.ref,
                     bytes: planned.value,
+                    headers: planned.transportHeaders,
                     detail: {
                         ...poisoned.detail,
                         pseudoTeam: planned.pseudoTeam,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.test.ts
@@ -1,0 +1,71 @@
+import { brotliCompressSync, deflateSync, gzipSync, zstdCompressSync } from 'node:zlib'
+
+import {
+    InvalidImageTransportError,
+    MAX_UNCOMPRESSED_IMAGE_BYTES,
+    SUPPORTED_IMAGE_MEDIA_TYPES,
+    imageBytesMatchMediaType,
+    prepareFetchedImage,
+} from './image-transport'
+
+const imageHeaders = {
+    'image/png': Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    'image/jpeg': Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+    'image/gif': Buffer.from('GIF89a', 'ascii'),
+    'image/webp': Buffer.from('RIFF\x04\x00\x00\x00WEBP', 'binary'),
+    'image/bmp': Buffer.from('BM', 'ascii'),
+    'image/avif': Buffer.concat([
+        Buffer.from([0x00, 0x00, 0x00, 0x18]),
+        Buffer.from('ftypavif', 'ascii'),
+        Buffer.alloc(4),
+        Buffer.from('avifmif1', 'ascii'),
+    ]),
+} satisfies Record<(typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number], Buffer>
+
+describe('image transport', () => {
+    test.each(SUPPORTED_IMAGE_MEDIA_TYPES)('accepts %s bytes that match the Kafka content-type', (contentType) => {
+        expect(imageBytesMatchMediaType(imageHeaders[contentType], contentType)).toBe(true)
+    })
+
+    test.each([
+        ['gzip', gzipSync],
+        ['deflate', deflateSync],
+        ['br', brotliCompressSync],
+        ['zstd', zstdCompressSync],
+    ] as const)('decodes %s response bytes before validating the image', async (contentEncoding, compress) => {
+        const png = imageHeaders['image/png']
+
+        await expect(prepareFetchedImage(compress(png), 'image/png', contentEncoding)).resolves.toEqual(png)
+    })
+
+    it('decodes stacked content codings in reverse application order', async () => {
+        const png = imageHeaders['image/png']
+        const encoded = brotliCompressSync(gzipSync(png))
+
+        await expect(prepareFetchedImage(encoded, 'image/png', 'gzip, br')).resolves.toEqual(png)
+    })
+
+    it('stops decompression when the decoded bytes cross the 20 MiB cap', async () => {
+        const compressed = gzipSync(Buffer.alloc(MAX_UNCOMPRESSED_IMAGE_BYTES + 1))
+
+        await expect(prepareFetchedImage(compressed, 'image/png', 'gzip')).rejects.toThrow(
+            `decoded image exceeds ${MAX_UNCOMPRESSED_IMAGE_BYTES} bytes`
+        )
+    })
+
+    it.each([
+        ['an unsupported content coding', imageHeaders['image/png'], 'compress'],
+        ['a malformed content coding list', imageHeaders['image/png'], 'gzip,'],
+        ['compressed bytes that are malformed', Buffer.from('not gzip'), 'gzip'],
+    ])('rejects %s', async (_case, bytes, contentEncoding) => {
+        await expect(prepareFetchedImage(bytes, 'image/png', contentEncoding)).rejects.toBeInstanceOf(
+            InvalidImageTransportError
+        )
+    })
+
+    it('rejects bytes that do not match the declared media type', async () => {
+        await expect(prepareFetchedImage(imageHeaders['image/jpeg'], 'image/png', undefined)).rejects.toThrow(
+            'image bytes do not match content-type image/png'
+        )
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.test.ts
@@ -13,7 +13,6 @@ const imageHeaders = {
     'image/jpeg': Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
     'image/gif': Buffer.from('GIF89a', 'ascii'),
     'image/webp': Buffer.from('RIFF\x04\x00\x00\x00WEBP', 'binary'),
-    'image/bmp': Buffer.from('BM', 'ascii'),
     'image/avif': Buffer.concat([
         Buffer.from([0x00, 0x00, 0x00, 0x18]),
         Buffer.from('ftypavif', 'ascii'),

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.test.ts
@@ -45,6 +45,16 @@ describe('image transport', () => {
         await expect(prepareFetchedImage(encoded, 'image/png', 'gzip, br')).resolves.toEqual(png)
     })
 
+    it('rejects more than four content coding layers', async () => {
+        await expect(
+            prepareFetchedImage(
+                imageHeaders['image/png'],
+                'image/png',
+                'identity, identity, identity, identity, identity'
+            )
+        ).rejects.toThrow('content-encoding exceeds 4 codings')
+    })
+
     it('stops decompression when the decoded bytes cross the 20 MiB cap', async () => {
         const compressed = gzipSync(Buffer.alloc(MAX_UNCOMPRESSED_IMAGE_BYTES + 1))
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.ts
@@ -5,6 +5,8 @@ export const MAX_UNCOMPRESSED_IMAGE_BYTES = 20 * 1024 * 1024
 export const CONTENT_TYPE_HEADER = 'content-type'
 export const CONTENT_ENCODING_HEADER = 'content-encoding'
 
+const MAX_CONTENT_ENCODING_LAYERS = 4
+
 export const SUPPORTED_IMAGE_MEDIA_TYPES = [
     'image/png',
     'image/jpeg',
@@ -30,6 +32,9 @@ function parseContentEncodings(contentEncoding: string | undefined): string[] {
         return []
     }
     const encodings = contentEncoding.split(',').map((encoding) => encoding.trim().toLowerCase())
+    if (encodings.length > MAX_CONTENT_ENCODING_LAYERS) {
+        throw new InvalidImageTransportError(`content-encoding exceeds ${MAX_CONTENT_ENCODING_LAYERS} codings`)
+    }
     if (encodings.some((encoding) => encoding.length === 0)) {
         throw new InvalidImageTransportError('content-encoding contains an empty coding')
     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.ts
@@ -1,0 +1,134 @@
+import { Readable, Transform } from 'node:stream'
+import { createBrotliDecompress, createGunzip, createInflate, createZstdDecompress } from 'node:zlib'
+
+export const MAX_UNCOMPRESSED_IMAGE_BYTES = 20 * 1024 * 1024
+export const CONTENT_TYPE_HEADER = 'content-type'
+export const CONTENT_ENCODING_HEADER = 'content-encoding'
+
+export const SUPPORTED_IMAGE_MEDIA_TYPES = [
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'image/bmp',
+    'image/avif',
+] as const
+
+export type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number]
+
+export class InvalidImageTransportError extends Error {}
+
+const decoderFactories: Record<string, () => Transform> = {
+    gzip: createGunzip,
+    deflate: createInflate,
+    br: createBrotliDecompress,
+    zstd: createZstdDecompress,
+}
+
+function parseContentEncodings(contentEncoding: string | undefined): string[] {
+    if (contentEncoding === undefined) {
+        return []
+    }
+    const encodings = contentEncoding.split(',').map((encoding) => encoding.trim().toLowerCase())
+    if (encodings.some((encoding) => encoding.length === 0)) {
+        throw new InvalidImageTransportError('content-encoding contains an empty coding')
+    }
+    return encodings.filter((encoding) => encoding !== 'identity')
+}
+
+async function decodeWithLimit(bytes: Buffer, encoding: string): Promise<Buffer> {
+    const decoderFactory = decoderFactories[encoding]
+    if (!decoderFactory) {
+        throw new InvalidImageTransportError(`unsupported content-encoding: ${encoding}`)
+    }
+
+    const input = Readable.from([bytes])
+    const decoder = decoderFactory()
+    const chunks: Buffer[] = []
+    let outputBytes = 0
+    input.pipe(decoder)
+
+    try {
+        for await (const chunk of decoder) {
+            const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+            if (outputBytes + buffer.length > MAX_UNCOMPRESSED_IMAGE_BYTES) {
+                throw new InvalidImageTransportError(`decoded image exceeds ${MAX_UNCOMPRESSED_IMAGE_BYTES} bytes`)
+            }
+            chunks.push(buffer)
+            outputBytes += buffer.length
+        }
+    } catch (error) {
+        if (error instanceof InvalidImageTransportError) {
+            throw error
+        }
+        throw new InvalidImageTransportError(`invalid ${encoding} content: ${String(error)}`)
+    } finally {
+        input.destroy()
+        decoder.destroy()
+    }
+
+    return Buffer.concat(chunks, outputBytes)
+}
+
+function isAvif(bytes: Buffer): boolean {
+    if (bytes.length < 16 || bytes.toString('ascii', 4, 8) !== 'ftyp') {
+        return false
+    }
+    const boxSize = bytes.readUInt32BE(0)
+    if (boxSize < 16 || boxSize > bytes.length) {
+        return false
+    }
+    for (let offset = 8; offset + 4 <= boxSize; offset += 4) {
+        const brand = bytes.toString('ascii', offset, offset + 4)
+        if (brand === 'avif' || brand === 'avis') {
+            return true
+        }
+    }
+    return false
+}
+
+export function isSupportedImageMediaType(contentType: string): contentType is SupportedImageMediaType {
+    return SUPPORTED_IMAGE_MEDIA_TYPES.includes(contentType as SupportedImageMediaType)
+}
+
+export function imageBytesMatchMediaType(bytes: Buffer, contentType: SupportedImageMediaType): boolean {
+    switch (contentType) {
+        case 'image/png':
+            return bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+        case 'image/jpeg':
+            return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff
+        case 'image/gif': {
+            const signature = bytes.toString('ascii', 0, 6)
+            return signature === 'GIF87a' || signature === 'GIF89a'
+        }
+        case 'image/webp':
+            return bytes.toString('ascii', 0, 4) === 'RIFF' && bytes.toString('ascii', 8, 12) === 'WEBP'
+        case 'image/bmp':
+            return bytes.toString('ascii', 0, 2) === 'BM'
+        case 'image/avif':
+            return isAvif(bytes)
+    }
+}
+
+export async function prepareFetchedImage(
+    bytes: Buffer,
+    contentType: string | undefined,
+    contentEncoding: string | undefined
+): Promise<Buffer> {
+    if (!contentType || !isSupportedImageMediaType(contentType)) {
+        throw new InvalidImageTransportError(`unsupported content-type: ${contentType ?? 'missing'}`)
+    }
+    if (bytes.length > MAX_UNCOMPRESSED_IMAGE_BYTES) {
+        throw new InvalidImageTransportError(`decoded image exceeds ${MAX_UNCOMPRESSED_IMAGE_BYTES} bytes`)
+    }
+
+    let decoded = bytes
+    const encodings = parseContentEncodings(contentEncoding)
+    for (const encoding of encodings.reverse()) {
+        decoded = await decodeWithLimit(decoded, encoding)
+    }
+    if (!imageBytesMatchMediaType(decoded, contentType)) {
+        throw new InvalidImageTransportError(`image bytes do not match content-type ${contentType}`)
+    }
+    return decoded
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-transport.ts
@@ -7,14 +7,7 @@ export const CONTENT_ENCODING_HEADER = 'content-encoding'
 
 const MAX_CONTENT_ENCODING_LAYERS = 4
 
-export const SUPPORTED_IMAGE_MEDIA_TYPES = [
-    'image/png',
-    'image/jpeg',
-    'image/gif',
-    'image/webp',
-    'image/bmp',
-    'image/avif',
-] as const
+export const SUPPORTED_IMAGE_MEDIA_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/avif'] as const
 
 export type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number]
 
@@ -108,8 +101,6 @@ export function imageBytesMatchMediaType(bytes: Buffer, contentType: SupportedIm
         }
         case 'image/webp':
             return bytes.toString('ascii', 0, 4) === 'RIFF' && bytes.toString('ascii', 8, 12) === 'WEBP'
-        case 'image/bmp':
-            return bytes.toString('ascii', 0, 2) === 'BM'
         case 'image/avif':
             return isAvif(bytes)
     }


### PR DESCRIPTION
## Problem

AI Research cannot safely process fetched images that use the formats, compression, or opt-out metadata required by the fetcher specification.

[PR #86640](https://github.com/PostHog/posthog/pull/86640) defines the transport and policy requirements for fetched images.

## Changes

- AI Research can process fetched PNG, JPEG, GIF, WebP, and AVIF images through the scrubber.
- The fetcher specification, fetcher, and scrubber transport refuse BMP input.
- The consumer decodes `identity`, `gzip`, `deflate`, `br`, and `zstd` in reverse application order.
- Streaming decompression stops before output exceeds 20 MiB.
- Content signatures must match the normalized Kafka `content-type`.
- The sidecar drops images whose PLUS XMP metadata prohibits AI training, including metadata in GIF application extensions.
- Dead-letter and replay paths preserve the original compressed bytes and transport headers.
- The remaining changes update metrics, dependencies, tests, and implementation notes.

### Before

```mermaid
flowchart LR
    Kafka["Kafka URL image"] --> Reject["Reject URL ref"] --> Drop["Drop image"]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class Kafka phYellow;
    class Reject,Drop phRed;
```

### After

```mermaid
flowchart LR
    Kafka["Kafka URL image"] --> Decode["Decode content encoding"] --> Type["Check content type"] --> Policy["Check XMP policy"] --> Scrub["Scrub image"] --> Store["Write scrubbed image"]
    Decode --> Drop["Drop invalid image"]
    Type --> Drop
    Policy --> Drop
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Kafka phYellow;
    class Decode,Type,Policy,Scrub phBlue;
    class Drop phRed;
    class Store phGray;
```

This PR has no UI changes.

## How did you test this code?

- Consumer Jest tests cover header decoding, stacked encodings, the size cap, signature mismatches, and dead-letter header preservation.
- Sidecar Jest tests cover the five image formats and every prohibited PLUS Data Mining value.
- Fetcher Jest tests verify that the fetcher refuses BMP input.
- TypeScript checks ran for Node.js and the sidecar.
- Sidecar lint and repository preflight ran locally.
- GitHub cannot verify these local runs. CI remains authoritative.
- End-to-end fetcher publishing remains untested because the fetcher still enforces dry-run mode.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated the fetcher requirements, implementation notes, and sidecar README.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex desktop agent used the local shell and GitHub CLI to implement, test, and publish the change.
- Skills: `/ingestion-pipeline-doctor-nodejs`, `/writing-tests`, `/writing-code-comments`, `/running-ci-preflight`, `/writing-pr-descriptions`, and Simplified Technical English.
- Focused tests cover the transport, format, metadata, and dead-letter paths.
- The public artifact uses only public repository context and invented test data.
