### PR TITLE
feat(desktop): track onboarding activation outcomes

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -2071,6 +2071,10 @@ export class SessionService {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.d.log.error("Failed to connect to task", { message });
+      this.d.track(ANALYTICS_EVENTS.AGENT_SESSION_ERROR, {
+        task_id: taskId,
+        error_type: "connect_failed",
+      });
 
       const taskRunId = latestRun?.id ?? `error-${taskId}`;
       const session = createBaseSession(taskRunId, taskId, taskTitle);
@@ -3082,6 +3086,12 @@ export class SessionService {
             error: err,
           });
           const session = this.getSessionByRunId(taskRunId);
+          if (session) {
+            this.d.track(ANALYTICS_EVENTS.AGENT_SESSION_ERROR, {
+              task_id: session.taskId,
+              error_type: "subscription_error",
+            });
+          }
           if (!session || session.isCloud) {
             this.d.store.updateSession(taskRunId, {
               status: "error",
@@ -8559,6 +8569,13 @@ export class SessionService {
     update: CloudTaskUpdatePayload,
   ): void {
     if (update.kind === "error") {
+      const session = this.d.store.getSessions()[taskRunId];
+      if (session) {
+        this.d.track(ANALYTICS_EVENTS.AGENT_SESSION_ERROR, {
+          task_id: session.taskId,
+          error_type: "cloud_task_error",
+        });
+      }
       this.d.store.updateSession(taskRunId, {
         status: "error",
         errorTitle: update.errorTitle,

--- a/products/desktop/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceRetryConfig.test.ts
@@ -1,4 +1,8 @@
-import type { AcpMessage, AgentSession } from "@posthog/shared";
+import {
+  type AcpMessage,
+  type AgentSession,
+  ANALYTICS_EVENTS,
+} from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -231,6 +235,7 @@ function assertRunConfigPersisted(setSession: ReturnType<typeof vi.fn>): void {
 describe("SessionService.connectToTask start failure", () => {
   it("persists the run configuration on the error session so retry keeps the model", async () => {
     const setSession = vi.fn();
+    const track = vi.fn();
     const deps = {
       store: {
         getSessionByTaskId: () => undefined,
@@ -238,6 +243,7 @@ describe("SessionService.connectToTask start failure", () => {
         setSession,
       },
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      track,
       settings: { customInstructions: "" },
       DEFAULT_GATEWAY_MODEL: "claude-opus-4-8",
       // Online for the create-branch check, offline in the catch so the
@@ -278,6 +284,10 @@ describe("SessionService.connectToTask start failure", () => {
     await service.connectToTask(CONNECT_PARAMS);
 
     assertRunConfigPersisted(setSession);
+    expect(track).toHaveBeenCalledWith(ANALYTICS_EVENTS.AGENT_SESSION_ERROR, {
+      task_id: "task-1",
+      error_type: "connect_failed",
+    });
   });
 });
 

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1119,6 +1119,13 @@ export interface CanvasRenderedProperties {
   build_id?: string;
 }
 
+export interface CanvasViewedProperties {
+  channel_id: string;
+  dashboard_id: string;
+  canvas_kind: "freeform" | "grid" | "component";
+  template_id: string;
+}
+
 export interface CanvasRuntimeErrorProperties {
   channel_id?: string;
   dashboard_id?: string;
@@ -1545,6 +1552,7 @@ export const ANALYTICS_EVENTS = {
   TASK_FEED_ACTION: "Task feed action",
   DASHBOARD_ACTION: "Dashboard action",
   CANVAS_PROMPT_SENT: "Canvas prompt sent",
+  CANVAS_VIEWED: "Canvas viewed",
   CANVAS_RENDERED: "Canvas rendered",
   CANVAS_RUNTIME_ERROR: "Canvas runtime error",
   CONTEXT_ACTION: "Context action",
@@ -1737,6 +1745,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.TASK_FEED_ACTION]: TaskFeedActionProperties;
   [ANALYTICS_EVENTS.DASHBOARD_ACTION]: DashboardActionProperties;
   [ANALYTICS_EVENTS.CANVAS_PROMPT_SENT]: CanvasPromptSentProperties;
+  [ANALYTICS_EVENTS.CANVAS_VIEWED]: CanvasViewedProperties;
   [ANALYTICS_EVENTS.CANVAS_RENDERED]: CanvasRenderedProperties;
   [ANALYTICS_EVENTS.CANVAS_RUNTIME_ERROR]: CanvasRuntimeErrorProperties;
   [ANALYTICS_EVENTS.CONTEXT_ACTION]: ContextActionProperties;

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
@@ -1,7 +1,10 @@
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { FreeformCanvasView } from "@posthog/ui/features/canvas/freeform/FreeformCanvasView";
 import { GridCanvasView } from "@posthog/ui/features/canvas/grid/GridCanvasView";
 import { useDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useIsDashboardEditing } from "@posthog/ui/features/canvas/stores/dashboardEditStore";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect, useRef } from "react";
 
 // Renders a canvas's app in a sandboxed iframe (view + edit). Edit mode adds
 // the chat panel + version controls; generation runs as a dedicated task. The
@@ -11,6 +14,19 @@ import { useIsDashboardEditing } from "@posthog/ui/features/canvas/stores/dashbo
 export function WebsiteDashboard({ dashboardId }: { dashboardId: string }) {
   const editing = useIsDashboardEditing(dashboardId);
   const { dashboard } = useDashboard(dashboardId);
+  const viewedDashboardIdRef = useRef<string>();
+
+  useEffect(() => {
+    if (!dashboard || viewedDashboardIdRef.current === dashboard.id) return;
+    viewedDashboardIdRef.current = dashboard.id;
+    track(ANALYTICS_EVENTS.CANVAS_VIEWED, {
+      channel_id: dashboard.channelId,
+      dashboard_id: dashboard.id,
+      canvas_kind: dashboard.kind,
+      template_id: dashboard.templateId,
+    });
+  }, [dashboard]);
+
   if (dashboard?.kind === "grid") {
     return <GridCanvasView canvasId={dashboardId} interactive={editing} />;
   }

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteDashboard.tsx
@@ -14,7 +14,7 @@ import { useEffect, useRef } from "react";
 export function WebsiteDashboard({ dashboardId }: { dashboardId: string }) {
   const editing = useIsDashboardEditing(dashboardId);
   const { dashboard } = useDashboard(dashboardId);
-  const viewedDashboardIdRef = useRef<string>();
+  const viewedDashboardIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (!dashboard || viewedDashboardIdRef.current === dashboard.id) return;

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -534,6 +534,10 @@ export function useTaskCreation({
           }
 
           if (!result.success) {
+            track(ANALYTICS_EVENTS.TASK_CREATION_FAILED, {
+              error_type: "task_creation_failed",
+              failed_step: result.failedStep,
+            });
             // Usage-limit blocks already show the upgrade modal; don't also toast an error.
             if (isUsageLimitResult(result)) {
               useUsageLimitStore.getState().show();
@@ -556,6 +560,9 @@ export function useTaskCreation({
           }
           return result.success;
         } catch (error) {
+          track(ANALYTICS_EVENTS.TASK_CREATION_FAILED, {
+            error_type: "unexpected_error",
+          });
           toastError("Failed to create task", error);
           log.error("Unexpected error during task creation", { error });
           if (pendingTaskKey) {


### PR DESCRIPTION
## Problem

Desktop onboarding analysis cannot distinguish activation failures or reliably identify prebuilt canvas views.

**Why:** Product decisions need an observable path from onboarding to successful use.

## Changes

- Records task creation and primary agent-session failures with safe failure categories.
- Records each canvas view with its canvas kind and template identity.
- Keeps the existing onboarding wizard, setup discovery, and canvas rendering telemetry unchanged.

## How did you test this code?

- Ran `pnpm biome check --write` on the changed files.
- Ran `pnpm --filter @posthog/shared typecheck`, `pnpm --filter @posthog/ui typecheck`, `pnpm --filter @posthog/core typecheck`, and `biome lint packages/core`.
- Not run: manual desktop UI verification. This changes telemetry only and has no visible UI change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed. The event schema is internal.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used the `posthog-desktop`, `instrument-product-analytics`, and `writing-pr-descriptions` skills. The change adds activation and failure observability without collecting prompt or error-message content.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*