### PR TITLE
fix(desktop): wrap activity feed header

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
@@ -88,7 +88,7 @@ export function ActivityFeedList({
 
   return (
     <div className={cn("flex min-h-0 flex-col", className)}>
-      <div className="flex h-10 shrink-0 items-center gap-2 border-border border-b pr-2 pl-3">
+      <div className="flex min-h-10 shrink-0 flex-wrap items-center gap-2 border-border border-b py-1 pr-2 pl-3">
         <span className="font-bold text-base">Activity</span>
         <div className="ml-auto flex shrink-0 items-center gap-1">
           {unreadItems.length > 0 && (


### PR DESCRIPTION
## Problem

The Activity header overflows when unread notifications add the “Mark all as read” action.

## Changes

- The Activity header now wraps its controls onto another row at narrow widths.
- The header grows beyond its 40px minimum height so wrapped controls remain visible.
- Screenshot unavailable because the Electron browser driver is not installed in this environment.

## How did you test this code?

- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check packages/ui/src/features/canvas/components/ActivityFeedList.tsx`
- `pnpm --filter @posthog/ui test -- ActivityFeedList.test.tsx`
- Live Electron verification was not run because the browser driver is unavailable.
- `hogli ci:preflight --fix` was unavailable because neither `hogli` nor `flox` is installed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested layout fix using the `/posthog-desktop` and `/writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*