### PR TITLE
fix(google-play-console): skip a metric set an app has no data for

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/google_play_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/google_play_console.py
@@ -42,9 +42,6 @@ METRIC_PAGE_SIZE = 10000
 LIST_PAGE_SIZE = 100
 APP_PAGE_SIZE = 50
 
-# Vitals are published with a delay; used only when a metric set reports no daily freshness.
-FRESHNESS_LAG_DAYS = 2
-
 
 class GooglePlayConsoleAuthError(Exception):
     """The service account key could not be exchanged for a Play Reporting access token."""
@@ -449,9 +446,13 @@ def _iter_metric_set_rows(
             window_start = _parse_date(resume_date) or history_start
             resume_app = None
 
-        latest = client.latest_available_date(package_name, endpoint.resource) or (
-            _today() - dt.timedelta(days=FRESHNESS_LAG_DAYS)
-        )
+        latest = client.latest_available_date(package_name, endpoint.resource)
+        if latest is None:
+            # No freshness for this metric set means the app has no data we can query for it — a metric
+            # set the app isn't eligible for, or one with too little volume to report. Querying a guessed
+            # window anyway is rejected with `400 invalid_timeframe`, which failed the whole multi-app
+            # sync every run; skip the app so the others still sync.
+            continue
 
         current = window_start
         while current <= latest:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/tests/test_google_play_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/tests/test_google_play_console.py
@@ -410,20 +410,18 @@ def test_metric_set_windows_the_timeline_and_stops_at_the_freshness_date() -> No
     assert manager.saved == [GooglePlayConsoleResumeConfig(app="com.example.app", date="2024-03-10")]
 
 
-def test_metric_set_falls_back_to_a_lagged_end_date_without_freshness() -> None:
+def test_metric_set_skips_an_app_without_freshness() -> None:
     manager = _manager()
+    calls: list[str] = []
 
     def request(method: str, path: str, params: Any = None, body: Any = None) -> dict[str, Any]:
-        if path.endswith(":query"):
-            return {"rows": []}
+        calls.append(path)
+        # Empty freshness — the app has no queryable data for this metric set.
         return {}
 
-    with (
-        mock.patch(f"{MODULE}._today", return_value=TODAY),
-        mock.patch.object(GooglePlayConsoleClient, "request", side_effect=request),
-    ):
+    with mock.patch.object(GooglePlayConsoleClient, "request", side_effect=request):
         client = _client(mock.MagicMock())
-        list(
+        batches = list(
             _iter_metric_set_rows(
                 client=client,
                 endpoint=METRIC_SETS["anr_rate"],
@@ -434,8 +432,10 @@ def test_metric_set_falls_back_to_a_lagged_end_date_without_freshness() -> None:
             )
         )
 
-    # 2024-03-29 is the last day queried (today minus the freshness lag), so the checkpoint moves past it.
-    assert manager.saved[-1].date == "2024-03-30"
+    # No freshness means no queryable data: the app is skipped rather than queried with a guessed
+    # window Google rejects as an invalid timeframe. No `:query` is issued and nothing is yielded.
+    assert batches == []
+    assert not any(path.endswith(":query") for path in calls)
 
 
 def test_metric_set_query_follows_pagination_until_the_token_runs_out() -> None:


### PR DESCRIPTION
## Problem

- A Google Play Console source fails on every scheduled sync when any one connected app has no data for a metric set (crashes, ANRs, error counts, and similar).
- Before querying a metric set, the source reads its freshness to find the last day with data. An app with no data for that metric set returns no freshness.
- The source then queried a guessed fallback window anyway. Google rejects that with a `400 Bad Request`, which failed the entire multi-app sync, not just the app without data.
- The failure was never classified, so the sync retried the whole activity budget and reported the error on every attempt, every run.

## Changes

- An app with no freshness for a metric set is now skipped for that metric set, so the remaining apps and metric sets still sync.
- Removes the fallback window that produced the rejected request.

## How did you test this code?

- Replaced the test that asserted the old fallback query with one asserting the new behavior: an app without freshness issues no query and yields no rows. It guards against reintroducing a fallback window that Google rejects.
- Ran the Google Play Console source suite locally.
- Not run: the Temporal/integration suites, which need the data-warehouse stack this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging a batch of data-warehouse sync failure classes. The 400 was traced to the `latest_available_date` fallback: no freshness means no queryable data for that metric set, so the guessed window is always rejected. Skipping the app is preferred over classifying the 400 as non-retryable, which would disable a whole table even when only some apps lack data. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The example error came from aggregated, redacted failure data; no customer identifiers appear in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
