### PR TITLE
feat(workflows): add server-side search to opt-out and suppression lists

### DIFF
--- a/products/messaging/backend/api/message_preferences.py
+++ b/products/messaging/backend/api/message_preferences.py
@@ -196,6 +196,13 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 required=False,
                 description="Message category key to list opt-outs for. If omitted, lists recipients opted out of all marketing messages.",
             ),
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Case-insensitive substring match on the recipient identifier.",
+            ),
             OpenApiParameter(name="page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, required=False),
             OpenApiParameter(name="page_size", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, required=False),
         ],
@@ -223,7 +230,15 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         opt_outs = MessageRecipientPreference.objects.filter(
             team_id=self.team_id,
             **{f"preferences__{preference_key}": PreferenceStatus.OPTED_OUT.value},
-        ).order_by("-updated_at")  # Order by most recently updated first
+        )
+
+        search = (request.query_params.get("search") or "").strip()
+        if search:
+            if len(search) > 512:
+                raise serializers.ValidationError({"search": "Search term must be 512 characters or fewer."})
+            opt_outs = opt_outs.filter(identifier__icontains=search)
+
+        opt_outs = opt_outs.order_by("-updated_at")  # Order by most recently updated first
 
         # Apply pagination
         paginator = OptOutsPagination()

--- a/products/messaging/backend/api/message_preferences.py
+++ b/products/messaging/backend/api/message_preferences.py
@@ -13,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.documentation import _FallbackSerializer
+from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.streaming import streaming_response
 from posthog.plugins import plugin_server_api
@@ -108,6 +109,22 @@ class MessagingErrorSerializer(serializers.Serializer):
     error = serializers.CharField(help_text="Human-readable description of what went wrong.")
 
 
+class OptOutsListQuerySerializer(serializers.Serializer):
+    # allow_blank preserves the pre-serializer behavior: an empty category_key reads as "no
+    # category" (the global list) rather than a 400.
+    category_key = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Message category key to list opt-outs for. If omitted, lists recipients opted out of all marketing messages.",
+    )
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=512,
+        help_text="Case-insensitive substring match on the recipient identifier.",
+    )
+
+
 class PaginatedOptOutsSerializer(serializers.Serializer):
     """OpenAPI shape for the paginated opt-outs response, so the generated clients get the
     {count, next, previous, results} envelope instead of an untyped object."""
@@ -187,37 +204,24 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         if not self.user_access_control.check_access_level_for_resource("hog_flow", required_level):
             raise PermissionDenied(message)
 
-    @extend_schema(
+    @validated_request(
+        query_serializer=OptOutsListQuerySerializer,
         parameters=[
-            OpenApiParameter(
-                name="category_key",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description="Message category key to list opt-outs for. If omitted, lists recipients opted out of all marketing messages.",
-            ),
-            OpenApiParameter(
-                name="search",
-                type=OpenApiTypes.STR,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description="Case-insensitive substring match on the recipient identifier.",
-            ),
             OpenApiParameter(name="page", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, required=False),
             OpenApiParameter(name="page_size", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY, required=False),
         ],
         responses={
-            200: PaginatedOptOutsSerializer,
+            200: OpenApiResponse(response=PaginatedOptOutsSerializer),
             404: OpenApiResponse(response=MessagingErrorSerializer),
         },
         summary="List recipients opted out of a message category",
     )
     @action(detail=False, methods=["get"])
-    def opt_outs(self, request: Request, **kwargs: Any) -> Response:
+    def opt_outs(self, request: ValidatedRequest, **kwargs: Any) -> Response:
         """Get opt-outs filtered by category or overall opt-outs if no category specified"""
         self._require_resource_access("viewer", "You need hog_flow viewer access to view the opt-out list.")
 
-        category_key = request.query_params.get("category_key")
+        category_key = request.validated_query_data.get("category_key")
 
         # Find recipients who have opted out of this specific category, or use the derived $all category if no specific category is provided
         preference_key = ALL_MESSAGE_PREFERENCE_CATEGORY_ID
@@ -232,10 +236,8 @@ class MessagePreferencesViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             **{f"preferences__{preference_key}": PreferenceStatus.OPTED_OUT.value},
         )
 
-        search = (request.query_params.get("search") or "").strip()
+        search = request.validated_query_data.get("search")
         if search:
-            if len(search) > 512:
-                raise serializers.ValidationError({"search": "Search term must be 512 characters or fewer."})
             opt_outs = opt_outs.filter(identifier__icontains=search)
 
         opt_outs = opt_outs.order_by("-updated_at")  # Order by most recently updated first

--- a/products/messaging/backend/api/message_suppression.py
+++ b/products/messaging/backend/api/message_suppression.py
@@ -4,7 +4,7 @@ from django.db.models import F
 from django.db.models.functions import Coalesce, Now
 from django.utils import timezone
 
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -13,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.documentation import _FallbackSerializer
+from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
 from products.messaging.backend.models.message_suppression import MessageSuppression, SuppressionSource
@@ -79,6 +80,15 @@ class PaginatedMessageSuppressionSerializer(serializers.Serializer):
     results = MessageSuppressionSerializer(many=True)
 
 
+class SuppressionsListQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=512,
+        help_text="Case-insensitive substring match on the recipient email address.",
+    )
+
+
 class AddSuppressionRequestSerializer(serializers.Serializer):
     identifier = serializers.CharField(
         max_length=512,
@@ -101,19 +111,13 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object_write_actions = ["add_suppression", "remove_suppression"]
     serializer_class = _FallbackSerializer
 
-    @extend_schema(
+    @validated_request(
+        query_serializer=SuppressionsListQuerySerializer,
         parameters=[
-            OpenApiParameter(
-                name="search",
-                type=str,
-                location=OpenApiParameter.QUERY,
-                required=False,
-                description="Case-insensitive substring match on the recipient email address.",
-            ),
             OpenApiParameter(name="page", type=int, location=OpenApiParameter.QUERY, required=False),
             OpenApiParameter(name="page_size", type=int, location=OpenApiParameter.QUERY, required=False),
         ],
-        responses={200: PaginatedMessageSuppressionSerializer},
+        responses={200: OpenApiResponse(response=PaginatedMessageSuppressionSerializer)},
         summary="List suppressed email addresses for the team",
     )
     # The rows carry recipient email addresses and their SMTP diagnostics, so reading them is
@@ -122,7 +126,7 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     # could enumerate who a team emails, and probe whether a given address is known by paging for
     # it. The UI uses session auth, which skips scope checks, so the suppression list is unaffected.
     @action(detail=False, methods=["get"], required_scopes=["hog_flow:read", "person:read"])
-    def suppressions(self, request: Request, **kwargs: Any) -> Response:
+    def suppressions(self, request: ValidatedRequest, **kwargs: Any) -> Response:
         """List suppressed recipients for the team, most recently updated first."""
         # Resource-level check: `AccessControlPermission` only guarantees the caller has some
         # hog_flow object access. Since this endpoint returns team-wide data (every suppressed
@@ -134,10 +138,8 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
         suppressions = MessageSuppression.objects.for_team(self.team_id).filter(suppressed=True, deleted=False)
 
-        search = (request.query_params.get("search") or "").strip()
+        search = request.validated_query_data.get("search")
         if search:
-            if len(search) > 512:
-                raise serializers.ValidationError({"search": "Search term must be 512 characters or fewer."})
             suppressions = suppressions.filter(identifier__icontains=search)
 
         suppressions = suppressions.order_by("-updated_at")

--- a/products/messaging/backend/api/message_suppression.py
+++ b/products/messaging/backend/api/message_suppression.py
@@ -103,6 +103,13 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
     @extend_schema(
         parameters=[
+            OpenApiParameter(
+                name="search",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Case-insensitive substring match on the recipient email address.",
+            ),
             OpenApiParameter(name="page", type=int, location=OpenApiParameter.QUERY, required=False),
             OpenApiParameter(name="page_size", type=int, location=OpenApiParameter.QUERY, required=False),
         ],
@@ -125,11 +132,15 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         if not self.user_access_control.check_access_level_for_resource("hog_flow", "viewer"):
             raise PermissionDenied("You need hog_flow viewer access to view the suppression list.")
 
-        suppressions = (
-            MessageSuppression.objects.for_team(self.team_id)
-            .filter(suppressed=True, deleted=False)
-            .order_by("-updated_at")
-        )
+        suppressions = MessageSuppression.objects.for_team(self.team_id).filter(suppressed=True, deleted=False)
+
+        search = (request.query_params.get("search") or "").strip()
+        if search:
+            if len(search) > 512:
+                raise serializers.ValidationError({"search": "Search term must be 512 characters or fewer."})
+            suppressions = suppressions.filter(identifier__icontains=search)
+
+        suppressions = suppressions.order_by("-updated_at")
 
         paginator = SuppressionPagination()
         page = paginator.paginate_queryset(suppressions, request)

--- a/products/messaging/backend/api/test/test_message_preferences.py
+++ b/products/messaging/backend/api/test/test_message_preferences.py
@@ -599,6 +599,35 @@ class TestMessagePreferencesAPIViewSet(APIBaseTest):
         self.assertEqual(len(data["results"]), 1)
         self.assertEqual(data["results"][0]["identifier"], "user1@example.com")
 
+    def test_opt_outs_search_filters_by_identifier(self):
+        for identifier in ["alice@example.com", "bob@example.com", "Alice.Smith@other.io"]:
+            MessageRecipientPreference.objects.create(
+                team=self.team,
+                identifier=identifier,
+                preferences={ALL_MESSAGE_PREFERENCE_CATEGORY_ID: PreferenceStatus.OPTED_OUT.value},
+            )
+        # Opted out of a category only, so a global-list search must not surface them
+        MessageRecipientPreference.objects.create(
+            team=self.team,
+            identifier="alice@category-only.com",
+            preferences={str(self.category.id): PreferenceStatus.OPTED_OUT.value},
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/messaging_preferences/opt_outs/", {"search": "ALICE"}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], 2)
+        identifiers = {item["identifier"] for item in data["results"]}
+        self.assertEqual(identifiers, {"alice@example.com", "Alice.Smith@other.io"})
+
+    def test_opt_outs_search_term_too_long(self):
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/messaging_preferences/opt_outs/", {"search": "a" * 513}
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_add_opt_out_global(self):
         response = self.client.post(
             f"/api/environments/{self.team.id}/messaging_preferences/add_opt_out/",

--- a/products/messaging/backend/api/test/test_message_suppression.py
+++ b/products/messaging/backend/api/test/test_message_suppression.py
@@ -66,6 +66,40 @@ class TestSuppressionListPersonalAPIKeyAccess(APIBaseTest):
             assert set(response.json()) == {"count", "next", "previous", "results"}
 
 
+class TestSuppressionListSearch(APIBaseTest):
+    def test_search_filters_by_identifier_within_suppressed_rows(self) -> None:
+        for identifier in ["alice@example.com", "bob@example.com"]:
+            MessageSuppression.objects.for_team(self.team.id).create(
+                team_id=self.team.id,
+                identifier=identifier,
+                source=SuppressionSource.MANUAL,
+                suppressed=True,
+            )
+        # Bounce-counting row that hasn't crossed the threshold: matches the search term but must
+        # stay off the list because it isn't suppressed
+        MessageSuppression.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            identifier="alice@not-suppressed.com",
+            source=SuppressionSource.BOUNCE,
+            suppressed=False,
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/messaging_suppressions/suppressions/", {"search": "ALICE"}
+        )
+
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert data["count"] == 1
+        assert data["results"][0]["identifier"] == "alice@example.com"
+
+    def test_search_term_too_long(self) -> None:
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/messaging_suppressions/suppressions/", {"search": "a" * 513}
+        )
+        assert response.status_code == 400
+
+
 class TestRemoveSuppressionResetsSource(APIBaseTest):
     """
     Guards against a regression where remove_suppression keeps source='MANUAL' on the removed row.

--- a/products/messaging/frontend/generated/api.schemas.ts
+++ b/products/messaging/frontend/generated/api.schemas.ts
@@ -517,6 +517,7 @@ export type MessagingPreferencesOptOutsRetrieveParams = {
     page_size?: number
     /**
      * Case-insensitive substring match on the recipient identifier.
+     * @maxLength 512
      */
     search?: string
 }
@@ -526,6 +527,7 @@ export type MessagingSuppressionsSuppressionsRetrieveParams = {
     page_size?: number
     /**
      * Case-insensitive substring match on the recipient email address.
+     * @maxLength 512
      */
     search?: string
 }

--- a/products/messaging/frontend/generated/api.schemas.ts
+++ b/products/messaging/frontend/generated/api.schemas.ts
@@ -515,11 +515,19 @@ export type MessagingPreferencesOptOutsRetrieveParams = {
     category_key?: string
     page?: number
     page_size?: number
+    /**
+     * Case-insensitive substring match on the recipient identifier.
+     */
+    search?: string
 }
 
 export type MessagingSuppressionsSuppressionsRetrieveParams = {
     page?: number
     page_size?: number
+    /**
+     * Case-insensitive substring match on the recipient email address.
+     */
+    search?: string
 }
 
 export type MessagingTemplatesListParams = {

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -41,6 +41,7 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
         importCsv,
         exportCsv,
         clearCsvImportResult,
+        setSearchTerm,
     } = useActions(logic)
     const {
         selectedIdentifier,
@@ -59,6 +60,7 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
         csvImportResult,
         csvImportResultLoading,
         csvExportLoading,
+        searchTerm,
     } = useValues(logic)
 
     const handleShowPersons = (identifier: string): void => {
@@ -136,7 +138,15 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
 
     return (
         <>
-            <div className="flex justify-end gap-2 mb-2 mt-[-3rem]">
+            <div className="flex flex-wrap justify-end gap-2 mb-2">
+                <LemonInput
+                    type="search"
+                    size="small"
+                    placeholder="Search recipients"
+                    value={searchTerm}
+                    onChange={setSearchTerm}
+                    className="w-60"
+                />
                 <LemonButton
                     icon={<IconPlus />}
                     size="small"
@@ -184,7 +194,11 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                     loading={optOutPersonsLoading}
                     loadingSkeletonRows={3}
                     rowKey="identifier"
-                    emptyState={`No opt-outs found${category?.name ? ` for ${category.name}` : ''}`}
+                    emptyState={
+                        searchTerm.trim()
+                            ? 'No opt-outs match your search'
+                            : `No opt-outs found${category?.name ? ` for ${category.name}` : ''}`
+                    }
                     size="small"
                 />
             </div>

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -181,7 +181,7 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
                     icon={<IconRefresh />}
                     size="small"
                     type="secondary"
-                    onClick={loadOptOutPersons}
+                    onClick={() => loadOptOutPersons()}
                     loading={optOutPersonsLoading}
                 >
                     Reload

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -1,4 +1,4 @@
-import { MakeLogicType, actions, afterMount, connect, kea, key, path, props, reducers } from 'kea'
+import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import Papa from 'papaparse'
 
@@ -63,6 +63,7 @@ export interface optOutListLogicValues {
     personsModalOpen: boolean
     removeOptOut: string | null
     removeOptOutLoading: boolean
+    searchTerm: string
     selectedIdentifier: string | null
     showAddOptOutModal: boolean
     showImportCsvModal: boolean
@@ -224,6 +225,9 @@ export interface optOutListLogicActions {
     setPersonsModalOpen: (open: boolean) => {
         open: boolean
     }
+    setSearchTerm: (searchTerm: string) => {
+        searchTerm: string
+    }
     setSelectedIdentifier: (identifier: string | null) => {
         identifier: string | null
     }
@@ -260,6 +264,7 @@ export const optOutListLogic = kea<optOutListLogicType>([
         setPersonsModalOpen: (open: boolean) => ({ open }),
         setManagePreferencesModalOpen: (open: boolean) => ({ open }),
         setSelectedIdentifier: (identifier: string | null) => ({ identifier }),
+        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setCurrentPage: (page: number) => ({ page }),
         loadNextPage: true,
         loadPreviousPage: true,
@@ -298,6 +303,12 @@ export const optOutListLogic = kea<optOutListLogicType>([
             null as string | null,
             {
                 setSelectedIdentifier: (_, { identifier }) => identifier,
+            },
+        ],
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
             },
         ],
         currentPage: [
@@ -367,6 +378,7 @@ export const optOutListLogic = kea<optOutListLogicType>([
             }
             return await messagingPreferencesOptOutsRetrieve(String(values.currentProjectId), {
                 category_key: props.category?.key,
+                search: values.searchTerm.trim() || undefined,
                 page,
             })
         }
@@ -524,6 +536,12 @@ export const optOutListLogic = kea<optOutListLogicType>([
             },
         }
     }),
+    listeners(({ actions }) => ({
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadOptOutPersons()
+        },
+    })),
     afterMount(({ props, actions }) => {
         // If no category is provided or it's a marketing category, load opt-out persons
         if (!props.category?.id || props.category?.category_type === 'marketing') {

--- a/products/workflows/frontend/OptOuts/optOutListLogic.ts
+++ b/products/workflows/frontend/OptOuts/optOutListLogic.ts
@@ -1,4 +1,16 @@
-import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import {
+    MakeLogicType,
+    actions,
+    afterMount,
+    connect,
+    isBreakpoint,
+    kea,
+    key,
+    listeners,
+    path,
+    props,
+    reducers,
+} from 'kea'
 import { loaders } from 'kea-loaders'
 import Papa from 'papaparse'
 
@@ -51,7 +63,10 @@ export interface optOutListLogicValues {
     csvExport: null
     csvExportLoading: boolean
     csvFile: File | null
-    csvImportProgress: { processed: number; total: number } | null
+    csvImportProgress: {
+        processed: number
+        total: number
+    } | null
     csvImportResult: BulkAddOptOutsResultApi | null
     csvImportResultLoading: boolean
     currentPage: number
@@ -135,25 +150,9 @@ export interface optOutListLogicActions {
     loadNextPage: () => {
         value: true
     }
-    loadNextPageFailure: (
-        error: string,
-        errorObject?: any
-    ) => {
-        error: string
-        errorObject?: any
+    loadOptOutPersons: (page?: number) => {
+        page: number
     }
-    loadNextPageSuccess: (
-        optOutPersons: PaginatedOptOutsApi,
-        payload?: {
-            value: true
-        }
-    ) => {
-        optOutPersons: PaginatedOptOutsApi
-        payload?: {
-            value: true
-        }
-    }
-    loadOptOutPersons: () => any
     loadOptOutPersonsFailure: (
         error: string,
         errorObject?: any
@@ -163,31 +162,17 @@ export interface optOutListLogicActions {
     }
     loadOptOutPersonsSuccess: (
         optOutPersons: PaginatedOptOutsApi,
-        payload?: any
+        payload?: {
+            page: number
+        }
     ) => {
         optOutPersons: PaginatedOptOutsApi
-        payload?: any
+        payload?: {
+            page: number
+        }
     }
     loadPreviousPage: () => {
         value: true
-    }
-    loadPreviousPageFailure: (
-        error: string,
-        errorObject?: any
-    ) => {
-        error: string
-        errorObject?: any
-    }
-    loadPreviousPageSuccess: (
-        optOutPersons: PaginatedOptOutsApi,
-        payload?: {
-            value: true
-        }
-    ) => {
-        optOutPersons: PaginatedOptOutsApi
-        payload?: {
-            value: true
-        }
     }
     loadUnsubscribeLink: () => {
         value: true
@@ -210,8 +195,16 @@ export interface optOutListLogicActions {
     setCsvFile: (file: File | null) => {
         file: File | null
     }
-    setCsvImportProgress: (progress: { processed: number; total: number } | null) => {
-        progress: { processed: number; total: number } | null
+    setCsvImportProgress: (
+        progress: {
+            processed: number
+            total: number
+        } | null
+    ) => {
+        progress: {
+            processed: number
+            total: number
+        } | null
     }
     setCurrentPage: (page: number) => {
         page: number
@@ -266,6 +259,7 @@ export const optOutListLogic = kea<optOutListLogicType>([
         setSelectedIdentifier: (identifier: string | null) => ({ identifier }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setCurrentPage: (page: number) => ({ page }),
+        loadOptOutPersons: (page?: number) => ({ page: page ?? 1 }),
         loadNextPage: true,
         loadPreviousPage: true,
         setShowAddOptOutModal: (show: boolean) => ({ show }),
@@ -315,9 +309,9 @@ export const optOutListLogic = kea<optOutListLogicType>([
             1,
             {
                 setCurrentPage: (_, { page }) => page,
-                loadOptOutPersonsSuccess: () => 1, // Reset to page 1 on initial load
-                loadNextPageSuccess: (state) => state + 1,
-                loadPreviousPageSuccess: (state) => Math.max(1, state - 1),
+                // Track the page that actually loaded, so a discarded stale response can't
+                // desync the label from the rows.
+                loadOptOutPersonsSuccess: (state, { payload }) => payload?.page ?? state,
             },
         ],
         showAddOptOutModal: [
@@ -426,30 +420,22 @@ export const optOutListLogic = kea<optOutListLogicType>([
             },
             optOutPersons: {
                 __default: EMPTY_OPT_OUTS,
-                loadOptOutPersons: async (): Promise<PaginatedOptOutsApi> => {
+                // Single loader for every page fetch (initial, search, next, prev) so overlapping
+                // requests share one action key and the breakpoint can discard the stale one — a
+                // pagination response resolving after a search reload must not overwrite it.
+                loadOptOutPersons: async ({ page }, breakpoint): Promise<PaginatedOptOutsApi> => {
                     try {
-                        return await fetchPage(1)
+                        const result = await fetchPage(page)
+                        breakpoint()
+                        return result
                     } catch (e) {
-                        lemonToast.error('Failed to load opt-out persons')
+                        if (isBreakpoint(e as Error)) {
+                            throw e
+                        }
+                        lemonToast.error('Failed to load opt-outs')
                         // Rethrow so kea-loaders emits a *Failure action: optOutPersons keeps its
                         // previous value instead of rendering a failed fetch as "no opt-outs found",
                         // and the currentPage reducer (which only moves on *Success) stays put.
-                        throw e
-                    }
-                },
-                loadNextPage: async (): Promise<PaginatedOptOutsApi> => {
-                    try {
-                        return await fetchPage(values.currentPage + 1)
-                    } catch (e) {
-                        lemonToast.error('Failed to load next page')
-                        throw e
-                    }
-                },
-                loadPreviousPage: async (): Promise<PaginatedOptOutsApi> => {
-                    try {
-                        return await fetchPage(Math.max(1, values.currentPage - 1))
-                    } catch (e) {
-                        lemonToast.error('Failed to load previous page')
                         throw e
                     }
                 },
@@ -536,11 +522,13 @@ export const optOutListLogic = kea<optOutListLogicType>([
             },
         }
     }),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         setSearchTerm: async (_, breakpoint) => {
             await breakpoint(300)
             actions.loadOptOutPersons()
         },
+        loadNextPage: () => actions.loadOptOutPersons(values.currentPage + 1),
+        loadPreviousPage: () => actions.loadOptOutPersons(Math.max(1, values.currentPage - 1)),
     })),
     afterMount(({ props, actions }) => {
         // If no category is provided or it's a marketing category, load opt-out persons

--- a/products/workflows/frontend/Suppression/SuppressionList.tsx
+++ b/products/workflows/frontend/Suppression/SuppressionList.tsx
@@ -110,7 +110,7 @@ export function SuppressionList(): JSX.Element {
                     icon={<IconRefresh />}
                     size="small"
                     type="secondary"
-                    onClick={loadSuppressions}
+                    onClick={() => loadSuppressions()}
                     loading={suppressionsLoading}
                 >
                     Reload

--- a/products/workflows/frontend/Suppression/SuppressionList.tsx
+++ b/products/workflows/frontend/Suppression/SuppressionList.tsx
@@ -21,6 +21,7 @@ export function SuppressionList(): JSX.Element {
         setNewIdentifier,
         addSuppression,
         removeSuppression,
+        setSearchTerm,
     } = useActions(suppressionListLogic)
     const {
         suppressions,
@@ -30,6 +31,7 @@ export function SuppressionList(): JSX.Element {
         addSuppressionLoading,
         removeSuppressionLoading,
         newIdentifier,
+        searchTerm,
     } = useValues(suppressionListLogic)
 
     const columns: LemonTableColumns<MessageSuppressionApi> = [
@@ -92,7 +94,15 @@ export function SuppressionList(): JSX.Element {
 
     return (
         <>
-            <div className="flex justify-end gap-2 mb-2">
+            <div className="flex flex-wrap justify-end gap-2 mb-2">
+                <LemonInput
+                    type="search"
+                    size="small"
+                    placeholder="Search addresses"
+                    value={searchTerm}
+                    onChange={setSearchTerm}
+                    className="w-60"
+                />
                 <LemonButton icon={<IconPlus />} size="small" type="secondary" onClick={() => setShowAddModal(true)}>
                     Add address
                 </LemonButton>
@@ -112,7 +122,11 @@ export function SuppressionList(): JSX.Element {
                 loading={suppressionsLoading}
                 loadingSkeletonRows={3}
                 rowKey="identifier"
-                emptyState="No suppressed addresses. Addresses land here automatically after repeated soft bounces, or when you add them manually."
+                emptyState={
+                    searchTerm.trim()
+                        ? 'No suppressed addresses match your search'
+                        : 'No suppressed addresses. Addresses land here automatically after repeated soft bounces, or when you add them manually.'
+                }
                 size="small"
             />
             {suppressions.count > PAGE_SIZE && (

--- a/products/workflows/frontend/Suppression/suppressionListLogic.test.ts
+++ b/products/workflows/frontend/Suppression/suppressionListLogic.test.ts
@@ -3,8 +3,23 @@ import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 
 import * as messagingApi from 'products/messaging/frontend/generated/api'
+import type { PaginatedMessageSuppressionApi } from 'products/messaging/frontend/generated/api.schemas'
 
 import { suppressionListLogic } from './suppressionListLogic'
+
+const suppressionRow = (identifier: string): any => ({
+    id: identifier,
+    identifier,
+    source: 'MANUAL',
+    reason: '',
+    transient_bounce_count: 0,
+    last_bounce_at: null,
+    last_bounce_diagnostic: null,
+    suppressed: true,
+    suppressed_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+})
 
 describe('suppressionListLogic', () => {
     beforeEach(() => {
@@ -13,17 +28,20 @@ describe('suppressionListLogic', () => {
 
     describe('page-state failure isolation', () => {
         // Guards against the "silent-swallow catch returns previous rows -> kea-loaders treats it as
-        // success -> currentPage still increments" bug. On a failed loadNextPage the counter must
+        // success -> currentPage still increments" bug. On a failed page fetch the counter must
         // stay put; otherwise the UI shows the wrong page number over old data, then permanently
         // skips the page it thought it advanced to.
         it('does not advance currentPage when loadNextPage fails', async () => {
             jest.spyOn(messagingApi, 'messagingSuppressionsSuppressionsRetrieve').mockRejectedValue(new Error('boom'))
             const logic = suppressionListLogic()
             logic.mount()
+            // Let the mount-time load fail first, so the assertion below can only match the
+            // pagination fetch's own failure.
+            await expectLogic(logic).toFinishAllListeners()
 
             await expectLogic(logic, () => {
                 logic.actions.loadNextPage()
-            }).toDispatchActions(['loadNextPageFailure'])
+            }).toDispatchActions(['loadSuppressionsFailure'])
 
             expect(logic.values.currentPage).toBe(1)
         })
@@ -32,13 +50,63 @@ describe('suppressionListLogic', () => {
             jest.spyOn(messagingApi, 'messagingSuppressionsSuppressionsRetrieve').mockRejectedValue(new Error('boom'))
             const logic = suppressionListLogic()
             logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
             logic.actions.setCurrentPage(3)
 
             await expectLogic(logic, () => {
                 logic.actions.loadPreviousPage()
-            }).toDispatchActions(['loadPreviousPageFailure'])
+            }).toDispatchActions(['loadSuppressionsFailure'])
 
             expect(logic.values.currentPage).toBe(3)
+        })
+    })
+
+    describe('overlapping request isolation', () => {
+        // Guards the loader breakpoint: a pagination fetch that resolves after a newer reload
+        // (e.g. a debounced search) must be discarded, not overwrite the newer rows and desync
+        // currentPage from what the table shows.
+        it('discards a stale pagination response that resolves after a newer reload', async () => {
+            let resolveStalePage: (value: PaginatedMessageSuppressionApi) => void = () => {}
+            const stalePagePromise = new Promise<PaginatedMessageSuppressionApi>((resolve) => {
+                resolveStalePage = resolve
+            })
+            const initialResult: PaginatedMessageSuppressionApi = {
+                count: 1,
+                next: null,
+                previous: null,
+                results: [suppressionRow('initial@example.com')],
+            }
+            const freshResult: PaginatedMessageSuppressionApi = {
+                count: 1,
+                next: null,
+                previous: null,
+                results: [suppressionRow('fresh@example.com')],
+            }
+            jest.spyOn(messagingApi, 'messagingSuppressionsSuppressionsRetrieve')
+                .mockResolvedValueOnce(initialResult)
+                .mockImplementationOnce(() => stalePagePromise)
+                .mockResolvedValueOnce(freshResult)
+
+            const logic = suppressionListLogic()
+            logic.mount()
+            // Let the mount-time load settle so the mocks line up with the two racing requests.
+            await expectLogic(logic).toDispatchActions(['loadSuppressionsSuccess'])
+
+            logic.actions.loadNextPage()
+            await expectLogic(logic, () => {
+                logic.actions.loadSuppressions()
+            }).toDispatchActions(['loadSuppressionsSuccess'])
+
+            resolveStalePage({
+                count: 100,
+                next: 'next-url',
+                previous: null,
+                results: [suppressionRow('stale@example.com')],
+            })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.suppressions).toEqual(freshResult)
+            expect(logic.values.currentPage).toBe(1)
         })
     })
 })

--- a/products/workflows/frontend/Suppression/suppressionListLogic.ts
+++ b/products/workflows/frontend/Suppression/suppressionListLogic.ts
@@ -1,4 +1,4 @@
-import { MakeLogicType, actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { MakeLogicType, actions, afterMount, connect, isBreakpoint, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -52,46 +52,12 @@ export interface suppressionListLogicActions {
     loadNextPage: () => {
         value: true
     }
-    loadNextPageFailure: (
-        error: string,
-        errorObject?: any
-    ) => {
-        error: string
-        errorObject?: any
-    }
-    loadNextPageSuccess: (
-        suppressions: PaginatedMessageSuppressionApi,
-        payload?: {
-            value: true
-        }
-    ) => {
-        suppressions: PaginatedMessageSuppressionApi
-        payload?: {
-            value: true
-        }
-    }
     loadPreviousPage: () => {
         value: true
     }
-    loadPreviousPageFailure: (
-        error: string,
-        errorObject?: any
-    ) => {
-        error: string
-        errorObject?: any
+    loadSuppressions: (page?: number) => {
+        page: number
     }
-    loadPreviousPageSuccess: (
-        suppressions: PaginatedMessageSuppressionApi,
-        payload?: {
-            value: true
-        }
-    ) => {
-        suppressions: PaginatedMessageSuppressionApi
-        payload?: {
-            value: true
-        }
-    }
-    loadSuppressions: () => any
     loadSuppressionsFailure: (
         error: string,
         errorObject?: any
@@ -101,10 +67,14 @@ export interface suppressionListLogicActions {
     }
     loadSuppressionsSuccess: (
         suppressions: PaginatedMessageSuppressionApi,
-        payload?: any
+        payload?: {
+            page: number
+        }
     ) => {
         suppressions: PaginatedMessageSuppressionApi
-        payload?: any
+        payload?: {
+            page: number
+        }
     }
     removeSuppression: (identifier: string) => string
     removeSuppressionFailure: (
@@ -158,6 +128,7 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
     })),
     actions({
         setCurrentPage: (page: number) => ({ page }),
+        loadSuppressions: (page?: number) => ({ page: page ?? 1 }),
         loadNextPage: true,
         loadPreviousPage: true,
         setShowAddModal: (show: boolean) => ({ show }),
@@ -169,9 +140,9 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
             1,
             {
                 setCurrentPage: (_, { page }) => page,
-                loadSuppressionsSuccess: () => 1,
-                loadNextPageSuccess: (state) => state + 1,
-                loadPreviousPageSuccess: (state) => Math.max(1, state - 1),
+                // Track the page that actually loaded, so a discarded stale response can't
+                // desync the label from the rows.
+                loadSuppressionsSuccess: (state, { payload }) => payload?.page ?? state,
             },
         ],
         showAddModal: [
@@ -199,34 +170,22 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
     loaders(({ values, actions }) => ({
         suppressions: {
             __default: EMPTY_SUPPRESSIONS,
-            loadSuppressions: async (): Promise<PaginatedMessageSuppressionApi> => {
+            // Single loader for every page fetch (initial, search, next, prev) so overlapping
+            // requests share one action key and the breakpoint can discard the stale one — a
+            // pagination response resolving after a search reload must not overwrite it.
+            loadSuppressions: async ({ page }, breakpoint): Promise<PaginatedMessageSuppressionApi> => {
                 try {
-                    return await fetchPage(values.currentProjectId, 1, values.searchTerm)
+                    const result = await fetchPage(values.currentProjectId, page, values.searchTerm)
+                    breakpoint()
+                    return result
                 } catch (e) {
+                    if (isBreakpoint(e as Error)) {
+                        throw e
+                    }
                     lemonToast.error('Failed to load suppression list')
                     // Rethrow so kea-loaders emits loadSuppressionsFailure and the currentPage reducer
-                    // (which only advances on *Success) stays put — otherwise a failed page fetch would
+                    // (which only moves on *Success) stays put — otherwise a failed page fetch would
                     // still tick currentPage and skip pages permanently.
-                    throw e
-                }
-            },
-            loadNextPage: async (): Promise<PaginatedMessageSuppressionApi> => {
-                try {
-                    return await fetchPage(values.currentProjectId, values.currentPage + 1, values.searchTerm)
-                } catch (e) {
-                    lemonToast.error('Failed to load next page')
-                    throw e
-                }
-            },
-            loadPreviousPage: async (): Promise<PaginatedMessageSuppressionApi> => {
-                try {
-                    return await fetchPage(
-                        values.currentProjectId,
-                        Math.max(1, values.currentPage - 1),
-                        values.searchTerm
-                    )
-                } catch (e) {
-                    lemonToast.error('Failed to load previous page')
                     throw e
                 }
             },
@@ -268,11 +227,13 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
             },
         },
     })),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         setSearchTerm: async (_, breakpoint) => {
             await breakpoint(300)
             actions.loadSuppressions()
         },
+        loadNextPage: () => actions.loadSuppressions(values.currentPage + 1),
+        loadPreviousPage: () => actions.loadSuppressions(Math.max(1, values.currentPage - 1)),
     })),
     afterMount(({ actions }) => {
         actions.loadSuppressions()

--- a/products/workflows/frontend/Suppression/suppressionListLogic.ts
+++ b/products/workflows/frontend/Suppression/suppressionListLogic.ts
@@ -1,4 +1,4 @@
-import { MakeLogicType, actions, afterMount, connect, kea, path, reducers } from 'kea'
+import { MakeLogicType, actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -26,6 +26,7 @@ export interface suppressionListLogicValues {
     newIdentifier: string
     removeSuppression: string | null
     removeSuppressionLoading: boolean
+    searchTerm: string
     showAddModal: boolean
     suppressions: PaginatedMessageSuppressionApi
     suppressionsLoading: boolean
@@ -126,6 +127,9 @@ export interface suppressionListLogicActions {
     setNewIdentifier: (identifier: string) => {
         identifier: string
     }
+    setSearchTerm: (searchTerm: string) => {
+        searchTerm: string
+    }
     setShowAddModal: (show: boolean) => {
         show: boolean
     }
@@ -133,11 +137,18 @@ export interface suppressionListLogicActions {
 
 export type suppressionListLogicType = MakeLogicType<suppressionListLogicValues, suppressionListLogicActions>
 
-const fetchPage = async (projectId: number | null, page: number): Promise<PaginatedMessageSuppressionApi> => {
+const fetchPage = async (
+    projectId: number | null,
+    page: number,
+    search: string
+): Promise<PaginatedMessageSuppressionApi> => {
     if (projectId === null) {
         return EMPTY_SUPPRESSIONS
     }
-    return await messagingSuppressionsSuppressionsRetrieve(String(projectId), { page })
+    return await messagingSuppressionsSuppressionsRetrieve(String(projectId), {
+        search: search.trim() || undefined,
+        page,
+    })
 }
 
 export const suppressionListLogic = kea<suppressionListLogicType>([
@@ -151,6 +162,7 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
         loadPreviousPage: true,
         setShowAddModal: (show: boolean) => ({ show }),
         setNewIdentifier: (identifier: string) => ({ identifier }),
+        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
     }),
     reducers({
         currentPage: [
@@ -177,13 +189,19 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
                 setShowAddModal: (state, { show }) => (show ? state : ''),
             },
         ],
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
+            },
+        ],
     }),
     loaders(({ values, actions }) => ({
         suppressions: {
             __default: EMPTY_SUPPRESSIONS,
             loadSuppressions: async (): Promise<PaginatedMessageSuppressionApi> => {
                 try {
-                    return await fetchPage(values.currentProjectId, 1)
+                    return await fetchPage(values.currentProjectId, 1, values.searchTerm)
                 } catch (e) {
                     lemonToast.error('Failed to load suppression list')
                     // Rethrow so kea-loaders emits loadSuppressionsFailure and the currentPage reducer
@@ -194,7 +212,7 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
             },
             loadNextPage: async (): Promise<PaginatedMessageSuppressionApi> => {
                 try {
-                    return await fetchPage(values.currentProjectId, values.currentPage + 1)
+                    return await fetchPage(values.currentProjectId, values.currentPage + 1, values.searchTerm)
                 } catch (e) {
                     lemonToast.error('Failed to load next page')
                     throw e
@@ -202,7 +220,11 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
             },
             loadPreviousPage: async (): Promise<PaginatedMessageSuppressionApi> => {
                 try {
-                    return await fetchPage(values.currentProjectId, Math.max(1, values.currentPage - 1))
+                    return await fetchPage(
+                        values.currentProjectId,
+                        Math.max(1, values.currentPage - 1),
+                        values.searchTerm
+                    )
                 } catch (e) {
                     lemonToast.error('Failed to load previous page')
                     throw e
@@ -244,6 +266,12 @@ export const suppressionListLogic = kea<suppressionListLogicType>([
                     throw e
                 }
             },
+        },
+    })),
+    listeners(({ actions }) => ({
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadSuppressions()
         },
     })),
     afterMount(({ actions }) => {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -92993,11 +92993,19 @@ export namespace Schemas {
     category_key?: string;
     page?: number;
     page_size?: number;
+    /**
+     * Case-insensitive substring match on the recipient identifier.
+     */
+    search?: string;
     };
 
     export type MessagingSuppressionsSuppressionsRetrieveParams = {
     page?: number;
     page_size?: number;
+    /**
+     * Case-insensitive substring match on the recipient email address.
+     */
+    search?: string;
     };
 
     export type MessagingTemplatesListParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -92995,6 +92995,7 @@ export namespace Schemas {
     page_size?: number;
     /**
      * Case-insensitive substring match on the recipient identifier.
+     * @maxLength 512
      */
     search?: string;
     };
@@ -93004,6 +93005,7 @@ export namespace Schemas {
     page_size?: number;
     /**
      * Case-insensitive substring match on the recipient email address.
+     * @maxLength 512
      */
     search?: string;
     };

--- a/services/mcp/src/generated/messaging/api.ts
+++ b/services/mcp/src/generated/messaging/api.ts
@@ -57,6 +57,8 @@ export const MessagingPreferencesOptOutsRetrieveParams = /* @__PURE__ */ zod.obj
         ),
 })
 
+export const messagingPreferencesOptOutsRetrieveQuerySearchMax = 512
+
 export const MessagingPreferencesOptOutsRetrieveQueryParams = /* @__PURE__ */ zod.object({
     category_key: zod
         .string()
@@ -66,7 +68,11 @@ export const MessagingPreferencesOptOutsRetrieveQueryParams = /* @__PURE__ */ zo
         ),
     page: zod.number().optional(),
     page_size: zod.number().optional(),
-    search: zod.string().optional().describe('Case-insensitive substring match on the recipient identifier.'),
+    search: zod
+        .string()
+        .max(messagingPreferencesOptOutsRetrieveQuerySearchMax)
+        .optional()
+        .describe('Case-insensitive substring match on the recipient identifier.'),
 })
 
 /**

--- a/services/mcp/src/generated/messaging/api.ts
+++ b/services/mcp/src/generated/messaging/api.ts
@@ -66,6 +66,7 @@ export const MessagingPreferencesOptOutsRetrieveQueryParams = /* @__PURE__ */ zo
         ),
     page: zod.number().optional(),
     page_size: zod.number().optional(),
+    search: zod.string().optional().describe('Case-insensitive substring match on the recipient identifier.'),
 })
 
 /**

--- a/services/mcp/src/tools/generated/messaging.ts
+++ b/services/mcp/src/tools/generated/messaging.ts
@@ -46,6 +46,7 @@ const optOutsList = (): ToolBase<typeof OptOutsListSchema, Schemas.PaginatedOptO
                 category_key: params.category_key,
                 page: params.page,
                 page_size: params.page_size,
+                search: params.search,
             },
         })
         return result

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/opt-outs-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/opt-outs-list.json
@@ -10,6 +10,10 @@
         },
         "page_size": {
             "type": "number"
+        },
+        "search": {
+            "description": "Case-insensitive substring match on the recipient identifier.",
+            "type": "string"
         }
     },
     "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/opt-outs-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/opt-outs-list.json
@@ -13,6 +13,7 @@
         },
         "search": {
             "description": "Case-insensitive substring match on the recipient identifier.",
+            "maxLength": 512,
             "type": "string"
         }
     },


### PR DESCRIPTION
## Problem

folks need to confirm that a specific recipient is opted out or suppressed. The Workflows opt-out and suppression tabs only paginate 20 rows at a time, so the only lookup path today is exporting the CSV and searching it by hand.

## Changes

https://github.com/user-attachments/assets/b73d2de0-3ba0-4655-983a-97567750c427

- The opt-outs tab (global list and each category panel) and the suppression tab get a search box that filters by recipient as you type, debounced 300 ms.
- The `opt_outs` and `suppressions` endpoints accept a `search` query param: a case-insensitive substring match on `identifier`, capped at 512 characters.

> [!NOTE]
> The `suppressions` endpoint requires `person:read` on API keys because listing lets a token probe whether an address is known. `opt_outs` only requires `hog_flow:read`, and search reduces that probe to one request. This PR leaves the scopes unchanged to avoid breaking existing callers; tightening `opt_outs` may deserve a follow-up decision.

## How did you test this code?

- New API tests on both endpoints: search matches substrings case-insensitively, only within the team's opted-out or suppressed rows, and an over-long term returns 400. No existing test covered filtering on these endpoints.
- Not run: the Jest suites and Playwright.
- local dev

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` covers the opt-out or suppression lists.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /improving-drf-endpoints, /writing-tests, /writing-kea-logics, /writing-user-facing-copy, /writing-pr-descriptions. The toolbar layout fix landed after visual feedback in the session: the search box exposed a pre-existing negative-margin overlay that overlapped the heading on narrow screens.
