### PR TITLE
fix(data-warehouse): redirect /data-warehouse/new to the new-source wizard

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -396,6 +396,7 @@ export const productRedirects: Record<
         return combineUrl(defaultTab, searchParams, hashParams).url
     },
     '/data-warehouse': () => urls.sources(),
+    '/data-warehouse/new': () => urls.dataWarehouseSourceNew(),
     '/data-warehouse/sources': () => urls.sources(),
     '/data-warehouse/sources/:id': ({ id }) => urls.dataWarehouseSource(id, 'schemas'),
     '/data-warehouse/sources/:id/:tab': ({ id, tab }) => urls.dataWarehouseSource(id, tab as SourceSceneTab),

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -87,6 +87,12 @@ describe('sceneLogic', () => {
         expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.projectCreateFirst())
     })
 
+    it('redirects /data-warehouse/new to the new-source wizard instead of a 404', async () => {
+        router.actions.push('/data-warehouse/new')
+        await expectLogic(logic).delay(1)
+        expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.dataWarehouseSourceNew())
+    })
+
     it('redirects the old /code_review path to /code-review, preserving the ?review= deep link and hash', async () => {
         router.actions.push('/code_review', { review: 'r-9' }, { panel: 'max:inspect' })
         await expectLogic(logic).delay(1)

--- a/products/data_warehouse/manifest.tsx
+++ b/products/data_warehouse/manifest.tsx
@@ -94,6 +94,9 @@ export const manifest: ProductManifest = {
         // Switching projects while in the new-source wizard truncates the URL to bare
         // `/data-warehouse`, which otherwise 404s. Send it to the sources list instead.
         '/data-warehouse': () => urls.sources(),
+        // `/data-warehouse/new` is a natural URL for "add a source" but was never a real route.
+        // Redirect it to the new-source wizard rather than 404ing.
+        '/data-warehouse/new': () => urls.dataWarehouseSourceNew(),
         '/data-warehouse/sources': () => urls.sources(),
         '/data-warehouse/sources/:id': ({ id }) => urls.dataWarehouseSource(id, 'schemas'),
         '/data-warehouse/sources/:id/:tab': ({ id, tab }) => urls.dataWarehouseSource(id, tab as SourceSceneTab),


### PR DESCRIPTION
## Problem

- Users who navigate to `/data-warehouse/new` to add a data source land on a 404 "Page not found" instead of the new-source wizard.
- `/data-warehouse/new` was never a registered route. The wizard lives at `/data-warehouse/new-source`, and the existing `/data-warehouse` and `/data-warehouse/sources` redirects match exactly, with no prefix fallback, so `/new` falls through to the 404 scene.

## Changes

- Visiting `/data-warehouse/new` now redirects to the new-source wizard.
- Adds one redirect entry to the data warehouse product manifest. `frontend/src/products.tsx` is regenerated from the manifest (mechanical).

## How did you test this code?

- Added a `sceneLogic` redirect test asserting `/data-warehouse/new` resolves to `urls.dataWarehouseSourceNew()`. It catches a regression where the redirect is dropped and the path 404s again. No existing test covered this path; it mirrors the existing `/project/new` redirect test.
- Ran that Jest test locally and it passes.
- Not run: the full frontend suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs reference this URL.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Opened by an autonomous agent triaging data-warehouse onboarding friction observed in session summaries. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The redirect follows the existing pattern in the same manifest block that already forwards `/data-warehouse` and `/data-warehouse/sources`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
