### PR TITLE
fix(salesforce): retry token refresh through a transient proxy failure

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/auth.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/auth.py
@@ -5,7 +5,11 @@ from typing import Any, Optional
 from django.conf import settings
 
 from requests import Response
-from requests.exceptions import JSONDecodeError
+from requests.exceptions import (
+    ConnectionError as RequestsConnectionError,
+    JSONDecodeError,
+    Timeout as RequestsTimeout,
+)
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import BearerTokenAuth
@@ -92,15 +96,26 @@ def salesforce_refresh_access_token(refresh_token: str, instance_url: str, *, ca
     session = make_tracked_session(redact_values=(refresh_token,), capture=capture)
     attempt = 0
     while True:
-        res = session.post(
-            f"{instance_url}/services/oauth2/token",
-            data={
-                "grant_type": "refresh_token",
-                "client_id": settings.SALESFORCE_CONSUMER_KEY,
-                "client_secret": settings.SALESFORCE_CONSUMER_SECRET,
-                "refresh_token": refresh_token,
-            },
-        )
+        try:
+            res = session.post(
+                f"{instance_url}/services/oauth2/token",
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": settings.SALESFORCE_CONSUMER_KEY,
+                    "client_secret": settings.SALESFORCE_CONSUMER_SECRET,
+                    "refresh_token": refresh_token,
+                },
+            )
+        except (RequestsConnectionError, RequestsTimeout):
+            # A failed connection or timeout reaching the token endpoint — most often PostHog's
+            # egress proxy returning a transient 502 on CONNECT — never minted a token, so it's safe
+            # to reissue. Without this in-process retry a single proxy blip fails the whole import
+            # activity before it reads a row, and the sync restarts from scratch.
+            attempt += 1
+            if attempt >= _MAX_TOKEN_REFRESH_ATTEMPTS:
+                raise
+            time.sleep(min(0.5 * attempt, 5))
+            continue
 
         try:
             SalesforceAuthRequestError.raise_from_response(res)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_auth.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_auth.py
@@ -108,6 +108,61 @@ def _session_returning(responses: list[requests.Response]):
     return type("_S", (), {"post": staticmethod(lambda *a, **k: next(it))})()
 
 
+def _session_with_side_effects(items: list):
+    # Each item is either a Response to return or an Exception to raise, in order.
+    it = iter(items)
+
+    def _post(*a, **k):
+        item = next(it)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    return type("_S", (), {"post": staticmethod(_post)})()
+
+
+def test_refresh_retries_transient_transport_error_then_succeeds():
+    # PostHog's egress proxy can return a transient 502 on CONNECT, surfaced as a requests
+    # ProxyError before any token is minted; retrying should recover instead of failing the sync.
+    items = [
+        requests.exceptions.ProxyError("Cannot connect to proxy"),
+        requests.exceptions.ProxyError("Cannot connect to proxy"),
+        _token_response(200, {"access_token": "fresh-token"}),
+    ]
+
+    with (
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.make_tracked_session",
+            return_value=_session_with_side_effects(items),
+        ),
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.time.sleep"
+        ) as mock_sleep,
+    ):
+        token = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
+
+    assert token == "fresh-token"
+    assert mock_sleep.call_count == 2
+
+
+def test_refresh_raises_transport_error_after_exhausting_retries():
+    items = [requests.exceptions.ProxyError("Cannot connect to proxy") for _ in range(auth._MAX_TOKEN_REFRESH_ATTEMPTS)]
+
+    with (
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.make_tracked_session",
+            return_value=_session_with_side_effects(items),
+        ),
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.time.sleep"
+        ) as mock_sleep,
+        pytest.raises(requests.exceptions.ProxyError),
+    ):
+        _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
+
+    assert mock_sleep.call_count == auth._MAX_TOKEN_REFRESH_ATTEMPTS - 1
+
+
 def test_refresh_retries_transient_token_request_then_succeeds():
     # Salesforce locks concurrent token requests with a 400 "token request is already being
     # processed"; the lock clears, so a retry should recover instead of failing the sync.


### PR DESCRIPTION
## Problem

Salesforce syncs fail when PostHog's egress proxy has a brief hiccup during an access-token refresh. Two teams hit this repeatedly.

- The token refresh posts to Salesforce's OAuth token endpoint through the egress proxy.
- A transient proxy failure on CONNECT surfaces as a requests `ProxyError` (a 502 "Tunnel connection failed") before any token is minted.
- That transport error was not retried in-process, so one blip failed the whole import activity before it read a row, and the sync restarted from scratch.

## Changes

- A Salesforce sync now survives a transient proxy blip during token refresh instead of failing the run.
- The token-refresh loop retries transient transport errors (`ConnectionError`, which covers `ProxyError`, and `Timeout`) in-process, bounded by the existing attempt cap and backoff. A failed connection or timeout minted no token, so reissuing the request is safe.
- Response-level handling is unchanged. A 5xx response still raises immediately, and Salesforce's concurrent-refresh lock (a 400 "token request is already being processed") retries as before. This keeps the fix scoped to the transport layer where the proxy failure lives.

## How did you test this code?

- Added `test_refresh_retries_transient_transport_error_then_succeeds`: a `ProxyError` on the first two attempts then a 200, asserting the token is returned and the loop backed off twice. Catches a regression that drops the transport-error retry.
- Added `test_refresh_raises_transport_error_after_exhausting_retries`: a persistent `ProxyError` raises after the attempt cap, so a genuinely-down proxy still fails rather than looping forever.
- Ran the Salesforce auth suite locally (`test_auth.py`, 11 passed). The existing "raises on server failure" test still passes, confirming 5xx behavior is unchanged.
- Not run: the Temporal/integration suites, which need the data-warehouse stack this sandbox doesn't have.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging data-warehouse sync failure classes. The failure was traced to `salesforce_refresh_access_token`, whose retry loop only handled Salesforce's 400 concurrent-refresh lock; a `ProxyError` from `session.post` bypassed it. The fix stays at the transport layer so it doesn't change how Salesforce 5xx responses are treated. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

The proxy-error shape came from aggregated, redacted failure data; no customer host or identifier appears in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
