### PR TITLE
fix(data-warehouse): surface terminal repartition give-ups in error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -165,6 +165,19 @@ class RepartitionSupersededError(Exception):
     """
 
 
+class RepartitionAttemptsExhausted(Exception):
+    """Every one of `MAX_REPARTITION_ATTEMPTS` rewrites was charged but none survived to record an
+    outcome, so the controller gives up and backs the table off to the daily cooldown.
+
+    Each attempt is charged before the rewrite runs and refunded on a clean stand-down (supersession,
+    cancellation, transient infra), so reaching the cap this way means every attempt was hard-killed
+    mid-run — worker OOM, activity timeout, or an eviction that didn't surface as a cancellation —
+    before it could fail cleanly or checkpoint progress. Terminal, and unlike a caught failure it
+    carries no underlying exception, so the give-up path constructs and captures this to keep the most
+    severe repartition outcome visible in error tracking rather than silently abandoned.
+    """
+
+
 @dataclasses.dataclass(frozen=True)
 class RepartitionTarget:
     """The partition scheme to rewrite a table into. `partition_mode=None` means auto-detect."""

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -33,6 +33,7 @@ from products.warehouse_sources.backend.temporal.data_imports import workload_re
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core import repartition_controller as ctrl
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition import (
+    RepartitionAttemptsExhausted,
     RepartitionSupersededError,
     RepartitionUnpartitionableError,
 )
@@ -952,6 +953,46 @@ class TestRepartitionActivity:
             }
         )
         self._run(self._inputs(team, schema), AsyncMock(side_effect=ValueError("boom")))
+        schema.refresh_from_db()
+        assert schema.repartition_pending is None
+
+    @pytest.mark.parametrize("trigger_reason", ["coarsening", "admin"])
+    def test_give_up_reports_to_error_tracking(self, team, trigger_reason):
+        # The give-up path fires when the cap is already spent by attempts that were hard-killed before
+        # they could record an outcome. It is the only terminal repartition path that never ran
+        # `_handle_failure` (which captures), so without an explicit capture here the most severe
+        # outcome — a table the controller has abandoned — is invisible in error tracking.
+        schema = _make_schema(team, {})
+        schema.set_repartition_pending(
+            {
+                "partition_mode": "md5",
+                "partition_count": 4,
+                "partition_keys": ["id"],
+                "trigger_reason": trigger_reason,
+                "attempts": ctrl.MAX_REPARTITION_ATTEMPTS,
+            }
+        )
+        rewrite = AsyncMock()
+        with (
+            patch.object(repartition_table, "HeartbeaterSync"),
+            patch.object(repartition_table, "repartition_table_in_place", new=rewrite),
+            patch.object(repartition_table, "capture_repartition_event") as capture,
+            patch.object(repartition_table, "capture_exception") as capture_exception,
+            patch.object(repartition_table, "is_auto_repartition_enabled", return_value=True),
+            # A coarsening trigger answers to the coarsen flag, not the repartition one; without this the
+            # activity releases the queued rewrite before reaching the give-up.
+            patch.object(repartition_table, "is_auto_coarsen_enabled", return_value=True),
+        ):
+            ActivityEnvironment().run(maybe_repartition_table_activity, self._inputs(team, schema))
+
+        # The cap was already spent, so no rewrite is attempted — this is the pre-run give-up.
+        rewrite.assert_not_called()
+        capture_exception.assert_called_once()
+        assert isinstance(capture_exception.call_args.args[0], RepartitionAttemptsExhausted)
+        failed = [c.args[1] for c in capture.call_args_list if c.args[0] == "warehouse_repartition_failed"]
+        assert len(failed) == 1
+        assert failed[0]["final"] is True
+        assert failed[0]["error_type"] == "RepartitionAttemptsExhausted"
         schema.refresh_from_db()
         assert schema.repartition_pending is None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -39,6 +39,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.del
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import DeltaTableRef
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition import (
+    RepartitionAttemptsExhausted,
     RepartitionBudgetExceededError,
     RepartitionSupersededError,
     RepartitionTarget,
@@ -673,17 +674,26 @@ def _give_up(
     schema.clear_repartition_swap()
     schema.clear_repartition_rewrite()
     schema.stamp_last_repartition_at()
+    error = RepartitionAttemptsExhausted(
+        f"repartition gave up after {MAX_REPARTITION_ATTEMPTS} attempts that did not survive to record "
+        f"an outcome (trigger_reason={trigger_reason})"
+    )
     props = base_event_props(schema, schema.source, inputs.job_id)
     props.update(
         {
             "trigger_reason": trigger_reason,
             "attempts": int((pending or {}).get("attempts", 0)),
             "final": True,
-            "error_type": "RepartitionAttemptsExhausted",
-            "error_message": "attempts exhausted without any surviving to record an outcome",
+            "error_type": type(error).__name__,
+            "error_message": str(error),
         }
     )
     capture_repartition_event("warehouse_repartition_failed", props)
+    # Terminal, and the only terminal path that did not already report to error tracking: every attempt
+    # was hard-killed before it could run `_handle_failure` (which captures). Capture here too so a table
+    # the controller has abandoned surfaces as an issue instead of only a metric — the sync context is
+    # already bound (bind_job_context) so the issue is attributed to the connector and table.
+    capture_exception(error)
     DELTA_REPARTITION_TOTAL.labels(team_id=str(inputs.team_id), outcome="failed").inc()
 
 


### PR DESCRIPTION
## Problem

When the data-warehouse repartition controller abandons a table, whoever owns that connector gets no signal they can act on. The controller gives up after `MAX_REPARTITION_ATTEMPTS` rewrites that were each hard-killed before recording an outcome — a worker OOM, an activity timeout, or an eviction that didn't surface as a cancellation. This give-up is terminal: it clears the pending markers and backs the table off to the daily cooldown, leaving the table un-repartitioned.

Every other terminal repartition path calls `capture_exception`, so it lands in error tracking. The give-up did not. The most severe outcome produced only an analytics event and a log line, with the opaque message "attempts exhausted without any surviving to record an outcome". So the failures that most need triage were the only ones invisible in error tracking.

## Changes

- A repartition controller give-up now raises an error-tracking issue, attributed to the connector and table (the sync context is already bound via `bind_job_context`). Before, it was silent there.
- The give-up event's `error_message` now names the `trigger_reason` (for example `coarsening`), so the event says which kind of rewrite was abandoned. `error_type` is unchanged (`RepartitionAttemptsExhausted`).
- Added a `RepartitionAttemptsExhausted` exception type. The give-up path constructs and captures it; previously the type name was a bare string literal on the event.
- No change to the give-up decision, attempt accounting, partition sizing, or sync semantics — a repartition failure still never fails the sync.

## How did you test this code?

- Added `test_give_up_reports_to_error_tracking` (parameterized over `coarsening` and `admin`). It catches a regression where the give-up path stops reporting to error tracking or drops the terminal event — no existing test asserted either (`test_failure_gives_up_after_max_attempts` only checks the pending marker is cleared).
- Ran the give-up and neighbouring activity tests locally against Postgres + ClickHouse: `test_give_up_reports_to_error_tracking`, `test_failure_gives_up_after_max_attempts`, `test_a_rewrite_whose_worker_dies_still_burns_an_attempt`, `test_cancellation_propagates_and_is_not_recorded`, `test_transient_infra_error_not_recorded_as_failure` — all pass.
- Not run: the full backend suite; CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal observability change, no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a batch of `warehouse_repartition_failed` events. Confirmed the mechanics from the code (the emit sites in `workflow_activities/repartition_table.py`, the rewrite/retry loop in `pipelines/core/repartition.py`, and the detection controller), and grouped the recent events by `error_type`, `trigger_reason`, `source_type`, `final`, and `attempts` to separate expected fallout from genuine defects.

Two failure modes were reviewed. `RepartitionBudgetExceededError` is a known limitation for large, actively-syncing tables: the interleaved merge advances the live Delta version between runs and invalidates the rewrite checkpoint, so the table cannot converge within one activity budget. The escape hatch already exists (the repartition-hold flag), so this needs no code change. `RepartitionAttemptsExhausted` is the terminal give-up; the defect fixed here is that it reported uselessly and never surfaced in error tracking.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
