### PR TITLE
fix(desktop): use 3px gap in activity list instead of gap-px

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
@@ -128,7 +128,7 @@ export function ActivityFeedList({
             </EmptyHeader>
           </Empty>
         ) : (
-          <div className="flex flex-col gap-px">
+          <div className="flex flex-col gap-[3px]">
             {shownItems.map((item) => (
               <ActivityRow
                 key={item.id}


### PR DESCRIPTION
## Problem

Rows in the desktop Activity list sit with a 1px gap between them; the design calls for exactly 3px of separation between activity rows in that list.

## Changes

- The Activity list now renders rows with a 3px gap instead of 1px. Single class change in `ActivityFeedList.tsx` (`gap-px` → `gap-[3px]`), fully mechanical.

## How did you test this code?

- Biome check passes on the changed file.
- Not re-rendered in the running app from this environment; the change is one Tailwind class on the activity-feed row wrapper, matching the existing `gap-[3px]` usage in the codebase.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Change was a one-class Tailwind swap in `products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx`; `gap-[3px]` was chosen over `gap-0.5` because the request specified exactly 3px.
- Skills invoked: /writing-pr-descriptions for this body. No other repo skills applied — no component restructuring, no migrations, no API or test changes.
- Verified with `pnpm exec biome check` on the changed file only; no in-app visual verification performed.
- Nothing in this PR carries non-public material.
