### PR TITLE
fix(session-replay): match policy wildcards in linear time

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
@@ -254,56 +254,6 @@ describe('ConfigurationPolicyService', () => {
         })
     })
 
-    it.each([
-        ['a middle wildcard', '/images/*/preview$', '/images/v1/preview', true],
-        ['an anchored suffix mismatch', '/images/*/preview$', '/images/v1/preview/more', false],
-        ['a leading wildcard', '*/private/*', '/v1/private/image.png', true],
-        ['literal regular expression characters', '/literal.+(item)$', '/literal.+(item)', true],
-        ['an unreserved percent encoding', '/asset%7Ename$', '/asset~name', true],
-        ['consecutive wildcards', '/asset/**/preview$', '/asset//preview', true],
-        ['overlapping anchored segments', '*a*a$', '/aaa', true],
-    ])('matches TDMRep locations with %s', async (_name, location, pathname, tdmrepReservation) => {
-        const { policy } = service()
-        const cache = new Map([
-            [configurationCacheKey(ORIGIN, 'robots'), cached('robots', 'absent')],
-            [
-                configurationCacheKey(ORIGIN, 'tdmrep'),
-                cached('tdmrep', 'available', JSON.stringify([{ location, 'tdm-reservation': 1 }])),
-            ],
-        ])
-
-        await expect(policy.check(`${ORIGIN}${pathname}`, cache, NOW_MS)).resolves.toMatchObject({
-            allowed: true,
-            tdmrepReservation,
-        })
-    })
-
-    it('matches wildcard-heavy TDMRep locations without compiling a regular expression', async () => {
-        const regexpConstructor = jest.spyOn(globalThis, 'RegExp').mockReturnValue(/$a/)
-        const { policy } = service()
-        const cache = new Map([
-            [configurationCacheKey(ORIGIN, 'robots'), cached('robots', 'absent')],
-            [
-                configurationCacheKey(ORIGIN, 'tdmrep'),
-                cached(
-                    'tdmrep',
-                    'available',
-                    JSON.stringify([{ location: `${'*a'.repeat(64)}*b$`, 'tdm-reservation': 1 }])
-                ),
-            ],
-        ])
-
-        try {
-            await expect(policy.check(`${ORIGIN}/${'a'.repeat(128)}c`, cache, NOW_MS)).resolves.toMatchObject({
-                allowed: true,
-                tdmrepReservation: false,
-            })
-            expect(regexpConstructor).not.toHaveBeenCalled()
-        } finally {
-            regexpConstructor.mockRestore()
-        }
-    })
-
     it('keeps a previous usable file when its refresh is unreachable', async () => {
         const { policy } = service({ robots: { outcome: 'unreachable' } })
         const previous = { ...cached('robots', 'absent'), refreshAtMs: NOW_MS - 1 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
@@ -254,6 +254,56 @@ describe('ConfigurationPolicyService', () => {
         })
     })
 
+    it.each([
+        ['a middle wildcard', '/images/*/preview$', '/images/v1/preview', true],
+        ['an anchored suffix mismatch', '/images/*/preview$', '/images/v1/preview/more', false],
+        ['a leading wildcard', '*/private/*', '/v1/private/image.png', true],
+        ['literal regular expression characters', '/literal.+(item)$', '/literal.+(item)', true],
+        ['an unreserved percent encoding', '/asset%7Ename$', '/asset~name', true],
+        ['consecutive wildcards', '/asset/**/preview$', '/asset//preview', true],
+        ['overlapping anchored segments', '*a*a$', '/aaa', true],
+    ])('matches TDMRep locations with %s', async (_name, location, pathname, tdmrepReservation) => {
+        const { policy } = service()
+        const cache = new Map([
+            [configurationCacheKey(ORIGIN, 'robots'), cached('robots', 'absent')],
+            [
+                configurationCacheKey(ORIGIN, 'tdmrep'),
+                cached('tdmrep', 'available', JSON.stringify([{ location, 'tdm-reservation': 1 }])),
+            ],
+        ])
+
+        await expect(policy.check(`${ORIGIN}${pathname}`, cache, NOW_MS)).resolves.toMatchObject({
+            allowed: true,
+            tdmrepReservation,
+        })
+    })
+
+    it('matches wildcard-heavy TDMRep locations without compiling a regular expression', async () => {
+        const regexpConstructor = jest.spyOn(globalThis, 'RegExp').mockReturnValue(/$a/)
+        const { policy } = service()
+        const cache = new Map([
+            [configurationCacheKey(ORIGIN, 'robots'), cached('robots', 'absent')],
+            [
+                configurationCacheKey(ORIGIN, 'tdmrep'),
+                cached(
+                    'tdmrep',
+                    'available',
+                    JSON.stringify([{ location: `${'*a'.repeat(64)}*b$`, 'tdm-reservation': 1 }])
+                ),
+            ],
+        ])
+
+        try {
+            await expect(policy.check(`${ORIGIN}/${'a'.repeat(128)}c`, cache, NOW_MS)).resolves.toMatchObject({
+                allowed: true,
+                tdmrepReservation: false,
+            })
+            expect(regexpConstructor).not.toHaveBeenCalled()
+        } finally {
+            regexpConstructor.mockRestore()
+        }
+    })
+
     it('keeps a previous usable file when its refresh is unreachable', async () => {
         const { policy } = service({ robots: { outcome: 'unreachable' } })
         const previous = { ...cached('robots', 'absent'), refreshAtMs: NOW_MS - 1 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
@@ -8,6 +8,7 @@ import { ConfigurationCacheItem, ConfigurationFile, HttpCacheMetadata, configura
 import { ImageFetchRequestMetrics } from './metrics'
 import { canonicalizeUrl, politenessKey } from './politeness-key'
 import { WebBotAuthRequestSigner } from './web-bot-auth'
+import { wildcardPatternMatchesPathname } from './wildcard-pattern'
 
 const BOT_NAME = 'PostHogImageFetcherBot'
 const USER_AGENT = `${BOT_NAME}/1.0 (+https://posthog.com/docs/ai-research/image-fetcher-bot)`
@@ -518,7 +519,7 @@ function tdmrepRefuses(parsed: unknown, url: URL): boolean {
         if (!isObject(rule) || typeof rule.location !== 'string') {
             continue
         }
-        if (tdmLocationMatches(rule.location, url.pathname)) {
+        if (wildcardPatternMatchesPathname(rule.location, url.pathname)) {
             return rule['tdm-reservation'] === 1
         }
     }
@@ -563,89 +564,6 @@ function configurationRevision(item: ConfigurationCacheItem): string {
     return `${item.key}\0${item.fetchedAtMs}`
 }
 
-function tdmLocationMatches(pattern: string, pathname: string): boolean {
-    const decodedPattern = decodeUnreserved(pattern)
-    const endAnchored = decodedPattern.endsWith('$')
-    const matchPattern = endAnchored ? decodedPattern.slice(0, -1) : decodedPattern
-    const decodedPathname = decodeUnreserved(pathname)
-
-    if (!matchPattern.includes('*')) {
-        return endAnchored ? decodedPathname === matchPattern : decodedPathname.startsWith(matchPattern)
-    }
-
-    const literalSegments = matchPattern.split('*').filter((segment) => segment.length > 0)
-    if (literalSegments.length === 0) {
-        return true
-    }
-
-    let nextSearchIndex = 0
-    let nextSegmentIndex = 0
-    if (!matchPattern.startsWith('*')) {
-        const firstSegment = literalSegments[0]
-        if (!decodedPathname.startsWith(firstSegment)) {
-            return false
-        }
-        nextSearchIndex = firstSegment.length
-        nextSegmentIndex = 1
-    }
-
-    let segmentSearchEnd = literalSegments.length
-    let pathnameSearchEnd = decodedPathname.length
-    if (endAnchored && !matchPattern.endsWith('*')) {
-        const finalSegmentIndex = literalSegments.length - 1
-        const finalSegment = literalSegments[finalSegmentIndex]
-        if (!decodedPathname.endsWith(finalSegment)) {
-            return false
-        }
-        segmentSearchEnd = finalSegmentIndex
-        pathnameSearchEnd = decodedPathname.length - finalSegment.length
-    }
-
-    for (; nextSegmentIndex < segmentSearchEnd; nextSegmentIndex++) {
-        const segment = literalSegments[nextSegmentIndex]
-        const matchIndex = findLiteralSegment(decodedPathname, segment, nextSearchIndex, pathnameSearchEnd)
-        if (matchIndex === -1) {
-            return false
-        }
-        nextSearchIndex = matchIndex + segment.length
-    }
-
-    return nextSearchIndex <= pathnameSearchEnd
-}
-
-function findLiteralSegment(value: string, segment: string, startIndex: number, endIndex: number): number {
-    const prefixLengths = Array<number>(segment.length).fill(0)
-    for (let index = 1, matchedLength = 0; index < segment.length; index++) {
-        while (matchedLength > 0 && segment[index] !== segment[matchedLength]) {
-            matchedLength = prefixLengths[matchedLength - 1]
-        }
-        if (segment[index] === segment[matchedLength]) {
-            matchedLength++
-        }
-        prefixLengths[index] = matchedLength
-    }
-
-    for (let index = startIndex, matchedLength = 0; index < endIndex; index++) {
-        while (matchedLength > 0 && value[index] !== segment[matchedLength]) {
-            matchedLength = prefixLengths[matchedLength - 1]
-        }
-        if (value[index] === segment[matchedLength]) {
-            matchedLength++
-        }
-        if (matchedLength === segment.length) {
-            return index - segment.length + 1
-        }
-    }
-    return -1
-}
-
-function decodeUnreserved(value: string): string {
-    return value.replace(/%[0-9A-Fa-f]{2}/g, (encoded) => {
-        const character = String.fromCharCode(Number.parseInt(encoded.slice(1), 16))
-        return /^[A-Za-z0-9._~-]$/.test(character) ? character : encoded.toUpperCase()
-    })
-}
-
 function isObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -667,7 +585,7 @@ function contentUsageRefuses(values: string[]): boolean {
 function contentSignalRefuses(value: string, url: string): boolean {
     const trimmed = value.trim()
     const pathEnd = trimmed.startsWith('/') ? trimmed.search(/\s/) : -1
-    if (pathEnd > 0 && !tdmLocationMatches(trimmed.slice(0, pathEnd), new URL(url).pathname)) {
+    if (pathEnd > 0 && !wildcardPatternMatchesPathname(trimmed.slice(0, pathEnd), new URL(url).pathname)) {
         return false
     }
     const preferences = (pathEnd > 0 ? trimmed.slice(pathEnd) : trimmed)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
@@ -567,13 +567,76 @@ function tdmLocationMatches(pattern: string, pathname: string): boolean {
     const decodedPattern = decodeUnreserved(pattern)
     const endAnchored = decodedPattern.endsWith('$')
     const matchPattern = endAnchored ? decodedPattern.slice(0, -1) : decodedPattern
-    const escaped = matchPattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')
-    const source = endAnchored ? `${escaped}$` : `${escaped}.*`
-    try {
-        return new RegExp(`^${source}`).test(decodeUnreserved(pathname))
-    } catch {
-        return false
+    const decodedPathname = decodeUnreserved(pathname)
+
+    if (!matchPattern.includes('*')) {
+        return endAnchored ? decodedPathname === matchPattern : decodedPathname.startsWith(matchPattern)
     }
+
+    const literalSegments = matchPattern.split('*').filter((segment) => segment.length > 0)
+    if (literalSegments.length === 0) {
+        return true
+    }
+
+    let nextSearchIndex = 0
+    let nextSegmentIndex = 0
+    if (!matchPattern.startsWith('*')) {
+        const firstSegment = literalSegments[0]
+        if (!decodedPathname.startsWith(firstSegment)) {
+            return false
+        }
+        nextSearchIndex = firstSegment.length
+        nextSegmentIndex = 1
+    }
+
+    let segmentSearchEnd = literalSegments.length
+    let pathnameSearchEnd = decodedPathname.length
+    if (endAnchored && !matchPattern.endsWith('*')) {
+        const finalSegmentIndex = literalSegments.length - 1
+        const finalSegment = literalSegments[finalSegmentIndex]
+        if (!decodedPathname.endsWith(finalSegment)) {
+            return false
+        }
+        segmentSearchEnd = finalSegmentIndex
+        pathnameSearchEnd = decodedPathname.length - finalSegment.length
+    }
+
+    for (; nextSegmentIndex < segmentSearchEnd; nextSegmentIndex++) {
+        const segment = literalSegments[nextSegmentIndex]
+        const matchIndex = findLiteralSegment(decodedPathname, segment, nextSearchIndex, pathnameSearchEnd)
+        if (matchIndex === -1) {
+            return false
+        }
+        nextSearchIndex = matchIndex + segment.length
+    }
+
+    return nextSearchIndex <= pathnameSearchEnd
+}
+
+function findLiteralSegment(value: string, segment: string, startIndex: number, endIndex: number): number {
+    const prefixLengths = Array<number>(segment.length).fill(0)
+    for (let index = 1, matchedLength = 0; index < segment.length; index++) {
+        while (matchedLength > 0 && segment[index] !== segment[matchedLength]) {
+            matchedLength = prefixLengths[matchedLength - 1]
+        }
+        if (segment[index] === segment[matchedLength]) {
+            matchedLength++
+        }
+        prefixLengths[index] = matchedLength
+    }
+
+    for (let index = startIndex, matchedLength = 0; index < endIndex; index++) {
+        while (matchedLength > 0 && value[index] !== segment[matchedLength]) {
+            matchedLength = prefixLengths[matchedLength - 1]
+        }
+        if (value[index] === segment[matchedLength]) {
+            matchedLength++
+        }
+        if (matchedLength === segment.length) {
+            return index - segment.length + 1
+        }
+    }
+    return -1
 }
 
 function decodeUnreserved(value: string): string {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/wildcard-pattern.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/wildcard-pattern.test.ts
@@ -1,0 +1,28 @@
+import { wildcardPatternMatchesPathname } from './wildcard-pattern'
+
+describe('wildcardPatternMatchesPathname', () => {
+    it.each([
+        ['a prefix', '/images/', '/images/photo.png', true],
+        ['an exact path', '/images/photo.png$', '/images/photo.png', true],
+        ['an exact path mismatch', '/images/photo.png$', '/images/photo.png/preview', false],
+        ['a middle wildcard', '/images/*/preview$', '/images/v1/preview', true],
+        ['an anchored suffix mismatch', '/images/*/preview$', '/images/v1/preview/more', false],
+        ['a leading wildcard', '*/private/*', '/v1/private/image.png', true],
+        ['literal regular expression characters', '/literal.+(item)$', '/literal.+(item)', true],
+        ['an unreserved percent encoding', '/asset%7Ename$', '/asset~name', true],
+        ['consecutive wildcards', '/asset/**/preview$', '/asset//preview', true],
+        ['overlapping anchored segments', '*a*a$', '/aaa', true],
+    ])('matches %s', (_name, pattern, pathname, expected) => {
+        expect(wildcardPatternMatchesPathname(pattern, pathname)).toBe(expected)
+    })
+
+    it('does not compile wildcard patterns as regular expressions', () => {
+        const regexpConstructor = jest.spyOn(globalThis, 'RegExp').mockReturnValue(/$a/)
+        try {
+            expect(wildcardPatternMatchesPathname(`${'*a'.repeat(64)}*b$`, `/${'a'.repeat(128)}c`)).toBe(false)
+            expect(regexpConstructor).not.toHaveBeenCalled()
+        } finally {
+            regexpConstructor.mockRestore()
+        }
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/wildcard-pattern.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/wildcard-pattern.ts
@@ -1,0 +1,86 @@
+export function wildcardPatternMatchesPathname(pattern: string, pathname: string): boolean {
+    const decodedPattern = decodeUnreserved(pattern)
+    const endAnchored = decodedPattern.endsWith('$')
+    const matchPattern = endAnchored ? decodedPattern.slice(0, -1) : decodedPattern
+    const decodedPathname = decodeUnreserved(pathname)
+
+    if (!matchPattern.includes('*')) {
+        return endAnchored ? decodedPathname === matchPattern : decodedPathname.startsWith(matchPattern)
+    }
+
+    const literalSegments = matchPattern.split('*').filter(Boolean)
+    if (literalSegments.length === 0) {
+        return true
+    }
+
+    let nextSearchIndex = 0
+    let nextSegmentIndex = 0
+    if (!matchPattern.startsWith('*')) {
+        const firstSegment = literalSegments[0]
+        if (!decodedPathname.startsWith(firstSegment)) {
+            return false
+        }
+        nextSearchIndex = firstSegment.length
+        nextSegmentIndex = 1
+    }
+
+    let segmentSearchEnd = literalSegments.length
+    let pathnameSearchEnd = decodedPathname.length
+    if (endAnchored && !matchPattern.endsWith('*')) {
+        const finalSegmentIndex = literalSegments.length - 1
+        const finalSegment = literalSegments[finalSegmentIndex]
+        if (!decodedPathname.endsWith(finalSegment)) {
+            return false
+        }
+        segmentSearchEnd = finalSegmentIndex
+        pathnameSearchEnd = decodedPathname.length - finalSegment.length
+    }
+
+    for (; nextSegmentIndex < segmentSearchEnd; nextSegmentIndex++) {
+        const segment = literalSegments[nextSegmentIndex]
+        const matchIndex = findLiteralSegment(decodedPathname, segment, nextSearchIndex, pathnameSearchEnd)
+        if (matchIndex === -1) {
+            return false
+        }
+        nextSearchIndex = matchIndex + segment.length
+    }
+
+    return nextSearchIndex <= pathnameSearchEnd
+}
+
+function findLiteralSegment(value: string, segment: string, startIndex: number, endIndex: number): number {
+    const prefixLengths = buildPrefixLengths(segment)
+    for (let index = startIndex, matchedLength = 0; index < endIndex; index++) {
+        while (matchedLength > 0 && value[index] !== segment[matchedLength]) {
+            matchedLength = prefixLengths[matchedLength - 1]
+        }
+        if (value[index] === segment[matchedLength]) {
+            matchedLength++
+        }
+        if (matchedLength === segment.length) {
+            return index - segment.length + 1
+        }
+    }
+    return -1
+}
+
+function buildPrefixLengths(value: string): number[] {
+    const prefixLengths = Array<number>(value.length).fill(0)
+    for (let index = 1, matchedLength = 0; index < value.length; index++) {
+        while (matchedLength > 0 && value[index] !== value[matchedLength]) {
+            matchedLength = prefixLengths[matchedLength - 1]
+        }
+        if (value[index] === value[matchedLength]) {
+            matchedLength++
+        }
+        prefixLengths[index] = matchedLength
+    }
+    return prefixLengths
+}
+
+function decodeUnreserved(value: string): string {
+    return value.replace(/%[0-9A-Fa-f]{2}/g, (encoded) => {
+        const character = String.fromCharCode(Number.parseInt(encoded.slice(1), 16))
+        return /^[A-Za-z0-9._~-]$/.test(character) ? character : encoded.toUpperCase()
+    })
+}


### PR DESCRIPTION
## Problem

An origin can block the image-fetch worker by serving a wildcard-heavy TDMRep or Content-Signal path.

The matcher compiled origin-controlled wildcards into a backtracking regular expression. The underlying image-fetch feature landed in #87501, so this fix can be reviewed separately.

## Changes

- Policy wildcard matching now completes in linear time for TDMRep and Content-Signal paths.
- The wildcard parser and search implementation live in a dedicated module. The policy module only calls the matcher.
- Existing wildcard, anchoring, and percent-decoding behavior stays the same.
- This internal change has no user interface effect.

Merge order:

1. [Grafana dashboards #404](https://github.com/PostHog/grafana-dashboards/pull/404)
2. [MLHog #259](https://github.com/PostHog/MLHog/pull/259)
3. [PostHog #87501](https://github.com/PostHog/posthog/pull/87501)
4. This PR
5. [Charts #14587](https://github.com/PostHog/charts/pull/14587)
6. [Charts #14588](https://github.com/PostHog/charts/pull/14588)
7. [Charts #14589](https://github.com/PostHog/charts/pull/14589)

## How did you test this code?

- The adversarial test fails if an origin-controlled location reaches the regular expression constructor.
- The matcher table covers wildcard placement, anchors, percent encoding, literal metacharacters, and overlapping segments.
- The focused policy and matcher suites pass with 55 tests.
- The complete fetch-lane suite passed before the code-only extraction, with 13 suites and 268 tests.
- TypeScript, ESLint, and Prettier pass after the extraction.
- Not run: the DynamoDB integration test because its local endpoint was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The path-policy behavior stays the same.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used local Git and test tools with /security-audit, /writing-tests, /ingestion-pipeline-doctor-nodejs, /stacking-prs, /writing-pr-descriptions, and ASD-STE100.

The test data is invented. This PR contains no private customer or operational material.
