### PR TITLE
fix(mux): keep the aggregate window within Mux's standard retention

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mux/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mux/settings.py
@@ -8,11 +8,12 @@ from products.warehouse_sources.backend.types import IncrementalField, Increment
 # retention than aggregates and the list endpoint isn't a bulk export, so we start modest; subsequent
 # syncs track the `view_end` watermark forward from here.
 VIDEO_VIEWS_INITIAL_LOOKBACK = timedelta(days=30)
-# Window for the full-refresh aggregate endpoints (errors, metric comparison). Mux Data retains
-# engagement/QoE metrics for ~13 months, so this pulls essentially everything Mux keeps; Mux clamps
-# the window to what's actually retained rather than erroring. The responses are small and replaced
-# each sync, so a wide window is cheap.
-AGGREGATE_LOOKBACK = timedelta(days=395)
+# Window for the full-refresh aggregate endpoints (errors, metric comparison). Mux Data's standard
+# retention for these metrics is 100 days; 13-month retention is a paid add-on not every account has.
+# A window past the account's retention is rejected with `400 invalid_timeframe` rather than clamped,
+# so stay within the 100-day floor every plan supports. The responses are small and replaced each
+# sync, so a wide window is cheap.
+AGGREGATE_LOOKBACK = timedelta(days=90)
 
 
 @dataclass

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mux/tests/test_mux.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mux/tests/test_mux.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Iterable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 import pytest
@@ -373,8 +373,9 @@ class TestTimeframeParams:
         assert abs((end - start) - int(VIDEO_VIEWS_INITIAL_LOOKBACK.total_seconds())) <= 5
 
     def test_full_refresh_aggregate_uses_wide_lookback(self) -> None:
-        # Aggregate endpoints ignore any watermark and window by the wide (~13 month) retention lookback,
-        # so a sync summarizes essentially all the history Mux keeps rather than a trailing month.
+        # Aggregate endpoints ignore any watermark and window by the aggregate retention lookback, which
+        # stays within Mux's standard 100-day retention so the request isn't rejected as an invalid
+        # timeframe on accounts without the 13-month add-on.
         params = _timeframe_params(
             MUX_ENDPOINTS["errors"],
             should_use_incremental_field=False,
@@ -382,6 +383,12 @@ class TestTimeframeParams:
         )
         start, end = params["timeframe[]"]
         assert abs((end - start) - int(AGGREGATE_LOOKBACK.total_seconds())) <= 5
+
+    def test_aggregate_lookback_stays_within_standard_retention(self) -> None:
+        # A window past the account's retention is rejected with `400 invalid_timeframe`, not clamped.
+        # Mux's standard retention floor is 100 days, so the aggregate lookback must not exceed it —
+        # this guards against widening it back toward the 13-month add-on window every plan doesn't have.
+        assert AGGREGATE_LOOKBACK <= timedelta(days=100)
 
 
 class TestMuxDataEndpoints:


### PR DESCRIPTION
## Problem

- The errors and metrics comparison tables of a Mux source fail on every scheduled sync for accounts on Mux's standard retention.
- These aggregate endpoints query a 395-day window. Mux's standard retention for these metrics is 100 days; 13-month retention is a paid add-on not every account has.
- A window past an account's retention is rejected with `400 invalid_timeframe`, not clamped as the code assumed.
- The sync had no handling for this error, so it retried the whole activity budget and reported the failure on every attempt.

## Changes

- The aggregate lookback drops from 395 to 90 days, within the 100-day retention every Mux plan supports, so these tables sync instead of failing every run.
- Mechanical: a test asserts the lookback stays at or under 100 days, guarding against widening it back toward the add-on-only window.

## How did you test this code?

- Extended `test_mux.py`: added a bound assertion on the aggregate lookback. It catches a regression the existing `test_full_refresh_aggregate_uses_wide_lookback` cannot, since that test ties the window to the constant and would pass if the constant were widened again.
- Ran the Mux source suite locally.
- Not run: the Temporal/integration suites, which need the data-warehouse stack this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging a batch of data-warehouse sync failure classes. The 400 was traced to the aggregate endpoints' `timeframe[]` window exceeding Mux's standard 100-day retention; the wide window predated knowing that the 13-month retention is a paid add-on. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The example error came from aggregated, redacted failure data; no customer identifiers appear in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
