### PR TITLE
fix(cli): accept camel-case chunk IDs

### DIFF
--- a/cli/.sampo/changesets/camel-case-chunk-id.md
+++ b/cli/.sampo/changesets/camel-case-chunk-id.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Accept sourcemaps that use the camel-case `chunkId` field when cloning or uploading Hermes sourcemaps.

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -80,7 +80,7 @@ pub fn get_injected_release_id(source: &str, chunk_id: &str) -> Option<String> {
 pub struct SourceMapContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "chunkId", skip_serializing_if = "Option::is_none")]
     pub chunk_id: Option<String>,
     /// Bundler-emitted ECMA-426 debug id. Kept separate from `chunk_id` so a bundler-stamped
     /// map isn't mistaken for one we already processed (which would skip the mapping
@@ -783,6 +783,26 @@ mod tests {
                     "sources": ["a.ts"],
                     "names": [],
                     "debugId": "11111111-2222-4333-8444-555555555555",
+                    "x_hermes_function_offsets": {},
+                })),
+            ),
+        };
+
+        let upload: SymbolSetUpload = file.try_into().expect("Failed to convert to upload");
+        assert_eq!(upload.chunk_id, "11111111-2222-4333-8444-555555555555");
+    }
+
+    #[test]
+    fn hermes_upload_accepts_map_with_camel_case_chunk_id() {
+        let file = SourceMapFile {
+            inner: SourceFile::new(
+                PathBuf::from("bundle.js.map"),
+                content_from(json!({
+                    "version": 3,
+                    "mappings": "AAAA",
+                    "sources": ["a.ts"],
+                    "names": [],
+                    "chunkId": "11111111-2222-4333-8444-555555555555",
                     "x_hermes_function_offsets": {},
                 })),
             ),


### PR DESCRIPTION
## Problem

React Native builds whose Hermes sourcemaps use `chunkId` cannot carry that identifier through PostHog CLI cloning or uploads.

The CLI recognizes `chunk_id` and `debugId`, but it ignores the camel-case `chunkId` field emitted by the SDK.

## Changes

- The CLI now accepts `chunkId` as an input alias for the existing chunk ID field.
- A focused Hermes upload test guards against dropping camel-case chunk IDs.
- No visual behavior changes.

## How did you test this code?

- `cargo test --all-features` guards CLI sourcemap behavior, including the new camel-case input.
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo update --workspace --locked` with no `Cargo.lock` changes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This change adds compatibility for an existing sourcemap field.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented and validated the change in a dedicated worktree. The workflow used `/pr`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/autoreview`, and `/running-ci-preflight`.
