### PR TITLE
feat(tasks): CPU billing attribution for hogland sandboxes

### DIFF
--- a/products/tasks/backend/logic/services/cpu_billing.py
+++ b/products/tasks/backend/logic/services/cpu_billing.py
@@ -1,0 +1,57 @@
+"""Shared CPU-billing sampler plumbing for sandbox providers.
+
+The in-sandbox sampler (``sandbox/images/cpu_billing_sampler.py``, baked into every
+image) accumulates ``billed += max(actual_cpu_delta, request_cores * elapsed)`` per
+interval — Modal's burstable billing formula — and writes
+``"<billed_usec> <cpu_usec> <time_ns>"`` to the state file. Providers differ only in
+how they read files out of the sandbox, so the command construction and the
+state/floor math live here and must not fork between backends.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+CPU_BILLING_STATE_PATH = "/tmp/posthog-cpu-billing.state"
+CPU_BILLING_SAMPLER_PATH = "/usr/local/bin/posthog-cpu-billing-sampler"
+
+
+def build_sampler_start_command(request_cores: float) -> str:
+    """Detached sampler launch plus a short poll for its first state write."""
+    return (
+        f"rm -f {shlex.quote(CPU_BILLING_STATE_PATH)}; "
+        f"setsid {shlex.quote(CPU_BILLING_SAMPLER_PATH)} "
+        f"{shlex.quote(CPU_BILLING_STATE_PATH)} {shlex.quote(str(request_cores))} "
+        ">/dev/null 2>&1 </dev/null & "
+        f"for _ in $(seq 1 50); do [ -f {shlex.quote(CPU_BILLING_STATE_PATH)} ] && exit 0; sleep 0.02; done; exit 1"
+    )
+
+
+def parse_cpu_stat_usage_usec(cpu_stat: str) -> int | None:
+    for line in cpu_stat.splitlines():
+        key, _, value = line.partition(" ")
+        if key == "usage_usec":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+    return None
+
+
+def compute_billed_cpu_usage_usec(
+    state_text: str,
+    current_cpu_usec: int,
+    request_cores: float,
+    now_ns: int,
+) -> int | None:
+    """Accumulated billed usage, topped up for the window since the sampler's last write."""
+    values = state_text.split()
+    if len(values) != 3:
+        return None
+    try:
+        billed_usec, previous_cpu, previous_time = (int(value) for value in values)
+    except ValueError:
+        return None
+    elapsed_ns = max(0, now_ns - previous_time)
+    floor_usec = round(request_cores * elapsed_ns / 1000)
+    return billed_usec + max(current_cpu_usec - previous_cpu, floor_usec)

--- a/products/tasks/backend/logic/services/hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/hogland_sandbox.py
@@ -18,6 +18,7 @@ Transport differences from Modal, handled by the callers that read
 
 from __future__ import annotations
 
+import time
 import uuid
 import shlex
 import logging
@@ -41,7 +42,14 @@ from products.tasks.backend.exceptions import (
 )
 from products.tasks.backend.logic.services.agent_server_launcher import AGENT_SERVER_PORT, AgentServerLaunchMixin
 from products.tasks.backend.logic.services.agentsh import AGENTSH_DAEMON_PORT
+from products.tasks.backend.logic.services.cpu_billing import (
+    CPU_BILLING_STATE_PATH,
+    build_sampler_start_command,
+    compute_billed_cpu_usage_usec,
+    parse_cpu_stat_usage_usec,
+)
 from products.tasks.backend.logic.services.sandbox import redact_sandbox_command
+from products.tasks.backend.logic.services.sandbox_config import BURSTABLE_REQUEST_CPU_CORES
 
 from .sandbox import AgentServerResult, ExecutionResult, ExecutionStream, SandboxConfig, SandboxStatus, SandboxTemplate
 
@@ -421,6 +429,37 @@ class HoglandSandbox(AgentServerLaunchMixin):
 
     def prune_snapshot_heavy_dirs(self, path: str) -> None:
         """No-op: hogland snapshots are block-level and have no file-count cap."""
+
+    def read_cpu_usage_usec(self) -> int | None:
+        # Must go through exec: hogpanion's file endpoint sets Content-Length from
+        # stat(), and sysfs files stat as size 0, so read_file returns an empty body.
+        result = self.execute("cat /sys/fs/cgroup/cpu.stat", timeout_seconds=10)
+        if result.exit_code != 0:
+            return None
+        return parse_cpu_stat_usage_usec(result.stdout)
+
+    def _cpu_billing_request_cores(self) -> float:
+        # Hogland reserves request == limit, so its own billing floor would be the full
+        # box. Running the sampler with Modal's default burstable floor instead makes
+        # provider_billed_* mean "what Modal would have billed this same workload" —
+        # the like-for-like number the platform cost comparison needs. Fixed constant
+        # rather than config so a get_by_id-synthesized config reads the same floor.
+        return BURSTABLE_REQUEST_CPU_CORES
+
+    def start_cpu_billing_sampler(self) -> bool:
+        result = self.execute(build_sampler_start_command(self._cpu_billing_request_cores()), timeout_seconds=10)
+        return result.exit_code == 0
+
+    def read_billed_cpu_usage_usec(self) -> int | None:
+        try:
+            # The state file is a regular file, so read_file works here.
+            state_text = self._box.read_file(CPU_BILLING_STATE_PATH).decode()
+        except Exception:
+            return None
+        current_cpu = self.read_cpu_usage_usec()
+        if current_cpu is None:
+            return None
+        return compute_billed_cpu_usage_usec(state_text, current_cpu, self._cpu_billing_request_cores(), time.time_ns())
 
     @staticmethod
     def delete_snapshot(external_id: str) -> None:

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -52,6 +52,13 @@ from products.tasks.backend.exceptions import (
     SnapshotFileLimitExceededError,
     SnapshotTimeoutError,
 )
+from products.tasks.backend.logic.services.cpu_billing import (
+    CPU_BILLING_SAMPLER_PATH as CPU_BILLING_SAMPLER_PATH,
+    CPU_BILLING_STATE_PATH,
+    build_sampler_start_command,
+    compute_billed_cpu_usage_usec,
+    parse_cpu_stat_usage_usec,
+)
 from products.tasks.backend.logic.services.local_packages import (
     LocalPackage,
     get_local_package_runtime_dependencies,
@@ -95,8 +102,6 @@ STREAMLIT_MODAL_APP_NAME = "posthog-sandbox-streamlit"
 # a snapshot baked under the default app.
 SELF_DRIVING_MODAL_APP_NAME = "posthog-sandbox-self-driving"
 
-CPU_BILLING_STATE_PATH = "/tmp/posthog-cpu-billing.state"
-CPU_BILLING_SAMPLER_PATH = "/usr/local/bin/posthog-cpu-billing-sampler"
 
 SANDBOX_BASE_IMAGE = "ghcr.io/posthog/posthog-sandbox-base"
 SANDBOX_NOTEBOOK_IMAGE = "ghcr.io/posthog/posthog-sandbox-notebook"
@@ -1374,11 +1379,8 @@ class ModalSandbox(AgentServerLaunchMixin):
             cpu_stat = self._sandbox.filesystem.read_text("/sys/fs/cgroup/cpu.stat")
         except Exception:
             cpu_stat = None
-        if cpu_stat is not None:
-            for line in cpu_stat.splitlines():
-                key, _, value = line.partition(" ")
-                if key == "usage_usec":
-                    return int(value)
+        if cpu_stat is not None and (usage := parse_cpu_stat_usage_usec(cpu_stat)) is not None:
+            return usage
         try:
             cpuacct_usage = self._sandbox.filesystem.read_text("/sys/fs/cgroup/cpuacct/cpuacct.usage")
             if cpuacct_usage.strip():
@@ -1387,34 +1389,19 @@ class ModalSandbox(AgentServerLaunchMixin):
             pass
         return None
 
+    def _cpu_billing_request_cores(self) -> float:
+        return self.config.effective_cpu_request_cores if self.config.burstable_resources else self.config.cpu_cores
+
     def start_cpu_billing_sampler(self) -> bool:
-        request_cores = (
-            self.config.effective_cpu_request_cores if self.config.burstable_resources else self.config.cpu_cores
-        )
-        command = (
-            f"rm -f {shlex.quote(CPU_BILLING_STATE_PATH)}; "
-            f"setsid {shlex.quote(CPU_BILLING_SAMPLER_PATH)} "
-            f"{shlex.quote(CPU_BILLING_STATE_PATH)} {shlex.quote(str(request_cores))} "
-            ">/dev/null 2>&1 </dev/null & "
-            f"for _ in $(seq 1 50); do [ -f {shlex.quote(CPU_BILLING_STATE_PATH)} ] && exit 0; sleep 0.02; done; exit 1"
-        )
-        result = self.execute(command, timeout_seconds=10)
+        result = self.execute(build_sampler_start_command(self._cpu_billing_request_cores()), timeout_seconds=10)
         return result.exit_code == 0
 
     def read_billed_cpu_usage_usec(self) -> int | None:
-        values = self._sandbox.filesystem.read_text(CPU_BILLING_STATE_PATH).split()
-        if len(values) != 3:
-            return None
-        billed_usec, previous_cpu, previous_time = (int(value) for value in values)
+        state_text = self._sandbox.filesystem.read_text(CPU_BILLING_STATE_PATH)
         current_cpu = self.read_cpu_usage_usec()
         if current_cpu is None:
             return None
-        elapsed_ns = max(0, time.time_ns() - previous_time)
-        request_cores = (
-            self.config.effective_cpu_request_cores if self.config.burstable_resources else self.config.cpu_cores
-        )
-        floor_usec = round(request_cores * elapsed_ns / 1000)
-        return billed_usec + max(current_cpu - previous_cpu, floor_usec)
+        return compute_billed_cpu_usage_usec(state_text, current_cpu, self._cpu_billing_request_cores(), time.time_ns())
 
     def is_running(self) -> bool:
         return self.get_status() == SandboxStatus.RUNNING

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -136,6 +136,7 @@ def open_sandbox_session(
                 "origin_product": run.task.origin_product,
                 "prewarmed": bool(state.get("prewarmed")),
                 "vm_runtime": config.is_vm,
+                "sandbox_backend": state.get("sandbox_backend"),
                 "cpu_cores": config.cpu_cores,
                 "memory_gb": config.memory_gb,
                 "ttl_seconds": config.ttl_seconds,
@@ -349,9 +350,11 @@ def get_task_sandbox_usage_by_team(begin: datetime, end: datetime) -> SandboxUsa
 
     Only the attributed slice of a session bills: ``[user_attributed_at,
     effective_end)``, clipped to the period so sessions spanning report boundaries
-    apportion across them. Every end is clamped to ``ttl_expires_at`` — the provider
+    apportion across them. A Modal end is clamped to ``ttl_expires_at`` — the provider
     kills the sandbox by then regardless, whether cleanup never ran (crashed
     workflows), stamped late, or the session is genuinely live (clamped to now).
+    Hogland's TTL is an idle timeout, not a kill deadline, so hogland rows keep their
+    real end time.
     Open rows whose TTL expired before the period are excluded in the query itself,
     so missed close stamps can't grow the scan without bound. Resource-second
     metrics use the configured limits; burstable request floors are recorded on the
@@ -365,14 +368,30 @@ def get_task_sandbox_usage_by_team(begin: datetime, end: datetime) -> SandboxUsa
             user_attributed_at__isnull=False,
             user_attributed_at__lt=end,
         )
-        .filter(Q(ended_at__isnull=True, ttl_expires_at__gt=begin) | Q(ended_at__gt=begin))
+        .filter(
+            Q(ended_at__isnull=True, ttl_expires_at__gt=begin)
+            # An open hogland box extends its idle TTL on every proxied request, so
+            # ttl_expires_at can fall before the period while the box still runs. The
+            # first clause would drop it and bill zero for every later period. Keep an
+            # open hogland row for any period after it started; the loop bills it to now.
+            # Bounded by created_at so a never-closed row can't grow the scan without bound.
+            | Q(sandbox_backend="hogland", ended_at__isnull=True, created_at__lte=end)
+            | Q(ended_at__gt=begin)
+        )
     )
 
     usage: dict[int, list[float]] = {}
     for session in sessions.iterator():
         assert session.user_attributed_at is not None
         start = max(session.user_attributed_at, begin)
-        effective_end = min(session.ended_at or now, session.ttl_expires_at)
+        end_time = session.ended_at or now
+        # Modal's TTL is a hard kill deadline, so its end clamps to ttl_expires_at. Hogland's
+        # TTL is an idle timeout that every proxied request extends, so a hogland box can
+        # outlive created_at + ttl_seconds; clamping there would undercount its billed window.
+        if session.sandbox_backend == "hogland":
+            effective_end = end_time
+        else:
+            effective_end = min(end_time, session.ttl_expires_at)
         stop = min(effective_end, end)
         if stop <= start:
             continue

--- a/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
@@ -13,6 +13,7 @@ from products.tasks.backend.exceptions import (
     SandboxTimeoutError,
     SnapshotCreationError,
 )
+from products.tasks.backend.logic.services.cpu_billing import CPU_BILLING_STATE_PATH
 from products.tasks.backend.logic.services.hogland_sandbox import (
     _STATIC_BOX_ENV,
     HoglandSandbox,
@@ -224,6 +225,64 @@ class TestSandboxIdPrefixDispatch:
     def test_get_by_id_routes_on_id_prefix(self, sandbox_id: str, expect_hogland: bool):
         resolved = get_sandbox_class_for_sandbox_id(sandbox_id)
         assert (resolved is HoglandSandbox) == expect_hogland
+
+
+class TestHoglandCpuBilling:
+    def test_cpu_usage_reads_cgroup_via_exec_not_read_file(self):
+        # hogpanion's file endpoint returns an empty body for sysfs paths (stat size 0),
+        # so a read_file port of the Modal code would silently zero all attribution.
+        box = _mock_box()
+        box.exec.return_value = _exec_result(stdout="usage_usec 123456\nuser_usec 100\n")
+        sandbox = _running_sandbox(box)
+
+        assert sandbox.read_cpu_usage_usec() == 123456
+        assert box.exec.call_args.args[0] == ["bash", "-c", "cat /sys/fs/cgroup/cpu.stat"]
+        box.read_file.assert_not_called()
+
+    def test_cpu_usage_returns_none_when_cgroup_read_fails(self):
+        box = _mock_box()
+        box.exec.return_value = _exec_result(exit_code=1)
+        assert _running_sandbox(box).read_cpu_usage_usec() is None
+
+    def test_sampler_and_billed_read_use_the_modal_equivalent_floor(self):
+        # The floor must stay Modal's 0.5-core burstable default, not hogland's
+        # 4-core reservation — otherwise the like-for-like billed number inflates 8x.
+        box = _mock_box()
+        box.exec.return_value = _exec_result()
+        sandbox = _running_sandbox(box)
+
+        assert sandbox.start_cpu_billing_sampler() is True
+        assert " 0.5 " in box.exec.call_args.args[0][2]
+
+    @parameterized.expand(
+        [
+            # Busy window: actual delta (2_000_000) beats the 0.5-core floor (500_000).
+            ("busy", "1000000 5000000 1000", 7_000_000, 1_000_000_000 + 1000, 1_000_000 + 2_000_000),
+            # Idle window: floor tops up — 0.5 cores over 1s of elapsed ns = 500_000 usec.
+            ("idle", "1000000 5000000 1000", 5_000_100, 1_000_000_000 + 1000, 1_000_000 + 500_000),
+        ]
+    )
+    def test_billed_usage_math(self, _name, state, current_cpu, now_ns, expected):
+        box = _mock_box()
+        box.read_file.return_value = state.encode()
+        box.exec.return_value = _exec_result(stdout=f"usage_usec {current_cpu}\n")
+        sandbox = _running_sandbox(box)
+
+        with patch("products.tasks.backend.logic.services.hogland_sandbox.time.time_ns", return_value=now_ns):
+            assert sandbox.read_billed_cpu_usage_usec() == expected
+        box.read_file.assert_called_once_with(CPU_BILLING_STATE_PATH)
+
+    @parameterized.expand([("malformed_state", "1 2"), ("empty_state", "")])
+    def test_billed_usage_returns_none_on_bad_state(self, _name, state):
+        box = _mock_box()
+        box.read_file.return_value = state.encode()
+        box.exec.return_value = _exec_result(stdout="usage_usec 1\n")
+        assert _running_sandbox(box).read_billed_cpu_usage_usec() is None
+
+    def test_billed_usage_returns_none_when_state_file_is_gone(self):
+        box = _mock_box()
+        box.read_file.side_effect = NotFoundError("gone", status_code=404)
+        assert _running_sandbox(box).read_billed_cpu_usage_usec() is None
 
 
 class TestHoglandAuthPrecedence:

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -554,6 +554,45 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
 
         assert usage.seconds == [(self.team.id, 6 * 3600)]
 
+    @parameterized.expand([("hogland", 9 * 3600), (None, 6 * 3600)])
+    def test_ttl_clamp_skips_hogland_but_holds_for_modal(self, sandbox_backend, expected_seconds):
+        # Hogland's ttl_seconds is an idle timeout that every request extends, so a box can
+        # end well after created_at + ttl_seconds; its billed window must keep the true end.
+        # Modal's hard TTL is a kill deadline, so a Modal row still clamps to it.
+        self._session(
+            created_at=datetime(2026, 1, 2, 1, tzinfo=UTC),
+            user_attributed_at=datetime(2026, 1, 2, 1, tzinfo=UTC),
+            ended_at=datetime(2026, 1, 2, 10, tzinfo=UTC),
+            ttl_seconds=6 * 60 * 60,
+            sandbox_backend=sandbox_backend,
+        )
+
+        usage = get_task_sandbox_usage_by_team(self.BEGIN, self.END)
+
+        assert usage.seconds == [(self.team.id, expected_seconds)]
+
+    @parameterized.expand([("hogland", 24 * 3600), (None, None)])
+    def test_open_session_past_its_ttl_bills_for_hogland_but_not_modal(self, sandbox_backend, expected_seconds):
+        # An open hogland box keeps extending its idle TTL, so ttl_expires_at can fall before
+        # the period while the box still runs. The open-arm TTL bound would drop it, so a
+        # hogland arm keeps it and bills the whole period. A Modal row with the same
+        # expired-TTL shape stays excluded, since its TTL is a hard kill deadline.
+        self._session(
+            created_at=datetime(2025, 12, 20, 1, tzinfo=UTC),
+            user_attributed_at=datetime(2025, 12, 20, 1, tzinfo=UTC),
+            ended_at=None,
+            ttl_seconds=6 * 60 * 60,
+            sandbox_backend=sandbox_backend,
+        )
+
+        with freeze_time("2026-01-05T00:00:00Z"):
+            usage = get_task_sandbox_usage_by_team(self.BEGIN, self.END)
+
+        if expected_seconds is None:
+            assert usage.seconds == []
+        else:
+            assert usage.seconds == [(self.team.id, expected_seconds)]
+
     def test_live_session_clamps_to_now(self):
         self._session(
             created_at=datetime(2026, 1, 2, 1, tzinfo=UTC),

--- a/products/tasks/backend/migrations/0106_sandboxsession_sandbox_backend.py
+++ b/products/tasks/backend/migrations/0106_sandboxsession_sandbox_backend.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("tasks", "0105_taskrun_webhook_lookup_indexes")]
+
+    operations = [
+        migrations.AddField(
+            model_name="sandboxsession",
+            name="sandbox_backend",
+            field=models.CharField(
+                blank=True,
+                help_text="Provider backend (e.g. hogland); NULL for Modal. Hogland's TTL is idle, not absolute",
+                max_length=32,
+                null=True,
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0105_taskrun_webhook_lookup_indexes
+0106_sandboxsession_sandbox_backend

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -3005,6 +3005,12 @@ class SandboxSession(TeamScopedRootMixin, UUIDModel):
     vm_runtime = models.BooleanField(
         default=False, help_text="Modal VM runtime rather than gVisor (billed differently)"
     )
+    sandbox_backend = models.CharField(
+        max_length=32,
+        null=True,
+        blank=True,
+        help_text="Provider backend (e.g. hogland); NULL for Modal. Hogland's TTL is idle, not absolute",
+    )
 
     # Resource shape at creation, already clamped by SandboxConfig. Limits are what the
     # sandbox may consume — raw usage metrics derive from these; the burstable request

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -757,7 +757,9 @@ def _create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cr
         # default, but the per-run state can opt out to pin a fixed-size box (request == limit).
         # The decision is captured once in the context at workflow start, so it's stable across
         # activity retries.
-        if ctx.burstable_sandbox_resources_enabled:
+        # Hogland reserves request == limit (no bursting); recording the burstable
+        # floor would misprice its reserved capacity 8-16x in the usage ledger.
+        if ctx.burstable_sandbox_resources_enabled and ctx.sandbox_backend != "hogland":
             config.burstable_resources = True
             emit_agent_log(
                 ctx.run_id,


### PR DESCRIPTION
## Problem

- Hogland task sandboxes (stack layers #87250-#87253) record no CPU usage: the ledger columns stay NULL, so finance cannot compare Modal and hogland costs.
- Worse, provisioning marked hogland boxes as burstable, so the ledger recorded a 0.5-core / 1-GiB request shape hogland does not have. Pricing would undercount hogland reserved capacity 8x on CPU and 16x on memory.

## Changes

- Hogland ledger rows now carry the true resource shape: provisioning skips the burstable marking for hogland, whose boxes reserve request == limit (4 CPU / 16 GiB).
- `HoglandSandbox` starts the existing in-guest billing sampler (the golden-image bake already installs it; the guest is cgroup-v2, so the script runs unchanged) and implements both usage reads.
- Raw usage reads `/sys/fs/cgroup/cpu.stat` via exec, not `read_file`: hogpanion's file endpoint sets Content-Length from `stat()`, and sysfs files stat as size 0, so a file read silently returns empty.
- The sampler runs with Modal's 0.5-core burstable floor on hogland. `provider_billed_cpu_usage_*` therefore means "what Modal would have billed this same workload", computed with identical per-interval `max(request, actual)` semantics — the direct like-for-like number.
- The sampler launch command and the state/floor math move to a shared `cpu_billing.py`; Modal delegates to it, so the two backends cannot fork the state-file format. Mechanical for Modal.

> [!NOTE]
> Boxes restored from the golden snapshot inherit the bake session's CPU counters (memory snapshots preserve `/proc` and cgroup state), so absolute readings are meaningless — only the attribution-to-cleanup deltas the ledger already stores are valid. Consumers must diff, which `get_task_sandbox_usage_by_team` already does.

## How did you test this code?

- The existing Modal billed/sampler tests pass unchanged on the shared-module refactor, which is what proves Modal behavior did not move.
- New hogland tests, one per regression: a `read_file` port of the cgroup read would zero all attribution (asserts exec + no `read_file` call); wiring the floor to the box's 4-core config would inflate the Modal-equivalent number 8x (asserts the 0.5 floor in the command); billed math busy/idle/malformed/missing-state cases.
- Not unit-tested: the one-line burstable guard sits inside the provisioning activity, and no test harness exists for that activity body; covered by the code comment and this description.
- Not run: a live hogland box; the first bake + boot on the dev cluster validates the sampler end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in a session directed by Tom Owers, from a dedicated feasibility investigation (guest cgroup availability, hogpanion file-endpoint behavior, hogd host-side sampling). Skills invoked: /writing-tests, /writing-pr-descriptions, /stacking-prs. A host-side cumulative counter on hogland's metrics endpoint (captures VMM overhead the guest cannot see) was scoped as a follow-up and deliberately left out.
