### PR TITLE
feat(flags): register override person properties for flag matching

### DIFF
--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -581,15 +581,9 @@ impl Client for MockRedisClient {
             key: format!("items={}", items.len()),
             value: MockRedisValue::VecString(keys.clone()),
         });
-        Ok(keys
-            .iter()
-            .map(|k| {
-                self.set_nx_ex_ret
-                    .get(k)
-                    .and_then(|r| r.clone().ok())
-                    .unwrap_or(false)
-            })
-            .collect())
+        keys.iter()
+            .map(|k| self.set_nx_ex_ret.get(k).cloned().unwrap_or(Ok(false)))
+            .collect()
     }
 
     async fn batch_del(&self, keys: Vec<String>) -> Result<(), CustomRedisError> {

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -859,6 +859,12 @@ pub struct Config {
     #[envconfig(from = "SKIP_WRITES", default = "false")]
     pub skip_writes: FlexBool,
 
+    /// When false, `/flags` will not register request-time `person_properties`
+    /// as person property definitions. Independent of `SKIP_WRITES` so a pod
+    /// can keep other writes and turn only this path off.
+    #[envconfig(from = "OVERRIDE_PERSON_PROPERTY_DEFS", default = "true")]
+    pub override_person_property_defs: FlexBool,
+
     // Explicit core count for thread pool sizing. Overrides available_parallelism()
     // which reads the CFS quota (K8s CPU limit), not the CPU request.
     // 0 = auto (use available_parallelism).
@@ -1145,6 +1151,7 @@ impl Config {
             max_concurrent_batch_evals: 0,
             rayon_semaphore_timeout_ms: 0,
             skip_writes: FlexBool(false),
+            override_person_property_defs: FlexBool(true),
             thread_pool_cores: 0,
             team_negative_cache_capacity: 10_000,
             team_negative_cache_ttl_seconds: 30,
@@ -1307,6 +1314,7 @@ mod tests {
         assert_eq!(config.debug, FlexBool(false));
         assert!(!config.flags_session_replay_quota_check);
         assert_eq!(config.skip_writes, FlexBool(false));
+        assert_eq!(config.override_person_property_defs, FlexBool(true));
         // Bot filter ships in LogOnly mode by default — pin the safe
         // posture so a future env-var rename / refactor can't silently
         // flip it back to Enforced.

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -265,9 +265,10 @@ async fn process_request_inner(
                 let property_overrides = properties::prepare_overrides(&context, &request)?;
 
                 // Taxonomy writes start here but do not wait; evaluation below is the
-                // response path. Gated on skip_writes like PAK last-used.
+                // response path. Off when SKIP_WRITES is set or OVERRIDE_PERSON_PROPERTY_DEFS=false.
                 override_property_defs::maybe_spawn_register_override_person_properties(
-                    *context.state.config.skip_writes,
+                    *context.state.config.skip_writes
+                        || !*context.state.config.override_person_property_defs,
                     context.state.redis_client.clone(),
                     context.state.database_pools.non_persons_writer.clone(),
                     team.id,

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -264,27 +264,16 @@ async fn process_request_inner(
 
                 let property_overrides = properties::prepare_overrides(&context, &request)?;
 
-                // Register request-time person property keys as taxonomy metadata so they
-                // appear in the flag release-condition picker. Does not write person profiles.
-                // Spawned, so it does not block the response.
-                if !*context.state.config.skip_writes {
-                    if let Some(person_properties) = request.person_properties.as_ref() {
-                        let names = override_property_defs::eligible_override_property_names(
-                            person_properties.keys(),
-                        );
-                        if !names.is_empty() {
-                            let redis = context.state.redis_client.clone();
-                            let pg_writer = context.state.database_pools.non_persons_writer.clone();
-                            let team_id = team.id;
-                            let project_id = team.project_id.unwrap_or(i64::from(team.id));
-                            tokio::spawn(
-                                override_property_defs::register_override_person_properties(
-                                    redis, pg_writer, team_id, project_id, names,
-                                ),
-                            );
-                        }
-                    }
-                }
+                // Taxonomy writes start here but do not wait; evaluation below is the
+                // response path. Gated on skip_writes like PAK last-used.
+                override_property_defs::maybe_spawn_register_override_person_properties(
+                    *context.state.config.skip_writes,
+                    context.state.redis_client.clone(),
+                    context.state.database_pools.non_persons_writer.clone(),
+                    team.id,
+                    team.project_id.unwrap_or(i64::from(team.id)),
+                    request.person_properties.as_ref(),
+                );
 
                 // Evaluate flags (this will return empty if is_flags_disabled is true)
                 let response = {

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -266,7 +266,7 @@ async fn process_request_inner(
 
                 // Register request-time person property keys as taxonomy metadata so they
                 // appear in the flag release-condition picker. Does not write person profiles.
-                // Off the response path; Redis + an in-process cache debounce repeats.
+                // Spawned, so it does not block the response.
                 if !*context.state.config.skip_writes {
                     if let Some(person_properties) = request.person_properties.as_ref() {
                         let names = override_property_defs::eligible_override_property_names(

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -8,6 +8,7 @@ pub mod decoding;
 pub mod error_tracking;
 pub mod evaluation;
 pub mod flags;
+pub mod override_property_defs;
 pub mod phases;
 pub mod properties;
 pub mod session_recording;
@@ -262,6 +263,28 @@ async fn process_request_inner(
                 tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
 
                 let property_overrides = properties::prepare_overrides(&context, &request)?;
+
+                // Register request-time person property keys as taxonomy metadata so they
+                // appear in the flag release-condition picker. Does not write person profiles.
+                // Off the response path; Redis + an in-process cache debounce repeats.
+                if !*context.state.config.skip_writes {
+                    if let Some(person_properties) = request.person_properties.as_ref() {
+                        let names = override_property_defs::eligible_override_property_names(
+                            person_properties.keys(),
+                        );
+                        if !names.is_empty() {
+                            let redis = context.state.redis_client.clone();
+                            let pg_writer = context.state.database_pools.non_persons_writer.clone();
+                            let team_id = team.id;
+                            let project_id = team.project_id.unwrap_or(i64::from(team.id));
+                            tokio::spawn(
+                                override_property_defs::register_override_person_properties(
+                                    redis, pg_writer, team_id, project_id, names,
+                                ),
+                            );
+                        }
+                    }
+                }
 
                 // Evaluate flags (this will return empty if is_flags_disabled is true)
                 let response = {

--- a/rust/feature-flags/src/handler/override_property_defs.rs
+++ b/rust/feature-flags/src/handler/override_property_defs.rs
@@ -62,7 +62,8 @@ fn in_flight_spawns() -> &'static Semaphore {
 /// Spawn taxonomy writes without waiting for them on the `/flags` response.
 ///
 /// Starts before evaluation; the task is detached so the request is not delayed.
-/// `skip_writes` is the process-wide off switch (same gate as PAK last-used).
+/// `skip_writes` is the process-wide off switch (same gate as PAK last-used),
+/// and also true when `OVERRIDE_PERSON_PROPERTY_DEFS=false`.
 pub fn maybe_spawn_register_override_person_properties(
     skip_writes: bool,
     redis: Arc<dyn RedisClient + Send + Sync>,

--- a/rust/feature-flags/src/handler/override_property_defs.rs
+++ b/rust/feature-flags/src/handler/override_property_defs.rs
@@ -7,8 +7,11 @@
 use common_database::Client as DatabaseClient;
 use common_redis::Client as RedisClient;
 use moka::sync::Cache;
+use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
+use tokio::sync::Semaphore;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -29,6 +32,9 @@ pub const DEBOUNCE_TTL_SECONDS: u64 = 86_400;
 /// Bounds the work a single request can trigger.
 pub const MAX_KEYS_PER_REQUEST: usize = 25;
 
+/// Caps concurrent background inserts so they cannot fill the writer pool.
+const MAX_IN_FLIGHT_SPAWNS: usize = 32;
+
 /// Matches the varchar(400) `name` column on `posthog_propertydefinition`.
 const MAX_PROPERTY_NAME_LEN: usize = 400;
 
@@ -46,6 +52,43 @@ fn seen_override_keys() -> &'static Cache<(i64, String), ()> {
             .time_to_live(Duration::from_secs(DEBOUNCE_TTL_SECONDS))
             .build()
     })
+}
+
+fn in_flight_spawns() -> &'static Semaphore {
+    static SPAWNS: OnceLock<Semaphore> = OnceLock::new();
+    SPAWNS.get_or_init(|| Semaphore::new(MAX_IN_FLIGHT_SPAWNS))
+}
+
+/// Spawn taxonomy writes without waiting for them on the `/flags` response.
+///
+/// Starts before evaluation; the task is detached so the request is not delayed.
+/// `skip_writes` is the process-wide off switch (same gate as PAK last-used).
+pub fn maybe_spawn_register_override_person_properties(
+    skip_writes: bool,
+    redis: Arc<dyn RedisClient + Send + Sync>,
+    pg_writer: Arc<dyn DatabaseClient + Send + Sync>,
+    team_id: i32,
+    project_id: i64,
+    person_properties: Option<&HashMap<String, Value>>,
+) {
+    if skip_writes {
+        return;
+    }
+    let Some(person_properties) = person_properties else {
+        return;
+    };
+    let names = eligible_override_property_names(person_properties.keys());
+    if names.is_empty() {
+        return;
+    }
+    let Ok(permit) = in_flight_spawns().try_acquire_owned() else {
+        warn!("dropping override person property definition spawn; too many in flight");
+        return;
+    };
+    tokio::spawn(async move {
+        let _permit = permit;
+        register_override_person_properties(redis, pg_writer, team_id, project_id, names).await;
+    });
 }
 
 /// Keys that should become person property definitions.
@@ -273,12 +316,13 @@ mod tests {
     #[test]
     fn test_eligible_names_cap_at_max_keys() {
         let names: Vec<String> = (0..(MAX_KEYS_PER_REQUEST + 5))
-            .map(|i| format!("prop_{i}"))
+            .map(|i| format!("prop_{i:02}"))
             .collect();
-        assert_eq!(
-            eligible_override_property_names(names.iter()).len(),
-            MAX_KEYS_PER_REQUEST
-        );
+        let got = eligible_override_property_names(names.iter());
+        let mut expected = names;
+        expected.sort();
+        expected.truncate(MAX_KEYS_PER_REQUEST);
+        assert_eq!(got, expected);
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/handler/override_property_defs.rs
+++ b/rust/feature-flags/src/handler/override_property_defs.rs
@@ -14,6 +14,11 @@ use uuid::Uuid;
 
 use crate::metrics::consts::OVERRIDE_PROPERTY_DEF_WRITES_COUNTER;
 
+#[cfg(test)]
+use super::test_metrics::inc;
+#[cfg(not(test))]
+use common_metrics::inc;
+
 /// `PropertyDefinition.Type.PERSON` in Django.
 const PERSON_PROPERTY_TYPE: i16 = 2;
 
@@ -51,16 +56,19 @@ pub fn eligible_override_property_names<'a, I>(names: I) -> Vec<String>
 where
     I: IntoIterator<Item = &'a String>,
 {
-    let mut out = Vec::new();
-    for name in names {
-        if out.len() >= MAX_KEYS_PER_REQUEST {
-            break;
-        }
-        if name.is_empty() || name.len() > MAX_PROPERTY_NAME_LEN || name.starts_with('$') {
-            continue;
-        }
-        out.push(name.clone());
-    }
+    let mut out: Vec<String> = names
+        .into_iter()
+        .filter(|name| {
+            !name.is_empty()
+                && name.len() <= MAX_PROPERTY_NAME_LEN
+                && !name.starts_with('$')
+                && !name.contains('\0')
+        })
+        .cloned()
+        .collect();
+    out.sort();
+    out.dedup();
+    out.truncate(MAX_KEYS_PER_REQUEST);
     out
 }
 
@@ -77,37 +85,55 @@ pub async fn register_override_person_properties(
     project_id: i64,
     names: Vec<String>,
 ) {
-    let mut to_write = Vec::new();
+    let mut candidates = Vec::new();
     let seen = seen_override_keys();
     for name in names {
-        if name.is_empty() || name.len() > MAX_PROPERTY_NAME_LEN || name.starts_with('$') {
+        if name.is_empty()
+            || name.len() > MAX_PROPERTY_NAME_LEN
+            || name.starts_with('$')
+            || name.contains('\0')
+        {
             continue;
         }
         let cache_key = (project_id, name.clone());
         if seen.contains_key(&cache_key) {
             continue;
         }
-        match redis
-            .set_nx_ex(
-                debounce_key(project_id, &name),
+        candidates.push(name);
+    }
+
+    if candidates.is_empty() {
+        return;
+    }
+
+    let items: Vec<(String, String, usize)> = candidates
+        .iter()
+        .map(|name| {
+            (
+                debounce_key(project_id, name),
                 "1".to_string(),
-                DEBOUNCE_TTL_SECONDS,
+                DEBOUNCE_TTL_SECONDS as usize,
             )
-            .await
-        {
-            Ok(true) => {
-                seen.insert(cache_key, ());
-                to_write.push(name);
-            }
-            Ok(false) => {
-                seen.insert(cache_key, ());
-            }
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    "Redis debounce check failed for override person property definition"
-                );
-            }
+        })
+        .collect();
+
+    let acquired = match redis.batch_set_nx_ex(items).await {
+        Ok(flags) => flags,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Redis debounce check failed for override person property definition"
+            );
+            return;
+        }
+    };
+
+    let mut to_write = Vec::new();
+    for (name, won) in candidates.into_iter().zip(acquired) {
+        let cache_key = (project_id, name.clone());
+        seen.insert(cache_key, ());
+        if won {
+            to_write.push(name);
         }
     }
 
@@ -115,7 +141,21 @@ pub async fn register_override_person_properties(
         return;
     }
 
-    insert_person_property_definitions(pg_writer, team_id, project_id, &to_write).await;
+    if !insert_person_property_definitions(pg_writer, team_id, project_id, &to_write).await {
+        let keys: Vec<String> = to_write
+            .iter()
+            .map(|name| debounce_key(project_id, name))
+            .collect();
+        if let Err(e) = redis.batch_del(keys).await {
+            warn!(
+                error = %e,
+                "Failed to roll back Redis debounce after override person property definition insert error"
+            );
+        }
+        for name in &to_write {
+            seen.invalidate(&(project_id, name.clone()));
+        }
+    }
 }
 
 /// Inserts person property definitions for `names`, skipping any that already exist.
@@ -128,16 +168,21 @@ pub async fn insert_person_property_definitions(
     team_id: i32,
     project_id: i64,
     names: &[String],
-) {
+) -> bool {
     let mut conn = match pg_writer.get_connection().await {
         Ok(conn) => conn,
         Err(e) => {
+            inc(
+                OVERRIDE_PROPERTY_DEF_WRITES_COUNTER,
+                &[("result".to_string(), "error".to_string())],
+                1,
+            );
             warn!(
                 team_id,
                 error = %e,
                 "Failed to acquire connection for override person property definitions"
             );
-            return;
+            return false;
         }
     };
 
@@ -162,17 +207,25 @@ pub async fn insert_person_property_definitions(
 
     match result {
         Ok(_) => {
-            metrics::counter!(OVERRIDE_PROPERTY_DEF_WRITES_COUNTER, &[("result", "success")])
-                .increment(1);
+            inc(
+                OVERRIDE_PROPERTY_DEF_WRITES_COUNTER,
+                &[("result".to_string(), "success".to_string())],
+                1,
+            );
+            true
         }
         Err(e) => {
-            metrics::counter!(OVERRIDE_PROPERTY_DEF_WRITES_COUNTER, &[("result", "error")])
-                .increment(1);
+            inc(
+                OVERRIDE_PROPERTY_DEF_WRITES_COUNTER,
+                &[("result".to_string(), "error".to_string())],
+                1,
+            );
             warn!(
                 team_id,
                 error = %e,
                 "Failed to write override person property definitions"
             );
+            false
         }
     }
 }
@@ -185,12 +238,12 @@ mod tests {
 
     const PERSON_TYPE: i16 = 2;
 
-    async fn count_person_definition(ctx: &TestContext, team_id: i32, name: &str) -> i64 {
+    async fn count_person_definition(ctx: &TestContext, project_id: i64, name: &str) -> i64 {
         let mut conn = ctx.get_non_persons_connection().await.unwrap();
         let row: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM posthog_propertydefinition WHERE team_id = $1 AND name = $2 AND type = $3",
+            "SELECT COUNT(*) FROM posthog_propertydefinition WHERE coalesce(project_id, team_id) = $1 AND name = $2 AND type = $3",
         )
-        .bind(team_id)
+        .bind(project_id)
         .bind(name)
         .bind(PERSON_TYPE)
         .fetch_one(&mut *conn)
@@ -205,6 +258,7 @@ mod tests {
         let names = vec![
             "$geoip_city_name".to_string(),
             "$lib".to_string(),
+            "plan\0evil".to_string(),
             String::new(),
             too_long,
             "plan_tier".to_string(),
@@ -242,7 +296,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 1);
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 1);
 
         let mut conn = ctx.get_non_persons_connection().await.unwrap();
         let row: (Option<String>,) = sqlx::query_as(
@@ -274,7 +328,7 @@ mod tests {
             .await;
         }
 
-        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 1);
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 1);
     }
 
     #[tokio::test]
@@ -300,14 +354,15 @@ mod tests {
                 plan.clone(),
                 region.clone(),
                 "$geoip_city_name".to_string(),
+                "plan\0evil".to_string(),
             ],
         )
         .await;
 
-        assert_eq!(count_person_definition(&ctx, team.id, &plan).await, 1);
-        assert_eq!(count_person_definition(&ctx, team.id, &region).await, 1);
+        assert_eq!(count_person_definition(&ctx, project_id, &plan).await, 1);
+        assert_eq!(count_person_definition(&ctx, project_id, &region).await, 1);
         assert_eq!(
-            count_person_definition(&ctx, team.id, "$geoip_city_name").await,
+            count_person_definition(&ctx, project_id, "$geoip_city_name").await,
             0
         );
     }
@@ -332,7 +387,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 0);
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 0);
     }
 
     #[tokio::test]
@@ -366,9 +421,74 @@ mod tests {
         let redis_calls = mock
             .get_calls()
             .into_iter()
-            .filter(|call| call.op == "set_nx_ex")
+            .filter(|call| call.op == "batch_set_nx_ex")
             .count();
         assert_eq!(redis_calls, 1);
-        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 1);
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_insert_scopes_on_project_id() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let other = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(other.id);
+        let name = format!("plan_tier_project_{}", team.id);
+
+        insert_person_property_definitions(
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            std::slice::from_ref(&name),
+        )
+        .await;
+
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 1);
+        assert_eq!(
+            count_person_definition(&ctx, i64::from(team.id), &name).await,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_register_retries_after_redis_error() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(team.id);
+        let name = format!("plan_tier_redis_err_{}", team.id);
+        let key = debounce_key(project_id, &name);
+
+        let mock = MockRedisClient::new()
+            .set_nx_ex_ret(&key, Err(common_redis::CustomRedisError::Timeout));
+        let redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock.clone());
+
+        register_override_person_properties(
+            redis.clone(),
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            vec![name.clone()],
+        )
+        .await;
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 0);
+
+        let mock = MockRedisClient::new().set_nx_ex_ret(&key, Ok(true));
+        let redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock.clone());
+        register_override_person_properties(
+            redis,
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            vec![name.clone()],
+        )
+        .await;
+        assert_eq!(count_person_definition(&ctx, project_id, &name).await, 1);
+        assert_eq!(
+            mock.get_calls()
+                .into_iter()
+                .filter(|call| call.op == "batch_set_nx_ex")
+                .count(),
+            1
+        );
     }
 }

--- a/rust/feature-flags/src/handler/override_property_defs.rs
+++ b/rust/feature-flags/src/handler/override_property_defs.rs
@@ -1,0 +1,374 @@
+//! Register `/flags` `person_properties` keys as person property definitions.
+//!
+//! `setPersonPropertiesForFlags` (and server-side `personProperties` overrides) evaluate flags
+//! without ingesting a `$set` event, so those keys never appear in the release-condition picker.
+//! A property definition is taxonomy metadata only — this writes no person profile values.
+
+use common_database::Client as DatabaseClient;
+use common_redis::Client as RedisClient;
+use moka::sync::Cache;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::metrics::consts::OVERRIDE_PROPERTY_DEF_WRITES_COUNTER;
+
+/// `PropertyDefinition.Type.PERSON` in Django.
+const PERSON_PROPERTY_TYPE: i16 = 2;
+
+/// Person property definitions change rarely. One attempt per key per day is enough
+/// to keep the picker current without adding steady-state write load.
+pub const DEBOUNCE_TTL_SECONDS: u64 = 86_400;
+
+/// Bounds the work a single request can trigger.
+pub const MAX_KEYS_PER_REQUEST: usize = 25;
+
+/// Matches the varchar(400) `name` column on `posthog_propertydefinition`.
+const MAX_PROPERTY_NAME_LEN: usize = 400;
+
+const LOCAL_CACHE_CAPACITY: u64 = 50_000;
+
+pub fn debounce_key(project_id: i64, name: &str) -> String {
+    format!("posthog:override_person_prop_def:{project_id}:{name}")
+}
+
+fn seen_override_keys() -> &'static Cache<(i64, String), ()> {
+    static CACHE: OnceLock<Cache<(i64, String), ()>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        Cache::builder()
+            .max_capacity(LOCAL_CACHE_CAPACITY)
+            .time_to_live(Duration::from_secs(DEBOUNCE_TTL_SECONDS))
+            .build()
+    })
+}
+
+/// Keys that should become person property definitions.
+///
+/// `$`-prefixed names are reserved (GeoIP, `$lib`, cookieless, …) and already get
+/// definitions from event ingestion, so they are skipped.
+pub fn eligible_override_property_names<'a, I>(names: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let mut out = Vec::new();
+    for name in names {
+        if out.len() >= MAX_KEYS_PER_REQUEST {
+            break;
+        }
+        if name.is_empty() || name.len() > MAX_PROPERTY_NAME_LEN || name.starts_with('$') {
+            continue;
+        }
+        out.push(name.clone());
+    }
+    out
+}
+
+/// Registers request-time `person_properties` keys as person property definitions.
+///
+/// Best-effort and debounced. Each `(project, key)` is written at most once per
+/// `DEBOUNCE_TTL_SECONDS` via an in-process cache and Redis `SET NX EX`. Meant to
+/// run off the request path; a failure only skips a definition the next request
+/// can retry.
+pub async fn register_override_person_properties(
+    redis: Arc<dyn RedisClient + Send + Sync>,
+    pg_writer: Arc<dyn DatabaseClient + Send + Sync>,
+    team_id: i32,
+    project_id: i64,
+    names: Vec<String>,
+) {
+    let mut to_write = Vec::new();
+    let seen = seen_override_keys();
+    for name in names {
+        if name.is_empty() || name.len() > MAX_PROPERTY_NAME_LEN || name.starts_with('$') {
+            continue;
+        }
+        let cache_key = (project_id, name.clone());
+        if seen.contains_key(&cache_key) {
+            continue;
+        }
+        match redis
+            .set_nx_ex(
+                debounce_key(project_id, &name),
+                "1".to_string(),
+                DEBOUNCE_TTL_SECONDS,
+            )
+            .await
+        {
+            Ok(true) => {
+                seen.insert(cache_key, ());
+                to_write.push(name);
+            }
+            Ok(false) => {
+                seen.insert(cache_key, ());
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Redis debounce check failed for override person property definition"
+                );
+            }
+        }
+    }
+
+    if to_write.is_empty() {
+        return;
+    }
+
+    insert_person_property_definitions(pg_writer, team_id, project_id, &to_write).await;
+}
+
+/// Inserts person property definitions for `names`, skipping any that already exist.
+///
+/// `ON CONFLICT DO NOTHING` means a real definition (with a resolved `property_type`)
+/// or an earlier registration always wins; this never overwrites one. `property_type`
+/// stays NULL until event ingestion resolves it.
+pub async fn insert_person_property_definitions(
+    pg_writer: Arc<dyn DatabaseClient + Send + Sync>,
+    team_id: i32,
+    project_id: i64,
+    names: &[String],
+) {
+    let mut conn = match pg_writer.get_connection().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            warn!(
+                team_id,
+                error = %e,
+                "Failed to acquire connection for override person property definitions"
+            );
+            return;
+        }
+    };
+
+    let ids: Vec<Uuid> = names.iter().map(|_| Uuid::now_v7()).collect();
+
+    let result = sqlx::query(
+        r#"
+        INSERT INTO posthog_propertydefinition (id, name, type, group_type_index, is_numerical, team_id, project_id)
+        SELECT DISTINCT ON (name) id, name, $3::smallint, NULL::smallint, false, $4::int, $5::bigint
+        FROM UNNEST($1::uuid[], $2::varchar[]) AS t(id, name)
+        ORDER BY name
+        ON CONFLICT DO NOTHING
+        "#,
+    )
+    .bind(&ids)
+    .bind(names)
+    .bind(PERSON_PROPERTY_TYPE)
+    .bind(team_id)
+    .bind(project_id)
+    .execute(&mut *conn)
+    .await;
+
+    match result {
+        Ok(_) => {
+            metrics::counter!(OVERRIDE_PROPERTY_DEF_WRITES_COUNTER, &[("result", "success")])
+                .increment(1);
+        }
+        Err(e) => {
+            metrics::counter!(OVERRIDE_PROPERTY_DEF_WRITES_COUNTER, &[("result", "error")])
+                .increment(1);
+            warn!(
+                team_id,
+                error = %e,
+                "Failed to write override person property definitions"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::TestContext;
+    use common_redis::MockRedisClient;
+
+    const PERSON_TYPE: i16 = 2;
+
+    async fn count_person_definition(ctx: &TestContext, team_id: i32, name: &str) -> i64 {
+        let mut conn = ctx.get_non_persons_connection().await.unwrap();
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM posthog_propertydefinition WHERE team_id = $1 AND name = $2 AND type = $3",
+        )
+        .bind(team_id)
+        .bind(name)
+        .bind(PERSON_TYPE)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        row.0
+    }
+
+    #[test]
+    fn test_eligible_names_skip_reserved_empty_and_cap() {
+        let too_long = "x".repeat(MAX_PROPERTY_NAME_LEN + 1);
+        let names = vec![
+            "$geoip_city_name".to_string(),
+            "$lib".to_string(),
+            String::new(),
+            too_long,
+            "plan_tier".to_string(),
+            "region".to_string(),
+        ];
+        assert_eq!(
+            eligible_override_property_names(names.iter()),
+            vec!["plan_tier".to_string(), "region".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_eligible_names_cap_at_max_keys() {
+        let names: Vec<String> = (0..(MAX_KEYS_PER_REQUEST + 5))
+            .map(|i| format!("prop_{i}"))
+            .collect();
+        assert_eq!(
+            eligible_override_property_names(names.iter()).len(),
+            MAX_KEYS_PER_REQUEST
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_creates_person_definition() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(team.id);
+        let name = format!("plan_tier_{}", team.id);
+
+        insert_person_property_definitions(
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            std::slice::from_ref(&name),
+        )
+        .await;
+
+        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 1);
+
+        let mut conn = ctx.get_non_persons_connection().await.unwrap();
+        let row: (Option<String>,) = sqlx::query_as(
+            "SELECT property_type FROM posthog_propertydefinition WHERE team_id = $1 AND name = $2 AND type = $3",
+        )
+        .bind(team.id)
+        .bind(&name)
+        .bind(PERSON_TYPE)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(row.0, None);
+    }
+
+    #[tokio::test]
+    async fn test_insert_is_idempotent() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(team.id);
+        let name = format!("plan_tier_idempotent_{}", team.id);
+
+        for _ in 0..2 {
+            insert_person_property_definitions(
+                ctx.non_persons_writer.clone(),
+                team.id,
+                project_id,
+                std::slice::from_ref(&name),
+            )
+            .await;
+        }
+
+        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_register_writes_new_keys_and_skips_reserved() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(team.id);
+        let plan = format!("plan_tier_reg_{}", team.id);
+        let region = format!("region_reg_{}", team.id);
+
+        let redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(
+            MockRedisClient::new()
+                .set_nx_ex_ret(&debounce_key(project_id, &plan), Ok(true))
+                .set_nx_ex_ret(&debounce_key(project_id, &region), Ok(true)),
+        );
+
+        register_override_person_properties(
+            redis,
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            vec![
+                plan.clone(),
+                region.clone(),
+                "$geoip_city_name".to_string(),
+            ],
+        )
+        .await;
+
+        assert_eq!(count_person_definition(&ctx, team.id, &plan).await, 1);
+        assert_eq!(count_person_definition(&ctx, team.id, &region).await, 1);
+        assert_eq!(
+            count_person_definition(&ctx, team.id, "$geoip_city_name").await,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_register_skips_debounced_keys() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(team.id);
+        let name = format!("plan_tier_debounced_{}", team.id);
+
+        let redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(
+            MockRedisClient::new().set_nx_ex_ret(&debounce_key(project_id, &name), Ok(false)),
+        );
+
+        register_override_person_properties(
+            redis,
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            vec![name.clone()],
+        )
+        .await;
+
+        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_register_uses_local_cache_to_skip_redis_on_repeat() {
+        let ctx = TestContext::new(None).await;
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let project_id = i64::from(team.id);
+        let name = format!("plan_tier_local_{}", team.id);
+        let key = debounce_key(project_id, &name);
+
+        let mock = MockRedisClient::new().set_nx_ex_ret(&key, Ok(true));
+        let redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock.clone());
+
+        register_override_person_properties(
+            redis.clone(),
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            vec![name.clone()],
+        )
+        .await;
+        register_override_person_properties(
+            redis,
+            ctx.non_persons_writer.clone(),
+            team.id,
+            project_id,
+            vec![name.clone()],
+        )
+        .await;
+
+        let redis_calls = mock
+            .get_calls()
+            .into_iter()
+            .filter(|call| call.op == "set_nx_ex")
+            .count();
+        assert_eq!(redis_calls, 1);
+        assert_eq!(count_person_definition(&ctx, team.id, &name).await, 1);
+    }
+}

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -1,7 +1,3 @@
-// Override property definition writes from request-time `person_properties`.
-// Labels: result="success" | "error".
-pub const OVERRIDE_PROPERTY_DEF_WRITES_COUNTER: &str = "flags_override_property_def_writes_total";
-
 // Group type cache metrics
 pub const GROUP_TYPE_CACHE_HIT_COUNTER: &str = "flags_group_type_cache_hit_total";
 pub const GROUP_TYPE_CACHE_MISS_COUNTER: &str = "flags_group_type_cache_miss_total";
@@ -533,3 +529,7 @@ pub const TOKIO_WORKER_OVERFLOW_DELTA: &str = "flags_tokio_worker_overflow_delta
 // Number of tasks stolen from other workers (gauge, delta). Labels: worker.
 // Active stealing indicates work imbalance being corrected by the scheduler.
 pub const TOKIO_WORKER_STEAL_DELTA: &str = "flags_tokio_worker_steal_delta";
+
+// Override property definition writes from request-time `person_properties`.
+// Labels: result="success" | "error".
+pub const OVERRIDE_PROPERTY_DEF_WRITES_COUNTER: &str = "flags_override_property_def_writes_total";

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -1,5 +1,4 @@
-// Best-effort writes of person property definitions harvested from request-time
-// `person_properties` overrides, so override-only keys show up in the release-condition picker.
+// Override property definition writes from request-time `person_properties`.
 // Labels: result="success" | "error".
 pub const OVERRIDE_PROPERTY_DEF_WRITES_COUNTER: &str = "flags_override_property_def_writes_total";
 

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -1,3 +1,8 @@
+// Best-effort writes of person property definitions harvested from request-time
+// `person_properties` overrides, so override-only keys show up in the release-condition picker.
+// Labels: result="success" | "error".
+pub const OVERRIDE_PROPERTY_DEF_WRITES_COUNTER: &str = "flags_override_property_def_writes_total";
+
 // Group type cache metrics
 pub const GROUP_TYPE_CACHE_HIT_COUNTER: &str = "flags_group_type_cache_hit_total";
 pub const GROUP_TYPE_CACHE_MISS_COUNTER: &str = "flags_group_type_cache_miss_total";


### PR DESCRIPTION
## Problem

Release conditions only list person properties that already have a property definition. `setPersonPropertiesForFlags` (and server-side `person_properties` overrides) evaluate flags without ingesting a `$set` event, so those keys never show up in the picker. The workaround is a dummy `$set`, which writes person profile data that was never meant to be stored.

Closes #87358

## Changes

After `/flags` evaluates with request-time person properties, those keys are registered as person property definitions (taxonomy only). No person profile value is written. `$`-prefixed keys are skipped because ingestion already defines them.

The write is off the response path. Repeats are debounced in-process and with Redis `SET NX EX` (24h) so browser `/flags` volume does not hit Postgres on every request. Gated on `skip_writes`.

Related stale draft: #81445 (server-side SDKs only). This covers client SDKs too, which is where `setPersonPropertiesForFlags` actually runs.

## How did you test this code?

Unit tests in `override_property_defs.rs`:

- Eligible keys skip `$` names, empty names, over-long names, and cap at 25 keys
- Insert creates a person definition with `property_type` NULL
- Re-insert of the same key is idempotent
- Reserved `$` keys are not written
- Redis debounce (`SET NX` false) skips the write
- A second call for the same key does not hit Redis again (in-process cache)

These tests need the feature-flags Postgres harness. They were not run locally (no Rust toolchain / test DB in this environment). CI on this PR is the run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None in this repo. Property-overrides docs live on posthog.com.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implementation is based on the approach in stale draft #81445, extended so client `setPersonPropertiesForFlags` traffic is included and repeats are cheap on the `/flags` hot path.
