### PR TITLE
chore(aio): pin retention on settle-poll test rows

### DIFF
--- a/posthog/temporal/ai_observability/test_run_aggregate_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_aggregate_evaluation.py
@@ -59,15 +59,21 @@ def _insert_ai_event(
     `_timestamp` from the same `timestamp` value it inserts, so tests that need to simulate
     ingestion lag write directly against the columns AI_EVENTS_TABLE_BASE_SQL leaves without
     a default.
+
+    `retention_days` is pinned the same way `bulk_create_ai_events` pins it. ai_events is
+    `TTL drop_date` with `drop_date = toDate(timestamp) + retention_days`, and TTL runs on the
+    server's real clock while these rows carry a frozen `timestamp` — on the column default of 30
+    days, a fixture row silently expires once the frozen date falls more than 30 days behind today
+    and the poll finds nothing.
     """
     sync_execute(
         """
         INSERT INTO sharded_ai_events (
             uuid, event, timestamp, team_id, distinct_id, person_id, properties,
-            trace_id, session_id, is_error, _timestamp, _offset, _partition
+            trace_id, session_id, is_error, retention_days, _timestamp, _offset, _partition
         ) VALUES (
             %(uuid)s, %(event)s, %(timestamp)s, %(team_id)s, %(distinct_id)s, %(person_id)s, %(properties)s,
-            %(trace_id)s, %(session_id)s, 0, %(_timestamp)s, 0, 0
+            %(trace_id)s, %(session_id)s, 0, %(retention_days)s, %(_timestamp)s, 0, 0
         )
         """,
         {
@@ -80,6 +86,7 @@ def _insert_ai_event(
             "properties": "{}",
             "trace_id": trace_id,
             "session_id": session_id,
+            "retention_days": 10000,
             "_timestamp": arrival.strftime("%Y-%m-%d %H:%M:%S"),
         },
         flush=False,


### PR DESCRIPTION
## Problem

Every backend PR shows a red "Django tests – Temporal (1/15)" check, and master has been red since 2026-08-22.

- Five tests in `posthog/temporal/ai_observability/test_run_aggregate_evaluation.py` fail with "no trace activity visible yet" or "no session activity visible yet".
- The two settle-poll test classes freeze the clock at `2026-07-23`, so their fixture rows carry that `timestamp`.
- `ai_events` is `TTL drop_date`, where `drop_date = toDate(timestamp) + retention_days`. `retention_days` defaults to 30, which put the drop date at 2026-08-22.
- ClickHouse evaluates that TTL against the server's real clock, so the rows aged out while the test's own clock stood still.
- The last green run of that job finished at [2026-08-21T23:55Z](https://github.com/PostHog/posthog/actions/runs/32536979349). The [next one](https://github.com/PostHog/posthog/actions/runs/32537978721) ran across midnight and failed.

## Changes

- The five settle-poll tests pass again, so the backend Temporal shard stops blocking unrelated PRs.
- `_insert_ai_event` writes `retention_days = 10000`, which puts the drop date beyond any clock a test will freeze.
- The shared `bulk_create_ai_events` helper already pins retention this way. This helper was written to control `_timestamp` separately and did not carry that part over.
- Nothing user-visible changes. The diff is one test helper.

## How did you test this code?

Both settle-poll classes ran against a local dev-stack ClickHouse, before and after the change. The pre-change run reproduced the same five failures CI reports, which makes this a deterministic repro rather than a flake.

<details>
<summary>Local run, before and after</summary>

```
# before
5 failed, 6 passed, 32 deselected in 362.76s
FAILED TestCheckTraceSettledActivity::test_annotation_events_do_not_defer_settling
FAILED TestCheckSessionSettledActivity::test_settled_when_quiet_beyond_margin
FAILED TestCheckSessionSettledActivity::test_events_carrying_another_session_id_do_not_count_as_activity
FAILED TestCheckSessionSettledActivity::test_evaluation_events_never_defer_settling
FAILED TestCheckSessionSettledActivity::test_over_cap_fails_fast_and_non_retryably

# after
11 passed, 32 deselected in 32.81s
```

</details>

Not checked: the rest of the Temporal shard, and any other suite. CI on this branch covers those.

No tests added. The regression is a clock boundary that no assertion can catch from inside the suite, and the fix removes the fixture's dependence on the ambient clock instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from Slack as "the same tests keep failing on my PR". The first useful finding was that the PR was innocent: master carried the identical five failures. Diagnosis came from walking master's run history until the pass-to-fail boundary lined up with the TTL arithmetic, then confirming it with a local repro.

The requester's GitHub handle was not resolvable in this session, so the PR is unassigned rather than assigned to a guessed account.

Tools: PostHog Slack app (Claude Code), `gh` for run history, docker compose plus pytest locally. Skills invoked: `/writing-pr-descriptions`.

An earlier draft dropped `@freeze_time` from both classes. Pinning retention won because it keeps the deterministic arithmetic the tests were written around, and because it matches the existing convention in `bulk_create_ai_events`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1787508716690039)*
