### PR TITLE
fix(desktop/message-editor): keep selection on release outside input

### DIFF
--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -12,6 +12,7 @@ import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import type { PromptRecallHandler } from "@posthog/ui/features/sessions/components/chat-thread/composerPromptRecall";
 import { cycleModeOption } from "@posthog/ui/features/sessions/sessionStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { shouldFocusOnBackgroundClick } from "@posthog/ui/utils/backgroundClick";
 import { hasOpenOverlay } from "@posthog/ui/utils/overlay";
 import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import { EditorContent } from "@tiptap/react";
@@ -35,6 +36,9 @@ import { AttachmentsBar, type AttachmentUploadStatus } from "./AttachmentsBar";
 import { SlotMachineSubmit } from "./SlotMachineSubmit";
 
 export type { EditorHandle };
+
+/** Parts of the composer that answer a click themselves. */
+const COMPOSER_SELF_HANDLED_SELECTOR = 'button, [role="menu"], .ProseMirror';
 
 // How long the send button holds its own busy state when the surface never
 // reports one — long enough to register as a press, short enough that a send
@@ -374,11 +378,11 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
 
     const handleContainerClick = useCallback(
       (e: React.MouseEvent) => {
-        const target = e.target as HTMLElement;
         if (
-          !target.closest("button") &&
-          !target.closest('[role="menu"]') &&
-          !target.closest(".ProseMirror")
+          shouldFocusOnBackgroundClick(
+            e.target as HTMLElement,
+            COMPOSER_SELF_HANDLED_SELECTOR,
+          )
         ) {
           focus();
         }

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -47,6 +47,7 @@ import { DotPatternBackground } from "../../../primitives/DotPatternBackground";
 import { toast } from "../../../primitives/toast";
 import { useActiveRepoStore } from "../../../shell/activeRepoStore";
 import { useHostCapabilities } from "../../../shell/useHostCapabilities";
+import { shouldFocusOnBackgroundClick } from "../../../utils/backgroundClick";
 import { FOCUSABLE_SELECTOR } from "../../../utils/overlay";
 import { useAuthStateValue } from "../../auth/store";
 import { AutoresearchComposerControls } from "../../autoresearch/AutoresearchComposerControls";
@@ -1229,7 +1230,11 @@ export function TaskInput({
 
   const handleContainerClick = useCallback((e: React.MouseEvent) => {
     if (!e.currentTarget.contains(e.target as Node)) return;
-    if ((e.target as HTMLElement).closest(FOCUSABLE_SELECTOR)) return;
+    if (
+      !shouldFocusOnBackgroundClick(e.target as HTMLElement, FOCUSABLE_SELECTOR)
+    ) {
+      return;
+    }
     editorRef.current?.focus();
   }, []);
 

--- a/products/desktop/packages/ui/src/utils/backgroundClick.test.ts
+++ b/products/desktop/packages/ui/src/utils/backgroundClick.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { shouldFocusOnBackgroundClick } from "./backgroundClick";
+
+const IGNORE_SELECTOR = 'button, [contenteditable="true"]';
+
+function mockSelection(isCollapsed: boolean | null): void {
+  vi.spyOn(window, "getSelection").mockReturnValue(
+    isCollapsed === null ? null : ({ isCollapsed } as Selection),
+  );
+}
+
+describe("shouldFocusOnBackgroundClick", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      gesture: "a plain click on background chrome",
+      html: '<div id="target"></div>',
+      isCollapsed: true,
+      expected: true,
+    },
+    {
+      // Releasing a drag-select outside the input targets the container, so
+      // the ignore selector never matches and only the live selection tells
+      // the two gestures apart.
+      gesture: "releasing a drag-select outside the input",
+      html: '<div id="target"></div>',
+      isCollapsed: false,
+      expected: false,
+    },
+    {
+      gesture: "a click on an element that answers clicks itself",
+      html: '<button id="target" type="button"></button>',
+      isCollapsed: true,
+      expected: false,
+    },
+    {
+      gesture: "a click with no selection object at all",
+      html: '<div id="target"></div>',
+      isCollapsed: null,
+      expected: true,
+    },
+  ])("returns $expected for $gesture", ({ html, isCollapsed, expected }) => {
+    document.body.innerHTML = html;
+    mockSelection(isCollapsed);
+
+    const target = document.getElementById("target") as HTMLElement;
+
+    expect(shouldFocusOnBackgroundClick(target, IGNORE_SELECTOR)).toBe(
+      expected,
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/utils/backgroundClick.ts
+++ b/products/desktop/packages/ui/src/utils/backgroundClick.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether a click that reached a container should hand focus to the input it
+ * wraps.
+ *
+ * Clicking the chrome around an input is meant to focus it. The catch is that
+ * releasing a drag-select outside the input looks the same from the container:
+ * `click` fires on the nearest common ancestor of press and release, so a
+ * selection gesture that ends anywhere outside the input arrives with the
+ * container as its target rather than the input. Focusing then would collapse
+ * the selection the user just made, so a live selection marks the gesture as a
+ * drag rather than a click.
+ *
+ * @param ignoreSelector elements that answer clicks themselves and should
+ * never redirect focus into the input.
+ */
+export function shouldFocusOnBackgroundClick(
+  target: HTMLElement,
+  ignoreSelector: string,
+): boolean {
+  if (target.closest(ignoreSelector)) return false;
+  return window.getSelection()?.isCollapsed !== false;
+}


### PR DESCRIPTION
## Problem

Anyone selecting text in the desktop app's composer loses that selection the moment they let go of the mouse outside the input. Dragging across the text and releasing over the input keeps it; releasing anywhere else wipes it and drops the caret at the end.

The cause is a click-to-focus affordance misreading the end of a drag:

- A `click` event fires on the nearest common ancestor of press and release, not on the element the press started in.
- So a drag that starts in the editor and ends outside it delivers a click whose target is the surrounding container.
- Both composers guard that handler by testing the event target for the editor, and neither guard matches a container.
- The focus command that then runs is `focus("end")`, which moves the caret to the end of the document and collapses the selection.

Two surfaces have this handler. The new-session composer (`TaskInput`) is the one people hit, because its container covers the whole screen. The session composer (`PromptInput`) has the same defect over the padding inside its box.

**Before** — the selection is gone on release:

![before](https://raw.githubusercontent.com/Silthus/posthog/composer-selection-assets/docs/assets/composer-selection-before.gif)

**After** — the selection survives:

![after](https://raw.githubusercontent.com/Silthus/posthog/composer-selection-assets/docs/assets/composer-selection-after.gif)

## Changes

- `shouldFocusOnBackgroundClick` decides whether a container click should hand focus to the input it wraps.
- The new rule: skip the affordance while a selection is live, because that click is the tail of a drag.
- Both composers call it in place of their own target tests, so the two guards cannot drift apart again.
- A plain click still focuses the editor. The browser collapses any prior selection on mousedown, so a real click always reaches the handler collapsed.

I rejected tracking whether the mousedown started inside the editor. That needs new state in two components, and it would still steal a selection made in the chrome around the input. Reading the selection covers both and stays stateless.

> [!NOTE]
> `products/desktop` is a verbatim import of PostHog/code at a pinned SHA. Per `products/desktop/MIGRATION.md`, the next resync reverts this unless the same fix lands upstream in PostHog/code.

## How did you test this code?

`packages/ui/src/utils/backgroundClick.test.ts` adds four parameterized cases. The one that earns the file asserts that a container click with a live selection does not focus: remove the guard and it fails, which is today's bug. No existing test touched these click handlers. The other three pin the affordance that has to keep working.

I confirmed the test is honest by running it against the pre-fix logic first. Only the drag-select case failed.

For the behavior itself I rendered the real `TaskInput` in Storybook and drove it with Playwright in Chromium, using a throwaway story that is not part of this diff. Both gifs come from that harness, recorded against this branch:

<details>
<summary>Gesture matrix, before and after</summary>

| Release point | Before | After |
| --- | --- | --- |
| Inside the editor | kept | kept |
| Above the editor | lost | kept |
| Below the editor | lost | kept |

Click-to-focus after the change: focuses on a plain background click, and still focuses when text was selected elsewhere first.

</details>

Not run: the Electron end-to-end suite, which needs a packaged app build I did not produce.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Desktop) diagnosed and fixed this. Michael reported the gesture and asked for gif evidence on both sides plus a test-first fix.

Skills invoked: `superpowers:systematic-debugging`, `posthog-desktop`, `writing-tests`, `writing-pr-descriptions`.

The diagnosis rested on a DOM claim I did not want to take on trust, so I verified in headless Chromium that a drag ending outside an element dispatches `click` on the common ancestor, and separately that a plain click arrives with any prior selection already collapsed. The second one is what makes the guard safe rather than a regression.

I started to write the regression test against `TaskInput` itself, then dropped it: that component is 1600 lines behind tRPC and DI, and standing it up in jsdom would have bought a slow test for the same assertion. Extracting the decision was cheaper and put the bug somewhere a test could reach it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
