### PR TITLE
feat(cli): add event release mode to the hermes commands

### DIFF
--- a/cli/.sampo/changesets/hermes-event-release-mode.md
+++ b/cli/.sampo/changesets/hermes-event-release-mode.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: minor
+---
+
+Add `--release-mode` to `hermes clone` and `hermes upload`. `event` leaves the uploaded Hermes source maps release-independent, so a React Native build that ships unchanged JavaScript across two releases keeps one symbol set instead of colliding on the release the first upload stamped on it. Each exception resolves its own release from the `$app_namespace` / `$app_version` / `$app_build` the SDK already sends, so pass `--release-name`, `--release-version` and `--build` matching the app's bundle identifier or applicationId, version and build number. `symbol-set` stays the default. `hermes inject --release-mode=event` no longer errors: it injects content-addressed chunk ids and, unlike a web build, embeds no release id, because a Hermes bytecode bundle has nothing to read one back out.

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -160,8 +160,7 @@ impl UploadConflictArgs {
     /// while the release id travels inside the payload. Every change to that release id makes the
     /// chunk conflict under an unchanged id. A web bundle carries it in the injected snippet, so
     /// it conflicts on every release. A Hermes map conflicts once, on the build that changes mode.
-    /// To honor `--skip-on-conflict` would keep the stored payload, and the release bound to it,
-    /// for every exception.
+    /// To honor `--skip-on-conflict` would keep the stored payload, so the newer one never lands.
     pub fn resolve(&self, release_mode: ReleaseMode) -> ConflictBehavior {
         match release_mode {
             ReleaseMode::Event => ConflictBehavior {

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -156,11 +156,12 @@ impl UploadConflictArgs {
     /// Resolve what to do about changed content, given the release mode.
     ///
     /// Event mode always overwrites, and neither flag changes that. A chunk's id and its uploaded
-    /// bytes move independently there: the id is derived from the pristine minified source and so
-    /// survives a new release, while the injected snippet inside the payload carries the release id
-    /// and changes with every release. Every chunk therefore conflicts on every release after the
-    /// first, so honoring `--skip-on-conflict` would skip all of them and leave the server serving
-    /// the previous release's id forever.
+    /// bytes move independently there. The id comes from content that survives a new release,
+    /// while the release id travels inside the payload. Every change to that release id makes the
+    /// chunk conflict under an unchanged id. A web bundle carries it in the injected snippet, so
+    /// it conflicts on every release. A Hermes map conflicts once, on the build that changes mode.
+    /// To honor `--skip-on-conflict` would keep the stored payload, and the release bound to it,
+    /// for every exception.
     pub fn resolve(&self, release_mode: ReleaseMode) -> ConflictBehavior {
         match release_mode {
             ReleaseMode::Event => ConflictBehavior {

--- a/cli/src/sourcemaps/hermes/clone.rs
+++ b/cli/src/sourcemaps/hermes/clone.rs
@@ -5,7 +5,11 @@ use tracing::info;
 
 use crate::{
     invocation_context::context,
-    sourcemaps::{args::ReleaseArgs, content::SourceMapFile, inject::get_release_for_maps},
+    sourcemaps::{
+        args::{ReleaseArgs, ReleaseMode},
+        content::SourceMapFile,
+        inject::get_release_for_maps,
+    },
 };
 
 #[derive(clap::Args)]
@@ -20,6 +24,20 @@ pub struct CloneArgs {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    /// How the release is associated with exceptions. `symbol-set` is the default. It stamps the
+    /// release id into the source maps, so the upload binds the symbol set to that release.
+    /// EXPERIMENTAL `event` stamps nothing and leaves the maps release-independent. Each event
+    /// then resolves its own release from the app version and namespace the SDK already sends.
+    /// The coordinates you pass to `hermes upload` must match the app's. Also settable via
+    /// `POSTHOG_RELEASE_MODE`.
+    #[arg(
+        long,
+        env = "POSTHOG_RELEASE_MODE",
+        value_enum,
+        default_value = "symbol-set"
+    )]
+    pub release_mode: ReleaseMode,
 }
 
 pub fn clone(args: &CloneArgs) -> Result<()> {
@@ -29,6 +47,7 @@ pub fn clone(args: &CloneArgs) -> Result<()> {
         minified_map_path,
         composed_map_path,
         release,
+        release_mode,
     } = args;
 
     let mut minified_map = SourceMapFile::load(minified_map_path).map_err(|e| {
@@ -47,8 +66,17 @@ pub fn clone(args: &CloneArgs) -> Result<()> {
         )
     })?;
 
-    let release_id = get_release_for_maps(minified_map_path, release.clone(), [&minified_map])?
-        .map(|r| r.id.to_string());
+    // Event mode resolves no release here. `hermes upload` creates the release row that the
+    // server resolves an event's app metadata onto. The maps must stay without a release id.
+    // A map id comes from the map's own content, so one symbol set serves every release.
+    // Without this, a later release collides with the release that uploaded the map first.
+    let release_id = match release_mode {
+        ReleaseMode::Event => None,
+        ReleaseMode::SymbolSet => {
+            get_release_for_maps(minified_map_path, release.clone(), [&minified_map])?
+                .map(|r| r.id.to_string())
+        }
+    };
 
     // The flow here differs from plain sourcemap injection a bit - here, we don't ever
     // overwrite the chunk ID, because at this point in the build process, we no longer
@@ -58,7 +86,7 @@ pub fn clone(args: &CloneArgs) -> Result<()> {
     // tries to run `clone` twice, changing release but not posthog env, we'll error out. The
     // correct way to upload the same set of artefacts to the same posthog env as part of
     // two different releases is, 1, not to, but failing that, 2, to re-run the bundling process
-    if !minified_map.has_release_id() || minified_map.get_release_id() != release_id {
+    if minified_map.get_release_id() != release_id {
         minified_map.set_release_id(release_id.clone());
         minified_map.save()?;
     }
@@ -84,9 +112,10 @@ pub fn clone_metadata(minified_map: &SourceMapFile, composed_map: &mut SourceMap
         composed_map.set_chunk_id(Some(chunk_id));
     }
 
-    if let Some(release_id) = minified_map.get_release_id() {
-        composed_map.set_release_id(Some(release_id));
-    }
+    // Copy the id even when there is none. A build that changes to event release mode then
+    // clears the id a previous run stamped. Without this, the composed map uploads still bound
+    // to that release.
+    composed_map.set_release_id(minified_map.get_release_id());
 }
 
 #[cfg(test)]
@@ -136,5 +165,31 @@ mod test {
             composed.get_release_id().as_deref(),
             Some("11111111-2222-4333-8444-555555555555")
         );
+    }
+
+    #[test]
+    fn clone_clears_a_release_id_the_composed_map_still_carries() {
+        // A build that changes to event release mode still has the previous run's release id on
+        // the composed map. To copy only the ids that exist would upload it bound to that
+        // release. That is the collision event mode prevents.
+        let minified = map_from(serde_json::json!({
+            "version": 3,
+            "mappings": "AAAA",
+            "sources": ["App.js"],
+            "names": [],
+            "debugId": "c96bfa94-ca84-4f98-8d5e-f15adba692ca",
+        }));
+        let mut composed = map_from(serde_json::json!({
+            "version": 3,
+            "mappings": "AAAA",
+            "sources": ["App.js"],
+            "names": [],
+            "release_id": "11111111-2222-4333-8444-555555555555",
+            "x_hermes_function_offsets": {},
+        }));
+
+        clone_metadata(&minified, &mut composed);
+
+        assert_eq!(composed.get_release_id(), None);
     }
 }

--- a/cli/src/sourcemaps/hermes/inject.rs
+++ b/cli/src/sourcemaps/hermes/inject.rs
@@ -2,28 +2,21 @@
 // It's intended as an escape hatch for people rolling their own build pipeline - we expect most users to be
 // using the metro plugin for injecting, and then calling clone
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use walkdir::DirEntry;
 
 use crate::{
     invocation_context::context,
-    sourcemaps::{
-        args::ReleaseMode,
-        inject::{inject_impl, InjectArgs},
-    },
+    sourcemaps::inject::{inject_impl, EventReleaseSource, InjectArgs},
 };
 
 pub fn inject(args: &InjectArgs) -> Result<()> {
     context().capture_command_invoked("hermes_inject");
     args.validate()?;
-    // The rest of the Hermes pipeline (clone, upload, the RN SDK) has no event-mode support,
-    // so accepting the flag would inject a global nothing reads while upload re-binds the
-    // release anyway. Rejecting also catches a POSTHOG_RELEASE_MODE=event env var set for a
-    // web build leaking into a React Native build in the same environment.
-    if args.release_mode == ReleaseMode::Event {
-        bail!("--release-mode=event is not supported for Hermes bundles. Remove the flag (or unset POSTHOG_RELEASE_MODE) and inject again.");
-    }
-    inject_impl(args, is_metro_bundle, None)
+    // A React Native app reports its release from the app metadata it already sends. Event mode
+    // therefore injects chunk ids and nothing else here. A release id in the chunk would do
+    // nothing, because the bundle compiles to Hermes bytecode and no SDK reads the global.
+    inject_impl(args, is_metro_bundle, None, EventReleaseSource::AppMetadata)
 }
 
 pub fn is_metro_bundle(entry: &DirEntry) -> bool {

--- a/cli/src/sourcemaps/hermes/mod.rs
+++ b/cli/src/sourcemaps/hermes/mod.rs
@@ -54,3 +54,73 @@ pub fn get_composed_map(pair: &SourcePair) -> Result<Option<SourceMapFile>> {
         format!("reading composed map at {composed_path:?}"),
     )?))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sourcemaps::args::ReleaseMode;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct HermesCli {
+        #[command(subcommand)]
+        command: HermesSubcommand,
+    }
+
+    fn parse(argv: &[&str]) -> HermesSubcommand {
+        HermesCli::parse_from(argv).command
+    }
+
+    #[test]
+    fn every_hermes_command_defaults_to_binding_the_release() {
+        // Every existing React Native build omits the flag. Those builds must keep uploading
+        // maps bound to their release. A different default here unbinds all of them, and
+        // nothing in the build output says so.
+        let HermesSubcommand::Clone(clone) = parse(&[
+            "hermes",
+            "clone",
+            "--minified-map-path",
+            "main.jsbundle.map",
+            "--composed-map-path",
+            "main.jsbundle.hbc.composed.map",
+        ]) else {
+            panic!("expected the clone subcommand");
+        };
+        assert_eq!(clone.release_mode, ReleaseMode::SymbolSet);
+
+        let HermesSubcommand::Upload(upload) = parse(&["hermes", "upload", "--directory", "dist"])
+        else {
+            panic!("expected the upload subcommand");
+        };
+        assert_eq!(upload.release_mode, ReleaseMode::SymbolSet);
+    }
+
+    #[test]
+    fn every_hermes_command_accepts_event_release_mode() {
+        let HermesSubcommand::Clone(clone) = parse(&[
+            "hermes",
+            "clone",
+            "--minified-map-path",
+            "main.jsbundle.map",
+            "--composed-map-path",
+            "main.jsbundle.hbc.composed.map",
+            "--release-mode",
+            "event",
+        ]) else {
+            panic!("expected the clone subcommand");
+        };
+        assert_eq!(clone.release_mode, ReleaseMode::Event);
+
+        let HermesSubcommand::Upload(upload) = parse(&[
+            "hermes",
+            "upload",
+            "--directory",
+            "dist",
+            "--release-mode",
+            "event",
+        ]) else {
+            panic!("expected the upload subcommand");
+        };
+        assert_eq!(upload.release_mode, ReleaseMode::Event);
+    }
+}

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -63,8 +63,11 @@ pub fn upload(args: &Args) -> Result<()> {
     // Event mode leaves nothing on the symbol set for the server to use. An exception then
     // resolves its release only from the app metadata on the event. Coordinates that come from
     // git instead of explicit flags do not match that metadata. The exception then reports no
-    // release, and nothing in the output says so.
-    if *release_mode == ReleaseMode::Event && (release.name.is_none() || release.version.is_none())
+    // release, and nothing in the output says so. The build number counts as a coordinate: the
+    // server packs it into the version it keys on, so a release without one matches no event that
+    // carries `$app_build`.
+    if *release_mode == ReleaseMode::Event
+        && (release.name.is_none() || release.version.is_none() || release.build.is_none())
     {
         warn!(
             "--release-mode=event resolves each exception's release from the app's namespace and \

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -55,8 +55,8 @@ pub fn upload(args: &Args) -> Result<()> {
     if conflict.skip_on_conflict_ignored(*release_mode) {
         warn!(
             "--skip-on-conflict is ignored with --release-mode=event. Skipping a conflict would \
-             leave the previously uploaded map, and the release bound to it, in place. \
-             Overwriting instead."
+             keep the previously uploaded map, so the build that changes release mode would \
+             fail to replace it. Overwriting instead."
         );
     }
 
@@ -147,10 +147,9 @@ pub fn upload(args: &Args) -> Result<()> {
         ],
     );
 
-    // The release id lives in the map's own bytes. The first upload after a project changes
-    // release mode therefore finds the stored symbol set with different content. To skip that
-    // conflict would keep the old release-bound map, and every exception would keep reporting
-    // its release. Event mode overwrites instead.
+    // A hermes chunk id comes from the bundle content, and the release id sits inside the
+    // uploaded map. The build that changes release mode therefore sends the same id with
+    // different bytes, and the server refuses it. Event mode overwrites so that build passes.
     let conflict = conflict.resolve(*release_mode);
 
     let started_at = Instant::now();

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -7,7 +7,7 @@ use walkdir::WalkDir;
 
 use crate::api::symbol_sets::{self, SymbolSetUpload};
 use crate::invocation_context::context;
-use crate::sourcemaps::args::{ReleaseArgs, UploadConflictArgs};
+use crate::sourcemaps::args::{ReleaseArgs, ReleaseMode, UploadConflictArgs};
 use crate::sourcemaps::content::SourceMapFile;
 use crate::sourcemaps::inject::get_release_for_maps;
 
@@ -26,6 +26,20 @@ pub struct Args {
 
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
+
+    /// How the release is associated with exceptions. `symbol-set` is the default. It stamps the
+    /// release id onto the uploaded maps. An exception then takes the release of the maps its
+    /// frames resolved against. EXPERIMENTAL `event` leaves the maps release-independent. Each
+    /// event then resolves its own release from the app version and namespace the SDK already
+    /// sends, so the release coordinates must match the app's. Both modes create the release.
+    /// Also settable via `POSTHOG_RELEASE_MODE`.
+    #[arg(
+        long,
+        env = "POSTHOG_RELEASE_MODE",
+        value_enum,
+        default_value = "symbol-set"
+    )]
+    pub release_mode: ReleaseMode,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -35,7 +49,30 @@ pub fn upload(args: &Args) -> Result<()> {
         release,
         batch_size,
         conflict,
+        release_mode,
     } = args;
+
+    if conflict.skip_on_conflict_ignored(*release_mode) {
+        warn!(
+            "--skip-on-conflict is ignored with --release-mode=event. Skipping a conflict would \
+             leave the previously uploaded map, and the release bound to it, in place. \
+             Overwriting instead."
+        );
+    }
+
+    // Event mode leaves nothing on the symbol set for the server to use. An exception then
+    // resolves its release only from the app metadata on the event. Coordinates that come from
+    // git instead of explicit flags do not match that metadata. The exception then reports no
+    // release, and nothing in the output says so.
+    if *release_mode == ReleaseMode::Event && (release.name.is_none() || release.version.is_none())
+    {
+        warn!(
+            "--release-mode=event resolves each exception's release from the app's namespace and \
+             version. Pass --release-name, --release-version and --build matching the app's bundle \
+             identifier or applicationId, its version and its build number, or exceptions will \
+             report no release."
+        );
+    }
 
     let directory = directory.canonicalize().map_err(|e| {
         anyhow!(
@@ -68,9 +105,18 @@ pub fn upload(args: &Args) -> Result<()> {
             continue;
         }
 
-        // Override release_id if we created/fetched one
-        if let Some(ref release_id) = created_release_id {
-            map.set_release_id(Some(release_id.clone()));
+        // Both modes create the release, so the server has a row to resolve an event's
+        // `$app_namespace` / `$app_version` / `$app_build` onto. Event mode only skips the
+        // binding. A chunk id comes from the bundle's own content, so one symbol set serves
+        // every release. Without this, a later release reports the release that uploaded first.
+        match release_mode {
+            ReleaseMode::Event => map.set_release_id(None),
+            ReleaseMode::SymbolSet => {
+                // Override release_id if we created/fetched one
+                if let Some(ref release_id) = created_release_id {
+                    map.set_release_id(Some(release_id.clone()));
+                }
+            }
         }
 
         uploads.push(map.try_into()?);
@@ -100,6 +146,12 @@ pub fn upload(args: &Args) -> Result<()> {
             ("empty_skipped", json!(empty_skipped)),
         ],
     );
+
+    // The release id lives in the map's own bytes. The first upload after a project changes
+    // release mode therefore finds the stored symbol set with different content. To skip that
+    // conflict would keep the old release-bound map, and every exception would keep reporting
+    // its release. Event mode overwrites instead.
+    let conflict = conflict.resolve(*release_mode);
 
     let started_at = Instant::now();
     let (summary, upload_result) = symbol_sets::upload_with_retry(

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -49,10 +49,24 @@ impl InjectArgs {
     }
 }
 
+/// Where an event-mode build's release comes from at runtime.
+///
+/// Web and Node bundles carry it in the chunk. The injected snippet sets `_posthogReleaseId`,
+/// and the SDK emits it on every exception. React Native cannot do this. The injected JS
+/// compiles to Hermes bytecode, and no SDK reads the global out of it. There the server
+/// rebuilds the release from the `$app_namespace` / `$app_version` / `$app_build` that every
+/// event already carries. This is what it does for iOS dSYMs and Android mappings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EventReleaseSource {
+    EmbeddedInChunk,
+    AppMetadata,
+}
+
 pub fn inject_impl(
     args: &InjectArgs,
     matcher: impl Fn(&DirEntry) -> bool + 'static,
     existing_release: Option<&Release>,
+    event_release_source: EventReleaseSource,
 ) -> Result<()> {
     let InjectArgs {
         file_selection,
@@ -77,13 +91,20 @@ pub fn inject_impl(
         ReleaseMode::Event => {
             // The release id travels inside each chunk for the SDK to emit, rather than being
             // stamped into the sourcemap, so the release exists but nothing binds a symbol set
-            // to it.
-            let release_id = resolve_release_id(release.clone(), existing_release)?;
-            if release_id.is_none() {
-                warn!(
-                    "no release could be resolved, injecting chunk ids only — events will carry no release"
-                );
-            }
+            // to it. When the SDK reads the release from the app instead, only the chunk ids go
+            // in. The upload then creates the release row that the server resolves onto.
+            let release_id = match event_release_source {
+                EventReleaseSource::EmbeddedInChunk => {
+                    let release_id = resolve_release_id(release.clone(), existing_release)?;
+                    if release_id.is_none() {
+                        warn!(
+                            "no release could be resolved, injecting chunk ids only — events will carry no release"
+                        );
+                    }
+                    release_id
+                }
+                EventReleaseSource::AppMetadata => None,
+            };
             pairs = inject_pairs(pairs, release_id.as_deref())?;
         }
         ReleaseMode::SymbolSet => {

--- a/cli/src/sourcemaps/plain/inject.rs
+++ b/cli/src/sourcemaps/plain/inject.rs
@@ -5,13 +5,18 @@ use walkdir::DirEntry;
 use crate::{
     api::releases::Release,
     invocation_context::context,
-    sourcemaps::inject::{inject_impl, InjectArgs},
+    sourcemaps::inject::{inject_impl, EventReleaseSource, InjectArgs},
 };
 
 pub fn inject(args: &InjectArgs, existing_release: Option<&Release>) -> Result<()> {
     context().capture_command_invoked("sourcemap_inject");
     args.validate()?;
-    inject_impl(args, is_javascript_file, existing_release)
+    inject_impl(
+        args,
+        is_javascript_file,
+        existing_release,
+        EventReleaseSource::EmbeddedInChunk,
+    )
 }
 
 pub fn is_javascript_file(entry: &DirEntry) -> bool {


### PR DESCRIPTION
## Changes

- adds hermes support for the new release mode,
- propagates appropriate flags to underlying native-scripts ios + android - this actually happens here https://github.com/PostHog/posthog-js/pull/4617

# Tests

I ran tests covering all use cases. Usual scenario is:
- upload source maps,
- do some changes and upload source maps again,
- don't do any changes but change a release and try uploading again

Tested that on:
- legacy android+ios,
- new release mode android+ios.

## ios (legacy)

### First run

<details>
<summary>posthog-cli, React Native source maps</summary>

```
WARN posthog_cli::api::releases: release com.posthog.example.rnexpo.suite@1.0.0+1 not found
INFO posthog_cli::api::releases: Release com.posthog.example.rnexpo.suite@1.0.0+1 created successfully! 01a03411-3f61-0000-a66f-34456962a6e5
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Intermediates.noindex/ETlegacy.build/Release-iphonesimulator/ETlegacy.build/DerivedSources/main.jsbundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Intermediates.noindex/ETlegacy.build/Release-iphonesimulator/ETlegacy.build/DerivedSources
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.suite@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, dSYMs (414 unreadable-source warnings elided)</summary>

```
INFO posthog_cli::dsym::upload: Found 1 dSYM bundle(s)
INFO posthog_cli::dsym::upload: Extracted plist info from ETlegacy.app.dSYM: PlistInfo { bundle_identifier: Some("com.apple.xcode.dsym.com.posthog.example.rnexpo.suite"), short_version: Some("1.0.0"), bundle_version: Some("1"), development_region: Some("English") }
INFO posthog_cli::dsym::upload: Release name: com.posthog.example.rnexpo.suite
INFO posthog_cli::dsym::upload: Release version: 1.0.0
INFO posthog_cli::dsym::upload: Build: 1
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.suite@1.0.0+1
INFO posthog_cli::dsym::upload: Processing dSYM: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Products/Release-iphonesimulator/ETlegacy.app.dSYM
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Products/Release-iphonesimulator/ETlegacy.app.dSYM/Contents/Resources/DWARF/ETlegacy, thinning to x86_64 slice (47583644 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETlegacy (x86_64 arch): 47583644 bytes → 24058338 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885828 bytes total)
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Products/Release-iphonesimulator/ETlegacy.app.dSYM/Contents/Resources/DWARF/ETlegacy, thinning to arm64 slice (47583644 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETlegacy (arm64 arch): 47583644 bytes → 23525212 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885828 bytes total)
INFO posthog_cli::dsym::upload:   UUIDs: 17772DE6-2915-3ED0-8889-976B9B3B5A82, 4D412748-1886-32E4-B5A0-03F4A4192D2F (2)
INFO posthog_cli::dsym::upload:   Total size: 16667663 bytes
INFO posthog_cli::dsym::upload: Uploading 2 dSYM(s)...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 2 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 2 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 2 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

</details>

JavaScript exception:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/b1cfddc6bdaf3785a6c5028b7109b40aed1da1c2/2026/08/ad78f7c1-a2a5-4ea0-9c8d-fcbe3f2c0c82.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/adfeda057feb1f0fad0f373e89f76afe0a947fb9/2026/08/440dadba-9c60-4bc6-936a-13fceddcd310.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/c28749618e890f40dd8136ab0717d626cff987db/2026/08/fac80a9a-fc21-43f0-9166-d7c7ae34320d.png) |

Native crash:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/927c77067836a898d1df7a114f6099d0f1d42515/2026/08/0c713314-3ed0-41b5-9d80-b7ca336e47d5.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/0a6a1bacb246e91148a76854619966351dfe2990/2026/08/0f8d72e1-8de1-48aa-80b1-9bfb8c4c10d9.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/d3942c3a3f1f3663e2a751f2cd00aa6673f1e639/2026/08/ed636613-6bff-4dcd-9f5d-a257d878bb6f.png) |

### Second run (with changes)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.suite@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Intermediates.noindex/ETlegacy.build/Release-iphonesimulator/ETlegacy.build/DerivedSources/main.jsbundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Intermediates.noindex/ETlegacy.build/Release-iphonesimulator/ETlegacy.build/DerivedSources
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.suite@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, dSYMs (414 unreadable-source warnings elided)</summary>

```
INFO posthog_cli::dsym::upload: Found 1 dSYM bundle(s)
INFO posthog_cli::dsym::upload: Extracted plist info from ETlegacy.app.dSYM: PlistInfo { bundle_identifier: Some("com.apple.xcode.dsym.com.posthog.example.rnexpo.suite"), short_version: Some("1.0.0"), bundle_version: Some("1"), development_region: Some("English") }
INFO posthog_cli::dsym::upload: Release name: com.posthog.example.rnexpo.suite
INFO posthog_cli::dsym::upload: Release version: 1.0.0
INFO posthog_cli::dsym::upload: Build: 1
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.suite@1.0.0+1
INFO posthog_cli::dsym::upload: Processing dSYM: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Products/Release-iphonesimulator/ETlegacy.app.dSYM
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Products/Release-iphonesimulator/ETlegacy.app.dSYM/Contents/Resources/DWARF/ETlegacy, thinning to x86_64 slice (47583644 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETlegacy (x86_64 arch): 47583644 bytes → 24058338 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885828 bytes total)
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Products/Release-iphonesimulator/ETlegacy.app.dSYM/Contents/Resources/DWARF/ETlegacy, thinning to arm64 slice (47583644 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETlegacy (arm64 arch): 47583644 bytes → 23525212 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885828 bytes total)
INFO posthog_cli::dsym::upload:   UUIDs: 17772DE6-2915-3ED0-8889-976B9B3B5A82, 4D412748-1886-32E4-B5A0-03F4A4192D2F (2)
INFO posthog_cli::dsym::upload:   Total size: 16667663 bytes
INFO posthog_cli::dsym::upload: Uploading 2 dSYM(s)...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 2 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (2 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 2 skipped (2 already present, 0 too large)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

</details>

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/5b1ac13015d2c6108c9f3368109b71f6528319fd/2026/08/b001a2b4-bd6c-4361-ae1a-2c533f00eab9.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/c6244b677f4d3b1b1082e07d1f215fbafe6d5c1c/2026/08/37dbfe26-beda-4329-bfb0-c4f692e14e6b.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/84be6179eb1dcf6d329034672f56210f04aa1c99/2026/08/10bb8716-50a5-4a7e-8d30-f5e78544342a.png) |

### Third run (no change, new release)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETlegacy-gwnvtpkazkctgtggrpvtxgwxxzop/Build/Intermediates.noindex/ETlegacy.build/Release-iphonesimulator/ETlegacy.build/DerivedSources
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.suite@1.0.0+2
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
WARN posthog_cli::api::symbol_sets: Operation failed: HTTP 400 "{\"type\":\"validation_error\",\"code\":\"release_id_mismatch\",\"detail\":\"Symbol set ebf9e75c-c10f-4670-85c6-b001a9c03560 already has a release ID\",\"attr\":null}"      [repeated 3x]
WARN posthog_cli::api::symbol_sets: Release ID mismatch detected. Retrying upload without release IDs...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
WARN posthog_cli::api::symbol_sets: Operation failed: HTTP 400 "{\"type\":\"validation_error\",\"code\":\"content_hash_mismatch\",\"detail\":\"Symbol set ebf9e75c-c10f-4670-85c6-b001a9c03560 already exists with different content.\",\"attr\":null}"      [repeated 3x]
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
Oops! Content mismatch: use --skip-on-conflict or --force
```

</details>

The build fails here, so the app is never installed and never reports anything. That is why this run
has no screenshots.

## ios (new release mode)

### First run

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Intermediates.noindex/ETreleaseless.build/Release-iphonesimulator/ETreleaseless.build/DerivedSources/main.jsbundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Intermediates.noindex/ETreleaseless.build/Release-iphonesimulator/ETreleaseless.build/DerivedSources
WARN posthog_cli::api::releases: release com.posthog.example.rnexpo.releaseless.suite@1.0.0+1 not found
INFO posthog_cli::api::releases: Release com.posthog.example.rnexpo.releaseless.suite@1.0.0+1 created successfully! 01a0341c-eb5d-0000-c723-67fbe7ae2683
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, dSYMs (414 unreadable-source warnings elided)</summary>

```
INFO posthog_cli::dsym::upload: Found 1 dSYM bundle(s)
INFO posthog_cli::dsym::upload: Extracted plist info from ETreleaseless.app.dSYM: PlistInfo { bundle_identifier: Some("com.apple.xcode.dsym.com.posthog.example.rnexpo.releaseless.suite"), short_version: Some("1.0.0"), bundle_version: Some("1"), development_region: Some("English") }
INFO posthog_cli::dsym::upload: Release name: com.posthog.example.rnexpo.releaseless.suite
INFO posthog_cli::dsym::upload: Release version: 1.0.0
INFO posthog_cli::dsym::upload: Build: 1
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.suite@1.0.0+1
INFO posthog_cli::dsym::upload: Processing dSYM: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM/Contents/Resources/DWARF/ETreleaseless, thinning to x86_64 slice (47586606 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETreleaseless (x86_64 arch): 47586606 bytes → 24059816 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885947 bytes total)
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM/Contents/Resources/DWARF/ETreleaseless, thinning to arm64 slice (47586606 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETreleaseless (arm64 arch): 47586606 bytes → 23526702 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885947 bytes total)
INFO posthog_cli::dsym::upload:   UUIDs: 3EECA8C2-5736-33C5-A696-EF38EE7376A9, 0EE98187-4D6E-3689-BEB5-162C5E38D9DC (2)
INFO posthog_cli::dsym::upload:   Total size: 16678049 bytes
INFO posthog_cli::dsym::upload: Uploading 2 dSYM(s)...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 2 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 2 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 2 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

</details>

JavaScript exception:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/4132c3c6259a40085e7765f5076de36acb147243/2026/08/33499315-8660-4c7e-8295-cb8812b303d9.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/7be21cfb87b232cdba20aaad07e9d5f51df8109c/2026/08/beb1776f-4f45-44a8-8386-cc533a4d1989.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/8985601684d89a16bc0a7ac8c489e11b31da2c18/2026/08/f73062b7-c1f1-45c5-8b5f-63de7b0cb215.png) |

Native crash:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/ee303b9071628a5c469b3e005b6e93e8831b2435/2026/08/b0fd283a-4255-4483-8c52-1ea6668b38ec.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/06656a4c815daa9d5bd5edd2c3032551c3bfb9f3/2026/08/b5dfe4ff-cd3f-4e17-a6db-69cac5a9d675.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/320304690a85b58dbab7dfca202c2cac142071b4/2026/08/62cd8bbe-7b64-473c-8aa3-403d437cc5b6.png) |

### Second run (with changes)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Intermediates.noindex/ETreleaseless.build/Release-iphonesimulator/ETreleaseless.build/DerivedSources/main.jsbundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Intermediates.noindex/ETreleaseless.build/Release-iphonesimulator/ETreleaseless.build/DerivedSources
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.suite@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, dSYMs (414 unreadable-source warnings elided)</summary>

```
INFO posthog_cli::dsym::upload: Found 1 dSYM bundle(s)
INFO posthog_cli::dsym::upload: Extracted plist info from ETreleaseless.app.dSYM: PlistInfo { bundle_identifier: Some("com.apple.xcode.dsym.com.posthog.example.rnexpo.releaseless.suite"), short_version: Some("1.0.0"), bundle_version: Some("1"), development_region: Some("English") }
INFO posthog_cli::dsym::upload: Release name: com.posthog.example.rnexpo.releaseless.suite
INFO posthog_cli::dsym::upload: Release version: 1.0.0
INFO posthog_cli::dsym::upload: Build: 1
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.suite@1.0.0+1
INFO posthog_cli::dsym::upload: Processing dSYM: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM/Contents/Resources/DWARF/ETreleaseless, thinning to x86_64 slice (47586606 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETreleaseless (x86_64 arch): 47586606 bytes → 24059816 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885947 bytes total)
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM/Contents/Resources/DWARF/ETreleaseless, thinning to arm64 slice (47586606 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETreleaseless (arm64 arch): 47586606 bytes → 23526702 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885947 bytes total)
INFO posthog_cli::dsym::upload:   UUIDs: 3EECA8C2-5736-33C5-A696-EF38EE7376A9, 0EE98187-4D6E-3689-BEB5-162C5E38D9DC (2)
INFO posthog_cli::dsym::upload:   Total size: 16678049 bytes
INFO posthog_cli::dsym::upload: Uploading 2 dSYM(s)...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 2 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (2 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 2 skipped (2 already present, 0 too large)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

</details>

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/d4e95e4eea5464b191df2d7fb39d4c01b0690fc0/2026/08/e6ed5c7b-c593-423b-88a7-f6c19b25105a.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/99d373ab49264dab0f7000248848858de4ab3d95/2026/08/ec7fb9c5-7ed1-47be-81d8-0024bdca8fe2.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/eab1b3c5b7b975a207f5ace6233f77bcc047eeb3/2026/08/c6b7bc9d-51bd-4e8e-83c4-24ab6400bc6a.png) |

### Third run (no change, new release)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Intermediates.noindex/ETreleaseless.build/Release-iphonesimulator/ETreleaseless.build/DerivedSources/main.jsbundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Intermediates.noindex/ETreleaseless.build/Release-iphonesimulator/ETreleaseless.build/DerivedSources
WARN posthog_cli::api::releases: release com.posthog.example.rnexpo.releaseless.suite@1.0.0+2 not found
INFO posthog_cli::api::releases: Release com.posthog.example.rnexpo.releaseless.suite@1.0.0+2 created successfully! 01a03421-6a18-0000-b17f-3cad38628d93
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (1 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, dSYMs (414 unreadable-source warnings elided)</summary>

```
INFO posthog_cli::dsym::upload: Found 1 dSYM bundle(s)
INFO posthog_cli::dsym::upload: Extracted plist info from ETreleaseless.app.dSYM: PlistInfo { bundle_identifier: Some("com.apple.xcode.dsym.com.posthog.example.rnexpo.releaseless.suite"), short_version: Some("1.0.0"), bundle_version: Some("2"), development_region: Some("English") }
INFO posthog_cli::dsym::upload: Release name: com.posthog.example.rnexpo.releaseless.suite
INFO posthog_cli::dsym::upload: Release version: 1.0.0
INFO posthog_cli::dsym::upload: Build: 2
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.suite@1.0.0+2
INFO posthog_cli::dsym::upload: Processing dSYM: /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM/Contents/Resources/DWARF/ETreleaseless, thinning to x86_64 slice (47586606 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETreleaseless (x86_64 arch): 47586606 bytes → 24059816 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885947 bytes total)
INFO posthog_cli::dsym: [lipo] fat binary detected at /Users/ablaszkiewicz/Library/Developer/Xcode/DerivedData/ETreleaseless-frchsbzvmfcvfmacuegvicvyrcsd/Build/Products/Release-iphonesimulator/ETreleaseless.app.dSYM/Contents/Resources/DWARF/ETreleaseless, thinning to arm64 slice (47586606 bytes total)
INFO posthog_cli::dsym: [lipo] thinned ETreleaseless (arm64 arch): 47586606 bytes → 23526702 bytes
INFO posthog_cli::dsym: Found 921 source paths in DWARF (921 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 714 source files (4885947 bytes total)
INFO posthog_cli::dsym::upload:   UUIDs: 3EECA8C2-5736-33C5-A696-EF38EE7376A9, 0EE98187-4D6E-3689-BEB5-162C5E38D9DC (2)
INFO posthog_cli::dsym::upload:   Total size: 16678049 bytes
INFO posthog_cli::dsym::upload: Uploading 2 dSYM(s)...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 2 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (2 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 2 skipped (2 already present, 0 too large)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

</details>

JavaScript exception:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/b3a8697b56904aeec984cbae14a13df36247cad4/2026/08/77a13219-a75d-4dda-907f-4895c25df420.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/24edc6e87e7d296387310290c88d15d0e3e0149b/2026/08/3ae0ed8b-e085-4d9f-96bb-1cbbf23ae836.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/f069589247134242b9c43a7f710147584cfcccd8/2026/08/efff1776-2da9-4dfa-b619-4d60f51f663f.png) |

Native crash:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/370e50d8171cbf19dabdac48754f8850fe0fcd4c/2026/08/2cba9d39-82be-460a-827d-0689f6d3913d.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/0fed60885b436d001668e9d3f4d5ba21f6a0f913/2026/08/b8393dd5-d260-4d1f-b136-ea3f7099ff02.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/e89ccf4ddddb67518153c304ffd0024690c6835f/2026/08/73d4e2b1-7cf9-4af6-a921-ece1cfc94296.png) |

## android (legacy)

### First run

<details>
<summary>posthog-cli, React Native source maps</summary>

```
WARN posthog_cli::api::releases: release com.posthog.example.rnexpo.droidbot@1.0.0+1 not found
INFO posthog_cli::api::releases: Release com.posthog.example.rnexpo.droidbot@1.0.0+1 created successfully! 01a0347e-ffed-0000-0c99-285c400eed63
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.droidbot@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, R8 mapping</summary>

```
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.droidbot@1.0.0+1
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

JavaScript exception:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/b7621c3608b1b18e67262278ed65c229ea9506ce/2026/08/6522ace2-9a09-4e89-861e-9ffb48e9bb73.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/56a72f9bd21ec3b5a90f4a37f7e3eb0a9ad37e8b/2026/08/062a3d38-edcb-4901-be86-5d811565540b.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/d548db3ccf0e83b2d70d17785012bb90ca302b99/2026/08/9252c28d-d7f3-46b8-a6ea-3993d301c01b.png) |

Native crash:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/5a76a961929d9b049bf563d840aa8a17c6105885/2026/08/b58aafd9-dd53-4776-87d3-57f5de672c3f.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/47ea8c9b5d1fd3839f4dd64fcd51e95067609145/2026/08/8af01bde-2d00-4930-8a11-603d3fe7b03d.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/91fcf653293b0824cb87dac234a946ff04d10870/2026/08/c2316741-392f-4e6c-ba01-399fad8e0ee2.png) |

### Second run (with changes)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.droidbot@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.droidbot@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (1 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
```

</details>

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/569137a0da6cac64d1f2c4a7f3dbb6df3dea40a6/2026/08/4f2d606a-f4f7-4afa-b4b0-c3921e3980c0.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/cad3a8849bd9d1c3e164eaf2613e981f5fff2a2e/2026/08/2a4da8e4-ff26-4477-ada1-3b13a8165ab4.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/625182a9023eedf6a32479ee3deb0e06d5ec978a/2026/08/4580d8ac-eeca-4e9a-bdcc-10c95b1b0890.png) |

### Third run (no change, new release)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.droidbot@1.0.0+2
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.droidbot@1.0.0+2
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
WARN posthog_cli::api::symbol_sets: Operation failed: HTTP 400 "{\"type\":\"validation_error\",\"code\":\"release_id_mismatch\",\"detail\":\"Symbol set 94baff3d-1412-45dc-911a-f1d05a5c6026 already has a release ID\",\"attr\":null}"      [repeated 3x]
WARN posthog_cli::api::symbol_sets: Release ID mismatch detected. Retrying upload without release IDs...
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
WARN posthog_cli::api::symbol_sets: Operation failed: HTTP 400 "{\"type\":\"validation_error\",\"code\":\"content_hash_mismatch\",\"detail\":\"Symbol set 94baff3d-1412-45dc-911a-f1d05a5c6026 already exists with different content.\",\"attr\":null}"      [repeated 3x]
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
Oops! Content mismatch: use --skip-on-conflict or --force
```

</details>

The build fails here, so the app is never installed and never reports anything. That is why this run
has no screenshots.

## android (new release mode)

### First run

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release
WARN posthog_cli::api::releases: release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+1 not found
INFO posthog_cli::api::releases: Release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+1 created successfully! 01a03484-b746-0000-9695-77f0744a83d0
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, R8 mapping</summary>

```
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+1
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

JavaScript exception:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/56370c45ec2c5a36ddf4d6ccf4bee58ae0850a42/2026/08/9b34f708-a746-4ebb-b878-8c810f9df25b.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/01d3614b1c13827245547d83823b329b5f6d64f4/2026/08/7989dc0d-ee63-4658-afce-5199b61c3b76.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/4a0a8dedbf1dbda56bdf0a2f19447e9deb7ccb12/2026/08/e57432d0-0ccc-44d1-ba8a-95606148c7cb.png) |

Native crash:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/32da3d35f96c2ea972314562aca71f22c38ed615/2026/08/8e64f070-3ea2-4d4f-8621-24a8826baf75.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/d2d28881c0bfa3f8a6804b518884113003a761cd/2026/08/64fc1004-5694-4ee0-bb3a-1a880a74d407.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/06e7f46c4ee3c7df45ad5572af40fffa899c9400/2026/08/210e9e19-477b-42e8-aa34-93c23442a604.png) |

### Second run (with changes)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+1
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 1 upload keys (0 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

</details>

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/bfbfb831f9d5e4cddb5f9b5ace7de514f746af04/2026/08/180a3b6d-e35c-45ad-80e8-a35cfc79060e.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/37d08eb358e436b99fd9bd52a3641e547763474f/2026/08/7fcc50a1-7f79-4b6e-ac58-7d46fc81a790.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/c818880e6d88553efb6a797da77b6f75971867ce/2026/08/b12fde5f-eef8-4ba3-8072-33f5ed7bc305.png) |

### Third run (no change, new release)

<details>
<summary>posthog-cli, React Native source maps</summary>

```
INFO posthog_cli::sourcemaps::hermes::clone: Successfully cloned metadata to /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
INFO posthog_cli::sourcemaps::hermes::clone: Finished cloning metadata
INFO posthog_cli::sourcemaps::hermes::upload: Processing directory: /Users/ablaszkiewicz/Documents/repos/error-tracking-examples/react-native-expo/android/app/build/generated/sourcemaps/react/release
WARN posthog_cli::api::releases: release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+2 not found
INFO posthog_cli::api::releases: Release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+2 created successfully! 01a03488-2b77-0000-0c73-9191298d227a
INFO posthog_cli::sourcemaps::hermes::upload: Found 1 maps to upload
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (1 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
```

</details>

<details>
<summary>posthog-cli, R8 mapping</summary>

```
INFO posthog_cli::api::releases: found release com.posthog.example.rnexpo.releaseless.droidbot@1.0.0+2
INFO posthog_cli::api::symbol_sets: Starting upload of batch 0, 1 symbol sets
INFO posthog_cli::api::symbol_sets: Server returned 0 upload keys (1 skipped as already present)
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
```

</details>

JavaScript exception:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/51fe559edab053d20caeb9e98579d59aa7f4564e/2026/08/f09e95f5-cd92-4b2f-9d83-d19570d17dd9.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/27d03afec0e3289e40690829501b418fa41b9829/2026/08/c964ca17-29a3-4778-aa6a-e8da05b9c9fd.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/069a530b6ecd0841801555047200cf396c2394b7/2026/08/9fff0c67-a150-4bbc-b042-02097b0c66dd.png) |

Native crash:

| Issue with readable stack trace | Release is associated | App the SDK reported |
| --- | --- | --- |
| ![stack](https://raw.githubusercontent.com/PostHog/pr-assets/149f4712d94c576ed31a1a857db5b68abcdfd02f/2026/08/8b68b903-fde7-4ecc-94aa-3e6402243d3c.png) | ![release](https://raw.githubusercontent.com/PostHog/pr-assets/985cebc2c8dbaa2c92739bb9d5844c0a0f3e074e/2026/08/a9f12939-5f43-46cd-a977-ebb90ee8fd63.png) | ![app](https://raw.githubusercontent.com/PostHog/pr-assets/c49f10c620164626c9b99fd12a046a52f738b68f/2026/08/923c8b24-6b78-45e1-ab71-a0fe137ebaec.png) |