### PR TITLE
fix(data-warehouse): write managed tables to team schema

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/SettingsTab.tsx
@@ -227,12 +227,38 @@ export function SettingsTab(): JSX.Element {
                     </div>
                     <div>
                         <LemonLabel>Schema name</LemonLabel>
-                        <LemonInput value={schemaName} onChange={setSchemaName} placeholder="my_project" fullWidth />
-                        {schemaName && !isValidSchemaName ? (
+                        <div className="flex items-center gap-2">
+                            <LemonInput
+                                value={schemaName}
+                                onChange={setSchemaName}
+                                placeholder="my_project"
+                                fullWidth
+                            />
+                            {schemaName &&
+                                isValidSchemaName &&
+                                (schemaNameChecking ? (
+                                    <Spinner className="text-muted" />
+                                ) : schemaNameAvailable === true ? (
+                                    <IconCheck className="text-success text-xl" />
+                                ) : (
+                                    <IconX className="text-danger text-xl" />
+                                ))}
+                        </div>
+                        {schemaName && !isValidSchemaName && (
                             <p className="text-danger text-xs mt-1">
                                 Use lowercase letters, numbers, and underscores only (max 63 characters).
                             </p>
-                        ) : (
+                        )}
+                        {schemaName && isValidSchemaName && !schemaNameChecking && schemaNameAvailable !== true && (
+                            <p className="text-danger text-xs mt-1">
+                                {isFailed
+                                    ? 'Availability checks are advisory during retry provisioning.'
+                                    : schemaNameAvailable === false
+                                      ? 'This schema name is already used by another project in your organization.'
+                                      : 'Unable to verify schema name availability.'}
+                            </p>
+                        )}
+                        {(!schemaName || schemaNameChecking || schemaNameAvailable === true) && (
                             <p className="text-muted text-xs mt-1">
                                 This project's data lands in its own schema in the warehouse. Other projects pick their
                                 own schema when they join. Unlike the project name, the schema name cannot be changed

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.test.ts
@@ -26,6 +26,7 @@ describe('warehouseProvisioningLogic', () => {
 
     afterEach(() => {
         logic?.unmount()
+        jest.useRealTimers()
         jest.restoreAllMocks()
     })
 
@@ -47,7 +48,7 @@ describe('warehouseProvisioningLogic', () => {
         expect(logic.values.warehouseStatus).toBeNull()
     })
 
-    it('validates database names and gates provisioning on availability', async () => {
+    it('validates names and gates provisioning on both availability checks', async () => {
         logic = warehouseProvisioningLogic()
         logic.mount()
 
@@ -63,7 +64,29 @@ describe('warehouseProvisioningLogic', () => {
         await expectLogic(logic, () => {
             logic.actions.setDatabaseName('valid-name')
             logic.actions.setDatabaseNameAvailable(true)
-        }).toMatchValues({ isValidDatabaseName: true, canProvision: true })
+        }).toMatchValues({ isValidDatabaseName: true, canProvision: false })
+
+        await expectLogic(logic, () => {
+            logic.actions.setSchemaNameAvailable(true)
+        }).toMatchValues({ canProvision: true })
+    })
+
+    it('checks schema availability while provisioning a new warehouse', async () => {
+        jest.useFakeTimers()
+        const checkSchemaName = jest.spyOn(dwApi, 'dataWarehouseCheckSchemaNameRetrieve').mockResolvedValue({
+            name: 'taken_schema',
+            available: false,
+        } as any)
+
+        logic = warehouseProvisioningLogic()
+        logic.mount()
+        logic.actions.setSchemaName('taken_schema')
+
+        await jest.advanceTimersByTimeAsync(400)
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(checkSchemaName).toHaveBeenCalledWith(expect.any(String), { name: 'taken_schema' })
+        expect(logic.values.schemaNameAvailable).toBe(false)
     })
 
     it('removes the org record once teardown reports the warehouse deleted, then stops polling', async () => {

--- a/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/warehouseProvisioningLogic.ts
@@ -26,20 +26,20 @@ import type { WarehouseStatusResponseStateEnumApi } from '../../../../../product
 import type { PreflightStatus } from '../../../types'
 
 // The warehouse name becomes the connection's SNI subdomain (a DNS-1123 label), so it
-// mirrors the backend validator in products/data_warehouse/backend/api/managed_warehouse.py:
+// mirrors the backend validator in products/managed_warehouse/backend/presentation/views.py:
 // 3-63 chars, lowercase alphanumerics and hyphens, starting/ending alphanumeric (no underscores).
 const WAREHOUSE_NAME_REGEX = /^[a-z][a-z0-9-]{1,61}[a-z0-9]$/
 
 // DNS zone the connection host lives under, selected by deployment region. Mirrors
-// _MANAGED_WAREHOUSE_DOMAINS in products/data_warehouse/backend/api/managed_warehouse.py.
+// _MANAGED_WAREHOUSE_DOMAINS in products/managed_warehouse/backend/presentation/views.py.
 const MANAGED_WAREHOUSE_DOMAINS: Partial<Record<Region, string>> = {
     [Region.US]: 'us.postwh.com',
     [Region.EU]: 'eu.postwh.com',
     [Region.DEV]: 'dev.postwh.com',
 }
 
-// The schema name is used verbatim as a SQL identifier (and as the backfill table suffix), so
-// it must already be safe. Mirrors validate_schema_name in products/managed_warehouse/backend/common.py.
+// The schema name is used verbatim as a SQL identifier, so it must already be safe.
+// Mirrors validate_schema_name in products/managed_warehouse/backend/common.py.
 const SCHEMA_NAME_REGEX = /^[a-z0-9_]{1,63}$/
 
 const databaseNameStorageKey = (teamId: number | null): string =>
@@ -201,7 +201,8 @@ export interface warehouseProvisioningLogicMeta {
         canProvision: (
             isValidDatabaseName: boolean,
             databaseNameAvailable: boolean | null,
-            isValidSchemaName: boolean
+            isValidSchemaName: boolean,
+            schemaNameAvailable: boolean | null
         ) => boolean
         canRetryProvision: (retryDatabaseName: string, isValidSchemaName: boolean) => boolean
         canOnboardTeam: (isValidSchemaName: boolean, schemaNameAvailable: boolean | null) => boolean
@@ -489,9 +490,13 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 status?.state === 'ready' && !teamOnboarded,
         ],
         canProvision: [
-            (s) => [s.isValidDatabaseName, s.databaseNameAvailable, s.isValidSchemaName],
-            (valid: boolean, available: boolean | null, validSchema: boolean): boolean =>
-                valid && available === true && validSchema,
+            (s) => [s.isValidDatabaseName, s.databaseNameAvailable, s.isValidSchemaName, s.schemaNameAvailable],
+            (
+                valid: boolean,
+                available: boolean | null,
+                validSchema: boolean,
+                schemaAvailable: boolean | null
+            ): boolean => valid && available === true && validSchema && schemaAvailable === true,
         ],
         canRetryProvision: [
             (s) => [s.retryDatabaseName, s.isValidSchemaName],
@@ -543,9 +548,7 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 if (schemaDebounceTimer) {
                     clearTimeout(schemaDebounceTimer)
                 }
-                // Availability only matters when joining an existing warehouse — at provision
-                // time this is the org's first schema, so there is nothing to collide with.
-                if (values.needsTeamOnboarding && SCHEMA_NAME_REGEX.test(name)) {
+                if (SCHEMA_NAME_REGEX.test(name)) {
                     actions.setSchemaNameChecking(true)
                     schemaDebounceTimer = setTimeout(() => {
                         actions.checkSchemaName(name)
@@ -717,9 +720,8 @@ export const warehouseProvisioningLogic = kea<warehouseProvisioningLogicType>([
                 } else {
                     actions.stopPolling()
                 }
-                // The default schema name is prefilled on mount, before this response can flip
-                // needsTeamOnboarding to true — so its availability was never checked. Re-set it
-                // here to run the debounced check once the onboarding form is actually shown.
+                // Retry an inconclusive prefill check once the onboarding state is known so a
+                // transient startup failure doesn't leave the form permanently disabled.
                 if (
                     values.needsTeamOnboarding &&
                     values.schemaName &&

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -99,7 +99,7 @@ from products.managed_warehouse.backend.facade.client import (
     mint_service_credential,
     refresh_service_credential,
 )
-from products.managed_warehouse.backend.facade.contracts import ManagedWarehouseTeamMembership
+from products.managed_warehouse.backend.facade.contracts import DucklingTables, ManagedWarehouseTeamMembership
 from products.managed_warehouse.backend.facade.metrics import record_duckling_backfill_workload, track_duckling_backfill
 from products.managed_warehouse.backend.facade.team_state import (
     list_enabled_backfill_team_memberships,
@@ -218,23 +218,25 @@ class DucklingTarget:
     organization_id: str
     bucket: str
     bucket_region: str
-    # Default to the shared tables; _resolve_duckling_target sets these per-team from table_suffix.
+    # Defaults preserve legacy single-team warehouses that have no control-plane row.
     events_table: str = "events"
     persons_table: str = "persons"
+    events_schema: str = "posthog"
+    persons_schema: str = "posthog"
 
 
-def _resolve_table_names(team_id: int) -> tuple[str, str]:
-    """Resolve this team's per-environment events/persons table names.
+def _resolve_table_names(team_id: int) -> DucklingTables:
+    """Resolve this team's per-environment events/persons table locations.
 
-    A team's duckgres control-plane row isolates its data into dedicated
-    `events_<suffix>` / `persons_<suffix>` tables so multiple teams sharing one
-    org-scoped duckling don't merge into the shared `posthog.events` / `posthog.persons`.
-    A team without a row (legacy single-team ducklings) keeps the shared table names.
+    A team's duckgres control-plane row isolates its data in its chosen schema. A team
+    without a row, or with explicit grandfathered names, keeps the shared `posthog` schema.
     """
     tables = resolve_events_persons_tables(team_id)
+    _validate_identifier(tables.events_schema)
+    _validate_identifier(tables.persons_schema)
     _validate_identifier(tables.events_table)
     _validate_identifier(tables.persons_table)
-    return tables.events_table, tables.persons_table
+    return tables
 
 
 def _resolve_duckling_target(team_id: int) -> DucklingTarget:
@@ -261,7 +263,7 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
     from products.managed_warehouse.backend.facade.api import get_control_plane_bucket  # noqa: PLC0415
 
     org_id = get_org_id_for_team(team_id)
-    events_table, persons_table = _resolve_table_names(team_id)
+    tables = _resolve_table_names(team_id)
 
     # Control plane first — authoritative, and rejects an org_id-mismatched status body.
     cp_bucket = get_control_plane_bucket(org_id)
@@ -277,8 +279,10 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
             organization_id=org_id,
             bucket=cp_bucket,
             bucket_region=DUCKGRES_BUCKET_REGION,
-            events_table=events_table,
-            persons_table=persons_table,
+            events_table=tables.events_table,
+            persons_table=tables.persons_table,
+            events_schema=tables.events_schema,
+            persons_schema=tables.persons_schema,
         )
 
     # CP couldn't answer — fall back to the stored row if it knows a bucket.
@@ -296,8 +300,10 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
             organization_id=org_id,
             bucket=bucket,
             bucket_region=bucket_region,
-            events_table=events_table,
-            persons_table=persons_table,
+            events_table=tables.events_table,
+            persons_table=tables.persons_table,
+            events_schema=tables.events_schema,
+            persons_schema=tables.persons_schema,
         )
 
     raise ValueError(
@@ -871,7 +877,7 @@ def _repair_stale_running_statuses(context: SensorEvaluationContext, dataset: st
 # SQL for creating the events table in DuckLake if it doesn't exist
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
 EVENTS_TABLE_DDL = """
-CREATE TABLE IF NOT EXISTS {catalog}.posthog.{table} (
+CREATE TABLE IF NOT EXISTS {catalog}.{schema}.{table} (
     uuid VARCHAR,
     event VARCHAR,
     properties VARCHAR,
@@ -904,7 +910,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.{table} (
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
 # Note: person_version uses UBIGINT to match ClickHouse's UInt64 type.
 PERSONS_TABLE_DDL = """
-CREATE TABLE IF NOT EXISTS {catalog}.posthog.{table} (
+CREATE TABLE IF NOT EXISTS {catalog}.{schema}.{table} (
     team_id BIGINT,
     distinct_id VARCHAR,
     id VARCHAR,
@@ -1122,6 +1128,7 @@ def table_exists(
 def _set_table_partitioning(
     conn: psycopg.Connection[Any],
     alias: str,
+    schema: str,
     table: str,
     partition_expr: str,
     context: AssetExecutionContext,
@@ -1135,6 +1142,7 @@ def _set_table_partitioning(
     Args:
         conn: psycopg connection to the org's duckgres server.
         alias: Catalog alias.
+        schema: Schema name (must be alphanumeric/underscore only).
         table: Table name (must be alphanumeric/underscore only).
         partition_expr: Partition expression (e.g., "year(timestamp), month(timestamp), day(timestamp)").
         context: Dagster asset execution context.
@@ -1144,11 +1152,12 @@ def _set_table_partitioning(
         True if partitioning was set successfully, False if it failed.
     """
     _validate_identifier(alias)
+    _validate_identifier(schema)
     _validate_identifier(table)
 
     context.log.info(f"Setting partitioning on {table} table...")
     try:
-        conn.execute(f"ALTER TABLE {alias}.posthog.{table} SET PARTITIONED BY ({partition_expr})")
+        conn.execute(f"ALTER TABLE {alias}.{schema}.{table} SET PARTITIONED BY ({partition_expr})")
         context.log.info(f"Successfully set partitioning on {table} table")
         logger.info(
             "duckling_table_partitioning_set",
@@ -1186,14 +1195,16 @@ def ensure_events_table_exists(
     idempotent - calling SET PARTITIONED BY multiple times with the same keys succeeds.
     """
     alias = DUCKLAKE_ALIAS
+    schema = target.events_schema
     table = target.events_table
 
-    if table_exists(conn, alias, "posthog", table):
+    if table_exists(conn, alias, schema, table):
         context.log.info("Events table already exists in duckling catalog")
         # Ensure partitioning is set even on existing tables (idempotent)
         _set_table_partitioning(
             conn,
             alias,
+            schema,
             table,
             "year(timestamp), month(timestamp), day(timestamp)",
             context,
@@ -1201,17 +1212,18 @@ def ensure_events_table_exists(
         )
         return False
 
-    context.log.info("Creating posthog schema if it doesn't exist...")
-    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
+    context.log.info(f"Creating {schema} schema if it doesn't exist...")
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.{schema}")
 
     context.log.info("Creating events table in duckling catalog...")
-    conn.execute(EVENTS_TABLE_DDL.format(catalog=alias, table=table))
+    conn.execute(EVENTS_TABLE_DDL.format(catalog=alias, schema=schema, table=table))
     context.log.info("Successfully created events table")
 
     # Set partitioning by year/month/day for efficient querying
     _set_table_partitioning(
         conn,
         alias,
+        schema,
         table,
         "year(timestamp), month(timestamp), day(timestamp)",
         context,
@@ -1242,14 +1254,16 @@ def ensure_persons_table_exists(
     idempotent - calling SET PARTITIONED BY multiple times with the same keys succeeds.
     """
     alias = DUCKLAKE_ALIAS
+    schema = target.persons_schema
     table = target.persons_table
 
-    if table_exists(conn, alias, "posthog", table):
+    if table_exists(conn, alias, schema, table):
         context.log.info("Persons table already exists in duckling catalog")
         # Ensure partitioning is set even on existing tables (idempotent)
         _set_table_partitioning(
             conn,
             alias,
+            schema,
             table,
             "year(_timestamp), month(_timestamp)",
             context,
@@ -1257,17 +1271,18 @@ def ensure_persons_table_exists(
         )
         return False
 
-    context.log.info("Creating posthog schema if it doesn't exist...")
-    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.posthog")
+    context.log.info(f"Creating {schema} schema if it doesn't exist...")
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {alias}.{schema}")
 
     context.log.info("Creating persons table in duckling catalog...")
-    conn.execute(PERSONS_TABLE_DDL.format(catalog=alias, table=table))
+    conn.execute(PERSONS_TABLE_DDL.format(catalog=alias, schema=schema, table=table))
     context.log.info("Successfully created persons table")
 
     # Set partitioning by year/month of _timestamp for efficient querying
     _set_table_partitioning(
         conn,
         alias,
+        schema,
         table,
         "year(_timestamp), month(_timestamp)",
         context,
@@ -1295,7 +1310,7 @@ def validate_duckling_schema(
     alias = DUCKLAKE_ALIAS
 
     with conn.cursor() as cur:
-        cur.execute(f"DESCRIBE {alias}.posthog.{target.events_table}")
+        cur.execute(f"DESCRIBE {alias}.{target.events_schema}.{target.events_table}")
         ducklake_columns = {row[0] for row in cur.fetchall()}
 
     missing_in_ducklake = EXPECTED_DUCKLAKE_EVENTS_COLUMNS - ducklake_columns
@@ -1336,7 +1351,7 @@ def validate_duckling_persons_schema(
     alias = DUCKLAKE_ALIAS
 
     with conn.cursor() as cur:
-        cur.execute(f"DESCRIBE {alias}.posthog.{target.persons_table}")
+        cur.execute(f"DESCRIBE {alias}.{target.persons_schema}.{target.persons_table}")
         ducklake_columns = {row[0] for row in cur.fetchall()}
 
     missing_in_ducklake = EXPECTED_DUCKLAKE_PERSONS_COLUMNS - ducklake_columns
@@ -1456,7 +1471,7 @@ def delete_events_partition_data(
     # to a single day's partition instead of scanning all data files.
     next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
     delete_sql = f"""
-    DELETE FROM {alias}.posthog.{target.events_table}
+    DELETE FROM {alias}.{target.events_schema}.{target.events_table}
     WHERE team_id = %s
       AND timestamp >= %s
       AND timestamp < %s
@@ -1518,7 +1533,7 @@ def delete_persons_partition_data(
     delete_params: tuple[Any, ...]
     if partition_date is None:
         delete_sql = f"""
-        DELETE FROM {alias}.posthog.{target.persons_table}
+        DELETE FROM {alias}.{target.persons_schema}.{target.persons_table}
         WHERE team_id = %s
         """
         delete_params = (team_id,)
@@ -1526,7 +1541,7 @@ def delete_persons_partition_data(
         date_str = partition_date.strftime("%Y-%m-%d")
         next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
         delete_sql = f"""
-        DELETE FROM {alias}.posthog.{target.persons_table}
+        DELETE FROM {alias}.{target.persons_schema}.{target.persons_table}
         WHERE team_id = %s
           AND _timestamp >= %s
           AND _timestamp < %s
@@ -1848,6 +1863,7 @@ def _release_ducklake_file_partition_value_session_advisory_lock(conn: Any) -> N
 def _assert_live_spec_matches(
     cur: Any,
     table_kind: Literal["events", "persons"],
+    schema_name: str,
     table_name: str,
     table_id: int,
     partition_id: int,
@@ -1872,7 +1888,7 @@ def _assert_live_spec_matches(
     expected = _DUCKLAKE_FILE_PARTITION_VALUE_SPEC[table_kind]
     if actual != expected:
         raise RuntimeError(
-            f"ducklake_file_partition_value fix-up: live catalog spec for posthog.{table_name} "
+            f"ducklake_file_partition_value fix-up: live catalog spec for {schema_name}.{table_name} "
             f"(kind={table_kind}, partition_id={partition_id}) is {actual}; expected {expected}. "
             f"Update _DUCKLAKE_FILE_PARTITION_VALUE_SPEC and redeploy before re-enabling the fix-up."
         )
@@ -1897,6 +1913,7 @@ def _fixup_partition_values_for_added_files(
     if not file_paths:
         return
 
+    schema_name = target.events_schema if table_kind == "events" else target.persons_schema
     spec = _DUCKLAKE_FILE_PARTITION_VALUE_SPEC.get(table_kind)
     path_regex = _DUCKLAKE_FILE_PARTITION_VALUE_PATH_REGEXES.get(table_kind)
     if spec is None or path_regex is None:
@@ -1947,21 +1964,21 @@ def _fixup_partition_values_for_added_files(
                       ON s.schema_id = t.schema_id AND s.end_snapshot IS NULL
                     JOIN public.ducklake_partition_info pi
                       ON pi.table_id = t.table_id AND pi.end_snapshot IS NULL
-                    WHERE s.schema_name = 'posthog'
+                    WHERE s.schema_name = %s
                       AND t.table_name = %s
                       AND t.end_snapshot IS NULL
                     """,
-                    (table_name,),
+                    (schema_name, table_name),
                 )
                 rows = cur.fetchall()
                 if len(rows) != 1:
                     raise RuntimeError(
                         f"ducklake_file_partition_value fix-up: expected exactly one live partition_info "
-                        f"for posthog.{table_name}, got {len(rows)}"
+                        f"for {schema_name}.{table_name}, got {len(rows)}"
                     )
                 table_id, partition_id = rows[0]
 
-                _assert_live_spec_matches(cur, table_kind, table_name, table_id, partition_id)
+                _assert_live_spec_matches(cur, table_kind, schema_name, table_name, table_id, partition_id)
 
                 # Single-statement DELETE + INSERT so no reader sees zero ducklake_file_partition_value rows.
                 # DELETE is scoped by table_id AND data_file_id (defense in depth).
@@ -2157,10 +2174,11 @@ def register_files_with_duckling(
             # column (team_id/uuid/timestamp) would only arise from an export bug, not
             # normal operation, and would surface as NULL-filled rows in downstream reads.
             conn.execute(
-                psql.SQL("CALL ducklake_add_data_files({}, {}, {}, schema => 'posthog', allow_missing => true)").format(
+                psql.SQL("CALL ducklake_add_data_files({}, {}, {}, schema => {}, allow_missing => true)").format(
                     psql.Literal(alias),
                     psql.Literal(target.events_table),
                     psql.Literal(s3_path),
+                    psql.Literal(target.events_schema),
                 )
             )
 
@@ -2429,10 +2447,11 @@ def register_persons_files_with_duckling(
         for s3_path in files:
             # See the events registration site for the allow_missing rationale.
             conn.execute(
-                psql.SQL("CALL ducklake_add_data_files({}, {}, {}, schema => 'posthog', allow_missing => true)").format(
+                psql.SQL("CALL ducklake_add_data_files({}, {}, {}, schema => {}, allow_missing => true)").format(
                     psql.Literal(alias),
                     psql.Literal(target.persons_table),
                     psql.Literal(s3_path),
+                    psql.Literal(target.persons_schema),
                 )
             )
 
@@ -2554,7 +2573,9 @@ def _run_duckling_events_backfill(context: AssetExecutionContext, config: Duckli
                 try:
                     session.run(
                         "drop events table",
-                        lambda c: c.execute(f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.posthog.{target.events_table}"),
+                        lambda c: c.execute(
+                            f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.{target.events_schema}.{target.events_table}"
+                        ),
                     )
                 except Exception:
                     context.log.exception(f"Failed to drop events table for team_id={team_id}")
@@ -2785,7 +2806,9 @@ def _run_duckling_persons_backfill(context: AssetExecutionContext, config: Duckl
                 try:
                     session.run(
                         "drop persons table",
-                        lambda c: c.execute(f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.posthog.{target.persons_table}"),
+                        lambda c: c.execute(
+                            f"DROP TABLE IF EXISTS {DUCKLAKE_ALIAS}.{target.persons_schema}.{target.persons_table}"
+                        ),
                     )
                 except Exception:
                     context.log.exception(f"Failed to drop persons table for team_id={team_id}")

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -97,7 +97,15 @@ class TestDucklingBackfillAlertRouting:
 
 
 class TestResolveDucklingTarget:
-    @patch("posthog.dags.events_backfill_to_duckling._resolve_table_names", return_value=("events", "persons"))
+    @patch(
+        "posthog.dags.events_backfill_to_duckling._resolve_table_names",
+        return_value=DucklingTables(
+            events_table="events",
+            persons_table="persons",
+            events_schema="permapeople",
+            persons_schema="permapeople",
+        ),
+    )
     @patch("posthog.dags.events_backfill_to_duckling.get_stored_bucket_config", return_value=None)
     @patch("posthog.dags.events_backfill_to_duckling.get_org_id_for_team", return_value="org-1")
     def test_resolves_bucket_from_control_plane(
@@ -115,11 +123,16 @@ class TestResolveDucklingTarget:
             organization_id="org-1",
             bucket="posthog-duckling-org-1-mw-prod-us",
             bucket_region="us-east-1",
+            events_schema="permapeople",
+            persons_schema="permapeople",
         )
         mock_org.assert_called_once_with(7)
         mock_cp.assert_called_once_with("org-1")
 
-    @patch("posthog.dags.events_backfill_to_duckling._resolve_table_names", return_value=("events", "persons"))
+    @patch(
+        "posthog.dags.events_backfill_to_duckling._resolve_table_names",
+        return_value=DucklingTables(events_table="events", persons_table="persons"),
+    )
     @patch("posthog.dags.events_backfill_to_duckling.get_org_id_for_team", return_value="org-1")
     def test_control_plane_wins_over_stale_stored_server_bucket(self, _mock_org: MagicMock, _mock_tables: MagicMock):
         # A row provisioned before the naming fix carries a stale bucket; the CP value
@@ -139,7 +152,10 @@ class TestResolveDucklingTarget:
 
         assert target.bucket == "posthog-duckling-org-1-mw-prod-us"
 
-    @patch("posthog.dags.events_backfill_to_duckling._resolve_table_names", return_value=("events", "persons"))
+    @patch(
+        "posthog.dags.events_backfill_to_duckling._resolve_table_names",
+        return_value=DucklingTables(events_table="events", persons_table="persons"),
+    )
     @patch("posthog.dags.events_backfill_to_duckling.get_org_id_for_team", return_value="org-1")
     def test_falls_back_to_stored_server_when_control_plane_unavailable(
         self, _mock_org: MagicMock, _mock_tables: MagicMock
@@ -160,7 +176,10 @@ class TestResolveDucklingTarget:
 
         assert target.bucket == "posthog-duckling-org-1-mw-prod-us"
 
-    @patch("posthog.dags.events_backfill_to_duckling._resolve_table_names", return_value=("events", "persons"))
+    @patch(
+        "posthog.dags.events_backfill_to_duckling._resolve_table_names",
+        return_value=DucklingTables(events_table="events", persons_table="persons"),
+    )
     @patch("posthog.dags.events_backfill_to_duckling.get_stored_bucket_config", return_value=None)
     @patch("posthog.dags.events_backfill_to_duckling.get_org_id_for_team", return_value="org-1")
     def test_raises_when_nothing_can_name_the_bucket(
@@ -175,19 +194,33 @@ class TestResolveDucklingTarget:
 
 
 class TestResolveTableNames:
-    """The DAG-side wrapper passes the accessor's names through fail-closed validation."""
+    """The DAG-side wrapper passes locations through fail-closed validation."""
 
     def test_passes_through_resolved_names(self):
         with patch(
             "posthog.dags.events_backfill_to_duckling.resolve_events_persons_tables",
-            return_value=DucklingTables(events_table="events_alpha", persons_table="persons_alpha"),
+            return_value=DucklingTables(
+                events_table="events",
+                persons_table="persons",
+                events_schema="alpha",
+                persons_schema="alpha",
+            ),
         ):
-            assert _resolve_table_names(1) == ("events_alpha", "persons_alpha")
+            assert _resolve_table_names(1) == DucklingTables(
+                events_table="events",
+                persons_table="persons",
+                events_schema="alpha",
+                persons_schema="alpha",
+            )
 
     def test_unsafe_resolved_name_is_rejected(self):
         with patch(
             "posthog.dags.events_backfill_to_duckling.resolve_events_persons_tables",
-            return_value=DucklingTables(events_table="events_a-b; DROP", persons_table="persons"),
+            return_value=DucklingTables(
+                events_table="events",
+                persons_table="persons",
+                events_schema="a-b; DROP",
+            ),
         ):
             with pytest.raises(ValueError):
                 _resolve_table_names(1)
@@ -310,7 +343,7 @@ class TestEventsDDL:
     def test_events_ddl_is_valid_sql(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = EVENTS_TABLE_DDL.format(catalog="memory", table="events")
+        ddl = EVENTS_TABLE_DDL.format(catalog="memory", schema="posthog", table="events")
         conn.execute(ddl)
 
         # Verify table was created with expected columns
@@ -323,18 +356,18 @@ class TestEventsDDL:
     def test_events_ddl_is_idempotent(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = EVENTS_TABLE_DDL.format(catalog="memory", table="events")
+        ddl = EVENTS_TABLE_DDL.format(catalog="memory", schema="posthog", table="events")
         # Should not raise on second execution
         conn.execute(ddl)
         conn.execute(ddl)
         conn.close()
 
-    def test_events_ddl_honors_suffixed_table_name(self):
+    def test_events_ddl_honors_team_schema(self):
         conn = duckdb.connect()
-        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        conn.execute(EVENTS_TABLE_DDL.format(catalog="memory", table="events_alpha"))
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.permapeople")
+        conn.execute(EVENTS_TABLE_DDL.format(catalog="memory", schema="permapeople", table="events"))
 
-        result = conn.execute("DESCRIBE memory.posthog.events_alpha").fetchall()
+        result = conn.execute("DESCRIBE memory.permapeople.events").fetchall()
         assert {row[0] for row in result} == EXPECTED_DUCKLAKE_EVENTS_COLUMNS
         conn.close()
 
@@ -343,7 +376,7 @@ class TestPersonsDDL:
     def test_persons_ddl_is_valid_sql(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = PERSONS_TABLE_DDL.format(catalog="memory", table="persons")
+        ddl = PERSONS_TABLE_DDL.format(catalog="memory", schema="posthog", table="persons")
         conn.execute(ddl)
 
         # Verify table was created with expected columns
@@ -356,18 +389,18 @@ class TestPersonsDDL:
     def test_persons_ddl_is_idempotent(self):
         conn = duckdb.connect()
         conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        ddl = PERSONS_TABLE_DDL.format(catalog="memory", table="persons")
+        ddl = PERSONS_TABLE_DDL.format(catalog="memory", schema="posthog", table="persons")
         # Should not raise on second execution
         conn.execute(ddl)
         conn.execute(ddl)
         conn.close()
 
-    def test_persons_ddl_honors_suffixed_table_name(self):
+    def test_persons_ddl_honors_team_schema(self):
         conn = duckdb.connect()
-        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.posthog")
-        conn.execute(PERSONS_TABLE_DDL.format(catalog="memory", table="persons_beta"))
+        conn.execute("CREATE SCHEMA IF NOT EXISTS memory.permapeople")
+        conn.execute(PERSONS_TABLE_DDL.format(catalog="memory", schema="permapeople", table="persons"))
 
-        result = conn.execute("DESCRIBE memory.posthog.persons_beta").fetchall()
+        result = conn.execute("DESCRIBE memory.permapeople.persons").fetchall()
         assert {row[0] for row in result} == EXPECTED_DUCKLAKE_PERSONS_COLUMNS
         conn.close()
 
@@ -485,6 +518,7 @@ class TestSetTablePartitioning:
             _set_table_partitioning(
                 MagicMock(),
                 "test; DROP TABLE",
+                "posthog",
                 "events",
                 "year(timestamp)",
                 mock_context,
@@ -496,6 +530,7 @@ class TestSetTablePartitioning:
             _set_table_partitioning(
                 MagicMock(),
                 "test_catalog",
+                "posthog",
                 "events'; --",
                 "year(timestamp)",
                 mock_context,
@@ -1175,7 +1210,7 @@ class TestDuckLakeAddDataFilesPartitioning:
         conn.execute("LOAD ducklake")
         conn.execute(f"ATTACH 'ducklake:{catalog_path}' AS test_lake (DATA_PATH '{data_path}')")
         conn.execute("CREATE SCHEMA IF NOT EXISTS test_lake.posthog")
-        conn.execute(EVENTS_TABLE_DDL.format(catalog="test_lake", table="events"))
+        conn.execute(EVENTS_TABLE_DDL.format(catalog="test_lake", schema="posthog", table="events"))
         conn.execute(
             "ALTER TABLE test_lake.posthog.events "
             "SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))"
@@ -1998,7 +2033,14 @@ class TestRegisterFilesWithDuckling:
         ]
     )
     def test_registers_every_globbed_file_once(self, _label, register_fn, table, target=None):
-        target = DucklingTarget(team_id=2, organization_id="org-1", bucket="bkt", bucket_region="us-east-1")
+        target = DucklingTarget(
+            team_id=2,
+            organization_id="org-1",
+            bucket="bkt",
+            bucket_region="us-east-1",
+            events_schema="permapeople",
+            persons_schema="permapeople",
+        )
         files = [f"s3://bkt/backfill/{table}/2/year=2026/month=06/day=17/run1_{i}.parquet" for i in range(3)]
         conn, _cur = _mock_glob_conn(files)
         config = DucklingBackfillConfig()
@@ -2010,6 +2052,7 @@ class TestRegisterFilesWithDuckling:
         assert conn.execute.call_count == 3
         calls = _registered_call_strings(conn)
         assert all("ducklake_add_data_files" in c for c in calls)
+        assert all("schema => 'permapeople'" in c for c in calls)
         # allow_missing => true must be on every CALL — it's what lets the backfill
         # tolerate columns the live ingestion path added to the duckling table via
         # schema evolution but the backfill export doesn't carry.
@@ -2222,10 +2265,8 @@ class TestDucklakeFilePartitionValueFixupHelper:
     def test_suffixed_table_name_uses_actual_name_in_catalog_lookup(
         self, _label, kind, actual_table_name, mock_open_conn
     ):
-        # When the team's CP row names suffixed tables, the dagster registration
-        # path writes to events_<suffix> / persons_<suffix>. The fix-up must
-        # look up THAT table in the catalog, not the bare kind name. Verified
-        # by inspecting the cur.execute call binding the table_name param.
+        # Grandfathered CP rows may name suffixed tables in the shared schema. The
+        # fix-up must look up that exact schema and table in the catalog.
         target = DucklingTarget(team_id=2, organization_id="org-1", bucket="bkt", bucket_region="us-east-1")
         ext = "/day=17/run1_0.parquet" if kind == "events" else "/run1_0.parquet"
         files = [f"s3://bkt/backfill/{kind}/2/year=2026/month=06{ext}"]
@@ -2235,11 +2276,11 @@ class TestDucklakeFilePartitionValueFixupHelper:
 
         _fixup_partition_values_for_added_files(MagicMock(), target, kind, actual_table_name, files)
 
-        # The partition_info SELECT is parameter-bound with (table_name,); pin
-        # that we're querying for the suffixed name, not the bare kind.
+        # The partition_info SELECT binds both identifiers instead of assuming the
+        # schema from the bare table kind.
         partition_info_calls = [c for c in cur.execute.call_args_list if "ducklake_partition_info" in str(c.args[0])]
         assert len(partition_info_calls) == 1
-        assert partition_info_calls[0].args[1] == (actual_table_name,)
+        assert partition_info_calls[0].args[1] == ("posthog", actual_table_name)
 
 
 class TestDucklakeFilePartitionValueFixupCatalogInteraction:
@@ -2521,7 +2562,7 @@ class TestFannedOutLayoutRoundTrip:
         # DUCKLAKE_ALIAS internally) targets this catalog.
         conn.execute(f"ATTACH 'ducklake:{catalog_path}' AS {DUCKLAKE_ALIAS} (DATA_PATH '{data_path}')")
         conn.execute(f"CREATE SCHEMA IF NOT EXISTS {DUCKLAKE_ALIAS}.posthog")
-        conn.execute(EVENTS_TABLE_DDL.format(catalog=DUCKLAKE_ALIAS, table="events"))
+        conn.execute(EVENTS_TABLE_DDL.format(catalog=DUCKLAKE_ALIAS, schema="posthog", table="events"))
         conn.execute(
             f"ALTER TABLE {DUCKLAKE_ALIAS}.posthog.events "
             "SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))"

--- a/posthog/dags/tests/test_events_backfill_to_duckling.py
+++ b/posthog/dags/tests/test_events_backfill_to_duckling.py
@@ -20,7 +20,7 @@ from posthog.dags.events_backfill_to_duckling import (
     _resolve_duckling_target,
 )
 
-from products.managed_warehouse.backend.facade.contracts import DuckgresStoredBucketConfig
+from products.managed_warehouse.backend.facade.contracts import DuckgresStoredBucketConfig, DucklingTables
 
 
 @dataclass
@@ -48,7 +48,10 @@ class TestResolveDucklingTarget:
                 return_value=cp_bucket,
             ) as mock_cp,
             # The per-environment table-name lookup hits the DB; this suite stays DB-free.
-            patch("posthog.dags.events_backfill_to_duckling._resolve_table_names", return_value=("events", "persons")),
+            patch(
+                "posthog.dags.events_backfill_to_duckling._resolve_table_names",
+                return_value=DucklingTables(events_table="events", persons_table="persons"),
+            ),
         ):
             target = _resolve_duckling_target(team_id=123)
         return target, mock_cp

--- a/products/managed_warehouse/backend/README.md
+++ b/products/managed_warehouse/backend/README.md
@@ -122,6 +122,14 @@ The Data Ops overview reads the latest workflow attempt for each source schema f
 
 Every copy is written to a deterministic schema inside DuckLake. Each workflow namespaces its data under a workflow-specific schema:
 
+### Events and persons
+
+- **Events table**: `<team_schema>.events`
+- **Persons table**: `<team_schema>.persons`
+- **Example**: `ducklake.permapeople.events`
+
+The team schema is chosen in Data Ops and must be unique within the organization's managed warehouse. Grandfathered teams with explicit table-name pins continue to use their existing tables in the `posthog` schema.
+
 ### Data Modeling
 
 - **Schema**: `posthog_data_modeling_team_<team_id>`
@@ -130,9 +138,9 @@ Every copy is written to a deterministic schema inside DuckLake. Each workflow n
 
 ### Data Imports and Data Import Registration
 
-- **Schema**: `posthog_data_imports_team_<team_id>`
+- **Schema**: `<team_schema>_data_imports`
 - **Table**: a physical name derived from the organization's naming version
-- **Example**: `ducklake.posthog_data_imports_team_123.stripe_prod_invoices`
+- **Example**: `ducklake.permapeople_data_imports.stripe_prod_invoices`
 - **Registered files**: `s3://<ducklake-bucket>/<ducklake-schema>/<ducklake-table>/_imports/<source-schema-id>/<job-id>/<generation-token>/<prepared-relative-path>`
 
 Duckgres stores a table-naming version on the organization. Organizations that existed when versioning was introduced keep the batch sink's snake-case format, such as `tik_tok_ads_ad_report`. New organizations use the copy workflow format, such as `tiktokads_ad_report`. Copy, registration, the batch sink, and query binding derive the same physical name from that organization-level policy. Do not change the policy after an organization has written data unless the underlying tables are migrated at the same time.
@@ -212,7 +220,7 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
    Once the import workflow completes it starts both independently gated child workflows. The enabled path appears as either `ducklake-copy.data-imports` or `ducklake-register.data-imports`; the disabled path exits after its gate activity.
 
 5. **Query the new DuckLake table**
-   The copy activity creates a table at `ducklake.posthog_data_imports_team_<team_id>.<source_type>_<prefix>_<table_name>`. From any DuckDB shell you can inspect it:
+   The copy activity creates a table at `ducklake.<team_schema>_data_imports.<source_type>_<prefix>_<table_name>`. From any DuckDB shell you can inspect it:
 
    ```sql
    duckdb -c "
@@ -234,6 +242,6 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
      SELECT table_schema, table_name FROM information_schema.tables WHERE table_catalog = 'ducklake';
 
      -- Query a specific table
-     SELECT * FROM ducklake.posthog_data_imports_team_${TEAM_ID}.${SOURCE_TYPE}_${PREFIX}_${TABLE_NAME} LIMIT 10;
+     SELECT * FROM ducklake.${TEAM_SCHEMA}_data_imports.${SOURCE_TYPE}_${PREFIX}_${TABLE_NAME} LIMIT 10;
    "
    ```

--- a/products/managed_warehouse/backend/common.py
+++ b/products/managed_warehouse/backend/common.py
@@ -520,7 +520,7 @@ def validate_duckgres_identifier(identifier: str) -> None:
 
     Only alphanumeric characters and underscores are allowed. Mirrors the
     events/persons duckling DAG's ``_validate_identifier`` so a user-supplied
-    schema name / table suffix is validated identically wherever it is
+    schema or table name is validated identically wherever it is
     interpolated into DuckDB DDL.
     """
     if not identifier or not identifier.replace("_", "").isalnum():
@@ -566,24 +566,20 @@ def duckgres_data_modeling_schema(team_id: int) -> str:
     return f"{DATA_MODELING_DUCKGRES_SHADOW_SCHEMA_PREFIX}_{team_id}_models"
 
 
-TABLE_SUFFIX_MAX_LENGTH = 63
-# A schema name doubles as the suffix in `events_<suffix>` / `persons_<suffix>`, so it must
-# already be a safe SQL identifier — lowercase letters, numbers, and underscores. We validate
-# rather than silently rewrite, so what the user types is exactly what they get.
-TABLE_SUFFIX_PATTERN = re.compile(r"^[a-z0-9_]+$")
+SCHEMA_NAME_MAX_LENGTH = 63
+SCHEMA_NAME_PATTERN = re.compile(r"^[a-z0-9_]+$")
 
 
 def validate_schema_name(name: str | None) -> str | None:
     """Return a human-readable error if `name` isn't a valid duckgres schema name, else None.
 
-    A team's schema name doubles as its warehouse table suffix: lowercase letters,
-    numbers, and underscores, at most 63 characters.
+    Schema names use lowercase letters, numbers, and underscores, at most 63 characters.
     """
     if not name:
         return "schema_name is required"
-    if len(name) > TABLE_SUFFIX_MAX_LENGTH:
-        return f"Schema name must be at most {TABLE_SUFFIX_MAX_LENGTH} characters"
-    if not TABLE_SUFFIX_PATTERN.match(name):
+    if len(name) > SCHEMA_NAME_MAX_LENGTH:
+        return f"Schema name must be at most {SCHEMA_NAME_MAX_LENGTH} characters"
+    if not SCHEMA_NAME_PATTERN.match(name):
         return "Schema name must use only lowercase letters, numbers, and underscores"
     return None
 

--- a/products/managed_warehouse/backend/cp_teams.py
+++ b/products/managed_warehouse/backend/cp_teams.py
@@ -7,15 +7,11 @@ HTTP call per batch.
 
 Legacy-name semantics of a CP row: a non-NULL ``events_table_name`` /
 ``persons_table_name`` / ``schema_data_imports_name`` is a grandfathered explicit
-pin; NULL means "derive from ``schema_name``". The derive rule here is the
-TRANSITIONAL one — writers still produce the old suffix-derived layout, so for
-every existing row it is byte-identical to the Django-side derivation:
+pin in the shared ``posthog`` namespace. NULL uses the team's schema-based layout:
 
-* events: ``events_<schema_name>``
-* persons: ``persons_<schema_name>``
-* data-imports schema: ``posthog_data_imports_<schema_name>``
-
-Do NOT change this to the future ``<schema_name>.events`` layout until the writers do.
+* events: ``<schema_name>.events``
+* persons: ``<schema_name>.persons``
+* data-imports schema: ``<schema_name>_data_imports``
 
 Every fetcher returns ``None`` when the control plane is unreachable or answers
 unusably — callers decide the failure posture (fail open, fail closed, or raise).
@@ -60,18 +56,28 @@ class CPTeam:
 
     @property
     def resolved_events_table(self) -> str:
-        """Events table name: the grandfathered pin, else the transitional derivation."""
-        return self.events_table_name or f"events_{self.schema_name}"
+        """Events table name, preserving a grandfathered explicit pin."""
+        return self.events_table_name or "events"
+
+    @property
+    def resolved_events_schema(self) -> str:
+        """Events schema, preserving the shared namespace for explicit pins."""
+        return "posthog" if self.events_table_name else self.schema_name
 
     @property
     def resolved_persons_table(self) -> str:
-        """Persons table name: the grandfathered pin, else the transitional derivation."""
-        return self.persons_table_name or f"persons_{self.schema_name}"
+        """Persons table name, preserving a grandfathered explicit pin."""
+        return self.persons_table_name or "persons"
+
+    @property
+    def resolved_persons_schema(self) -> str:
+        """Persons schema, preserving the shared namespace for explicit pins."""
+        return "posthog" if self.persons_table_name else self.schema_name
 
     @property
     def resolved_data_imports_schema(self) -> str:
-        """Data-imports schema: the grandfathered pin, else the transitional derivation."""
-        return self.schema_data_imports_name or f"posthog_data_imports_{self.schema_name}"
+        """Data-imports schema, preserving a grandfathered explicit pin."""
+        return self.schema_data_imports_name or f"{self.schema_name}_data_imports"
 
 
 def _parse_earliest_event_date(raw: object) -> date | None:

--- a/products/managed_warehouse/backend/facade/contracts.py
+++ b/products/managed_warehouse/backend/facade/contracts.py
@@ -172,10 +172,12 @@ class DuckgresStoredServerConfig:
 
 @frozen
 class DucklingTables:
-    """The per-team events/persons duckling table names the backfill writes to."""
+    """The per-team events/persons DuckLake locations the backfill writes to."""
 
     events_table: str
     persons_table: str
+    events_schema: str = "posthog"
+    persons_schema: str = "posthog"
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/products/managed_warehouse/backend/presentation/views.py
+++ b/products/managed_warehouse/backend/presentation/views.py
@@ -299,44 +299,12 @@ def provision(
             return resp
         _invalidate_team_state_cache(organization_id)
         _persist_duckgres_server(organization_id, database_name, resp.data)
-        # Complete the row BEFORE registering the team: registration kicks off the
-        # SQL-editor query-source setup and discovery against this row's warehouse.
-        _complete_provisioning_team_row(organization_id, team_id, schema_name, require_enabled=require_enabled)
         _register_provisioning_team(organization_id, team_id, activated_generation)
         # The bucket is internal infra detail, persisted above and consumed by the
         # backfill via cp_bucket_for — not part of the UI-facing ProvisionWarehouseResponse
         # schema. Strip it so the response matches its OpenAPI contract.
         _strip_bucket_fields(resp.data)
     return resp
-
-
-def _complete_provisioning_team_row(
-    organization_id: UUID | str, team_id: int, schema_name: str, *, require_enabled: bool
-) -> None:
-    """Pin the first team's legacy table names onto the row duckgres just created.
-
-    The provision body cannot carry them, so without this step the row describes the derived
-    layout no data lands in yet (see onboard_team). Best-effort:
-    the warehouse is already provisioned, so a transient failure must not fail the provision —
-    re-running onboarding completes the row later.
-    """
-    legacy = _legacy_table_fields(schema_name)
-    resp = create_team(
-        organization_id,
-        team_id,
-        schema_name,
-        events_table_name=legacy["events_table_name"],
-        persons_table_name=legacy["persons_table_name"],
-        schema_data_imports_name=legacy["schema_data_imports_name"],
-        require_enabled=require_enabled,
-    )
-    if not status.is_success(resp.status_code):
-        logger.warning(
-            "Provisioned warehouse team row could not be completed with legacy table names",
-            organization_id=str(organization_id),
-            team_id=team_id,
-            status_code=resp.status_code,
-        )
 
 
 def _strip_bucket_fields(body: dict) -> None:
@@ -365,10 +333,9 @@ def team_backfill_state(team_id: int) -> dict[str, object]:
 def _register_provisioning_team(organization_id: UUID | str, team_id: int, source_generation: int) -> None:
     """Finish the provisioning (calling) team's onboarding after its row exists.
 
-    duckgres creates the provisioning team's row from the provision request itself (and
-    `_complete_provisioning_team_row` pins its legacy table names), so nothing is written
-    here. The team gets its managed SQL-editor source and starts its earliest-event-date
-    sync, matching the tail that `onboard_team` runs later.
+    duckgres creates the provisioning team's row from the provision request itself, so
+    nothing is written here. The team gets its managed SQL-editor source and starts its
+    earliest-event-date sync, matching the tail that `onboard_team` runs later.
 
     Best-effort, mirroring `_persist_duckgres_server`: a failure is logged, not raised, so
     the one-time provision password is never lost to it.
@@ -681,29 +648,19 @@ def onboard_team(
         )
     if existing is not None:
         if existing.get("schema_name") != schema_name:
-            events_table = existing.get("events_table_name") or f"events_{existing.get('schema_name')}"
-            current = "the shared tables" if events_table == "events" else events_table
+            current_schema = existing.get("schema_name")
             return Response(
                 {
-                    "error": f"This project already writes to {current}, and its warehouse table can't be changed — "
-                    "that would split its existing data across two tables."
+                    "error": f"This project already writes to the '{current_schema}' schema, and its warehouse "
+                    "schema can't be changed — that would split its existing data across two schemas."
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
     else:
-        # Pin the legacy table names the duckling DAG writes today (posthog.events_<suffix>,
-        # posthog_data_imports_<suffix>): the suffix for a newly onboarded team IS its schema
-        # name. A row without them describes the derived layout no data lands in yet (the EU
-        # placeholder-row bug). Drop this once the duckling DAG writes the derived
-        # <schema_name>.events layout for real.
-        legacy = _legacy_table_fields(schema_name)
         resp = create_team(
             organization_id,
             team_id,
             schema_name,
-            events_table_name=legacy["events_table_name"],
-            persons_table_name=legacy["persons_table_name"],
-            schema_data_imports_name=legacy["schema_data_imports_name"],
             require_enabled=require_enabled,
         )
         if resp.status_code == status.HTTP_409_CONFLICT:
@@ -724,21 +681,6 @@ def _org_has_warehouse(organization_id: UUID | str) -> bool:
     from products.managed_warehouse.backend.facade.api import has_provisioned_warehouse  # noqa: PLC0415
 
     return has_provisioned_warehouse(organization_id)
-
-
-def _legacy_table_fields(schema_name: str) -> dict:
-    """The legacy suffix-derived table names to pin on a new duckgres team row.
-
-    The duckling DAG and the v3 sink still write the suffix-derived layout
-    (`posthog.events_<schema>`, `posthog_data_imports_<schema>`), so a new row pins those
-    names explicitly instead of leaving duckgres to derive the future
-    `<schema_name>.events` layout no data lands in yet.
-    """
-    return {
-        "events_table_name": f"events_{schema_name}",
-        "persons_table_name": f"persons_{schema_name}",
-        "schema_data_imports_name": f"posthog_data_imports_{schema_name}",
-    }
 
 
 def _teams_from_response(resp: Response) -> list[dict] | None:
@@ -788,6 +730,8 @@ def check_schema_name(organization_id: UUID | str, name: str | None) -> Response
         return Response({"error": schema_error}, status=status.HTTP_400_BAD_REQUEST)
 
     resp = list_teams(organization_id)
+    if resp.status_code == status.HTTP_404_NOT_FOUND:
+        return Response({"name": name, "available": True}, status=status.HTTP_200_OK)
     teams = _teams_from_response(resp)
     if teams is None:
         return resp

--- a/products/managed_warehouse/backend/team_state.py
+++ b/products/managed_warehouse/backend/team_state.py
@@ -60,7 +60,7 @@ def _to_membership(row: cp_teams.CPTeam) -> ManagedWarehouseTeamMembership:
 
 
 def resolve_events_persons_tables(team_id: int) -> DucklingTables:
-    """The per-team events/persons duckling table names the backfill writes to.
+    """The per-team events/persons DuckLake locations the backfill writes to.
 
     Failure posture: raises :class:`CPUnavailableError` when the control plane can't
     answer and the cache is cold — the backfill run fails and retries rather than
@@ -70,10 +70,18 @@ def resolve_events_persons_tables(team_id: int) -> DucklingTables:
     if row is None:
         # Legacy single-team ducklings without a team row share the base tables.
         return DucklingTables(events_table="events", persons_table="persons")
+    events_schema, persons_schema = row.resolved_events_schema, row.resolved_persons_schema
     events_table, persons_table = row.resolved_events_table, row.resolved_persons_table
+    validate_duckgres_identifier(events_schema)
+    validate_duckgres_identifier(persons_schema)
     validate_duckgres_identifier(events_table)
     validate_duckgres_identifier(persons_table)
-    return DucklingTables(events_table=events_table, persons_table=persons_table)
+    return DucklingTables(
+        events_table=events_table,
+        persons_table=persons_table,
+        events_schema=events_schema,
+        persons_schema=persons_schema,
+    )
 
 
 # --- data-imports schema (v3 sink hot path) ---------------------------------------

--- a/products/managed_warehouse/backend/tests/api/test_presentation.py
+++ b/products/managed_warehouse/backend/tests/api/test_presentation.py
@@ -310,18 +310,7 @@ def test_provision_sends_team_id_and_schema_name_to_control_plane(
     assert json_body["schema_name"] == "prod_events"
     assert "default_team_id" not in json_body
 
-    # The provision body cannot carry legacy table names, so the first team's row is
-    # completed with a follow-up org-teams upsert — same fields onboard_team writes.
-    method, org_id, path = mock_request.call_args_list[1].args
-    assert (method, org_id, path) == ("POST", org.id, "/teams")
-    teams_body = mock_request.call_args_list[1].kwargs["json_body"]
-    assert teams_body == {
-        "team_id": team.id,
-        "schema_name": "prod_events",
-        "events_table_name": "events_prod_events",
-        "persons_table_name": "persons_prod_events",
-        "schema_data_imports_name": "posthog_data_imports_prod_events",
-    }
+    assert len(mock_request.call_args_list) == 1
     _onboarding_side_effects.ensure.assert_called_once_with(
         team_id=team.id,
         organization_id=org.id,
@@ -330,25 +319,6 @@ def test_provision_sends_team_id_and_schema_name_to_control_plane(
 
 
 @pytest.mark.django_db
-@patch("products.managed_warehouse.backend.presentation.views._request")
-def test_provision_succeeds_even_when_the_team_row_completion_fails(mock_request: MagicMock) -> None:
-    # The follow-up upsert is best-effort: the warehouse is already provisioned, so a
-    # transient teams-API failure must not fail the provision response.
-    org = Organization.objects.create(name="Org")
-    team = Team.objects.create(organization=org)
-    mock_request.side_effect = [
-        Response(
-            {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
-            status=202,
-        ),
-        Response({"error": "store unavailable"}, status=500),
-    ]
-
-    resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, "prod_events")
-
-    assert resp.status_code == 202
-
-
 @pytest.mark.django_db
 @patch("products.data_warehouse.backend.facade.api.schedule_managed_warehouse_direct_source_ensure")
 @patch("products.managed_warehouse.backend.presentation.views._request")
@@ -359,13 +329,10 @@ def test_provision_schedules_generation_fenced_source_recovery_when_inline_ensur
 ) -> None:
     org = Organization.objects.create(name="Org")
     team = Team.objects.create(organization=org)
-    mock_request.side_effect = [
-        Response(
-            {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
-            status=202,
-        ),
-        Response({"team_id": team.id, "schema_name": "events"}, status=200),
-    ]
+    mock_request.return_value = Response(
+        {"status": "provisioning started", "org": str(org.id), "username": "root", "password": "secret"},
+        status=202,
+    )
     _onboarding_side_effects.ensure.side_effect = RuntimeError("database unavailable")
 
     response = managed_warehouse.provision(org.id, "my-warehouse", team.id, "events")
@@ -710,7 +677,7 @@ def test_teams_response_attaches_the_org_naming_policy_to_each_row() -> None:
 @pytest.mark.django_db
 @patch("products.managed_warehouse.backend.presentation.views.is_enabled", return_value=True)
 @patch("products.managed_warehouse.backend.presentation.views._request")
-def test_onboard_team_creates_duckgres_row_with_legacy_names(
+def test_onboard_team_creates_schema_based_duckgres_row(
     mock_request: MagicMock, _mock_enabled: MagicMock, _onboarding_side_effects
 ) -> None:
     org, team, _ = _provisioned_org()
@@ -724,19 +691,12 @@ def test_onboard_team_creates_duckgres_row_with_legacy_names(
     assert resp.status_code == 200
     assert resp.data == {"onboarded": True, "schema_name": "my_events"}
 
-    # duckgres team row created via the org-teams upsert WITH the legacy table names the
-    # duckling DAG actually writes today (posthog.events_<suffix> + posthog_data_imports_<suffix>).
-    # A row without them describes the derived layout no data lands in yet — the EU
-    # placeholder-row bug.
     assert mock_request.call_args_list[0].args == ("GET", org.id, "/teams")
     method, org_id, path = mock_request.call_args_list[1].args
     assert (method, org_id, path) == ("POST", org.id, "/teams")
     assert mock_request.call_args_list[1].kwargs["json_body"] == {
         "team_id": team.id,
         "schema_name": "my_events",
-        "events_table_name": "events_my_events",
-        "persons_table_name": "persons_my_events",
-        "schema_data_imports_name": "posthog_data_imports_my_events",
     }
     # Onboarding's tail: the query connection and the earliest-date sync.
     _onboarding_side_effects.ensure.assert_called_once_with(
@@ -859,7 +819,7 @@ def test_onboard_team_same_name_is_idempotent(
 @patch("products.managed_warehouse.backend.presentation.views.is_enabled", return_value=True)
 @patch("products.managed_warehouse.backend.presentation.views._request")
 def test_onboard_team_refuses_to_change_an_existing_schema(mock_request: MagicMock, _mock_enabled: MagicMock) -> None:
-    # Changing a set schema would split the team's data across two tables — rejected before
+    # Changing a set schema would split the team's data across two schemas — rejected before
     # the upsert, so the duckgres row keeps its schema.
     org, team, _ = _provisioned_org()
     mock_request.return_value = Response(
@@ -869,7 +829,7 @@ def test_onboard_team_refuses_to_change_an_existing_schema(mock_request: MagicMo
     resp = managed_warehouse.onboard_team(org.id, team.id, "second")
 
     assert resp.status_code == 400
-    assert "events_first" in resp.data["error"]
+    assert "'first' schema" in resp.data["error"]
     assert [c.args[0] for c in mock_request.call_args_list] == ["GET"]
 
 
@@ -887,7 +847,7 @@ def test_onboard_team_refuses_to_rename_a_legacy_shared_team(mock_request: Magic
     resp = managed_warehouse.onboard_team(org.id, team.id, "new_name")
 
     assert resp.status_code == 400
-    assert "shared tables" in resp.data["error"]
+    assert f"'team_{team.id}' schema" in resp.data["error"]
     assert [c.args[0] for c in mock_request.call_args_list] == ["GET"]
 
 
@@ -1056,6 +1016,16 @@ def test_check_schema_name_rejects_invalid_name(mock_list: MagicMock) -> None:
 
     assert resp.status_code == 400
     mock_list.assert_not_called()
+
+
+@patch("products.managed_warehouse.backend.presentation.views.list_teams")
+def test_check_schema_name_is_available_before_the_warehouse_exists(mock_list: MagicMock) -> None:
+    mock_list.return_value = Response({"error": "not found"}, status=404)
+
+    resp = managed_warehouse.check_schema_name(uuid4(), "first_schema")
+
+    assert resp.status_code == 200
+    assert resp.data == {"name": "first_schema", "available": True}
 
 
 @pytest.mark.django_db

--- a/products/managed_warehouse/backend/tests/test_cp_teams.py
+++ b/products/managed_warehouse/backend/tests/test_cp_teams.py
@@ -29,15 +29,12 @@ def _row(**overrides) -> dict:
 
 
 class TestCPTeamResolution:
-    # The transitional derive rule must stay byte-identical to the django-suffix layout;
-    # a premature switch to the future `<schema>.events` derivation (or broken pin
-    # precedence) would point readers/writers at tables that don't exist.
     @parameterized.expand(
         [
             (
                 "null_pins_derive_from_schema",
                 {"schema_name": "us_prod"},
-                ("events_us_prod", "persons_us_prod", "posthog_data_imports_us_prod"),
+                ("us_prod", "events", "us_prod", "persons", "us_prod_data_imports"),
             ),
             (
                 "pins_win_over_derivation",
@@ -47,24 +44,30 @@ class TestCPTeamResolution:
                     "persons_table_name": "persons",
                     "schema_data_imports_name": "posthog_data_imports_team_7",
                 },
-                ("events", "persons", "posthog_data_imports_team_7"),
+                ("posthog", "events", "posthog", "persons", "posthog_data_imports_team_7"),
             ),
             (
                 "partial_pins_mix_with_derivation",
                 {"schema_name": "beta", "events_table_name": "events_legacy"},
-                ("events_legacy", "persons_beta", "posthog_data_imports_beta"),
+                ("posthog", "events_legacy", "beta", "persons", "beta_data_imports"),
             ),
             (
                 "empty_string_pins_are_treated_as_unset",
                 {"schema_name": "beta", "events_table_name": "", "schema_data_imports_name": ""},
-                ("events_beta", "persons_beta", "posthog_data_imports_beta"),
+                ("beta", "events", "beta", "persons", "beta_data_imports"),
             ),
         ]
     )
-    def test_resolved_names(self, _name: str, overrides: dict, expected: tuple[str, str, str]) -> None:
+    def test_resolved_names(self, _name: str, overrides: dict, expected: tuple[str, str, str, str, str]) -> None:
         team = team_from_row(_row(**overrides))
         assert team is not None
-        assert (team.resolved_events_table, team.resolved_persons_table, team.resolved_data_imports_schema) == expected
+        assert (
+            team.resolved_events_schema,
+            team.resolved_events_table,
+            team.resolved_persons_schema,
+            team.resolved_persons_table,
+            team.resolved_data_imports_schema,
+        ) == expected
 
 
 class TestTeamFromRow:

--- a/products/managed_warehouse/backend/tests/test_team_state.py
+++ b/products/managed_warehouse/backend/tests/test_team_state.py
@@ -54,7 +54,7 @@ class TestDataImportsSchema:
     def test_resolves_from_cp_row(self) -> None:
         org, team = _team()
         with _patch_org_rows([_cp_row(team, "cp_schema")]):
-            assert team_state.data_imports_schema(team.id) == "posthog_data_imports_cp_schema"
+            assert team_state.data_imports_schema(team.id) == "cp_schema_data_imports"
 
     def test_without_cp_row_falls_back_to_team_id_schema(self) -> None:
         org, team = _team()
@@ -72,7 +72,7 @@ class TestDataImportsSchema:
         with _patch_org_rows([_cp_row(team, "cp_schema")]):
             team_state.data_imports_schema(team.id)
         with _patch_org_rows(None):
-            assert team_state.data_imports_schema(team.id) == "posthog_data_imports_cp_schema"
+            assert team_state.data_imports_schema(team.id) == "cp_schema_data_imports"
 
 
 @pytest.mark.django_db
@@ -96,7 +96,12 @@ class TestEventsPersonsTables:
             (
                 "derived",
                 {},
-                team_state.DucklingTables(events_table="events_cp_schema", persons_table="persons_cp_schema"),
+                team_state.DucklingTables(
+                    events_table="events",
+                    persons_table="persons",
+                    events_schema="cp_schema",
+                    persons_schema="cp_schema",
+                ),
             ),
             (
                 "grandfathered_shared_pins",
@@ -207,9 +212,9 @@ class TestListEnabledBackfillRows:
             enabled=True,
             backfill_enabled=True,
             table_names=ManagedWarehouseTableNames(
-                events_table="events_cp_schema",
-                persons_table="persons_cp_schema",
-                data_imports_schema="posthog_data_imports_cp_schema",
+                events_table="events",
+                persons_table="persons",
+                data_imports_schema="cp_schema_data_imports",
             ),
             earliest_event_date=date(2020, 6, 15),
         )


### PR DESCRIPTION
## Problem

Managed warehouse users who choose `permapeople` currently receive `posthog.events_permapeople` instead of the schema layout shown in Data Ops.

Data Ops also lets projects select an organization schema already used by another project.

## Changes

- New managed teams write events to `<team_schema>.events` and persons to `<team_schema>.persons`.

Before:

```mermaid
flowchart LR
    A["Data Ops schema"] --> B["Control plane"] --> C["Dagster backfill"] --> D["posthog.events_schema"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phYellow;
    class B phRed;
    class C phBlue;
```

After:

```mermaid
flowchart LR
    A["Data Ops schema"] --> B["Control plane"] --> C["Dagster backfill"] --> D["schema.events"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phYellow;
    class B phRed;
    class C phBlue;
```

- New data-import tables use `<team_schema>_data_imports`.
- Explicit legacy table pins continue using the shared `posthog` schema.
- Data Ops checks schema availability and blocks provisioning or onboarding until the organization schema is available.
- The control plane remains the final uniqueness check and returns a conflict for concurrent duplicate requests.
- The form adds an inline schema availability indicator. No screenshot was captured because this environment lacks Docker.

## How did you test this code?

- Focused Dagster tests cover schema resolution, DDL, file registration, partition metadata, and legacy pins.
- Managed-warehouse tests cover derived names and schema availability before provisioning.
- Frontend Jest tests cover availability checks and form gating.
- Frontend TypeScript, repo-wide mypy, formatting, lint, and CI preflight completed locally.
- Not run: database-backed suites, live UI verification, and OpenAPI generation because the local Docker stack was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The managed-warehouse backend README documents team schemas, legacy pins, and data-import naming.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used repository and terminal tools to implement and validate the change.
- Skills invoked: `/improving-drf-endpoints`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/run-posthog`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The implementation removed the transitional legacy-pin shim while preserving explicit pins for existing warehouses.
- The public patch uses only repository context and invented examples.