### PR TITLE
fix(gitlab): stop reporting exhausted transient retries as errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/source.py
@@ -109,6 +109,13 @@ For self-managed GitLab, set the instance URL (for example `https://gitlab.examp
             HTTP_NOT_ALLOWED_ERROR: "The GitLab host must use HTTPS. Please update the instance URL to use https://.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A GitLabRetryableError (rate limit or transient upstream 5xx) that survives
+        # fetch_page's own tenacity retry still gets picked up by Temporal's activity retry;
+        # classify it as retryable so it's logged as a warning rather than tracked as an
+        # exception. Mirrors GitHub's equivalent case.
+        return {"GitLab API error (retryable)"}
+
     def get_schemas(
         self,
         config: GitLabSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab_source.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.gitlab.gitlab import GitLabResumeConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.gitlab.settings import ENDPOINTS
@@ -55,6 +56,15 @@ class TestGitLabSource:
     @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", "404 Client Error"])
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
+
+    def test_transient_5xx_error_is_retryable_not_non_retryable(self):
+        # A GitLabRetryableError (any transient upstream 5xx) that exhausts fetch_page's tenacity
+        # retry must stay retryable, so a GitLab-side outage doesn't disable the source.
+        observed_error = "GitLab API error (retryable): status=502, url=https://gitlab.com/api/v4/projects/1/issues"
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in observed_error for key in non_retryable_errors)
+        retryable_errors = self.source.get_retryable_errors()
+        assert error_message_matches(observed_error, retryable_errors)
 
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

A GitLab sync that hits a transient upstream 5xx or rate limit gets reported to [error tracking](https://us.posthog.com/project/2/error_tracking/01a03227-1a76-7c91-86e3-5358f5a3c85f) as a bug, even though the failure is self-recovering and Temporal already retries the whole sync.

`GitLabSource` never overrode `get_retryable_errors()`, so once the source's own `fetch_page` tenacity retry is exhausted, the resulting `GitLabRetryableError` message falls through the shared error-handling path unclassified and gets logged as an exception instead of a warning.

## Changes

- `GitLabSource.get_retryable_errors()` now matches its own `"GitLab API error (retryable)"` message, so an exhausted transient 5xx/429 logs as a warning and is excluded from error tracking, while Temporal still retries the activity.
- Mirrors `GithubSource.get_retryable_errors()`, which already does this for the equivalent GitHub failure shape.

## How did you test this code?

Added `test_transient_5xx_error_is_retryable_not_non_retryable`, mirroring GitHub's equivalent test — catches the case where this message is absent from (or drops out of) `get_retryable_errors()`, which would silently start reporting a benign, self-recovering outage as a bug again.

Ran the full `gitlab` source test suite locally (100 passed) plus ruff lint/format on the changed files. Did not run the broader integration/CI suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for a `GitLabRetryableError` (HTTP 502) surfaced in `products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py`. Confirmed the stack trace originates in this source's `fetch_page`, then traced how `_handle_import_error` classifies exhausted-retry exceptions via each source's `get_retryable_errors()`/`get_non_retryable_errors()`. Found GitLab was the only REST-style source among several checked (GitHub, Stripe, etc.) missing a `get_retryable_errors()` override for this exact failure shape. Searched open PRs (issue text, module path, maintainer's own PRs) for a duplicate fix — found none, though the maintainer has recently landed the identical fix for other sources (e.g. #87523 for FeatureBase).

Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body, `hogli` skill for local test running guidance.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*