### PR TITLE
feat(desktop): gate home tab behind feature flag

### DIFF
--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -18,6 +18,7 @@ export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";
 export const CHANNELS_LAYOUT_FLAG = "code-spaces-layout";
 // Gates the Loops feature: the sidebar Loops space and the per-channel Loops tab.
 export const LOOPS_FLAG = "loops";
+export const DESKTOP_HOME_FLAG = "desktop-home-flag";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";
 export const GLM_MODEL_FLAG = "posthog-code-glm-model";
 export const GLM53_MODEL_FLAG = "posthog-code-glm-53-model";

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  featureFlags: new Map<string, boolean>(),
   fullPath: "/",
   navigate: vi.fn(),
   navigateToActivity: vi.fn(),
@@ -31,7 +32,7 @@ vi.mock(
   () => ({ useCommandCenterActiveCount: () => 0 }),
 );
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
-  useFeatureFlag: () => false,
+  useFeatureFlag: (key: string) => mocks.featureFlags.get(key) ?? false,
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelsLayout", () => ({
   useChannelsLayout: () => true,
@@ -57,6 +58,7 @@ vi.mock("@posthog/ui/features/canvas/components/ActivityHoverCard", () => ({
   ActivityHoverCard: () => <div>Recent activity card</div>,
 }));
 
+import { DESKTOP_HOME_FLAG } from "@posthog/shared";
 import {
   clearKeepListForRoute,
   shouldKeepListForRoute,
@@ -70,12 +72,22 @@ import { NavRail } from "./NavRail";
 describe("NavRail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.featureFlags.clear();
+    mocks.featureFlags.set(DESKTOP_HOME_FLAG, true);
     mocks.fullPath = "/";
     useSidebarStore.setState({ navItemOverrides: {}, navItemOrder: [] });
     useCurrentChannelStore.setState({ currentChannelId: null });
     useChannelPaneStore.setState({ pane: "channel" });
     useRailHistoryStore.setState({ lastByPane: {} });
     clearKeepListForRoute();
+  });
+
+  it("hides Home when its feature flag is off", () => {
+    mocks.featureFlags.set(DESKTOP_HOME_FLAG, false);
+
+    render(<NavRail />);
+
+    expect(screen.queryByLabelText("Home")).not.toBeInTheDocument();
   });
 
   // The route is the whole answer, so a destination can never be lit over a

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
@@ -10,7 +10,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@posthog/quill";
-import { LOOPS_FLAG } from "@posthog/shared";
+import { DESKTOP_HOME_FLAG, LOOPS_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { ActivityHoverCard } from "@posthog/ui/features/canvas/components/ActivityHoverCard";
 import {
@@ -171,6 +171,7 @@ function ActivityNavItem({
  * that sidebar leaves the destinations reachable.
  */
 export function NavRail() {
+  const homeEnabled = useFeatureFlag(DESKTOP_HOME_FLAG);
   const loopsEnabled = useFeatureFlag(LOOPS_FLAG, import.meta.env.DEV);
 
   const { counts: inboxCounts } = useInboxAllReports({
@@ -192,6 +193,7 @@ export function NavRail() {
   const destinations = visibleRailDestinations({
     overrides: navItemOverrides,
     order: navItemOrder,
+    home: homeEnabled,
     loops: loopsEnabled,
   });
   const settingsVisible = isNavItemVisible(navItemOverrides, "configure");

--- a/products/desktop/packages/ui/src/features/canvas/components/railDestinations.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/railDestinations.ts
@@ -62,7 +62,7 @@ export interface RailDestination {
   shortcut?: string;
   count?: (counts: RailCounts) => number;
   countTone?: CountBadgeTone;
-  enabled?: (flags: { loops: boolean }) => boolean;
+  enabled?: (flags: { home: boolean; loops: boolean }) => boolean;
 }
 
 /**
@@ -118,6 +118,7 @@ export const RAIL_DESTINATIONS: readonly RailDestination[] = [
     analyticsId: "home",
     Icon: HouseSimple,
     onPick: navigateToHome,
+    enabled: (flags) => flags.home,
   },
   {
     pane: "spaces",
@@ -174,15 +175,17 @@ export const RAIL_DESTINATIONS: readonly RailDestination[] = [
 export function visibleRailDestinations({
   overrides,
   order,
+  home,
   loops,
 }: {
   overrides: NavItemOverrides;
   order: readonly CustomizableNavItemId[];
+  home: boolean;
   loops: boolean;
 }): readonly RailDestination[] {
   const shown = RAIL_DESTINATIONS.filter(
     ({ customizableId, enabled }) =>
-      (enabled?.({ loops }) ?? true) &&
+      (enabled?.({ home, loops }) ?? true) &&
       (!customizableId || isNavItemVisible(overrides, customizableId)),
   );
   if (order.length === 0) return shown;


### PR DESCRIPTION
## Problem

Desktop users need the Home tab controlled independently during rollout.

## Changes

- The Home tab appears only when `desktop-home-flag` evaluates true.
- Existing Home routes remain available for direct navigation.
- Screenshot omitted because the change only removes one existing rail icon when the flag is off.

## How did you test this code?

- The NavRail test covers the Home tab when the flag is disabled.
- The full UI test suite, UI typecheck, formatter, and host-boundary check pass.
- Repo preflight was unavailable because this environment has neither `hogli` nor `flox` on PATH.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The rollout uses an internal feature flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex via PostHog Desktop authored the change. It used the `/posthog-desktop`, `/instrument-feature-flags`, and `/writing-pr-descriptions` skills.

The change reuses the existing client-side flag service and leaves route handling unchanged.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*