### PR TITLE
fix(data-imports): retry the revenue analytics ready check on a transient db error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -111,7 +111,6 @@ async def notify_revenue_analytics_that_sync_has_completed(
 
     try:
 
-        @database_sync_to_async_pool
         def _check_and_notify():
             if (
                 schema.name == STRIPE_CHARGE_RESOURCE_NAME
@@ -133,7 +132,7 @@ async def notify_revenue_analytics_that_sync_has_completed(
                 schema.team.revenue_analytics_config.notified_first_sync = True
                 schema.team.revenue_analytics_config.save()
 
-        await _check_and_notify()
+        await database_sync_to_async_pool(retry_on_operational_error(_check_and_notify))()
     except Exception as e:
         # Silently fail, we don't want this to crash the pipeline
         # Sending an email is not critical to the pipeline

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -15,10 +15,15 @@ from products.warehouse_sources.backend.temporal.data_imports.external_data_job 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.load import (
     IncrementalFieldMissingFromDataError,
     get_incremental_field_value,
+    notify_revenue_analytics_that_sync_has_completed,
     run_post_load_operations,
     update_job_row_count,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.maintenance import DeltaMaintenance
+from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.constants import (
+    CHARGE_RESOURCE_NAME as STRIPE_CHARGE_RESOURCE_NAME,
+)
+from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 _LOAD_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.common.load"
 _DB_RETRY_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.common.db_retry"
@@ -404,3 +409,39 @@ class TestUpdateJobRowCount:
         assert update.call_count == 2
         close.assert_called_once()
         sleep.assert_called_once_with(2)
+
+
+class TestNotifyRevenueAnalyticsThatSyncHasCompleted:
+    @pytest.mark.asyncio
+    async def test_retries_transient_operational_error_then_notifies(self):
+        # Opening a fresh pooled Postgres connection from the Temporal worker's thread pool can
+        # hit a momentary DNS resolution blip; retrying it is safe and avoids silently skipping
+        # the "revenue analytics ready" notification over a transient failure.
+        attempts = MagicMock(side_effect=[OperationalError("Name or service not known"), True])
+
+        class _RevenueAnalyticsConfig:
+            @property
+            def enabled(self):
+                return attempts()
+
+        source = MagicMock(
+            source_type=ExternalDataSourceType.STRIPE, revenue_analytics_config=_RevenueAnalyticsConfig()
+        )
+        schema = MagicMock()
+        schema.name = STRIPE_CHARGE_RESOURCE_NAME
+        schema.team.revenue_analytics_config.notified_first_sync = False
+        schema.team.all_users_with_access.return_value = []
+        logger = MagicMock(aexception=AsyncMock())
+
+        with (
+            patch(f"{_DB_RETRY_MODULE}.close_old_connections") as close,
+            patch(f"{_DB_RETRY_MODULE}.time.sleep") as sleep,
+        ):
+            await notify_revenue_analytics_that_sync_has_completed(schema, source, logger)
+
+        assert attempts.call_count == 2
+        close.assert_called_once()
+        sleep.assert_called_once_with(2)
+        assert schema.team.revenue_analytics_config.notified_first_sync is True
+        schema.team.revenue_analytics_config.save.assert_called_once()
+        logger.aexception.assert_not_called()


### PR DESCRIPTION
## Problem

A customer's "revenue analytics ready" notification (which triggers an email to org admins after their first Stripe charges sync) can go missing after a one-off database blip, with no retry and no visible failure.

[Error tracking](https://us.posthog.com/project/2/error_tracking/01a02961-05a3-7702-ad7a-454f6f70ed89) surfaced an `OperationalError: [Errno -2] Name or service not known` from `notify_revenue_analytics_that_sync_has_completed` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py`. The stack trace shows a fresh pooled Postgres connection failing DNS resolution inside the Temporal worker's thread pool while checking the sync's revenue analytics config.

The function already catches this exception to avoid crashing the pipeline (sending the notification isn't critical to the sync), so the failure is silent rather than a hard error. But unlike the sibling `update_job_row_count` in the same file, its DB check wasn't wrapped in the shared `retry_on_operational_error` helper, so a transient connection blip skips the notification entirely instead of retrying.

## Changes

- `notify_revenue_analytics_that_sync_has_completed` now wraps its DB check with `retry_on_operational_error`, the same helper `update_job_row_count` already uses for this exact transient-`OperationalError` class.

## How did you test this code?

- Added `TestNotifyRevenueAnalyticsThatSyncHasCompleted` to `test_load.py`, mirroring the existing `TestUpdateJobRowCount` retry test: the first DB access raises `OperationalError`, the second succeeds, and the notification's side effects (marking the team notified, saving) happen exactly once.
- Confirmed this test fails without the fix (the notification is skipped after a single transient error) and passes with it.
- Ran `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py` locally (30 passed), plus `ruff check --fix`, `ruff format`, and `mypy --cache-fine-grained` on both changed files.
- Not run: no manual reproduction against a live Temporal worker.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the full stack trace and confirm the failure originates in shared pipeline code rather than the Stripe connector. Read `db_retry.py` and the sibling `update_job_row_count` usage to identify the existing convention, then applied it here. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*