### PR TITLE
fix(data-imports): unwrap Apitally Apps envelope in fan-out parent

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apitally/apitally.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apitally/apitally.py
@@ -163,6 +163,9 @@ def apitally_source(
                 child_endpoint=endpoint,
                 fanout=endpoint_config.fanout,
                 client_config=client_config,
+                # The Apps list wraps its rows in a `data` envelope; the parent must unwrap it so
+                # the fan-out can bind each app's `id` to the child's `app_id` path param.
+                parent_endpoint_extra={"data_selector": "data"},
                 path_format_values={},
                 team_id=team_id,
                 job_id=job_id,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apitally/tests/test_apitally.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apitally/tests/test_apitally.py
@@ -206,6 +206,18 @@ class TestApitallyFanout:
         assert kwargs["page_size_param"] is None
         assert isinstance(kwargs["child_endpoint_extra"]["paginator"], SinglePagePaginator)
 
+    @parameterized.expand(["Consumers", "Endpoints", "Traffic", "RequestLogs"])
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.apitally.apitally.build_dependent_resource"
+    )
+    def test_fanout_unwraps_parent_data_envelope(self, endpoint, mock_build) -> None:
+        mock_build.return_value = iter([])
+
+        apitally_source(api_key="key", endpoint=endpoint, team_id=1, job_id="job-1")
+
+        _, kwargs = mock_build.call_args
+        assert kwargs["parent_endpoint_extra"] == {"data_selector": "data"}
+
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.apitally.apitally.build_dependent_resource"
     )


### PR DESCRIPTION
## Problem

- Every Apitally warehouse sync of Consumers, Endpoints, Traffic, or RequestLogs fails with a ValueError and imports nothing.
- These schemas fan out from the Apps list and bind each app's `id` to the child request's `app_id` path param.
- The fan-out parent resource never set a `data_selector`, so the `{"data": [...]}` response was passed through as one row with no `id`, and binding raised the error.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a033ad-6a85-7480-a38c-a3c2f19f15fa

## Changes

- Apitally fan-out syncs now import rows instead of failing on the first parent record.
- `apitally_source` passes `parent_endpoint_extra={"data_selector": "data"}` to `build_dependent_resource`, so the parent unwraps the `data` envelope before the fan-out reads `id`.
- This matches the standalone Apps resource, which already sets `data_selector: "data"`, and every other fan-out source, which passes its parent's `data_selector` the same way.

## How did you test this code?

- Added a parameterized case in `test_apitally.py` over all four fan-out schemas asserting the parent `data_selector` is passed. It catches the regression where the parent envelope goes unwrapped; the existing fan-out test hand-fed already-unwrapped parent rows and never exercised this.
- Confirmed the new case fails without the fix (KeyError on the missing `parent_endpoint_extra`) and passes with it.
- Ran the Apitally source unit tests locally. Not run: database-backed suites and a live Apitally sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error tracking issue. Read the stack trace into `process_parent_data_item`, traced the fan-out build in `build_dependent_resource`, and compared Apitally against other fan-out sources.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Root cause is source-specific: shared fan-out code requires each source to declare its parent's `data_selector`, and Apitally was the only source that omitted it. The fix stays in the source rather than the shared layer.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
