### PR TITLE
fix(desktop): label pull request comment links

### DIFF
--- a/products/desktop/packages/core/src/message-editor/githubIssueUrl.test.ts
+++ b/products/desktop/packages/core/src/message-editor/githubIssueUrl.test.ts
@@ -19,6 +19,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1808,
         normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+        isReviewComment: false,
       },
     },
     {
@@ -30,6 +31,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1454,
         normalizedUrl: "https://github.com/PostHog/code/pull/1454",
+        isReviewComment: false,
       },
     },
     {
@@ -41,6 +43,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1454,
         normalizedUrl: "https://github.com/PostHog/code/pull/1454",
+        isReviewComment: false,
       },
     },
     {
@@ -52,6 +55,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1808,
         normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+        isReviewComment: false,
       },
     },
     {
@@ -64,6 +68,7 @@ describe("parseGithubIssueUrl", () => {
         number: 1808,
         normalizedUrl:
           "https://github.com/PostHog/code/issues/1808#issuecomment-123",
+        isReviewComment: false,
       },
     },
     {
@@ -77,6 +82,7 @@ describe("parseGithubIssueUrl", () => {
         number: 72409,
         normalizedUrl:
           "https://github.com/PostHog/posthog/pull/72409#discussion_r3647131256",
+        isReviewComment: true,
       },
     },
     {
@@ -89,6 +95,7 @@ describe("parseGithubIssueUrl", () => {
         number: 1454,
         normalizedUrl:
           "https://github.com/PostHog/code/pull/1454/files#r3647131256",
+        isReviewComment: true,
       },
     },
     {
@@ -100,6 +107,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1808,
         normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+        isReviewComment: false,
       },
     },
     {
@@ -111,6 +119,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1808,
         normalizedUrl: "https://github.com/PostHog/code/issues/1808",
+        isReviewComment: false,
       },
     },
     {
@@ -122,6 +131,7 @@ describe("parseGithubIssueUrl", () => {
         repo: "code",
         number: 1,
         normalizedUrl: "https://github.com/PostHog/code/issues/1",
+        isReviewComment: false,
       },
     },
   ];

--- a/products/desktop/packages/core/src/message-editor/githubIssueUrl.ts
+++ b/products/desktop/packages/core/src/message-editor/githubIssueUrl.ts
@@ -8,6 +8,7 @@ export interface ParsedGithubIssueUrl {
   repo: string;
   number: number;
   normalizedUrl: string;
+  isReviewComment: boolean;
 }
 
 const GITHUB_ISSUE_URL_PATTERN =
@@ -28,11 +29,13 @@ export function parseGithubIssueUrl(text: string): ParsedGithubIssueUrl | null {
   // they were copied from. Without a fragment the tab/query suffix is noise.
   const hashIndex = suffix.indexOf("#");
   const hasFragment = hashIndex !== -1 && hashIndex < suffix.length - 1;
+  const fragment = hasFragment ? suffix.slice(hashIndex + 1) : "";
   return {
     kind,
     owner,
     repo,
     number,
     normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}${hasFragment ? suffix : ""}`,
+    isReviewComment: kind === "pr" && /^(?:discussion_)?r\d+$/.test(fragment),
   };
 }

--- a/products/desktop/packages/ui/src/features/editor/components/githubRefChipFor.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/githubRefChipFor.tsx
@@ -17,9 +17,12 @@ export function githubRefChipFor(
 
   // A bare URL reads as noise in a sentence, so it becomes owner/repo#number.
   const isAutoLink = typeof children === "string" && children === href;
-  const label = isAutoLink
-    ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
-    : children;
+  const label =
+    isAutoLink && githubRef.isReviewComment
+      ? `Comment on PR #${githubRef.number}`
+      : isAutoLink
+        ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
+        : children;
 
   if (githubRef.kind === "pr") {
     return (

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
@@ -73,6 +73,15 @@ Verdict: valid.
       'data-github-ref-url="https://github.com/PostHog/posthog/pull/23985"',
     );
   });
+
+  it("labels a pull request review comment without dropping its anchor", () => {
+    const href =
+      "https://github.com/PostHog/posthog/pull/86811/changes#r3832262653";
+    const html = renderToStaticMarkup(<ChatMarkdown content={href} />);
+
+    expect(html).toContain("Comment on PR #86811");
+    expect(html).toContain(`data-github-ref-url="${href}"`);
+  });
 });
 
 describe("ChatMarkdown object tags", () => {


### PR DESCRIPTION
## Problem

- Pasted GitHub review-comment links look like pull request links, so chat users can doubt the comment target remains.

## Changes

- Review-comment links now display as `Comment on PR #…`.
- The chip keeps the original comment anchor and pull request status.
- No screenshot: the chip styling does not change.

## How did you test this code?

- Added parser and chat-rendering coverage for review-comment anchors, preventing a generic PR label or a dropped anchor.
- Ran focused Vitest tests and scoped TypeScript checks.
- Ran `pnpm lint`; existing warnings remained outside this change.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used the `/posthog-desktop`, `/writing-tests`, and `/writing-pr-descriptions` skills.
- The change distinguishes GitHub review-comment anchors from ordinary pull request links.
- No private session material appears in the change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*