### PR TITLE
fix(posthog-ai): hide slash commands that do nothing on the sandbox runtime

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1897,6 +1897,22 @@ describe('maxThreadLogic', () => {
             expect(names).not.toContain(SlashCommandName.SlashTicket)
         })
 
+        it('hides every command for a new conversation with the sandbox toggle on', () => {
+            // No conversation row yet, so `agent_runtime` is unknown — the toggle is the only runtime signal.
+            logic.actions.setIsSandboxMode(true)
+            maxLogicInstance.actions.setQuestion('')
+            organizationLogic.actions.loadCurrentOrganizationSuccess({
+                created_at: dayjs().toISOString(),
+            } as OrganizationType)
+            expect(logic.values.conversation).toBeNull()
+            const names = logic.values.filteredCommands.map((c) => c.name)
+            expect(names).not.toContain(SlashCommandName.SlashInit)
+            expect(names).not.toContain(SlashCommandName.SlashRemember)
+            expect(names).not.toContain(SlashCommandName.SlashUsage)
+            expect(names).not.toContain(SlashCommandName.SlashFeedback)
+            expect(names).not.toContain(SlashCommandName.SlashTicket)
+        })
+
         it('keeps the core-memory commands for langgraph conversations', async () => {
             setRuntime('langgraph')
             const names = logic.values.filteredCommands.map((c) => c.name)

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1883,28 +1883,23 @@ describe('maxThreadLogic', () => {
             maxLogicInstance.actions.setQuestion('')
         }
 
-        it('hides every command that has no sandbox implementation', () => {
-            setRuntime('sandbox')
+        it.each([
+            ['an existing sandbox conversation', (): void => setRuntime('sandbox')],
+            [
+                'a new conversation with the sandbox toggle on',
+                (): void => {
+                    logic.actions.setIsSandboxMode(true)
+                    maxLogicInstance.actions.setQuestion('')
+                    // Pins the case: with a row present the toggle would no longer be the only signal
+                    expect(logic.values.conversation).toBeNull()
+                },
+            ],
+        ])('hides every command that has no sandbox implementation, given %s', (_label, enterSandbox) => {
+            enterSandbox()
             // Eligible for support, so /ticket's absence is down to the runtime rather than entitlement
             organizationLogic.actions.loadCurrentOrganizationSuccess({
                 created_at: dayjs().toISOString(),
             } as OrganizationType)
-            const names = logic.values.filteredCommands.map((c) => c.name)
-            expect(names).not.toContain(SlashCommandName.SlashInit)
-            expect(names).not.toContain(SlashCommandName.SlashRemember)
-            expect(names).not.toContain(SlashCommandName.SlashUsage)
-            expect(names).not.toContain(SlashCommandName.SlashFeedback)
-            expect(names).not.toContain(SlashCommandName.SlashTicket)
-        })
-
-        it('hides every command for a new conversation with the sandbox toggle on', () => {
-            // No conversation row yet, so `agent_runtime` is unknown — the toggle is the only runtime signal.
-            logic.actions.setIsSandboxMode(true)
-            maxLogicInstance.actions.setQuestion('')
-            organizationLogic.actions.loadCurrentOrganizationSuccess({
-                created_at: dayjs().toISOString(),
-            } as OrganizationType)
-            expect(logic.values.conversation).toBeNull()
             const names = logic.values.filteredCommands.map((c) => c.name)
             expect(names).not.toContain(SlashCommandName.SlashInit)
             expect(names).not.toContain(SlashCommandName.SlashRemember)

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1883,13 +1883,18 @@ describe('maxThreadLogic', () => {
             maxLogicInstance.actions.setQuestion('')
         }
 
-        it('hides /init and /remember for sandbox conversations, keeps /usage and /feedback', async () => {
+        it('hides every command that has no sandbox implementation', () => {
             setRuntime('sandbox')
+            // Eligible for support, so /ticket's absence is down to the runtime rather than entitlement
+            organizationLogic.actions.loadCurrentOrganizationSuccess({
+                created_at: dayjs().toISOString(),
+            } as OrganizationType)
             const names = logic.values.filteredCommands.map((c) => c.name)
             expect(names).not.toContain(SlashCommandName.SlashInit)
             expect(names).not.toContain(SlashCommandName.SlashRemember)
-            expect(names).toContain(SlashCommandName.SlashUsage)
-            expect(names).toContain(SlashCommandName.SlashFeedback)
+            expect(names).not.toContain(SlashCommandName.SlashUsage)
+            expect(names).not.toContain(SlashCommandName.SlashFeedback)
+            expect(names).not.toContain(SlashCommandName.SlashTicket)
         })
 
         it('keeps the core-memory commands for langgraph conversations', async () => {

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -698,7 +698,8 @@ export interface maxThreadLogicMeta {
             featureFlags: FeatureFlagsSet,
             threadLoading: boolean,
             conversation: Conversation | null,
-            canCreateTicket: boolean
+            canCreateTicket: boolean,
+            isSandboxMode: boolean
         ) => SlashCommand[]
         showDeepResearchModeToggle: (conversation: Conversation | null, featureFlags: FeatureFlagsSet) => boolean
         showContextUI: (conversation: Conversation | null, featureFlags: FeatureFlagsSet) => boolean
@@ -2871,9 +2872,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 canCreateTicket: boolean,
                 isSandboxMode: boolean
             ): SlashCommand[] => {
-                // Sandbox runtime drops core-memory commands; LangGraph keeps the full set. A brand-new
-                // conversation has no `agent_runtime` yet, so also honor the sandbox toggle — otherwise
-                // the commands stay visible until the first message stamps the runtime.
+                // A conversation that doesn't exist yet has no `agent_runtime`, so before the first
+                // message the toggle is the only signal that this turn goes to the sandbox runtime.
                 const isSandboxRuntime = conversation?.agent_runtime === 'sandbox' || isSandboxMode
 
                 return MAX_SLASH_COMMANDS.filter(

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -2862,16 +2862,19 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         filteredCommands: [
-            (s) => [s.question, s.featureFlags, s.threadLoading, s.conversation, s.canCreateTicket],
+            (s) => [s.question, s.featureFlags, s.threadLoading, s.conversation, s.canCreateTicket, s.isSandboxMode],
             (
                 question: string,
                 featureFlags: Record<string, boolean | string>,
                 threadLoading: boolean,
                 conversation: Conversation | null,
-                canCreateTicket: boolean
+                canCreateTicket: boolean,
+                isSandboxMode: boolean
             ): SlashCommand[] => {
-                // Sandbox runtime drops core-memory commands; LangGraph keeps the full set.
-                const isSandboxRuntime = conversation?.agent_runtime === 'sandbox'
+                // Sandbox runtime drops core-memory commands; LangGraph keeps the full set. A brand-new
+                // conversation has no `agent_runtime` yet, so also honor the sandbox toggle — otherwise
+                // the commands stay visible until the first message stamps the runtime.
+                const isSandboxRuntime = conversation?.agent_runtime === 'sandbox' || isSandboxMode
 
                 return MAX_SLASH_COMMANDS.filter(
                     (command) =>

--- a/frontend/src/scenes/max/slash-commands.tsx
+++ b/frontend/src/scenes/max/slash-commands.tsx
@@ -16,7 +16,8 @@ export interface SlashCommand {
     requiresIdle?: boolean
     /**
      * If true, this command is hidden for sandbox-runtime conversations.
-     * Core-memory commands (`/init`, `/remember`) are not yet supported under sandbox AI.
+     * Slash commands are handled by the LangGraph runtime; the sandbox runtime has no equivalent,
+     * so a command left visible there reaches the agent as plain text instead of running.
      * LangGraph conversations are unaffected.
      */
     hiddenInSandbox?: boolean
@@ -40,17 +41,20 @@ export const MAX_SLASH_COMMANDS: SlashCommand[] = [
         name: SlashCommandName.SlashUsage,
         description: 'View AI credit usage for this conversation and billing period',
         icon: <IconActivity />,
+        hiddenInSandbox: true,
     },
     {
         name: SlashCommandName.SlashFeedback,
         arg: '[your feedback]',
         description: 'Share feedback about your PostHog AI experience',
         icon: <IconThumbsUp />,
+        hiddenInSandbox: true,
     },
     {
         name: SlashCommandName.SlashTicket,
         description: 'Create a support ticket with a summary of this conversation',
         icon: <IconSupport />,
         requiresIdle: true,
+        hiddenInSandbox: true,
     },
 ]


### PR DESCRIPTION
## Problem

On the sandbox runtime, picking `/usage`, `/feedback` or `/ticket` from the PostHog AI autocomplete does nothing.

- Slash commands run in the LangGraph runtime's command layer, and the sandbox runtime has no equivalent.
- The command text reaches the agent as an ordinary message, so no usage report, feedback record or support ticket is produced.
- The menu offered all three anyway, so an absent feature looked like a broken one.
- The filter that hides commands read `conversation.agent_runtime`, which is null until the conversation row exists. Every command stayed visible for the first turn, `/init` and `/remember` included.

## Changes

- Typing `/` in a sandbox conversation no longer opens a command menu, including before the first message.
- LangGraph conversations still offer every command, unchanged.
- The three commands now carry `hiddenInSandbox`, alongside `/init` and `/remember`.
- The filter treats a conversation as sandbox when the toggle is on as well, matching the pair of conditions `SandboxModeToggle` and the send path already use.
- That hides every command on the sandbox runtime, and the popover already hides itself when nothing matches, so the menu stops appearing rather than rendering empty.
- Implementing these commands on the sandbox runtime is separate work. Hiding them stops the menu promising what it cannot do meanwhile.

No screenshot: the change removes menu entries, and capturing it needs a running stack with a live sandbox conversation, which this session did not start.

## How did you test this code?

- One parameterized case in `maxThreadLogic.test.ts` asserts all five commands are absent, for an existing sandbox conversation and for a new one with only the toggle set.
- The case loads an eligible organization, so `/ticket`'s absence follows from the runtime rather than from support entitlement. Without it the assertion passes for the wrong reason.
- Reverting `slash-commands.tsx` fails the case with `["/usage", "/feedback", "/ticket"]`. Reverting the selector fails it with all five.
- Not checked: the composer in a browser, and the send-button icon, which still reflects any typed command name on both runtimes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written in Claude Code under direction.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The first commit hid the three commands. ReviewHog then found that the filter never applied before a conversation existed, and committed the fix itself; a follow-up commit corrected typegen signature drift, collapsed two duplicate test cases into one, and removed a comment claim that the filter only affects core-memory commands.
- The change came out of an investigation into which slash commands the sandbox runtime implements. That investigation is also producing a follow-up stack that adds a working `/support` command there, which is why these are hidden rather than implemented here.
- No customer or session material reached this diff.
