### PR TITLE
fix(aio): keep the evaluation save button on screen while scrolling

### DIFF
--- a/frontend/src/layout/scenes/components/SceneStickyBar.tsx
+++ b/frontend/src/layout/scenes/components/SceneStickyBar.tsx
@@ -17,7 +17,9 @@ export function SceneStickyBar({
         <div
             className={cn(
                 'scene-sticky-bar @2xl/main-content:sticky z-20 bg-primary @2xl/main-content:top-[34px] space-y-2 py-2 -mx-4 px-4 rounded-t-xl',
-                !hasSceneTitleSection && '@2xl/main-content:top-0',
+                // Without a scene title section the bar pins itself. Sticky offsets start inside the
+                // scroll container's padding, so pull it up by that padding to stop content showing above.
+                !hasSceneTitleSection && '@2xl/main-content:-top-4',
                 className,
                 showBorderBottom && 'border-b'
             )}

--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -27,6 +27,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
+import { SceneStickyBar } from '~/layout/scenes/components/SceneStickyBar'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { urls } from '~/scenes/urls'
 import { AccessControlLevel, AccessControlResourceType, ChartDisplayType, HogQLMathType } from '~/types'
@@ -275,9 +276,11 @@ export function AIObservabilityEvaluation(): JSX.Element {
         <div className="space-y-6">
             <SceneBreadcrumbBackButton />
             {/* Header */}
-            <div className="flex justify-between items-start pb-4 border-b">
-                <div className="space-y-2">
-                    <h1 className="text-2xl font-semibold">{isNewEvaluation ? 'New evaluation' : evaluation.name}</h1>
+            <SceneStickyBar hasSceneTitleSection={false} className="flex justify-between items-start gap-2 space-y-0">
+                <div className="space-y-2 min-w-0">
+                    <h1 className="text-2xl font-semibold break-words">
+                        {isNewEvaluation ? 'New evaluation' : evaluation.name}
+                    </h1>
                     <div className="flex items-center gap-2">
                         {isNewEvaluation ? (
                             <LemonTag type="primary">New</LemonTag>
@@ -297,7 +300,7 @@ export function AIObservabilityEvaluation(): JSX.Element {
                         )}
                     </div>
                 </div>
-                <div className="flex gap-2">
+                <div className="flex gap-2 shrink-0">
                     {trendInsightUrl ? (
                         <LemonButton
                             type="secondary"
@@ -339,7 +342,7 @@ export function AIObservabilityEvaluation(): JSX.Element {
                         </AccessControlAction>
                     )}
                 </div>
-            </div>
+            </SceneStickyBar>
 
             {evaluation.status === 'error' && (
                 <LemonBanner type="error">


### PR DESCRIPTION
## Problem

Someone configuring an evaluator has to scroll back to the top of the page to save their work. The Configuration tab is a long form — basic information, prompt or code, judge model, triggers, scheduled reports — and the only "Save changes" button sits in a header that scrolls out of view.

A long evaluation name makes it worse. The title pushes the button group past the right edge of the content area, and "Save changes" is clipped off screen even at the top.

## Changes

- The header now stays pinned at the top while the form scrolls, so "Save changes" is reachable at any scroll position.
- A long evaluation name now wraps under the title instead of pushing the buttons off screen.
- The scene reuses the shared `SceneStickyBar` in place of its own header `div`. The header's contents are unchanged.
- `SceneStickyBar` now pins flush with the top of the scroll area when a scene has no title section. Its previous offset started inside the scroller's padding, leaving a strip where content showed above the bar. This scene is its only caller passing that prop.

No screenshots: the image upload step was blocked in this environment. Before the change, the bottom of the Configuration tab shows no save button at all. After it, the pinned header sits above the form with "Save changes" on the right.

> [!NOTE]
> The bar follows the house convention and pins only at the `@2xl` container width and above. Below that the header scrolls as it does today.

## How did you test this code?

Ran the change in a local dev stack and drove the scene with Playwright at 1440x900:

- Scrolled to the bottom of the Configuration tab on a saved LLM-judge evaluation. The header stays pinned and no content shows above it.
- Measured the pinned bar against the scroll container. The 16px gap that let content show through is gone.
- Edited the description, scrolled to the bottom, and clicked "Save changes" in the pinned bar. The save succeeded and the "Unsaved changes" tag cleared.
- Checked a 91-character evaluation name. The title wraps and all four buttons stay inside the content area.
- Checked the Runs tab, where the save button is correctly absent, and a 700px-wide viewport, where the header scrolls as before.

No tests added. The change is layout only, with no behavior for a test to assert that an existing test does not already cover.

Not run: the repo-wide TypeScript check does not pass in this sandbox because the nested `@posthog/quill` workspace is not built. Neither changed file appears in its output.

Before
<img width="1440" height="900" alt="before-scrolled-to-bottom" src="https://github.com/user-attachments/assets/40a917ff-7f10-4393-b6d6-1cb78715dde3" />

After
<img width="1440" height="900" alt="after-scrolled-to-bottom" src="https://github.com/user-attachments/assets/7cb530ec-df35-4d21-8370-a66bdbb0cdea" />

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The assignee is left unset because no verified GitHub handle for the requester was available in this session.

Skills invoked: `/writing-pr-descriptions`.

The first plan added a second copy of the save buttons at the bottom of the form, following the `HogFunctionConfiguration` precedent. The requester preferred a single pinned header instead, so the bottom copy was dropped. Running the scene surfaced two problems the code alone did not show: the sticky offset left a strip of content visible above the bar, and the long-name overflow already clipped the save button before this change. Both are fixed here, since pinning the header would otherwise make the clipping permanent.

Migrating this scene to `SceneTitleSection`, which is sticky by design and would remove the hand-rolled header entirely, is a larger refactor left for a separate PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
