### PR TITLE
chore(ai-research): own ml-mirror ingestion lanes

### DIFF
--- a/nodejs/src/owners.yaml
+++ b/nodejs/src/owners.yaml
@@ -12,6 +12,6 @@ rules:
     - match:
           - '/ingestion/pipelines/sessionreplay/ml-mirror/'
           - '/ingestion/pipelines/sessionreplay/ml-mirror-*/'
-      owners: [ai-research, team-ingestion]
+      owners: ai-research
     - match: '/session-replay/recording-rasterizer/'
       owners: team-replay


### PR DESCRIPTION
## Problem

AI Research shares review responsibility for the `ml-mirror` ingestion lanes with Ingestion, which no longer matches the intended ownership.

## Changes

- AI Research becomes the only owner of the base `ml-mirror` lane and all `ml-mirror-*` lanes.

```diff
-owners: [ai-research, team-ingestion]
+owners: ai-research
```

- This metadata change does not change ingestion behavior.

## How did you test this code?

- Local check: `hogli owners:lint`
- Local check: `hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex desktop used shell and GitHub CLI tools.
- Skills: `/establishing-code-ownership`, `/writing-pr-descriptions`, and Simplified Technical English.
- The change uses the existing wildcard rule for all `ml-mirror` ingestion lanes.
