### PR TITLE
chore(hogql_queries): add owners rule for actor_strategies.py

### DIFF
--- a/posthog/hogql_queries/owners.yaml
+++ b/posthog/hogql_queries/owners.yaml
@@ -1,7 +1,7 @@
 version: 1
 owners: []
 rules:
-    - match: '/actors_query_runner.py'
+    - match: ['/actor_strategies.py', '/actors_query_runner.py']
       owners: team-product-analytics
     - match: '/ai/'
       owners: team-ai-observability


### PR DESCRIPTION
TL;DR: `actor_strategies.py` matched no rule in `posthog/hogql_queries/owners.yaml`, so ownership tooling reported nobody for it. It now shares the product-analytics rule with `actors_query_runner.py`.

## Problem

Triaging a persons-page query error stalled on "who owns this file": the distributed owners resolver returns an empty list for `actor_strategies.py` while every neighbouring file resolves to a team. Ownership was confirmed as product analytics in [this Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787327015146319?thread_ts=1786996155.908889&cid=C0ACRAMJUAG).

## Changes

- The existing product-analytics rule becomes the list form already used elsewhere in this file, covering both files. Config only, no behavior change.

## How did you test this code?

None — one-line config change matching the file's existing list-form rules.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by a PostHog Desktop cloud task (Claude Code) as a follow-up to the ownership question in the linked thread. No assignee set — no verified GitHub handle for the requester in this session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
