### PR TITLE
chore(cdp): remove fully rolled out cdp-new-pricing flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -271,7 +271,6 @@ export const FEATURE_FLAGS = {
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp
     CDP_DWH_VIEW_SOURCE: 'cdp-dwh-view-source', // owner: #team-workflows-cdp
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-workflows-cdp
-    CDP_NEW_PRICING: 'cdp-new-pricing', // owner: #team-workflows
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp
     CDP_VERCEL_LOG_DRAIN: 'cdp-vercel-log-drain', // owner: #team-workflows-cdp
     CLEARABLE_NOTIFICATIONS: 'clearable-notifications', // owner: @jordanm-posthog #team-web-analytics


### PR DESCRIPTION
## Problem

Nothing changes for anyone using PostHog. The `cdp-new-pricing` flag has been at 100% for all users with no targeting since 2025-09-11, and a repo-wide search found no code that reads it, so its declaration is dead.

This is part of a workflows/CDP feature flag cleanup. The flag will be deleted in PostHog once this merges.

## Changes

- Mechanical: removes the `CDP_NEW_PRICING` entry from the `FEATURE_FLAGS` enum in `frontend/src/lib/constants.tsx`. No user-visible change.

## How did you test this code?

No manual testing was done. Verification was a search for `CDP_NEW_PRICING` and `cdp-new-pricing` across the whole repository, including Python, Rust, and Node.js code, plus a check for dynamic `FEATURE_FLAGS[...]` lookups that could reference the key indirectly. The enum entry was the only hit, and no references remain after the change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code. The work was scoped as a single flag removal: confirm there are no consumers, then delete the declaration. No repo skills were needed for a one-line constant deletion.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1787564930544919)*
