### PR TITLE
fix(conversations): show full author name on ticket messages

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2262,6 +2262,34 @@ class TestTicketMessagesAPI(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("full_name", "Ada", "Lovelace", "Ada Lovelace"),
+            ("first_name_only", "Ada", "", "Ada"),
+            ("last_name_only", "", "Lovelace", "Lovelace"),
+            # Empty expected_name means "falls back to the user's email"
+            ("email_fallback", "", "", ""),
+        ]
+    )
+    def test_messages_staff_author_name_uses_full_name(
+        self, mock_on_commit, _name, first_name, last_name, expected_name
+    ):
+        self.user.first_name = first_name
+        self.user.last_name = last_name
+        self.user.save(update_fields=["first_name", "last_name"])
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="msg",
+            item_context={"author_type": "support"},
+        )
+
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"][0]["author_name"] == (expected_name or self.user.email)
+
+    @parameterized.expand(
+        [
             ("real_true", True, True),
             ("string_false_is_not_private", "false", False),
             ("string_true_is_not_private", "true", False),
@@ -2366,7 +2394,7 @@ class TestTicketReplyAPI(APIBaseTest):
         assert body["content"] == "A reply"
         assert body["author_type"] == "support"
         assert body["is_private"] is is_private
-        assert body["author_name"] == (self.user.first_name or self.user.email)
+        assert body["author_name"] == (f"{self.user.first_name} {self.user.last_name}".strip() or self.user.email)
 
         comment = Comment.objects.get(id=body["id"])
         assert comment.created_by == self.user

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1129,7 +1129,10 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
         )
 
         if comment.created_by:
-            author_name = comment.created_by.first_name or comment.created_by.email
+            # Full name, so two teammates who share a first name stay distinguishable
+            # in the agent-facing thread.
+            created_by = comment.created_by
+            author_name = f"{created_by.first_name} {created_by.last_name}".strip() or created_by.email
         elif author_type == "AI":
             author_name = "PostHog Assistant"
         elif context_author_name:


### PR DESCRIPTION
## Problem

A support agent reading a ticket thread saw teammates by first name only — "Ada" replied, "Ada" left the internal note. With two Adas on the team there is no way to tell who said what.

The ticket messages endpoint resolved a staff author as `first_name or email`, dropping the last name. HogDesk and the in-app ticket scene both render that string verbatim.

## Changes

- Ticket messages (and the reply/note responses built from the same serializer) now name a staff author by full name, e.g. "Ada Lovelace".
- Blank name fields still fall back to the user's email, so no author goes unnamed.
- The customer-facing widget serializer is deliberately untouched — customers keep seeing agents by first name.

## How did you test this code?

Added `test_messages_staff_author_name_uses_full_name`, covering the four resolution branches (first + last, first only, last only, email fallback). No existing test exercised a staff author with a last name set — the default test user has none, which is why the truncation went unnoticed.

Updated the reply-endpoint assertion, which had encoded the first-name-only rule.

Not run: the suite locally (no backend dev environment in this session) — CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from HogDesk, where the truncation is most visible. The fix is server-side because the messages payload carries only the resolved `author_name` string, so no client can recover the last name on its own. The companion HogDesk change ([PostHog/hogdesk#190](https://github.com/PostHog/hogdesk/pull/190)) keeps its send-recovery matcher in sync with this rule; until it ships, an older client falls back to "we couldn't confirm that your message was added" on an already-failing send — safe, no duplicate sends.

Tools: PostHog Slack app (Claude Code). No repo skills invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B4F70U140/p1787564019453589)*

