### PR TITLE
chore(cdp): remove fully rolled out hog-invocation-results-runs-tab flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -342,7 +342,6 @@ export const FEATURE_FLAGS = {
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics
     HEALTH_ASK_AI: 'health-ask-ai', // owner: @jordanm-posthog #team-web-analytics, gates the "Ask PostHog AI" buttons on the Health overview
-    HOG_INVOCATION_RESULTS_RUNS_TAB: 'hog-invocation-results-runs-tab', // owner: #team-workflows
     HOGQL_WAREHOUSE_ACCESS_CONTROL: 'hogql-warehouse-access-control', // owner: @a-lider #team-platform-features, gates per-object access control for warehouse tables and views
     IDENTITY_MATCHING: 'identity-matching', // owner: @fercgomes #team-growth, gates new identity matching scene on marketing analytics
     INBOX_SLACK_NOTIFICATIONS: 'inbox-slack-notifications', // owner: #team-self-driving, gates the Slack notifications config card in the inbox


### PR DESCRIPTION
## Problem

The `hog-invocation-results-runs-tab` flag has been at 100% for all users with no property targeting since 2026-07-17, so nothing gates on it anymore. Nobody sees a behavior change from this PR.

A repo-wide search across the frontend, Python, Rust, and Node found no consumers: the only reference was the `FEATURE_FLAGS` enum declaration itself. Dynamic and string-built lookups were checked too, and there were none. The declaration is dead code.

This is part of a workflows/CDP flag cleanup. The flag will be deleted in PostHog once this merges.

## Changes

- Removes the `HOG_INVOCATION_RESULTS_RUNS_TAB` entry from the `FEATURE_FLAGS` enum in `frontend/src/lib/constants.tsx`. Mechanical, one line, no other files.

## How did you test this code?

No behavioral change to test. The verification was a repo-wide search for both the enum key and the flag string, which returns nothing after the deletion. No automated tests were run, since the only removed line is an unreferenced constant that TypeScript compilation would catch if anything still used it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs reference this flag.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written with Claude Code. The task was flag-removal triage: confirm the flag has no consumers before deleting it, and remove the enabled code path's gate if it did. Verification came first — grep for the enum key and the flag string across all languages, plus a check for dynamically constructed flag keys — and it showed the declaration standing alone. That reduced the change to a single-line deletion rather than a code-path unwind.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1787564930544919)*
