### PR TITLE
fix(clerk): recognize Clerk's 404 feature-off signal for gated tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
@@ -271,13 +271,18 @@ def validate_credentials(secret_key: str) -> tuple[bool, str | None]:
 # statuses Clerk returns them under: 402 carries no body code, so the status alone is the signal.
 _FEATURE_DISABLED_CODES = frozenset({"billing_not_enabled", "feature_not_enabled"})
 
+# A gated list endpoint (the Restrictions allow-list and block-list) answers 404 `resource_not_found`
+# instead of a 4xx feature code when its feature is off. This check only runs for endpoints that carry
+# a `gated_feature`, so a 404 here means the feature is not on rather than a genuinely missing record.
+_FEATURE_DISABLED_NOT_FOUND_CODE = "resource_not_found"
+
 
 def _is_feature_disabled(response: Optional[Response]) -> bool:
     if response is None:
         return False
     if response.status_code == 402:
         return True
-    if response.status_code not in (400, 403):
+    if response.status_code not in (400, 403, 404):
         return False
 
     try:
@@ -288,7 +293,10 @@ def _is_feature_disabled(response: Optional[Response]) -> bool:
     errors = body.get("errors") if isinstance(body, dict) else None
     if not isinstance(errors, list):
         return False
-    return any(isinstance(error, dict) and error.get("code") in _FEATURE_DISABLED_CODES for error in errors)
+    codes = {error.get("code") for error in errors if isinstance(error, dict)}
+    if response.status_code == 404:
+        return _FEATURE_DISABLED_NOT_FOUND_CODE in codes
+    return bool(codes & _FEATURE_DISABLED_CODES)
 
 
 def _skip_when_feature_disabled(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -518,6 +518,8 @@ class TestClerkFeatureGatedEndpoints:
             ("commerce_plans", 400, {"errors": [{"code": "billing_not_enabled"}]}),
             ("commerce_subscription_items", 400, {"errors": [{"code": "billing_not_enabled"}]}),
             ("commerce_plans", 403, {"errors": [{"code": "feature_not_enabled"}]}),
+            # Restrictions off: the allow-list endpoint answers 404 resource_not_found, not a 4xx code.
+            ("allowlist_identifiers", 404, {"errors": [{"code": "resource_not_found"}]}),
         ],
     )
     def test_feature_not_enabled_syncs_no_rows_instead_of_failing(
@@ -534,6 +536,8 @@ class TestClerkFeatureGatedEndpoints:
         [
             # A gated endpoint failing for an unrelated reason must still fail the sync.
             ("commerce_plans", 400, {"errors": [{"code": "invalid_request"}]}),
+            # A 404 with an unrelated code is a real failure, not the feature-off signal.
+            ("allowlist_identifiers", 404, {"errors": [{"code": "invalid_request"}]}),
             # A table with no feature gate never swallows an error.
             ("users", 402, {"errors": [{"code": "payment_required"}]}),
         ],


### PR DESCRIPTION
## Problem

- A Clerk source with the allow-list or block-list table selected fails every scheduled sync when the account has Clerk's Restrictions feature turned off. Several teams hit this repeatedly.
- These endpoints are already gated behind the Restrictions feature, so the intended behavior is to sync zero rows and keep the table enabled.
- Clerk signals the feature being off on these list endpoints with a `404 resource_not_found`, not the `402`/`400`/`403` feature codes the detector already knows.
- The unrecognized 404 skipped the feature-off path, so the sync failed and the customer saw a raw `404 Client Error` string instead of the table quietly syncing nothing.

## Changes

- The allow-list and block-list tables now sync zero rows and stay enabled when Restrictions is off, instead of failing every run.
- `_is_feature_disabled` now treats a `404` carrying the `resource_not_found` code as feature-off, alongside the existing `402`/`400`/`403` handling.
- The 404 branch requires the `resource_not_found` code, and this check only runs for endpoints that carry a `gated_feature`, so a genuine missing-record 404 still fails the sync.

## How did you test this code?

- Extended `TestClerkFeatureGatedEndpoints` in `test_clerk.py`: added an allow-list `404 resource_not_found` case to the "syncs no rows" test (catches a regression that stops recognizing the 404 feature-off shape), and an allow-list `404 invalid_request` case to the "still fails" test (catches a regression that broadens the match to any 404).
- Ran the Clerk source suite locally.
- Not run: the Temporal/integration suites, which need the data-warehouse stack this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging a batch of data-warehouse sync failure classes. The 404 was traced through the shared REST client to `_skip_when_feature_disabled`, which caught the `HTTPError` but `_is_feature_disabled` returned false for a 404, so the error re-raised and failed the table. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Related work: #87435 (Gilbert09) classifies a deterministic Clerk `redirect_urls` 404 on a non-gated endpoint via the non-retryable map. This PR is a distinct root cause: the feature-off detector for gated endpoints missing the 404 shape.

The example error came from aggregated, redacted failure data; no customer identifiers appear in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
