### PR TITLE
chore(ci): run fork frontend typechecking on a 32 GB runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,7 +6,6 @@ self-hosted-runner:
         - depot-ubuntu-24.04-4
         - depot-ubuntu-24.04-8
         - depot-macos-15
-        # GitHub-hosted larger runner (8 vCPU / 32 GB), for fork PRs that must not reach Depot.
         - ubuntu-24.04-8core
 
 # The vendored .github/actions/paths-filter emits one output per filter name at

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,8 @@ self-hosted-runner:
         - depot-ubuntu-24.04-4
         - depot-ubuntu-24.04-8
         - depot-macos-15
+        # GitHub-hosted larger runner (8 vCPU / 32 GB), for fork PRs that must not reach Depot.
+        - ubuntu-24.04-8core
 
 # The vendored .github/actions/paths-filter emits one output per filter name at
 # runtime, but action.yml can only declare the static `changes` output, so

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -625,18 +625,19 @@ jobs:
         name: Frontend typechecking
         needs: [changes]
         if: needs.changes.outputs.frontend_code == 'true'
-        # tsgo peaks ~12 GB type-checking the whole frontend, which OOM-kills it on ~6% of runs
-        # on any 16 GB runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks the
-        # type graph, not parallelism or lib checking: skipLibCheck is already on, GOMAXPROCS
-        # and declaration:false change nothing, and dropping all of products/ from include
-        # removes only 891 of 13703 files because imports pull them back in. 32 GB is the next
-        # rung on Depot's ladder. Talk to #team-devex before changing.
+        # tsgo peaks ~12 GB type-checking the whole frontend, which OOM-kills it on a 16 GB
+        # runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks the type graph,
+        # not parallelism or lib checking: skipLibCheck is already on, GOMAXPROCS and
+        # declaration:false change nothing, and dropping all of products/ from include removes
+        # only 891 of 13703 files because imports pull them back in. Both runners below give
+        # the job 32 GB. Talk to #team-devex before changing.
         #
-        # Forks stay on GitHub-hosted: this job runs `pnpm install`, so a fork PR controls
-        # lifecycle scripts, and Depot runners inject shared cache credentials ambiently
-        # (see _rust-build-images.yml, which skips sccache creds for the same reason).
-        # Fork PRs keep the pre-existing OOM flake; internal PRs and master get the fix.
-        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-8' || 'ubuntu-latest' }}
+        # Forks get a GitHub-hosted larger runner instead of Depot: this job runs
+        # `pnpm install`, so a fork PR controls lifecycle scripts, and Depot runners inject
+        # shared cache credentials ambiently (see _rust-build-images.yml, which skips sccache
+        # creds for the same reason). GitHub warns against exposing a larger runner with a
+        # static IP range to fork pull requests, so keep this runner's group off static IPs.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-8' || 'ubuntu-24.04-8core' }}
         # Kea typegen invalidates on changes to any logic plus everything that depends on it.
         # For changes to shared core (TaxonomicFilter, Insight, etc.) the dependent set is
         # large, so the budget must fit a cache miss on top of the baseline build.


### PR DESCRIPTION
## Problem

External contributors cannot get a green check on a pull request that touches frontend code, whatever they change.

- `tsgo` peaks around 12 GB, and fork pull requests typecheck on the 16 GB `ubuntu-latest` runner.
- The kernel kills tsgo, so the job names no TypeScript error and fails with `Command failed with signal "SIGTERM"`.
- `Frontend Tests Pass` aggregates that job and is a required check on master, so the pull request cannot merge.
- Internal pull requests and master pass the same code on a 32 GB Depot runner.

[#84625](https://github.com/PostHog/posthog/pull/84625) shows the pattern: four attempts, four kills, every one on `ubuntu-latest` ([latest run](https://github.com/PostHog/posthog/actions/runs/32704779364/job/97363718179)).

## Changes

- Fork pull requests now typecheck with 32 GB, so the job finishes and reports real TypeScript errors.
- The fork branch of `runs-on` takes a GitHub-hosted larger runner, sized to match what internal pull requests already use.

| Trigger | Runner | vCPU | RAM |
| --- | --- | --- | --- |
| master, internal PR | `depot-ubuntu-24.04-8` | 8 | 32 GB |
| fork PR | `ubuntu-24.04-8core` | 8 | 32 GB |

- Depot stays off the fork path. This job runs `pnpm install`, so a fork controls lifecycle scripts, and Depot runners inject shared cache credentials ambiently. A GitHub-hosted runner carries none.
- The `.github/actionlint.yaml` allowlist gains the label, and the job comment drops a stale flake rate. Both mechanical.

> [!WARNING]
> Merging before the runner exists makes fork typechecking queue instead of fail. An org admin must first create a GitHub-hosted larger runner named exactly `ubuntu-24.04-8core`, Ubuntu 24.04, 8 vCPU, in a runner group that allows public repositories. Keep static IP ranges off that group: [GitHub warns](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/manage-larger-runners) against exposing a fixed-IP larger runner to fork pull requests.

Larger runners are [billed on public repositories](https://docs.github.com/en/billing/reference/actions-runner-pricing), at $0.022 per minute for 8 vCPU Linux. The job runs under 10 minutes, and fork pull requests that touch frontend code are rare, so this costs a few dollars a month.

## How did you test this code?

- `actionlint` 1.7.12, run the way `ci-actionlint.yml` runs it (repo config plus `flatten-parallel-steps-for-actionlint.awk`): passes.
- `hogli lint:workflows`: 8 checks pass across 128 workflows. `hogli ci:preflight --strict`: no failures.
- actionlint does not validate a runner label inside a `${{ }}` expression. Removing the allowlist entry gives the same clean exit. The entry follows the convention in `/authoring-ci-workflows` and covers a future literal use, but no check enforces it today.
- Not verified: that the job passes on the new runner. That needs the runner provisioned and this workflow on master, since `pull_request` runs take workflow files from the merge commit.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Nothing user-facing changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app, working from a Slack thread that opened as a question about why one contributor's pull request failed the frontend check alone. The investigation traced it to the runner memory limit rather than the diff, and the ask became replacing `ubuntu-latest` on the fork path with a paid GitHub-hosted runner large enough for the job. Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.

The sizing picked 8 vCPU over 16 because 8 vCPU carries 32 GB, matching the Depot runner already proven on internal pull requests, and the 16 vCPU rung costs about double. An earlier candidate, tuning `GOMEMLIMIT` and swap to survive on 16 GB, was dropped once the ask specified a larger runner.

No assignee is set. The person who directed this has no GitHub handle verified in this session, and guessing one would tag an unrelated account.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1787560770351649)*
