### PR TITLE
fix(postgres): classify Supavisor's nxdomain pooler failure as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -349,6 +349,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "deleted, or the pooler username/host is wrong. Check that your database is active "
                 "and the connection details are correct, then re-enable the sync."
             ),
+            # Supabase's Supavisor pooler reports a permanent DNS failure resolving its upstream
+            # backend as "FATAL: Failed to connect to database: {:error, :nxdomain}" — Erlang's
+            # resolver returning "no such domain", unlike the sibling ":etimedout"/":econnrefused"
+            # tuples in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, which mean a transient blip reaching
+            # a backend that still exists. NXDOMAIN means the backend's DNS record is gone, which
+            # happens when the underlying project is paused or deleted — permanent until the
+            # customer restores it, so don't retry. Match the stable erlang-tuple fragment.
+            "{:error, :nxdomain}": (
+                "Your database connection pooler couldn't resolve your database's address "
+                '("nxdomain"). This usually means the database project is paused or deleted. Check '
+                "that your database is active, then re-enable the sync."
+            ),
             # Supabase/Supavisor poolers reject a connection that carries no tenant identifier with
             # "FATAL: (ENOIDENTIFIER) no tenant identifier provided (external_id or sni_hostname
             # required)". The shared regional pooler host (e.g. aws-0-<region>.pooler.supabase.com)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -756,6 +756,21 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Supavisor's Erlang resolver can't find a DNS record for its upstream backend — the
+            # stable signal that the underlying project is paused or deleted. Distinct from the
+            # sibling ":etimedout"/":econnrefused" tuples, which are transient and stay retryable.
+            'connection failed: connection to server at "203.0.113.10", port 5432 failed: FATAL:  Failed to connect to database: {:error, :nxdomain}',
+            'connection failed: connection to server at "203.0.113.20", port 6543 failed: FATAL:  Failed to connect to database: {:error, :nxdomain}',
+        ],
+    )
+    def test_supavisor_nxdomain_pooler_dns_failure_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Supavisor nxdomain pooler DNS failure should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Supabase Supavisor rejects a connection with no tenant identifier when the pooler
             # username omits the project ref. The host/IP and port are volatile; the message is stable.
             'connection failed: connection to server at "54.255.219.82", port 5432 failed: FATAL:  (ENOIDENTIFIER) no tenant identifier provided (external_id or sni_hostname required)',


### PR DESCRIPTION
## Problem

A Postgres or Supabase sync whose connection pooler can no longer reach its backend database keeps retrying until the retry budget runs out, instead of failing fast with actionable guidance.

Surfaced by an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a03245-72c3-7511-bff4-aa12f8fa076b) landing in `SupabaseSource.get_schemas`, which calls into the shared Postgres connection code: `OperationalError`, `FATAL: Failed to connect to database: {:error, :nxdomain}`.

## Changes

- `get_non_retryable_errors` already treats sibling Supavisor pooler failures (missing tenant/user, no tenant identifier) as permanent, but not this one. Add it alongside them.
- The erlang-tuple wording distinguishes this from the transient `{:error, :etimedout}` / `{:error, :econnrefused}` tuples already classified as retryable connection drops: `nxdomain` means the pooler's backend DNS record no longer exists, which happens when the underlying database project is paused or deleted.
- Mechanical: extend the existing parametrized non-retryable-error test with this message shape.

## How did you test this code?

Added 2 cases to `TestPostgresSourceNonRetryableErrors` asserting the `{:error, :nxdomain}` message is recognized as non-retryable — guards against Temporal burning its retry budget retrying a permanently gone pooler backend. No existing test covered this message shape.

Ran locally:
```
python -m pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -k "NonRetryableErrors or non_retryable" -q
```
152 passed (one unrelated pre-existing test in the same file errors here because it needs a live Postgres server, which this sandbox lacks).

Also ran `ruff check` and `ruff format --check` on both changed files — clean.

Not run: DB-backed and Temporal-workflow-level tests, since this sandbox has no live Postgres or Temporal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry classification only, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the failure's call path runs through `supabase/source.py` before reaching the shared Postgres connection code. Read the existing `get_non_retryable_errors` classification and its Supavisor-specific entries to place the new key consistently with that pattern, and confirmed the erlang-tuple `nxdomain` reason is distinct from the already-retryable `etimedout`/`econnrefused` tuples.

Skills invoked: `/writing-tests` before extending the parametrized test, `/writing-pr-descriptions` before writing this body.

No customer-identifying data is included; the example host/IP values in the test are invented, not the real customer values from the linked error tracking issue.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*