### PR TITLE
fix(cohorts): emit SLO gauges via pushgateway and lock the coordinator

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -100,13 +100,8 @@ task_timings: dict[str, float] = {}
 
 
 def _initialize_worker_metrics() -> None:
-    """Initialize metrics that need to survive pod restarts.
-
-    Each initializer runs unconditionally and carries its own worker-type gate, so
-    adding one here cannot be silently skipped by another's early return.
-    """
+    """Initialize metrics that need to survive pod restarts."""
     _initialize_liveness_alerted_task_series()
-    _initialize_cohort_backlog_metric()
 
 
 def _initialize_liveness_alerted_task_series() -> None:
@@ -121,36 +116,6 @@ def _initialize_liveness_alerted_task_series() -> None:
                 counter.labels(task_name=task_name)
     except Exception:
         logger.warning("failed_to_initialize_task_metric_series", exc_info=True)
-
-
-def _initialize_cohort_backlog_metric() -> None:
-    # Only initialize cohort metrics on long-running workers that handle cohort calculations
-    if not _is_longrunning_worker():
-        return
-
-    try:
-        # Initialize cohort backlog metric from database state
-        from posthog.tasks.calculate_cohort import (
-            COHORT_RECALCULATIONS_BACKLOG_GAUGE,
-            get_cohort_calculation_candidates_queryset,
-        )
-
-        backlog = get_cohort_calculation_candidates_queryset().count()
-        COHORT_RECALCULATIONS_BACKLOG_GAUGE.set(backlog)
-
-        logger.info("worker_metrics_initialized", cohort_backlog=backlog)
-    except Exception as e:
-        # Don't let metric initialization break worker startup
-        logger.warning("failed_to_initialize_worker_metrics", error=str(e))
-
-
-def _is_longrunning_worker() -> bool:
-    """Check if this is a long-running worker that handles cohort calculations."""
-    from posthog.tasks.utils import CeleryQueue
-
-    # Check if LONG_RUNNING queue is in the worker's queue list
-    worker_queues = os.environ.get("CELERY_WORKER_QUEUES", "").split(",")
-    return CeleryQueue.LONG_RUNNING.value in worker_queues
 
 
 @setup_logging.connect

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -10,7 +10,7 @@ import structlog
 import posthoganalytics
 from celery import Task, chain, current_task, shared_task
 from dateutil.relativedelta import relativedelta
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
 from posthog.hogql.errors import ExposedHogQLError
 
@@ -43,35 +43,9 @@ from products.cohorts.backend.models.util import (
 )
 from products.cohorts.backend.realtime_teams import is_cohort_backfill_trigger_team
 
-COHORT_RECALCULATIONS_BACKLOG_GAUGE = Gauge(
-    "cohort_recalculations_backlog",
-    "Number of cohorts that are waiting to be calculated",
-    multiprocess_mode="max",
-)
-
 COHORT_STALENESS_HOURS_GAUGE = Gauge(
     "cohort_staleness_hours",
     "Cohort's count of hours since last calculation",
-    multiprocess_mode="max",
-)
-
-COHORTS_STALE_COUNT_GAUGE = Gauge(
-    "cohorts_stale",
-    "Number of cohorts that haven't been calculated in more than X hours",
-    ["hours"],
-    multiprocess_mode="max",
-)
-
-COHORTS_TOTAL_GAUGE = Gauge(
-    "cohorts_total",
-    "Total number of eligible cohorts for recalculation (non-static, non-deleted)",
-    multiprocess_mode="max",
-)
-
-COHORT_STUCK_COUNT_GAUGE = Gauge(
-    # TODO: rename to cohorts_stuck because this is a gauge not a counter
-    "cohort_stuck_count",
-    "Number of cohorts that are stuck calculating for more than 1 hour",
     multiprocess_mode="max",
 )
 
@@ -81,12 +55,6 @@ COHORT_DEPENDENCY_CALCULATION_FAILURES_COUNTER = Counter(
 )
 
 COHORT_STUCK_RESETS_COUNTER = Counter("cohort_stuck_resets_total", "Number of stuck cohorts that have been reset")
-
-COHORT_MAXED_ERRORS_GAUGE = Gauge(
-    "cohort_maxed_errors",
-    "Number of cohorts that have reached the maximum number of errors",
-    multiprocess_mode="max",
-)
 
 COHORT_CALCULATION_STARTED_COUNTER = Counter(
     "cohort_calculation_started_total",
@@ -254,8 +222,37 @@ def reset_stuck_cohorts() -> None:
         )
 
 
-def update_cohort_metrics() -> None:
+def update_cohort_metrics(registry: CollectorRegistry) -> None:
     now = timezone.now()
+
+    cohorts_total_gauge = Gauge(
+        "cohorts_total",
+        "Total number of eligible cohorts for recalculation (non-static, non-deleted)",
+        registry=registry,
+    )
+    cohorts_stale_gauge = Gauge(
+        "cohorts_stale",
+        "Number of cohorts that haven't been calculated in more than X hours",
+        ["hours"],
+        registry=registry,
+    )
+    cohort_stuck_gauge = Gauge(
+        # TODO: rename to cohorts_stuck because this is a gauge not a counter
+        "cohort_stuck_count",
+        "Number of cohorts that are stuck calculating for more than 1 hour",
+        registry=registry,
+    )
+    cohort_maxed_errors_gauge = Gauge(
+        "cohort_maxed_errors",
+        "Number of cohorts that have reached the maximum number of errors",
+        registry=registry,
+    )
+    cohort_backlog_gauge = Gauge(
+        "cohort_recalculations_backlog",
+        "Number of cohorts that are waiting to be calculated",
+        registry=registry,
+    )
+
     base_queryset = Cohort.objects.filter(
         Q(last_calculation__isnull=False),
         deleted=False,
@@ -263,11 +260,11 @@ def update_cohort_metrics() -> None:
         errors_calculating__lte=MAX_ERRORS_CALCULATING,
     ).exclude(is_static=True)
 
-    COHORTS_TOTAL_GAUGE.set(base_queryset.count())
+    cohorts_total_gauge.set(base_queryset.count())
 
     for hours in [24, 36, 48]:
         stale_count = base_queryset.filter(last_calculation__lte=now - relativedelta(hours=hours)).count()
-        COHORTS_STALE_COUNT_GAUGE.labels(hours=str(hours)).set(stale_count)
+        cohorts_stale_gauge.labels(hours=str(hours)).set(stale_count)
 
     stuck_count = (
         Cohort.objects.filter(
@@ -279,15 +276,16 @@ def update_cohort_metrics() -> None:
         .exclude(is_static=True)
         .count()
     )
-
-    COHORT_STUCK_COUNT_GAUGE.set(stuck_count)
+    cohort_stuck_gauge.set(stuck_count)
 
     maxed_error_count = (
         Cohort.objects.filter(deleted=False, errors_calculating__gt=MAX_ERRORS_CALCULATING)
         .exclude(is_static=True)
         .count()
     )
-    COHORT_MAXED_ERRORS_GAUGE.set(maxed_error_count)
+    cohort_maxed_errors_gauge.set(maxed_error_count)
+
+    cohort_backlog_gauge.set(get_cohort_calculation_candidates_queryset().count())
 
 
 def enqueue_cohorts_to_calculate(parallel_count: int) -> None:
@@ -336,19 +334,11 @@ def enqueue_cohorts_to_calculate(parallel_count: int) -> None:
             # Skip this cohort and continue with others
             continue
 
-    backlog = get_cohort_calculation_candidates_queryset().count()
-    COHORT_RECALCULATIONS_BACKLOG_GAUGE.set(backlog)
-
     logger.warning(
         "enqueued_cohort_calculation",
         cohort_ids=cohort_ids,
-        COHORT_RECALCULATIONS_BACKLOG_GAUGE=backlog,
+        count=len(cohort_ids),
     )
-
-    try:
-        update_cohort_metrics()
-    except Exception as e:
-        logger.exception("failed_to_update_cohort_metrics", error=str(e))
 
 
 def increment_version_and_enqueue_calculate_cohort(cohort: Cohort, *, initiating_user: Optional[User]) -> bool:

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -680,7 +680,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         get_crontab(settings.CALCULATE_COHORTS_DAY_SCHEDULE),
         calculate_cohort.s(),
         name="recalculate cohorts day",
-        expires=60 * 1.5,
+        expires=120 * 1.5,
         args=(settings.CALCULATE_X_PARALLEL_COHORTS_DURING_DAY,),
     )
 

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -55,6 +55,7 @@ from posthog.tasks.tasks import (
     pg_plugin_server_query_timing,
     pg_table_cache_hit_rate,
     process_scheduled_changes,
+    record_cohort_metrics,
     redis_celery_queue_depth,
     redis_heartbeat,
     redispatch_orphaned_queued_task_runs,
@@ -679,7 +680,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         get_crontab(settings.CALCULATE_COHORTS_DAY_SCHEDULE),
         calculate_cohort.s(),
         name="recalculate cohorts day",
-        expires=120 * 1.5,
+        expires=60 * 1.5,
         args=(settings.CALCULATE_X_PARALLEL_COHORTS_DURING_DAY,),
     )
 
@@ -689,6 +690,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="recalculate cohorts night",
         expires=60 * 1.5,
         args=(settings.CALCULATE_X_PARALLEL_COHORTS_DURING_NIGHT,),
+    )
+
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="*/2"),
+        record_cohort_metrics.s(),
+        name="cohort SLO metrics",
     )
 
     add_periodic_task_with_expiry(

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 from uuid import UUID
 
 from django.conf import settings
+from django.core.cache import cache
 from django.db import OperationalError, ProgrammingError, connection
 from django.utils import timezone
 
@@ -914,12 +915,44 @@ def clean_stale_partials() -> None:
     Partial.objects.filter(timestamp__lt=timezone.now() - datetime.timedelta(7)).delete()
 
 
+CALCULATE_COHORT_LOCK_KEY = "posthog:calculate_cohort_coordinator:lock"
+# Happy path releases the lock in finally; this TTL only bounds the skip window after a SIGKILL
+# strands it (~5 missed minute-cycles, then self-heals). A run outliving the TTL lets a second
+# start, but the per-cohort is_calculating flag bounds the double-pick.
+CALCULATE_COHORT_LOCK_TTL_SECONDS = 300
+
+CALCULATE_COHORT_LOCK_CONTENTION_COUNTER = Counter(
+    "posthog_calculate_cohort_lock_contentions_total",
+    "Times the cohort recalculation coordinator was skipped because its lock was held",
+)
+
+
 @shared_task(ignore_result=True)
 def calculate_cohort(parallel_count: int) -> None:
     from posthog.tasks.calculate_cohort import enqueue_cohorts_to_calculate, reset_stuck_cohorts
 
-    enqueue_cohorts_to_calculate(parallel_count)
-    reset_stuck_cohorts()
+    if not cache.add(CALCULATE_COHORT_LOCK_KEY, "locked", timeout=CALCULATE_COHORT_LOCK_TTL_SECONDS):
+        CALCULATE_COHORT_LOCK_CONTENTION_COUNTER.inc()
+        logger.info("calculate_cohort_coordinator_already_running")
+        return
+
+    try:
+        enqueue_cohorts_to_calculate(parallel_count)
+        reset_stuck_cohorts()
+    finally:
+        cache.delete(CALCULATE_COHORT_LOCK_KEY)
+
+
+@shared_task(bind=True, base=PushGatewayTask, ignore_result=True, queue=CeleryQueue.STATS.value)
+@skip_team_scope_audit
+def record_cohort_metrics(self: PushGatewayTask) -> None:
+    from posthog.tasks.calculate_cohort import update_cohort_metrics
+
+    registry = self.metrics_registry
+    if registry is None:
+        # mypy narrowing; unreachable via Celery dispatch
+        raise RuntimeError("record_cohort_metrics must run via PushGatewayTask")
+    update_cohort_metrics(registry)
 
 
 class Polling:

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -126,6 +126,7 @@
     'posthog.tasks.tasks.poll_query_performance',
     'posthog.tasks.tasks.process_query_task',
     'posthog.tasks.tasks.process_scheduled_changes',
+    'posthog.tasks.tasks.record_cohort_metrics',
     'posthog.tasks.tasks.redis_celery_queue_depth',
     'posthog.tasks.tasks.redis_heartbeat',
     'posthog.tasks.tasks.redispatch_orphaned_queued_task_runs',

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -4,20 +4,19 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
+from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
 
 from celery.exceptions import Retry
 from dateutil.relativedelta import relativedelta
 from parameterized import parameterized
+from prometheus_client import REGISTRY, CollectorRegistry
 
 from posthog.hogql.errors import QueryError
 
 from posthog.exceptions import ClickHouseAtCapacity
 from posthog.tasks.calculate_cohort import (
-    COHORT_STUCK_COUNT_GAUGE,
-    COHORTS_STALE_COUNT_GAUGE,
-    COHORTS_TOTAL_GAUGE,
     MAX_AGE_MINUTES,
     MAX_ERRORS_CALCULATING,
     MAX_STUCK_COHORTS_TO_RESET,
@@ -29,6 +28,7 @@ from posthog.tasks.calculate_cohort import (
     trigger_cohort_backfill_run_task,
     update_cohort_metrics,
 )
+from posthog.tasks.tasks import CALCULATE_COHORT_LOCK_KEY, calculate_cohort, record_cohort_metrics
 from posthog.test.persons import create_person
 
 from products.cohorts.backend.models.backfill import CohortBackfillKind, CohortBackfillRun
@@ -177,162 +177,6 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             )
             enqueue_cohorts_to_calculate(5)
             self.assertEqual(patch_increment_version_and_enqueue_calculate_cohort.call_count, 2)
-
-        @patch.object(COHORTS_TOTAL_GAUGE, "set")
-        @patch.object(COHORTS_STALE_COUNT_GAUGE, "labels")
-        def test_update_stale_cohort_metrics(self, mock_labels: MagicMock, mock_total_set: MagicMock) -> None:
-            mock_gauge = MagicMock()
-            mock_labels.return_value = mock_gauge
-
-            now = timezone.now()
-
-            # Create cohorts with different staleness levels
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="fresh_cohort",
-                last_calculation=now - relativedelta(hours=12),  # Not stale
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="stale_24h",
-                last_calculation=now - relativedelta(hours=30),  # Stale for 24h
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="stale_36h",
-                last_calculation=now - relativedelta(hours=40),  # Stale for 36h
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="stale_48h",
-                last_calculation=now - relativedelta(hours=50),  # Stale for 48h
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            # Create cohorts that should be excluded
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="null_last_calc",  # Should be excluded
-                last_calculation=None,
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="deleted_cohort",
-                last_calculation=now - relativedelta(hours=50),
-                deleted=True,  # Should be excluded
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="static_cohort",
-                last_calculation=now - relativedelta(hours=50),
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=0,
-                is_static=True,  # Should be excluded
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="high_errors",
-                last_calculation=now - relativedelta(hours=50),
-                deleted=False,
-                is_calculating=False,
-                errors_calculating=MAX_ERRORS_CALCULATING + 1,  # Should be excluded (>20 errors)
-                is_static=False,
-            )
-
-            update_cohort_metrics()
-
-            mock_labels.assert_any_call(hours="24")
-            mock_labels.assert_any_call(hours="36")
-            mock_labels.assert_any_call(hours="48")
-
-            set_calls = mock_gauge.set.call_args_list
-            self.assertEqual(len(set_calls), 3)
-
-            self.assertEqual(set_calls[0][0][0], 3)  # 24h: stale_24h, stale_36h, stale_48h
-            self.assertEqual(set_calls[1][0][0], 2)  # 36h: stale_36h, stale_48h
-            self.assertEqual(set_calls[2][0][0], 1)  # 48h: stale_48h
-
-            # 4 eligible cohorts: fresh_cohort, stale_24h, stale_36h, stale_48h
-            # Excluded: null_last_calc (no last_calculation), deleted_cohort, static_cohort, high_errors
-            mock_total_set.assert_called_once_with(4)
-
-        @patch.object(COHORT_STUCK_COUNT_GAUGE, "set")
-        def test_stuck_cohort_metrics(self, mock_set: MagicMock) -> None:
-            now = timezone.now()
-
-            # Create stuck cohort - is_calculating=True and last_calculation > 12 hours ago
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="stuck_cohort",
-                last_calculation=now - relativedelta(hours=2),
-                deleted=False,
-                is_calculating=True,  # Stuck calculating
-                errors_calculating=5,
-                is_static=False,
-            )
-
-            # Create another stuck cohort
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="stuck_cohort_2",
-                last_calculation=now - relativedelta(hours=3),
-                deleted=False,
-                is_calculating=True,  # Stuck calculating
-                errors_calculating=2,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="not_calculating",
-                last_calculation=now - relativedelta(hours=24),  # Old but not calculating
-                deleted=False,
-                is_calculating=False,  # Not calculating
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            Cohort.objects.create(
-                team_id=self.team.pk,
-                name="recent_calculation",
-                last_calculation=now - relativedelta(minutes=59),  # Recent calculation
-                deleted=False,
-                is_calculating=True,
-                errors_calculating=0,
-                is_static=False,
-            )
-
-            update_cohort_metrics()
-            mock_set.assert_called_with(2)
 
         @patch("posthog.tasks.calculate_cohort.logger")
         def test_reset_stuck_cohorts(self, mock_logger: MagicMock) -> None:
@@ -1436,6 +1280,207 @@ class TestCohortCalculationTasks(APIBaseTest):
         cohort_b.refresh_from_db()
         self.assertFalse(cohort_a.is_calculating)
         self.assertFalse(cohort_b.is_calculating)
+
+    def test_update_stale_cohort_metrics(self) -> None:
+        now = timezone.now()
+
+        # Baseline before the fixtures so assertions are deltas — the gauges count across all
+        # teams, so this stays correct regardless of cohorts already in the DB.
+        baseline = CollectorRegistry()
+        update_cohort_metrics(baseline)
+
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="fresh_cohort",
+            last_calculation=now - relativedelta(hours=12),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="stale_24h",
+            last_calculation=now - relativedelta(hours=30),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="stale_36h",
+            last_calculation=now - relativedelta(hours=40),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="stale_48h",
+            last_calculation=now - relativedelta(hours=50),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        # Null last_calculation: out of cohorts_total, still a backlog candidate.
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="never_calculated",
+            last_calculation=None,
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="deleted_cohort",
+            last_calculation=now - relativedelta(hours=50),
+            deleted=True,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="static_cohort",
+            last_calculation=now - relativedelta(hours=50),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=True,
+        )
+        # Over the error cap: excluded from totals/backlog, counted only in cohort_maxed_errors.
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="maxed_errors",
+            last_calculation=now - relativedelta(hours=50),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=MAX_ERRORS_CALCULATING + 1,
+            is_static=False,
+        )
+
+        registry = CollectorRegistry()
+        update_cohort_metrics(registry)
+
+        def added(name: str, labels: dict[str, str] | None = None) -> float:
+            after = registry.get_sample_value(name, labels) or 0.0
+            before = baseline.get_sample_value(name, labels) or 0.0
+            return after - before
+
+        self.assertEqual(added("cohorts_total"), 4)
+        self.assertEqual(added("cohorts_stale", {"hours": "24"}), 3)
+        self.assertEqual(added("cohorts_stale", {"hours": "36"}), 2)
+        self.assertEqual(added("cohorts_stale", {"hours": "48"}), 1)
+        self.assertEqual(added("cohort_recalculations_backlog"), 5)
+        self.assertEqual(added("cohort_maxed_errors"), 1)
+
+    def test_stuck_cohort_metrics(self) -> None:
+        now = timezone.now()
+
+        baseline = CollectorRegistry()
+        update_cohort_metrics(baseline)
+
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="stuck_cohort",
+            last_calculation=now - relativedelta(hours=2),
+            deleted=False,
+            is_calculating=True,
+            errors_calculating=5,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="stuck_cohort_2",
+            last_calculation=now - relativedelta(hours=3),
+            deleted=False,
+            is_calculating=True,
+            errors_calculating=2,
+            is_static=False,
+        )
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="not_calculating",
+            last_calculation=now - relativedelta(hours=24),
+            deleted=False,
+            is_calculating=False,
+            errors_calculating=0,
+            is_static=False,
+        )
+        # Calculating but only for 59 minutes: under the 1-hour stuck threshold.
+        Cohort.objects.create(
+            team_id=self.team.pk,
+            name="recent_calculation",
+            last_calculation=now - relativedelta(minutes=59),
+            deleted=False,
+            is_calculating=True,
+            errors_calculating=0,
+            is_static=False,
+        )
+
+        registry = CollectorRegistry()
+        update_cohort_metrics(registry)
+
+        before = baseline.get_sample_value("cohort_stuck_count") or 0.0
+        after = registry.get_sample_value("cohort_stuck_count") or 0.0
+        self.assertEqual(after - before, 2)
+
+    def test_calculate_cohort_skips_when_lock_held(self) -> None:
+        cache.add(CALCULATE_COHORT_LOCK_KEY, "locked", timeout=60)
+        self.addCleanup(cache.delete, CALCULATE_COHORT_LOCK_KEY)
+
+        metric = "posthog_calculate_cohort_lock_contentions_total"
+        before = REGISTRY.get_sample_value(metric) or 0.0
+
+        with (
+            patch("posthog.tasks.calculate_cohort.enqueue_cohorts_to_calculate") as mock_enqueue,
+            patch("posthog.tasks.calculate_cohort.reset_stuck_cohorts") as mock_reset,
+        ):
+            calculate_cohort(1)
+
+        mock_enqueue.assert_not_called()
+        mock_reset.assert_not_called()
+        self.assertEqual((REGISTRY.get_sample_value(metric) or 0.0) - before, 1.0)
+
+    @parameterized.expand(
+        [
+            ("success", None),
+            ("failure", RuntimeError("enqueue blew up")),
+        ]
+    )
+    def test_calculate_cohort_releases_lock(self, _name: str, enqueue_side_effect: Exception | None) -> None:
+        self.addCleanup(cache.delete, CALCULATE_COHORT_LOCK_KEY)
+
+        with (
+            patch("posthog.tasks.calculate_cohort.enqueue_cohorts_to_calculate", side_effect=enqueue_side_effect),
+            patch("posthog.tasks.calculate_cohort.reset_stuck_cohorts"),
+        ):
+            if enqueue_side_effect is not None:
+                with self.assertRaises(RuntimeError):
+                    calculate_cohort(1)
+            else:
+                calculate_cohort(1)
+
+        # Lock is free again, so the next scheduled run can acquire it.
+        self.assertTrue(cache.add(CALCULATE_COHORT_LOCK_KEY, "locked", timeout=60))
+
+    @patch("posthog.metrics.push_to_gateway")
+    @patch("django.conf.settings.PROM_PUSHGATEWAY_ADDRESS", value="127.0.0.1")
+    def test_record_cohort_metrics_emits_through_pushed_registry(
+        self, _address: MagicMock, mock_push_to_gateway: MagicMock
+    ) -> None:
+        record_cohort_metrics()
+
+        self.assertEqual(mock_push_to_gateway.call_count, 1)
+        registry = mock_push_to_gateway.call_args[1]["registry"]
+        # The sample lands in the pushed registry, not the default one — proves the task emits
+        # through self.metrics_registry.
+        self.assertIsNotNone(registry.get_sample_value("cohorts_total"))
 
 
 class TestCalculateCohortFromListRetries(APIBaseTest):

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -1,4 +1,3 @@
-import os
 import threading
 
 from unittest import TestCase
@@ -73,9 +72,6 @@ class TestAnalyticsMetricsConfig(TestCase):
 
 
 class TestWorkerMetricsInitialization(TestCase):
-    # "celery" excludes long_running, so this also proves the seed does not depend on
-    # the queue set (and keeps the DB-touching cohort branch off).
-    @patch.dict(os.environ, {"CELERY_WORKER_QUEUES": "celery"})
     def test_seeds_hypercache_verification_task_series(self) -> None:
         _initialize_worker_metrics()
 


### PR DESCRIPTION
## Problem

On call never gets paged for a real cohort recalculation SLO breach, because the gauges the alerts read vanish whenever the Django worker pods autoscale.
The gauges are process local multiprocess gauges, set only inside the per minute `calculate_cohort` coordinator and scraped from pods that scale up and down.
When a pod holding fresh samples rolls, `max()` over the series goes empty and the alerting `for` timer resets.
The coordinator also runs with no lock, so two overlapping runs can pick the same candidates.

Related to https://github.com/PostHog/charts/pull/14590.

## Changes

- A new `record_cohort_metrics` task emits the SLO gauges every 2 minutes through the pushgateway, as stable region level series that survive worker scale events, so the alerts stay continuous.
- `update_cohort_metrics` now writes to a passed in registry; metric names, help strings, and the `hours` label stay identical, so the alerts and dashboard keep keying on them.
- `calculate_cohort` takes a singleton cache lock (300s TTL, released in `finally`) so overlapping runs cannot double pick candidates, and `posthog_calculate_cohort_lock_contentions_total` counts skips.
- The per minute coordinator sheds several full table counts, now run by the metrics task instead.
- The day coordinator `expires` drops to match the every minute cadence.
- Mechanical: removed the five module level gauge objects and the boot time backlog init in `celery.py`; `cohort_staleness_hours` stays worker side.

## How did you test this code?

- Reworked the cohort metric tests and added lock and wiring tests in `posthog/tasks/test/test_calculate_cohort.py`, and trimmed `posthog/test/test_celery.py`.
- The metric tests catch queryset or label drift; the lock tests catch a coordinator that double runs or never releases; the wiring test catches gauges emitted to the default registry instead of the pushed one.
- Ran those two test files against a local Postgres, plus repo wide `mypy` and `ruff`. Did not run the full CI suite.

## Docs update

No.