### PR TITLE
chore(cdp): remove fully rolled out cdp-activity-log-notifications flag

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
@@ -101,11 +101,11 @@ export const SidePanelMax: Story = {
 }
 
 export const SidePanelActivity: Story = {
-    // The tab needs the audit logs entitlement, which the feature flags below don't grant
+    // The tab needs the audit logs entitlement, which the feature flag below doesn't grant
     args: { panel: SidePanelTab.Activity, availableFeatures: [AvailableFeature.AUDIT_LOGS] },
     parameters: {
         pageUrl: objectScenePageUrl,
-        featureFlags: [FEATURE_FLAGS.CDP_ACTIVITY_LOG_NOTIFICATIONS, FEATURE_FLAGS.AUDIT_LOGS_ACCESS],
+        featureFlags: [FEATURE_FLAGS.AUDIT_LOGS_ACCESS],
     },
 }
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -137,30 +137,28 @@ export const SidePanelActivity = (): JSX.Element => {
                                             : `all ${humanizeScope(contextFromPage!.scope!).toLowerCase()}`}
                                     </strong>
                                 </span>
-                                {featureFlags[FEATURE_FLAGS.CDP_ACTIVITY_LOG_NOTIFICATIONS] && (
-                                    <ActivityLogSubscribeMenu
-                                        properties={[
-                                            {
-                                                key: 'scope',
-                                                type: PropertyFilterType.Event,
-                                                value: contextFromPage!.scope!,
-                                                operator: PropertyOperator.Exact,
-                                            },
-                                            ...(hasItemContext
-                                                ? [
-                                                      {
-                                                          key: 'item_id',
-                                                          type: PropertyFilterType.Event as const,
-                                                          value: contextFromPage!.item_id,
-                                                          operator: PropertyOperator.Exact,
-                                                      },
-                                                  ]
-                                                : []),
-                                        ]}
-                                        onNavigate={closeSidePanel}
-                                        iconOnly
-                                    />
-                                )}
+                                <ActivityLogSubscribeMenu
+                                    properties={[
+                                        {
+                                            key: 'scope',
+                                            type: PropertyFilterType.Event,
+                                            value: contextFromPage!.scope!,
+                                            operator: PropertyOperator.Exact,
+                                        },
+                                        ...(hasItemContext
+                                            ? [
+                                                  {
+                                                      key: 'item_id',
+                                                      type: PropertyFilterType.Event as const,
+                                                      value: contextFromPage!.item_id,
+                                                      operator: PropertyOperator.Exact,
+                                                  },
+                                              ]
+                                            : []),
+                                    ]}
+                                    onNavigate={closeSidePanel}
+                                    iconOnly
+                                />
                             </div>
                             <MemberSelect
                                 value={activeFilters?.user ?? null}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -267,7 +267,6 @@ export const FEATURE_FLAGS = {
     AVERAGE_PAGE_VIEW_COLUMN: 'average-page-view-column', // owner: @jordanm-posthog #team-web-analytics
     BACKFILL_WORKFLOWS_DESTINATION: 'backfill-workflows-destination', // owner: #team-batch-exports
     BILLING_ALERTS: 'billing-alerts', // owner: #team-billing, gates the Billing > Alerts tab
-    CDP_ACTIVITY_LOG_NOTIFICATIONS: 'cdp-activity-log-notifications', // owner: #team-workflows-cdp
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp
     CDP_DWH_VIEW_SOURCE: 'cdp-dwh-view-source', // owner: #team-workflows-cdp
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-workflows-cdp

--- a/frontend/src/scenes/audit-logs/AdvancedActivityLogFiltersPanel.tsx
+++ b/frontend/src/scenes/audit-logs/AdvancedActivityLogFiltersPanel.tsx
@@ -4,8 +4,6 @@ import { IconDownload } from '@posthog/icons'
 import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
 
 import { ActivityLogSubscribeMenu } from 'lib/components/ActivityLog/ActivityLogSubscribeMenu'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { advancedActivityFiltersToHogProperties } from './advancedActivityFilterTranslation'
 import { advancedActivityLogsLogic } from './advancedActivityLogsLogic'
@@ -14,7 +12,6 @@ import { BasicFiltersTab } from './BasicFiltersTab'
 export function AdvancedActivityLogFiltersPanel(): JSX.Element {
     const { hasActiveFilters, exportsLoading, filters, isOrganizationView } = useValues(advancedActivityLogsLogic)
     const { clearAllFilters, exportLogs } = useActions(advancedActivityLogsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const { properties: subscribeProperties } = advancedActivityFiltersToHogProperties(filters)
 
@@ -59,7 +56,7 @@ export function AdvancedActivityLogFiltersPanel(): JSX.Element {
                             </LemonButton>
                         </LemonDropdown>
                     )}
-                    {!isOrganizationView && featureFlags[FEATURE_FLAGS.CDP_ACTIVITY_LOG_NOTIFICATIONS] && (
+                    {!isOrganizationView && (
                         <ActivityLogSubscribeMenu
                             properties={subscribeProperties}
                             data-attr="audit-logs-subscribe-button"

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1448,7 +1448,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: 'Notifications',
                 description: 'Get notified about activity log events via configured destinations.',
                 component: <ActivityLogNotifications />,
-                flag: 'CDP_ACTIVITY_LOG_NOTIFICATIONS',
                 allowForTeam: (t) => (t?.effective_membership_level ?? 0) >= OrganizationMembershipLevel.Admin,
                 keywords: ['notification', 'alert', 'activity', 'webhook'],
             },


### PR DESCRIPTION
## Problem

Activity log notifications are already on for everyone. The `cdp-activity-log-notifications` flag has been at 100% rollout with no targeting or property filters since 2026-01-05, so the checks around it are dead weight that only make the gated surfaces harder to read.

### Why

Removing the check is step one of a workflows/CDP flag cleanup. The flag itself will be deleted in PostHog once this merges.

## Changes

- Nothing changes for a person using PostHog: every gated surface was already showing.
- The activity log subscribe menu in the team activity side panel and on the audit logs filters panel now renders unconditionally.
- The activity log "Notifications" settings page is no longer flag-gated; the existing admin-level access check still applies.
- Mechanical: dropped the flag from `FEATURE_FLAGS`, from the side panel Storybook story, and removed the imports that became unused.

## How did you test this code?

No automated tests were run. The repository checkout had no installed frontend dependencies, and installing them plus running the TypeScript check did not fit the time budget for this change, so CI is the first typecheck and lint pass over the diff. The change is a mechanical flag removal with no behavior change on the enabled path.

Verified by hand that no reference to `CDP_ACTIVITY_LOG_NOTIFICATIONS` or `cdp-activity-log-notifications` remains outside test fixture data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs reference this flag.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude via the PostHog agent tooling. No repo skills were invoked. The one judgment call: an extra reference beyond the obvious component guards turned up in `frontend/src/scenes/settings/SettingsMap.tsx`, where the settings entry carried a `flag` property naming the same flag. That property is optional, so it was removed rather than replaced.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1787564930544919)*
