### PR TITLE
fix(desktop): respect model entitlement in onboarding

### DIFF
--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError, transaction
 import structlog
 import posthoganalytics
 
+from posthog.constants import AvailableFeature
 from posthog.event_usage import groups
 from posthog.models.team.team import Team
 from posthog.models.user import User
@@ -40,7 +41,8 @@ from ee.billing.salesforce_enrichment.constants import PERSONAL_EMAIL_DOMAINS
 logger = structlog.get_logger(__name__)
 
 ONBOARDING_SESSION_TITLE = "Getting set up"
-ONBOARDING_SESSION_MODEL = "claude-opus-4-8"
+ONBOARDING_SESSION_PAID_MODEL = "claude-opus-4-8"
+ONBOARDING_SESSION_FREE_MODEL = "@cf/zai-org/glm-5.2"
 ONBOARDING_SESSION_EFFORT = "medium"
 ONBOARDING_SESSION_SCOPES = ["task:read", "task:write", "canvas:read"]
 
@@ -71,6 +73,12 @@ def company_domain_from(email: str) -> str | None:
     if not domain or domain in PERSONAL_EMAIL_DOMAINS:
         return None
     return normalize_target(domain)
+
+
+def onboarding_session_model(team: Team) -> str:
+    if team.organization.is_feature_available(AvailableFeature.POSTHOG_CODE_USAGE):
+        return ONBOARDING_SESSION_PAID_MODEL
+    return ONBOARDING_SESSION_FREE_MODEL
 
 
 def gather_onboarding_facts(team: Team, user: User) -> tuple[OnboardingFacts, str]:
@@ -205,7 +213,7 @@ def start_onboarding_session(team: Team, user: User) -> UUID | None:
                 client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
                 create_pr=False,
                 mode="interactive",
-                model=ONBOARDING_SESSION_MODEL,
+                model=onboarding_session_model(team),
                 reasoning_effort=ONBOARDING_SESSION_EFFORT,
                 posthog_mcp_scopes=ONBOARDING_SESSION_SCOPES,
                 initial_permission_mode="auto",

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -8,6 +8,9 @@ from django.db import IntegrityError
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from parameterized import parameterized
+
+from posthog.constants import AvailableFeature
 from posthog.models import Organization, Team
 from posthog.models.user import User
 
@@ -91,12 +94,27 @@ class TestOnboardingSessionIdempotency(TestCase):
         with self.assertRaises(IntegrityError):
             self._start(create_side_effect=IntegrityError("duplicate key"))
 
-    def test_a_first_request_starts_a_session_keyed_to_the_user(self):
+    @parameterized.expand(
+        [
+            ("free", [], "@cf/zai-org/glm-5.2"),
+            (
+                "paid",
+                [{"key": AvailableFeature.POSTHOG_CODE_USAGE, "name": "PostHog Desktop usage billing"}],
+                "claude-opus-4-8",
+            ),
+        ]
+    )
+    def test_a_first_request_starts_an_entitled_session_keyed_to_the_user(
+        self, _name: str, available_product_features: list[dict[str, str]], expected_model: str
+    ) -> None:
+        self.organization.available_product_features = available_product_features
+        self.organization.save(update_fields=["available_product_features"])
         task_id = uuid4()
 
         def succeed(**kwargs):
             self.assertEqual(kwargs["origin_key"], _origin_key(self.user.id))
             self.assertEqual(kwargs["client_provenance"], TaskClientProvenance.POSTHOG_DESKTOP)
+            self.assertEqual(kwargs["model"], expected_model)
             return contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
 
         started, create_calls = self._start(create_side_effect=succeed)


### PR DESCRIPTION
## Problem

Free-tier organizations can enter PostHog Desktop onboarding, but the first session selects a paid model and fails before responding.

**Why:** New users should receive a working first session without adding a payment method.

## Changes

- Free-tier organizations start onboarding with an allowed open-source model.
- Subscribed organizations continue using Claude Opus 4.8.
- The backend uses the same Desktop billing entitlement that protects gateway model access.

## How did you test this code?

- Extended the onboarding session test for free and subscribed organizations. This catches restricted models reaching free-tier sessions.
- Ran the focused Django test suite, Ruff checks, repository preflight, and the repo-wide mypy check.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The onboarding behavior now matches the existing billing policy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and verified this change using the `posthog-desktop`, `writing-tests`, and `writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*