### PR TITLE
fix(desktop): show starting state on session dot

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -367,6 +367,8 @@ export interface SessionTrpc {
 export interface ISessionStore {
   setSession(session: AgentSession): void;
   removeSession(taskRunId: string): void;
+  setTaskStarting?(taskId: string): void;
+  clearTaskStarting?(taskId: string): void;
   updateSession(taskRunId: string, updates: Partial<AgentSession>): void;
   appendEvents(
     taskRunId: string,
@@ -1898,6 +1900,7 @@ export class SessionService {
     const { task } = params;
     const taskId = task.id;
     this.taskCreationMarks.delete(taskId);
+    this.d.store.clearTaskStarting?.(taskId);
     this.localRepoPaths.set(taskId, params.repoPath);
     this.sessionLastUsedAt.set(taskId, Date.now());
     void this.evictIdleSessions(taskId);
@@ -5222,6 +5225,7 @@ export class SessionService {
       runtimeOptions = getCloudRuntimeOptions(session, previousRun);
 
       try {
+        this.markTaskCreationInFlight(session.taskId);
         // Backend derives the snapshot from resumeFromRunId and restores the sandbox.
         updatedTask = await authCredentials.client.runTaskInCloud(
           session.taskId,
@@ -5261,11 +5265,13 @@ export class SessionService {
         throw error;
       }
     } catch (error) {
+      this.clearTaskCreationInFlight(session.taskId);
       rollbackOptimisticPrompt();
       throw error;
     }
     const newRun = updatedTask.latest_run;
     if (!newRun?.id) {
+      this.clearTaskCreationInFlight(session.taskId);
       rollbackOptimisticPrompt();
       throw new Error("Failed to create resume run");
     }
@@ -8209,6 +8215,12 @@ export class SessionService {
 
   public markTaskCreationInFlight(taskId: string): void {
     this.taskCreationMarks.set(taskId, Date.now());
+    this.d.store.setTaskStarting?.(taskId);
+  }
+
+  private clearTaskCreationInFlight(taskId: string): void {
+    this.taskCreationMarks.delete(taskId);
+    this.d.store.clearTaskStarting?.(taskId);
   }
 
   private isTaskCreationInFlight(taskId: string): boolean {
@@ -8217,7 +8229,7 @@ export class SessionService {
     const expired =
       Date.now() - markedAt > SessionService.TASK_CREATION_IN_FLIGHT_TTL_MS;
     if (expired) {
-      this.taskCreationMarks.delete(taskId);
+      this.clearTaskCreationInFlight(taskId);
       return false;
     }
     return true;

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -1900,7 +1900,6 @@ export class SessionService {
     const { task } = params;
     const taskId = task.id;
     this.taskCreationMarks.delete(taskId);
-    this.d.store.clearTaskStarting?.(taskId);
     this.localRepoPaths.set(taskId, params.repoPath);
     this.sessionLastUsedAt.set(taskId, Date.now());
     void this.evictIdleSessions(taskId);
@@ -1914,8 +1913,12 @@ export class SessionService {
     // Check for existing connected session
     const existingSession = this.d.store.getSessionByTaskId(taskId);
     if (existingSession?.status === "connected") {
+      this.d.store.clearTaskStarting?.(taskId);
       this.d.log.info("Already connected to task", { taskId });
       return;
+    }
+    if (task.latest_run?.environment !== "cloud") {
+      this.d.store.setTaskStarting?.(taskId);
     }
     if (existingSession?.status === "connecting") {
       this.d.log.info("Session already in connecting state", { taskId });

--- a/products/desktop/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -45,6 +45,8 @@ function createHarness({ spyConnect = true } = {}) {
     getSessionByTaskId: (taskId: string) =>
       Object.values(sessions).find((s) => s.taskId === taskId),
     removeSession: vi.fn(),
+    setTaskStarting: vi.fn(),
+    clearTaskStarting: vi.fn(),
     updateSession: vi.fn(),
   };
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
@@ -73,7 +75,7 @@ function createHarness({ spyConnect = true } = {}) {
   const connectToTask = spyConnect
     ? vi.spyOn(service, "connectToTask").mockResolvedValue(undefined)
     : undefined;
-  return { service, sessions, connectToTask, log };
+  return { service, sessions, connectToTask, log, store };
 }
 
 function reconcile(
@@ -162,13 +164,21 @@ describe("SessionService run-less local task recovery", () => {
     expect(connectToTask).toHaveBeenCalledTimes(1);
   });
 
-  it("clears the in-flight mark when a connect starts", async () => {
-    const { service, sessions } = createHarness({ spyConnect: false });
+  it("keeps the starting marker while clearing the recovery in-flight mark", async () => {
+    const { service, sessions, store } = createHarness({ spyConnect: false });
     const task = makeTask();
-    sessions[`run-${task.id}`] = makeSession(task.id);
+    sessions[`run-${task.id}`] = {
+      ...makeSession(task.id),
+      status: "connecting",
+    };
     service.markTaskCreationInFlight(task.id);
+    vi.mocked(store.setTaskStarting).mockClear();
+    vi.mocked(store.clearTaskStarting).mockClear();
 
     await service.connectToTask({ task, repoPath: "/repo" });
+
+    expect(store.setTaskStarting).toHaveBeenCalledWith(task.id);
+    expect(store.clearTaskStarting).not.toHaveBeenCalled();
 
     const connectToTask = vi
       .spyOn(service, "connectToTask")

--- a/products/desktop/packages/core/src/sessions/sessionStore.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStore.ts
@@ -25,12 +25,15 @@ export interface SessionState {
   sessions: Record<string, AgentSession>;
   /** Index mapping taskId -> taskRunId for O(1) lookups */
   taskIdIndex: Record<string, string>;
+  /** Task ids whose first/resumed agent session is being created. */
+  startingTaskIds: Record<string, true>;
 }
 
 export const sessionStore = createStore<SessionState>()(
   immer(() => ({
     sessions: {},
     taskIdIndex: {},
+    startingTaskIds: {},
   })),
 );
 
@@ -94,6 +97,7 @@ export const sessionStoreSetters = {
 
       state.sessions[session.taskRunId] = session;
       state.taskIdIndex[session.taskId] = session.taskRunId;
+      delete state.startingTaskIds[session.taskId];
     });
   },
 
@@ -102,8 +106,21 @@ export const sessionStoreSetters = {
       const session = state.sessions[taskRunId];
       if (session) {
         delete state.taskIdIndex[session.taskId];
+        delete state.startingTaskIds[session.taskId];
       }
       delete state.sessions[taskRunId];
+    });
+  },
+
+  setTaskStarting: (taskId: string) => {
+    sessionStore.setState((state) => {
+      state.startingTaskIds[taskId] = true;
+    });
+  },
+
+  clearTaskStarting: (taskId: string) => {
+    sessionStore.setState((state) => {
+      delete state.startingTaskIds[taskId];
     });
   },
 
@@ -436,6 +453,7 @@ export const sessionStoreSetters = {
     sessionStore.setState((state) => {
       state.sessions = {};
       state.taskIdIndex = {};
+      state.startingTaskIds = {};
     });
   },
 };

--- a/products/desktop/packages/core/src/sessions/sessionStoreEviction.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStoreEviction.test.ts
@@ -24,6 +24,21 @@ function seedWithEvents() {
 afterEach(() => sessionStoreSetters.removeSession(RUN));
 
 describe("evictEvents / restoreEvents", () => {
+  it("clears a starting marker when the session arrives", () => {
+    sessionStoreSetters.setTaskStarting(TASK);
+
+    sessionStoreSetters.setSession({
+      taskRunId: RUN,
+      taskId: TASK,
+      events: [],
+      messageQueue: [],
+      pendingPermissions: new Map(),
+      status: "connected",
+    } as unknown as AgentSession);
+
+    expect(sessionStore.getState().startingTaskIds[TASK]).toBeUndefined();
+  });
+
   it("evictEvents frees the transcript and resets the line cursor", () => {
     seedWithEvents();
     expect(sessionStore.getState().sessions[RUN].events).toHaveLength(1);

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -118,6 +118,11 @@ describe("ChannelItemRow", () => {
   // rather than the status: starting, live but stalled, or something to read.
   it.each([
     ["a permission prompt", { needsPermission: true }, "Needs your input"],
+    [
+      "an agent session being created",
+      { isAgentSessionStarting: true },
+      "Starting",
+    ],
     ["a streaming agent", { isGenerating: true }, "Working"],
     [
       // A background run is one-shot and unattended, so its in_progress really

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
@@ -1,6 +1,7 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import type { Task } from "@posthog/shared/domain-types";
 import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
+import { useTaskSessionStarting } from "@posthog/ui/features/sessions/useSession";
 import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
@@ -32,6 +33,7 @@ export function useTaskStatusInput(
 ): TaskStatusInput | null {
   const taskData = useChannelTaskData(task);
   const workspace = useWorkspace(task?.id);
+  const isAgentSessionStarting = useTaskSessionStarting(task?.id);
   const { prState, hasDiff, prUrl } = useTaskPrStatus({
     // An empty id is the hook's own "nothing to look up", so this asks for no
     // query rather than one it throws away.
@@ -56,6 +58,7 @@ export function useTaskStatusInput(
     slackThreadUrl: taskData.slackThreadUrl,
     prState,
     hasDiff,
+    isAgentSessionStarting,
     // The url is the early signal: a cloud run writes it the moment it opens the
     // PR, long before (or without ever) resolving the PR's state. A local run
     // has no cloud url, so the one the host cached against the task stands in.

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -67,6 +67,8 @@ const mockTrpcOs = vi.hoisted(() => ({
 const mockSessionStoreSetters = vi.hoisted(() => ({
   setSession: vi.fn(),
   removeSession: vi.fn(),
+  setTaskStarting: vi.fn(),
+  clearTaskStarting: vi.fn(),
   updateSession: vi.fn(),
   updateCloudStatus: vi.fn(),
   appendEvents: vi.fn(),
@@ -7680,6 +7682,9 @@ describe("SessionService", () => {
       );
 
       expect(result.stopReason).toBe("queued");
+      expect(mockSessionStoreSetters.setTaskStarting).toHaveBeenCalledWith(
+        "task-123",
+      );
       expect(mockAuthenticatedClient.runTaskInCloud).toHaveBeenCalledWith(
         "task-123",
         "feature/codex-run",

--- a/products/desktop/packages/ui/src/features/sessions/useSession.ts
+++ b/products/desktop/packages/ui/src/features/sessions/useSession.ts
@@ -198,3 +198,10 @@ export const useSessionHandoffInProgress = (
     return s.sessions[taskRunId]?.handoffInProgress ?? false;
   });
 };
+
+export const useTaskSessionStarting = (taskId: string | undefined): boolean => {
+  return useSessionStore((s) => {
+    if (!taskId) return false;
+    return s.startingTaskIds[taskId] === true;
+  });
+};

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -24,6 +24,7 @@ import { SlackMark } from "@posthog/ui/primitives/SlackMark";
  */
 export type TaskStatusInput = TaskIconProps & {
   prUrl?: string | null;
+  isAgentSessionStarting?: boolean;
 };
 
 /**
@@ -146,13 +147,14 @@ export function taskDot(props: TaskStatusInput): TaskDot {
   // status, so it can sit there for hours after the agent is done with it.
   const isStartingCloudRun =
     props.taskRunStatus === "queued" && props.workspaceMode === "cloud";
-  if (props.isGenerating || isStartingCloudRun) {
+  const isStarting = props.isAgentSessionStarting || isStartingCloudRun;
+  if (props.isGenerating || isStarting) {
     return {
       tone: "yellow",
       style: "solid",
       pulse: false,
       spinner: true,
-      label: props.isGenerating ? "Working" : "Starting",
+      label: props.isGenerating && !isStarting ? "Working" : "Starting",
     };
   }
   // Only a background run's status is a claim about work. An interactive run is


### PR DESCRIPTION
## Problem

People starting or resuming an agent session did not see the session dot move until the run or session appeared.

## Changes

- The session dot now shows the existing spinning Starting state while the app creates a first or resumed agent session.
- The starting marker clears when the new session reaches the shared session store, or when resume creation fails.
- The rest is mechanical: the status hook reads the new marker and passes it to the existing dot vocabulary.

No screenshot included. The changed state is a short-lived spinner before the session connects.

## How did you test this code?

- `pnpm --filter @posthog/core test src/sessions/sessionStoreEviction.test.ts`
- `pnpm --filter @posthog/ui test src/features/canvas/components/ChannelItemRow.test.tsx src/features/sessions/sessionServiceHost.test.ts`
- `pnpm exec biome check --write --unsafe packages/core/src/sessions/sessionStore.ts packages/core/src/sessions/sessionService.ts packages/core/src/sessions/sessionStoreEviction.test.ts packages/ui/src/features/sessions/useSession.ts packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx packages/ui/src/features/sessions/sessionServiceHost.test.ts`
- `pnpm --filter @posthog/core typecheck`
- `pnpm --filter @posthog/ui typecheck`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This fixes a transient desktop status indicator.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). No assignee set because no GitHub handle was provided in this thread.

The implementation used the `/posthog-desktop` and `/writing-pr-descriptions` skills. The change keeps the existing dot spinner vocabulary and adds only the missing observable starting state.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
