### PR TITLE
fix(desktop): stop deleting unmanaged parents when removing worktrees

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
@@ -45,8 +45,10 @@ import {
 } from "@posthog/workspace-server/db/repositories/worktree-repository.mock";
 import { ArchiveService } from "./archive";
 
-async function createTempGitRepo(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "archive-test-"));
+async function createTempGitRepo(parentDir?: string): Promise<string> {
+  const dir = await fs.mkdtemp(
+    path.join(parentDir ?? os.tmpdir(), "archive-test-"),
+  );
   execSync("git init", { cwd: dir, stdio: "pipe" });
   execSync("git config user.email 'test@test.com'", {
     cwd: dir,
@@ -502,6 +504,60 @@ describe("ArchiveService integration", () => {
 
         expect(archived.checkpointId).toBeTruthy();
         expect(await pathExists(legacyPath)).toBe(false);
+      }));
+
+    it("archiving an adopted external worktree keeps its parent directory", () =>
+      withTestContext({}, async (ctx) => {
+        const scenarioRoot = await fs.mkdtemp(
+          path.join(os.tmpdir(), "archive-adopted-"),
+        );
+        try {
+          // Incident layout: adopted sibling worktree sharing a parent with the main repo.
+          const codeParent = path.join(scenarioRoot, "code-parent");
+          await fs.mkdir(codeParent, { recursive: true });
+          const externalRepoPath = await createTempGitRepo(codeParent);
+          const externalWorktreePath = `${externalRepoPath}.feature`;
+          execSync(`git worktree add "${externalWorktreePath}" -b feature`, {
+            cwd: externalRepoPath,
+            stdio: "pipe",
+          });
+          const sentinelPath = path.join(codeParent, "unrelated-sentinel.txt");
+          await fs.writeFile(sentinelPath, "survivor");
+
+          const repo = ctx.repositoryRepo.create({ path: externalRepoPath });
+          const workspace = ctx.workspaceRepo.create({
+            taskId: "task-adopted",
+            repositoryId: repo.id,
+            mode: "worktree",
+          });
+          ctx.worktreeRepo.create({
+            workspaceId: workspace.id,
+            name: "feature",
+            path: externalWorktreePath,
+          });
+
+          await ctx.service.archiveTask({ taskId: "task-adopted" });
+
+          expect(await pathExists(externalWorktreePath)).toBe(false);
+          expect(await pathExists(codeParent)).toBe(true);
+          expect(await pathExists(externalRepoPath)).toBe(true);
+          expect(await pathExists(path.join(externalRepoPath, ".git"))).toBe(
+            true,
+          );
+          expect(await pathExists(sentinelPath)).toBe(true);
+        } finally {
+          await fs.rm(scenarioRoot, { recursive: true, force: true });
+        }
+      }));
+
+    it("archiving a managed worktree removes its empty app-owned wrapper", () =>
+      withTestContext({}, async (ctx) => {
+        const { worktreePath } = await ctx.setupWorktree("detached");
+
+        await ctx.service.archiveTask(ctx.archiveInput());
+
+        expect(await pathExists(worktreePath)).toBe(false);
+        expect(await pathExists(path.dirname(worktreePath))).toBe(false);
       }));
 
     it("archive succeeds when worktree was deleted externally", () =>

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   ROOT_LOGGER,
   type RootLogger,
@@ -7,7 +6,6 @@ import {
 import { createGitClient } from "@posthog/git/client";
 import { isGitRepository } from "@posthog/git/queries";
 import { deleteCheckpoint } from "@posthog/git/sagas/checkpoint";
-import { forceRemove } from "@posthog/git/utils";
 import { WorktreeManager } from "@posthog/git/worktree";
 import {
   type IWorkspaceSettings,
@@ -50,7 +48,10 @@ import {
   captureWorktreeCheckpoint,
   restoreWorktreeFromCheckpoint,
 } from "../worktree-checkpoint/worktree-checkpoint";
-import { deriveWorktreePath as deriveWorktreePathFromBase } from "../worktree-path/worktree-path";
+import {
+  deriveWorktreePath as deriveWorktreePathFromBase,
+  removeManagedWorktreeWrapper,
+} from "../worktree-path/worktree-path";
 import { getCurrentBranchName } from "../worktree-query/worktree-query";
 import { recoverArchiveDetailsFromLogs } from "./archive-recovery";
 import { ARCHIVE_FILE_WATCHER, ARCHIVE_SESSION_CANCELLER } from "./identifiers";
@@ -329,8 +330,15 @@ export class ArchiveService {
                 logger: this.log,
               });
               await manager.deleteWorktree(worktreePath);
-              const parentDir = path.dirname(worktreePath);
-              await forceRemove(parentDir);
+              const wrapperRemoved = await removeManagedWorktreeWrapper(
+                worktreePath,
+                this.workspaceSettings.getWorktreeLocation(),
+              );
+              if (!wrapperRemoved) {
+                this.log.info(
+                  `Kept parent of deleted worktree at ${worktreePath}: not an app-managed worktree location`,
+                );
+              }
             } catch (error) {
               this.log.warn(
                 `Failed to remove worktree at ${worktreePath}; archiving anyway (on-disk worktree may need manual cleanup)`,
@@ -484,8 +492,15 @@ export class ArchiveService {
                 restoredWorktreeName,
               );
               await manager.deleteWorktree(worktreePath);
-              const parentDir = path.dirname(worktreePath);
-              await forceRemove(parentDir);
+              const wrapperRemoved = await removeManagedWorktreeWrapper(
+                worktreePath,
+                this.workspaceSettings.getWorktreeLocation(),
+              );
+              if (!wrapperRemoved) {
+                this.log.info(
+                  `Kept parent of deleted worktree at ${worktreePath}: not an app-managed worktree location`,
+                );
+              }
             }
           },
         );

--- a/products/desktop/packages/workspace-server/src/services/suspension/suspension.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/suspension/suspension.test.ts
@@ -46,9 +46,12 @@ vi.mock("node:fs/promises", () => {
       ),
     chmod: vi.fn(),
     readdir: vi.fn().mockResolvedValue([]),
+    rmdir: vi.fn().mockResolvedValue(undefined),
   };
   return { default: fns, ...fns };
 });
+
+import fsp from "node:fs/promises";
 
 import type { IWorkspaceSettings } from "@posthog/platform/workspace-settings";
 import { createMockArchiveRepository } from "@posthog/workspace-server/db/repositories/archive-repository.mock";
@@ -332,6 +335,41 @@ describe("SuspensionService", () => {
         "Injected failure on suspension create",
       );
       expect(mocks.suspensionRepo.findAll()).toHaveLength(0);
+    });
+  });
+
+  describe("worktree deletion on disk", () => {
+    it("removes the app-owned wrapper of a managed worktree", async () => {
+      seedWorktreeWorkspace(mocks);
+
+      await service.suspendTask("task-1", "manual");
+
+      expect(mockWorktreeManagerProto.deleteWorktree).toHaveBeenCalledWith(
+        "/tmp/worktrees/wt-task-1/repo",
+      );
+      expect(vi.mocked(fsp.rmdir)).toHaveBeenCalledWith(
+        "/tmp/worktrees/wt-task-1",
+      );
+    });
+
+    it("never removes the parent of an adopted external worktree", async () => {
+      const ws = mocks.workspaceRepo.create({
+        taskId: "task-adopted",
+        repositoryId: "repo-1",
+        mode: "worktree",
+      });
+      mocks.worktreeRepo.create({
+        workspaceId: ws.id,
+        name: "feature",
+        path: "/Users/dev/code/parent/repo.feature",
+      });
+
+      await service.suspendTask("task-adopted", "manual");
+
+      expect(mockWorktreeManagerProto.deleteWorktree).toHaveBeenCalledWith(
+        "/Users/dev/code/parent/repo.feature",
+      );
+      expect(vi.mocked(fsp.rmdir)).not.toHaveBeenCalled();
     });
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
+++ b/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   ROOT_LOGGER,
   type RootLogger,
@@ -6,7 +5,6 @@ import {
 } from "@posthog/di/logger";
 import { createGitClient } from "@posthog/git/client";
 import { deleteCheckpoint } from "@posthog/git/sagas/checkpoint";
-import { forceRemove } from "@posthog/git/utils";
 import { WorktreeManager } from "@posthog/git/worktree";
 import {
   type IWorkspaceSettings,
@@ -38,7 +36,10 @@ import {
   captureWorktreeCheckpoint,
   restoreWorktreeFromCheckpoint,
 } from "../worktree-checkpoint/worktree-checkpoint";
-import { deriveWorktreePath as deriveWorktreePathFromBase } from "../worktree-path/worktree-path";
+import {
+  deriveWorktreePath as deriveWorktreePathFromBase,
+  removeManagedWorktreeWrapper,
+} from "../worktree-path/worktree-path";
 import { getCurrentBranchName } from "../worktree-query/worktree-query";
 import {
   SUSPENSION_FILE_WATCHER,
@@ -317,7 +318,15 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
   ): Promise<void> {
     const manager = this.createWorktreeManager(folderPath);
     await manager.deleteWorktree(worktreePath);
-    await forceRemove(path.dirname(worktreePath));
+    const wrapperRemoved = await removeManagedWorktreeWrapper(
+      worktreePath,
+      this.workspaceSettings.getWorktreeLocation(),
+    );
+    if (!wrapperRemoved) {
+      this.log.info(
+        `Kept parent of deleted worktree at ${worktreePath}: not an app-managed worktree location`,
+      );
+    }
   }
 
   private async killTaskProcesses(

--- a/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.test.ts
@@ -2,7 +2,10 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { deriveWorktreePath } from "./worktree-path";
+import {
+  deriveWorktreePath,
+  removeManagedWorktreeWrapper,
+} from "./worktree-path";
 
 const REPO = "/repos/posthog";
 const REPO_NAME = "posthog";
@@ -55,5 +58,101 @@ describe("deriveWorktreePath", () => {
     expect(deriveWorktreePath(tmpDir, "/a/b/other-repo", "feat")).toBe(
       path.join(tmpDir, "feat", "other-repo"),
     );
+  });
+});
+
+describe("removeManagedWorktreeWrapper", () => {
+  let tmpDir: string;
+  let externalRoot: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "wt-wrapper-"));
+    externalRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wt-external-"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+    await fsp.rm(externalRoot, { recursive: true, force: true });
+  });
+
+  it.each([
+    {
+      label: "new layout wrapper <base>/<name>",
+      layout: (base: string) => path.join(base, NAME, "repo"),
+    },
+    {
+      label: "legacy layout wrapper <base>/<repo>",
+      layout: (base: string) => path.join(base, "repo", NAME),
+    },
+  ])(
+    "removes the empty $label after the worktree is gone",
+    async ({ layout }) => {
+      const worktreePath = layout(tmpDir);
+      await fsp.mkdir(path.dirname(worktreePath), { recursive: true });
+
+      const removed = await removeManagedWorktreeWrapper(worktreePath, tmpDir);
+
+      expect(removed).toBe(true);
+      await expect(fsp.access(path.dirname(worktreePath))).rejects.toThrow();
+      await expect(fsp.access(tmpDir)).resolves.toBeUndefined();
+    },
+  );
+
+  it.each([
+    {
+      label: "an adopted checkout outside the base",
+      worktreePath: () =>
+        path.join(externalRoot, "code-parent", "repo.feature"),
+      sentinel: () => path.join(externalRoot, "code-parent", "main-repo"),
+    },
+    {
+      label: "a nested path two levels under the base",
+      worktreePath: () => path.join(tmpDir, "nested", "deeper", "repo"),
+      sentinel: () => path.join(tmpDir, "nested", "keep-me.txt"),
+    },
+    {
+      label: "the base directory itself",
+      worktreePath: () => path.join(tmpDir, "repo"),
+      sentinel: () => path.join(tmpDir, "keep-me"),
+    },
+  ])(
+    "refuses to touch the parent of $label",
+    async ({ worktreePath, sentinel }) => {
+      const wt = worktreePath();
+      const guard = sentinel();
+      await fsp.mkdir(path.dirname(wt), { recursive: true });
+      await fsp.writeFile(guard, "survivor");
+
+      const removed = await removeManagedWorktreeWrapper(wt, tmpDir);
+
+      expect(removed).toBe(false);
+      await expect(fsp.access(path.dirname(wt))).resolves.toBeUndefined();
+      await expect(fsp.access(guard)).resolves.toBeUndefined();
+    },
+  );
+
+  it("keeps a non-empty legacy wrapper holding sibling worktrees", async () => {
+    const wrapper = path.join(tmpDir, "repo");
+    await fsp.mkdir(path.join(wrapper, NAME), { recursive: true });
+    await fsp.mkdir(path.join(wrapper, "sibling-wt"), { recursive: true });
+
+    const removed = await removeManagedWorktreeWrapper(
+      path.join(wrapper, NAME),
+      tmpDir,
+    );
+
+    expect(removed).toBe(false);
+    await expect(
+      fsp.access(path.join(wrapper, "sibling-wt")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns false without throwing for paths that do not exist", async () => {
+    const removed = await removeManagedWorktreeWrapper(
+      path.join(tmpDir, "missing-name", "repo"),
+      tmpDir,
+    );
+
+    expect(removed).toBe(false);
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.ts
+++ b/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -19,4 +20,43 @@ export function deriveWorktreePath(
   if (fs.existsSync(newFormatPath)) return newFormatPath;
   if (fs.existsSync(legacyFormatPath)) return legacyFormatPath;
   return newFormatPath;
+}
+
+/**
+ * Removes the app-managed wrapper directory (`<base>/<name>`) around a
+ * just-deleted worktree. Refuses anything that is not a direct child of the
+ * configured base: an adopted external checkout's parent belongs to the user
+ * and often holds the main repository itself. Uses `rmdir`, not recursive
+ * removal, so even a containment bug could not delete more than one empty
+ * directory.
+ */
+export async function removeManagedWorktreeWrapper(
+  worktreePath: string,
+  worktreeBasePath: string,
+): Promise<boolean> {
+  const resolvedBase = path.resolve(worktreeBasePath);
+  const resolvedParent = path.dirname(path.resolve(worktreePath));
+  const relative = path.relative(resolvedBase, resolvedParent);
+
+  // Empty relative path = parent IS the base; ".." or absolute = outside it;
+  // a separator means it is nested deeper than the managed <base>/<name>
+  // layout. Case-insensitive filesystems surface case mismatches as ".."
+  // paths, so this check fails closed.
+  if (
+    !relative ||
+    relative.startsWith("..") ||
+    path.isAbsolute(relative) ||
+    relative.includes(path.sep)
+  ) {
+    return false;
+  }
+
+  try {
+    const entries = await fsp.readdir(resolvedParent);
+    if (entries.length > 0) return false;
+    await fsp.rmdir(resolvedParent);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Problem

Archiving or suspending an adopted external worktree deleted that worktree's entire parent directory on disk. Users lost their main repository's `.git`, every sibling checkout, and any unrelated folder next to it, bypassing the Trash.

The teardown ran `forceRemove(path.dirname(worktreePath))` after deleting the worktree. For app-managed worktrees (`<base>/<name>/<repo>`) that parent is an app-owned wrapper. For an adopted external checkout it belongs to the user.

Closes #81530

## Changes

- Archiving or suspending an adopted external worktree now leaves its parent directory and all sibling content untouched.
- App-managed wrappers (`<base>/<name>`) are still cleaned up after deletion, but only while empty, so a legacy wrapper holding sibling worktrees survives.
- Mechanical: a new `removeManagedWorktreeWrapper` helper replaces the three unconditional `forceRemove(path.dirname(...))` call sites (archive, unarchive rollback, suspension). It accepts only a direct child of the configured worktree base and uses `rmdir`, which cannot recurse by construction.

## How did you test this code?

Automated tests only; no manual run of the packaged app.

- Unit tests (`worktree-path.test.ts`) cover the containment boundary: removes a direct-child wrapper in both layouts, refuses the base itself, deeper-nested paths, and anything outside the base, keeps a non-empty legacy wrapper with siblings, returns false without throwing on missing paths. Regression caught: no unmanaged parent is ever touched.
- Integration test (`archive.integration.test.ts`) reproduces the incident layout: main repo plus externally created sibling worktree plus sentinel file under one parent. Against the previous code the parent is deleted; with this change the worktree goes away and the parent, main repo, `.git`, and sentinel survive. Red-to-green was verified by running the test against both versions during development.
- Suspension tests assert `rmdir` targets the managed wrapper and never runs for an external parent.
- Full workspace-server suite passes (855 tests), `tsc --noEmit` and Biome are clean on the changed packages.
- Not checked: the packaged macOS/Windows app end to end, and case-insensitive path handling on real volumes (the guard fails closed there by design).

- [x] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored end to end by an agent session (opencode CLI) run locally at the repository owner's direction; owner reviewed and approved the approach before submission. No shareable session link (local session).
- Repo-provided skills were not directly invokable in the environment; their guidance was applied by reading the source files: `/writing-pr-descriptions` (this body), `AGENTS.md` and `frontend`/desktop `CONTRIBUTING.md` conventions, and the AI contributions policy.
- Key decisions: guard placed in `worktree-path` beside `deriveWorktreePath`; `rmdir` instead of recursive removal chosen so a future containment regression still cannot delete more than one empty directory; the emptiness requirement additionally protects legacy `<base>/<repo>` wrappers shared by sibling worktrees.
- An earlier version of the helper lacked the single-segment check; the new unit test caught it before commit and the check was restored.
- Nothing in this PR carries material that is not already public.
