### PR TITLE
fix(experiments): enforce object-level access in experiment Max tools

### DIFF
--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -22,6 +22,7 @@ from products.feature_flags.backend.models.feature_flag import FeatureFlag, expe
 
 from ee.hogai.context.experiment.context import ExperimentContext
 from ee.hogai.tool import MaxTool
+from ee.hogai.tool_errors import MaxToolAccessDeniedError
 
 CREATE_EXPERIMENT_TOOL_DESCRIPTION = dedent("""
     Use this tool to create A/B test experiments that measure the impact of changes.
@@ -248,6 +249,8 @@ class ExperimentSummaryTool(MaxTool):
             # Otherwise, fetch data via the data service (agent-initiated call)
             return await self._fetch_and_format(resolved_experiment_id)
 
+        except MaxToolAccessDeniedError:
+            raise
         except Exception as e:
             capture_exception(
                 e,
@@ -265,6 +268,8 @@ class ExperimentSummaryTool(MaxTool):
         experiment = await experiment_context.aget_experiment()
         if experiment is None:
             return f"Experiment {experiment_id} not found", {"error": "not_found"}
+
+        await self.check_object_access(experiment, "viewer", resource="experiment", action="read")
 
         try:
             primary_metrics = [MaxExperimentMetricResult(**m) for m in context.get("primary_metrics_results", [])]
@@ -293,6 +298,14 @@ class ExperimentSummaryTool(MaxTool):
 
     async def _fetch_and_format(self, experiment_id: int) -> tuple[str, dict[str, Any]]:
         """Fetch experiment data from query runners and format it."""
+        experiment_context = ExperimentContext(team=self._team, experiment_id=experiment_id)
+        experiment = await experiment_context.aget_experiment()
+        if experiment is None:
+            return f"Experiment {experiment_id} not found", {"error": "not_found"}
+
+        # Before the metric queries run, so a denied user costs no ClickHouse work
+        await self.check_object_access(experiment, "viewer", resource="experiment", action="read")
+
         data_service = ExperimentSummaryDataService(self._team, self._user)
 
         try:
@@ -301,11 +314,6 @@ class ExperimentSummaryTool(MaxTool):
             return str(e), {"error": "not_found"}
 
         summary_context = summary_data.context
-
-        experiment_context = ExperimentContext(team=self._team, experiment_id=experiment_id)
-        experiment = await experiment_context.aget_experiment()
-        if experiment is None:
-            return f"Experiment {experiment_id} not found", {"error": "not_found"}
 
         formatted_data = await experiment_context.format_experiment_results_data(
             experiment,
@@ -435,6 +443,8 @@ class SessionReplaySummaryTool(MaxTool):
 
             experiment = await get_experiment()
 
+            await self.check_object_access(experiment, "viewer", resource="experiment", action="read")
+
             if experiment.is_draft:
                 output = SessionReplaySummaryOutput(
                     experiment_id=experiment_id,
@@ -538,6 +548,8 @@ class SessionReplaySummaryTool(MaxTool):
 
             return user_message, output.model_dump()
 
+        except MaxToolAccessDeniedError:
+            raise
         except ValueError as e:
             return f"❌ {str(e)}", {"error": "validation_error", "details": str(e)}
         except Exception as e:

--- a/products/experiments/backend/test/test_max_tools.py
+++ b/products/experiments/backend/test/test_max_tools.py
@@ -14,6 +14,7 @@ from products.experiments.backend.max_tools import CreateExperimentTool, Experim
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
+from ee.hogai.tool_errors import MaxToolAccessDeniedError
 from ee.hogai.utils.types import AssistantState
 
 
@@ -655,16 +656,27 @@ class TestExperimentSummaryTool(APIBaseTest):
     async def test_fetch_and_format_handles_nonexistent_experiment(self):
         tool = self._create_tool({})
 
-        with patch("products.experiments.backend.max_tools.ExperimentSummaryDataService") as mock_service_class:
-            mock_service = mock_service_class.return_value
-            mock_service.fetch_experiment_data = AsyncMock(
-                side_effect=ValueError("Experiment 99999 not found or access denied")
-            )
+        result, artifact = await tool._arun_impl(experiment_id=99999)
 
-            result, artifact = await tool._arun_impl(experiment_id=99999)
-
-        assert "not found or access denied" in result
+        assert "not found" in result
         assert artifact["error"] == "not_found"
+
+    async def test_denies_object_level_restricted_experiment(self):
+        experiment = await self._create_experiment(flag_key="restricted-test")
+
+        # Agent-initiated path: denied before any metric queries run
+        tool = self._create_tool({})
+        with patch.object(tool, "user_access_control") as mock_uac:
+            mock_uac.check_access_level_for_object.return_value = False
+            with self.assertRaises(MaxToolAccessDeniedError):
+                await tool._arun_impl(experiment_id=experiment.id)
+
+        # Frontend-context path
+        tool = self._create_tool(self._build_context(experiment_id=experiment.id))
+        with patch.object(tool, "user_access_control") as mock_uac:
+            mock_uac.check_access_level_for_object.return_value = False
+            with self.assertRaises(MaxToolAccessDeniedError):
+                await tool._arun_impl()
 
     async def test_context_experiment_id_takes_priority_over_argument(self):
         experiment = await self._create_experiment(

--- a/products/experiments/backend/test/test_session_replay_summary_tool.py
+++ b/products/experiments/backend/test/test_session_replay_summary_tool.py
@@ -11,6 +11,7 @@ from products.experiments.backend.max_tools import SessionReplaySummaryTool
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
+from ee.hogai.tool_errors import MaxToolAccessDeniedError
 from ee.hogai.utils.types import AssistantState
 
 
@@ -173,6 +174,15 @@ class TestSessionReplaySummaryTool(APIBaseTest):
         self.assertEqual(artifact["error"], "no_recordings")
         self.assertEqual(artifact["experiment_id"], experiment.id)
         self.assertEqual(artifact["recording_counts"], {"control": 0, "test": 0})
+
+    async def test_denies_object_level_restricted_experiment(self):
+        experiment = await self.acreate_experiment(name="restricted-replay-test")
+        tool = await self.create_tool()
+
+        with patch.object(tool, "user_access_control") as mock_uac:
+            mock_uac.check_access_level_for_object.return_value = False
+            with self.assertRaises(MaxToolAccessDeniedError):
+                await tool._arun_impl(experiment_id=experiment.id)
 
     async def test_experiment_not_found(self):
         """Test error when experiment ID doesn't exist."""


### PR DESCRIPTION
## Problem

`ExperimentSummaryTool` and `SessionReplaySummaryTool` only check resource-level `experiment:viewer` access. A team member with an explicit object-level denial on a specific experiment can still summarize it (or list its replay counts) by passing the experiment ID. Flagged by veria-ai on #84320.

## Changes

- Call `check_object_access(experiment, "viewer")` after loading the experiment in both summary tool paths and in the replay tool.
- In the summary fetch path, load the experiment and check access before running the metric queries, so a denied user costs no ClickHouse work.
- Re-raise `MaxToolAccessDeniedError` past the tools' catch-all exception handlers so the framework renders the denial instead of a generic failure message.

## How did you test this code?

Added one denial test per tool (mocking `user_access_control` to deny, same pattern as the dashboard tool's test): removing any of the three checks fails the corresponding test. Adjusted `test_fetch_and_format_handles_nonexistent_experiment` for the reordered lookup. All 71 tests across the three experiment tool test files pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code follow-up to a veria-ai review finding on #84320 (pre-existing gap, deferred there as out of scope). Used the existing `MaxTool.check_object_access` helper; precedent from alerts/customer_analytics/upsert_dashboard tools. Skills invoked: /wt, /writing-tests. Sibling cleanup PR: #87799. Note: #87799 removes the frontend-context path this PR also touches; whichever lands second needs a trivial rebase.
