### PR TITLE
chore(alerts): drop unused chartjs-plugin-annotation dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2470,9 +2470,6 @@ importers:
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
-      chartjs-plugin-annotation:
-        specifier: '*'
-        version: 3.1.0(chart.js@4.5.1)
       fast-equals:
         specifier: 'catalog:'
         version: 6.0.1

--- a/products/alerts/package.json
+++ b/products/alerts/package.json
@@ -22,7 +22,6 @@
         "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@types/react": "*",
-        "chartjs-plugin-annotation": "*",
         "fast-equals": "catalog:",
         "react": "*",
         "typescript": "catalog:*",


### PR DESCRIPTION
## Problem

`products/alerts` no longer imports `chartjs-plugin-annotation`. Its three charts were migrated to `@posthog/quill-charts`, so the annotation plugin dependency is now dead weight in the product's `package.json`.

**Why:** housekeeping left over from the alerts charts migration — the dep was only there for the old Chart.js-based charts.

## Changes

- Remove `chartjs-plugin-annotation` from `products/alerts/package.json` peer dependencies and drop its entry from the alerts importer in `pnpm-lock.yaml`.

The shared `frontend` copy of the plugin stays — `Sparkline.tsx` still uses it. No source files change.

## How did you test this code?

No behavior change. Verified nothing under `products/alerts` references `chartjs-plugin-annotation` (only the `package.json` declaration did), and regenerated the lockfile with `pnpm install --lockfile-only` so the change is limited to removing the alerts importer entry.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored dependency cleanup. No skills required — single-line `package.json` removal plus the matching lockfile entry.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*