### PR TITLE
fix(desktop): mobile label pull request comment links

### DIFF
--- a/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.test.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.test.tsx
@@ -11,6 +11,21 @@ vi.mock("@/features/auth", () => ({
   getCloudUrlFromRegion: () => null,
 }));
 
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({
+    gray: { 11: "#444444", 12: "#000000" },
+    status: { success: "#00aa00", error: "#cc0000" },
+  }),
+  toRgba: (hex: string, alpha: number) => `${hex}/${alpha}`,
+  MERGED_COLOR: "#8e4ec6",
+}));
+
+vi.mock("@/lib/openExternalUrl", () => ({ openExternalUrl: vi.fn() }));
+
+vi.mock("../../tasks/hooks/usePrStatus", () => ({
+  usePrStatus: () => ({ data: undefined }),
+}));
+
 function renderTree(content: string): string {
   let renderer: ReturnType<typeof create> | null = null;
   act(() => {
@@ -57,6 +72,20 @@ describe("MarkdownText", () => {
       content: 'Loading <flag id="4',
       present: ["Loading"],
       absent: ["<flag"],
+    },
+    {
+      name: "bare review-comment link labels the comment",
+      content:
+        "[https://github.com/o/r/pull/12#discussion_r99](https://github.com/o/r/pull/12#discussion_r99)",
+      present: ["Comment on PR #12"],
+      absent: ["o/r#12"],
+    },
+    {
+      name: "review-comment link with explicit text keeps that text",
+      content:
+        "[see the review](https://github.com/o/r/pull/12#discussion_r99)",
+      present: ["see the review"],
+      absent: ["Comment on PR"],
     },
   ])("$name", ({ content, present, absent }) => {
     const tree = renderTree(content);

--- a/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.tsx
@@ -367,9 +367,10 @@ function renderInline(
       const githubRef = parseGithubIssueUrl(url);
       if (githubRef) {
         const isAutoLink = linkText === url;
-        const label = isAutoLink
-          ? `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`
-          : linkText;
+        const autoLinkLabel = githubRef.isReviewComment
+          ? `Comment on PR #${githubRef.number}`
+          : `${githubRef.owner}/${githubRef.repo}#${githubRef.number}`;
+        const label = isAutoLink ? autoLinkLabel : linkText;
         nodes.push(
           <GithubRefChip
             key={match.index}

--- a/products/desktop/apps/mobile/src/lib/githubIssueUrl.test.ts
+++ b/products/desktop/apps/mobile/src/lib/githubIssueUrl.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseGithubIssueUrl } from "./githubIssueUrl";
+
+describe("parseGithubIssueUrl", () => {
+  it.each([
+    {
+      name: "PR review comment via discussion anchor",
+      url: "https://github.com/o/r/pull/12#discussion_r3647131256",
+      isReviewComment: true,
+    },
+    {
+      name: "PR review comment via files anchor",
+      url: "https://github.com/o/r/pull/12/files#r3647131256",
+      isReviewComment: true,
+    },
+    {
+      name: "PR issue comment is not a review comment",
+      url: "https://github.com/o/r/pull/12#issuecomment-123",
+      isReviewComment: false,
+    },
+    {
+      name: "issue with an r-style anchor is not a review comment",
+      url: "https://github.com/o/r/issues/12#r3647131256",
+      isReviewComment: false,
+    },
+    {
+      name: "plain PR url",
+      url: "https://github.com/o/r/pull/12",
+      isReviewComment: false,
+    },
+    {
+      name: "plain issue url",
+      url: "https://github.com/o/r/issues/12",
+      isReviewComment: false,
+    },
+  ])("$name", ({ url, isReviewComment }) => {
+    expect(parseGithubIssueUrl(url)?.isReviewComment).toBe(isReviewComment);
+  });
+
+  it("keeps the comment anchor in the normalized url", () => {
+    expect(
+      parseGithubIssueUrl(
+        "https://github.com/o/r/pull/12#discussion_r3647131256",
+      )?.normalizedUrl,
+    ).toBe("https://github.com/o/r/pull/12#discussion_r3647131256");
+  });
+});

--- a/products/desktop/apps/mobile/src/lib/githubIssueUrl.ts
+++ b/products/desktop/apps/mobile/src/lib/githubIssueUrl.ts
@@ -6,6 +6,7 @@ export interface ParsedGithubIssueUrl {
   repo: string;
   number: number;
   normalizedUrl: string;
+  isReviewComment: boolean;
 }
 
 const GITHUB_ISSUE_URL_PATTERN =
@@ -26,11 +27,13 @@ export function parseGithubIssueUrl(text: string): ParsedGithubIssueUrl | null {
   // they were copied from. Without a fragment the tab/query suffix is noise.
   const hashIndex = suffix.indexOf("#");
   const hasFragment = hashIndex !== -1 && hashIndex < suffix.length - 1;
+  const fragment = hasFragment ? suffix.slice(hashIndex + 1) : "";
   return {
     kind,
     owner,
     repo,
     number,
     normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}${hasFragment ? suffix : ""}`,
+    isReviewComment: kind === "pr" && /^(?:discussion_)?r\d+$/.test(fragment),
   };
 }


### PR DESCRIPTION
## Problem

In the mobile app's agent chat, a bare GitHub link to a pull request review comment showed the same chip as a link to the PR itself — `owner/repo#number`. From the thread you could not tell the link pointed at a specific review comment.

This is a port of #87545, which fixed the same thing on desktop.

## Changes

- A bare review-comment link now renders the chip label `Comment on PR #<number>` instead of `owner/repo#number`.
- A link with explicit link text keeps that text.
- Mechanical: the mobile URL parser gains an `isReviewComment` flag, set when a PR URL fragment matches a review-comment anchor (`#discussion_r<digits>` or `/files#r<digits>`). The normalized URL keeps the anchor, so the link still opens on the right comment.

The mobile app carries its own copy of the parser and its own markdown renderer, so the change lives in the mobile tree rather than the shared packages the desktop PR touched.

Nothing else looks different; the chip styling and tap behavior are unchanged.

## How did you test this code?

Automated tests, added in the mobile tree:

- Parser cases in `githubIssueUrl.test.ts` cover the two review-comment anchor shapes, an issue-comment anchor, an issue URL with an `r`-style fragment, and plain PR/issue URLs — guarding against the flag firing on non-review-comment links or on issues. One case locks in that the anchor survives in the normalized URL.
- `MarkdownText.test.tsx` gains a case that a bare review-comment link renders `Comment on PR #<number>`, and one that an explicit-link-text link keeps its text.

Ran `pnpm --filter @posthog/mobile test`, `lint`, and `node scripts/check-mobile-types.mjs` locally. Not run: the app itself in a simulator — this was verified through the unit tests only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Ported desktop PR #87545 into `products/desktop/apps/mobile`. Skills invoked: `/writing-tests`, `/simplify`, `/writing-pr-descriptions`.

The desktop PR carried explanatory docstrings on the parser and chip helper; those were left out here per the porting request to keep comments minimal. `/simplify` flattened a nested ternary in the label computation. The mobile chip's accessibility label prepends "GitHub pull request" to the label, so a review comment reads "GitHub pull request Comment on PR #12" — kept as-is, since category + name + state stacking is a normal accessibility pattern and matches the chip's existing convention.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
