### PR TITLE
fix(featurebase): stop reporting exhausted transient retries as errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/featurebase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/featurebase/source.py
@@ -150,6 +150,16 @@ class FeaturebaseSource(
             ),
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_fetch_page` (featurebase.py) already retries `FeaturebaseRetryableError` (429/5xx),
+        # read timeouts, connection errors, and chunked-encoding errors with backoff; if that
+        # budget still exhausts, Temporal retries the whole activity, so the failure is transient
+        # and self-recovering rather than a bug to page on.
+        return {
+            "Featurebase API error (retryable)",
+            "HTTPSConnectionPool(host='do.featurebase.app', port=443)",
+        }
+
     def get_schemas(
         self,
         config: FeaturebaseSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/featurebase/tests/test_featurebase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/featurebase/tests/test_featurebase_source.py
@@ -124,6 +124,14 @@ class TestFeaturebaseSource:
         assert any(key.startswith("403 Client Error") for key in errors)
         assert any(key.startswith("401 Client Error") for key in errors)
 
+    def test_retryable_errors_cover_exhausted_transient_failures(self) -> None:
+        errors = self.source.get_retryable_errors()
+        # The sentinel `_fetch_page` raises after exhausting its own 429/5xx retries.
+        assert any("Featurebase API error (retryable)" in error for error in errors)
+        # A read timeout or dropped connection surfaces as a raw requests exception whose
+        # message includes the connection pool host, not the sentinel above.
+        assert any("do.featurebase.app" in error for error in errors)
+
     def test_resumable_source_manager_bound_to_resume_config(self) -> None:
         with patch.object(ResumableSourceManager, "__init__", return_value=None) as init:
             self.source.get_resumable_source_manager(_make_inputs())


### PR DESCRIPTION
## Problem

Featurebase data warehouse syncs report a tracked exception every time a
transient 503/429 from the API, or a read timeout / dropped connection,
exhausts `_fetch_page`'s internal retry budget — even though Temporal
retries the whole activity and the sync recovers on its own.

Observed via [error tracking](https://us.posthog.com/project/2/error_tracking/01a02e02-2406-7a92-9d7c-f4bcab275dc6):
`_fetch_page` raised `FeaturebaseRetryableError` for a 503 on `post_statuses`,
which is exactly the case its own tenacity retry (5 attempts, exponential
backoff) is built to absorb.

## Changes

- `FeaturebaseSource` now overrides `get_retryable_errors()`, matching the
  `_fetch_page` retryable sentinel and the connection-pool host string for
  timeouts/dropped connections.
- Matching errors are now logged as a warning and left for Temporal's
  activity retry, instead of being reported as a tracked exception.
- Mirrors the existing pattern in the Decagon, Langfuse, Matomo, and Notion
  sources, which classify the same shape of already-retried, self-recovering
  failure the same way.

## How did you test this code?

Added `test_retryable_errors_cover_exhausted_transient_failures`, asserting
the new patterns are recognized as retryable — guards against this
classification silently regressing and error tracking noise coming back.

Ran the full Featurebase source test suite locally (29 passed) and `ruff
check`/`ruff format --check` on the touched files. Did not run the wider
CI matrix or mypy locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from a live error tracking issue for the Featurebase
source. Investigated the stack trace and source code, then compared against
the `get_retryable_errors()` convention already used by Decagon, Langfuse,
Matomo, and Notion for the same failure shape, and applied it here. Ran
`/writing-tests` before adding the regression test and `/writing-pr-descriptions`
before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*