### PR TITLE
fix(desktop): stop bare shift/windows key from opening settings

### DIFF
--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.test.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatHotkeyParts,
   getShortcutsByCategory,
   KEYBOARD_SHORTCUTS,
   panelTabShortcut,
@@ -77,5 +78,22 @@ describe("SHORTCUTS", () => {
     expect(panelTabShortcut(false)).toBe(
       "alt+1,alt+2,alt+3,alt+4,alt+5,alt+6,alt+7,alt+8,alt+9",
     );
+  });
+
+  // react-hotkeys-hook splits a hotkey string on "," (alternatives) and then
+  // on "+" (the keys in one combination). A dangling separator - a trailing
+  // "," or "+" - produces an empty-string key, which used to make SETTINGS
+  // ("mod+,") register a second, degenerate hotkey that matched bare
+  // modifier keydowns (Right Shift, the Windows key).
+  it("never splits into an empty key token", () => {
+    for (const value of Object.values(SHORTCUTS)) {
+      for (const alternative of value.split(",")) {
+        expect(alternative.split("+")).not.toContain("");
+      }
+    }
+  });
+
+  it("still displays settings as a comma, not the key name", () => {
+    expect(formatHotkeyParts(SHORTCUTS.SETTINGS)).toContain(",");
   });
 });

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -12,7 +12,7 @@ export const SHORTCUTS = {
   COMMAND_MENU: "mod+k",
   NEW_TASK: "mod+n",
   NEW_TAB: "mod+t",
-  SETTINGS: "mod+,",
+  SETTINGS: "mod+comma",
   SHORTCUTS_SHEET: "mod+/",
   GO_BACK: "mod+[",
   GO_FORWARD: "mod+]",
@@ -370,7 +370,7 @@ function formatKey(key: string): string {
   if (k === "down" || k === "arrowdown") return "↓";
   if (k === "left" || k === "arrowleft") return "←";
   if (k === "right" || k === "arrowright") return "→";
-  if (k === ",") return ",";
+  if (k === "," || k === "comma") return ",";
   if (k === "[") return "[";
   if (k === "]") return "]";
   if (k === "=") return "+";


### PR DESCRIPTION
## Problem

Pressing a bare Right Shift or the Windows key opens Settings in the desktop app, interrupting whatever the person was doing.

Closes #76193

## Changes

- `SETTINGS` changes from `"mod+,"` to `"mod+comma"`. react-hotkeys-hook splits a hotkey string on commas to read alternative bindings. The trailing comma in the old value produced a second, empty-key hotkey that any bare modifier keydown satisfied.
- `formatKey()` gains a `"comma"` case so the shortcuts sheet keeps showing `,` instead of the literal word. Mechanical: display parity only, no behavior change.

## How did you test this code?

- Added a test asserting no `SHORTCUTS` value splits into an empty key token. It fails against the previous `"mod+,"` value and passes against `"mod+comma"`.
- Added a test asserting the shortcuts sheet still renders `SETTINGS` as `,`.
- Ran the full `@posthog/ui` unit suite, the desktop workspace typecheck, and `hogli ci:preflight`'s Biome check locally. All three are clean, and this branch is up to date with `master`.
- While running the full desktop test suite, found one pre-existing failure in `@posthog/code`'s binary-signing test (`scripts/download-binaries.test.mjs`). It sits in an unrelated package and code path, so it is not investigated further here.
- Not checked: reproducing the bare-modifier keydown opening Settings inside the actual Electron app. A jsdom-level `useHotkeys` test with a synthetic bare Shift/Meta keydown did not fire the callback, either before or after the fix. That result could not confirm the exact runtime mechanism the issue describes. The fix follows from react-hotkeys-hook's documented comma-separated `splitKey` behavior and matches the diagnosis in the earlier, unmerged #76796.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Anthropic).
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- An earlier draft tested the fix by dispatching a synthetic bare-modifier `KeyboardEvent` through `useHotkeys` directly. It passed both before and after the fix, so it was dropped in favor of the structural test above, which does fail pre-fix.
