### PR TITLE
fix(tasks): index webhook task run lookups

### DIFF
--- a/products/tasks/backend/migrations/0105_taskrun_webhook_lookup_indexes.py
+++ b/products/tasks/backend/migrations/0105_taskrun_webhook_lookup_indexes.py
@@ -1,0 +1,39 @@
+from django.contrib.postgres.indexes import GinIndex, OpClass
+from django.db import migrations, models
+from django.db.models.fields.json import KeyTransform
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1315_githubinstallrequest_account"),
+        ("tasks", "0104_desktop_beta_terms_acceptance"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="taskrun",
+            index=GinIndex(
+                OpClass(KeyTransform("verified_pr_urls", "state"), name="jsonb_path_ops"),
+                name="task_run_verified_pr_urls_idx",
+            ),
+        ),
+        SafeAddIndexConcurrently(
+            model_name="taskrun",
+            index=GinIndex(
+                OpClass(KeyTransform("head_branches", "output"), name="jsonb_path_ops"),
+                name="task_run_head_branches_idx",
+            ),
+        ),
+        SafeAddIndexConcurrently(
+            model_name="taskrun",
+            index=models.Index(
+                fields=["branch"],
+                name="task_run_branch_idx",
+                condition=models.Q(branch__isnull=False),
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0104_desktop_beta_terms_acceptance
+0105_taskrun_webhook_lookup_indexes

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
-from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.indexes import GinIndex, OpClass
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection, models, transaction
 from django.db.models.fields.json import KeyTransform
@@ -1987,6 +1987,19 @@ class TaskRun(models.Model):
         db_table = "posthog_task_run"
         ordering = ["-created_at"]
         indexes = [
+            GinIndex(
+                OpClass(KeyTransform("verified_pr_urls", "state"), name="jsonb_path_ops"),
+                name="task_run_verified_pr_urls_idx",
+            ),
+            GinIndex(
+                OpClass(KeyTransform("head_branches", "output"), name="jsonb_path_ops"),
+                name="task_run_head_branches_idx",
+            ),
+            models.Index(
+                fields=["branch"],
+                name="task_run_branch_idx",
+                condition=models.Q(branch__isnull=False),
+            ),
             # Partial functional index backing the per-PR-webhook lookup
             # `filter(output__pr_url=...)`. The equality lookup implies the key is
             # present, so the `IS NOT NULL` condition keeps the index off the many


### PR DESCRIPTION
## Problem

GitHub webhooks can slow down as a team's task run history grows.

Three lookup predicates lack matching indexes, so each lookup scans the team's scoped task runs.

## Changes

- GitHub webhook task run matching now uses dedicated indexes for verified PR URLs, branches, and output head branches.
- The migration builds all three indexes concurrently to avoid blocking writes.
- This change does not modify lookup behavior or any user-visible interface.

## How did you test this code?

- `./manage.py sqlmigrate tasks 0105`
- `./manage.py makemigrations tasks --check --dry-run`
- `./manage.py test_migrations_are_safe`
- `hogli ci:preflight --fix`

The preflight migration conflict check did not run because local ClickHouse was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only adds database indexes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code used repository tools with the `/django-migrations` and `/writing-pr-descriptions` skills. The public diff contains only model index definitions and their migration.
