### PR TITLE
fix(warehouse-sources): capture SQLSTATE for unclassified CDC failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -1670,14 +1670,21 @@ class CDCExtractActivity:
             self.log.warning("cdc_non_retryable_capture_failed", exc_info=True)
 
     def _capture_unclassified(self, exc: BaseException) -> None:
-        # Send the exception types in the cause chain — never str(exc), which can embed the customer's
-        # host, database, schema, or table names — so the taxonomy can be extended to catch this.
+        # Send the exception types and psycopg SQLSTATE codes in the cause chain — never str(exc),
+        # which can embed the customer's host, database, schema, or table names — so the taxonomy can
+        # be extended to catch this. A SQLSTATE is a fixed 5-character code (e.g. 42501 = insufficient
+        # privilege), carries no customer data, and pins down which deterministic error is looping
+        # where the exception type alone is ambiguous (many map to the same psycopg class).
         seen: set[int] = set()
         type_names: list[str] = []
+        sqlstates: list[str] = []
         current: BaseException | None = exc
         while current is not None and id(current) not in seen:
             seen.add(id(current))
             type_names.append(type(current).__name__)
+            sqlstate = getattr(current, "sqlstate", None)
+            if isinstance(sqlstate, str) and sqlstate not in sqlstates:
+                sqlstates.append(sqlstate)
             current = current.__cause__ or current.__context__
         # Best-effort: analytics must never mask the failure the caller is about to re-raise.
         try:
@@ -1688,6 +1695,7 @@ class CDCExtractActivity:
                     "team_id": self.inputs.team_id,
                     "source_id": str(self.inputs.source_id),
                     "exception_types": type_names,
+                    "sqlstates": sqlstates,
                 },
             )
         except Exception:

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -2490,6 +2490,61 @@ class TestErrorClassification:
         # human needs to teach the taxonomy to recognise this failure.
         assert "RuntimeError" in captured["properties"]["exception_types"]
 
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_machine_id",
+        return_value="machine-1",
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.posthoganalytics")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataJob")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_terminal_unclassified_error_captures_sqlstate_for_triage(
+        self,
+        mock_close_conns,
+        MockJob,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        mock_activity,
+        mock_posthoganalytics,
+        mock_get_machine_id,
+    ):
+        # A revoked REPLICATION/SELECT grant surfaces as psycopg InsufficientPrivilege, which the
+        # adapter doesn't classify, so it loops as retryable UNKNOWN. Its SQLSTATE (42501) is what
+        # tells a human this is a permission error and not some other ProgrammingError.
+        source = _make_source()
+        MockSourceModel.objects.get.return_value = source
+        schema = _make_schema("users", cdc_mode="streaming", source=source)
+        mock_get_schemas.return_value = [schema]
+
+        mock_reader = MagicMock()
+        mock_reader.read_changes.side_effect = psycopg.errors.InsufficientPrivilege("permission denied")
+        mock_reader.truncated_tables = []
+        mock_adapter = MagicMock()
+        mock_adapter.create_reader.return_value = mock_reader
+        mock_adapter.is_slot_invalidation_error.return_value = False
+        mock_adapter.classify_error = PostgresCDCAdapter().classify_error
+        mock_get_adapter.return_value = mock_adapter
+
+        mock_activity.heartbeat = MagicMock()
+        mock_activity.info.return_value = MagicMock(
+            workflow_id="wf-1", workflow_run_id="run-1", attempt=CDC_MAX_EXTRACTION_ATTEMPTS
+        )
+
+        inputs = CDCExtractInput(team_id=1, source_id=source.id)
+        with (
+            patch("products.data_warehouse.backend.facade.tasks.schedule_external_data_failure_digest"),
+            pytest.raises(psycopg.errors.InsufficientPrivilege),
+        ):
+            cdc_extract_activity(inputs)
+
+        captured = mock_posthoganalytics.capture.call_args.kwargs
+        assert captured["event"] == "cdc extraction unclassified error"
+        assert "42501" in captured["properties"]["sqlstates"]
+
 
 class TestSlotInvalidationRecovery:
     """When the replication slot is invalidated/dropped on the source DB, the activity


### PR DESCRIPTION
## Problem

A change-data-capture (CDC) failure the taxonomy can't classify is treated as a retryable UNKNOWN error. If the underlying failure is deterministic, it re-fails on every scheduled run and never pauses the schedule, so it keeps burning jobs.

- These loops never reach error triage: only the non-retryable path emits analytics, and UNKNOWN stays retryable.
- The one telemetry event that does fire for a terminal UNKNOWN sends only the exception type names.
- Type names are ambiguous. Many deterministic Postgres failures share one psycopg class (a revoked grant, a bad query, and an unsupported feature can all be `ProgrammingError`), so a human can't tell from the type which error is looping.

## Changes

- The "cdc extraction unclassified error" event now also carries the psycopg SQLSTATE codes from the exception cause chain, so a maintainer can see which deterministic error is looping and teach the taxonomy to stop retrying it.
- SQLSTATE is a fixed 5-character code (for example `42501` for insufficient privilege). It carries no host, database, schema, or table name, so it stays within the same credential-safe rule the existing capture follows (it never sends `str(exc)`).
- This is diagnostic only. It does not change retry behavior or classification. It makes the invisible loops visible so a follow-up can classify the confirmed cases.

## How did you test this code?

- Added `test_terminal_unclassified_error_captures_sqlstate_for_triage`: a psycopg `InsufficientPrivilege` (a permission error the adapter leaves UNKNOWN) drives the activity to its terminal failure, and the test asserts `42501` reaches the captured event. Catches a regression that drops SQLSTATE collection.
- Ran the CDC extract-activity unclassified tests locally (2 passed). The existing exception-types test is unchanged.
- Not run: the full Temporal/integration suites, which need the data-warehouse stack this sandbox doesn't have.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging data-warehouse sync failure classes. A high-volume single-team CDC retry loop surfaced only as the generic UNKNOWN friendly message, with no way to see the underlying error from here. Rather than guess a classification, this adds the credential-safe SQLSTATE diagnostic that the existing capture was missing, so the real cause can be identified before any non-retryable mapping is added. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

No customer data appears in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
