### PR TITLE
fix(clerk): stop retrying a deterministic redirect_urls 404 every sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/source.py
@@ -119,6 +119,12 @@ The secret key starts with `sk_live_`.
             # not all of api.clerk.com, since a 400 elsewhere can be a genuinely bad request worth
             # investigating rather than an endpoint that can't be listed.
             "400 Client Error: Bad Request for url: https://api.clerk.com/v1/api_keys": "The API keys table can't be synced from Clerk. Turn off syncing for this table.",
+            # Clerk answers 404 resource_not_found for redirect_urls on instances/plans where the
+            # resource isn't available. The request is identical every run, so it re-fails on every
+            # schedule; classify it so the schema is paused instead of burning a job each time. Scoped
+            # to this path, not all of api.clerk.com, since a 404 elsewhere can be a genuinely missing
+            # record worth investigating rather than an account limitation.
+            "404 Client Error: Not Found for url: https://api.clerk.com/v1/redirect_urls": "The redirect URLs table isn't available on your Clerk plan or instance. Turn off syncing for this table.",
             **{reason: reason for reason in RETIRED_ENDPOINTS.values()},
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -55,6 +55,8 @@ class TestClerkSource:
             "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/saml_connections?limit=100",
             # `api_keys` endpoint, which Clerk rejects without a subject param on the list request.
             "400 Client Error: Bad Request for url: https://api.clerk.com/v1/api_keys?limit=100",
+            # `redirect_urls` endpoint, not available on the account's Clerk plan or instance.
+            "404 Client Error: Not Found for url: https://api.clerk.com/v1/redirect_urls?limit=100 | api error: code=resource_not_found",
         ],
     )
     def test_non_retryable_errors_matches_observed_error_message(self, observed_error):
@@ -80,6 +82,14 @@ class TestClerkSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
 
         assert not any(key in other_vendor_error for key in non_retryable_errors)
+
+    def test_non_retryable_errors_does_not_match_404_on_other_clerk_endpoints(self):
+        # A 404 from a different endpoint may be a genuinely missing record worth investigating, not
+        # the redirect_urls account limitation — the match must stay scoped to `redirect_urls`.
+        other_endpoint_error = "404 Client Error: Not Found for url: https://api.clerk.com/v1/users?limit=100"
+
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_endpoint_error for key in non_retryable_errors)
 
     def test_non_retryable_errors_does_not_match_422_on_other_clerk_endpoints(self):
         # A 422 from a different endpoint is a genuinely bad request worth investigating, not an


### PR DESCRIPTION
## Problem

A Clerk data-warehouse source with the redirect_urls table selected fails every scheduled sync and burns a job each time. Two teams hit this repeatedly.

- Clerk answers `404 resource_not_found` for `/v1/redirect_urls` on instances or plans where that resource isn't available.
- The request is identical on every run, so the failure is deterministic.
- The failure was never classified as non-retryable, so the schema stayed enabled and the schedule kept firing. The customer saw the raw `404 Client Error` string, not an actionable message.

## Changes

- The redirect_urls table now pauses with a clear message ("The redirect URLs table isn't available on your Clerk plan or instance. Turn off syncing for this table.") after it fails, instead of re-failing every schedule.
- Adds a scoped entry to Clerk's non-retryable error map. A matched non-retryable error both rewrites `latest_error` to the friendly copy and disables the schema, which stops the job burn.
- The entry is scoped to the redirect_urls path, not all of api.clerk.com, so a 404 on another endpoint still surfaces as a real failure worth investigating. This mirrors the existing scoped entries for api_keys (400) and saml_connections (422).

## How did you test this code?

- Extended `test_clerk_source.py`: added the redirect_urls 404 to the observed-error match cases, and a scoping test that a 404 on a different Clerk endpoint is not swallowed by this entry. The scoping test guards against broadening the match to all of api.clerk.com.
- Ran the Clerk source suite locally (`test_clerk_source.py`, 45 passed).
- Not run: the Temporal/integration suites, which need the data-warehouse stack this sandbox doesn't have.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging a batch of data-warehouse sync failure classes. The failure was traced through the shared REST client and the finalizer's non-retryable disable path: a deterministic 404 stops in-run retries but only a `get_non_retryable_errors` match disables the schema, and Clerk had no entry for this path. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

The example error string came from aggregated, redacted failure data; no customer identifiers are included in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
