### PR TITLE
feat(warehouse-sources): promote Custom REST source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -786,7 +786,7 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             name=SchemaExternalDataSourceType.CUSTOM,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Custom REST source",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             caption=(
                 "Set up a source using custom configured mappings. "
                 "Define a REST API source by providing a manifest that follows the same shape "


### PR DESCRIPTION
## Problem

The Custom REST source lets people define a data warehouse source from a manifest. It has been labelled Alpha in the new-source wizard, which signals "new, lightly tested" to users deciding whether to rely on it. Recent usage and reliability now clear the bar for Beta.

## Changes

- The Custom REST source now shows a **Beta** label instead of **Alpha** in the source picker. This is the label the `/api/public_source_configs/` endpoint surfaces for `Custom`.
- Mechanical: single-line change of `releaseStatus` from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` in the source's `get_source_config`.

The `featureFlag="dwh_custom_source"` rollout gate is left untouched — it controls who sees the connector and is orthogonal to the release-status label, so promotion does not call for removing it.

### Why it qualifies (last 7 days)

- Used by 71 teams (threshold ≥ 30).
- Import error rate 2.4% (threshold < 5.0%).

## How did you test this code?

No behavior, schema, or sync logic changed — this only changes the displayed release-status label. No new tests were added; existing Custom source tests do not assert the release status. The agent did not run the app or curl the live endpoint.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Status-only promotion of the Custom REST source from alpha to beta. Invoked the `/implementing-warehouse-sources` skill to confirm where release status lives and the `releaseStatus`/`unreleasedSource`/`featureFlag` conventions. Confirmed no test pins the release status, and checked open PRs (including the maintainer's own and excluding the automation bot) to rule out a duplicate promotion.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
