### PR TITLE
fix(desktop): refresh organization consent

### DIFF
--- a/products/desktop/packages/ui/src/features/consent/ConsentPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/consent/ConsentPanel.test.tsx
@@ -34,6 +34,7 @@ function renderPanel(
     needsAiConsent: boolean;
     needsBetaTerms: boolean;
   },
+  onRefresh?: () => Promise<void>,
 ) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -50,6 +51,7 @@ function renderPanel(
         }}
         requirements={requirements}
         isAdmin={isAdmin}
+        onRefresh={onRefresh}
       />
     </QueryClientProvider>,
   );
@@ -120,8 +122,23 @@ describe("ConsentPanel", () => {
   });
 
   it("asks members to contact an admin without rendering an accept button", () => {
-    renderPanel(true, true, false);
+    renderPanel(true, true, false, undefined, async () => undefined);
 
     expect(screen.queryByText("Accept beta terms")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "I've asked an admin — check again" }),
+    ).toBeInTheDocument();
+  });
+
+  it("lets members refresh consent after an admin accepts", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderPanel(true, true, false, undefined, onRefresh);
+
+    await user.click(
+      screen.getByRole("button", { name: "I've asked an admin — check again" }),
+    );
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledExactlyOnceWith());
   });
 });

--- a/products/desktop/packages/ui/src/features/consent/ConsentPanel.tsx
+++ b/products/desktop/packages/ui/src/features/consent/ConsentPanel.tsx
@@ -24,6 +24,7 @@ interface ConsentPanelProps {
     needsBetaTerms: boolean;
   };
   isAdmin: boolean;
+  onRefresh?: () => Promise<void>;
   onSubmittingChange?: (isSubmitting: boolean) => void;
 }
 
@@ -31,6 +32,7 @@ export function ConsentPanel({
   consent,
   requirements,
   isAdmin,
+  onRefresh,
   onSubmittingChange,
 }: ConsentPanelProps) {
   const client = useAuthenticatedClient();
@@ -40,6 +42,7 @@ export function ConsentPanel({
     refetchOnWindowFocus: "always",
   });
   const [submitting, setSubmitting] = useState<"ai" | "beta" | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const organization = currentUser?.organization;
   const showAiConsent = requirements?.needsAiConsent ?? consent.needsAiConsent;
@@ -74,6 +77,16 @@ export function ConsentPanel({
     } finally {
       setSubmitting(null);
       onSubmittingChange?.(false);
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    if (!onRefresh || refreshing) return;
+    setRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      setRefreshing(false);
     }
   };
 
@@ -179,6 +192,19 @@ export function ConsentPanel({
         >
           {error}
         </div>
+      )}
+
+      {!isAdmin && (showAiConsent || showBetaTerms) && onRefresh && (
+        <Button
+          variant="outline"
+          size="lg"
+          className="w-fit"
+          loading={refreshing}
+          disabled={submitting !== null}
+          onClick={() => void refresh()}
+        >
+          I've asked an admin — check again
+        </Button>
       )}
     </div>
   );

--- a/products/desktop/packages/ui/src/features/consent/ConsentScreen.tsx
+++ b/products/desktop/packages/ui/src/features/consent/ConsentScreen.tsx
@@ -66,7 +66,11 @@ export function ConsentScreen({
           {consent.status === "error" ? (
             <ConsentErrorContent onRetry={consent.retry} />
           ) : consent.status === "resolved" ? (
-            <ConsentPanel consent={consent} isAdmin={isAdmin === true} />
+            <ConsentPanel
+              consent={consent}
+              isAdmin={isAdmin === true}
+              onRefresh={consent.retry}
+            />
           ) : null}
         </div>
       </FullScreenLayout>

--- a/products/desktop/packages/ui/src/features/consent/ConsentStep.tsx
+++ b/products/desktop/packages/ui/src/features/consent/ConsentStep.tsx
@@ -54,6 +54,7 @@ export function ConsentStep({
                     consent={consent}
                     requirements={requirements}
                     isAdmin={isAdmin === true}
+                    onRefresh={consent.retry}
                     onSubmittingChange={(submitting) => {
                       setIsSubmitting(submitting);
                       onSubmittingChange?.(submitting);

--- a/products/desktop/packages/ui/src/features/consent/useOrgConsent.ts
+++ b/products/desktop/packages/ui/src/features/consent/useOrgConsent.ts
@@ -9,7 +9,7 @@ import { useCallback } from "react";
 
 export type OrgConsent =
   | { status: "loading"; organizationId?: string }
-  | { status: "error"; organizationId?: string; retry: () => void }
+  | { status: "error"; organizationId?: string; retry: () => Promise<void> }
   | {
       status: "resolved";
       organizationId: string;
@@ -53,7 +53,7 @@ export function useOrgConsent(enabled = true): OrgConsent {
   const betaTermsQuery = useDesktopBetaTerms(organization?.id, enabled);
   const queryClient = useQueryClient();
   const retry = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: ["auth"] });
+    return queryClient.invalidateQueries({ queryKey: ["auth"] });
   }, [queryClient]);
 
   const reportableError = [currentUserQuery.error, betaTermsQuery.error].some(


### PR DESCRIPTION
## Problem

- Desktop members remain on the consent gate after an organization admin accepts a required item.

## Changes

- Members can recheck organization consent without restarting PostHog Desktop.
- The recheck refreshes both AI approval and Desktop beta terms.
- No screenshot: this small control was covered by an automated component test.

## How did you test this code?

- Updated the consent panel test to prevent a regression where members cannot refresh after an admin accepts.
- Ran the Desktop UI test suite, lint, and typecheck.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used the `posthog-desktop`, `querying-posthog-data`, `writing-tests`, and `writing-pr-descriptions` skills.
- Investigated the consent API and Desktop telemetry before adding an in-app refresh path.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*