### PR TITLE
fix(warehouse-sources): give Redshift SSH tunnel failures an actionable error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -40,6 +40,17 @@ if TYPE_CHECKING:
 
 _REDSHIFT_IMPLEMENTATION = RedshiftImplementation()
 
+# sshtunnel raises BaseSSHTunnelForwarderError("Could not establish session to SSH gateway") when it
+# can't open a session to the bastion — the SSH host/port is wrong or unreachable, the bastion is
+# down, or its firewall blocks PostHog's IPs. The raw message tells the user nothing actionable, so
+# replace it with concrete guidance (the sibling SQL sources already do the same).
+_SSH_GATEWAY_SESSION_ERROR = "Could not establish session to SSH gateway"
+_SSH_GATEWAY_UNREACHABLE_MESSAGE = (
+    "Could not connect to your SSH tunnel. Check that the SSH host, port, and credentials are "
+    "correct, the bastion host is running and reachable, and that PostHog's IP addresses are "
+    "allowed through its firewall."
+)
+
 RedshiftErrors = {
     "password authentication failed for user": "Invalid user or password",
     "could not translate host name": "Could not connect to the host",
@@ -217,9 +228,12 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
             capture_exception(e)
             return False, f"Could not connect to {self.source_name}. Please check all connection details are valid."
         except BaseSSHTunnelForwarderError as e:
+            raw = e.value or ""
+            if _SSH_GATEWAY_SESSION_ERROR in raw:
+                return False, _SSH_GATEWAY_UNREACHABLE_MESSAGE
             return (
                 False,
-                e.value
+                raw
                 or f"Could not connect to {self.source_name} via the SSH tunnel. Please check all connection details are valid.",
             )
         except Exception as e:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -7,6 +7,7 @@ import psycopg
 import pyarrow as pa
 from psycopg import sql
 from psycopg.pq import TransactionStatus
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     TemporaryFileSizeExceedsLimitException,
@@ -1277,6 +1278,26 @@ class TestRedshiftValidateCredentials:
         assert ok is False
         assert error is not None and "does not support SSL" in error
         capture.assert_not_called()
+
+    def test_ssh_gateway_session_error_maps_to_actionable_message(self, mocker):
+        # sshtunnel's raw "Could not establish session to SSH gateway" is meaningless to the user;
+        # it must be replaced with concrete guidance rather than surfaced verbatim.
+        config = _make_config()
+        source = RedshiftSource()
+        mocker.patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None))
+        mocker.patch.object(source, "is_database_host_valid", return_value=(True, None))
+        mocker.patch.object(
+            source,
+            "get_schemas",
+            side_effect=BaseSSHTunnelForwarderError("Could not establish session to SSH gateway"),
+        )
+
+        ok, error = source.validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert error is not None
+        assert "Could not establish session to SSH gateway" not in error
+        assert "SSH tunnel" in error and "firewall" in error
 
 
 class TestRedshiftSourceForPipeline:


### PR DESCRIPTION
## Problem

A user setting up a Redshift source over an SSH tunnel saw the raw error "Could not establish session to SSH gateway" in the new-source wizard when PostHog could not open a session to their bastion. The message comes straight from the `sshtunnel` library and tells the user nothing they can act on.

- Redshift's `validate_credentials` caught `BaseSSHTunnelForwarderError` and returned its raw value verbatim.
- Every sibling SQL source (Postgres, MySQL, MSSQL, ClickHouse) already replaces this exact string with actionable guidance. Redshift was the only one that leaked it.

## Changes

- A failed SSH tunnel now surfaces guidance to check the SSH host, port, and credentials, that the bastion is reachable, and that PostHog's IPs are allowed through its firewall.
- The raw sshtunnel string is mapped in the `BaseSSHTunnelForwarderError` handler; other tunnel errors keep the existing fallback message. Mechanical otherwise.

## How did you test this code?

- Added `test_ssh_gateway_session_error_maps_to_actionable_message` to `TestRedshiftValidateCredentials`. It catches a regression that reverts to returning the raw `e.value`, which no existing Redshift test covered (the SSH tunnel validate path was untested).
- Ran the `TestRedshiftValidateCredentials` class locally: both cases pass.
- Not run: the database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this error string.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a report of failed data-warehouse source creations. Redshift was the only SQL source missing the SSH gateway error translation that Postgres, MySQL, MSSQL, and ClickHouse already have. Skills invoked: /writing-tests, /writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
