### PR TITLE
fix(canvas): pin framer-motion's transitive motion-dom

### DIFF
--- a/products/canvas/backend/tests/test_cloud_builder.py
+++ b/products/canvas/backend/tests/test_cloud_builder.py
@@ -12,7 +12,7 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 
 from products.canvas.backend.build_service import node_executable, run_cloud_builder, validate_builder_output
-from products.canvas.backend.contract import platform_dependencies
+from products.canvas.backend.contract import allowed_import_specifiers, platform_dependencies
 from products.canvas.backend.presentation.serializers import CanvasSourceProjectSerializer
 from products.canvas.backend.source import synthetic_source_project, validate_source_project
 
@@ -90,21 +90,18 @@ class TestCanvasCloudBuilder(SimpleTestCase):
         self.assertFalse(manifest["capabilities"]["posthog"]["inlineQueries"])
         self.assertTrue(any(file["path"].endswith(".js") for file in files))
 
-    def test_bundles_the_extended_platform_libraries(self) -> None:
-        source = """
-import { useVirtualizer } from "@tanstack/react-virtual"
-import { useForm } from "react-hook-form"
-import { groupBy } from "lodash-es"
-import ReactMarkdown from "react-markdown"
-import Papa from "papaparse"
-void useVirtualizer
-void useForm
-void groupBy
-void ReactMarkdown
-void Papa
-"""
+    def test_bundles_every_allowlisted_platform_library(self) -> None:
+        # Transitive versions are not pinned, so a caret range can drift onto a
+        # dependency that dropped an export and break every canvas importing the
+        # library, while source validation still passes because the specifier is
+        # allowlisted. Namespace imports keep the whole module graph reachable,
+        # so a missing deep export fails here instead of in a user's publish.
+        imports: list[str] = []
+        for index, specifier in enumerate(sorted(allowed_import_specifiers())):
+            imports.append(f'import * as library{index} from "{specifier}"')
+            imports.append(f"void library{index}")
 
-        project = self._project(source)
+        project = self._project("\n".join(imports))
         project["dependencies"] = platform_dependencies()
         result = run_cloud_builder(project)
 

--- a/products/canvas/packages/canvas_builder/package-lock.json
+++ b/products/canvas/packages/canvas_builder/package-lock.json
@@ -1740,6 +1740,21 @@
         }
       }
     },
+    "node_modules/framer-motion/node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/framer-motion/node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2515,21 +2530,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/motion-dom": {
-      "version": "12.43.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
-      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.39.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.39.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
-      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/products/canvas/packages/canvas_builder/package.json
+++ b/products/canvas/packages/canvas_builder/package.json
@@ -22,5 +22,10 @@
         "tailwindcss": "4.3.1",
         "three": "0.179.1",
         "zod": "3.25.76"
+    },
+    "$comment": "framer-motion depends on motion-dom and motion-utils by caret range, and motion removes exports within that range: motion-dom 12.43.0 dropped `activeAnimations`, which framer-motion 12.23.12 imports. Pin both to what framer-motion was released against, and move them whenever framer-motion moves.",
+    "overrides": {
+        "motion-dom": "12.23.12",
+        "motion-utils": "12.23.6"
     }
 }

--- a/products/canvas/packages/canvas_builder/package.json
+++ b/products/canvas/packages/canvas_builder/package.json
@@ -23,9 +23,9 @@
         "three": "0.179.1",
         "zod": "3.25.76"
     },
-    "$comment": "framer-motion depends on motion-dom and motion-utils by caret range, and motion removes exports within that range: motion-dom 12.43.0 dropped `activeAnimations`, which framer-motion 12.23.12 imports. Pin both to what framer-motion was released against, and move them whenever framer-motion moves.",
     "overrides": {
         "motion-dom": "12.23.12",
         "motion-utils": "12.23.6"
-    }
+    },
+    "$comment": "framer-motion depends on motion-dom and motion-utils by caret range, and motion removes exports within that range: motion-dom 12.43.0 dropped `activeAnimations`, which framer-motion 12.23.12 imports. Pin both to what framer-motion was released against, and move them whenever framer-motion moves."
 }


### PR DESCRIPTION
## Problem

Publishing a canvas that imports framer-motion fails, and the author cannot fix it from their source.

- The builder resolves `motion-dom` through a caret range, and it landed on 12.43.0, which dropped the `activeAnimations` export that framer-motion 12.23.12 imports.
- esbuild rejects the missing export, so the build fails with `bundle_error` pointing at a file inside `node_modules`.
- Source validation still passes, because `framer-motion` sits on the import allowlist. The author gets a valid canvas that will not build.

## Changes

- Canvases that import framer-motion build again. `motion-dom` and `motion-utils` are pinned by npm `overrides` to the versions framer-motion 12.23.12 was released against.
- The builder's bundling test now covers every allowlisted specifier instead of five of seventeen. framer-motion, d3, three, recharts, lucide-react, zod and `@tanstack/react-table` had no build coverage.
- That test reads the allowlist from `manifest.json`, so a newly allowed library is covered without a test edit.
- Namespace imports replace named imports in that test. A named import of a symbol that still exists hides a missing export deeper in the module graph.
- Pinning beats bumping framer-motion to 13.1.1, which also resolves a matching motion-dom. The bump moves the pinned version in `manifest.json`, the esm.sh URL and the desktop whitelist contract, and the caret range still floats afterward.
- Mechanical: the two lockfile entries for the pinned packages.
- Nothing changes for a canvas that does not import framer-motion, and no UI changed.

## How did you test this code?

- `products/canvas/backend/tests/test_cloud_builder.py` passes with the pin. Reverting only `package.json` and `package-lock.json`, then reinstalling, reproduces the original `bundle_error` on `activeAnimations`.
- The widened test catches one regression no existing test caught: a transitive version of an allowlisted library drifting onto an incompatible release, which breaks every canvas importing that library while source validation still reports the source as valid.
- Both runs went through `npm ci`, the command the production image and CI use, so the resolution under test matches the one that ships.
- Not run: the database-backed canvas suites, because this sandbox has no Postgres. No manual publish through the app.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The work started from a report that canvas builds using framer-motion were failing. The cause was confirmed by bundling the whole allowlisted set through the repo's own builder before anything changed, which is also what turned into the widened test.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. Tools: the PostHog Slack app, with an Explore subagent used to locate the builder package.

No GitHub handle for the driver was verified this session, so the PR is left unassigned rather than assigned to a guessed account.

Public artifact: everything committed comes from this repository and the public npm registry. No session material reached the diff.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787510398104099)*
