### PR TITLE
feat(desktop): add onboarding test tools

### DIFF
--- a/products/canvas/backend/teaching.py
+++ b/products/canvas/backend/teaching.py
@@ -508,7 +508,7 @@ def _lock_teaching_seed(team_id: int, channel_id: UUID) -> None:
         )
 
 
-def seed_teaching_canvas(*, team_id: int, channel_id: UUID, user: User) -> UUID | None:
+def seed_teaching_canvas(*, team_id: int, channel_id: UUID, user: User, refresh: bool = False) -> UUID | None:
     """Get or seed the team's teaching-tour canvas in its general space.
 
     Returns ``None`` when a previously seeded tour was deleted: someone removed it
@@ -516,6 +516,10 @@ def seed_teaching_canvas(*, team_id: int, channel_id: UUID, user: User) -> UUID 
     first publish failed gets its publish retried, so a transient storage outage
     heals on the next sign-in. Raises on failure; callers treat seeding as
     best-effort.
+
+    ``refresh`` is for the onboarding test tools, which reseed the same space over
+    and over: it revives a deleted tour and republishes the current source, so
+    deleting the canvas is how a tester resets it rather than how they lose it.
     """
     with transaction.atomic():
         _lock_teaching_seed(team_id, channel_id)
@@ -526,9 +530,13 @@ def seed_teaching_canvas(*, team_id: int, channel_id: UUID, user: User) -> UUID 
             .first()
         )
         if existing is not None:
-            if existing.deleted:
+            if existing.deleted and not refresh:
                 return None
-            if existing.current_source_version_id is None:
+            if existing.deleted:
+                existing.deleted = False
+                existing.pinned_at = timezone.now()
+                existing.save(update_fields=["deleted", "pinned_at"])
+            if refresh or existing.current_source_version_id is None:
                 _publish_tour(existing, user)
             return existing.id
         canvas = Canvas.objects.create(

--- a/products/canvas/backend/tests/test_teaching.py
+++ b/products/canvas/backend/tests/test_teaching.py
@@ -50,8 +50,10 @@ class TestSeedTeachingCanvas(TestCase):
             created_by=self.user,
         )
 
-    def _seed(self) -> object:
-        return teaching.seed_teaching_canvas(team_id=self.team.id, channel_id=self.channel.id, user=self.user)
+    def _seed(self, *, refresh: bool = False) -> object:
+        return teaching.seed_teaching_canvas(
+            team_id=self.team.id, channel_id=self.channel.id, user=self.user, refresh=refresh
+        )
 
     def _tours(self):
         return Canvas.objects.for_team(self.team.id).filter(
@@ -80,6 +82,16 @@ class TestSeedTeachingCanvas(TestCase):
 
         self.assertIsNone(self._seed())
         self.assertEqual(self._tours().count(), 1)
+
+    def test_a_refreshing_seed_revives_a_deleted_tour_and_republishes_it(self):
+        first = self._seed()
+        self._tours().update(deleted=True)
+
+        self.assertEqual(self._seed(refresh=True), first)
+        canvas = self._tours().get()
+        self.assertFalse(canvas.deleted)
+        self.assertIsNotNone(canvas.pinned_at)
+        self.assertIsNotNone(canvas.current_source_version_id)
 
     def test_a_tour_whose_publish_failed_heals_on_the_next_seed(self):
         canvas_id = self._seed()

--- a/products/desktop/docs/LOCAL-DEVELOPMENT.md
+++ b/products/desktop/docs/LOCAL-DEVELOPMENT.md
@@ -135,6 +135,19 @@ region you pick at login.
 > `posthog.featureFlags.override({ "mcp-gateway": true })` in the renderer
 > console (clear with `posthog.featureFlags.override(false)`).
 
+### Test first-run onboarding
+
+Staff users with `posthog-desktop-onboarding-test-tools` enabled see onboarding
+test tools in **Settings > Advanced**. The form creates repeatable sessions from
+explicit company, organization, data, findings, and signal-source inputs. A
+separate action resolves or creates the teaching canvas in the general space.
+
+Local development can enable the panel with the renderer override:
+
+```js
+posthog.featureFlags.override({ "posthog-desktop-onboarding-test-tools": true })
+```
+
 ## Troubleshooting
 
 ### Feature flags never enabled (flag-gated UI missing)

--- a/products/desktop/docs/LOCAL-DEVELOPMENT.md
+++ b/products/desktop/docs/LOCAL-DEVELOPMENT.md
@@ -137,10 +137,10 @@ region you pick at login.
 
 ### Test first-run onboarding
 
-Staff users with `posthog-desktop-onboarding-test-tools` enabled see onboarding
-test tools in **Settings > Advanced**. The form creates repeatable sessions from
-explicit company, organization, data, findings, and signal-source inputs. A
-separate action resolves or creates the teaching canvas in the general space.
+Users with `posthog-desktop-onboarding-test-tools` enabled see onboarding test
+tools in **Settings > Advanced**. Scenario presets fill the form with useful
+defaults, and every prompt input remains editable. A separate action resolves
+or creates the teaching canvas in the general space.
 
 Local development can enable the panel with the renderer override:
 

--- a/products/desktop/docs/LOCAL-DEVELOPMENT.md
+++ b/products/desktop/docs/LOCAL-DEVELOPMENT.md
@@ -138,9 +138,13 @@ region you pick at login.
 ### Test first-run onboarding
 
 Users with `posthog-desktop-onboarding-test-tools` enabled see onboarding test
-tools in **Settings > Advanced**. Scenario presets fill the form with useful
-defaults, and every prompt input remains editable. A separate action resolves
-or creates the teaching canvas in the general space.
+tools in **Settings > Advanced**. A short wizard asks who is arriving and what
+is happening in the project, then opens the session it builds. A separate
+action resolves or creates the teaching canvas.
+
+Both run in your own `#me` space rather than `#general`, so repeat runs stay
+out of everyone else's way. They also revive a teaching canvas you deleted and
+republish the current tour, so deleting the canvas is how you reset it.
 
 Local development can enable the panel with the renderer override:
 

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2931,6 +2931,52 @@ export class PostHogAPIClient {
     return data.task_id ?? null;
   }
 
+  async startOnboardingTestSession(input: {
+    company_domain: string;
+    joining_existing_organization: boolean;
+    has_events: boolean;
+    signal_reports_waiting: number;
+    other_members: string[];
+    sources_enabled: string[];
+    sources_watching: string[];
+    sources_newly_enabled: boolean;
+    include_teaching_canvas: boolean;
+  }): Promise<{ task_id: string; channel_id: string }> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/task_channels/onboarding_session_test/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: { body: JSON.stringify(input) },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to start test onboarding session: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as { task_id: string; channel_id: string };
+  }
+
+  async createTeachingCanvasForTest(): Promise<{
+    canvas_id: string;
+    channel_id: string;
+  }> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/task_channels/teaching_canvas_test/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to create teaching canvas: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as { canvas_id: string; channel_id: string };
+  }
+
   async updateTaskChannelRepositories(
     id: string,
     githubIntegration: number | null,

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2940,7 +2940,6 @@ export class PostHogAPIClient {
     sources_enabled: string[];
     sources_watching: string[];
     sources_newly_enabled: boolean;
-    include_teaching_canvas: boolean;
   }): Promise<{ task_id: string; channel_id: string }> {
     const teamId = await this.getTeamId();
     const urlPath = `/api/projects/${teamId}/task_channels/onboarding_session_test/`;

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -7,6 +7,8 @@ export const EXPERIMENT_SUGGESTIONS_FLAG =
 /** Autoresearch (metric-optimization loop). Staff-gated while it bakes. */
 export const AUTORESEARCH_FLAG = "posthog-code-autoresearch";
 export const DISCOVERY_RUN_FLAG = "posthog-code-discovery-run";
+export const ONBOARDING_TEST_TOOLS_FLAG =
+  "posthog-desktop-onboarding-test-tools";
 // Gates the entire canvas feature: the app rail's Channels space, the /website
 // routes, channels and dashboards.
 export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";

--- a/products/desktop/packages/ui/src/features/settings/hooks/useOpenSettings.ts
+++ b/products/desktop/packages/ui/src/features/settings/hooks/useOpenSettings.ts
@@ -42,6 +42,15 @@ export function prepareSettingsPage(
 }
 
 /**
+ * Leave the settings page for a route the caller navigates to itself. Resets
+ * the store without the history pop `closeSettings` does, which would land the
+ * user back on the prior route after their own navigation.
+ */
+export function leaveSettings(): void {
+  useSettingsPageStore.getState().reset();
+}
+
+/**
  * Close the settings page — returns the user to their prior route via
  * router history. If they came in via a deep link, falls back to /code.
  */

--- a/products/desktop/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
@@ -1,8 +1,6 @@
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { ONBOARDING_TEST_TOOLS_FLAG } from "@posthog/shared";
-import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
-import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import {
@@ -38,15 +36,10 @@ export function AdvancedSettings() {
   const hostTRPC = useHostTRPC();
   const { data: rtkStatus } = useQuery(hostTRPC.agent.rtkStatus.queryOptions());
   const devModeClient = useServiceOptional<DevModeClient>(DEV_MODE_CLIENT);
-  const authenticatedClient = useOptionalAuthenticatedClient();
-  const { data: currentUser } = useCurrentUser({ client: authenticatedClient });
-  const showOnboardingTestTools =
-    useFeatureFlag(ONBOARDING_TEST_TOOLS_FLAG) &&
-    currentUser?.is_staff === true;
+  const showOnboardingTools = useFeatureFlag(ONBOARDING_TEST_TOOLS_FLAG);
 
   return (
     <Flex direction="column">
-      {showOnboardingTestTools && <OnboardingTestTools />}
       <SettingRow
         label="Always create pull requests for cloud runs"
         description="Cloud runs push their changes and open a draft pull request when they finish, without waiting for you to ask"
@@ -96,23 +89,28 @@ export function AdvancedSettings() {
           )}
         </Flex>
       </SettingRow>
-      <SettingRow
-        label="Reset onboarding and tours"
-        description="Re-run the onboarding tutorial and product tours on next app restart"
-      >
-        <Button
-          variant="soft"
-          size="1"
-          onClick={() => {
-            closeSettings();
-            useOnboardingStore.getState().resetOnboarding();
-            useSetupStore.getState().resetSetup();
-            useTourStore.getState().resetTours();
-          }}
-        >
-          Reset
-        </Button>
-      </SettingRow>
+      {showOnboardingTools && (
+        <>
+          <SettingRow
+            label="Reset onboarding and tours"
+            description="Re-run the onboarding tutorial and product tours on next app restart"
+          >
+            <Button
+              variant="soft"
+              size="1"
+              onClick={() => {
+                closeSettings();
+                useOnboardingStore.getState().resetOnboarding();
+                useSetupStore.getState().resetSetup();
+                useTourStore.getState().resetTours();
+              }}
+            >
+              Reset
+            </Button>
+          </SettingRow>
+          <OnboardingTestTools />
+        </>
+      )}
       <SettingRow
         label="Clear application storage"
         description="This will remove all locally stored application data"

--- a/products/desktop/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
@@ -1,5 +1,8 @@
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { ONBOARDING_TEST_TOOLS_FLAG } from "@posthog/shared";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import {
@@ -15,6 +18,7 @@ import { clearApplicationStorage } from "@posthog/ui/utils/clearStorage";
 import { Button, Checkbox, Flex, Switch, Text } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 import { useSyncExternalStore } from "react";
+import { OnboardingTestTools } from "./OnboardingTestTools";
 
 export function AdvancedSettings() {
   const showDebugLogsToggle =
@@ -34,9 +38,15 @@ export function AdvancedSettings() {
   const hostTRPC = useHostTRPC();
   const { data: rtkStatus } = useQuery(hostTRPC.agent.rtkStatus.queryOptions());
   const devModeClient = useServiceOptional<DevModeClient>(DEV_MODE_CLIENT);
+  const authenticatedClient = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client: authenticatedClient });
+  const showOnboardingTestTools =
+    useFeatureFlag(ONBOARDING_TEST_TOOLS_FLAG) &&
+    currentUser?.is_staff === true;
 
   return (
     <Flex direction="column">
+      {showOnboardingTestTools && <OnboardingTestTools />}
       <SettingRow
         label="Always create pull requests for cloud runs"
         description="Cloud runs push their changes and open a draft pull request when they finish, without waiting for you to ask"

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
@@ -5,6 +5,7 @@ import {
   SettingsCardRow,
   SettingsSection,
 } from "@posthog/ui/features/settings/components/SettingsCard";
+import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
 import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { toast } from "@posthog/ui/primitives/toast";
 import {
@@ -20,20 +21,100 @@ function commaSeparated(value: string): string[] {
     .filter(Boolean);
 }
 
+const ONBOARDING_SCENARIOS = {
+  "first-user-new-project": {
+    label: "First user, new project",
+    companyDomain: "posthog.com",
+    joiningExistingOrganization: false,
+    hasEvents: false,
+    signalReportsWaiting: 0,
+    otherMembers: "",
+    sourcesEnabled: "",
+    sourcesWatching: "",
+    sourcesNewlyEnabled: false,
+  },
+  "first-user-active-project": {
+    label: "First user, active project",
+    companyDomain: "posthog.com",
+    joiningExistingOrganization: false,
+    hasEvents: true,
+    signalReportsWaiting: 0,
+    otherMembers: "",
+    sourcesEnabled: "error tracking, web analytics",
+    sourcesWatching: "errors, conversion drops",
+    sourcesNewlyEnabled: false,
+  },
+  "joining-existing-organization": {
+    label: "Joining an existing organization",
+    companyDomain: "",
+    joiningExistingOrganization: true,
+    hasEvents: true,
+    signalReportsWaiting: 3,
+    otherMembers: "Max, Lotte",
+    sourcesEnabled: "error tracking, web analytics, experiments",
+    sourcesWatching: "errors, conversion drops, experiment regressions",
+    sourcesNewlyEnabled: false,
+  },
+  "new-signal-sources": {
+    label: "First user, sources newly enabled",
+    companyDomain: "posthog.com",
+    joiningExistingOrganization: false,
+    hasEvents: true,
+    signalReportsWaiting: 0,
+    otherMembers: "",
+    sourcesEnabled: "error tracking, web analytics",
+    sourcesWatching: "errors, conversion drops",
+    sourcesNewlyEnabled: true,
+  },
+} as const;
+
+type OnboardingScenario = keyof typeof ONBOARDING_SCENARIOS;
+
+const DEFAULT_SCENARIO: OnboardingScenario = "first-user-new-project";
+const DEFAULT_VALUES = ONBOARDING_SCENARIOS[DEFAULT_SCENARIO];
+
 export function OnboardingTestTools(): ReactElement {
   const client = useAuthenticatedClient();
-  const [companyDomain, setCompanyDomain] = useState("");
+  const [scenario, setScenario] =
+    useState<OnboardingScenario>(DEFAULT_SCENARIO);
+  const [companyDomain, setCompanyDomain] = useState<string>(
+    DEFAULT_VALUES.companyDomain,
+  );
   const [joiningExistingOrganization, setJoiningExistingOrganization] =
-    useState(false);
-  const [hasEvents, setHasEvents] = useState(false);
-  const [signalReportsWaiting, setSignalReportsWaiting] = useState(0);
-  const [otherMembers, setOtherMembers] = useState("");
-  const [sourcesEnabled, setSourcesEnabled] = useState("");
-  const [sourcesWatching, setSourcesWatching] = useState("");
-  const [sourcesNewlyEnabled, setSourcesNewlyEnabled] = useState(false);
+    useState<boolean>(DEFAULT_VALUES.joiningExistingOrganization);
+  const [hasEvents, setHasEvents] = useState<boolean>(DEFAULT_VALUES.hasEvents);
+  const [signalReportsWaiting, setSignalReportsWaiting] = useState<number>(
+    DEFAULT_VALUES.signalReportsWaiting,
+  );
+  const [otherMembers, setOtherMembers] = useState<string>(
+    DEFAULT_VALUES.otherMembers,
+  );
+  const [sourcesEnabled, setSourcesEnabled] = useState<string>(
+    DEFAULT_VALUES.sourcesEnabled,
+  );
+  const [sourcesWatching, setSourcesWatching] = useState<string>(
+    DEFAULT_VALUES.sourcesWatching,
+  );
+  const [sourcesNewlyEnabled, setSourcesNewlyEnabled] = useState<boolean>(
+    DEFAULT_VALUES.sourcesNewlyEnabled,
+  );
   const [includeTeachingCanvas, setIncludeTeachingCanvas] = useState(true);
   const [startingSession, setStartingSession] = useState(false);
   const [creatingCanvas, setCreatingCanvas] = useState(false);
+
+  const applyScenario = (nextScenario: string): void => {
+    const selected = nextScenario as OnboardingScenario;
+    const values = ONBOARDING_SCENARIOS[selected];
+    setScenario(selected);
+    setCompanyDomain(values.companyDomain);
+    setJoiningExistingOrganization(values.joiningExistingOrganization);
+    setHasEvents(values.hasEvents);
+    setSignalReportsWaiting(values.signalReportsWaiting);
+    setOtherMembers(values.otherMembers);
+    setSourcesEnabled(values.sourcesEnabled);
+    setSourcesWatching(values.sourcesWatching);
+    setSourcesNewlyEnabled(values.sourcesNewlyEnabled);
+  };
 
   const startSession = async (): Promise<void> => {
     setStartingSession(true);
@@ -81,6 +162,24 @@ export function OnboardingTestTools(): ReactElement {
       description="Create repeatable first-run experiences from explicit prompt inputs."
     >
       <SettingsCard>
+        <SettingsCardRow
+          label="Scenario"
+          description="Choose a useful starting point, then adjust any input below."
+        >
+          <SettingsSelect
+            value={scenario}
+            options={Object.entries(ONBOARDING_SCENARIOS).map(
+              ([value, preset]) => ({ value, label: preset.label }),
+            )}
+            onChange={(value) => {
+              if (value) {
+                applyScenario(value);
+              }
+            }}
+            ariaLabel="Onboarding test scenario"
+            triggerClassName="w-64"
+          />
+        </SettingsCardRow>
         <div className="grid grid-cols-2 gap-3 p-3.5">
           <Field>
             <FieldLabel htmlFor="onboarding-company-domain">

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
@@ -1,0 +1,212 @@
+import { Button, Checkbox, Field, FieldLabel, Input } from "@posthog/quill";
+import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import {
+  SettingsCard,
+  SettingsCardRow,
+  SettingsSection,
+} from "@posthog/ui/features/settings/components/SettingsCard";
+import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { toast } from "@posthog/ui/primitives/toast";
+import {
+  navigateToChannelDashboard,
+  navigateToChannelTask,
+} from "@posthog/ui/router/navigationBridge";
+import { type ReactElement, useState } from "react";
+
+function commaSeparated(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function OnboardingTestTools(): ReactElement {
+  const client = useAuthenticatedClient();
+  const [companyDomain, setCompanyDomain] = useState("");
+  const [joiningExistingOrganization, setJoiningExistingOrganization] =
+    useState(false);
+  const [hasEvents, setHasEvents] = useState(false);
+  const [signalReportsWaiting, setSignalReportsWaiting] = useState(0);
+  const [otherMembers, setOtherMembers] = useState("");
+  const [sourcesEnabled, setSourcesEnabled] = useState("");
+  const [sourcesWatching, setSourcesWatching] = useState("");
+  const [sourcesNewlyEnabled, setSourcesNewlyEnabled] = useState(false);
+  const [includeTeachingCanvas, setIncludeTeachingCanvas] = useState(true);
+  const [startingSession, setStartingSession] = useState(false);
+  const [creatingCanvas, setCreatingCanvas] = useState(false);
+
+  const startSession = async (): Promise<void> => {
+    setStartingSession(true);
+    try {
+      const result = await client.startOnboardingTestSession({
+        company_domain: companyDomain.trim(),
+        joining_existing_organization: joiningExistingOrganization,
+        has_events: hasEvents,
+        signal_reports_waiting: signalReportsWaiting,
+        other_members: commaSeparated(otherMembers),
+        sources_enabled: commaSeparated(sourcesEnabled),
+        sources_watching: commaSeparated(sourcesWatching),
+        sources_newly_enabled: sourcesNewlyEnabled,
+        include_teaching_canvas: includeTeachingCanvas,
+      });
+      closeSettings();
+      navigateToChannelTask(result.channel_id, result.task_id);
+    } catch (error) {
+      toast.error("Couldn't start the onboarding test session", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setStartingSession(false);
+    }
+  };
+
+  const createTeachingCanvas = async (): Promise<void> => {
+    setCreatingCanvas(true);
+    try {
+      const result = await client.createTeachingCanvasForTest();
+      closeSettings();
+      navigateToChannelDashboard(result.channel_id, result.canvas_id);
+    } catch (error) {
+      toast.error("Couldn't create the teaching canvas", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setCreatingCanvas(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      label="Onboarding test tools"
+      description="Create repeatable first-run experiences from explicit prompt inputs."
+    >
+      <SettingsCard>
+        <div className="grid grid-cols-2 gap-3 p-3.5">
+          <Field>
+            <FieldLabel htmlFor="onboarding-company-domain">
+              Company domain
+            </FieldLabel>
+            <Input
+              id="onboarding-company-domain"
+              value={companyDomain}
+              onChange={(event) => setCompanyDomain(event.target.value)}
+              placeholder="example.com"
+              disabled={joiningExistingOrganization || startingSession}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="onboarding-findings">
+              Waiting findings
+            </FieldLabel>
+            <Input
+              id="onboarding-findings"
+              type="number"
+              min={0}
+              value={signalReportsWaiting}
+              onChange={(event) =>
+                setSignalReportsWaiting(Math.max(0, Number(event.target.value)))
+              }
+              disabled={startingSession}
+            />
+          </Field>
+          <Field className="col-span-2">
+            <FieldLabel htmlFor="onboarding-members">Other members</FieldLabel>
+            <Input
+              id="onboarding-members"
+              value={otherMembers}
+              onChange={(event) => setOtherMembers(event.target.value)}
+              placeholder="Max, Lotte"
+              disabled={startingSession}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="onboarding-sources-enabled">
+              Enabled sources
+            </FieldLabel>
+            <Input
+              id="onboarding-sources-enabled"
+              value={sourcesEnabled}
+              onChange={(event) => setSourcesEnabled(event.target.value)}
+              placeholder="error tracking, web analytics"
+              disabled={startingSession}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="onboarding-sources-watching">
+              Watched sources
+            </FieldLabel>
+            <Input
+              id="onboarding-sources-watching"
+              value={sourcesWatching}
+              onChange={(event) => setSourcesWatching(event.target.value)}
+              placeholder="errors, conversion drops"
+              disabled={startingSession}
+            />
+          </Field>
+        </div>
+        <SettingsCardRow label="Joining an existing organization">
+          <Checkbox
+            checked={joiningExistingOrganization}
+            onCheckedChange={(checked) =>
+              setJoiningExistingOrganization(checked === true)
+            }
+            disabled={startingSession}
+          />
+        </SettingsCardRow>
+        <SettingsCardRow label="Project has events">
+          <Checkbox
+            checked={hasEvents}
+            onCheckedChange={(checked) => setHasEvents(checked === true)}
+            disabled={startingSession}
+          />
+        </SettingsCardRow>
+        <SettingsCardRow label="Sources newly enabled">
+          <Checkbox
+            checked={sourcesNewlyEnabled}
+            onCheckedChange={(checked) =>
+              setSourcesNewlyEnabled(checked === true)
+            }
+            disabled={startingSession}
+          />
+        </SettingsCardRow>
+        <SettingsCardRow label="Include teaching canvas in the prompt">
+          <Checkbox
+            checked={includeTeachingCanvas}
+            onCheckedChange={(checked) =>
+              setIncludeTeachingCanvas(checked === true)
+            }
+            disabled={startingSession}
+          />
+        </SettingsCardRow>
+        <SettingsCardRow
+          label="First-run session"
+          description="Creates a new session every time and opens it in #general."
+        >
+          <Button
+            variant="primary"
+            size="sm"
+            loading={startingSession}
+            disabled={creatingCanvas}
+            onClick={() => void startSession()}
+          >
+            Start session
+          </Button>
+        </SettingsCardRow>
+        <SettingsCardRow
+          label="Teaching canvas"
+          description="Creates or repairs the canvas, then opens it."
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            loading={creatingCanvas}
+            disabled={startingSession}
+            onClick={() => void createTeachingCanvas()}
+          >
+            Create canvas
+          </Button>
+        </SettingsCardRow>
+      </SettingsCard>
+    </SettingsSection>
+  );
+}

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
@@ -5,7 +5,7 @@ import {
   SettingsCardRow,
   SettingsSection,
 } from "@posthog/ui/features/settings/components/SettingsCard";
-import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { leaveSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { OnboardingTestToolsDialog } from "@posthog/ui/features/settings/sections/OnboardingTestToolsDialog";
 import { toast } from "@posthog/ui/primitives/toast";
 import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
@@ -20,7 +20,7 @@ export function OnboardingTestTools(): ReactElement {
     setCreatingCanvas(true);
     try {
       const result = await client.createTeachingCanvasForTest();
-      closeSettings();
+      leaveSettings();
       navigateToChannelDashboard(result.channel_id, result.canvas_id);
     } catch (error) {
       toast.error("Couldn't create the teaching canvas", {

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestTools.tsx
@@ -1,145 +1,20 @@
-import { Button, Checkbox, Field, FieldLabel, Input } from "@posthog/quill";
+import { Button } from "@posthog/quill";
 import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import {
   SettingsCard,
   SettingsCardRow,
   SettingsSection,
 } from "@posthog/ui/features/settings/components/SettingsCard";
-import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
 import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { OnboardingTestToolsDialog } from "@posthog/ui/features/settings/sections/OnboardingTestToolsDialog";
 import { toast } from "@posthog/ui/primitives/toast";
-import {
-  navigateToChannelDashboard,
-  navigateToChannelTask,
-} from "@posthog/ui/router/navigationBridge";
+import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
 import { type ReactElement, useState } from "react";
-
-function commaSeparated(value: string): string[] {
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-const ONBOARDING_SCENARIOS = {
-  "first-user-new-project": {
-    label: "First user, new project",
-    companyDomain: "posthog.com",
-    joiningExistingOrganization: false,
-    hasEvents: false,
-    signalReportsWaiting: 0,
-    otherMembers: "",
-    sourcesEnabled: "",
-    sourcesWatching: "",
-    sourcesNewlyEnabled: false,
-  },
-  "first-user-active-project": {
-    label: "First user, active project",
-    companyDomain: "posthog.com",
-    joiningExistingOrganization: false,
-    hasEvents: true,
-    signalReportsWaiting: 0,
-    otherMembers: "",
-    sourcesEnabled: "error tracking, web analytics",
-    sourcesWatching: "errors, conversion drops",
-    sourcesNewlyEnabled: false,
-  },
-  "joining-existing-organization": {
-    label: "Joining an existing organization",
-    companyDomain: "",
-    joiningExistingOrganization: true,
-    hasEvents: true,
-    signalReportsWaiting: 3,
-    otherMembers: "Max, Lotte",
-    sourcesEnabled: "error tracking, web analytics, experiments",
-    sourcesWatching: "errors, conversion drops, experiment regressions",
-    sourcesNewlyEnabled: false,
-  },
-  "new-signal-sources": {
-    label: "First user, sources newly enabled",
-    companyDomain: "posthog.com",
-    joiningExistingOrganization: false,
-    hasEvents: true,
-    signalReportsWaiting: 0,
-    otherMembers: "",
-    sourcesEnabled: "error tracking, web analytics",
-    sourcesWatching: "errors, conversion drops",
-    sourcesNewlyEnabled: true,
-  },
-} as const;
-
-type OnboardingScenario = keyof typeof ONBOARDING_SCENARIOS;
-
-const DEFAULT_SCENARIO: OnboardingScenario = "first-user-new-project";
-const DEFAULT_VALUES = ONBOARDING_SCENARIOS[DEFAULT_SCENARIO];
 
 export function OnboardingTestTools(): ReactElement {
   const client = useAuthenticatedClient();
-  const [scenario, setScenario] =
-    useState<OnboardingScenario>(DEFAULT_SCENARIO);
-  const [companyDomain, setCompanyDomain] = useState<string>(
-    DEFAULT_VALUES.companyDomain,
-  );
-  const [joiningExistingOrganization, setJoiningExistingOrganization] =
-    useState<boolean>(DEFAULT_VALUES.joiningExistingOrganization);
-  const [hasEvents, setHasEvents] = useState<boolean>(DEFAULT_VALUES.hasEvents);
-  const [signalReportsWaiting, setSignalReportsWaiting] = useState<number>(
-    DEFAULT_VALUES.signalReportsWaiting,
-  );
-  const [otherMembers, setOtherMembers] = useState<string>(
-    DEFAULT_VALUES.otherMembers,
-  );
-  const [sourcesEnabled, setSourcesEnabled] = useState<string>(
-    DEFAULT_VALUES.sourcesEnabled,
-  );
-  const [sourcesWatching, setSourcesWatching] = useState<string>(
-    DEFAULT_VALUES.sourcesWatching,
-  );
-  const [sourcesNewlyEnabled, setSourcesNewlyEnabled] = useState<boolean>(
-    DEFAULT_VALUES.sourcesNewlyEnabled,
-  );
-  const [includeTeachingCanvas, setIncludeTeachingCanvas] = useState(true);
-  const [startingSession, setStartingSession] = useState(false);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const [creatingCanvas, setCreatingCanvas] = useState(false);
-
-  const applyScenario = (nextScenario: string): void => {
-    const selected = nextScenario as OnboardingScenario;
-    const values = ONBOARDING_SCENARIOS[selected];
-    setScenario(selected);
-    setCompanyDomain(values.companyDomain);
-    setJoiningExistingOrganization(values.joiningExistingOrganization);
-    setHasEvents(values.hasEvents);
-    setSignalReportsWaiting(values.signalReportsWaiting);
-    setOtherMembers(values.otherMembers);
-    setSourcesEnabled(values.sourcesEnabled);
-    setSourcesWatching(values.sourcesWatching);
-    setSourcesNewlyEnabled(values.sourcesNewlyEnabled);
-  };
-
-  const startSession = async (): Promise<void> => {
-    setStartingSession(true);
-    try {
-      const result = await client.startOnboardingTestSession({
-        company_domain: companyDomain.trim(),
-        joining_existing_organization: joiningExistingOrganization,
-        has_events: hasEvents,
-        signal_reports_waiting: signalReportsWaiting,
-        other_members: commaSeparated(otherMembers),
-        sources_enabled: commaSeparated(sourcesEnabled),
-        sources_watching: commaSeparated(sourcesWatching),
-        sources_newly_enabled: sourcesNewlyEnabled,
-        include_teaching_canvas: includeTeachingCanvas,
-      });
-      closeSettings();
-      navigateToChannelTask(result.channel_id, result.task_id);
-    } catch (error) {
-      toast.error("Couldn't start the onboarding test session", {
-        description: error instanceof Error ? error.message : undefined,
-      });
-    } finally {
-      setStartingSession(false);
-    }
-  };
 
   const createTeachingCanvas = async (): Promise<void> => {
     setCreatingCanvas(true);
@@ -157,138 +32,18 @@ export function OnboardingTestTools(): ReactElement {
   };
 
   return (
-    <SettingsSection
-      label="Onboarding test tools"
-      description="Create repeatable first-run experiences from explicit prompt inputs."
-    >
+    <SettingsSection label="Onboarding test tools">
       <SettingsCard>
         <SettingsCardRow
-          label="Scenario"
-          description="Choose a useful starting point, then adjust any input below."
-        >
-          <SettingsSelect
-            value={scenario}
-            options={Object.entries(ONBOARDING_SCENARIOS).map(
-              ([value, preset]) => ({ value, label: preset.label }),
-            )}
-            onChange={(value) => {
-              if (value) {
-                applyScenario(value);
-              }
-            }}
-            ariaLabel="Onboarding test scenario"
-            triggerClassName="w-64"
-          />
-        </SettingsCardRow>
-        <div className="grid grid-cols-2 gap-3 p-3.5">
-          <Field>
-            <FieldLabel htmlFor="onboarding-company-domain">
-              Company domain
-            </FieldLabel>
-            <Input
-              id="onboarding-company-domain"
-              value={companyDomain}
-              onChange={(event) => setCompanyDomain(event.target.value)}
-              placeholder="example.com"
-              disabled={joiningExistingOrganization || startingSession}
-            />
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="onboarding-findings">
-              Waiting findings
-            </FieldLabel>
-            <Input
-              id="onboarding-findings"
-              type="number"
-              min={0}
-              value={signalReportsWaiting}
-              onChange={(event) =>
-                setSignalReportsWaiting(Math.max(0, Number(event.target.value)))
-              }
-              disabled={startingSession}
-            />
-          </Field>
-          <Field className="col-span-2">
-            <FieldLabel htmlFor="onboarding-members">Other members</FieldLabel>
-            <Input
-              id="onboarding-members"
-              value={otherMembers}
-              onChange={(event) => setOtherMembers(event.target.value)}
-              placeholder="Max, Lotte"
-              disabled={startingSession}
-            />
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="onboarding-sources-enabled">
-              Enabled sources
-            </FieldLabel>
-            <Input
-              id="onboarding-sources-enabled"
-              value={sourcesEnabled}
-              onChange={(event) => setSourcesEnabled(event.target.value)}
-              placeholder="error tracking, web analytics"
-              disabled={startingSession}
-            />
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="onboarding-sources-watching">
-              Watched sources
-            </FieldLabel>
-            <Input
-              id="onboarding-sources-watching"
-              value={sourcesWatching}
-              onChange={(event) => setSourcesWatching(event.target.value)}
-              placeholder="errors, conversion drops"
-              disabled={startingSession}
-            />
-          </Field>
-        </div>
-        <SettingsCardRow label="Joining an existing organization">
-          <Checkbox
-            checked={joiningExistingOrganization}
-            onCheckedChange={(checked) =>
-              setJoiningExistingOrganization(checked === true)
-            }
-            disabled={startingSession}
-          />
-        </SettingsCardRow>
-        <SettingsCardRow label="Project has events">
-          <Checkbox
-            checked={hasEvents}
-            onCheckedChange={(checked) => setHasEvents(checked === true)}
-            disabled={startingSession}
-          />
-        </SettingsCardRow>
-        <SettingsCardRow label="Sources newly enabled">
-          <Checkbox
-            checked={sourcesNewlyEnabled}
-            onCheckedChange={(checked) =>
-              setSourcesNewlyEnabled(checked === true)
-            }
-            disabled={startingSession}
-          />
-        </SettingsCardRow>
-        <SettingsCardRow label="Include teaching canvas in the prompt">
-          <Checkbox
-            checked={includeTeachingCanvas}
-            onCheckedChange={(checked) =>
-              setIncludeTeachingCanvas(checked === true)
-            }
-            disabled={startingSession}
-          />
-        </SettingsCardRow>
-        <SettingsCardRow
           label="First-run session"
-          description="Creates a new session every time and opens it in #general."
+          description="Describe who's arriving, then open a session built from those answers."
         >
           <Button
-            variant="primary"
+            variant="outline"
             size="sm"
-            loading={startingSession}
-            disabled={creatingCanvas}
-            onClick={() => void startSession()}
+            onClick={() => setWizardOpen(true)}
           >
-            Start session
+            Set up
           </Button>
         </SettingsCardRow>
         <SettingsCardRow
@@ -299,13 +54,17 @@ export function OnboardingTestTools(): ReactElement {
             variant="outline"
             size="sm"
             loading={creatingCanvas}
-            disabled={startingSession}
             onClick={() => void createTeachingCanvas()}
           >
             Create canvas
           </Button>
         </SettingsCardRow>
       </SettingsCard>
+
+      <OnboardingTestToolsDialog
+        open={wizardOpen}
+        onOpenChange={setWizardOpen}
+      />
     </SettingsSection>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
@@ -1,37 +1,49 @@
 import {
   Button,
-  Checkbox,
   Dialog,
   DialogBody,
   DialogClose,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
   Input,
-  Label,
-  RadioGroup,
-  RadioGroupItem,
+  Questionnaire,
+  QuestionnaireChoice,
+  QuestionnaireChoiceDescription,
+  QuestionnaireChoices,
+  QuestionnaireDescription,
+  QuestionnaireInput,
+  QuestionnaireItem,
+  QuestionnaireNext,
+  QuestionnairePrevious,
+  QuestionnaireProgress,
+  QuestionnaireSubmit,
+  QuestionnaireTitle,
 } from "@posthog/quill";
 import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
-import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { leaveSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { toast } from "@posthog/ui/primitives/toast";
 import { navigateToChannelTask } from "@posthog/ui/router/navigationBridge";
-import { type ReactElement, type ReactNode, useState } from "react";
+import {
+  type ChangeEvent,
+  type ComponentProps,
+  type FormEvent,
+  type ReactElement,
+  useState,
+} from "react";
+
+/** What "PostHog is already watching" stands for, so that answer needs no input. */
+const ALREADY_WATCHING = ["error tracking", "web analytics"];
+
+/** What "findings are waiting" stands for, so that answer needs no input. */
+const FINDINGS_WAITING = 3;
 
 function commaSeparated(value: string): string[] {
   return value
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
-}
-
-function prose(items: string[]): string {
-  if (items.length <= 1) {
-    return items[0] ?? "";
-  }
-  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
 }
 
 /**
@@ -49,10 +61,7 @@ interface Draft {
   companyDomain: string;
   otherMembers: string;
   situation: Situation;
-  findingsWaiting: number;
   sourcesWatching: string;
-  sourcesEnabled: string;
-  includeTeachingCanvas: boolean;
 }
 
 const DEFAULT_DRAFT: Draft = {
@@ -60,55 +69,8 @@ const DEFAULT_DRAFT: Draft = {
   companyDomain: "posthog.com",
   otherMembers: "Max, Lotte",
   situation: "nothing-connected",
-  findingsWaiting: 3,
   sourcesWatching: "errors, conversion drops",
-  sourcesEnabled: "error tracking, web analytics",
-  includeTeachingCanvas: true,
 };
-
-/** Mirrors `onboarding_brief.build_opening_brief`. */
-function describeOpeningMessage(draft: Draft): string[] {
-  const lines: string[] = [];
-  const members = prose(commaSeparated(draft.otherMembers));
-  const domain = draft.companyDomain.trim();
-
-  if (draft.joining) {
-    lines.push(
-      members
-        ? `Welcome them and say ${members} are already here`
-        : "Welcome them to the workspace",
-    );
-  } else if (domain) {
-    lines.push(`Read ${domain} and summarize what the company does`);
-  } else {
-    lines.push("Welcome them, with no company research");
-  }
-
-  if (draft.situation === "nothing-connected") {
-    lines.push("Say no data is arriving yet, because nothing is connected");
-    lines.push("Offer to add PostHog and open a pull request");
-  } else if (draft.situation === "findings-waiting") {
-    lines.push(
-      `Say ${draft.findingsWaiting} findings are waiting in Self-driving`,
-    );
-    lines.push("Offer to walk them through one of the findings");
-  } else if (draft.situation === "just-switched-on") {
-    const watching = prose(commaSeparated(draft.sourcesWatching));
-    if (watching) {
-      lines.push(`Say PostHog is now watching for ${watching}`);
-    }
-  } else {
-    const enabled = prose(commaSeparated(draft.sourcesEnabled));
-    if (enabled) {
-      lines.push(`Say PostHog is already watching ${enabled}`);
-    }
-  }
-
-  if (draft.includeTeachingCanvas) {
-    lines.push("Mention the teaching canvas and offer to open it");
-  }
-  return lines;
-}
 
 function toRequest(draft: Draft) {
   return {
@@ -116,57 +78,46 @@ function toRequest(draft: Draft) {
     joining_existing_organization: draft.joining,
     has_events: draft.situation !== "nothing-connected",
     signal_reports_waiting:
-      draft.situation === "findings-waiting" ? draft.findingsWaiting : 0,
+      draft.situation === "findings-waiting" ? FINDINGS_WAITING : 0,
     other_members: draft.joining ? commaSeparated(draft.otherMembers) : [],
     sources_enabled:
-      draft.situation === "already-watching"
-        ? commaSeparated(draft.sourcesEnabled)
-        : [],
+      draft.situation === "already-watching" ? ALREADY_WATCHING : [],
     sources_watching:
       draft.situation === "just-switched-on"
         ? commaSeparated(draft.sourcesWatching)
         : [],
     sources_newly_enabled: draft.situation === "just-switched-on",
-    include_teaching_canvas: draft.includeTeachingCanvas,
   };
 }
 
-function Question({
+/** A question answered by typing, so it wears a plain field instead of a choice row. */
+function TextAnswer({
   label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}): ReactElement {
-  return (
-    <div className="flex flex-col gap-2">
-      <span className="font-medium text-[13px] text-gray-12">{label}</span>
-      {children}
-    </div>
-  );
-}
-
-function Choice({
-  id,
   value,
-  label,
-  children,
+  onValueChange,
+  ...props
 }: {
-  id: string;
-  value: string;
   label: string;
-  children?: ReactNode;
-}): ReactElement {
+  value: string;
+  onValueChange: (value: string) => void;
+} & Omit<
+  ComponentProps<typeof QuestionnaireInput>,
+  "value" | "onChange" | "render"
+>): ReactElement {
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-2">
-        <RadioGroupItem value={value} id={id} />
-        <Label htmlFor={id} className="font-normal">
-          {label}
-        </Label>
-      </div>
-      {children && <div className="pl-6">{children}</div>}
-    </div>
+    <QuestionnaireChoices>
+      <QuestionnaireInput
+        aria-label={label}
+        value={value}
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          onValueChange(event.target.value)
+        }
+        render={(inputProps: ComponentProps<"input">) => (
+          <Input {...inputProps} />
+        )}
+        {...props}
+      />
+    </QuestionnaireChoices>
   );
 }
 
@@ -189,7 +140,7 @@ export function OnboardingTestToolsDialog({
     try {
       const result = await client.startOnboardingTestSession(toRequest(draft));
       onOpenChange(false);
-      closeSettings();
+      leaveSettings();
       navigateToChannelTask(result.channel_id, result.task_id);
     } catch (error) {
       toast.error("Couldn't start the onboarding test session", {
@@ -199,6 +150,15 @@ export function OnboardingTestToolsDialog({
       setStarting(false);
     }
   };
+
+  // Nothing is required, because every question opens on a usable default.
+  const questions = [
+    { name: "arriving" },
+    { name: "company", disabled: draft.joining },
+    { name: "members", disabled: !draft.joining },
+    { name: "situation" },
+    { name: "watching", disabled: draft.situation !== "just-switched-on" },
+  ];
 
   return (
     <Dialog
@@ -211,182 +171,169 @@ export function OnboardingTestToolsDialog({
       }}
     >
       <DialogContent className="sm:max-w-lg" showCloseButton={!starting}>
-        <DialogHeader>
-          <DialogTitle>Test the first-run session</DialogTitle>
-          <DialogDescription>
-            See what the agent opens with in a given situation.
-          </DialogDescription>
-        </DialogHeader>
+        {/* `contents` leaves the header, body, and footer in the dialog's own grid. */}
+        <Questionnaire
+          items={questions}
+          className="contents"
+          onSubmit={(event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            void startSession();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Test the first-run session</DialogTitle>
+          </DialogHeader>
 
-        <DialogBody>
-          <div className="flex flex-col gap-6">
-            <Question label="Who's arriving">
-              <RadioGroup
-                value={draft.joining ? "joining" : "first"}
-                onValueChange={(value) =>
-                  patch({ joining: value === "joining" })
-                }
-                className="gap-3"
-              >
-                <Choice
-                  id="arriving-first"
+          <DialogBody viewportClassName="flex flex-col gap-4">
+            <QuestionnaireProgress />
+
+            <QuestionnaireItem name="arriving">
+              <QuestionnaireTitle>Who is arriving?</QuestionnaireTitle>
+              <QuestionnaireChoices>
+                <QuestionnaireChoice
                   value="first"
-                  label="The first person in the workspace"
+                  checked={!draft.joining}
+                  onChange={() => patch({ joining: false })}
                 >
-                  {!draft.joining && (
-                    <Input
-                      aria-label="Company domain"
-                      value={draft.companyDomain}
-                      onChange={(event) =>
-                        patch({ companyDomain: event.target.value })
-                      }
-                      placeholder="Company domain, or empty to skip research"
-                    />
-                  )}
-                </Choice>
-                <Choice
-                  id="arriving-joining"
+                  The first person in the workspace
+                </QuestionnaireChoice>
+                <QuestionnaireChoice
                   value="joining"
-                  label="Joining people who are already here"
+                  checked={draft.joining}
+                  onChange={() => patch({ joining: true })}
                 >
-                  {draft.joining && (
-                    <Input
-                      aria-label="Who's already here"
-                      value={draft.otherMembers}
-                      onChange={(event) =>
-                        patch({ otherMembers: event.target.value })
-                      }
-                      placeholder="Who's already here, comma separated"
-                    />
-                  )}
-                </Choice>
-              </RadioGroup>
-            </Question>
+                  Someone joining people who are already here
+                </QuestionnaireChoice>
+              </QuestionnaireChoices>
+            </QuestionnaireItem>
 
-            <Question label="What's happening in the project">
-              <RadioGroup
-                value={draft.situation}
-                onValueChange={(value) =>
-                  patch({ situation: value as Situation })
-                }
-                className="gap-3"
-              >
-                <Choice
-                  id="situation-nothing"
+            <QuestionnaireItem name="company" disabled={draft.joining}>
+              <QuestionnaireTitle>
+                Which website should the agent read?
+              </QuestionnaireTitle>
+              <QuestionnaireDescription>
+                This is usually pulled from the user's email domain. Leave empty
+                to simulate a personal email like gmail.com
+              </QuestionnaireDescription>
+              <TextAnswer
+                label="Company website"
+                placeholder="posthog.com"
+                value={draft.companyDomain}
+                onValueChange={(companyDomain) => patch({ companyDomain })}
+              />
+            </QuestionnaireItem>
+
+            <QuestionnaireItem name="members" disabled={!draft.joining}>
+              <QuestionnaireTitle>
+                Who is already in the workspace?
+              </QuestionnaireTitle>
+              <QuestionnaireDescription>
+                The agent names them in its welcome. Separate names with commas,
+                or leave this empty to name nobody.
+              </QuestionnaireDescription>
+              <TextAnswer
+                label="People already in the workspace"
+                placeholder="Max, Lotte"
+                value={draft.otherMembers}
+                onValueChange={(otherMembers) => patch({ otherMembers })}
+              />
+            </QuestionnaireItem>
+
+            <QuestionnaireItem name="situation">
+              <QuestionnaireTitle>
+                What is happening in the project?
+              </QuestionnaireTitle>
+              <QuestionnaireChoices>
+                <QuestionnaireChoice
                   value="nothing-connected"
-                  label="Nothing is connected yet"
-                />
-                <Choice
-                  id="situation-findings"
+                  checked={draft.situation === "nothing-connected"}
+                  onChange={() => patch({ situation: "nothing-connected" })}
+                >
+                  Nothing is connected yet
+                  <QuestionnaireChoiceDescription>
+                    No data is arriving, so the agent offers to add PostHog and
+                    open a pull request.
+                  </QuestionnaireChoiceDescription>
+                </QuestionnaireChoice>
+                <QuestionnaireChoice
                   value="findings-waiting"
-                  label="Findings are waiting"
+                  checked={draft.situation === "findings-waiting"}
+                  onChange={() => patch({ situation: "findings-waiting" })}
                 >
-                  {draft.situation === "findings-waiting" && (
-                    <Input
-                      aria-label="How many findings"
-                      type="number"
-                      min={1}
-                      className="w-24"
-                      value={draft.findingsWaiting}
-                      onChange={(event) =>
-                        patch({
-                          findingsWaiting: Math.max(
-                            1,
-                            Number(event.target.value),
-                          ),
-                        })
-                      }
-                    />
-                  )}
-                </Choice>
-                <Choice
-                  id="situation-switched-on"
+                  Findings are waiting
+                  <QuestionnaireChoiceDescription>
+                    Self-driving has {FINDINGS_WAITING} findings, so the agent
+                    offers to walk through one.
+                  </QuestionnaireChoiceDescription>
+                </QuestionnaireChoice>
+                <QuestionnaireChoice
                   value="just-switched-on"
-                  label="Sources were just switched on"
+                  checked={draft.situation === "just-switched-on"}
+                  onChange={() => patch({ situation: "just-switched-on" })}
                 >
-                  {draft.situation === "just-switched-on" && (
-                    <Input
-                      aria-label="What PostHog now watches for"
-                      value={draft.sourcesWatching}
-                      onChange={(event) =>
-                        patch({ sourcesWatching: event.target.value })
-                      }
-                      placeholder="errors, conversion drops"
-                    />
-                  )}
-                </Choice>
-                <Choice
-                  id="situation-watching"
+                  Sources were just switched on
+                  <QuestionnaireChoiceDescription>
+                    The agent says what PostHog now watches for.
+                  </QuestionnaireChoiceDescription>
+                </QuestionnaireChoice>
+                <QuestionnaireChoice
                   value="already-watching"
-                  label="PostHog is already watching"
+                  checked={draft.situation === "already-watching"}
+                  onChange={() => patch({ situation: "already-watching" })}
                 >
-                  {draft.situation === "already-watching" && (
-                    <Input
-                      aria-label="What PostHog already watches"
-                      value={draft.sourcesEnabled}
-                      onChange={(event) =>
-                        patch({ sourcesEnabled: event.target.value })
-                      }
-                      placeholder="error tracking, web analytics"
-                    />
-                  )}
-                </Choice>
-              </RadioGroup>
-            </Question>
+                  PostHog is already watching
+                  <QuestionnaireChoiceDescription>
+                    The agent says {ALREADY_WATCHING.join(" and ")} are already
+                    covered.
+                  </QuestionnaireChoiceDescription>
+                </QuestionnaireChoice>
+              </QuestionnaireChoices>
+            </QuestionnaireItem>
 
-            <div className="flex flex-col gap-2 rounded-(--radius-3) border border-(--gray-5) bg-gray-2 p-3">
-              <span className="font-medium text-[13px] text-gray-12">
-                The agent will
-              </span>
-              <ol className="m-0 flex list-none flex-col gap-1.5 p-0">
-                {describeOpeningMessage(draft).map((line, index) => (
-                  <li
-                    key={line}
-                    className="flex gap-2 text-[12px] text-gray-11 leading-snug"
-                  >
-                    <span className="text-gray-9 tabular-nums">
-                      {index + 1}.
-                    </span>
-                    <span>{line}</span>
-                  </li>
-                ))}
-              </ol>
-              <div className="mt-1 flex items-center gap-2">
-                <Checkbox
-                  id="include-teaching-canvas"
-                  checked={draft.includeTeachingCanvas}
-                  onCheckedChange={(checked) =>
-                    patch({ includeTeachingCanvas: checked === true })
-                  }
-                />
-                <Label
-                  htmlFor="include-teaching-canvas"
-                  className="font-normal text-[12px] text-gray-11"
-                >
-                  Include the teaching canvas
-                </Label>
-              </div>
-            </div>
-          </div>
-        </DialogBody>
+            <QuestionnaireItem
+              name="watching"
+              disabled={draft.situation !== "just-switched-on"}
+            >
+              <QuestionnaireTitle>
+                What does PostHog now watch for?
+              </QuestionnaireTitle>
+              <QuestionnaireDescription>
+                The agent lists these back. Separate them with commas.
+              </QuestionnaireDescription>
+              <TextAnswer
+                label="What PostHog now watches for"
+                placeholder="errors, conversion drops"
+                value={draft.sourcesWatching}
+                onValueChange={(sourcesWatching) => patch({ sourcesWatching })}
+              />
+            </QuestionnaireItem>
+          </DialogBody>
 
-        <DialogFooter>
-          <DialogClose
-            render={
-              <Button variant="outline" size="sm" disabled={starting}>
-                Cancel
-              </Button>
-            }
-          />
-          <Button
-            variant="primary"
-            size="sm"
-            loading={starting}
-            onClick={() => void startSession()}
-          >
-            Start session
-          </Button>
-        </DialogFooter>
+          <DialogFooter>
+            <DialogClose
+              render={
+                <Button variant="outline" size="sm" disabled={starting}>
+                  Cancel
+                </Button>
+              }
+            />
+            <QuestionnairePrevious
+              render={
+                <Button variant="outline" size="sm" disabled={starting} />
+              }
+            >
+              Back
+            </QuestionnairePrevious>
+            <QuestionnaireNext render={<Button variant="primary" size="sm" />}>
+              Next
+            </QuestionnaireNext>
+            <QuestionnaireSubmit
+              render={<Button variant="primary" size="sm" loading={starting} />}
+            >
+              Start session
+            </QuestionnaireSubmit>
+          </DialogFooter>
+        </Questionnaire>
       </DialogContent>
     </Dialog>
   );

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
@@ -1,0 +1,393 @@
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+} from "@posthog/quill";
+import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { toast } from "@posthog/ui/primitives/toast";
+import { navigateToChannelTask } from "@posthog/ui/router/navigationBridge";
+import { type ReactElement, type ReactNode, useState } from "react";
+
+function commaSeparated(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function prose(items: string[]): string {
+  if (items.length <= 1) {
+    return items[0] ?? "";
+  }
+  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+}
+
+/**
+ * One answer per branch of `onboarding_brief._status_line`. That cascade picks a
+ * single status line, so these are alternatives rather than independent facts.
+ */
+type Situation =
+  | "nothing-connected"
+  | "findings-waiting"
+  | "just-switched-on"
+  | "already-watching";
+
+interface Draft {
+  joining: boolean;
+  companyDomain: string;
+  otherMembers: string;
+  situation: Situation;
+  findingsWaiting: number;
+  sourcesWatching: string;
+  sourcesEnabled: string;
+  includeTeachingCanvas: boolean;
+}
+
+const DEFAULT_DRAFT: Draft = {
+  joining: false,
+  companyDomain: "posthog.com",
+  otherMembers: "Max, Lotte",
+  situation: "nothing-connected",
+  findingsWaiting: 3,
+  sourcesWatching: "errors, conversion drops",
+  sourcesEnabled: "error tracking, web analytics",
+  includeTeachingCanvas: true,
+};
+
+/** Mirrors `onboarding_brief.build_opening_brief`. */
+function describeOpeningMessage(draft: Draft): string[] {
+  const lines: string[] = [];
+  const members = prose(commaSeparated(draft.otherMembers));
+  const domain = draft.companyDomain.trim();
+
+  if (draft.joining) {
+    lines.push(
+      members
+        ? `Welcome them and say ${members} are already here`
+        : "Welcome them to the workspace",
+    );
+  } else if (domain) {
+    lines.push(`Read ${domain} and summarize what the company does`);
+  } else {
+    lines.push("Welcome them, with no company research");
+  }
+
+  if (draft.situation === "nothing-connected") {
+    lines.push("Say no data is arriving yet, because nothing is connected");
+    lines.push("Offer to add PostHog and open a pull request");
+  } else if (draft.situation === "findings-waiting") {
+    lines.push(
+      `Say ${draft.findingsWaiting} findings are waiting in Self-driving`,
+    );
+    lines.push("Offer to walk them through one of the findings");
+  } else if (draft.situation === "just-switched-on") {
+    const watching = prose(commaSeparated(draft.sourcesWatching));
+    if (watching) {
+      lines.push(`Say PostHog is now watching for ${watching}`);
+    }
+  } else {
+    const enabled = prose(commaSeparated(draft.sourcesEnabled));
+    if (enabled) {
+      lines.push(`Say PostHog is already watching ${enabled}`);
+    }
+  }
+
+  if (draft.includeTeachingCanvas) {
+    lines.push("Mention the teaching canvas and offer to open it");
+  }
+  return lines;
+}
+
+function toRequest(draft: Draft) {
+  return {
+    company_domain: draft.joining ? "" : draft.companyDomain.trim(),
+    joining_existing_organization: draft.joining,
+    has_events: draft.situation !== "nothing-connected",
+    signal_reports_waiting:
+      draft.situation === "findings-waiting" ? draft.findingsWaiting : 0,
+    other_members: draft.joining ? commaSeparated(draft.otherMembers) : [],
+    sources_enabled:
+      draft.situation === "already-watching"
+        ? commaSeparated(draft.sourcesEnabled)
+        : [],
+    sources_watching:
+      draft.situation === "just-switched-on"
+        ? commaSeparated(draft.sourcesWatching)
+        : [],
+    sources_newly_enabled: draft.situation === "just-switched-on",
+    include_teaching_canvas: draft.includeTeachingCanvas,
+  };
+}
+
+function Question({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="font-medium text-[13px] text-gray-12">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function Choice({
+  id,
+  value,
+  label,
+  children,
+}: {
+  id: string;
+  value: string;
+  label: string;
+  children?: ReactNode;
+}): ReactElement {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <RadioGroupItem value={value} id={id} />
+        <Label htmlFor={id} className="font-normal">
+          {label}
+        </Label>
+      </div>
+      {children && <div className="pl-6">{children}</div>}
+    </div>
+  );
+}
+
+export function OnboardingTestToolsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}): ReactElement {
+  const client = useAuthenticatedClient();
+  const [draft, setDraft] = useState<Draft>(DEFAULT_DRAFT);
+  const [starting, setStarting] = useState(false);
+
+  const patch = (values: Partial<Draft>): void =>
+    setDraft((current) => ({ ...current, ...values }));
+
+  const startSession = async (): Promise<void> => {
+    setStarting(true);
+    try {
+      const result = await client.startOnboardingTestSession(toRequest(draft));
+      onOpenChange(false);
+      closeSettings();
+      navigateToChannelTask(result.channel_id, result.task_id);
+    } catch (error) {
+      toast.error("Couldn't start the onboarding test session", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && starting) {
+          return;
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg" showCloseButton={!starting}>
+        <DialogHeader>
+          <DialogTitle>Test the first-run session</DialogTitle>
+          <DialogDescription>
+            See what the agent opens with in a given situation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody>
+          <div className="flex flex-col gap-6">
+            <Question label="Who's arriving">
+              <RadioGroup
+                value={draft.joining ? "joining" : "first"}
+                onValueChange={(value) =>
+                  patch({ joining: value === "joining" })
+                }
+                className="gap-3"
+              >
+                <Choice
+                  id="arriving-first"
+                  value="first"
+                  label="The first person in the workspace"
+                >
+                  {!draft.joining && (
+                    <Input
+                      aria-label="Company domain"
+                      value={draft.companyDomain}
+                      onChange={(event) =>
+                        patch({ companyDomain: event.target.value })
+                      }
+                      placeholder="Company domain, or empty to skip research"
+                    />
+                  )}
+                </Choice>
+                <Choice
+                  id="arriving-joining"
+                  value="joining"
+                  label="Joining people who are already here"
+                >
+                  {draft.joining && (
+                    <Input
+                      aria-label="Who's already here"
+                      value={draft.otherMembers}
+                      onChange={(event) =>
+                        patch({ otherMembers: event.target.value })
+                      }
+                      placeholder="Who's already here, comma separated"
+                    />
+                  )}
+                </Choice>
+              </RadioGroup>
+            </Question>
+
+            <Question label="What's happening in the project">
+              <RadioGroup
+                value={draft.situation}
+                onValueChange={(value) =>
+                  patch({ situation: value as Situation })
+                }
+                className="gap-3"
+              >
+                <Choice
+                  id="situation-nothing"
+                  value="nothing-connected"
+                  label="Nothing is connected yet"
+                />
+                <Choice
+                  id="situation-findings"
+                  value="findings-waiting"
+                  label="Findings are waiting"
+                >
+                  {draft.situation === "findings-waiting" && (
+                    <Input
+                      aria-label="How many findings"
+                      type="number"
+                      min={1}
+                      className="w-24"
+                      value={draft.findingsWaiting}
+                      onChange={(event) =>
+                        patch({
+                          findingsWaiting: Math.max(
+                            1,
+                            Number(event.target.value),
+                          ),
+                        })
+                      }
+                    />
+                  )}
+                </Choice>
+                <Choice
+                  id="situation-switched-on"
+                  value="just-switched-on"
+                  label="Sources were just switched on"
+                >
+                  {draft.situation === "just-switched-on" && (
+                    <Input
+                      aria-label="What PostHog now watches for"
+                      value={draft.sourcesWatching}
+                      onChange={(event) =>
+                        patch({ sourcesWatching: event.target.value })
+                      }
+                      placeholder="errors, conversion drops"
+                    />
+                  )}
+                </Choice>
+                <Choice
+                  id="situation-watching"
+                  value="already-watching"
+                  label="PostHog is already watching"
+                >
+                  {draft.situation === "already-watching" && (
+                    <Input
+                      aria-label="What PostHog already watches"
+                      value={draft.sourcesEnabled}
+                      onChange={(event) =>
+                        patch({ sourcesEnabled: event.target.value })
+                      }
+                      placeholder="error tracking, web analytics"
+                    />
+                  )}
+                </Choice>
+              </RadioGroup>
+            </Question>
+
+            <div className="flex flex-col gap-2 rounded-(--radius-3) border border-(--gray-5) bg-gray-2 p-3">
+              <span className="font-medium text-[13px] text-gray-12">
+                The agent will
+              </span>
+              <ol className="m-0 flex list-none flex-col gap-1.5 p-0">
+                {describeOpeningMessage(draft).map((line, index) => (
+                  <li
+                    key={line}
+                    className="flex gap-2 text-[12px] text-gray-11 leading-snug"
+                  >
+                    <span className="text-gray-9 tabular-nums">
+                      {index + 1}.
+                    </span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ol>
+              <div className="mt-1 flex items-center gap-2">
+                <Checkbox
+                  id="include-teaching-canvas"
+                  checked={draft.includeTeachingCanvas}
+                  onCheckedChange={(checked) =>
+                    patch({ includeTeachingCanvas: checked === true })
+                  }
+                />
+                <Label
+                  htmlFor="include-teaching-canvas"
+                  className="font-normal text-[12px] text-gray-11"
+                >
+                  Include the teaching canvas
+                </Label>
+              </div>
+            </div>
+          </div>
+        </DialogBody>
+
+        <DialogFooter>
+          <DialogClose
+            render={
+              <Button variant="outline" size="sm" disabled={starting}>
+                Cancel
+              </Button>
+            }
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            loading={starting}
+            onClick={() => void startSession()}
+          >
+            Start session
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -1,6 +1,6 @@
 """Open a new user's first agent session."""
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from django.conf import settings
 from django.db import IntegrityError, transaction
@@ -152,9 +152,17 @@ def _teaching_canvas(team_id: int, channel_id: UUID, user: User) -> TeachingCanv
         return None
 
 
-def start_onboarding_session(team: Team, user: User) -> UUID | None:
+def start_onboarding_session(
+    team: Team,
+    user: User,
+    *,
+    facts_override: OnboardingFacts | None = None,
+    homepage_override: str = "",
+    force: bool = False,
+    include_teaching_canvas: bool = True,
+) -> UUID | None:
     """Create the session a new user lands in. ``None`` when no session was started."""
-    if not _session_enabled(team, user):
+    if not force and not _session_enabled(team, user):
         logger.info("onboarding_session_skipped", team_id=team.id, reason="flag_disabled")
         return None
 
@@ -163,15 +171,17 @@ def start_onboarding_session(team: Team, user: User) -> UUID | None:
         logger.info("onboarding_session_skipped", team_id=team.id, reason="no_general_channel")
         return None
 
-    started = _started_session_id(team.id, user.id)
+    started = None if force else _started_session_id(team.id, user.id)
     if started is not None:
         logger.info("onboarding_session_skipped", team_id=team.id, reason="already_started")
         return started
 
-    origin_key = _origin_key(user.id)
+    origin_key = f"{ONBOARDING_ORIGIN_KEY_PREFIX}_test:{user.id}:{uuid4()}" if force else _origin_key(user.id)
 
-    teaching = _teaching_canvas(team.id, channel_id, user)
-    facts, homepage = gather_onboarding_facts(team, user)
+    teaching = _teaching_canvas(team.id, channel_id, user) if include_teaching_canvas else None
+    facts, homepage = (
+        (facts_override, homepage_override) if facts_override is not None else gather_onboarding_facts(team, user)
+    )
     prompt = load_onboarding_prompt()
     missing_placeholders = missing_onboarding_prompt_placeholders(prompt.prompt)
     prompt_template = prompt.prompt
@@ -247,3 +257,40 @@ def start_onboarding_session(team: Team, user: User) -> UUID | None:
         groups=groups(team.organization, team),
     )
     return created.task_id
+
+
+def start_onboarding_test_session(
+    team: Team,
+    user: User,
+    *,
+    company_domain: str,
+    joining_existing_organization: bool,
+    has_events: bool,
+    signal_reports_waiting: int,
+    other_members: list[str],
+    sources_enabled: list[str],
+    sources_watching: list[str],
+    sources_newly_enabled: bool,
+    include_teaching_canvas: bool,
+) -> UUID | None:
+    domain = normalize_target(company_domain) if company_domain else None
+    research = research_domain(domain) if domain and not joining_existing_organization else None
+    facts = OnboardingFacts(
+        org_has_context=joining_existing_organization,
+        research=research,
+        has_events=has_events,
+        signal_reports_waiting=signal_reports_waiting,
+        other_members=prose_list(other_members),
+        sources_enabled=tuple(sources_enabled),
+        sources_watching=tuple(sources_watching),
+        sources_newly_enabled=sources_newly_enabled,
+    )
+    homepage = research.markdown or "" if research and research.outcome == "scraped" else ""
+    return start_onboarding_session(
+        team,
+        user,
+        facts_override=facts,
+        homepage_override=homepage,
+        force=True,
+        include_teaching_canvas=include_teaching_canvas,
+    )

--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -17,6 +17,7 @@ from products.signals.backend.facade.api import enable_onboarding_signal_sources
 from products.tasks.backend.facade.api import (
     create_and_run_task,
     desktop_users_in_team,
+    ensure_personal_channel_id,
     find_general_channel_id,
     organization_has_context,
 )
@@ -168,10 +169,10 @@ def onboarding_test_tools_enabled(team: Team, user: User) -> bool:
         return False
 
 
-def _teaching_canvas(team_id: int, channel_id: UUID, user: User) -> TeachingCanvas | None:
+def _teaching_canvas(team_id: int, channel_id: UUID, user: User, *, refresh: bool) -> TeachingCanvas | None:
     """Best-effort: a session without the tour beats no session."""
     try:
-        return ensure_teaching_canvas(team_id, channel_id, user)
+        return ensure_teaching_canvas(team_id, channel_id, user, refresh=refresh)
     except Exception:
         logger.warning("onboarding_teaching_canvas_failed", team_id=team_id, exc_info=True)
         return None
@@ -184,14 +185,15 @@ def start_onboarding_session(
     facts_override: OnboardingFacts | None = None,
     homepage_override: str = "",
     force: bool = False,
-    include_teaching_canvas: bool = True,
+    channel_id: UUID | None = None,
 ) -> UUID | None:
     """Create the session a new user lands in. ``None`` when no session was started."""
     if not force and not _session_enabled(team, user):
         logger.info("onboarding_session_skipped", team_id=team.id, reason="flag_disabled")
         return None
 
-    channel_id = find_general_channel_id(team.id)
+    if channel_id is None:
+        channel_id = find_general_channel_id(team.id)
     if channel_id is None:
         logger.info("onboarding_session_skipped", team_id=team.id, reason="no_general_channel")
         return None
@@ -203,7 +205,7 @@ def start_onboarding_session(
 
     origin_key = f"{ONBOARDING_ORIGIN_KEY_PREFIX}_test:{user.id}:{uuid4()}" if force else _origin_key(user.id)
 
-    teaching = _teaching_canvas(team.id, channel_id, user) if include_teaching_canvas else None
+    teaching = _teaching_canvas(team.id, channel_id, user, refresh=force)
     facts, homepage = (
         (facts_override, homepage_override) if facts_override is not None else gather_onboarding_facts(team, user)
     )
@@ -296,8 +298,8 @@ def start_onboarding_test_session(
     sources_enabled: list[str],
     sources_watching: list[str],
     sources_newly_enabled: bool,
-    include_teaching_canvas: bool,
 ) -> UUID | None:
+    """Runs in the requester's personal space, so repeated tests leave #general alone."""
     domain = normalize_target(company_domain) if company_domain else None
     research = research_domain(domain) if domain and not joining_existing_organization else None
     facts = OnboardingFacts(
@@ -317,5 +319,5 @@ def start_onboarding_test_session(
         facts_override=facts,
         homepage_override=homepage,
         force=True,
-        include_teaching_canvas=include_teaching_canvas,
+        channel_id=ensure_personal_channel_id(team.id, user.id),
     )

--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -47,6 +47,7 @@ ONBOARDING_SESSION_EFFORT = "medium"
 ONBOARDING_SESSION_SCOPES = ["task:read", "task:write", "canvas:read"]
 
 SPACES_FLAGS = ("code-spaces-layout", "project-bluebird")
+ONBOARDING_TEST_TOOLS_FLAG = "posthog-desktop-onboarding-test-tools"
 
 ONBOARDING_ORIGIN_KEY_PREFIX = "desktop_onboarding_session"
 
@@ -140,6 +141,30 @@ def _session_enabled(team: Team, user: User) -> bool:
         )
     except Exception:
         logger.warning("onboarding_session_flag_check_failed", team_id=team.id)
+        return False
+
+
+def onboarding_test_tools_enabled(team: Team, user: User) -> bool:
+    if settings.DEBUG:
+        return True
+
+    distinct_id = user.distinct_id
+    if not distinct_id:
+        return False
+    organization_id = str(team.organization_id)
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                ONBOARDING_TEST_TOOLS_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.warning("onboarding_test_tools_flag_check_failed", team_id=team.id)
         return False
 
 

--- a/products/tasks/backend/facade/onboarding_brief.py
+++ b/products/tasks/backend/facade/onboarding_brief.py
@@ -33,6 +33,15 @@ NO_DATA_YET = (
 
 HAS_DATA = "Their project has data flowing, so whatever they name is something you can act on now."
 
+# This offer ends on its own question, so it is the message's closing ask and nothing follows it.
+INSTRUMENT_OFFER = (
+    "Offer to add PostHog to their codebase and open a pull request for them to review, "
+    "and ask which repository to add it to. Make it something they accept, not something "
+    "you have started. End on that question."
+)
+
+FINDINGS_OFFER = "Offer to walk them through one of the findings that is waiting."
+
 _NAMED_SOURCE_LIMIT = 3
 
 
@@ -78,9 +87,7 @@ def _joining_brief(facts: OnboardingFacts) -> list[str]:
     status = _status_line(facts)
     if status:
         brief.append(status)
-    if facts.signal_reports_waiting:
-        brief.append("Offer to walk them through one of the findings.")
-    brief.append(_closing_question(facts, researched=True))
+    brief.extend(_offer_and_close(facts, researched=True))
     return brief
 
 
@@ -115,25 +122,25 @@ def _status_line(facts: OnboardingFacts) -> str | None:
     return f"Tell them PostHog is already watching {enabled}. Then say the write-ups land in {_WHERE}."
 
 
-def _offer_line(facts: OnboardingFacts) -> str | None:
-    if not facts.has_events:
-        return (
-            "Offer to add PostHog to their codebase and open a pull request for them to review, "
-            "and ask which repository to add it to. Make it something they accept, not something "
-            "you have started."
-        )
-    if facts.signal_reports_waiting:
-        return "Offer to walk them through one of the findings that is waiting."
-    return None
-
-
 def _closing_question(facts: OnboardingFacts, *, researched: bool) -> str:
-    """The one question the message ends on."""
     if not researched:
         return NO_RESEARCH_QUESTION
     if facts.has_events and not facts.signal_reports_waiting:
         return NOTHING_YET
     return TOP_OF_MIND
+
+
+def _offer_and_close(facts: OnboardingFacts, *, researched: bool) -> list[str]:
+    """The offer and the question the message ends on, which is always one ask.
+
+    Nothing connected means the instrumentation offer is both, because the repository
+    it asks for is a better place to land than whatever a second question would add.
+    """
+    if not facts.has_events:
+        return [INSTRUMENT_OFFER]
+    lines = [FINDINGS_OFFER] if facts.signal_reports_waiting else []
+    lines.append(_closing_question(facts, researched=researched))
+    return lines
 
 
 def build_opening_brief(facts: OnboardingFacts) -> list[str]:
@@ -157,11 +164,7 @@ def build_opening_brief(facts: OnboardingFacts) -> list[str]:
     if status:
         brief.append(status)
 
-    offer = _offer_line(facts)
-    if offer:
-        brief.append(offer)
-
-    brief.append(_closing_question(facts, researched=scraped or unreachable))
+    brief.extend(_offer_and_close(facts, researched=scraped or unreachable))
     return brief
 
 

--- a/products/tasks/backend/facade/onboarding_canvas.py
+++ b/products/tasks/backend/facade/onboarding_canvas.py
@@ -23,8 +23,10 @@ class TeachingCanvas:
     canvas_id: UUID
 
 
-def ensure_teaching_canvas(team_id: int, channel_id: UUID, user: User) -> TeachingCanvas | None:
-    canvas_id = seed_teaching_canvas(team_id=team_id, channel_id=channel_id, user=user)
+def ensure_teaching_canvas(
+    team_id: int, channel_id: UUID, user: User, *, refresh: bool = False
+) -> TeachingCanvas | None:
+    canvas_id = seed_teaching_canvas(team_id=team_id, channel_id=channel_id, user=user, refresh=refresh)
     if canvas_id is None:
         return None
     return TeachingCanvas(channel_id=channel_id, canvas_id=canvas_id)

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2032,7 +2032,7 @@ class OnboardingSessionSerializer(serializers.Serializer):
 
 
 class OnboardingSessionTestResponseSerializer(OnboardingSessionSerializer):
-    channel_id = serializers.UUIDField(help_text="The #general space containing the session.")
+    channel_id = serializers.UUIDField(help_text="The requester's personal space containing the session.")
 
 
 class OnboardingSessionTestSerializer(serializers.Serializer):
@@ -2072,14 +2072,11 @@ class OnboardingSessionTestSerializer(serializers.Serializer):
     sources_newly_enabled = serializers.BooleanField(
         default=False, help_text="Whether onboarding enabled any signal sources."
     )
-    include_teaching_canvas = serializers.BooleanField(
-        default=True, help_text="Whether the session prompt should offer the teaching canvas."
-    )
 
 
 class TeachingCanvasSerializer(serializers.Serializer):
     canvas_id = serializers.UUIDField(help_text="The teaching canvas that was resolved or created.")
-    channel_id = serializers.UUIDField(help_text="The #general space containing the canvas.")
+    channel_id = serializers.UUIDField(help_text="The requester's personal space containing the canvas.")
 
 
 class ProvisionedChannelsSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2031,6 +2031,57 @@ class OnboardingSessionSerializer(serializers.Serializer):
     task_id = serializers.UUIDField(help_text="The agent session opened in the team's #general space.")
 
 
+class OnboardingSessionTestResponseSerializer(OnboardingSessionSerializer):
+    channel_id = serializers.UUIDField(help_text="The #general space containing the session.")
+
+
+class OnboardingSessionTestSerializer(serializers.Serializer):
+    company_domain = serializers.CharField(
+        required=False,
+        default="",
+        allow_blank=True,
+        max_length=253,
+        help_text="Company domain to research. Blank simulates a personal email address.",
+    )
+    joining_existing_organization = serializers.BooleanField(
+        default=False,
+        help_text="Whether the user is joining an organization that already has shared context.",
+    )
+    has_events = serializers.BooleanField(default=False, help_text="Whether the project has ingested events.")
+    signal_reports_waiting = serializers.IntegerField(
+        default=0, min_value=0, max_value=10000, help_text="Number of findings waiting in #general."
+    )
+    other_members = serializers.ListField(
+        child=serializers.CharField(max_length=100),
+        default=list,
+        max_length=25,
+        help_text="Display names of other Desktop users in the organization.",
+    )
+    sources_enabled = serializers.ListField(
+        child=serializers.CharField(max_length=100),
+        default=list,
+        max_length=25,
+        help_text="Signal sources that were already enabled.",
+    )
+    sources_watching = serializers.ListField(
+        child=serializers.CharField(max_length=100),
+        default=list,
+        max_length=25,
+        help_text="Signal sources the onboarding flow is watching.",
+    )
+    sources_newly_enabled = serializers.BooleanField(
+        default=False, help_text="Whether onboarding enabled any signal sources."
+    )
+    include_teaching_canvas = serializers.BooleanField(
+        default=True, help_text="Whether the session prompt should offer the teaching canvas."
+    )
+
+
+class TeachingCanvasSerializer(serializers.Serializer):
+    canvas_id = serializers.UUIDField(help_text="The teaching canvas that was resolved or created.")
+    channel_id = serializers.UUIDField(help_text="The #general space containing the canvas.")
+
+
 class ProvisionedChannelsSerializer(serializers.Serializer):
     """The requester's default channels, plus whether this call is what created them."""
 

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -174,7 +174,10 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         request=OnboardingSessionTestSerializer,
         responses={200: OnboardingSessionTestResponseSerializer},
         summary="Start a test first-run onboarding session",
-        description="Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs.",
+        description=(
+            "Feature-flagged test path that creates a repeatable session from explicit prompt-building "
+            "inputs, in the requester's personal space."
+        ),
     )
     @action(methods=["POST"], detail=False, url_path="onboarding_session_test")
     def onboarding_session_test(self, request: Request, **kwargs) -> Response:
@@ -188,25 +191,23 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             request.user,
             **values,
         )
-        channel_id = tasks_facade.find_general_channel_id(self.team_id)
-        if task_id is None or channel_id is None:
-            return Response({"detail": "No #general space to open a session in."}, status=409)
+        if task_id is None:
+            return Response({"detail": "No personal space to open a session in."}, status=409)
+        channel_id = tasks_facade.ensure_personal_channel_id(self.team_id, request.user.id)
         return Response(OnboardingSessionTestResponseSerializer({"task_id": task_id, "channel_id": channel_id}).data)
 
     @extend_schema(
         request=None,
         responses={200: TeachingCanvasSerializer},
         summary="Create the teaching canvas for testing",
-        description="Feature-flagged test path that resolves or creates the teaching canvas in #general.",
+        description="Feature-flagged test path that resolves or creates the teaching canvas in the requester's personal space.",
     )
     @action(methods=["POST"], detail=False, url_path="teaching_canvas_test")
     def teaching_canvas_test(self, request: Request, **kwargs) -> Response:
         if not isinstance(request.user, User) or not onboarding_test_tools_enabled(self.team, request.user):
             raise PermissionDenied("The onboarding test tools feature is not enabled.")
-        channel_id = tasks_facade.find_general_channel_id(self.team_id)
-        if channel_id is None:
-            return Response({"detail": "No #general space for the teaching canvas."}, status=409)
-        teaching = ensure_teaching_canvas(self.team_id, channel_id, request.user)
+        channel_id = tasks_facade.ensure_personal_channel_id(self.team_id, request.user.id)
+        teaching = ensure_teaching_canvas(self.team_id, channel_id, request.user, refresh=True)
         if teaching is None:
             return Response({"detail": "The teaching canvas was previously deleted."}, status=409)
         return Response(TeachingCanvasSerializer(teaching).data)

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -20,7 +20,11 @@ from posthog.permissions import APIScopePermission
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.access import compute_quota_limit_response
 from products.tasks.backend.facade.compute_quota import ComputeBillingLimitExceeded
-from products.tasks.backend.facade.onboarding import start_onboarding_session, start_onboarding_test_session
+from products.tasks.backend.facade.onboarding import (
+    onboarding_test_tools_enabled,
+    start_onboarding_session,
+    start_onboarding_test_session,
+)
 from products.tasks.backend.facade.onboarding_canvas import ensure_teaching_canvas
 from products.tasks.backend.presentation.serializers import (
     ChannelContextGenerationSerializer,
@@ -170,12 +174,12 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         request=OnboardingSessionTestSerializer,
         responses={200: OnboardingSessionTestResponseSerializer},
         summary="Start a test first-run onboarding session",
-        description="Staff-only test path that creates a repeatable session from explicit prompt-building inputs.",
+        description="Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs.",
     )
     @action(methods=["POST"], detail=False, url_path="onboarding_session_test")
     def onboarding_session_test(self, request: Request, **kwargs) -> Response:
-        if not isinstance(request.user, User) or not request.user.is_staff:
-            raise PermissionDenied("Testing onboarding sessions requires staff access.")
+        if not isinstance(request.user, User) or not onboarding_test_tools_enabled(self.team, request.user):
+            raise PermissionDenied("The onboarding test tools feature is not enabled.")
         serializer = OnboardingSessionTestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         values = serializer.validated_data
@@ -193,12 +197,12 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         request=None,
         responses={200: TeachingCanvasSerializer},
         summary="Create the teaching canvas for testing",
-        description="Staff-only test path that resolves or creates the teaching canvas in #general.",
+        description="Feature-flagged test path that resolves or creates the teaching canvas in #general.",
     )
     @action(methods=["POST"], detail=False, url_path="teaching_canvas_test")
     def teaching_canvas_test(self, request: Request, **kwargs) -> Response:
-        if not isinstance(request.user, User) or not request.user.is_staff:
-            raise PermissionDenied("Testing the teaching canvas requires staff access.")
+        if not isinstance(request.user, User) or not onboarding_test_tools_enabled(self.team, request.user):
+            raise PermissionDenied("The onboarding test tools feature is not enabled.")
         channel_id = tasks_facade.find_general_channel_id(self.team_id)
         if channel_id is None:
             return Response({"detail": "No #general space for the teaching canvas."}, status=409)

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -20,7 +20,8 @@ from posthog.permissions import APIScopePermission
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.access import compute_quota_limit_response
 from products.tasks.backend.facade.compute_quota import ComputeBillingLimitExceeded
-from products.tasks.backend.facade.onboarding import start_onboarding_session
+from products.tasks.backend.facade.onboarding import start_onboarding_session, start_onboarding_test_session
+from products.tasks.backend.facade.onboarding_canvas import ensure_teaching_canvas
 from products.tasks.backend.presentation.serializers import (
     ChannelContextGenerationSerializer,
     ChannelDeleteConflictSerializer,
@@ -33,6 +34,8 @@ from products.tasks.backend.presentation.serializers import (
     ChannelUpdateSerializer,
     ChannelWriteSerializer,
     OnboardingSessionSerializer,
+    OnboardingSessionTestResponseSerializer,
+    OnboardingSessionTestSerializer,
     ProvisionedChannelsSerializer,
     TaskActivityMarkReadResponseSerializer,
     TaskActivityMarkReadSerializer,
@@ -44,6 +47,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskRunErrorResponseSerializer,
     TaskThreadMessageSerializer,
     TaskThreadMessageWriteSerializer,
+    TeachingCanvasSerializer,
 )
 
 # Shared by the PUT and PATCH verbs on /instructions/ — same request/response contract,
@@ -83,6 +87,8 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         "create",
         "provision_defaults",
         "onboarding_session",
+        "onboarding_session_test",
+        "teaching_canvas_test",
         "partial_update",
         "destroy",
         "publish_instructions",
@@ -159,6 +165,47 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if task_id is None:
             return Response({"detail": "No #general space to open a session in."}, status=409)
         return Response(OnboardingSessionSerializer({"task_id": task_id}).data)
+
+    @extend_schema(
+        request=OnboardingSessionTestSerializer,
+        responses={200: OnboardingSessionTestResponseSerializer},
+        summary="Start a test first-run onboarding session",
+        description="Staff-only test path that creates a repeatable session from explicit prompt-building inputs.",
+    )
+    @action(methods=["POST"], detail=False, url_path="onboarding_session_test")
+    def onboarding_session_test(self, request: Request, **kwargs) -> Response:
+        if not isinstance(request.user, User) or not request.user.is_staff:
+            raise PermissionDenied("Testing onboarding sessions requires staff access.")
+        serializer = OnboardingSessionTestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        values = serializer.validated_data
+        task_id = start_onboarding_test_session(
+            self.team,
+            request.user,
+            **values,
+        )
+        channel_id = tasks_facade.find_general_channel_id(self.team_id)
+        if task_id is None or channel_id is None:
+            return Response({"detail": "No #general space to open a session in."}, status=409)
+        return Response(OnboardingSessionTestResponseSerializer({"task_id": task_id, "channel_id": channel_id}).data)
+
+    @extend_schema(
+        request=None,
+        responses={200: TeachingCanvasSerializer},
+        summary="Create the teaching canvas for testing",
+        description="Staff-only test path that resolves or creates the teaching canvas in #general.",
+    )
+    @action(methods=["POST"], detail=False, url_path="teaching_canvas_test")
+    def teaching_canvas_test(self, request: Request, **kwargs) -> Response:
+        if not isinstance(request.user, User) or not request.user.is_staff:
+            raise PermissionDenied("Testing the teaching canvas requires staff access.")
+        channel_id = tasks_facade.find_general_channel_id(self.team_id)
+        if channel_id is None:
+            return Response({"detail": "No #general space for the teaching canvas."}, status=409)
+        teaching = ensure_teaching_canvas(self.team_id, channel_id, request.user)
+        if teaching is None:
+            return Response({"detail": "The teaching canvas was previously deleted."}, status=409)
+        return Response(TeachingCanvasSerializer(teaching).data)
 
     @extend_schema(
         request=ChannelWriteSerializer,

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -137,14 +137,14 @@ class ChannelsAPITestCase(TestCase):
             [general[0]["id"]],
         )
 
-    def test_onboarding_test_tools_require_staff(self):
+    @patch("products.tasks.backend.presentation.views.channels_api.onboarding_test_tools_enabled", return_value=False)
+    def test_onboarding_test_tools_require_the_feature_flag(self, _enabled):
         for action in ("onboarding_session_test", "teaching_canvas_test"):
             response = self.client.post(f"{self._channels_url()}{action}/", {}, format="json")
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_staff_can_create_test_onboarding_artifacts(self):
-        self.user.is_staff = True
-        self.user.save(update_fields=["is_staff"])
+    @patch("products.tasks.backend.presentation.views.channels_api.onboarding_test_tools_enabled", return_value=True)
+    def test_flagged_user_can_create_test_onboarding_artifacts(self, _enabled):
         general_id = next(
             channel["id"] for channel in self._provision()["channels"] if channel["system_role"] == "general"
         )

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 from unittest.mock import patch
 
@@ -15,6 +16,7 @@ from posthog.models.utils import generate_random_token_personal
 
 from products.tasks.backend.exceptions import ComputeBillingLimitError
 from products.tasks.backend.facade import api as tasks_facade
+from products.tasks.backend.facade.onboarding_canvas import TeachingCanvas
 from products.tasks.backend.models import Channel, ChannelFeedMessage, Task, TaskActivity, TaskRun, TaskThreadMessage
 from products.tasks.backend.push_dispatcher import (
     notify_task_run_awaiting_input,
@@ -134,6 +136,43 @@ class ChannelsAPITestCase(TestCase):
             [c["id"] for c in again["channels"] if c["system_role"] == "general"],
             [general[0]["id"]],
         )
+
+    def test_onboarding_test_tools_require_staff(self):
+        for action in ("onboarding_session_test", "teaching_canvas_test"):
+            response = self.client.post(f"{self._channels_url()}{action}/", {}, format="json")
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_can_create_test_onboarding_artifacts(self):
+        self.user.is_staff = True
+        self.user.save(update_fields=["is_staff"])
+        general_id = next(
+            channel["id"] for channel in self._provision()["channels"] if channel["system_role"] == "general"
+        )
+        task_id = uuid4()
+        canvas_id = uuid4()
+
+        with patch(
+            "products.tasks.backend.presentation.views.channels_api.start_onboarding_test_session", return_value=task_id
+        ) as start:
+            response = self.client.post(
+                f"{self._channels_url()}onboarding_session_test/",
+                {"joining_existing_organization": True, "other_members": ["Max"], "has_events": True},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json(), {"task_id": str(task_id), "channel_id": general_id})
+        self.assertTrue(start.call_args.kwargs["joining_existing_organization"])
+        self.assertEqual(start.call_args.kwargs["other_members"], ["Max"])
+
+        teaching = TeachingCanvas(channel_id=uuid4(), canvas_id=canvas_id)
+        with patch(
+            "products.tasks.backend.presentation.views.channels_api.ensure_teaching_canvas", return_value=teaching
+        ):
+            response = self.client.post(f"{self._channels_url()}teaching_canvas_test/", {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json(), {"canvas_id": str(canvas_id), "channel_id": str(teaching.channel_id)})
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -145,8 +145,8 @@ class ChannelsAPITestCase(TestCase):
 
     @patch("products.tasks.backend.presentation.views.channels_api.onboarding_test_tools_enabled", return_value=True)
     def test_flagged_user_can_create_test_onboarding_artifacts(self, _enabled):
-        general_id = next(
-            channel["id"] for channel in self._provision()["channels"] if channel["system_role"] == "general"
+        personal_id = next(
+            channel["id"] for channel in self._provision()["channels"] if channel["system_role"] == "personal"
         )
         task_id = uuid4()
         canvas_id = uuid4()
@@ -161,7 +161,7 @@ class ChannelsAPITestCase(TestCase):
             )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        self.assertEqual(response.json(), {"task_id": str(task_id), "channel_id": general_id})
+        self.assertEqual(response.json(), {"task_id": str(task_id), "channel_id": personal_id})
         self.assertTrue(start.call_args.kwargs["joining_existing_organization"])
         self.assertEqual(start.call_args.kwargs["other_members"], ["Max"])
 

--- a/products/tasks/backend/tests/test_onboarding_brief.py
+++ b/products/tasks/backend/tests/test_onboarding_brief.py
@@ -8,6 +8,8 @@ from parameterized import parameterized
 from products.signals.backend.facade.api import InboxReportSummary
 from products.tasks.backend.facade.domain_research import DomainResearch
 from products.tasks.backend.facade.onboarding_brief import (
+    INSTRUMENT_OFFER,
+    NO_RESEARCH_QUESTION,
     NOTHING_YET,
     TOP_OF_MIND,
     OnboardingFacts,
@@ -24,6 +26,7 @@ from products.tasks.backend.facade.onboarding_prompt import (
 )
 
 SCRAPED = DomainResearch(outcome="scraped", url="northwind.example", markdown="# Northwind")
+UNREACHABLE = DomainResearch(outcome="unreachable", url="northwind.example", markdown=None)
 
 
 def _setup_facts(**overrides: object) -> OnboardingFacts:
@@ -116,7 +119,7 @@ class TestOpeningBrief(SimpleTestCase):
 
     def test_joining_a_workspace_with_no_findings_yet_promises_none(self) -> None:
         brief = build_opening_brief(
-            OnboardingFacts(org_has_context=True, signal_reports_waiting=0, other_members="Dana")
+            OnboardingFacts(org_has_context=True, has_events=True, signal_reports_waiting=0, other_members="Dana")
         )
 
         joined = " ".join(brief)
@@ -126,16 +129,70 @@ class TestOpeningBrief(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("no events offers to instrument, asking which repo", False, 0, "add PostHog to their codebase"),
-            ("findings waiting offers to walk through one", True, 4, "walk them through"),
+            ("no events offers to instrument, asking which repo", False, False, 0, "add PostHog to their codebase"),
+            ("findings waiting offers to walk through one", False, True, 4, "walk them through"),
+            ("joining with no events still offers to instrument", True, False, 0, "add PostHog to their codebase"),
+            ("joining with findings offers to walk through one", True, True, 4, "walk them through"),
         ]
     )
-    def test_the_offer_matches_the_situation(self, _name: str, has_events: bool, reports: int, expected: str) -> None:
-        brief = build_opening_brief(_setup_facts(has_events=has_events, signal_reports_waiting=reports))
+    def test_the_offer_matches_the_situation(
+        self, _name: str, joining: bool, has_events: bool, reports: int, expected: str
+    ) -> None:
+        brief = build_opening_brief(
+            _setup_facts(
+                has_events=has_events,
+                signal_reports_waiting=reports,
+                org_has_context=joining,
+                other_members="Dana" if joining else None,
+            )
+        )
 
         offers = [line for line in brief if line.startswith("Offer to")]
         assert len(offers) == 1
         assert expected in offers[0]
+
+    # Every ask the message can end on. The prompt tells the agent to write exactly the
+    # questions the brief carries, so a brief holding two of these gets two questions.
+    ASKS = (TOP_OF_MIND, NOTHING_YET, NO_RESEARCH_QUESTION, INSTRUMENT_OFFER)
+
+    @parameterized.expand(
+        [
+            ("first, no events, 0 findings, scraped", False, False, 0, "scraped"),
+            ("first, no events, 0 findings, unreachable", False, False, 0, "unreachable"),
+            ("first, no events, 0 findings, none", False, False, 0, "none"),
+            ("first, events, 0 findings, scraped", False, True, 0, "scraped"),
+            ("first, events, 0 findings, unreachable", False, True, 0, "unreachable"),
+            ("first, events, 0 findings, none", False, True, 0, "none"),
+            ("first, events, 4 findings, scraped", False, True, 4, "scraped"),
+            ("first, events, 4 findings, unreachable", False, True, 4, "unreachable"),
+            ("first, events, 4 findings, none", False, True, 4, "none"),
+            ("joining, no events, 0 findings, scraped", True, False, 0, "scraped"),
+            ("joining, no events, 0 findings, unreachable", True, False, 0, "unreachable"),
+            ("joining, no events, 0 findings, none", True, False, 0, "none"),
+            ("joining, events, 0 findings, scraped", True, True, 0, "scraped"),
+            ("joining, events, 0 findings, unreachable", True, True, 0, "unreachable"),
+            ("joining, events, 0 findings, none", True, True, 0, "none"),
+            ("joining, events, 4 findings, scraped", True, True, 4, "scraped"),
+            ("joining, events, 4 findings, unreachable", True, True, 4, "unreachable"),
+            ("joining, events, 4 findings, none", True, True, 4, "none"),
+        ]
+    )
+    def test_every_branch_ends_on_exactly_one_ask(
+        self, _name: str, joining: bool, has_events: bool, reports: int, research: str
+    ) -> None:
+        brief = build_opening_brief(
+            _setup_facts(
+                org_has_context=joining,
+                other_members="Dana" if joining else None,
+                has_events=has_events,
+                signal_reports_waiting=reports,
+                research={"scraped": SCRAPED, "unreachable": UNREACHABLE, "none": None}[research],
+            )
+        )
+
+        asks = [line for line in brief if line in self.ASKS]
+        assert len(asks) == 1, brief
+        assert brief[-1] == asks[0], brief
 
     def test_a_quiet_project_ends_on_an_open_question_rather_than_a_bare_one(self) -> None:
         brief = build_opening_brief(_setup_facts(has_events=True, signal_reports_waiting=0))

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -16,7 +16,12 @@ from posthog.models.user import User
 
 from products.tasks.backend.facade import contracts
 from products.tasks.backend.facade.domain_research import DomainResearch
-from products.tasks.backend.facade.onboarding import _origin_key, _session_enabled, start_onboarding_session
+from products.tasks.backend.facade.onboarding import (
+    _origin_key,
+    _session_enabled,
+    onboarding_test_tools_enabled,
+    start_onboarding_session,
+)
 from products.tasks.backend.facade.onboarding_canvas import TeachingCanvas
 from products.tasks.backend.models import Task, TaskClientProvenance
 
@@ -51,6 +56,13 @@ class TestOnboardingSessionIdempotency(TestCase):
             [call.args[0] for call in feature_enabled.call_args_list],
             ["code-spaces-layout", "project-bluebird"],
         )
+
+    @override_settings(DEBUG=False)
+    def test_onboarding_test_tools_use_their_feature_flag(self) -> None:
+        with patch("posthoganalytics.feature_enabled", return_value=True) as feature_enabled:
+            self.assertTrue(onboarding_test_tools_enabled(self.team, self.user))
+
+        self.assertEqual(feature_enabled.call_args.args[0], "posthog-desktop-onboarding-test-tools")
 
     def _start(self, create_side_effect) -> tuple[UUID | None, int]:
         with (

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1323,8 +1323,6 @@ export interface OnboardingSessionTestApi {
     sources_watching?: string[]
     /** Whether onboarding enabled any signal sources. */
     sources_newly_enabled?: boolean
-    /** Whether the session prompt should offer the teaching canvas. */
-    include_teaching_canvas?: boolean
 }
 
 /**
@@ -1333,7 +1331,7 @@ export interface OnboardingSessionTestApi {
 export interface OnboardingSessionTestResponseApi {
     /** The agent session opened in the team's #general space. */
     task_id: string
-    /** The #general space containing the session. */
+    /** The requester's personal space containing the session. */
     channel_id: string
 }
 
@@ -1352,7 +1350,7 @@ export interface ProvisionedChannelsApi {
 export interface TeachingCanvasApi {
     /** The teaching canvas that was resolved or created. */
     canvas_id: string
-    /** The #general space containing the canvas. */
+    /** The requester's personal space containing the canvas. */
     channel_id: string
 }
 

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1287,6 +1287,56 @@ export interface OnboardingSessionApi {
     task_id: string
 }
 
+export interface OnboardingSessionTestApi {
+    /**
+     * Company domain to research. Blank simulates a personal email address.
+     * @maxLength 253
+     */
+    company_domain?: string
+    /** Whether the user is joining an organization that already has shared context. */
+    joining_existing_organization?: boolean
+    /** Whether the project has ingested events. */
+    has_events?: boolean
+    /**
+     * Number of findings waiting in #general.
+     * @minimum 0
+     * @maximum 10000
+     */
+    signal_reports_waiting?: number
+    /**
+     * Display names of other Desktop users in the organization.
+     * @maxItems 25
+     * @items.maxLength 100
+     */
+    other_members?: string[]
+    /**
+     * Signal sources that were already enabled.
+     * @maxItems 25
+     * @items.maxLength 100
+     */
+    sources_enabled?: string[]
+    /**
+     * Signal sources the onboarding flow is watching.
+     * @maxItems 25
+     * @items.maxLength 100
+     */
+    sources_watching?: string[]
+    /** Whether onboarding enabled any signal sources. */
+    sources_newly_enabled?: boolean
+    /** Whether the session prompt should offer the teaching canvas. */
+    include_teaching_canvas?: boolean
+}
+
+/**
+ * The first-run session that was started for the requester.
+ */
+export interface OnboardingSessionTestResponseApi {
+    /** The agent session opened in the team's #general space. */
+    task_id: string
+    /** The #general space containing the session. */
+    channel_id: string
+}
+
 /**
  * The requester's default channels, plus whether this call is what created them.
  */
@@ -1297,6 +1347,13 @@ export interface ProvisionedChannelsApi {
     personal_created: boolean
     /** Whether this call created the team's shared #general channel. True only for the first user to provision it, so clients can branch first-user setup on it. */
     general_created: boolean
+}
+
+export interface TeachingCanvasApi {
+    /** The teaching canvas that was resolved or created. */
+    canvas_id: string
+    /** The #general space containing the canvas. */
+    channel_id: string
 }
 
 /**

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -1165,7 +1165,7 @@ export const getTaskChannelsOnboardingSessionTestCreateUrl = (projectId: string)
 }
 
 /**
- * Staff-only test path that creates a repeatable session from explicit prompt-building inputs.
+ * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs.
  * @summary Start a test first-run onboarding session
  */
 export const taskChannelsOnboardingSessionTestCreate = async (
@@ -1204,7 +1204,7 @@ export const getTaskChannelsTeachingCanvasTestCreateUrl = (projectId: string) =>
 }
 
 /**
- * Staff-only test path that resolves or creates the teaching canvas in #general.
+ * Feature-flagged test path that resolves or creates the teaching canvas in #general.
  * @summary Create the teaching canvas for testing
  */
 export const taskChannelsTeachingCanvasTestCreate = async (

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -1165,7 +1165,7 @@ export const getTaskChannelsOnboardingSessionTestCreateUrl = (projectId: string)
 }
 
 /**
- * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs.
+ * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs, in the requester's personal space.
  * @summary Start a test first-run onboarding session
  */
 export const taskChannelsOnboardingSessionTestCreate = async (
@@ -1204,7 +1204,7 @@ export const getTaskChannelsTeachingCanvasTestCreateUrl = (projectId: string) =>
 }
 
 /**
- * Feature-flagged test path that resolves or creates the teaching canvas in #general.
+ * Feature-flagged test path that resolves or creates the teaching canvas in the requester's personal space.
  * @summary Create the teaching canvas for testing
  */
 export const taskChannelsTeachingCanvasTestCreate = async (

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -36,6 +36,8 @@ import type {
     LoopsTriggerCreateBodyTwo,
     ModelCatalogueResponseApi,
     OnboardingSessionApi,
+    OnboardingSessionTestApi,
+    OnboardingSessionTestResponseApi,
     PaginatedChannelDTOListApi,
     PaginatedChannelFeedMessageDTOListApi,
     PaginatedChannelInstructionsDTOListApi,
@@ -143,6 +145,7 @@ import type {
     TasksSlackThreadContextRetrieveParams,
     TasksSummariesCreateParams,
     TasksThreadMessagesListParams,
+    TeachingCanvasApi,
     WarmTaskRequestApi,
     WarmTaskResponseApi,
     WarmTaskResumeRequestApi,
@@ -1157,6 +1160,27 @@ export const taskChannelsOnboardingSessionCreate = async (
     })
 }
 
+export const getTaskChannelsOnboardingSessionTestCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/task_channels/onboarding_session_test/`
+}
+
+/**
+ * Staff-only test path that creates a repeatable session from explicit prompt-building inputs.
+ * @summary Start a test first-run onboarding session
+ */
+export const taskChannelsOnboardingSessionTestCreate = async (
+    projectId: string,
+    onboardingSessionTestApi?: OnboardingSessionTestApi,
+    options?: RequestInit
+): Promise<OnboardingSessionTestResponseApi> => {
+    return apiMutator<OnboardingSessionTestResponseApi>(getTaskChannelsOnboardingSessionTestCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(onboardingSessionTestApi),
+    })
+}
+
 export const getTaskChannelsProvisionDefaultsCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/task_channels/provision_defaults/`
 }
@@ -1170,6 +1194,24 @@ export const taskChannelsProvisionDefaultsCreate = async (
     options?: RequestInit
 ): Promise<ProvisionedChannelsApi> => {
     return apiMutator<ProvisionedChannelsApi>(getTaskChannelsProvisionDefaultsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+    })
+}
+
+export const getTaskChannelsTeachingCanvasTestCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/task_channels/teaching_canvas_test/`
+}
+
+/**
+ * Staff-only test path that resolves or creates the teaching canvas in #general.
+ * @summary Create the teaching canvas for testing
+ */
+export const taskChannelsTeachingCanvasTestCreate = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<TeachingCanvasApi> => {
+    return apiMutator<TeachingCanvasApi>(getTaskChannelsTeachingCanvasTestCreateUrl(projectId), {
         ...options,
         method: 'POST',
     })

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1056,7 +1056,7 @@ export const TaskChannelsStarCreateBody = /* @__PURE__ */ zod
     .describe('Request body for starring\/unstarring a channel for the requesting user.')
 
 /**
- * Staff-only test path that creates a repeatable session from explicit prompt-building inputs.
+ * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs.
  * @summary Start a test first-run onboarding session
  */
 export const taskChannelsOnboardingSessionTestCreateBodyCompanyDomainDefault = ``

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1056,6 +1056,79 @@ export const TaskChannelsStarCreateBody = /* @__PURE__ */ zod
     .describe('Request body for starring\/unstarring a channel for the requesting user.')
 
 /**
+ * Staff-only test path that creates a repeatable session from explicit prompt-building inputs.
+ * @summary Start a test first-run onboarding session
+ */
+export const taskChannelsOnboardingSessionTestCreateBodyCompanyDomainDefault = ``
+export const taskChannelsOnboardingSessionTestCreateBodyCompanyDomainMax = 253
+
+export const taskChannelsOnboardingSessionTestCreateBodyJoiningExistingOrganizationDefault = false
+export const taskChannelsOnboardingSessionTestCreateBodyHasEventsDefault = false
+export const taskChannelsOnboardingSessionTestCreateBodySignalReportsWaitingDefault = 0
+export const taskChannelsOnboardingSessionTestCreateBodySignalReportsWaitingMin = 0
+export const taskChannelsOnboardingSessionTestCreateBodySignalReportsWaitingMax = 10000
+
+export const taskChannelsOnboardingSessionTestCreateBodyOtherMembersItemMax = 100
+
+export const taskChannelsOnboardingSessionTestCreateBodyOtherMembersMax = 25
+
+export const taskChannelsOnboardingSessionTestCreateBodySourcesEnabledItemMax = 100
+
+export const taskChannelsOnboardingSessionTestCreateBodySourcesEnabledMax = 25
+
+export const taskChannelsOnboardingSessionTestCreateBodySourcesWatchingItemMax = 100
+
+export const taskChannelsOnboardingSessionTestCreateBodySourcesWatchingMax = 25
+
+export const taskChannelsOnboardingSessionTestCreateBodySourcesNewlyEnabledDefault = false
+export const taskChannelsOnboardingSessionTestCreateBodyIncludeTeachingCanvasDefault = true
+
+export const TaskChannelsOnboardingSessionTestCreateBody = /* @__PURE__ */ zod.object({
+    company_domain: zod
+        .string()
+        .max(taskChannelsOnboardingSessionTestCreateBodyCompanyDomainMax)
+        .default(taskChannelsOnboardingSessionTestCreateBodyCompanyDomainDefault)
+        .describe('Company domain to research. Blank simulates a personal email address.'),
+    joining_existing_organization: zod
+        .boolean()
+        .default(taskChannelsOnboardingSessionTestCreateBodyJoiningExistingOrganizationDefault)
+        .describe('Whether the user is joining an organization that already has shared context.'),
+    has_events: zod
+        .boolean()
+        .default(taskChannelsOnboardingSessionTestCreateBodyHasEventsDefault)
+        .describe('Whether the project has ingested events.'),
+    signal_reports_waiting: zod
+        .number()
+        .min(taskChannelsOnboardingSessionTestCreateBodySignalReportsWaitingMin)
+        .max(taskChannelsOnboardingSessionTestCreateBodySignalReportsWaitingMax)
+        .default(taskChannelsOnboardingSessionTestCreateBodySignalReportsWaitingDefault)
+        .describe('Number of findings waiting in #general.'),
+    other_members: zod
+        .array(zod.string().max(taskChannelsOnboardingSessionTestCreateBodyOtherMembersItemMax))
+        .max(taskChannelsOnboardingSessionTestCreateBodyOtherMembersMax)
+        .optional()
+        .describe('Display names of other Desktop users in the organization.'),
+    sources_enabled: zod
+        .array(zod.string().max(taskChannelsOnboardingSessionTestCreateBodySourcesEnabledItemMax))
+        .max(taskChannelsOnboardingSessionTestCreateBodySourcesEnabledMax)
+        .optional()
+        .describe('Signal sources that were already enabled.'),
+    sources_watching: zod
+        .array(zod.string().max(taskChannelsOnboardingSessionTestCreateBodySourcesWatchingItemMax))
+        .max(taskChannelsOnboardingSessionTestCreateBodySourcesWatchingMax)
+        .optional()
+        .describe('Signal sources the onboarding flow is watching.'),
+    sources_newly_enabled: zod
+        .boolean()
+        .default(taskChannelsOnboardingSessionTestCreateBodySourcesNewlyEnabledDefault)
+        .describe('Whether onboarding enabled any signal sources.'),
+    include_teaching_canvas: zod
+        .boolean()
+        .default(taskChannelsOnboardingSessionTestCreateBodyIncludeTeachingCanvasDefault)
+        .describe('Whether the session prompt should offer the teaching canvas.'),
+})
+
+/**
  * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
  */
 export const tasksCreateBodyTitleMax = 255

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1056,7 +1056,7 @@ export const TaskChannelsStarCreateBody = /* @__PURE__ */ zod
     .describe('Request body for starring\/unstarring a channel for the requesting user.')
 
 /**
- * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs.
+ * Feature-flagged test path that creates a repeatable session from explicit prompt-building inputs, in the requester's personal space.
  * @summary Start a test first-run onboarding session
  */
 export const taskChannelsOnboardingSessionTestCreateBodyCompanyDomainDefault = ``
@@ -1081,7 +1081,6 @@ export const taskChannelsOnboardingSessionTestCreateBodySourcesWatchingItemMax =
 export const taskChannelsOnboardingSessionTestCreateBodySourcesWatchingMax = 25
 
 export const taskChannelsOnboardingSessionTestCreateBodySourcesNewlyEnabledDefault = false
-export const taskChannelsOnboardingSessionTestCreateBodyIncludeTeachingCanvasDefault = true
 
 export const TaskChannelsOnboardingSessionTestCreateBody = /* @__PURE__ */ zod.object({
     company_domain: zod
@@ -1122,10 +1121,6 @@ export const TaskChannelsOnboardingSessionTestCreateBody = /* @__PURE__ */ zod.o
         .boolean()
         .default(taskChannelsOnboardingSessionTestCreateBodySourcesNewlyEnabledDefault)
         .describe('Whether onboarding enabled any signal sources.'),
-    include_teaching_canvas: zod
-        .boolean()
-        .default(taskChannelsOnboardingSessionTestCreateBodyIncludeTeachingCanvasDefault)
-        .describe('Whether the session prompt should offer the teaching canvas.'),
 })
 
 /**

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -352,6 +352,9 @@ tools:
     task-channels-onboarding-session-create:
         operation: task_channels_onboarding_session_create
         enabled: false
+    task-channels-onboarding-session-test-create:
+        operation: task_channels_onboarding_session_test_create
+        enabled: false
     task-channels-partial-update:
         operation: task_channels_partial_update
         enabled: false
@@ -360,6 +363,9 @@ tools:
         enabled: false
     task-channels-star-create:
         operation: task_channels_star_create
+        enabled: false
+    task-channels-teaching-canvas-test-create:
+        operation: task_channels_teaching_canvas_test_create
         enabled: false
     task-mentions-list:
         operation: task_mentions_list

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -51206,6 +51206,56 @@ export namespace Schemas {
       task_id: string;
     }
 
+    export interface OnboardingSessionTest {
+      /**
+         * Company domain to research. Blank simulates a personal email address.
+         * @maxLength 253
+         */
+      company_domain?: string;
+      /** Whether the user is joining an organization that already has shared context. */
+      joining_existing_organization?: boolean;
+      /** Whether the project has ingested events. */
+      has_events?: boolean;
+      /**
+         * Number of findings waiting in #general.
+         * @minimum 0
+         * @maximum 10000
+         */
+      signal_reports_waiting?: number;
+      /**
+         * Display names of other Desktop users in the organization.
+         * @maxItems 25
+         * @items.maxLength 100
+         */
+      other_members?: string[];
+      /**
+         * Signal sources that were already enabled.
+         * @maxItems 25
+         * @items.maxLength 100
+         */
+      sources_enabled?: string[];
+      /**
+         * Signal sources the onboarding flow is watching.
+         * @maxItems 25
+         * @items.maxLength 100
+         */
+      sources_watching?: string[];
+      /** Whether onboarding enabled any signal sources. */
+      sources_newly_enabled?: boolean;
+      /** Whether the session prompt should offer the teaching canvas. */
+      include_teaching_canvas?: boolean;
+    }
+
+    /**
+     * The first-run session that was started for the requester.
+     */
+    export interface OnboardingSessionTestResponse {
+      /** The agent session opened in the team's #general space. */
+      task_id: string;
+      /** The #general space containing the session. */
+      channel_id: string;
+    }
+
     /**
      * * `later` - Later
      * * `other` - Other
@@ -82870,6 +82920,13 @@ export namespace Schemas {
          * @nullable
          */
       channel?: string | null;
+    }
+
+    export interface TeachingCanvas {
+      /** The teaching canvas that was resolved or created. */
+      canvas_id: string;
+      /** The #general space containing the canvas. */
+      channel_id: string;
     }
 
     export type TeamDefaultModifiers = { [key: string]: unknown };

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -51242,8 +51242,6 @@ export namespace Schemas {
       sources_watching?: string[];
       /** Whether onboarding enabled any signal sources. */
       sources_newly_enabled?: boolean;
-      /** Whether the session prompt should offer the teaching canvas. */
-      include_teaching_canvas?: boolean;
     }
 
     /**
@@ -51252,7 +51250,7 @@ export namespace Schemas {
     export interface OnboardingSessionTestResponse {
       /** The agent session opened in the team's #general space. */
       task_id: string;
-      /** The #general space containing the session. */
+      /** The requester's personal space containing the session. */
       channel_id: string;
     }
 
@@ -82925,7 +82923,7 @@ export namespace Schemas {
     export interface TeachingCanvas {
       /** The teaching canvas that was resolved or created. */
       canvas_id: string;
-      /** The #general space containing the canvas. */
+      /** The requester's personal space containing the canvas. */
       channel_id: string;
     }
 


### PR DESCRIPTION
## Problem

it's hard to test the concierge flow

## Changes

- adds a new concierge test "wizard"
- fixes a couple branches i found broken during the development of this tool lol


---- ai gen below ----

## How did you test this code?

- `test_every_branch_ends_on_exactly_one_ask` walks 24 combinations of joining, events, findings and research outcome. It catches a brief that asks two questions, which is how the second bug reached a live session.
- `test_the_offer_matches_the_situation` now runs over joining and non-joining. It catches an offer that reaches only one of the two paths.
- `test_a_refreshing_seed_revives_a_deleted_tour_and_republishes_it` catches a test run that hands back no canvas after someone deleted it.
- The channels API test asserts the test session lands in the personal space rather than `#general`.
- Run against a local backend: the wizard opened sessions, and both message bugs above showed up in what those sessions wrote.
- Not checked: nobody has read the corrected message back out of a live session yet. No run against cloud.
- No screenshot attached. The wizard's questions and copy are quoted above.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/LOCAL-DEVELOPMENT.md` now describes the wizard, the personal space, and the canvas reset.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex opened this PR with the earlier commits. Claude Code (Opus 5) shaped the current state, invoking `/writing-pr-descriptions` and the quill primitives guide.

The wizard uses quill's `Questionnaire` rather than a hand-rolled step component, which is what supplies the progress line, the navigation, and the branching. Values a tester never varied became constants instead of inputs, on the grounds that a test tool with a knob for everything is slower to use than one with three questions.

The two production bugs surfaced from running the tool, which is the argument for the tool. The brief's tail moved into one function so a future branch cannot append a second question by accident.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
