### PR TITLE
fix(clerk): stop retrying enterprise_connections when Enterprise SSO is off

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/source.py
@@ -114,6 +114,12 @@ The secret key starts with `sk_live_`.
             # instance. Scoped to this path, not all of api.clerk.com, since 422 elsewhere can mean
             # a genuinely bad request that's worth investigating rather than an account limitation.
             "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/saml_connections": "SAML connections (Enterprise SSO) aren't available on your Clerk plan or instance. Turn off syncing for this table, or enable SAML connections in your Clerk dashboard.",
+            # Clerk answers 422 feature_requires_email_address_enabled for enterprise_connections when
+            # Enterprise SSO isn't available on the instance. The unfiltered list request is identical
+            # every run, so it re-fails on every schedule; classify it so the schema pauses instead of
+            # retrying. Scoped to this path, mirroring saml_connections, since a 422 elsewhere can be a
+            # genuinely bad request worth investigating rather than an account limitation.
+            "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/enterprise_connections": "Enterprise SSO connections aren't available on your Clerk plan or instance. Turn off syncing for this table, or enable Enterprise SSO in your Clerk dashboard.",
             # Clerk's list api_keys endpoint requires a subject (a user or organization id), so the
             # unfiltered list request we send is rejected with a 400 every run. Scoped to this path,
             # not all of api.clerk.com, since a 400 elsewhere can be a genuinely bad request worth

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -53,6 +53,8 @@ class TestClerkSource:
             "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/users?limit=100",
             # `saml_connections` endpoint, SAML/Enterprise SSO not available on the account's plan.
             "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/saml_connections?limit=100",
+            # `enterprise_connections` endpoint, Enterprise SSO not available on the account's instance.
+            "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/enterprise_connections?limit=100 | api error: code=feature_requires_email_address_enabled",
             # `api_keys` endpoint, which Clerk rejects without a subject param on the list request.
             "400 Client Error: Bad Request for url: https://api.clerk.com/v1/api_keys?limit=100",
         ],


### PR DESCRIPTION
## Problem

- A Clerk source with the enterprise_connections table selected fails every scheduled sync when the account doesn't have Enterprise SSO available. A few teams hit this repeatedly.
- Clerk answers the unfiltered list request with a deterministic `422 feature_requires_email_address_enabled`.
- The request is identical every run, so the failure never resolves on its own.
- It was classified as neither retryable nor non-retryable, so the sync retried the whole activity budget and the customer saw a raw `422 Client Error` string, not an actionable message.

## Changes

- The enterprise_connections table now pauses with a clear message ("Enterprise SSO connections aren't available on your Clerk plan or instance. Turn off syncing for this table, or enable Enterprise SSO in your Clerk dashboard.") instead of re-failing every schedule.
- Adds a scoped entry to Clerk's non-retryable error map. A matched non-retryable error both rewrites `latest_error` to the friendly copy and disables the schema, which stops the job burn.
- The entry is scoped to the enterprise_connections path, mirroring the existing saml_connections (422) and api_keys (400) entries, so a 422 on another endpoint still surfaces as a real failure worth investigating.

## How did you test this code?

- Extended `test_clerk_source.py`: added the enterprise_connections 422 to the observed-error match cases. The existing "422 on other endpoints is not matched" scoping test already guards against broadening the match.
- Ran the Clerk source suite locally.
- Not run: the Temporal/integration suites, which need the data-warehouse stack this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Desktop) while triaging a batch of data-warehouse sync failure classes. enterprise_connections is Clerk's other Enterprise SSO endpoint alongside saml_connections, which already had this treatment; the fix mirrors it. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Related work: #87435 (Gilbert09) adds a similar scoped non-retryable entry for a deterministic Clerk `redirect_urls` 404. These two PRs touch the same map and test file for different endpoints, so expect a trivial merge alignment if both land.

The example error came from aggregated, redacted failure data; no customer identifiers appear in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
