### PR TITLE
fix(desktop): hide internal logs from session chat

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -801,10 +801,12 @@ describe("buildConversationItems", () => {
       });
     });
 
-    it("hides debug-level console logs by default and renders them inline when showDebugLogs is true", () => {
+    it("hides internal console logs by default and renders them inline when showDebugLogs is true", () => {
       const events: AcpMessage[] = [
         progressMsg(1, "sandbox", "in_progress", "Setting up sandbox"),
         consoleMsg(2, "sandbox provisioned", "debug"),
+        consoleMsg(3, "handoff skipped", "warn"),
+        consoleMsg(4, "checkpoint captured", "info"),
       ];
 
       const hidden = buildConversationItems(events, null);
@@ -819,11 +821,11 @@ describe("buildConversationItems", () => {
         showDebugLogs: true,
       });
       expect(
-        shown.items.some(
+        shown.items.filter(
           (i) =>
             i.type === "session_update" && i.update.sessionUpdate === "console",
         ),
-      ).toBe(true);
+      ).toHaveLength(3);
     });
 
     it("emits no progress group for a conversation without progress notifications", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -774,7 +774,7 @@ function handleNotification(
     const params = msg.params as { level?: string; message?: string };
     if (!params?.message) return;
     const level = params.level ?? "info";
-    if (level === "debug" && !options?.showDebugLogs) return;
+    if (!options?.showDebugLogs) return;
     ensureImplicitTurn(b, ts);
     pushItem(b, {
       sessionUpdate: "console",


### PR DESCRIPTION
## Problem

Session chats expose internal diagnostic messages that do not help users complete their work.

**Why:** The chat feed should contain agent activity and user-relevant status, not implementation logs.

## Changes

- Session chats now hide all internal console messages by default.
- The cloud debug logs setting still reveals these messages for diagnosis.
- No screenshot: the visible change only removes diagnostic rows.

## How did you test this code?

- Added coverage that hides debug, info, and warning console messages by default.
- Verified the debug setting reveals all three levels.
- Ran the full desktop typecheck and lint.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is needed because this restores the intended chat behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this change through PostHog Desktop. The posthog-desktop and writing-pr-descriptions skills shaped the implementation and handoff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*