### PR TITLE
fix(datadog): stop retrying syncs after a 410 Gone response

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/source.py
@@ -125,6 +125,7 @@ Logs, audit logs, and events read access is governed by your Datadog account's d
         return {
             "401 Client Error": "Invalid Datadog API key. Generate a valid key and reconnect.",
             "403 Client Error": "Your Datadog application key is missing the required read scopes for this data. Grant the scopes and reconnect.",
+            "410 Client Error: Gone": "The requested Datadog data has fallen outside your account's retention window, or its pagination cursor expired. Retry the sync to start a fresh query.",
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/tests/test_datadog_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/tests/test_datadog_source.py
@@ -90,7 +90,7 @@ class TestDatadogSource:
         assert app_key_field.required is True
         assert app_key_field.secret is True
 
-    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error"])
+    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", "410 Client Error: Gone"])
     def test_non_retryable_errors(self, expected_key: str) -> None:
         assert expected_key in self.source.get_non_retryable_errors()
 


### PR DESCRIPTION
## Problem

A Datadog data warehouse sync keeps retrying a request that will never succeed: [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a02cd9-7420-75c2-837d-57a0e89c70cb) shows `HTTPError: 410 Client Error: Gone` raised from `fetch_page` in `datadog.py`.

Datadog answers 410 when a logs/events/audit-log query's time range has fallen outside the account's retention window, or a pagination cursor has expired. Retrying with the same parameters hits the same 410 every time, burning the activity's retry budget for nothing.

## Changes

- `DatadogSource.get_non_retryable_errors` now recognizes `410 Client Error: Gone` and stops the sync with a clear message instead of retrying, mirroring how this source already handles the CloudZero source's equivalent expired-cursor 410.

## How did you test this code?

Added a parametrized case to the existing `test_non_retryable_errors` test asserting `"410 Client Error: Gone"` is recognized. Ran the full `datadog` source test suite locally (17 passed) and `ruff check`/`ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Datadog warehouse source. Confirmed the stack trace's top in-app frame is `fetch_page` in this source's own code, then classified the 410 as a permanent, non-retryable upstream condition based on the existing `CloudzeroSource` precedent for the same status code and failure shape. No skills were invoked beyond `/writing-pr-descriptions` for this body.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*