### PR TITLE
fix(tasks): allow flagged users to analyze public tasks

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -843,6 +843,7 @@ const FeedItem = memo(function FeedItem({
       id: task.id,
       title: task.title,
       isPinned: taskData?.isPinned ?? false,
+      task,
       channelId: task.channel ?? undefined,
       onAddToCommandCenter: commandCenterCells.includes(task.id)
         ? undefined
@@ -860,6 +861,7 @@ const FeedItem = memo(function FeedItem({
       archiveTaskFromFeed,
       beginTitleEdit,
       canStop,
+      task,
       commandCenterCells,
       task.channel,
       task.id,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -1,5 +1,6 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import { formatRelativeTimeShort } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
 import { CANVAS_DRAG_TYPE } from "@posthog/ui/features/canvas/canvasDrag";
 import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import {
@@ -19,6 +20,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   status: null as TaskStatusInput | null,
   currentUserId: 999 as number | undefined,
+  analysis: {
+    canAnalyze: false,
+    isPending: false,
+    run: vi.fn(),
+  },
 }));
 vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
   useCurrentUser: () => ({ data: { id: mocks.currentUserId } }),
@@ -37,6 +43,12 @@ vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => true,
 }));
+vi.mock(
+  "@posthog/ui/features/task-detail/components/TaskAnalysisButton",
+  () => ({
+    useTaskAnalysis: () => mocks.analysis,
+  }),
+);
 // The handoff dialog is tested on its own; here it only opens.
 vi.mock(
   "@posthog/ui/features/task-detail/components/HandoffTaskDialog",
@@ -103,6 +115,7 @@ function renderRow(model: ChannelItemModel) {
 
 beforeEach(() => {
   mocks.status = null;
+  mocks.analysis = { canAnalyze: false, isPending: false, run: vi.fn() };
   useSidebarStore.setState({ listItemMetadataFields: [] });
   usePendingCanvasDeleteStore.setState({ pending: {} });
   useTaskSelectionStore.setState({
@@ -387,6 +400,38 @@ describe("ChannelItemRow", () => {
     for (const label of MENU_ITEMS) {
       expect(screen.getByRole("menuitem", { name: label })).not.toBeNull();
     }
+  });
+
+  it("offers Run analysis for a task with a terminal run", () => {
+    const run = vi.fn();
+    mocks.analysis = { canAnalyze: true, isPending: false, run };
+    const task = {
+      id: "task-1",
+      task_number: 1,
+      slug: "task-1",
+      title: "Investigate signup drop-off",
+      description: "",
+      created_at: "2026-07-16T12:00:00.000Z",
+      updated_at: "2026-07-16T12:00:00.000Z",
+      origin_product: "user_created",
+      latest_run: { id: "run-1", status: "completed" },
+    } as Task;
+
+    renderInList(
+      <ChannelItemRow
+        actions={actions}
+        isActive={false}
+        item={item({ task })}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText("Investigate signup drop-off"));
+
+    const analysisItem = screen.getByRole("menuitem", {
+      name: "Run analysis",
+    });
+    expect(analysisItem).not.toBeNull();
+    fireEvent.click(analysisItem);
+    expect(run).toHaveBeenCalledOnce();
   });
 
   it("offers Hand off… only to the task's owner", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -343,6 +343,7 @@ export function ChannelItemRow({
             id: item.id,
             title: item.title,
             isPinned: item.pinned,
+            task: item.task ?? undefined,
             channelId,
             onAddToCommandCenter,
             onRename,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -489,6 +489,7 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
       id: item.id,
       title: item.title,
       isPinned: item.pinned,
+      task: item.task ?? undefined,
       // Ticks the space the session is already in, inside "File to…".
       channelId: spaceId,
       onAddToCommandCenter: actions.commandCenterAssigner(item.id),

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -3,6 +3,7 @@ import {
   CaretRightIcon,
   DotsThreeIcon,
   FolderSimpleIcon,
+  MagnifyingGlassIcon,
   PencilSimpleIcon,
   PushPinIcon,
   PushPinSlashIcon,
@@ -28,16 +29,24 @@ import {
   DropdownMenuTrigger,
 } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import type { SidebarBulkActions } from "@posthog/ui/features/sidebar/useSidebarBulkActions";
+import { useTaskAnalysis } from "@posthog/ui/features/task-detail/components/TaskAnalysisButton";
 import {
   type MenuFlyoutItem,
   MenuSubFlyout,
   SearchableMenuFlyout,
 } from "@posthog/ui/primitives/SearchableMenuFlyout";
-import { type ComponentType, type ReactNode, useMemo, useState } from "react";
+import {
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+  useMemo,
+  useState,
+} from "react";
 
 /**
  * What a row's menu can do. The row owns the handlers because they're the same
@@ -53,6 +62,7 @@ export interface TaskRowMenuProps {
   id: string;
   title: string;
   isPinned: boolean;
+  task?: Task;
   /** The channel this task is already filed to, ticked in "File to…". */
   channelId?: string;
   /** Absent when the command centre is full, which disables the item. */
@@ -95,6 +105,24 @@ const DROPDOWN_PARTS: MenuParts = {
   SubTrigger: DropdownMenuSubTrigger,
 };
 
+function TaskAnalysisMenuItem({
+  Item,
+  task,
+}: {
+  Item: MenuParts["Item"];
+  task: Task;
+}): ReactElement | null {
+  const { canAnalyze, isPending, run } = useTaskAnalysis(task);
+  if (!canAnalyze) return null;
+
+  return (
+    <Item disabled={isPending} onClick={run}>
+      <MagnifyingGlassIcon size={14} />
+      {isPending ? "Analyzing…" : "Run analysis"}
+    </Item>
+  );
+}
+
 /**
  * The row's actions, in the order the native menu used: the edits, then the
  * places a task can be sent, then the destructive one last.
@@ -114,6 +142,7 @@ function TaskRowMenuItems({
     import.meta.env.DEV,
   );
   const isTask = menu.kind === "task";
+  const analysisTask = isTask && menu.task?.latest_run ? menu.task : null;
   const { channels } = useChannels({ enabled: bluebirdEnabled && isTask });
   const fileToChannel = useFileTaskToChannel();
 
@@ -140,6 +169,7 @@ function TaskRowMenuItems({
           Rename
         </Item>
       )}
+      {analysisTask && <TaskAnalysisMenuItem Item={Item} task={analysisTask} />}
       {menu.onStop && (
         <Item onClick={menu.onStop}>
           <StopCircle size={14} />

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskAnalysisButton.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskAnalysisButton.tsx
@@ -7,6 +7,7 @@ import {
 import type { Task } from "@posthog/shared/domain-types";
 import { toastError } from "@posthog/ui/features/notifications/errorDetails";
 import { toast } from "@posthog/ui/primitives/toast";
+import type { ReactElement } from "react";
 import { useAuthenticatedMutation } from "../../../hooks/useAuthenticatedMutation";
 import { navigateToTaskDetail } from "../../../router/navigationBridge";
 import { track } from "../../../shell/analytics";
@@ -17,11 +18,15 @@ interface AnalyzeResult {
   created: boolean;
 }
 
-export function TaskAnalysisButton({ task }: { task: Task }) {
+export interface TaskAnalysisControls {
+  canAnalyze: boolean;
+  isPending: boolean;
+  run: () => void;
+}
+
+export function useTaskAnalysis(task: Task): TaskAnalysisControls {
   const enabled = useFeatureFlag(TASK_ANALYSIS_FLAG) || import.meta.env.DEV;
   const runId = task.latest_run?.id;
-  const isAnalyzableOrigin = task.origin_product !== "task_analysis";
-
   const mutation = useAuthenticatedMutation<AnalyzeResult, Error, void>(
     (client) => {
       if (!runId) throw new Error("This task has no run to analyze yet.");
@@ -47,21 +52,33 @@ export function TaskAnalysisButton({ task }: { task: Task }) {
     },
   );
 
-  if (
-    !enabled ||
-    !runId ||
-    !isAnalyzableOrigin ||
-    !isTerminalStatus(task.latest_run?.status)
-  )
-    return null;
+  return {
+    canAnalyze:
+      enabled &&
+      !!runId &&
+      task.origin_product !== "task_analysis" &&
+      isTerminalStatus(task.latest_run?.status),
+    isPending: mutation.isPending,
+    run: () => mutation.mutate(),
+  };
+}
+
+export function TaskAnalysisButton({
+  task,
+}: {
+  task: Task;
+}): ReactElement | null {
+  const { canAnalyze, isPending, run } = useTaskAnalysis(task);
+
+  if (!canAnalyze) return null;
 
   return (
     <Button
       size="sm"
       variant="outline"
-      onClick={() => mutation.mutate()}
-      loading={mutation.isPending}
-      disabled={mutation.isPending}
+      onClick={run}
+      loading={isPending}
+      disabled={isPending}
     >
       Run analysis
     </Button>

--- a/products/tasks/backend/logic/services/task_analysis.py
+++ b/products/tasks/backend/logic/services/task_analysis.py
@@ -206,6 +206,10 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
     if attempt >= MAX_ANALYSES_PER_TARGET_RUN:
         raise TaskAnalysisError("This run has been analyzed as many times as allowed.")
 
+    # Keep the analysis in the target task owner's personal space. A teammate may start an
+    # analysis for a public task, but the resulting task must remain visible to its owner.
+    analysis_user_id = target_task.created_by_id or user_id
+
     log_keys = _analysis_log_sources(target_run)
     if not log_keys:
         raise TaskAnalysisError("The run has no log to analyze yet.")
@@ -232,7 +236,7 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
                 title=f"Task analysis: {target_task.title[:120]}",
                 description=prompt,
                 origin_product=Task.OriginProduct.TASK_ANALYSIS,
-                user_id=user_id,
+                user_id=analysis_user_id,
                 repository=None,
                 create_pr=False,
                 mode="background",
@@ -277,7 +281,7 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
     enqueue_or_start_workflow(
         run,
         options=WorkflowDispatchOptions(
-            user_id=user_id,
+            user_id=analysis_user_id,
             create_pr=False,
             slack_thread_context=None,
             posthog_mcp_scopes="read_only",

--- a/products/tasks/backend/logic/services/task_analysis.py
+++ b/products/tasks/backend/logic/services/task_analysis.py
@@ -206,10 +206,6 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
     if attempt >= MAX_ANALYSES_PER_TARGET_RUN:
         raise TaskAnalysisError("This run has been analyzed as many times as allowed.")
 
-    # Keep the analysis in the target task owner's personal space. A teammate may start an
-    # analysis for a public task, but the resulting task must remain visible to its owner.
-    analysis_user_id = target_task.created_by_id or user_id
-
     log_keys = _analysis_log_sources(target_run)
     if not log_keys:
         raise TaskAnalysisError("The run has no log to analyze yet.")
@@ -236,7 +232,7 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
                 title=f"Task analysis: {target_task.title[:120]}",
                 description=prompt,
                 origin_product=Task.OriginProduct.TASK_ANALYSIS,
-                user_id=analysis_user_id,
+                user_id=user_id,
                 repository=None,
                 create_pr=False,
                 mode="background",
@@ -281,7 +277,7 @@ def create_task_analysis(*, team: Team, user_id: int, target_task: Task, target_
     enqueue_or_start_workflow(
         run,
         options=WorkflowDispatchOptions(
-            user_id=analysis_user_id,
+            user_id=user_id,
             create_pr=False,
             slack_thread_context=None,
             posthog_mcp_scopes="read_only",

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1242,10 +1242,11 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def _is_sandbox_agent_request(self, task_id: str) -> bool:
         return is_sandbox_agent_request(self.request, task_id)
 
-    # Actions that only read run state. Everything else mutates or drives the
-    # run, so it requires task control (not just visibility): public-channel
-    # visibility lets teammates watch a run, never command it. connection_token
-    # is a GET but mints a write-capable token, so it is deliberately absent.
+    # Actions that only read run state. The visibility-only exception creates a
+    # separate analysis task without driving the target run. Other actions
+    # require task control (not just visibility): public-channel visibility lets
+    # teammates watch a run, never command it. connection_token is a GET but
+    # mints a write-capable token, so it is deliberately absent.
     _READ_ONLY_ACTIONS = (
         "list",
         "retrieve",
@@ -1258,6 +1259,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         "artifacts_download",
         "artifacts_download_by_id",
     )
+    _VISIBILITY_ONLY_ACTIONS = ("analyze",)
 
     def _one_shot_analysis_response(self, task_id: str) -> Response | None:
         """Refuse to add runs to a server-created analysis task; see the facade reader."""
@@ -1272,6 +1274,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         """Gate access to the parent task, including exact task-bound sandbox access."""
         task_id = self._task_id()
         is_read_only = self.action in self._READ_ONLY_ACTIONS
+        is_visibility_only = self.action in self._VISIBILITY_ONLY_ACTIONS
         bypass_visibility = self._is_sandbox_agent_request(task_id) or (
             is_read_only and _can_bypass_visibility(self.request, self.team_id)
         )
@@ -1280,7 +1283,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             self.team_id,
             self._user_id(),
             bypass_visibility=bypass_visibility,
-            for_control=not is_read_only,
+            for_control=not (is_read_only or is_visibility_only),
         ):
             raise NotFound("Task not found")
         run_id = self.kwargs.get("pk")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -13488,12 +13488,7 @@ class TestTaskRunAnalyzeAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(response.json()["created"])
-        analysis_task = Task.objects.get(id=response.json()["analysis_task_id"])
-        self.assertEqual(analysis_task.created_by_id, teammate.id)
-
-        self.client.force_authenticate(teammate)
-        detail_response = self.client.get(f"/api/projects/@current/tasks/{analysis_task.id}/")
-        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Task.objects.filter(origin_product=Task.OriginProduct.TASK_ANALYSIS).count(), 1)
 
     def test_analyze_is_idempotent_per_run(self):
         read_p, write_p, tag_p, dispatch_p = self._patch_boundaries()

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -13488,7 +13488,12 @@ class TestTaskRunAnalyzeAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(response.json()["created"])
-        self.assertEqual(Task.objects.filter(origin_product=Task.OriginProduct.TASK_ANALYSIS).count(), 1)
+        analysis_task = Task.objects.get(id=response.json()["analysis_task_id"])
+        self.assertEqual(analysis_task.created_by_id, teammate.id)
+
+        self.client.force_authenticate(teammate)
+        detail_response = self.client.get(f"/api/projects/@current/tasks/{analysis_task.id}/")
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
 
     def test_analyze_is_idempotent_per_run(self):
         read_p, write_p, tag_p, dispatch_p = self._patch_boundaries()

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -13461,6 +13461,35 @@ class TestTaskRunAnalyzeAPI(BaseTaskAPITest):
         mock_dispatch.assert_called_once()
         self.assertEqual(run.state["pending_dispatch"]["posthog_mcp_scopes"], "read_only")
 
+    def test_flagged_user_can_analyze_a_teammate_public_task(self):
+        teammate = self.create_organization_user("teammate")
+        channel = Channel.objects.unscoped().create(
+            team=self.team,
+            name="shared-analysis",
+            created_by=teammate,
+        )
+        task = Task.objects.create(
+            team=self.team,
+            created_by=teammate,
+            channel=channel,
+            title="Teammate task",
+            description="Inspect it",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+        )
+
+        read_p, write_p, tag_p, dispatch_p = self._patch_boundaries()
+        with read_p, write_p, tag_p, dispatch_p:
+            response = self.client.post(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/analyze/")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.json()["created"])
+        self.assertEqual(Task.objects.filter(origin_product=Task.OriginProduct.TASK_ANALYSIS).count(), 1)
+
     def test_analyze_is_idempotent_per_run(self):
         read_p, write_p, tag_p, dispatch_p = self._patch_boundaries()
         with read_p, write_p, tag_p, dispatch_p:


### PR DESCRIPTION
## Problem

Flagged PostHog Code users can analyze their own task runs, but they cannot start analysis for completed teammate tasks in public spaces.

## Changes

- Task context menus now show `Run analysis` for visible terminal tasks when the requester has the task-analysis flag.
- The existing header action remains unchanged for current task owners.
- The analyze endpoint now checks task visibility for this action, while other task controls still require task control.
- The existing terminal-run, flag, approval, sandbox, and analysis safety checks remain in place.
- No screenshot is included because this change adds one item to an existing menu and no new surface.

### Request path before

```mermaid
flowchart LR
    user{{Flagged user}} --> own[Own-task list]
    public[Teammate public task] --> space[Visible in public space]
    space --> own
    own --> absent[No analysis action]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class user phYellow;
    class own,space phBlue;
    class public phGray;
    class absent phRed;
```

### Request path after

```mermaid
flowchart LR
    user{{Requester}} --> menu[Task context menu]
    task[Visible terminal task] --> menu
    menu --> flag{Requester has flag?}
    flag -->|yes| visible[Task visibility check]
    flag -->|no| absent[No analysis action]
    visible --> analysis[Create funded analysis task]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class user phYellow;
    class menu,visible phBlue;
    class task phGray;
    class flag,analysis phRed;
    class absent phGray;
```

## How did you test this code?

- Passed `cd products/desktop/packages/ui && pnpm test`.
- Passed `cd products/desktop && pnpm exec turbo typecheck --concurrency=1`.
- Passed Ruff checks and formatting for the changed Python files.
- Ran the full Desktop Biome lint. It reported existing `noExplicitAny` warnings outside this change.
- The frontend test covers the menu action for a terminal task.
- The backend test covers a flagged requester analyzing a teammate-owned public task.
- Not completed: the focused Django test could not start because local test database migrations did not finish, leaving a stale schema.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change was directed through [PostHog Desktop](https://posthog.com/desktop) and the GitHub CLI.

Skills invoked: `/posthog-desktop`, `/querying-posthog-data`, `/improving-drf-endpoints`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `/writing-pr-descriptions`.

The temporary action stays in the existing task menus, so the owner-only header controls do not broaden.
