### PR TITLE
fix(ci): deploy the replay vision worker on any product backend change

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -528,7 +528,7 @@ jobs:
             - name: Check for changes that affect replay vision temporal worker
               id: check_changes_replay_vision_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/replay_vision/backend/temporal/|^products/replay_vision/backend/models/|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/replay_vision/backend/|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/|^.github/workflows/container-images-cd.yml$'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

A change to the Replay Vision sweep's query layer never deploys its temporal worker, so the code sits on master while production keeps running the old version.

- The deploy dispatch matches changed paths against `^products/replay_vision/backend/temporal/` and `^products/replay_vision/backend/models/` only.
- `products/replay_vision/backend/queries/` is not listed, and that is where the sweep's candidate query lives, which only the temporal worker runs.
- Two merged PRs hit this. The image built, the dispatch named other releases, and the worker was never told.
- One of them reached production only because an unrelated PR touching a matching path carried it along hours later. The other is still undeployed.
- The failure is silent: CI is green, the merge queue is happy, and the state file simply never moves.

## Changes

- A merged Replay Vision backend change now reaches production instead of waiting for an unrelated PR to carry it.
- The path filter widens from two subdirectories to `^products/replay_vision/backend/`, so any backend change to the product deploys its worker.
- The filter also matches this workflow file, so a change to the deploy config refreshes the worker. That is what lets this PR deploy the fix currently stranded on master.
- A test-only change under that path now triggers a deploy it does not need. That is the cost of the wider match, and it is far cheaper than shipping nothing and not noticing.
- No other release's filter changes.

## How did you test this code?

`hogli lint:workflows` passes, 8 checks across 128 workflows. Could not run `actionlint` locally, it is not on PATH here; CI runs it.

The change is a widened `grep -qE` alternation, so it can only match more paths than before. Unrebased PRs are unaffected, since nothing new is required of a branch for the filter to work.

Verified against the real dispatch that missed: that commit changed only `products/replay_vision/backend/queries/scanner_candidate_query.py` and a test under `products/replay_vision/backend/tests/`, neither of which matched the old alternation, and both of which match `^products/replay_vision/backend/`.

Not checked: the deploy itself, which can only be confirmed after merge by watching the worker's state file move.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this. Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`, `/shepherd-pr`.

Found while verifying whether a merged performance fix had taken effect in production. It had not, and the charts state file for the worker had not moved in eleven hours despite a successful image build. Tracing the dispatch commits in the charts repo showed it naming other releases, which pointed at the path filter.

Considered widening only to `queries/`, and chose the whole backend instead: the same omission would recur for any other subdirectory the worker executes.

No customer conversation, ticket, or log fed this change.
