### PR TITLE
fix(data-warehouse): chargebee sync excludes null updated_at rows

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/chargebee.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/chargebee.py
@@ -27,7 +27,15 @@ def incremental_param(cursor_path: str) -> dict[str, Any]:
     }
 
 
-def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResource:
+def get_resource(
+    name: str, should_use_incremental_field: bool, db_incremental_field_last_value: Optional[Any] = None
+) -> EndpointResource:
+    # Chargebee only guarantees `updated_at`/`occurred_at` on records touched after
+    # 2016-09-28 and omits it entirely on some older ones (e.g. voided authorization
+    # transactions). Sending the cursor filter with its initial value (0) excludes those
+    # records server-side, and no later resync can recover them since the filter goes out
+    # again. Only apply the filter once a real watermark exists from a previous sync.
+    apply_incremental_filter = should_use_incremental_field and db_incremental_field_last_value is not None
     resources: dict[str, EndpointResource] = {
         "Customers": {
             "name": "Customers",
@@ -43,7 +51,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                 "path": "/v2/customers",
                 "params": {
                     # the parameters below can optionally be configured
-                    "updated_at[after]": incremental_param("updated_at") if should_use_incremental_field else None,
+                    "updated_at[after]": incremental_param("updated_at") if apply_incremental_filter else None,
                     "limit": 100,
                     # by default, API does not return deleted resources
                     "include_deleted": "true",
@@ -67,7 +75,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                 "path": "/v2/events",
                 "params": {
                     # the parameters below can optionally be configured
-                    "occurred_at[after]": incremental_param("occurred_at") if should_use_incremental_field else None,
+                    "occurred_at[after]": incremental_param("occurred_at") if apply_incremental_filter else None,
                     "limit": 100,
                 },
             },
@@ -87,7 +95,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                 "path": "/v2/invoices",
                 "params": {
                     # the parameters below can optionally be configured
-                    "updated_at[after]": incremental_param("updated_at") if should_use_incremental_field else None,
+                    "updated_at[after]": incremental_param("updated_at") if apply_incremental_filter else None,
                     "limit": 100,
                     # by default, API does not return deleted resources
                     "include_deleted": "true",
@@ -109,7 +117,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                 "path": "/v2/orders",
                 "params": {
                     # the parameters below can optionally be configured
-                    "updated_at[after]": incremental_param("updated_at") if should_use_incremental_field else None,
+                    "updated_at[after]": incremental_param("updated_at") if apply_incremental_filter else None,
                     "limit": 100,
                     # by default, API does not return deleted resources
                     "include_deleted": "true",
@@ -131,7 +139,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                 "path": "/v2/subscriptions",
                 "params": {
                     # the parameters below can optionally be configured
-                    "updated_at[after]": incremental_param("updated_at") if should_use_incremental_field else None,
+                    "updated_at[after]": incremental_param("updated_at") if apply_incremental_filter else None,
                     "limit": 100,
                     # by default, API does not return deleted resources
                     "include_deleted": "true",
@@ -153,7 +161,7 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
                 "path": "/v2/transactions",
                 "params": {
                     # the parameters below can optionally be configured
-                    "updated_at[after]": incremental_param("updated_at") if should_use_incremental_field else None,
+                    "updated_at[after]": incremental_param("updated_at") if apply_incremental_filter else None,
                     "limit": 100,
                     # by default, API does not return deleted resources
                     "include_deleted": "true",
@@ -238,7 +246,7 @@ def chargebee_source(
             if should_use_incremental_field
             else "replace",
         },
-        "resources": [get_resource(endpoint, should_use_incremental_field)],
+        "resources": [get_resource(endpoint, should_use_incremental_field, db_incremental_field_last_value)],
     }
 
     initial_paginator_state: Optional[dict[str, Any]] = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/tests/test_chargebee.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/tests/test_chargebee.py
@@ -121,46 +121,51 @@ def _make_http_response(body: dict[str, Any], status_code: int = 200) -> Respons
     return resp
 
 
+def _drive(
+    endpoint: str,
+    manager: MagicMock,
+    responses: list[Response],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> tuple[MagicMock, list[dict[str, Any]]]:
+    """Drive ``chargebee_source`` with a mocked HTTP session.
+
+    Returns ``(mock_session, sent_params)`` where ``sent_params`` is a list
+    of shallow copies of ``request.params`` captured at send-time — the
+    underlying Request object is mutated in-place by the paginator between
+    pages, so we can't rely on mock ``call_args_list`` to preserve history.
+    """
+    sent_params: list[dict[str, Any]] = []
+    response_iter = iter(responses)
+
+    def fake_send(request: Any, *_args: Any, **_kwargs: Any) -> Response:
+        sent_params.append(dict(request.params or {}))
+        return next(response_iter)
+
+    with patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    ) as MockSession:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.side_effect = lambda req: req
+        mock_session.send.side_effect = fake_send
+
+        resource = chargebee_source(
+            api_key="test-key",
+            site_name="site-test",
+            endpoint=endpoint,
+            team_id=123,
+            job_id="test_job",
+            resumable_source_manager=manager,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            should_use_incremental_field=should_use_incremental_field,
+        )
+        list(cast(Iterable[Any], resource))
+        return mock_session, sent_params
+
+
 class TestChargebeeSourceResumeBehavior:
     """End-to-end resume behaviour of ``chargebee_source`` via ``rest_api_resource``."""
-
-    def _drive(
-        self, endpoint: str, manager: MagicMock, responses: list[Response]
-    ) -> tuple[MagicMock, list[dict[str, Any]]]:
-        """Drive ``chargebee_source`` with a mocked HTTP session.
-
-        Returns ``(mock_session, sent_params)`` where ``sent_params`` is a list
-        of shallow copies of ``request.params`` captured at send-time — the
-        underlying Request object is mutated in-place by the paginator between
-        pages, so we can't rely on mock ``call_args_list`` to preserve history.
-        """
-        sent_params: list[dict[str, Any]] = []
-        response_iter = iter(responses)
-
-        def fake_send(request: Any, *_args: Any, **_kwargs: Any) -> Response:
-            sent_params.append(dict(request.params or {}))
-            return next(response_iter)
-
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
-        ) as MockSession:
-            mock_session = MockSession.return_value
-            mock_session.headers = {}
-            mock_session.prepare_request.side_effect = lambda req: req
-            mock_session.send.side_effect = fake_send
-
-            resource = chargebee_source(
-                api_key="test-key",
-                site_name="site-test",
-                endpoint=endpoint,
-                team_id=123,
-                job_id="test_job",
-                resumable_source_manager=manager,
-                db_incremental_field_last_value=None,
-                should_use_incremental_field=False,
-            )
-            list(cast(Iterable[Any], resource))
-            return mock_session, sent_params
 
     @pytest.mark.parametrize("endpoint", ["Customers", "Events", "Invoices", "Subscriptions", "Transactions", "Orders"])
     def test_fresh_run_saves_offset_after_each_non_terminal_page(self, endpoint: str) -> None:
@@ -174,7 +179,7 @@ class TestChargebeeSourceResumeBehavior:
             _make_http_response({"list": [{"customer": {"id": "c2"}}], "next_offset": "cursor-2"}),
             _make_http_response({"list": [{"customer": {"id": "c3"}}]}),
         ]
-        _, sent_params = self._drive(endpoint, manager, responses)
+        _, sent_params = _drive(endpoint, manager, responses)
 
         # First request has no offset (fresh run); subsequent requests carry the prior page's cursor.
         offsets_sent = [p.get("offset") for p in sent_params]
@@ -194,7 +199,7 @@ class TestChargebeeSourceResumeBehavior:
         responses = [
             _make_http_response({"list": [{"customer": {"id": "c4"}}]}),
         ]
-        _, sent_params = self._drive("Customers", manager, responses)
+        _, sent_params = _drive("Customers", manager, responses)
 
         assert [p.get("offset") for p in sent_params] == ["cursor-resumed"]
         manager.load_state.assert_called_once()
@@ -206,7 +211,7 @@ class TestChargebeeSourceResumeBehavior:
         responses = [
             _make_http_response({"list": [{"customer": {"id": "only"}}]}),
         ]
-        self._drive("Customers", manager, responses)
+        _drive("Customers", manager, responses)
 
         manager.save_state.assert_not_called()
 
@@ -217,9 +222,79 @@ class TestChargebeeSourceResumeBehavior:
         responses = [
             _make_http_response({"list": [{"customer": {"id": "a"}}]}),
         ]
-        self._drive("Customers", manager, responses)
+        _drive("Customers", manager, responses)
 
         manager.load_state.assert_not_called()
+
+
+class TestChargebeeIncrementalCursorFilter:
+    """Chargebee excludes records with no `updated_at`/`occurred_at` when the cursor filter is
+    sent, and a resync can't recover them once excluded — so the filter must be omitted until a
+    real watermark exists (first sync, or a full resync that resets the watermark), and only
+    sent once one does."""
+
+    @pytest.mark.parametrize(
+        ("endpoint", "cursor_param"),
+        [
+            ("Customers", "updated_at[after]"),
+            ("Events", "occurred_at[after]"),
+            ("Invoices", "updated_at[after]"),
+            ("Orders", "updated_at[after]"),
+            ("Subscriptions", "updated_at[after]"),
+            ("Transactions", "updated_at[after]"),
+        ],
+    )
+    def test_first_incremental_sync_omits_cursor_filter(self, endpoint: str, cursor_param: str) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+        responses = [_make_http_response({"list": [{"customer": {"id": "c1"}}]})]
+
+        _, sent_params = _drive(
+            endpoint,
+            manager,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+        )
+
+        assert cursor_param not in sent_params[0]
+
+    @pytest.mark.parametrize(
+        ("endpoint", "cursor_param"),
+        [
+            ("Customers", "updated_at[after]"),
+            ("Events", "occurred_at[after]"),
+        ],
+    )
+    def test_later_incremental_sync_sends_cursor_filter(self, endpoint: str, cursor_param: str) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+        responses = [_make_http_response({"list": [{"customer": {"id": "c1"}}]})]
+
+        _, sent_params = _drive(
+            endpoint,
+            manager,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=1700000000,
+        )
+
+        assert sent_params[0][cursor_param] == 1700000000
+
+    def test_non_incremental_sync_never_sends_cursor_filter(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+        responses = [_make_http_response({"list": [{"customer": {"id": "c1"}}]})]
+
+        _, sent_params = _drive(
+            "Customers",
+            manager,
+            responses,
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=1700000000,
+        )
+
+        assert "updated_at[after]" not in sent_params[0]
 
 
 class TestChargebeeSiteNameValidation:


### PR DESCRIPTION
## Problem

Chargebee customers using incremental sync silently lose records that never received an `updated_at`/`occurred_at` attribute — Chargebee only guarantees that field on resources touched after 2016-09-28, so older records (e.g. voided authorization transactions from 2020-2022) can have none at all. Verified on a live customer site: a direct unfiltered export had 7,836 transactions, the warehouse table had 7,400 — the 436 missing were exactly the null-`updated_at` records. The gap is silent: sync jobs report Completed and the table looks healthy.

Switching a schema to full refresh is the only current workaround, and it isn't a fix — a resync still sends the same cursor filter, so it can't recover the missing rows either.

Closes #76090

## Changes

- Chargebee's incremental sync no longer excludes records with no `updated_at`/`occurred_at`. The cursor filter (`updated_at[after]` / `occurred_at[after]`) is now withheld until a real watermark exists from a previous sync; the first incremental sync (and any full resync, which resets the watermark) pulls the complete set, and only later incremental runs apply the filter.
- Mechanical: `get_resource()` takes the current watermark and derives `apply_incremental_filter` instead of gating each endpoint's params directly on `should_use_incremental_field`.

## How did you test this code?

Added `TestChargebeeIncrementalCursorFilter`, parametrized across all six affected endpoints (Customers, Events, Invoices, Orders, Subscriptions, Transactions):
- filter omitted when there's no stored watermark (first sync / post-resync)
- filter sent with the correct value once a watermark exists
- filter never sent when the schema isn't incremental at all, even if a stale watermark value is passed in

None of the existing tests asserted on filter presence, so this is new coverage, not overlapping.

Ran locally: `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/tests/test_chargebee.py -v` — 38 passed (29 existing + 9 new).
Typechecked the two touched files with `uv run mypy --cache-fine-grained`: 0 errors on both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal source-connector fix, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The fix design isn't original to this PR: an internal automation opened #76117 against this same issue with the same `apply_incremental_filter` approach and parametrized test shape, but it went stale and was auto-closed without human review or merge. This PR re-derives that design against current `main` (the source file and its test suite have both changed since #76117 was opened) and completes it, adding one extra edge-case test (non-incremental sync with a stale watermark value present) that wasn't in the original.
