### PR TITLE
fix(error-tracking): prevent issue list query timeout

### DIFF
--- a/products/error_tracking/backend/facade/api.py
+++ b/products/error_tracking/backend/facade/api.py
@@ -159,7 +159,7 @@ def get_issue(issue_id: UUID, team_id: int) -> contracts.ErrorTrackingIssue:
 def list_issues_detailed(
     team_id: int, *, limit: int | None = None, offset: int = 0
 ) -> tuple[list[contracts.ErrorTrackingIssue], int]:
-    qs = logic.get_issue_detail_queryset(team_id)
+    qs = logic.get_issue_detail_queryset(team_id).order_by("-id")
     total = qs.count()
     rows = qs if limit is None else qs[offset : offset + limit]
     return [_to_issue(issue) for issue in rows], total

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -33,8 +33,13 @@ logger = structlog.get_logger(__name__)
 
 
 class ErrorTrackingIssueManager(models.Manager):
-    def with_first_seen(self):
-        return self.annotate(first_seen=models.Min("fingerprints__first_seen"))
+    def with_first_seen(self) -> models.QuerySet["ErrorTrackingIssue"]:
+        first_seen = (
+            ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=models.OuterRef("pk"))
+            .order_by("first_seen")
+            .values("first_seen")[:1]
+        )
+        return self.annotate(first_seen=models.Subquery(first_seen))
 
 
 class ErrorTrackingIssueMergeResult(StrEnum):

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -33,7 +33,7 @@ logger = structlog.get_logger(__name__)
 
 
 class ErrorTrackingIssueManager(models.Manager):
-    def with_first_seen(self) -> models.QuerySet["ErrorTrackingIssue"]:
+    def with_first_seen(self):
         first_seen = (
             ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=models.OuterRef("pk"))
             .order_by("first_seen")

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -136,6 +136,49 @@ class TestErrorTracking(APIBaseTest):
             "external_issues": [],
         }
 
+    def test_issue_list_paginates_without_aggregating_all_fingerprints(self) -> None:
+        issues = [ErrorTrackingIssue.objects.create(team=self.team) for _ in range(3)]
+        expected_issue = sorted(issues, key=lambda issue: issue.id, reverse=True)[1]
+        later_fingerprint = ErrorTrackingIssueFingerprintV2.objects.create(
+            team=self.team, issue=expected_issue, fingerprint="later"
+        )
+        earlier_fingerprint = ErrorTrackingIssueFingerprintV2.objects.create(
+            team=self.team, issue=expected_issue, fingerprint="earlier"
+        )
+        ErrorTrackingIssueFingerprintV2.objects.filter(id=later_fingerprint.id).update(
+            first_seen=datetime(2025, 1, 2, tzinfo=UTC)
+        )
+        ErrorTrackingIssueFingerprintV2.objects.filter(id=earlier_fingerprint.id).update(
+            first_seen=datetime(2025, 1, 1, tzinfo=UTC)
+        )
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(
+                f"/api/environments/{self.team.id}/error_tracking/issues", data={"limit": 1, "offset": 1}
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["count"] == 3
+        assert [issue["id"] for issue in body["results"]] == [str(expected_issue.id)]
+        assert body["results"][0]["first_seen"] == "2025-01-01T00:00:00Z"
+
+        issue_table = ErrorTrackingIssue._meta.db_table
+        fingerprint_table = ErrorTrackingIssueFingerprintV2._meta.db_table
+        count_query = next(
+            query["sql"]
+            for query in queries.captured_queries
+            if issue_table in query["sql"] and "COUNT(" in query["sql"].upper()
+        )
+        page_query = next(
+            query["sql"]
+            for query in queries.captured_queries
+            if issue_table in query["sql"] and "LIMIT 1" in query["sql"].upper()
+        )
+        assert fingerprint_table not in count_query
+        assert "GROUP BY" not in page_query.upper()
+        assert f'ORDER BY "{issue_table}"."id" DESC' in page_query
+
     @parameterized.expand(["user", "role"])
     def test_issue_fetch_assignee_id_preserves_type(self, assignee_type):
         # The frontend resolves the assignee by strict-comparing the numeric member id with


### PR DESCRIPTION
## Problem

Teams with many error tracking issues can see a blank issue list when the database query exceeds its statement timeout.

The list query grouped every issue against all fingerprints before applying the page limit. The pagination count repeated the same aggregate.

## Changes

- Issue list pages now calculate `first_seen` with a per-issue subquery after pagination limits the result.
- Pagination now uses deterministic, primary-key ordering instead of database-dependent row order.
- The API response and earliest fingerprint semantics stay unchanged.

## How did you test this code?

- Added an API regression test that rejects full-team fingerprint aggregation and verifies stable pagination and `first_seen`.
- Passed Ruff lint, Ruff format, Python compilation, test collection, and `hogli ci:preflight --fix`.
- The database-backed test did not complete because the local test database migration exceeded the sandbox time limit.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The API contract does not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code used Pi and the PostHog MCP. Skills invoked: `/investigating-error-issue`, `/writing-tests`, and `/writing-pr-descriptions`.

The implementation uses a correlated subquery instead of adding an index migration because it removes the unbounded aggregate while keeping the change small.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr) from [this inbox report](https://us.posthog.com/project/2/inbox/01a0257d-b6a3-7946-b3ca-60843879627a).*
