### PR TITLE
feat(hogql): expose the logs_volume_buckets rollup as a table

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -100,7 +100,12 @@ from posthog.hogql.database.schema.log_entries import (
     LogEntriesTable,
     ReplayConsoleLogsLogEntriesTable,
 )
-from posthog.hogql.database.schema.logs import LogAttributesTable, LogsKafkaMetricsTable, LogsTable
+from posthog.hogql.database.schema.logs import (
+    LogAttributesTable,
+    LogsKafkaMetricsTable,
+    LogsTable,
+    LogsVolumeBucketsTable,
+)
 from posthog.hogql.database.schema.marketing_conversions_preaggregated import MarketingConversionsPreaggregatedTable
 from posthog.hogql.database.schema.marketing_costs_preaggregated import MarketingCostsPreaggregatedTable
 from posthog.hogql.database.schema.marketing_costs_precomputed import MarketingCostsPrecomputedTable
@@ -406,6 +411,7 @@ def _construct_database_root_node(*, include_posthog_tables: bool) -> TableNode:
                 children={
                     **clone_root_tables(),
                     # Add new tables here
+                    "logs_volume_buckets": TableNode(name="logs_volume_buckets", table=LogsVolumeBucketsTable()),
                     "ai_events": TableNode(name="ai_events", table=AiEventsTable()),
                     "trace_spans": TableNode(name="trace_spans", table=TraceSpansTable()),
                     "trace_attributes": TableNode(name="trace_attributes", table=TraceAttributesTable()),

--- a/posthog/hogql/database/schema/logs.py
+++ b/posthog/hogql/database/schema/logs.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from posthog.hogql.database.models import (
     DANGEROUS_NoTeamIdCheckTable,
     DateTimeDatabaseField,
@@ -10,6 +12,9 @@ from posthog.hogql.database.models import (
 )
 
 from posthog.clickhouse.workload import Workload
+
+if TYPE_CHECKING:
+    from posthog.hogql.context import HogQLContext
 
 # 50GB - limit for user-provided HogQL queries on log tables to prevent expensive full scans
 HOGQL_MAX_BYTES_TO_READ_FOR_LOGS_USER_QUERIES = 50_000_000_000
@@ -96,6 +101,49 @@ class LogsTable(Table):
 
     def to_printed_hogql(self):
         return "logs"
+
+
+class LogsVolumeBucketsTable(Table):
+    description: str = (
+        "Log volume rollup on a 5-minute UTC grid, one row per (service, namespace, environment, severity) "
+        "series per bucket. Holds partial counts: always GROUP BY the key columns and sum(log_count)."
+    )
+    workload: Workload | None = Workload.LOGS
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "time_bucket": DateTimeDatabaseField(
+            name="time_bucket",
+            nullable=False,
+            description="Start of the 5-minute UTC bucket the counts fall in.",
+        ),
+        "service_name": StringDatabaseField(
+            name="service_name", nullable=False, description="Name of the service that emitted the logs."
+        ),
+        "namespace": StringDatabaseField(
+            name="namespace",
+            nullable=False,
+            description="Kubernetes or service namespace of the emitting resource; empty string when absent.",
+        ),
+        "environment": StringDatabaseField(
+            name="environment",
+            nullable=False,
+            description="Deployment environment of the emitting resource; empty string when absent.",
+        ),
+        "severity_text": StringDatabaseField(
+            name="severity_text", nullable=False, description="Lowercased log severity (for example info, warn, error)."
+        ),
+        "log_count": IntegerDatabaseField(
+            name="log_count",
+            nullable=False,
+            description="Partial log count for the bucket; sum() across rows for the true count.",
+        ),
+    }
+
+    def to_printed_clickhouse(self, context: "HogQLContext") -> str:
+        return "logs_volume_buckets_distributed"
+
+    def to_printed_hogql(self) -> str:
+        return "logs_volume_buckets"
 
 
 class LogAttributesTable(Table):


### PR DESCRIPTION
## Problem

The logs product needs to read its `logs_volume_buckets` rollup through HogQL, and the table is not in the HogQL database. The consumer is the per-series band endpoint in #87684, which stacks on this PR.

## Changes

Nothing user-visible changes; this only makes the table queryable.

- `logs_volume_buckets` becomes a HogQL table in the `posthog` namespace, mapping to `logs_volume_buckets_distributed` on the logs workload.
- The table is team-scoped like every other non-`DANGEROUS_` table, and its description warns that readers must GROUP BY and sum the partial counts.

## How did you test this code?

- The existing HogQL database suite passes, including the root-table guard and serialization snapshots, with no snapshot changes.
- Query-shape coverage lives in #87684, where live ClickHouse tests read the table end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Table and column descriptions ship in the schema itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, directed by the assignee. Split out of #87684 so the HogQL codeowner review covers only this slice. Skills invoked: `/writing-clickhouse-queries`, `/stacking-prs`, `/writing-pr-descriptions`.
