### PR TITLE
chore(workflows): remove fully rolled out workflows-batch-audience-query flag

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -828,6 +828,21 @@ class BlastRadiusSerializer(serializers.Serializer):
     )
 
 
+class InternalBlastRadiusPersonsSerializer(serializers.Serializer):
+    """Response contract for the internal blast-radius persons endpoint. Mirrors
+    BlastRadiusPersonsResponse in nodejs hogflow-batch-person-query.service.ts."""
+
+    users_affected = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Person identifiers in this page, in stable pagination order.",
+    )
+    cursor = serializers.CharField(
+        allow_null=True,
+        help_text="Cursor for the next call, or null when this page is the last.",
+    )
+    has_more = serializers.BooleanField(help_text="Whether another page may follow.")
+
+
 class WorkflowGlobalStatsRequestSerializer(serializers.Serializer):
     after = serializers.CharField(
         required=False,
@@ -4752,11 +4767,13 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
                 team, filters, group_type_index, cursor, dedupe_key=dedupe_key
             )
             return Response(
-                {
-                    "users_affected": users_affected,
-                    "cursor": users_affected[-1] if users_affected else None,
-                    "has_more": len(users_affected) == WORKFLOWS_PERSON_BATCH_SIZE,
-                }
+                InternalBlastRadiusPersonsSerializer(
+                    {
+                        "users_affected": users_affected,
+                        "cursor": users_affected[-1] if users_affected else None,
+                        "has_more": len(users_affected) == WORKFLOWS_PERSON_BATCH_SIZE,
+                    }
+                ).data
             )
         except exceptions.ValidationError as e:
             return Response({"error": _validation_error_message(e)}, status=400)

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -89,12 +89,7 @@ from posthog.utils import relative_date_parse_with_delta_mapping
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cohorts.backend.models.cohort import Cohort
 from products.cohorts.backend.models.util import get_all_cohort_dependencies
-from products.feature_flags.backend.user_blast_radius import (
-    PERSON_BATCH_SIZE,
-    BlastRadiusResult,
-    get_user_blast_radius,
-    get_user_blast_radius_persons,
-)
+from products.feature_flags.backend.user_blast_radius import BlastRadiusResult, get_user_blast_radius
 from products.messaging.backend.api.design_operations import apply_design_operations
 from products.messaging.backend.api.design_validation import validate_design
 from products.messaging.backend.api.message_templates import DesignOperationSerializer
@@ -142,7 +137,6 @@ from products.workflows.backend.services.batch_audience import (
     SUPPORTED_DEDUPE_KEYS,
     get_batch_audience_count,
     get_batch_audience_person_ids,
-    use_workflows_batch_audience_query,
 )
 from products.workflows.backend.services.timing_reschedule import (
     get_all_timing_action_ids,
@@ -4021,9 +4015,9 @@ class HogFlowViewSet(
         # the legacy person-count query is skipped entirely, "total" comes straight from
         # the cached team-wide count it would have returned anyway. The applied key is
         # echoed back so the frontend labels the count from the response instead of
-        # guessing whether the flag-gated dedup actually ran.
+        # guessing whether the dedup actually ran.
         applied_dedupe_key = None
-        if dedupe_key is not None and group_type_index is None and use_workflows_batch_audience_query(self.team):
+        if dedupe_key is not None and group_type_index is None:
             total = self.team.persons_seen_so_far
             affected = min(get_batch_audience_count(self.team, filters, dedupe_key), total)
             blast_radius = BlastRadiusResult(affected=affected, total=total)
@@ -4754,19 +4748,14 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
 
         try:
             reject_flag_conditions_in_audience(team, filters)
-            if use_workflows_batch_audience_query(team):
-                users_affected = get_batch_audience_person_ids(
-                    team, filters, group_type_index, cursor, dedupe_key=dedupe_key
-                )
-                batch_size = WORKFLOWS_PERSON_BATCH_SIZE
-            else:
-                users_affected = get_user_blast_radius_persons(team, filters, group_type_index, cursor)
-                batch_size = PERSON_BATCH_SIZE
+            users_affected = get_batch_audience_person_ids(
+                team, filters, group_type_index, cursor, dedupe_key=dedupe_key
+            )
             return Response(
                 {
                     "users_affected": users_affected,
                     "cursor": users_affected[-1] if users_affected else None,
-                    "has_more": len(users_affected) == batch_size,
+                    "has_more": len(users_affected) == WORKFLOWS_PERSON_BATCH_SIZE,
                 }
             )
         except exceptions.ValidationError as e:

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -2902,8 +2902,8 @@ class TestHogFlowAPI(APIBaseTest):
     @override_settings(INTERNAL_API_SECRET="test-secret-123")
     def test_internal_user_blast_radius_persons_rejects_flag_condition(self):
         with patch(
-            "products.workflows.backend.api.hog_flow.get_user_blast_radius_persons"
-        ) as mock_get_user_blast_radius_persons:
+            "products.workflows.backend.api.hog_flow.get_batch_audience_person_ids"
+        ) as mock_get_batch_audience_person_ids:
             response = self.client.post(
                 f"/api/projects/{self.team.id}/internal/hog_flows/user_blast_radius_persons",
                 {"filters": {"properties": [{"key": "my-other-flag", "type": "flag", "value": "true"}]}},
@@ -2913,28 +2913,13 @@ class TestHogFlowAPI(APIBaseTest):
 
         assert response.status_code == 400, response.json()
         assert "Feature flags can't be used as a batch audience condition" in response.json().get("error", "")
-        mock_get_user_blast_radius_persons.assert_not_called()
+        mock_get_batch_audience_person_ids.assert_not_called()
 
-    @parameterized.expand(
-        [
-            ("flag_on_uses_workflows_query", True),
-            ("flag_off_uses_legacy_query", False),
-        ]
-    )
     @override_settings(INTERNAL_API_SECRET="test-secret-123")
-    def test_internal_user_blast_radius_persons_query_selection(self, _name, flag_enabled):
-        with (
-            patch(
-                "products.workflows.backend.api.hog_flow.use_workflows_batch_audience_query",
-                return_value=flag_enabled,
-            ),
-            patch(
-                "products.workflows.backend.api.hog_flow.get_batch_audience_person_ids", return_value=["id-1"]
-            ) as mock_workflows_query,
-            patch(
-                "products.workflows.backend.api.hog_flow.get_user_blast_radius_persons", return_value=["id-1"]
-            ) as mock_legacy_query,
-        ):
+    def test_internal_user_blast_radius_persons_uses_workflows_query(self):
+        with patch(
+            "products.workflows.backend.api.hog_flow.get_batch_audience_person_ids", return_value=["id-1"]
+        ) as mock_workflows_query:
             response = self.client.post(
                 f"/api/projects/{self.team.id}/internal/hog_flows/user_blast_radius_persons",
                 {"filters": {"properties": []}, "dedupe_key": "email"},
@@ -2944,27 +2929,22 @@ class TestHogFlowAPI(APIBaseTest):
 
         assert response.status_code == 200, response.json()
         assert response.json()["users_affected"] == ["id-1"]
-        if flag_enabled:
-            mock_workflows_query.assert_called_once_with(self.team, {"properties": []}, None, None, dedupe_key="email")
-            mock_legacy_query.assert_not_called()
-        else:
-            mock_legacy_query.assert_called_once_with(self.team, {"properties": []}, None, None)
-            mock_workflows_query.assert_not_called()
+        mock_workflows_query.assert_called_once_with(self.team, {"properties": []}, None, None, dedupe_key="email")
 
     @parameterized.expand(
         [
-            ("flag_on_uses_deduped_count", True, 3),
-            ("flag_off_keeps_person_count", False, 5),
+            ("dedupe_key_uses_deduped_count", "email", 3),
+            ("no_dedupe_key_keeps_person_count", None, 5),
         ]
     )
-    def test_user_blast_radius_dedupe_key_affects_count(self, _name, flag_enabled, expected_affected):
+    def test_user_blast_radius_dedupe_key_affects_count(self, _name, dedupe_key, expected_affected):
         from products.feature_flags.backend.user_blast_radius import BlastRadiusResult  # noqa: PLC0415
 
+        payload: dict = {"filters": {"properties": []}}
+        if dedupe_key is not None:
+            payload["dedupe_key"] = dedupe_key
+
         with (
-            patch(
-                "products.workflows.backend.api.hog_flow.use_workflows_batch_audience_query",
-                return_value=flag_enabled,
-            ),
             patch(
                 "products.workflows.backend.api.hog_flow.get_user_blast_radius",
                 return_value=BlastRadiusResult(affected=5, total=10),
@@ -2980,16 +2960,16 @@ class TestHogFlowAPI(APIBaseTest):
         ):
             response = self.client.post(
                 f"/api/projects/{self.team.id}/hog_flows/user_blast_radius",
-                {"filters": {"properties": []}, "dedupe_key": "email"},
+                payload,
             )
 
         assert response.status_code == 200, response.json()
         assert response.json()["affected"] == expected_affected
         assert response.json()["total"] == 10
         # The applied key is echoed so the frontend can label the count correctly
-        assert response.json()["dedupe_key"] == ("email" if flag_enabled else None)
-        if flag_enabled:
-            # The legacy person-count query is skipped — only the deduped count runs
+        assert response.json()["dedupe_key"] == dedupe_key
+        if dedupe_key is not None:
+            # The person-count query is skipped — only the deduped count runs
             mock_deduped_count.assert_called_once_with(self.team, {"properties": []}, "email")
             mock_legacy_count.assert_not_called()
         else:

--- a/products/workflows/backend/services/batch_audience.py
+++ b/products/workflows/backend/services/batch_audience.py
@@ -1,8 +1,5 @@
 from typing import Optional
 
-import structlog
-import posthoganalytics
-
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import property_to_expr
@@ -19,44 +16,10 @@ from products.feature_flags.backend.user_blast_radius import (
     unevaluable_filters_as_validation_errors,
 )
 
-logger = structlog.get_logger(__name__)
-
 PERSON_BATCH_SIZE = 500
 
 EMAIL_DEDUPE_KEY = "email"
 SUPPORTED_DEDUPE_KEYS = (EMAIL_DEDUPE_KEY,)
-
-WORKFLOWS_BATCH_AUDIENCE_QUERY_FLAG = "workflows-batch-audience-query"
-
-
-def use_workflows_batch_audience_query(team: Team) -> bool:
-    """Gates the workflows-owned audience query; off means the legacy flags-owned query.
-
-    A raised exception (Redis/HyperCache blip, network glitch, SDK bug) is treated as
-    "flag off" — the legacy path is the safe fallback per the PR's kill-switch design.
-    Batch sends are a critical path, so a transient flag-eval failure must not 500 the
-    preview endpoint or cause the resolver to exhaust its retry budget and fail the job.
-    """
-    try:
-        return bool(
-            posthoganalytics.feature_enabled(
-                WORKFLOWS_BATCH_AUDIENCE_QUERY_FLAG,
-                str(team.uuid),
-                groups={"organization": str(team.organization_id), "project": str(team.id)},
-                group_properties={
-                    "organization": {"id": str(team.organization_id)},
-                    "project": {"id": str(team.id)},
-                },
-            )
-        )
-    except Exception:
-        logger.warning(
-            "workflows.batch_audience.feature_flag_check_failed_defaulting_off",
-            team_id=team.id,
-            flag=WORKFLOWS_BATCH_AUDIENCE_QUERY_FLAG,
-            exc_info=True,
-        )
-        return False
 
 
 def get_batch_audience_person_ids(

--- a/products/workflows/backend/test/test_batch_audience.py
+++ b/products/workflows/backend/test/test_batch_audience.py
@@ -5,11 +5,7 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from products.feature_flags.backend.user_blast_radius import get_user_blast_radius_persons
-from products.workflows.backend.services.batch_audience import (
-    get_batch_audience_count,
-    get_batch_audience_person_ids,
-    use_workflows_batch_audience_query,
-)
+from products.workflows.backend.services.batch_audience import get_batch_audience_count, get_batch_audience_person_ids
 
 FILTERS = {"properties": [{"key": "subscribed", "type": "person", "value": ["true"], "operator": "exact"}]}
 
@@ -90,13 +86,3 @@ class TestBatchAudience(ClickhouseTestMixin, BaseTest):
                 cursor = page[-1]
 
         assert collected == [_uuid(i) for i in expected_indices]
-
-    def test_use_flag_defaults_off_when_feature_enabled_raises(self):
-        # Batch sends are a critical path — a Redis/HyperCache blip that makes
-        # posthoganalytics.feature_enabled() throw must fall back to the legacy
-        # audience query, not 500 the preview endpoint or fail the resolver job.
-        with patch(
-            "products.workflows.backend.services.batch_audience.posthoganalytics.feature_enabled",
-            side_effect=RuntimeError("HyperCache is down"),
-        ):
-            assert use_workflows_batch_audience_query(self.team) is False


### PR DESCRIPTION
## Problem

The `workflows-batch-audience-query` feature flag has been at 100% rollout for all projects with no property filters since 2026-07-13. The workflows-owned audience query is therefore permanently on, and the legacy flags-owned fallback behind the flag can no longer be reached at runtime. Keeping the gate in place only adds a dead branch and a live flag evaluation on the batch-send critical path.

This is part of a workflows/CDP flag cleanup. The flag will be deleted in PostHog once this merges.

> Reviewer note: this flag was a fail-closed kill switch back to the legacy query path, so reverting it now needs a code change rather than a flag toggle.

## Changes

- Batch audience preview and person paging now always use the workflows-owned query. No user-visible behavior changes, because the flag was already on everywhere.
- Mechanical: deleted the flag constant and its `use_workflows_batch_audience_query` helper, dropped the unreachable legacy branch from the internal person-paging endpoint, and removed imports that became unused.
- The audience preview keeps both of its branches. Dedup still applies only when a `dedupe_key` is supplied and no group type is set; without those the plain person-count query still runs.
- Tests that toggled the flag now assert the always-on behavior, and the preview test is parameterized on `dedupe_key` instead.

## How did you test this code?

Automated tests were not run. This environment has no Python dependencies installed and no Postgres or ClickHouse, and the affected suites need all three. `ruff check` and `ruff format` pass on the changed files. CI is the evidence for the test suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code. No repo skill applied cleanly here: `/writing-tests` is referenced by the repo rules but is not present in this environment, so the test edits were kept to the minimum needed to drop the removed symbol while preserving the coverage each case already had.

One decision worth flagging: the preview call site guarded on three conditions, and only the flag term was removed. The remaining `dedupe_key is not None and group_type_index is None` branch still has a reachable `else`, so that fallback was kept rather than deleted along with the flag.

`products/feature_flags/backend/user_blast_radius.get_user_blast_radius_persons` is no longer called from `hog_flow.py`, but it is still used by `batch_audience.py` for the group path, so it stays.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1787564930544919)*
