### PR TITLE
feat(loops): add pause action to Loop admin

### DIFF
--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -1,6 +1,8 @@
+import logging
 from typing import cast
 
 from django.contrib import admin, messages
+from django.db.models import QuerySet
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import path, reverse
@@ -10,6 +12,7 @@ from posthog.models.user import User
 from posthog.storage import object_storage
 
 from . import loop_service
+from .loop_lifecycle import DISABLED_REASON_ADMIN_PAUSED, pause_loop
 from .models import (
     CodeInvite,
     CodeInviteQuerySet,
@@ -21,6 +24,8 @@ from .models import (
     TaskRun,
 )
 from .visibility import task_run_visibility_q, task_visibility_q
+
+logger = logging.getLogger(__name__)
 
 
 @admin.register(Task)
@@ -219,10 +224,36 @@ class LoopAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ("team", "created_by", "creator")
     raw_id_fields = ("sandbox_environment",)
+    actions = ["pause_loops"]
 
     def get_queryset(self, request: HttpRequest):
         # Admin has no team context; Loop's default manager is fail-closed.
         return Loop.objects.unscoped().select_related("team", "created_by")
+
+    @admin.action(description="Pause selected loops")
+    def pause_loops(self, request: HttpRequest, queryset: QuerySet[Loop]) -> None:
+        selected = queryset.count()
+        paused = 0
+        failed: list[Loop] = []
+        for loop in queryset.filter(enabled=True, deleted=False):
+            try:
+                pause_loop(loop, DISABLED_REASON_ADMIN_PAUSED, cancel_runs=False)
+                paused += 1
+            except Exception:
+                logger.exception("loop_admin.pause_failed", extra={"loop_id": str(loop.id)})
+                failed.append(loop)
+
+        message = f"Paused {paused} of {selected} selected loop(s)."
+        if paused + len(failed) < selected:
+            message += " Loops that were already paused or deleted were left unchanged."
+        self.message_user(request, message)
+        if failed:
+            failed_ids = ", ".join(str(loop.id) for loop in failed)
+            self.message_user(
+                request,
+                f"Could not pause {len(failed)} loop(s): {failed_ids}. Check their schedules by hand.",
+                level=messages.ERROR,
+            )
 
     def delete_model(self, request: HttpRequest, obj: Loop) -> None:
         # Tear down Temporal Schedules before the row is gone; CASCADE never talks to Temporal, so

--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -240,6 +240,10 @@ class LoopAdmin(admin.ModelAdmin):
                 pause_loop(loop, DISABLED_REASON_ADMIN_PAUSED, cancel_runs=False)
                 paused += 1
             except Exception:
+                # Temporal never lands here: `pause_loop_schedules` swallows and logs its own
+                # failures, and a schedule left running can't start anything because `fire_loop`
+                # refuses a disabled loop. What reaches this is a failed row save (loop still
+                # enabled) or a failed notification dispatch (loop paused, owner not told).
                 logger.exception("loop_admin.pause_failed", extra={"loop_id": str(loop.id)})
                 failed.append(loop)
 
@@ -251,7 +255,8 @@ class LoopAdmin(admin.ModelAdmin):
             failed_ids = ", ".join(str(loop.id) for loop in failed)
             self.message_user(
                 request,
-                f"Could not pause {len(failed)} loop(s): {failed_ids}. Check their schedules by hand.",
+                f"Could not pause {len(failed)} loop(s): {failed_ids}. Check the logs and confirm their "
+                "state in the list.",
                 level=messages.ERROR,
             )
 

--- a/products/tasks/backend/loop_lifecycle.py
+++ b/products/tasks/backend/loop_lifecycle.py
@@ -28,11 +28,13 @@ _NON_TERMINAL_TASK_RUN_STATUSES = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QU
 DISABLED_REASON_OWNER_DEACTIVATED = "owner_deactivated"
 DISABLED_REASON_OWNER_REMOVED = "owner_removed_from_org"
 DISABLED_REASON_GITHUB_DISCONNECTED = "github_integration_disconnected"
+DISABLED_REASON_ADMIN_PAUSED = "admin_paused"
 
 DEFAULT_PAUSE_MESSAGE = "This loop has been paused."
 _PAUSE_MESSAGES = {
     DISABLED_REASON_OWNER_DEACTIVATED: "This loop's owner was deactivated, so it has been paused.",
     DISABLED_REASON_OWNER_REMOVED: "This loop's owner was removed from the organization, so it has been paused.",
+    DISABLED_REASON_ADMIN_PAUSED: "PostHog paused this loop. Contact support if you need it running again.",
 }
 
 

--- a/products/tasks/backend/tests/test_admin.py
+++ b/products/tasks/backend/tests/test_admin.py
@@ -3,11 +3,12 @@ import uuid
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.contrib.messages import get_messages
 from django.urls import reverse
 
 from posthog.admin import register_all_admin
 
-from products.tasks.backend.models import Channel, CodeInvite, Task, TaskRun
+from products.tasks.backend.models import Channel, CodeInvite, Loop, Task, TaskRun
 
 register_all_admin()
 
@@ -129,3 +130,74 @@ class TestCodeInviteAdminExpireAction(BaseTest):
         other.refresh_from_db()
         self.assertIsNotNone(selected.expires_at)
         self.assertIsNone(other.expires_at)
+
+
+class TestLoopAdminPauseAction(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.client.force_login(self.user)
+        self.mock_pause_schedules = patch("products.tasks.backend.loop_lifecycle.pause_loop_schedules").start()
+        self.mock_dispatch = patch("products.tasks.backend.loop_lifecycle.dispatch_loop_event").start()
+        self.addCleanup(patch.stopall)
+        self.enabled = self._loop("enabled")
+        self.already_paused = self._loop("already paused", enabled=False)
+        self.deleted = self._loop("deleted", deleted=True)
+        self.unselected = self._loop("unselected")
+
+    def _loop(self, name: str, **overrides: object) -> Loop:
+        fields: dict[str, object] = {
+            "team": self.team,
+            "created_by": self.user,
+            "name": name,
+            "instructions": "Summarize",
+            "runtime_adapter": "claude",
+            "model": "claude-sonnet-5",
+            "enabled": True,
+        }
+        fields.update(overrides)
+        return Loop.objects.unscoped().create(**fields)
+
+    def _pause(self, *loops: Loop) -> list[str]:
+        resp = self.client.post(
+            reverse("admin:tasks_loop_changelist"),
+            {"action": "pause_loops", "_selected_action": [str(loop.id) for loop in loops]},
+        )
+        self.assertEqual(resp.status_code, 302)
+        return [notice.message for notice in get_messages(resp.wsgi_request)]
+
+    def _state(self, loop: Loop) -> tuple[bool, str | None]:
+        fresh = Loop.objects.unscoped().get(id=loop.id)
+        return fresh.enabled, fresh.disabled_reason
+
+    def test_pauses_selected_enabled_loops_only(self) -> None:
+        notices = self._pause(self.enabled, self.already_paused, self.deleted)
+
+        self.assertEqual(self._state(self.enabled), (False, "admin_paused"))
+        self.assertEqual(self._state(self.already_paused), (False, None))
+        self.assertEqual(self._state(self.deleted), (True, None))
+        self.assertEqual(self._state(self.unselected), (True, None))
+        self.assertEqual([call.args[0].id for call in self.mock_pause_schedules.call_args_list], [self.enabled.id])
+        self.mock_dispatch.assert_called_once()
+        self.assertEqual(self.mock_dispatch.call_args.args[2]["reason"], "admin_paused")
+        self.assertEqual(
+            notices,
+            ["Paused 1 of 3 selected loop(s). Loops that were already paused or deleted were left unchanged."],
+        )
+
+    def test_keeps_going_when_one_loop_fails(self) -> None:
+        failing = self._loop("failing")
+
+        def fail_for_failing(loop: Loop) -> None:
+            if loop.id == failing.id:
+                raise RuntimeError("temporal down")
+
+        self.mock_pause_schedules.side_effect = fail_for_failing
+
+        notices = self._pause(failing, self.enabled)
+
+        self.assertEqual(self._state(self.enabled), (False, "admin_paused"))
+        self.assertEqual(len(notices), 2)
+        self.assertEqual(notices[0], "Paused 1 of 2 selected loop(s).")
+        self.assertIn(str(failing.id), notices[1])

--- a/products/tasks/backend/tests/test_admin.py
+++ b/products/tasks/backend/tests/test_admin.py
@@ -189,15 +189,18 @@ class TestLoopAdminPauseAction(BaseTest):
     def test_keeps_going_when_one_loop_fails(self) -> None:
         failing = self._loop("failing")
 
-        def fail_for_failing(loop: Loop) -> None:
+        def fail_for_failing(loop: Loop, event: str, payload: dict[str, object]) -> None:
             if loop.id == failing.id:
-                raise RuntimeError("temporal down")
+                raise RuntimeError("notifications down")
 
-        self.mock_pause_schedules.side_effect = fail_for_failing
+        self.mock_dispatch.side_effect = fail_for_failing
 
         notices = self._pause(failing, self.enabled)
 
         self.assertEqual(self._state(self.enabled), (False, "admin_paused"))
+        # pause_loop saves the row before it notifies, so the failing loop is paused even though
+        # the action reports it as a failure. The report is deliberately the pessimistic one.
+        self.assertEqual(self._state(failing), (False, "admin_paused"))
         self.assertEqual(len(notices), 2)
         self.assertEqual(notices[0], "Paused 1 of 2 selected loop(s).")
         self.assertIn(str(failing.id), notices[1])


### PR DESCRIPTION
## Problem

Staff who open the Loop list in Django admin can only delete loops in bulk. Pausing them means a toolbox pod and the `disable_loops` command from #87364.

## Changes

- The Loop admin action menu gains "Pause selected loops". Select the loops, pick the action, press Go.
- Each selected enabled loop is paused with reason `admin_paused`, its schedules stop and the owner gets a needs-attention notification: "PostHog paused this loop. Contact support if you need it running again."
- In-flight runs keep going. Use `disable_loops --cancel-runs` when those must stop too.
- Loops that are already paused or deleted are skipped, and the success message says so.
- If one loop fails partway, the rest are still paused. The failing loop ids show in an error message and go to the log.
- A stranded Temporal schedule never shows up in that error message. `pause_loop_schedules` logs and swallows its own failures, and a schedule left running starts no run, because the fire path refuses a disabled loop.
- The action calls the existing `pause_loop` helper, so it behaves like the other backend pauses.
- Mechanical: a new `DISABLED_REASON_ADMIN_PAUSED` constant and notification copy in `loop_lifecycle.py`.
- The desktop app shows this reason with the generic "Auto-paused" badge until copy for it lands there.

## How did you test this code?

- `products/tasks/backend/tests/test_admin.py::TestLoopAdminPauseAction`, run locally.
  - The first test catches the action touching already paused, deleted or unselected loops, or storing the wrong reason.
  - The second catches one loop's failure aborting the whole batch. It fails the notification dispatch, which is a path that can actually raise.
- Not clicked through in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Staff-only admin surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills read: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- A fixed reason code was chosen over an intermediate form page. Custom reasons and messages stay with the management command.
- Runs are left alone by default to match the command, since "pause" should mean no new fires.
- The AI observability settle-poll fix this branch carried landed separately in #87573, so the rebase onto master dropped it. This PR now touches the loops files only.
- Review round (Claude Code, Opus 5). ReviewHog showed the advertised failure path could not fire: `pause_loop_schedules` swallows Temporal errors, so the test that mocked it raising proved nothing. The test now fails a notification dispatch, the error copy no longer points at schedules, and this description no longer promises Temporal reporting.

