### PR TITLE
fix(usage-report): attribute AI credits from the project group

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -3585,6 +3585,14 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
             group_type_index=group_type_index,
         )
 
+    def _setup_project_group_mapping(self, team: Team, group_type_index: int = 2) -> None:
+        create_group_type_mapping_without_created_at(
+            team=team,
+            project_id=team.project_id,
+            group_type="project",
+            group_type_index=group_type_index,
+        )
+
     @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_llm_observability_usage_metrics(
@@ -3730,6 +3738,89 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
 
         # Expected: 1.0 USD * 100 * 1.2 = 120 credits
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], self.org_1_team_1.id)
+        self.assertEqual(result[0][1], 120)
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_ai_credits_attribute_to_the_project_group_not_the_caller_property(self, mock_region: MagicMock) -> None:
+        """The payer comes from the $groups-derived slot, not the caller's team_id property.
+
+        A gateway caller controls unprefixed event properties, so a forged team_id
+        would charge another team's credits. $groups is stripped and re-stamped
+        gateway-side, so the resolved slot is the same fact the caller cannot write.
+        """
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+        self._setup_project_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_1",
+            timestamp=period.start + relativedelta(hours=1),
+            properties={
+                # The caller names a team that is not the payer; the group slot
+                # names the real one. Any value here must lose, real team or not.
+                "team_id": 999999,
+                "$ai_total_cost_usd": 1.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_ai",
+                "$group_1": "https://us.posthog.com",
+                "$group_2": str(self.org_1_team_1.id),
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], self.org_1_team_1.id)
+        self.assertEqual(result[0][1], 120)
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_ai_credits_fall_back_to_team_id_when_project_group_unregistered(self, mock_region: MagicMock) -> None:
+        """With no project group type registered, attribution keeps using the property.
+
+        This is the transitional path: it keeps a deploy that has not registered the
+        group type billing as before instead of silently crediting nobody.
+        """
+        from posthog.tasks.usage_report import get_teams_with_ai_credits_used_in_period
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_1",
+            timestamp=period.start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_total_cost_usd": 1.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_ai",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][0], self.org_1_team_1.id)
         self.assertEqual(result[0][1], 120)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1664,6 +1664,9 @@ POSTHOG_CODE_COST_MARKUP_PERCENT = 0.0
 # Tools excluded from AI billing (traces with only these tools are not billed)
 AI_BILLING_EXCLUDED_TOOLS = ["summarize_sessions", "search"]
 AI_BILLING_INSTANCE_GROUP_TYPE = "instance"
+# Customer team the spend was incurred for. Both gateways stamp it in $groups, so
+# ingestion resolves it to a $group_N slot a caller cannot write.
+AI_BILLING_PROJECT_GROUP_TYPE = "project"
 # Region-to-team mapping for where AI events are stored
 CLOUD_REGION_TO_TEAM_ID = {
     "EU": 1,
@@ -1691,13 +1694,18 @@ UNBILLED_TASK_ORIGIN_PRODUCTS = ("task_analysis",)
 POSTHOG_CODE_AI_PRODUCTS = ["posthog_code"]
 
 
-def get_ai_billing_instance_group_type_index(team_id: int) -> int | None:
-    """Resolve the $group_N index that holds the customer cloud URL for the internal AI events team."""
+def get_ai_billing_group_type_index(team_id: int, group_type: str) -> int | None:
+    """Resolve the $group_N index holding group_type for the internal AI events team."""
     for mapping in get_group_types_for_team(team_id):
-        if mapping.get("group_type") == AI_BILLING_INSTANCE_GROUP_TYPE:
+        if mapping.get("group_type") == group_type:
             index = mapping.get("group_type_index")
             return int(index) if index is not None else None
     return None
+
+
+def get_ai_billing_instance_group_type_index(team_id: int) -> int | None:
+    """Resolve the $group_N index that holds the customer cloud URL for the internal AI events team."""
+    return get_ai_billing_group_type_index(team_id, AI_BILLING_INSTANCE_GROUP_TYPE)
 
 
 def build_ai_billing_region_filter(team_id: int, region_url: str) -> dict[str, str] | None:
@@ -1776,6 +1784,25 @@ def _get_teams_with_ai_credits_for_products(
     customer_team_id_expr, _ = get_property_string_expr(
         "events", "team_id", "'team_id'", "properties", use_new_events_schema=use_new
     )
+    # team_id is caller-supplied, so a caller can name the team its own spend is
+    # charged to; the $groups-derived slot is the same fact in a form it cannot
+    # write. The per-row fallback keeps a deploy with the group type unregistered
+    # billing as before; drop it once the type is confirmed on both internal teams.
+    project_group_index = get_ai_billing_group_type_index(team_to_query, AI_BILLING_PROJECT_GROUP_TYPE)
+    if project_group_index is None:
+        logger.warning(
+            "ai_billing_project_group_unregistered",
+            team_to_query=team_to_query,
+            group_type=AI_BILLING_PROJECT_GROUP_TYPE,
+            detail="falling back to the caller-supplied team_id property for credit attribution",
+        )
+        customer_team_id_source = customer_team_id_expr
+    else:
+        project_property = f"$group_{project_group_index}"
+        project_expr, _ = get_property_string_expr(
+            "events", project_property, f"'{project_property}'", "properties", use_new_events_schema=use_new
+        )
+        customer_team_id_source = f"if(notEmpty({project_expr}), {project_expr}, {customer_team_id_expr})"
     total_cost_expr, _ = get_property_string_expr(
         "events", "$ai_total_cost_usd", "'$ai_total_cost_usd'", "properties", use_new_events_schema=use_new
     )
@@ -1852,7 +1879,7 @@ def _get_teams_with_ai_credits_for_products(
                     cost_usd
                 FROM (
                     SELECT
-                        toInt64OrZero({customer_team_id_expr}) AS customer_team_id,
+                        toInt64OrZero({customer_team_id_source}) AS customer_team_id,
                         {trace_id_expr} AS trace_id,
                         toDecimal32OrNull(
                             {total_cost_expr},


### PR DESCRIPTION
> **Retracted, not merged.** The premise is wrong: `$groups.project` carries the
> team that owns the gateway credential, not the customer the spend is for. The
> internal callers share one credential and pass the customer separately as an
> unprefixed `team_id` property, so preferring the group slot would rewrite
> `customer_team_id` to a single internal team on every gateway row and drop
> customer credit attribution entirely.
>
> The forgeable-payer problem the change was aimed at is real. The fix has to keep
> `team_id` as the payer, since it is the only place the customer appears, and
> instead authorize which credentials may set it.

---

## Problem

AI credit usage is attributed to whichever team an event's `team_id` property names, and that property is caller-supplied. Callers of the AI gateway set it themselves, so a caller can charge its spend to a team it does not own. `$groups` already carries the same team in a form no caller can write, and this query already resolves a group slot for its region filter.

## Changes

- `customer_team_id` resolves from the `project` group slot, with a per-row fallback to the `team_id` property.
- `get_ai_billing_instance_group_type_index` generalizes to `get_ai_billing_group_type_index(team_id, group_type)`; the old name stays as a wrapper.
- A deploy with no `project` group type registered logs `ai_billing_project_group_unregistered` and keeps the existing attribution, so credits never silently drop to zero.

The fallback is transitional. Drop it once the `project` group type is confirmed registered on both internal AI-events teams, after which the property is ignored entirely.

Both `get_teams_with_ai_credits_used_in_period` and the PostHog Desktop equivalent route through the changed function, so both pick this up.

## How did you test this code?

Two tests in `posthog/tasks/test/test_usage_report.py`. One asserts a forged `team_id` loses to the group slot; one pins the unregistered-group fallback. No existing test covered which source attribution comes from, so both catch regressions nothing else would.

The agent could not execute them locally. The local ClickHouse container predates this branch's schema and fails test setup on an unmodified test in the same class, missing `ai_tags_fixed` from a materialized view target, so a full `--create-db` rebuild reproduced the same failure. Verification was instead by asserting the generated SQL in both the registered and unregistered branches, with the group-type lookup and `sync_execute` patched out. `ruff check`, `ruff format --check`, and `mypy` pass on the changed file. CI is the first real execution of the two tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5) at a human's direction, while reviewing PostHog/ai-gateway#414, which starts stamping `$ai_billable` and so makes this attribution path decide real money. Skills invoked: `/branch-review`, `/code-comments`, `/pr-descriptions`.

One design change during the session: the gateway was first made to stamp `team_id` itself. That was reverted after finding callers such as `products/ai_observability/backend/summarization/llm/openai.py` send the key deliberately to name the customer team, so overwriting it would have discarded the attribution they intend.

Requires human review.

