### PR TITLE
chore(agents): add announcing-behavior-changes skill

### DIFF
--- a/.agents/skills/announcing-behavior-changes/SKILL.md
+++ b/.agents/skills/announcing-behavior-changes/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: announcing-behavior-changes
+description: >
+  Decides whether a behavior-changing fix needs an in-app notice, then builds one that reaches only the affected users and can be removed later.
+  Use when a change alters what an existing user sees without them doing anything — a metric moves, a chart shifts, a count drops, a date range resolves differently, a matcher matches differently — and when adding, reviewing, or removing such a notice.
+  Trigger terms: behavior change, breaking change, semantics change, "results may differ", change notice, deprecation banner, migration banner.
+  Carries the gate (narrow to the affected users with a tested predicate, or do not ship a notice at all), the pattern from `SqlInsightDateFilterNotice`, where to anchor the notice, and the flag-based removal path.
+  Not for new features (use the changelog), not for permanent per-object warnings computed by the backend, and not for the wording itself (see `/writing-user-facing-copy`).
+---
+
+# Announcing behavior changes
+
+Some fixes correct wrong behavior but change what a user sees. The number moves, the chart shifts, the count drops. Nothing is broken, but from the user's side it is indistinguishable from a regression, and they have no way to find out why.
+
+An in-app change notice closes that gap: it appears where the user sees the different result, says what changed, and then goes away.
+
+The reference implementation is `frontend/src/queries/nodes/DataVisualization/Components/SqlInsightDateFilterNotice.tsx`, shipped in commit `76f2905222a` alongside the backend change it explains. Read it before writing a new one — it is 60 lines and it is the whole pattern.
+
+## First: does this change need a notice?
+
+Most changes do not. A notice that fires for people it does not concern is worse than no notice, because it teaches everyone to dismiss banners without reading them. Ship one only when all four hold.
+
+1. **A user who does nothing sees something different.** Not a new feature, not a change they opted into behind a flag.
+2. **They cannot work out why from the screen.** If the UI already explains it, the UI is the notice.
+3. **The difference is big enough to notice.** A rounding change in the fourth decimal is not.
+4. **You can identify who is affected, in code.** See below — this is the one that usually fails.
+
+### The narrowing test
+
+Write the predicate first. If you cannot express "this user is affected" as a function of state the client already has, you are about to show a banner to everyone about something that concerns a minority.
+
+When that happens, pick a different mechanism instead of widening the blast radius:
+
+| Situation                                                                   | Use instead                                                                                                                                                                    |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Only the backend can tell who is affected                                   | A per-object field on the API response, rendered where that object is shown. `Action.selector_warning` ([#80653](https://github.com/PostHog/posthog/pull/80653)) is the model. |
+| The condition is permanent, not a one-time transition                       | Same — a computed warning, not a time-boxed notice.                                                                                                                            |
+| Everyone is affected but the change is minor                                | Changelog only.                                                                                                                                                                |
+| The old behavior was plainly broken and the new one is self-evidently right | Nothing. An error that stops happening needs no announcement.                                                                                                                  |
+
+## The pattern
+
+Five pieces. All of them ship in the **same PR as the behavior change**, so a reviewer sees the change and its explanation together, and the notice cannot be forgotten once the change is out.
+
+### 1. An exported, tested predicate
+
+Mirror the backend rule in a named function, and say in a comment which backend code it mirrors so the two can be kept honest.
+
+```ts
+/** Whether the SQL date filter resolution fix can produce different results for this query.
+ * Mirrors the affected shapes of ReplaceFilters in posthog/hogql/filters.py. */
+export function isAffectedByDateFilterResolutionChange(source: HogQLQuery): boolean {
+```
+
+Export it separately from the component so it can be unit tested without rendering.
+
+### 2. A feature flag
+
+Declare it in `frontend/src/lib/constants.tsx` with an owner comment, in the same style as the neighbours:
+
+```ts
+SQL_INSIGHT_DATE_FILTER_NOTICE: 'sql-insight-date-filter-notice', // owner: #team-product-analytics, gates the notice on SQL insights affected by the date filter resolution fix
+```
+
+The flag does three jobs: it lets you roll the notice out gradually, it lets you turn it off without a deploy if the copy is wrong or the predicate is too broad, and it is the handle you retire the notice by when it has served its purpose.
+
+### 3. A component that returns `null` by default
+
+Both gates, flag first — it is the cheaper check and the kill switch:
+
+```tsx
+export function SqlInsightDateFilterNotice({ source }: { source: HogQLQuery }): JSX.Element | null {
+  const { featureFlags } = useValues(featureFlagLogic)
+
+  if (!featureFlags[FEATURE_FLAGS.SQL_INSIGHT_DATE_FILTER_NOTICE] || !isAffectedByDateFilterResolutionChange(source)) {
+    return null
+  }
+
+  return (
+    <LemonBanner type="info" dismissKey="sql-insight-date-filter-notice">
+      Date filters on SQL insights now match other insights: relative ranges start at midnight, and open-ended ranges
+      include all of today but nothing after. Results may differ slightly from before.
+    </LemonBanner>
+  )
+}
+```
+
+Use `LemonBanner` — do not hand-roll. `type="info"`, because nothing is wrong. `dismissKey` gives permanent per-user dismissal through `lemonBannerLogic`'s `persist: true` reducer, at no cost. Keep the key stable and equal to the flag key; changing it re-shows the notice to everyone who already dismissed it.
+
+### 4. An anchor where the result appears
+
+Render it next to the thing that looks different, not next to the control that changed. The exemplar sits above the visualization in `DataVisualization.tsx`, not on the date filter, because the chart is what the user is staring at.
+
+Prefer one shared render site over many. A notice about relative date ranges placed in `frontend/src/lib/components/DateFilter/DateFilter.tsx` reaches insights, dashboards, web analytics, session replay, error tracking, and AI observability at once, because they all render that component.
+
+### 5. A removal date
+
+The exemplar is missing this, and it is the reason the repo still carries `WebAnalyticsFiltersV2MigrationBanner.tsx` (added January 2026, untouched since) and `SamplingDeprecationNotice.tsx`. Nobody deletes these.
+
+Put the date in a comment above the component, and repeat it in the flag's description in PostHog so it is visible to whoever audits flags later:
+
+```tsx
+// Remove after 2026-11-01, once affected users have had a full quarter to see it.
+```
+
+Be aware of what this does and does not buy you. Turning the flag off kills the notice immediately and without a deploy, so the user-visible half of removal is solved. Deleting the code is not: **nothing in CI or in any scheduled job currently checks these dates**, and the repo has no automated stale-flag sweep. The date is a note to a human.
+
+So take the last step yourself. When you turn the flag off, open the follow-up in the same sitting and delete the component, its test, the flag constant, and the render site together. `/cleaning-up-stale-feature-flags` helps find the flag once it has gone quiet, but it works against a PostHog project's flags, not against this repo's code — it will not tell you the component is still there.
+
+If you are reading this because notices have piled up, that is the gap to close, and it is a better investment than adding features to the notices themselves.
+
+## Writing the copy
+
+Invoke `/writing-user-facing-copy` for the voice rules. The shape that works for this genre is two clauses: **what changed, concretely**, then **that results may differ**.
+
+> Date filters on SQL insights now match other insights: relative ranges start at midnight, and open-ended ranges include all of today but nothing after. Results may differ slightly from before.
+
+- Describe the new behavior in terms of what the user sees, not the internals. "Relative ranges start at midnight", not "`date_from` snaps via `relative_date_parse`".
+- Say plainly that numbers may differ. That sentence is the whole point — it is what stops someone filing a bug.
+- Do not apologize, and do not call it a fix or an improvement. Both editorialize, and "we fixed a bug" implies their old numbers were worthless, which is usually more alarming than the truth.
+- Two sentences. If it needs more, link to docs.
+
+## Testing
+
+The predicate gets a parameterized unit test covering affected **and** unaffected cases — a wrong predicate means either silence for the people who needed telling, or a banner for everyone else. `SqlInsightDateFilterNotice.test.ts` is the model: `it.each` over `[name, input, expected]`, with comments grouping the cases by the rule they exercise.
+
+Do not test the component's rendering. The flag check and `LemonBanner` are both already covered; per `/writing-tests`, that test catches no realistic regression.
+
+## Checklist
+
+- [ ] The four gate conditions hold, and the predicate narrows to the affected users
+- [ ] Predicate exported, commented with the backend code it mirrors, and unit tested both ways
+- [ ] Flag declared in `lib/constants.tsx` with an owner comment
+- [ ] Component returns `null` unless flag and predicate both pass
+- [ ] `LemonBanner type="info"` with a `dismissKey` equal to the flag key
+- [ ] Anchored where the changed result appears, at the most shared render site available
+- [ ] `// Remove after YYYY-MM-DD` comment above the component
+- [ ] Shipped in the same PR as the behavior change it explains

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 **Invoke when in the area:**
 
 - `/writing-dataclasses` — adding or changing a Python dataclass, replacing a tuple or `dict[str, Any]` payload, or passing a dataclass or facade contract through internal layers
+- `/announcing-behavior-changes` — shipping a fix that changes what an existing user sees (a metric moves, a count drops, a range resolves differently), or adding, reviewing, or removing an in-app change notice
 - `/merging-prs` — merging a PR, or babysitting one through the Trunk merge queue
 - `/stacking-prs` — creating, restacking, adopting, or landing a stack of PRs (`gh stack`)
 - `/implementing-mcp-tools` — adding/modifying endpoints or `tools.yaml`


### PR DESCRIPTION
## Problem

A fix that corrects wrong behavior changes what an existing user already sees. The number moves, nothing on screen says why, and it reads as a regression.

Three notices answer that today, each hand-rolled independently: `SamplingDeprecationNotice.tsx`, `WebAnalyticsFiltersV2MigrationBanner.tsx`, and `SqlInsightDateFilterNotice.tsx`. The last one shipped in July alongside the change it explains, and it solved every hard part: a tested predicate that narrows to affected queries, a feature flag to roll out and kill, and an anchor at the chart the user is looking at. Nothing points the next engineer at it.

More of these are coming. [#80653](https://github.com/PostHog/posthog/pull/80653) changes autocapture selector matching in both directions, so some existing actions will count differently after deploy.

## Changes

- An engineer shipping a behavior change gets a documented pattern and, first, a gate on whether to use one at all.
- The gate: ship a notice only if you can express "this user is affected" as a predicate. Cases that fail route to a per-object API warning, the changelog, or nothing.
- The pattern is the five parts of `SqlInsightDateFilterNotice`: tested predicate, flag with an owner comment, component that returns `null` unless both gates pass, anchor where the changed result appears, removal date.
- The skill states that removal is unenforced. No CI check and no scheduled job read the removal date, and the repo has no stale-flag sweep.
- `AGENTS.md` gains one line in the "Invoke when in the area" list. Mechanical.

This PR changes nothing a user sees. It ships agent instructions only. The screenshot below is the target those instructions describe, rendered from the already-merged exemplar rather than from anything in this diff.

![change-notice-example](https://raw.githubusercontent.com/PostHog/pr-assets/3223c872f2a3a8718fe2768d5d4f14a5e69b9ed3/2026/08/4887ba2c-2ed4-4103-8d1c-8fc3ce00f6ae.png)

The notice sits between the date filter that set the range and the chart that now reads differently. It states what changed and that results may differ, and it dismisses. That placement is the skill's fourth rule: anchor where the result appears, not on the control that changed.

> [!NOTE]
> The skill argues against the obvious alternative. A generalized notice system with a registry, per-user dismissal and a roll-up feed was scoped first. The three existing notices, one of them three weeks old, show the pattern reproduces without one, so this documents the pattern instead of replacing it.

## How did you test this code?

`hogli ci:preflight` passes on both files in strict mode. Nothing in the diff executes, and no automated test covers skill markdown.

The screenshot came from rendering the real `SqlInsightDateFilterNotice` in Storybook, through a throwaway story that turned its flag on and gave it a query shaped to trip the predicate. That confirms the documented pattern renders as described. The story and its capture script were deleted, so neither appears in this diff.

Every claim the skill makes about the repo was checked against it: `git log --diff-filter=A` for the ages of the existing notices, and a search of `.github/workflows/` and the feature flag model for a stale-flag sweep, which found none.

Not checked: whether an agent picks the skill up from a realistic prompt. That needs a live run against the trigger terms in the description.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Agent instructions only, and no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude via PostHog Desktop, directed by @GeneralistDev. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`, `/setting-feature-flags-in-storybook`.

The session opened as a design for a general change-notice system: an in-repo registry, backend-persisted dismissal, expiry enforcement, and a "recent changes" roll-up in the side panel. Exploring the codebase turned up `SqlInsightDateFilterNotice`, added three weeks earlier for a comparable change, already doing the hard parts correctly. That evidence collapsed the scope to documenting the existing pattern.

Two things were deliberately left undone. Removal has no enforcement, and the skill says so plainly rather than implying a process exists, because closing that gap needs a scheduled sweep that belongs in its own change. An earlier draft proposed failing CI on an expired removal date; that was dropped, since a time-bomb that breaks master for an unrelated pusher is the wrong shape.

**Public artifact:** the diff carries no material from the agent session that is not already public. The referenced PR, commit, and files are public in this repository, and the screenshot renders committed Storybook fixture data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
