### PR TITLE
fix(tasks): end analysis runs promptly and enrich insight events

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -121,6 +121,7 @@ type AppServerSessionMeta = {
   taskId?: string;
   persistence?: { taskId?: string };
   environment?: "local" | "cloud";
+  mode?: string;
   channelMode?: boolean;
   spokenNarration?: boolean;
   baseBranch?: string;
@@ -678,6 +679,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     if (!meta) return undefined;
     return {
       environment: meta.environment,
+      background: meta.mode === "background",
       channelMode: meta.channelMode,
       spokenNarration: resolveSpokenNarration(meta),
       taskId: meta.taskId,

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 const updateTaskRun = vi.fn();
 
-vi.mock("../../../signed-commit-artefacts", () => ({
+vi.mock("../../../signed-commit-artefacts", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../signed-commit-artefacts")
+  >()),
   createSandboxPosthogClient: () => ({ updateTaskRun }),
 }));
 
@@ -94,10 +97,12 @@ describe("finish tool", () => {
       { cwd: "/repo", taskId: "task-1", taskRunId: "run-1" },
       { status: "failed", reason: "blocked" },
     );
-    expect(updateTaskRun).toHaveBeenCalledWith("task-1", "run-1", {
-      status: "failed",
-      error_message: "blocked",
-    });
+    expect(updateTaskRun).toHaveBeenCalledWith(
+      "task-1",
+      "run-1",
+      { status: "failed", error_message: "blocked" },
+      expect.any(AbortSignal),
+    );
     expect(result.isError).toBeUndefined();
   });
 

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+
+const updateTaskRun = vi.fn();
+
+vi.mock("../../../signed-commit-artefacts", () => ({
+  createSandboxPosthogClient: () => ({ updateTaskRun }),
+}));
+
 import { enabledLocalTools } from "../index";
 import type { LocalToolCtx, LocalToolGateMeta } from "../registry";
 import { FINISH_TOOL_NAME, finishSchema, finishTool } from "./finish";
@@ -14,10 +21,16 @@ describe("finish tool", () => {
       expected: true,
     },
     {
-      name: "background cloud run without requestFinish",
+      name: "background cloud run without requestFinish or run ids",
       ctx: { cwd: "/repo" },
       meta: { environment: "cloud", background: true },
       expected: false,
+    },
+    {
+      name: "background cloud run with run ids only (out-of-process adapter)",
+      ctx: { cwd: "/repo", taskId: "task-1", taskRunId: "run-1" },
+      meta: { environment: "cloud", background: true },
+      expected: true,
     },
     {
       name: "interactive cloud run (background unset)",
@@ -72,6 +85,19 @@ describe("finish tool", () => {
       { status: "failed", reason: "ran out of quota" },
     );
     expect(spy).toHaveBeenCalledWith("failed", "ran out of quota");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("marks the run terminal via the API when no requestFinish callback exists", async () => {
+    updateTaskRun.mockResolvedValue({});
+    const result = await finishTool.handler(
+      { cwd: "/repo", taskId: "task-1", taskRunId: "run-1" },
+      { status: "failed", reason: "blocked" },
+    );
+    expect(updateTaskRun).toHaveBeenCalledWith("task-1", "run-1", {
+      status: "failed",
+      error_message: "blocked",
+    });
     expect(result.isError).toBeUndefined();
   });
 

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { defineLocalTool, type LocalToolResult } from "../registry";
+import { createSandboxPosthogClient } from "../../../signed-commit-artefacts";
+import {
+  defineLocalTool,
+  type LocalToolCtx,
+  type LocalToolResult,
+} from "../registry";
 
 export const FINISH_TOOL_NAME = "finish";
 
@@ -39,6 +44,24 @@ export const FINISH_TOOL_DESCRIPTION =
  * down. Gated to cloud runs that actually own a sandbox — local sessions have
  * no `requestFinish` and no sandbox to reclaim, so the tool stays hidden there.
  */
+// Adapters that run local tools in a separate process (codex) cannot pass the
+// in-process `requestFinish` callback through the serialized tool context, so
+// the tool falls back to the same PostHog API PATCH that callback performs.
+function buildSandboxRequestFinish(
+  ctx: LocalToolCtx,
+): LocalToolCtx["requestFinish"] {
+  const { taskId, taskRunId } = ctx;
+  if (!taskId || !taskRunId) return undefined;
+  const client = createSandboxPosthogClient();
+  if (!client) return undefined;
+  return async (status, message) => {
+    await client.updateTaskRun(taskId, taskRunId, {
+      status,
+      ...(status === "failed" && message ? { error_message: message } : {}),
+    });
+  };
+}
+
 export const finishTool = defineLocalTool({
   name: FINISH_TOOL_NAME,
   description: FINISH_TOOL_DESCRIPTION,
@@ -47,9 +70,10 @@ export const finishTool = defineLocalTool({
   isEnabled: (ctx, meta) =>
     meta?.environment === "cloud" &&
     meta?.background === true &&
-    ctx.requestFinish !== undefined,
+    (ctx.requestFinish !== undefined || (!!ctx.taskId && !!ctx.taskRunId)),
   handler: async (ctx, args): Promise<LocalToolResult> => {
-    if (!ctx.requestFinish) {
+    const requestFinish = ctx.requestFinish ?? buildSandboxRequestFinish(ctx);
+    if (!requestFinish) {
       return {
         content: [
           { type: "text", text: "finish is not available in this session." },
@@ -57,7 +81,7 @@ export const finishTool = defineLocalTool({
         isError: true,
       };
     }
-    await ctx.requestFinish(args.status, args.reason);
+    await requestFinish(args.status, args.reason);
     return {
       content: [
         {

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.ts
@@ -47,13 +47,20 @@ export const FINISH_TOOL_DESCRIPTION =
 // Adapters that run local tools in a separate process (codex) cannot pass the
 // in-process `requestFinish` callback through the serialized tool context, so
 // the tool falls back to the same PostHog API PATCH that callback performs.
-function buildSandboxRequestFinish(
+function resolveRequestFinish(
   ctx: LocalToolCtx,
 ): LocalToolCtx["requestFinish"] {
+  if (ctx.requestFinish) {
+    return ctx.requestFinish;
+  }
   const { taskId, taskRunId } = ctx;
-  if (!taskId || !taskRunId) return undefined;
+  if (!taskId || !taskRunId) {
+    return undefined;
+  }
   const client = createSandboxPosthogClient();
-  if (!client) return undefined;
+  if (!client) {
+    return undefined;
+  }
   return async (status, message) => {
     await client.updateTaskRun(taskId, taskRunId, {
       status,
@@ -70,9 +77,9 @@ export const finishTool = defineLocalTool({
   isEnabled: (ctx, meta) =>
     meta?.environment === "cloud" &&
     meta?.background === true &&
-    (ctx.requestFinish !== undefined || (!!ctx.taskId && !!ctx.taskRunId)),
+    resolveRequestFinish(ctx) !== undefined,
   handler: async (ctx, args): Promise<LocalToolResult> => {
-    const requestFinish = ctx.requestFinish ?? buildSandboxRequestFinish(ctx);
+    const requestFinish = resolveRequestFinish(ctx);
     if (!requestFinish) {
       return {
         content: [

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/finish.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { createSandboxPosthogClient } from "../../../signed-commit-artefacts";
+import {
+  createSandboxPosthogClient,
+  withReportDeadline,
+} from "../../../signed-commit-artefacts";
 import {
   defineLocalTool,
   type LocalToolCtx,
@@ -62,10 +65,21 @@ function resolveRequestFinish(
     return undefined;
   }
   return async (status, message) => {
-    await client.updateTaskRun(taskId, taskRunId, {
-      status,
-      ...(status === "failed" && message ? { error_message: message } : {}),
-    });
+    await withReportDeadline(
+      (signal) =>
+        client.updateTaskRun(
+          taskId,
+          taskRunId,
+          {
+            status,
+            ...(status === "failed" && message
+              ? { error_message: message }
+              : {}),
+          },
+          signal,
+        ),
+      "run finish",
+    );
   };
 }
 

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.test.ts
@@ -3,11 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const getTaskRun = vi.fn();
 const reportAnalysisInsight = vi.fn();
 
 vi.mock("../../../signed-commit-artefacts", () => ({
-  createSandboxPosthogClient: () => ({ getTaskRun, reportAnalysisInsight }),
+  createSandboxPosthogClient: () => ({ reportAnalysisInsight }),
   withReportDeadline: <T>(work: (signal: AbortSignal) => Promise<T>) =>
     work(new AbortController().signal),
 }));
@@ -94,8 +93,7 @@ describe("reportInsightTool", () => {
     const logPath = path.join(cwd, LOG_RELATIVE_PATH);
     await mkdir(path.dirname(logPath), { recursive: true });
     await writeFile(logPath, RUN_LOG);
-    getTaskRun.mockResolvedValue({ state: {} });
-    reportAnalysisInsight.mockResolvedValue({});
+    reportAnalysisInsight.mockResolvedValue({ insight_index: 0 });
   });
 
   afterEach(async () => {
@@ -225,32 +223,17 @@ describe("reportInsightTool", () => {
     expect(reportAnalysisInsight).not.toHaveBeenCalled();
   });
 
-  it("enforces the per-run cap and the no-findings contradiction", async () => {
-    getTaskRun.mockResolvedValue({
-      state: {
-        [INSIGHTS_STATE_KEY]: Array(5).fill({ category: "missing_tool" }),
-      },
-    });
-    const capped = await reportInsightTool.handler(ctx(cwd), validFinding());
-    expect(capped.isError).toBe(true);
-    expect(capped.content[0].text).toMatch(/cap/);
-
-    getTaskRun.mockResolvedValue({
-      state: {
-        [INSIGHTS_STATE_KEY]: [{ no_findings_reason: "run_was_efficient" }],
-      },
-    });
-    const contradictory = await reportInsightTool.handler(
-      ctx(cwd),
-      validFinding(),
+  it("numbers the recorded finding from the server's index", async () => {
+    reportAnalysisInsight.mockResolvedValue({ insight_index: 2 });
+    const result = await reportInsightTool.handler(ctx(cwd), validFinding());
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toMatch(
+      /Recorded finding 3 .+ 2 more allowed/,
     );
-    expect(contradictory.isError).toBe(true);
-    expect(contradictory.content[0].text).toMatch(/contradictory/);
   });
 
   it("accumulates findings filed as parallel tool calls", async () => {
     const state: Record<string, unknown> = {};
-    getTaskRun.mockImplementation(() => Promise.resolve({ state }));
     reportAnalysisInsight.mockImplementation(appendingUpdateMock(state));
 
     const second = validFinding({

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.test.ts
@@ -232,6 +232,20 @@ describe("reportInsightTool", () => {
     );
   });
 
+  it("returns a coaching error when the server rejects the report", async () => {
+    reportAnalysisInsight.mockRejectedValueOnce(
+      new Error(
+        'Failed request: [400] {"evidence":[{"quote":["Ensure this value has at least 20 characters."]}]}',
+      ),
+    );
+    const result = await reportInsightTool.handler(ctx(cwd), validFinding());
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/was rejected by the server/);
+    expect(result.content[0].text).toContain(
+      "Ensure this value has at least 20 characters",
+    );
+  });
+
   it("accumulates findings filed as parallel tool calls", async () => {
     const state: Record<string, unknown> = {};
     reportAnalysisInsight.mockImplementation(appendingUpdateMock(state));

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.ts
@@ -45,7 +45,7 @@ const WASTED_EFFORT_REQUIRED_CATEGORIES = new Set([
 const evidenceSchema = z.object({
   quote: z
     .string()
-    .min(10)
+    .min(20)
     .max(300)
     .describe(
       "Verbatim span copied from your jq query output. Checked against the raw run log; a paraphrase is rejected.",
@@ -92,6 +92,18 @@ function enqueueReport<T>(run: () => Promise<T>): Promise<T> {
 
 function errorResult(message: string): LocalToolResult {
   return { content: [{ type: "text", text: message }], isError: true };
+}
+
+// Desktop ships on its own schedule with no orchestration against backend deploys, so a
+// report can hit an older server contract (a 10-19 char quote, an output_bytes-only
+// finding). The API throws a raw `Failed request: [400] {...}` blob that loses the finding
+// silently. Turn a rejection into an actionable error so the model can correct the input
+// and retry, matching the coaching style of every other rejection path in this tool.
+function reportRejectionResult(error: unknown, what: string): LocalToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return errorResult(
+    `The ${what} was rejected by the server and was not recorded. Correct the flagged field and call report_insight again. Server response: ${message}`,
+  );
 }
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching the ESC byte is the point
@@ -302,16 +314,20 @@ export const reportInsightTool = defineLocalTool({
             "no_findings_reason cannot be combined with a finding. Either report the finding (drop no_findings_reason) or report no findings (drop every other field).",
           );
         }
-        await withReportDeadline(
-          (signal) =>
-            client.reportAnalysisInsight(
-              ctx.taskId as string,
-              ctx.taskRunId as string,
-              { no_findings_reason: args.no_findings_reason },
-              signal,
-            ),
-          "no-findings report",
-        );
+        try {
+          await withReportDeadline(
+            (signal) =>
+              client.reportAnalysisInsight(
+                ctx.taskId as string,
+                ctx.taskRunId as string,
+                { no_findings_reason: args.no_findings_reason },
+                signal,
+              ),
+            "no-findings report",
+          );
+        } catch (error) {
+          return reportRejectionResult(error, "no-findings report");
+        }
         return {
           content: [
             {
@@ -399,25 +415,29 @@ export const reportInsightTool = defineLocalTool({
         confidence_basis: args.confidence_basis,
         suggested_fix: args.suggested_fix,
       };
-      const { insight_index } = await withReportDeadline(
-        (signal) =>
-          client.reportAnalysisInsight(
-            ctx.taskId as string,
-            ctx.taskRunId as string,
-            insight,
-            signal,
-          ),
-        "insight report",
-      );
+      try {
+        const { insight_index } = await withReportDeadline(
+          (signal) =>
+            client.reportAnalysisInsight(
+              ctx.taskId as string,
+              ctx.taskRunId as string,
+              insight,
+              signal,
+            ),
+          "insight report",
+        );
 
-      const remaining = MAX_INSIGHTS_PER_RUN - insight_index - 1;
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Recorded finding ${insight_index + 1} (${args.category}). ${remaining} more allowed; only report findings that clear the evidence bar.`,
-          },
-        ],
-      };
+        const remaining = MAX_INSIGHTS_PER_RUN - insight_index - 1;
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Recorded finding ${insight_index + 1} (${args.category}). ${remaining} more allowed; only report findings that clear the evidence bar.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return reportRejectionResult(error, "finding");
+      }
     }),
 });

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/report-insight.ts
@@ -45,7 +45,7 @@ const WASTED_EFFORT_REQUIRED_CATEGORIES = new Set([
 const evidenceSchema = z.object({
   quote: z
     .string()
-    .min(20)
+    .min(10)
     .max(300)
     .describe(
       "Verbatim span copied from your jq query output. Checked against the raw run log; a paraphrase is rejected.",
@@ -251,6 +251,14 @@ export const reportInsightTool = defineLocalTool({
           .describe(
             "Tokens consumed across the wasted span, measured from the run log.",
           ),
+        output_bytes: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "Sum of tool-output sizes across the wasted span, measured from the log. Works in both log formats even when token counters are absent.",
+          ),
       })
       .optional()
       .describe(
@@ -282,20 +290,6 @@ export const reportInsightTool = defineLocalTool({
         );
       }
 
-      const run = await withReportDeadline(
-        (signal) =>
-          client.getTaskRun(
-            ctx.taskId as string,
-            ctx.taskRunId as string,
-            signal,
-          ),
-        "analysis run lookup",
-      );
-      const state = (run.state ?? {}) as Record<string, unknown>;
-      const existing = Array.isArray(state[INSIGHTS_STATE_KEY])
-        ? (state[INSIGHTS_STATE_KEY] as StoredInsight[])
-        : [];
-
       if (args.no_findings_reason) {
         const findingFields = [
           args.observation,
@@ -306,11 +300,6 @@ export const reportInsightTool = defineLocalTool({
         if (findingFields.length > 0) {
           return errorResult(
             "no_findings_reason cannot be combined with a finding. Either report the finding (drop no_findings_reason) or report no findings (drop every other field).",
-          );
-        }
-        if (existing.length > 0) {
-          return errorResult(
-            "Findings were already reported for this run, so a no-findings report is contradictory. Stop reporting.",
           );
         }
         await withReportDeadline(
@@ -338,16 +327,6 @@ export const reportInsightTool = defineLocalTool({
           "A finding requires observation, evidence, and category (or use only no_findings_reason for a clean run).",
         );
       }
-      if (existing.some((entry) => "no_findings_reason" in entry)) {
-        return errorResult(
-          "This run was already reported as having no findings; a finding now is contradictory. Stop reporting.",
-        );
-      }
-      if (existing.length >= MAX_INSIGHTS_PER_RUN) {
-        return errorResult(
-          `The ${MAX_INSIGHTS_PER_RUN}-finding cap for this run is reached. Stop reporting; summarize what you filed.`,
-        );
-      }
       if (args.category === "other" && !args.other_justification) {
         return errorResult(
           "category 'other' requires other_justification (50-200 chars).",
@@ -361,7 +340,7 @@ export const reportInsightTool = defineLocalTool({
         wastedDimensions.length === 0
       ) {
         return errorResult(
-          `category '${args.category}' requires wasted_effort with at least one measured dimension (tool_calls, seconds, or tokens) — count or subtract it from the log.`,
+          `category '${args.category}' requires wasted_effort with at least one measured dimension (tool_calls, seconds, tokens, or output_bytes) — count or subtract it from the log.`,
         );
       }
       if (!args.recurrence || !args.confidence_basis || !args.suggested_fix) {
@@ -420,7 +399,7 @@ export const reportInsightTool = defineLocalTool({
         confidence_basis: args.confidence_basis,
         suggested_fix: args.suggested_fix,
       };
-      await withReportDeadline(
+      const { insight_index } = await withReportDeadline(
         (signal) =>
           client.reportAnalysisInsight(
             ctx.taskId as string,
@@ -431,12 +410,12 @@ export const reportInsightTool = defineLocalTool({
         "insight report",
       );
 
-      const remaining = MAX_INSIGHTS_PER_RUN - existing.length - 1;
+      const remaining = MAX_INSIGHTS_PER_RUN - insight_index - 1;
       return {
         content: [
           {
             type: "text",
-            text: `Recorded finding ${existing.length + 1} (${args.category}). ${remaining} more allowed; only report findings that clear the evidence bar.`,
+            text: `Recorded finding ${insight_index + 1} (${args.category}). ${remaining} more allowed; only report findings that clear the evidence bar.`,
           },
         ],
       };


### PR DESCRIPTION
## Problem

Every task analysis idles ~10 minutes of paid sandbox time after its ~2 minutes of real work. Across one day of production data, 11,526 non-analysis codex background runs closed within 20 seconds of their last activity (p99), while all analysis runs hit the 600-second inactivity reaper — because the codex adapter never exposes the `finish` tool, so the agent has no way to end its run.

Dogfooding also showed the `report_insight` tool always reporting "Recorded finding 1" (its counter read API-redacted state), and a rejected report throwing a raw HTTP blob that silently dropped the finding.

Stacked on the backend companion #87804, which adds the `output_bytes` server serializer field and the `wasted_output_bytes` event property. The merge queue lands and deploys #87804 before this desktop change (stack #87884).

## Changes

- Analysis runs can now end themselves: `finish` works in out-of-process adapters (codex) by falling back to the same run-status PATCH the in-process callback performs, and the codex adapter passes `background` into the tool gate. The out-of-process PATCH is wrapped in `withReportDeadline` so a stalled request aborts and resolves promptly instead of holding the run non-terminal until the 600s inactivity reaper.
- `finish` becomes available to every codex cloud background run, not only analyses. Fleet data shows those runs already close promptly, so the tool is a no-op safety valve there; this is the one behavior change outside task analysis.
- Both `reportAnalysisInsight` calls are wrapped in try/catch so a server rejection returns an actionable coaching error (with the server's message) instead of throwing a raw `Failed request: [400] {...}` blob that silently loses the finding. Desktop ships on its own schedule with no orchestration against backend deploys, so the client no longer assumes the server is always current.
- Findings can carry a measured `output_bytes` dimension in `wasted_effort` — the sum of tool-output sizes across the wasted span, measurable in both log formats including targets whose logs have no token counters. The server field and event property land in #87804; the stack guarantees the server half deploys first.
- The finding counter now uses the server's `insight_index` (previously always "finding 1"), and the redundant client-side cap and contradiction pre-checks are gone — the server has enforced them under a row lock since #87431.

The evidence quote minimum stays at 20 characters. A 10-char client floor was tried but reverted: #87804 does not lower the server serializer's `min_length`, so a 10-char floor would accept quotes the API rejects and drop the finding — a step back from master for that input. The 10-char relaxation is deferred to a follow-up that lowers both sides together.

## How did you test this code?

- Fleet evidence for the idle tail: 11,529 codex background runs over one day — non-analysis origins p50 ~6 s / p99 ~20 s / max 240 s from last activity to `completed_at`; the three analysis runs sat at 585–624 s. Ten runs verified against raw session logs.
- `finish.test.ts` gains the out-of-process cases: the gate exposes the tool with run ids and no callback, the handler PATCHes the run terminal through the sandbox client, and the deadline's abort signal reaches `updateTaskRun` — catches the codex wiring regressing to callback-only and the deadline being silently dropped.
- `report-insight.test.ts` covers the server-index counter message and a new case asserting a server rejection returns a coaching error that includes the server's message, not a thrown blob.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — flag-gated internal dogfood.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). Skills invoked: /posthog-desktop, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Split from a combined PR by the desktop-backend coupling check; the backend half is #87804. This PR is stacked on #87804 (stack #87884) so the server contract deploys first.
- Every change traces to a measured production defect from six dogfooded analyses plus a fleet-wide idle-gap study.
