### PR TITLE
feat(desktop): mobile organization consent gate

### DIFF
--- a/products/desktop/apps/mobile/src/app/_layout.tsx
+++ b/products/desktop/apps/mobile/src/app/_layout.tsx
@@ -15,6 +15,7 @@ import {
   OfflineBanner,
 } from "@/components/OfflineBanner";
 import { useAuthStore } from "@/features/auth";
+import { useOrgConsent } from "@/features/consent/hooks/useOrgConsent";
 import { setupNotificationResponseListener } from "@/features/notifications/lib/notifications";
 import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
 import { PendingPromptRecovery } from "@/features/tasks/components/PendingPromptRecovery";
@@ -37,6 +38,7 @@ function RootLayoutNav({ isConnected }: RootLayoutNavProps) {
   const { isAuthenticated, isLoading, initializeAuth } = useAuthStore();
   const themeColors = useThemeColors();
   const pathname = usePathname();
+  const consent = useOrgConsent();
 
   useScreenTracking();
   useIdentifyUser();
@@ -64,7 +66,24 @@ function RootLayoutNav({ isConnected }: RootLayoutNavProps) {
     router.replace(next ? { pathname: "/auth", params: { next } } : "/auth");
   }, [isAuthenticated, isLoading, pathname]);
 
-  if (isLoading) {
+  // Consent gate. Keep a signed-in user out of the app until their organization
+  // has met both consent requirements, even if a deep link drops them straight
+  // onto a protected route. Wait for the status to resolve before routing so we
+  // never bounce a user whose consent we haven't checked yet.
+  const consentSatisfied = consent.status === "resolved" && consent.satisfied;
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || pathname === "/auth") return;
+    if (consent.status === "loading") return;
+    if (!consentSatisfied && pathname !== "/consent") {
+      router.replace("/consent");
+    } else if (consentSatisfied && pathname === "/consent") {
+      router.replace("/(tabs)/tasks");
+    }
+  }, [isAuthenticated, isLoading, consent.status, consentSatisfied, pathname]);
+
+  // Hold the app on a spinner until consent resolves, so tabs never render for
+  // a frame before the gate redirects an unconsented user.
+  if (isLoading || (isAuthenticated && consent.status === "loading")) {
     return (
       <View className="flex-1 items-center justify-center bg-background">
         <ActivityIndicator size="large" color={themeColors.accent[9]} />
@@ -84,6 +103,7 @@ function RootLayoutNav({ isConnected }: RootLayoutNavProps) {
     >
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="auth" options={{ headerShown: false }} />
+      <Stack.Screen name="consent" options={{ headerShown: false }} />
       <Stack.Screen name="index" options={{ headerShown: false }} />
 
       {/* Tinder-style inbox review */}

--- a/products/desktop/apps/mobile/src/app/_layout.tsx
+++ b/products/desktop/apps/mobile/src/app/_layout.tsx
@@ -6,7 +6,7 @@ import { router, Stack, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useColorScheme } from "nativewind";
 import { PostHogProvider } from "posthog-react-native";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { ActivityIndicator, View } from "react-native";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -71,19 +71,33 @@ function RootLayoutNav({ isConnected }: RootLayoutNavProps) {
   // onto a protected route. Wait for the status to resolve before routing so we
   // never bounce a user whose consent we haven't checked yet.
   const consentSatisfied = consent.status === "resolved" && consent.satisfied;
+  // Where the user was heading when the gate intercepted, so a deep link opened
+  // before consent is restored once both requirements are met.
+  const pendingHrefRef = useRef<string | null>(null);
   useEffect(() => {
     if (isLoading || !isAuthenticated || pathname === "/auth") return;
     if (consent.status === "loading") return;
-    if (!consentSatisfied && pathname !== "/consent") {
-      router.replace("/consent");
-    } else if (consentSatisfied && pathname === "/consent") {
-      router.replace("/(tabs)/tasks");
+    if (!consentSatisfied) {
+      if (pathname !== "/consent") {
+        if (pathname !== "/") pendingHrefRef.current = pathname;
+        router.replace("/consent");
+      }
+    } else if (pathname === "/consent") {
+      const next = pendingHrefRef.current ?? "/(tabs)/tasks";
+      pendingHrefRef.current = null;
+      router.replace(next);
     }
   }, [isAuthenticated, isLoading, consent.status, consentSatisfied, pathname]);
 
-  // Hold the app on a spinner until consent resolves, so tabs never render for
-  // a frame before the gate redirects an unconsented user.
-  if (isLoading || (isAuthenticated && consent.status === "loading")) {
+  // Hold the app on a spinner while an authenticated user's consent is unknown
+  // or unmet, so no protected route renders for a frame before the gate
+  // redirects to /consent.
+  const blockUntilConsent =
+    isAuthenticated &&
+    !consentSatisfied &&
+    pathname !== "/consent" &&
+    pathname !== "/auth";
+  if (isLoading || blockUntilConsent) {
     return (
       <View className="flex-1 items-center justify-center bg-background">
         <ActivityIndicator size="large" color={themeColors.accent[9]} />

--- a/products/desktop/apps/mobile/src/app/consent.tsx
+++ b/products/desktop/apps/mobile/src/app/consent.tsx
@@ -1,0 +1,96 @@
+import { Text } from "@components/text";
+import { EXTERNAL_LINKS } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+import { usePostHog } from "posthog-react-native";
+import {
+  ActivityIndicator,
+  ScrollView,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useAuthStore, useUserQuery } from "@/features/auth";
+import { ConsentError } from "@/features/consent/components/ConsentError";
+import { ConsentPanel } from "@/features/consent/components/ConsentPanel";
+import {
+  desktopBetaTermsKeys,
+  useOrgConsent,
+} from "@/features/consent/hooks/useOrgConsent";
+import { openExternalUrl } from "@/lib/openExternalUrl";
+import { getPostHogApiClient } from "@/lib/posthogApiClient";
+import { useThemeColors } from "@/lib/theme";
+
+const ORGANIZATION_ADMIN_LEVEL = 8;
+
+export default function ConsentScreen() {
+  const themeColors = useThemeColors();
+  const consent = useOrgConsent();
+  const { data: user } = useUserQuery();
+  const logout = useAuthStore((s) => s.logout);
+  const posthog = usePostHog();
+  const queryClient = useQueryClient();
+
+  const organization = user?.organization;
+  const isAdmin =
+    (organization?.membership_level ?? 0) >= ORGANIZATION_ADMIN_LEVEL;
+
+  const acceptAi = async (): Promise<void> => {
+    if (!organization) return;
+    await getPostHogApiClient().approveAiDataProcessing(organization.id);
+    posthog?.capture(ANALYTICS_EVENTS.AI_CONSENT_GRANTED_INAPP);
+    await queryClient.invalidateQueries({ queryKey: ["user"] });
+  };
+
+  const acceptBeta = async (): Promise<void> => {
+    if (!organization) return;
+    await getPostHogApiClient().acceptDesktopBetaTerms(organization.id);
+    posthog?.capture(ANALYTICS_EVENTS.DESKTOP_BETA_TERMS_ACCEPTED_INAPP);
+    await queryClient.invalidateQueries({
+      queryKey: desktopBetaTermsKeys.all(),
+    });
+  };
+
+  const handleLogout = async (): Promise<void> => {
+    await logout();
+    router.replace("/auth");
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-gray-1">
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="px-6 pt-12 pb-8"
+        keyboardShouldPersistTaps="handled"
+      >
+        {consent.status === "error" ? (
+          <ConsentError onRetry={consent.retry} />
+        ) : consent.status === "resolved" && !consent.satisfied ? (
+          <ConsentPanel
+            organizationName={organization?.name}
+            needsAiConsent={consent.needsAiConsent}
+            needsBetaTerms={consent.needsBetaTerms}
+            isAdmin={isAdmin}
+            onAcceptAi={acceptAi}
+            onAcceptBeta={acceptBeta}
+          />
+        ) : (
+          <View className="items-center py-24">
+            <ActivityIndicator size="large" color={themeColors.accent[9]} />
+          </View>
+        )}
+      </ScrollView>
+      <View className="flex-row items-center justify-between px-6 pb-4">
+        <TouchableOpacity
+          onPress={() => openExternalUrl(EXTERNAL_LINKS.discord)}
+        >
+          <Text className="text-gray-11 text-sm">Get support</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={handleLogout}>
+          <Text className="text-gray-11 text-sm">Log out</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/products/desktop/apps/mobile/src/app/consent.tsx
+++ b/products/desktop/apps/mobile/src/app/consent.tsx
@@ -4,12 +4,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useQueryClient } from "@tanstack/react-query";
 import { router } from "expo-router";
 import { usePostHog } from "posthog-react-native";
-import {
-  ActivityIndicator,
-  ScrollView,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { ActivityIndicator, Pressable, ScrollView, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAuthStore, useUserQuery } from "@/features/auth";
 import { ConsentError } from "@/features/consent/components/ConsentError";
@@ -82,14 +77,12 @@ export default function ConsentScreen() {
         )}
       </ScrollView>
       <View className="flex-row items-center justify-between px-6 pb-4">
-        <TouchableOpacity
-          onPress={() => openExternalUrl(EXTERNAL_LINKS.discord)}
-        >
+        <Pressable onPress={() => openExternalUrl(EXTERNAL_LINKS.discord)}>
           <Text className="text-gray-11 text-sm">Get support</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={handleLogout}>
+        </Pressable>
+        <Pressable onPress={handleLogout}>
           <Text className="text-gray-11 text-sm">Log out</Text>
-        </TouchableOpacity>
+        </Pressable>
       </View>
     </SafeAreaView>
   );

--- a/products/desktop/apps/mobile/src/app/index.tsx
+++ b/products/desktop/apps/mobile/src/app/index.tsx
@@ -4,7 +4,8 @@ import { useAuthStore } from "@/features/auth";
 export default function Index() {
   const { isAuthenticated } = useAuthStore();
 
-  // Redirect to tasks if authenticated, otherwise to login
+  // Redirect to tasks if authenticated, otherwise to login. The consent gate in
+  // the root layout bounces unconsented users to /consent from here.
   if (isAuthenticated) {
     return <Redirect href="/(tabs)/tasks" />;
   }

--- a/products/desktop/apps/mobile/src/features/auth/hooks/useUserQuery.ts
+++ b/products/desktop/apps/mobile/src/features/auth/hooks/useUserQuery.ts
@@ -12,6 +12,8 @@ export interface UserData {
   organization?: {
     id: string;
     name: string;
+    is_ai_data_processing_approved?: boolean;
+    membership_level?: number;
   };
   team?: {
     id: number;

--- a/products/desktop/apps/mobile/src/features/auth/lib/constants.ts
+++ b/products/desktop/apps/mobile/src/features/auth/lib/constants.ts
@@ -10,6 +10,10 @@ export const OAUTH_SCOPES = [
   // rejects push-token registration with 403 and notifications never fire.
   "user:write",
   "project:read",
+  // Required for the organization consent gate: the beta-terms read and the
+  // AI-data-processing / beta-terms writes hit organization-scoped endpoints.
+  "organization:read",
+  "organization:write",
   "task:write",
   "integration:read",
   "conversation:write",
@@ -17,7 +21,7 @@ export const OAUTH_SCOPES = [
   "llm_skill:read",
 ];
 
-export const OAUTH_SCOPE_VERSION = 1;
+export const OAUTH_SCOPE_VERSION = 2;
 
 // Token refresh settings
 export const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes before expiry

--- a/products/desktop/apps/mobile/src/features/consent/components/ConsentError.tsx
+++ b/products/desktop/apps/mobile/src/features/consent/components/ConsentError.tsx
@@ -1,0 +1,28 @@
+import { Text } from "@components/text";
+import { TouchableOpacity, View } from "react-native";
+
+interface ConsentErrorProps {
+  onRetry: () => void;
+}
+
+export function ConsentError({ onRetry }: ConsentErrorProps) {
+  return (
+    <View className="gap-4">
+      <Text className="font-semibold text-2xl text-gray-12">
+        Couldn't check organization consent
+      </Text>
+      <Text className="text-base text-gray-11">
+        Check your connection and try again. If it keeps happening, contact
+        support.
+      </Text>
+      <TouchableOpacity
+        className="mt-1 items-center rounded-lg bg-accent-9 py-3"
+        onPress={onRetry}
+      >
+        <Text className="font-semibold text-accent-contrast text-sm">
+          Retry
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/consent/components/ConsentError.tsx
+++ b/products/desktop/apps/mobile/src/features/consent/components/ConsentError.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@components/text";
-import { TouchableOpacity, View } from "react-native";
+import { Pressable, View } from "react-native";
 
 interface ConsentErrorProps {
   onRetry: () => void;
@@ -15,14 +15,14 @@ export function ConsentError({ onRetry }: ConsentErrorProps) {
         Check your connection and try again. If it keeps happening, contact
         support.
       </Text>
-      <TouchableOpacity
-        className="mt-1 items-center rounded-lg bg-accent-9 py-3"
+      <Pressable
+        className="mt-1 items-center rounded-lg bg-accent-9 py-3 active:opacity-80"
         onPress={onRetry}
       >
         <Text className="font-semibold text-accent-contrast text-sm">
           Retry
         </Text>
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 }

--- a/products/desktop/apps/mobile/src/features/consent/components/ConsentPanel.test.tsx
+++ b/products/desktop/apps/mobile/src/features/consent/components/ConsentPanel.test.tsx
@@ -1,0 +1,80 @@
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { ConsentPanel } from "./ConsentPanel";
+
+type Renderer = NonNullable<ReturnType<typeof create>>;
+
+function render(props: Partial<Parameters<typeof ConsentPanel>[0]> = {}) {
+  let renderer!: Renderer;
+  act(() => {
+    renderer = create(
+      createElement(ConsentPanel, {
+        organizationName: "Acme",
+        needsAiConsent: true,
+        needsBetaTerms: false,
+        isAdmin: true,
+        onAcceptAi: vi.fn(async () => {}),
+        onAcceptBeta: vi.fn(async () => {}),
+        ...props,
+      }),
+    );
+  });
+  return renderer;
+}
+
+function texts(renderer: Renderer): string[] {
+  return renderer.root
+    .findAll((node) => typeof node.props.children === "string")
+    .map((node) => node.props.children as string);
+}
+
+function acceptButton(renderer: Renderer) {
+  return renderer.root.find(
+    (node) =>
+      typeof node.props.onPress === "function" && "disabled" in node.props,
+  );
+}
+
+describe("ConsentPanel", () => {
+  it("shows the accept action for an admin", () => {
+    const renderer = render({ isAdmin: true });
+    expect(texts(renderer)).toContain("Approve AI data processing");
+  });
+
+  it("directs a non-admin to an org admin with no accept action", () => {
+    const renderer = render({ isAdmin: false });
+    const content = texts(renderer);
+    expect(content).toContain(
+      "Ask an organization admin to approve AI data processing.",
+    );
+    expect(content).not.toContain("Approve AI data processing");
+  });
+
+  it("cannot be double-submitted while a request is in flight", async () => {
+    let resolveAccept!: () => void;
+    const onAcceptAi = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAccept = resolve;
+        }),
+    );
+    const renderer = render({ isAdmin: true, onAcceptAi });
+
+    act(() => {
+      acceptButton(renderer).props.onPress();
+    });
+    act(() => {
+      acceptButton(renderer).props.onPress();
+    });
+
+    expect(onAcceptAi).toHaveBeenCalledTimes(1);
+    expect(acceptButton(renderer).props.disabled).toBe(true);
+
+    await act(async () => {
+      resolveAccept();
+    });
+
+    expect(acceptButton(renderer).props.disabled).toBe(false);
+  });
+});

--- a/products/desktop/apps/mobile/src/features/consent/components/ConsentPanel.tsx
+++ b/products/desktop/apps/mobile/src/features/consent/components/ConsentPanel.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@components/text";
 import { useState } from "react";
-import { ActivityIndicator, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Pressable, View } from "react-native";
 import { openExternalUrl } from "@/lib/openExternalUrl";
 import { useThemeColors } from "@/lib/theme";
 
@@ -137,14 +137,14 @@ function ConsentCard({
       </View>
       <Text className="text-gray-11 text-sm leading-5">{detail}</Text>
       {link && (
-        <TouchableOpacity onPress={() => openExternalUrl(link.url)}>
+        <Pressable onPress={() => openExternalUrl(link.url)}>
           <Text className="text-accent-11 text-sm">{link.label}</Text>
-        </TouchableOpacity>
+        </Pressable>
       )}
       {isAdmin ? (
-        <TouchableOpacity
+        <Pressable
           className={`mt-1 items-center rounded-lg py-3 ${
-            isDisabled ? "bg-gray-7" : "bg-accent-9"
+            isDisabled ? "bg-gray-7" : "bg-accent-9 active:opacity-80"
           }`}
           onPress={onAccept}
           disabled={isDisabled}
@@ -156,7 +156,7 @@ function ConsentCard({
               {actionLabel}
             </Text>
           )}
-        </TouchableOpacity>
+        </Pressable>
       ) : (
         <Text className="text-gray-11 text-sm">{adminHelp}</Text>
       )}

--- a/products/desktop/apps/mobile/src/features/consent/components/ConsentPanel.tsx
+++ b/products/desktop/apps/mobile/src/features/consent/components/ConsentPanel.tsx
@@ -1,0 +1,165 @@
+import { Text } from "@components/text";
+import { useState } from "react";
+import { ActivityIndicator, TouchableOpacity, View } from "react-native";
+import { openExternalUrl } from "@/lib/openExternalUrl";
+import { useThemeColors } from "@/lib/theme";
+
+type Requirement = "ai" | "beta";
+
+interface ConsentPanelProps {
+  organizationName?: string;
+  needsAiConsent: boolean;
+  needsBetaTerms: boolean;
+  isAdmin: boolean;
+  onAcceptAi: () => Promise<void>;
+  onAcceptBeta: () => Promise<void>;
+}
+
+const ERROR_COPY: Record<Requirement, string> = {
+  ai: "Couldn't approve AI data processing. Try again, or contact support.",
+  beta: "Couldn't save your beta terms acceptance. Try again, or contact support.",
+};
+
+export function ConsentPanel({
+  organizationName,
+  needsAiConsent,
+  needsBetaTerms,
+  isAdmin,
+  onAcceptAi,
+  onAcceptBeta,
+}: ConsentPanelProps) {
+  const [submitting, setSubmitting] = useState<Requirement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const accept = async (kind: Requirement): Promise<void> => {
+    if (submitting) return;
+    setError(null);
+    setSubmitting(kind);
+    try {
+      await (kind === "ai" ? onAcceptAi() : onAcceptBeta());
+    } catch {
+      setError(ERROR_COPY[kind]);
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  return (
+    <View className="gap-5">
+      <View className="gap-1">
+        <Text className="font-semibold text-2xl text-gray-12">
+          Before you continue
+        </Text>
+        <Text className="text-base text-gray-11">
+          {organizationName
+            ? `Review the required items for ${organizationName}.`
+            : "Review the required items for your organization."}
+        </Text>
+      </View>
+
+      {needsAiConsent && (
+        <ConsentCard
+          title="PostHog AI needs approval"
+          summary={
+            organizationName
+              ? `${organizationName} hasn't approved AI data processing yet.`
+              : "Your organization hasn't approved AI data processing yet."
+          }
+          detail="PostHog AI features process identifying user data with external AI providers. Your data won't be used to train their models."
+          actionLabel="Approve AI data processing"
+          adminHelp="Ask an organization admin to approve AI data processing."
+          isAdmin={isAdmin}
+          isSubmitting={submitting === "ai"}
+          isDisabled={submitting !== null}
+          onAccept={() => void accept("ai")}
+        />
+      )}
+
+      {needsBetaTerms && (
+        <ConsentCard
+          title="PostHog Desktop beta terms"
+          summary="Accept the additional data-processing terms for the PostHog Desktop beta."
+          detail="PostHog Desktop uses Baseten and Modal to process customer data, personal data, and PII. They aren't listed as PostHog subprocessors for this feature yet. Your organization agrees to proceed. This beta may change or be discontinued."
+          actionLabel="Accept beta terms"
+          adminHelp="Ask an organization admin to accept the Desktop beta terms."
+          isAdmin={isAdmin}
+          isSubmitting={submitting === "beta"}
+          isDisabled={submitting !== null}
+          onAccept={() => void accept("beta")}
+          link={{
+            label: "View PostHog subprocessors",
+            url: "https://posthog.com/subprocessors",
+          }}
+        />
+      )}
+
+      {error && (
+        <View className="rounded-lg border border-status-error bg-status-error/10 p-3">
+          <Text className="text-sm text-status-error">{error}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+interface ConsentCardProps {
+  title: string;
+  summary: string;
+  detail: string;
+  actionLabel: string;
+  adminHelp: string;
+  isAdmin: boolean;
+  isSubmitting: boolean;
+  isDisabled: boolean;
+  onAccept: () => void;
+  link?: { label: string; url: string };
+}
+
+function ConsentCard({
+  title,
+  summary,
+  detail,
+  actionLabel,
+  adminHelp,
+  isAdmin,
+  isSubmitting,
+  isDisabled,
+  onAccept,
+  link,
+}: ConsentCardProps) {
+  const themeColors = useThemeColors();
+
+  return (
+    <View className="gap-3 rounded-lg border border-gray-6 bg-gray-2 p-4">
+      <View className="gap-1">
+        <Text className="font-semibold text-base text-gray-12">{title}</Text>
+        <Text className="text-gray-11 text-sm">{summary}</Text>
+      </View>
+      <Text className="text-gray-11 text-sm leading-5">{detail}</Text>
+      {link && (
+        <TouchableOpacity onPress={() => openExternalUrl(link.url)}>
+          <Text className="text-accent-11 text-sm">{link.label}</Text>
+        </TouchableOpacity>
+      )}
+      {isAdmin ? (
+        <TouchableOpacity
+          className={`mt-1 items-center rounded-lg py-3 ${
+            isDisabled ? "bg-gray-7" : "bg-accent-9"
+          }`}
+          onPress={onAccept}
+          disabled={isDisabled}
+        >
+          {isSubmitting ? (
+            <ActivityIndicator color={themeColors.accent.contrast} />
+          ) : (
+            <Text className="font-semibold text-accent-contrast text-sm">
+              {actionLabel}
+            </Text>
+          )}
+        </TouchableOpacity>
+      ) : (
+        <Text className="text-gray-11 text-sm">{adminHelp}</Text>
+      )}
+    </View>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/consent/consentState.test.ts
+++ b/products/desktop/apps/mobile/src/features/consent/consentState.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { deriveOrgConsent, type OrgConsentInputs } from "./consentState";
+
+describe("deriveOrgConsent", () => {
+  const org = (approved: boolean | undefined) => ({
+    is_ai_data_processing_approved: approved,
+  });
+
+  it.each<{
+    name: string;
+    inputs: OrgConsentInputs;
+    expected: ReturnType<typeof deriveOrgConsent>;
+  }>([
+    {
+      name: "loading while the user has not resolved",
+      inputs: {
+        organization: undefined,
+        betaTermsAccepted: undefined,
+        hasError: false,
+      },
+      expected: { status: "loading" },
+    },
+    {
+      name: "loading while beta terms are still pending",
+      inputs: {
+        organization: org(true),
+        betaTermsAccepted: undefined,
+        hasError: false,
+      },
+      expected: { status: "loading" },
+    },
+    {
+      name: "error takes priority over loaded data",
+      inputs: {
+        organization: org(true),
+        betaTermsAccepted: true,
+        hasError: true,
+      },
+      expected: { status: "error" },
+    },
+    {
+      name: "both requirements unmet",
+      inputs: {
+        organization: org(false),
+        betaTermsAccepted: false,
+        hasError: false,
+      },
+      expected: {
+        status: "resolved",
+        needsAiConsent: true,
+        needsBetaTerms: true,
+        satisfied: false,
+      },
+    },
+    {
+      name: "only beta terms unmet",
+      inputs: {
+        organization: org(true),
+        betaTermsAccepted: false,
+        hasError: false,
+      },
+      expected: {
+        status: "resolved",
+        needsAiConsent: false,
+        needsBetaTerms: true,
+        satisfied: false,
+      },
+    },
+    {
+      name: "only AI consent unmet",
+      inputs: {
+        organization: org(false),
+        betaTermsAccepted: true,
+        hasError: false,
+      },
+      expected: {
+        status: "resolved",
+        needsAiConsent: true,
+        needsBetaTerms: false,
+        satisfied: false,
+      },
+    },
+    {
+      name: "both requirements satisfied",
+      inputs: {
+        organization: org(true),
+        betaTermsAccepted: true,
+        hasError: false,
+      },
+      expected: {
+        status: "resolved",
+        needsAiConsent: false,
+        needsBetaTerms: false,
+        satisfied: true,
+      },
+    },
+  ])("returns $name", ({ inputs, expected }) => {
+    expect(deriveOrgConsent(inputs)).toEqual(expected);
+  });
+});

--- a/products/desktop/apps/mobile/src/features/consent/consentState.ts
+++ b/products/desktop/apps/mobile/src/features/consent/consentState.ts
@@ -1,0 +1,37 @@
+export type OrgConsent =
+  | { status: "loading" }
+  | { status: "error" }
+  | {
+      status: "resolved";
+      needsAiConsent: boolean;
+      needsBetaTerms: boolean;
+      satisfied: boolean;
+    };
+
+export interface OrgConsentInputs {
+  organization: { is_ai_data_processing_approved?: boolean } | undefined;
+  betaTermsAccepted: boolean | undefined;
+  hasError: boolean;
+}
+
+export function deriveOrgConsent({
+  organization,
+  betaTermsAccepted,
+  hasError,
+}: OrgConsentInputs): OrgConsent {
+  if (hasError) {
+    return { status: "error" };
+  }
+  if (!organization || betaTermsAccepted === undefined) {
+    return { status: "loading" };
+  }
+
+  const needsAiConsent = organization.is_ai_data_processing_approved !== true;
+  const needsBetaTerms = !betaTermsAccepted;
+  return {
+    status: "resolved",
+    needsAiConsent,
+    needsBetaTerms,
+    satisfied: !needsAiConsent && !needsBetaTerms,
+  };
+}

--- a/products/desktop/apps/mobile/src/features/consent/hooks/useOrgConsent.ts
+++ b/products/desktop/apps/mobile/src/features/consent/hooks/useOrgConsent.ts
@@ -1,0 +1,49 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useUserQuery } from "@/features/auth/hooks/useUserQuery";
+import { useAuthStore } from "@/features/auth/stores/authStore";
+import { getPostHogApiClient } from "@/lib/posthogApiClient";
+import { deriveOrgConsent, type OrgConsent } from "../consentState";
+
+export type OrgConsentResult = OrgConsent & { retry: () => void };
+
+export const desktopBetaTermsKeys = {
+  all: () => ["consent", "desktop-beta-terms"] as const,
+  acceptance: (organizationId: string) =>
+    [...desktopBetaTermsKeys.all(), organizationId] as const,
+};
+
+export function useDesktopBetaTerms(organizationId: string | undefined) {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  return useQuery({
+    queryKey: desktopBetaTermsKeys.acceptance(organizationId ?? "unknown"),
+    queryFn: () => {
+      if (!organizationId) throw new Error("No organization");
+      return getPostHogApiClient().areDesktopBetaTermsAccepted(organizationId);
+    },
+    enabled: isAuthenticated && !!organizationId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useOrgConsent(): OrgConsentResult {
+  const userQuery = useUserQuery();
+  const organization = userQuery.data?.organization;
+  const betaTermsQuery = useDesktopBetaTerms(organization?.id);
+  const queryClient = useQueryClient();
+
+  const retry = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ["user"] });
+    void queryClient.invalidateQueries({
+      queryKey: desktopBetaTermsKeys.all(),
+    });
+  }, [queryClient]);
+
+  const consent = deriveOrgConsent({
+    organization,
+    betaTermsAccepted: betaTermsQuery.data,
+    hasError: userQuery.isError || betaTermsQuery.isError,
+  });
+
+  return { ...consent, retry };
+}


### PR DESCRIPTION
## Problem

A signed-in user on the PostHog Desktop mobile app could create cloud agent runs even when their organization had not met the consent requirements the desktop app enforces. Mobile had no consent handling at all, so the gate desktop added in #87554 (which builds on #87546) was missing on the phone.

Two requirements must be met before an organization can use the app:

- AI data processing approval on the organization.
- Desktop beta terms acceptance, read from `GET /api/organizations/<id>/desktop_beta_terms/`.

## Changes

- A signed-in user whose organization has not met both requirements now lands on a blocking consent screen instead of the tabs.
- An organization admin (`membership_level >= 8`) accepts each unmet requirement in-app. The accept button disables and shows a spinner while the request is in flight, and re-enables on success or error.
- A non-admin sees the same requirement with copy telling them to ask an organization admin, and no accept button.
- A failed requirement check shows a retryable error state. A log-out escape lets a user in the wrong organization leave.
- Accepting invalidates the relevant queries, so the gate clears and the user reaches the tabs without an app restart.
- The gate lives in the root layout (`app/_layout.tsx`) as the single navigation authority, alongside the existing auth gate. It holds the app on a spinner until consent resolves, so a deep link onto a protected route cannot flash the tabs before the redirect.
- Accepting fires `Ai consent granted in-app` and `Desktop beta terms accepted in-app` through the mobile posthog-react-native client, using the shared constants, so desktop and mobile funnel into one bucket.
- Reads and writes go through the existing shared `@posthog/api-client` (`areDesktopBetaTermsAccepted` / `approveAiDataProcessing` / `acceptDesktopBetaTerms`); no second client was added.
- Mechanical: `useUserQuery` now types `is_ai_data_processing_approved` and `membership_level` on `organization` (the API already returned them).

## How did you test this code?

Automated tests added, run locally with `pnpm --filter @posthog/mobile test` (full suite green), plus `typecheck` and `lint`:

- `consentState.test.ts` covers the gate derivation: both requirements unmet, one unmet either way, both satisfied, error, and loading. Catches a regression where `satisfied` stops requiring both requirements, or an error is misread as loading.
- `ConsentPanel.test.tsx` covers admin vs non-admin rendering, and that a second tap during an in-flight accept does not fire a second request.

Not done: no manual run on a device or simulator, so no screenshot of the running screen. The gate's routing was verified by reading state transitions and the tests above, not by launching the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ported the desktop consent feature (#87554, on top of #87546) to `products/desktop/apps/mobile`. Skills invoked: `/writing-user-facing-copy` (screen copy), `/writing-tests` (test gate), `/writing-pr-descriptions` (this body), and `/simplify` on the diff before opening.

Simplify pass reshaped the routing: an earlier draft split the decision between `index.tsx` and a screen-level redirect. The shipped design makes the root-layout gate the sole authority and blocks the tabs during the loading window, which is why a deep link cannot leak the tabs. It also dropped an unused `enabled` hook parameter and an unused `organizationId` field, and routed the subprocessors link through the existing `openExternalUrl` helper.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
