### PR TITLE
feat(cdp): allow OR conditions in destination global filters

### DIFF
--- a/frontend/src/lib/components/Alerting/AlertWizard/alertWizardLogic.test.ts
+++ b/frontend/src/lib/components/Alerting/AlertWizard/alertWizardLogic.test.ts
@@ -47,8 +47,9 @@ describe('applyKindFilter', () => {
             ],
         }
         const result = applyKindFilter(withProps, ['sdk_outdated'])
-        expect(result?.properties).toHaveLength(1)
-        expect(result?.properties?.[0].key).toBe('kind')
+        const props = Array.isArray(result?.properties) ? result.properties : []
+        expect(props).toHaveLength(1)
+        expect(props[0].key).toBe('kind')
     })
 
     it('leaves events untouched', () => {

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -169,12 +169,13 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
         alertId: [
             (s) => [s.configuration],
             (configuration: HogFunctionType | null): string | undefined => {
-                if (!configuration?.filters?.properties) {
+                const properties = configuration?.filters?.properties
+                // Internal alert destinations always store a flat property list; a property group
+                // (used for OR filters on regular destinations) never binds an alert id.
+                if (!Array.isArray(properties)) {
                     return undefined
                 }
-                const alertIdProp = configuration.filters.properties.find(
-                    (p: CyclotronJobFilterPropertyFilter) => p.key === 'alert_id'
-                )
+                const alertIdProp = properties.find((p: CyclotronJobFilterPropertyFilter) => p.key === 'alert_id')
                 const value = alertIdProp?.value
                 return value ? String(value) : undefined
             },

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -84,6 +84,7 @@ import {
 
 import type { GroupType, GroupTypeIndex, HogFunctionMappingTemplateType, ProjectType } from '../../../types'
 import type { TeamPublicType, TeamType } from '../../../types'
+import { normalizeHogFunctionProperties } from '../hog-function-utils'
 import { performWideEventsQueryInTwoPhases } from '../sampleEventsQuery'
 import { eventToHogFunctionContextId } from '../sub-templates/sub-templates'
 import { SAMPLE_GLOBALS_CONTEXTS } from './sampleGlobalsContexts'
@@ -1663,15 +1664,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                         values: actionProperties,
                     })
                 }
-                if ((configuration.filters?.properties?.length ?? 0) > 0) {
-                    const globalProperties: PropertyGroupFilterValue = {
-                        type: FilterLogicalOperator.And,
-                        values: [],
-                    }
-                    for (const property of configuration.filters?.properties ?? []) {
-                        globalProperties.values.push(property as AnyPropertyFilter)
-                    }
-                    properties.values.push(globalProperties)
+                const { type: globalType, values: globalValues } = normalizeHogFunctionProperties(
+                    configuration.filters?.properties
+                )
+                if (globalValues.length > 0) {
+                    properties.values.push({
+                        type: globalType,
+                        values: globalValues as AnyPropertyFilter[],
+                    })
                 }
                 return properties
             },
@@ -1684,7 +1684,8 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 const filters = configuration.filters
                 let containsPersonProperties = false
                 if (filters?.properties && !containsPersonProperties) {
-                    containsPersonProperties = filters.properties.some((p) => p.type === 'person')
+                    const { values } = normalizeHogFunctionProperties(filters.properties)
+                    containsPersonProperties = values.some((p) => p.type === 'person')
                 }
                 if (filters?.actions && !containsPersonProperties) {
                     containsPersonProperties = filters.actions.some((a) =>

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -20,12 +20,24 @@ import MaxTool from 'scenes/max/MaxTool'
 import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
-import { AnyPropertyFilter, CyclotronJobFiltersType, EntityTypes, FilterType } from '~/types'
+import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
+import {
+    AnyPropertyFilter,
+    CyclotronJobFilterPropertyFilter,
+    CyclotronJobFiltersType,
+    EntityTypes,
+    FilterLogicalOperator,
+    FilterType,
+} from '~/types'
 
 import { useAttachedContext } from 'products/posthog_ai/frontend/api/logics'
 
 import { hogFunctionConfigurationLogic } from '../configuration/hogFunctionConfigurationLogic'
-import { truncateHogFunctionContext } from '../hog-function-utils'
+import {
+    normalizeHogFunctionProperties,
+    serializeHogFunctionProperties,
+    truncateHogFunctionContext,
+} from '../hog-function-utils'
 import { HogFunctionFiltersInternal } from './HogFunctionFiltersInternal'
 
 const MASKING_HASH_ALL = 'all'
@@ -300,19 +312,47 @@ export function HogFunctionFilters({
                                             fullWidth
                                         />
                                     )}
-                                    <PropertyFilters
-                                        propertyFilters={(currentFilters?.properties ?? []) as AnyPropertyFilter[]}
-                                        taxonomicGroupTypes={taxonomicGroupTypes}
-                                        onChange={(properties: AnyPropertyFilter[]) => {
-                                            const newValue = {
-                                                ...currentFilters,
-                                                properties,
-                                            }
-                                            onChange(newValue as CyclotronJobFiltersType)
-                                        }}
-                                        pageKey={`HogFunctionPropertyFilters.${type}`}
-                                        excludedProperties={excludedProperties}
-                                    />
+                                    {(() => {
+                                        const { type: propertiesOperator, values: propertyValues } =
+                                            normalizeHogFunctionProperties(currentFilters?.properties)
+                                        return (
+                                            <>
+                                                {propertyValues.length > 1 && (
+                                                    <AndOrFilterSelect
+                                                        value={propertiesOperator}
+                                                        onChange={(operator) => {
+                                                            onChange({
+                                                                ...currentFilters,
+                                                                properties: serializeHogFunctionProperties(
+                                                                    operator,
+                                                                    propertyValues
+                                                                ),
+                                                            } as CyclotronJobFiltersType)
+                                                        }}
+                                                        prefix="Match"
+                                                        suffix={['filter', 'filters']}
+                                                    />
+                                                )}
+                                                <PropertyFilters
+                                                    propertyFilters={propertyValues as AnyPropertyFilter[]}
+                                                    taxonomicGroupTypes={taxonomicGroupTypes}
+                                                    onChange={(properties: AnyPropertyFilter[]) => {
+                                                        onChange({
+                                                            ...currentFilters,
+                                                            properties: serializeHogFunctionProperties(
+                                                                propertiesOperator,
+                                                                properties as CyclotronJobFilterPropertyFilter[]
+                                                            ),
+                                                        } as CyclotronJobFiltersType)
+                                                    }}
+                                                    pageKey={`HogFunctionPropertyFilters.${type}`}
+                                                    excludedProperties={excludedProperties}
+                                                    orFiltering={propertiesOperator === FilterLogicalOperator.Or}
+                                                    propertyGroupType={propertiesOperator}
+                                                />
+                                            </>
+                                        )
+                                    })()}
                                 </>
                             )}
 
@@ -334,7 +374,9 @@ export function HogFunctionFilters({
                                     </p>
                                     <ActionFilter
                                         bordered
-                                        filters={currentFilters ?? {} /* TODO: this is any */}
+                                        // ActionFilter only reads events/actions; drop the global
+                                        // property group, which its FilterType prop can't hold.
+                                        filters={{ ...currentFilters, properties: undefined } as FilterType}
                                         setFilters={(payload) => {
                                             onChange({
                                                 ...currentFilters,

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -194,7 +194,7 @@ const setSimpleFilterValue = (
     // binding to the parent resource must survive.
     if (
         (contextId === 'logs-alerting' || contextId === 'batch-export-alerts') &&
-        previous?.properties &&
+        Array.isArray(previous?.properties) &&
         previous.properties.length > 0
     ) {
         next.properties = previous.properties
@@ -251,7 +251,7 @@ export function HogFunctionFiltersInternal(): JSX.Element {
                         {taxonomicGroupTypes.length > 0 ? (
                             <PropertyFilters
                                 key={contextId}
-                                propertyFilters={value?.properties ?? []}
+                                propertyFilters={Array.isArray(value?.properties) ? value.properties : []}
                                 taxonomicGroupTypes={taxonomicGroupTypes}
                                 onChange={(properties: AnyPropertyFilter[]) => {
                                     onChange({
@@ -273,7 +273,9 @@ export function HogFunctionFiltersInternal(): JSX.Element {
 }
 
 function LogsAlertBindingHint({ filters }: { filters: CyclotronJobFiltersType | undefined }): JSX.Element | null {
-    const alertIdProp = filters?.properties?.find((p) => 'key' in p && p.key === 'alert_id')
+    const alertIdProp = Array.isArray(filters?.properties)
+        ? filters.properties.find((p) => 'key' in p && p.key === 'alert_id')
+        : undefined
     const rawValue = alertIdProp && 'value' in alertIdProp ? alertIdProp.value : undefined
     const alertId =
         typeof rawValue === 'string'

--- a/frontend/src/scenes/hog-functions/hog-function-utils.test.ts
+++ b/frontend/src/scenes/hog-functions/hog-function-utils.test.ts
@@ -1,6 +1,18 @@
-import { CyclotronJobInputSchemaType } from '~/types'
+import { CyclotronJobFilterPropertyFilter, CyclotronJobInputSchemaType, FilterLogicalOperator } from '~/types'
 
-import { getHogFunctionDeliveryType, redactSecretHogFunctionInputs } from './hog-function-utils'
+import {
+    getHogFunctionDeliveryType,
+    normalizeHogFunctionProperties,
+    redactSecretHogFunctionInputs,
+    serializeHogFunctionProperties,
+} from './hog-function-utils'
+
+const CLICKID: CyclotronJobFilterPropertyFilter = {
+    key: 'clickid',
+    value: 'is_set',
+    operator: 'is_set',
+    type: 'event',
+} as CyclotronJobFilterPropertyFilter
 
 // The diff-builder test covers schema-marked secrets end to end; this covers the entry-marked branch
 // (a saved secret carries `secret: true` on the input entry itself, with no schema flag needed).
@@ -15,6 +27,35 @@ describe('redactSecretHogFunctionInputs', () => {
         )
         expect(redacted.token.value).toBe('[secret]')
         expect(redacted.url.value).toBe('https://example.com')
+    })
+})
+
+// Guards the backward-compat contract for global property filters: a legacy flat list reads as AND,
+// a group reads with its own operator, and only OR round-trips to the group shape — so a flat list
+// stays flat (no churn for existing destinations) while an OR selection actually persists as OR.
+describe('normalize/serialize hog function properties', () => {
+    it('normalizes a flat list to an AND group', () => {
+        expect(normalizeHogFunctionProperties([CLICKID])).toEqual({
+            type: FilterLogicalOperator.And,
+            values: [CLICKID],
+        })
+    })
+
+    it('normalizes an empty/undefined value to an empty AND group', () => {
+        expect(normalizeHogFunctionProperties(undefined)).toEqual({ type: FilterLogicalOperator.And, values: [] })
+    })
+
+    it('preserves the operator of a group', () => {
+        const group = { type: FilterLogicalOperator.Or, values: [CLICKID] }
+        expect(normalizeHogFunctionProperties(group)).toEqual(group)
+    })
+
+    it('serializes AND back to a flat list and OR to a group', () => {
+        expect(serializeHogFunctionProperties(FilterLogicalOperator.And, [CLICKID])).toEqual([CLICKID])
+        expect(serializeHogFunctionProperties(FilterLogicalOperator.Or, [CLICKID])).toEqual({
+            type: FilterLogicalOperator.Or,
+            values: [CLICKID],
+        })
     })
 })
 

--- a/frontend/src/scenes/hog-functions/hog-function-utils.ts
+++ b/frontend/src/scenes/hog-functions/hog-function-utils.ts
@@ -1,6 +1,43 @@
-import { CyclotronJobInputSchemaType, CyclotronJobInputType, HogFunctionTypeType } from '~/types'
+import {
+    CyclotronJobFilterPropertyFilter,
+    CyclotronJobFilterPropertyGroup,
+    CyclotronJobInputSchemaType,
+    CyclotronJobInputType,
+    FilterLogicalOperator,
+    HogFunctionTypeType,
+} from '~/types'
 
 export type HogFunctionDeliveryType = 'batch' | 'realtime'
+
+export interface NormalizedHogFunctionProperties {
+    type: FilterLogicalOperator
+    values: CyclotronJobFilterPropertyFilter[]
+}
+
+/**
+ * Global property filters are stored either as a flat list (combined with AND — the shape every
+ * existing destination uses) or as a single group `{ type, values }` so conditions can be combined
+ * with OR. Normalize both shapes to a group for rendering.
+ */
+export function normalizeHogFunctionProperties(
+    properties: CyclotronJobFilterPropertyFilter[] | CyclotronJobFilterPropertyGroup | null | undefined
+): NormalizedHogFunctionProperties {
+    if (properties && !Array.isArray(properties)) {
+        return { type: properties.type, values: properties.values ?? [] }
+    }
+    return { type: FilterLogicalOperator.And, values: properties ?? [] }
+}
+
+/**
+ * Serialize a normalized group back to storage: a flat list for AND (so existing destinations keep
+ * their shape and don't churn), a group object for OR.
+ */
+export function serializeHogFunctionProperties(
+    type: FilterLogicalOperator,
+    values: CyclotronJobFilterPropertyFilter[]
+): CyclotronJobFilterPropertyFilter[] | CyclotronJobFilterPropertyGroup {
+    return type === FilterLogicalOperator.Or ? { type, values } : values
+}
 
 // Batch exports vs realtime destinations share `type: 'destination'`; the only signal is the id prefix.
 export function getHogFunctionDeliveryType(item: { id: string }): HogFunctionDeliveryType {

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.test.ts
@@ -166,6 +166,36 @@ describe('surveyNotificationModalLogic', () => {
         ])
     })
 
+    it('keeps the OR operator of grouped global filters in the last-response lookup', () => {
+        // A dropped or AND-ed group makes the lookup select a response the compiled destination
+        // filter then rejects, so the test invocation is silently skipped.
+        const chromeFilter: EventPropertyFilter = {
+            key: '$browser',
+            type: PropertyFilterType.Event,
+            value: 'Chrome',
+            operator: PropertyOperator.Exact,
+        }
+        const firefoxFilter: EventPropertyFilter = {
+            key: '$browser',
+            type: PropertyFilterType.Event,
+            value: 'Firefox',
+            operator: PropertyOperator.Exact,
+        }
+
+        const query = buildLastSurveyResponseQuery('survey-abc', {
+            events: [{ id: SurveyEventName.SENT, type: 'events', properties: [] }],
+            properties: { type: FilterLogicalOperator.Or, values: [chromeFilter, firefoxFilter] },
+        })
+
+        expect(query?.fixedProperties?.[1]).toMatchObject({
+            type: FilterLogicalOperator.And,
+            values: [
+                expect.objectContaining({ type: FilterLogicalOperator.Or }),
+                { type: FilterLogicalOperator.Or, values: [chromeFilter, firefoxFilter] },
+            ],
+        })
+    })
+
     it.each([
         [
             'copies an exact value the sample is missing',

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -9,6 +9,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { convertToHogFunctionInvocationGlobals } from 'scenes/hog-functions/configuration/hogFunctionConfigurationLogic'
+import { normalizeHogFunctionProperties } from 'scenes/hog-functions/hog-function-utils'
 import { DESTINATION_OPTIONS, DestinationKey } from 'scenes/hog-functions/list/newNotificationDialogLogic'
 import {
     HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
@@ -295,14 +296,17 @@ function buildNotificationMatchGroup(filters: CyclotronJobFiltersType | null): P
             ],
         })),
     }
-    const globalProperties = (filters?.properties ?? []) as AnyPropertyFilter[]
+    // Global properties are stored either as a flat list (AND) or as a single group whose operator
+    // must survive into the query — dropping an OR group here would select a response the compiled
+    // filter then rejects, which is the exact skip this helper exists to prevent.
+    const { type: globalOperator, values: globalValues } = normalizeHogFunctionProperties(filters?.properties)
 
     return {
         type: FilterLogicalOperator.And,
         values: [
             eventGroups,
-            ...(globalProperties.length > 0
-                ? [{ type: FilterLogicalOperator.And, values: globalProperties } as PropertyGroupFilterValue]
+            ...(globalValues.length > 0
+                ? [{ type: globalOperator, values: globalValues as AnyPropertyFilter[] } as PropertyGroupFilterValue]
                 : []),
         ],
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7296,12 +7296,19 @@ export type CyclotronJobFilterPropertyFilter =
     | HogQLPropertyFilter
     | FlagPropertyFilter
 
+// Global property filters combined with a logical operator, so conditions can be combined with OR.
+// The legacy flat-list shape (`CyclotronJobFilterPropertyFilter[]`) is always treated as AND.
+export interface CyclotronJobFilterPropertyGroup {
+    type: FilterLogicalOperator
+    values: CyclotronJobFilterPropertyFilter[]
+}
+
 export interface CyclotronJobFiltersType {
     source?: 'events' | 'person-updates' | 'data-warehouse-table' | 'data-warehouse-view'
     events?: CyclotronJobFilterEvents[]
     data_warehouse?: CyclotronJobFilterDataWarehouse[]
     actions?: CyclotronJobFilterActions[]
-    properties?: CyclotronJobFilterPropertyFilter[]
+    properties?: CyclotronJobFilterPropertyFilter[] | CyclotronJobFilterPropertyGroup
     filter_test_accounts?: boolean
     bytecode?: any[]
     bytecode_error?: string

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import Any, Optional
 
 from django.conf import settings
@@ -198,6 +199,26 @@ def _build_global_property_filters(filters: dict, team: Team) -> list[ast.Expr]:
             return []
         return [property_to_expr(PropertyGroupFilterValue(**properties), team)]
     return [property_to_expr(prop, team) for prop in properties]
+
+
+def iter_global_property_leaves(properties: Any) -> Iterator[dict]:
+    """Yield the leaf filter dicts of `filters.properties`, whichever shape they are stored in.
+
+    For consumers that inspect individual conditions rather than compiling the whole thing —
+    list-only handling would silently skip every condition inside a group.
+    """
+    if isinstance(properties, dict):
+        stack: list[Any] = list(properties.get("values") or [])
+        while stack:
+            item = stack.pop()
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") in ("AND", "OR"):
+                stack.extend(item.get("values") or [])
+            else:
+                yield item
+    elif isinstance(properties, list):
+        yield from (item for item in properties if isinstance(item, dict))
 
 
 def _build_event_filter_expr(filter: dict) -> ast.Expr:

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -2,6 +2,8 @@ from typing import Any, Optional
 
 from django.conf import settings
 
+from posthog.schema import PropertyGroupFilterValue
+
 from posthog.hogql.compiler.bytecode import create_bytecode
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.parser import parse_expr
@@ -181,10 +183,21 @@ def _build_test_account_filters(filters: dict, team: Team) -> list[ast.Expr]:
 
 
 def _build_global_property_filters(filters: dict, team: Team) -> list[ast.Expr]:
-    """Build global property filters that apply to all events."""
-    if not filters.get("properties"):
+    """Build global property filters that apply to all events.
+
+    Properties are stored either as a flat list of filters (ANDed together — the legacy shape every
+    existing destination uses) or as a single property group `{"type": "AND"|"OR", "values": [...]}`,
+    which lets a destination combine conditions with OR. A group is folded into a single And/Or
+    expression by `property_to_expr`; a flat list keeps the historical per-filter AND behavior.
+    """
+    properties = filters.get("properties")
+    if not properties:
         return []
-    return [property_to_expr(prop, team) for prop in filters["properties"]]
+    if isinstance(properties, dict):
+        if not properties.get("values"):
+            return []
+        return [property_to_expr(PropertyGroupFilterValue(**properties), team)]
+    return [property_to_expr(prop, team) for prop in properties]
 
 
 def _build_event_filter_expr(filter: dict) -> ast.Expr:

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -228,6 +228,27 @@ class TestHogFunctionFilters(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
         assert execute_bytecode(bytecode, {"properties": {"$survey_response_1": 6}}).result is True
         assert execute_bytecode(bytecode, {"properties": {"$survey_response_1": 7}}).result is False
 
+    def test_global_property_group_combines_with_or(self):
+        # A global property group with `type: "OR"` must match when either leaf matches — the whole
+        # reason the group shape exists. A flat list (or an AND group) still requires every leaf.
+        leaves = [
+            {"key": "clickid", "value": "is_set", "operator": "is_set", "type": "event"},
+            {"key": "stored_clickid", "value": "is_set", "operator": "is_set", "type": "person"},
+        ]
+        event_only = {"properties": {"clickid": "abc"}, "person": {"properties": {}}}
+        person_only = {"properties": {}, "person": {"properties": {"stored_clickid": "abc"}}}
+        neither = {"properties": {}, "person": {"properties": {}}}
+
+        or_bytecode = compile_filters_bytecode({"properties": {"type": "OR", "values": leaves}}, self.team)["bytecode"]
+        assert execute_bytecode(or_bytecode, event_only).result is True
+        assert execute_bytecode(or_bytecode, person_only).result is True
+        assert execute_bytecode(or_bytecode, neither).result is False
+
+        and_bytecode = compile_filters_bytecode({"properties": {"type": "AND", "values": leaves}}, self.team)[
+            "bytecode"
+        ]
+        assert execute_bytecode(and_bytecode, event_only).result is False
+
     @parameterized.expand(
         [
             (True, True),

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -235,9 +235,9 @@ class TestHogFunctionFilters(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
             {"key": "clickid", "value": "is_set", "operator": "is_set", "type": "event"},
             {"key": "stored_clickid", "value": "is_set", "operator": "is_set", "type": "person"},
         ]
-        event_only = {"properties": {"clickid": "abc"}, "person": {"properties": {}}}
-        person_only = {"properties": {}, "person": {"properties": {"stored_clickid": "abc"}}}
-        neither = {"properties": {}, "person": {"properties": {}}}
+        event_only: dict = {"properties": {"clickid": "abc"}, "person": {"properties": {}}}
+        person_only: dict = {"properties": {}, "person": {"properties": {"stored_clickid": "abc"}}}
+        neither: dict = {"properties": {}, "person": {"properties": {}}}
 
         or_bytecode = compile_filters_bytecode({"properties": {"type": "OR", "values": leaves}}, self.team)["bytecode"]
         assert execute_bytecode(or_bytecode, event_only).result is True

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -12,6 +12,7 @@ from posthog.hogql import ast
 
 from posthog.cdp.validation import (
     HogFunctionFiltersSerializer,
+    HogFunctionGlobalPropertiesField,
     InputsSchemaItemSerializer,
     MappingsSerializer,
     RecordAliasRewriter,
@@ -1159,6 +1160,43 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
             )
         # The original value round-trips so the UI can still render the templated source string.
         assert validated["tags"]["value"] == value
+
+
+EVENT_LEAF = {"key": "clickid", "value": "is_set", "operator": "is_set", "type": "event"}
+
+
+class TestHogFunctionGlobalPropertiesField(SimpleTestCase):
+    # Property groups compile through the strict PropertyGroupFilterValue pydantic model, and the
+    # transpiled (site destination/app) path runs that compile with no guard - so anything the
+    # model would reject must already have failed here as a field error, not escaped as a 500.
+    @parameterized.expand(
+        [
+            ("flat_list", [EVENT_LEAF], True),
+            ("or_group", {"type": "OR", "values": [EVENT_LEAF]}, True),
+            ("and_group", {"type": "AND", "values": [EVENT_LEAF]}, True),
+            ("nested_group", {"type": "OR", "values": [{"type": "AND", "values": [EVENT_LEAF]}]}, True),
+            ("empty_group", {"type": "OR", "values": []}, True),
+            ("malformed_leaf", {"type": "OR", "values": [{"foo": "bar"}]}, False),
+            ("leaf_with_stray_key", {"type": "OR", "values": [{**EVENT_LEAF, "stray": 1}]}, False),
+            ("stray_key_on_group", {"type": "OR", "values": [EVENT_LEAF], "stray": 1}, False),
+            ("lowercase_operator", {"type": "or", "values": [EVENT_LEAF]}, False),
+            ("non_list_values", {"type": "OR", "values": "nope"}, False),
+            ("non_dict_list_item", ["nope"], False),
+            ("scalar", "nope", False),
+        ]
+    )
+    def test_property_shapes(self, _name, data, expect_valid):
+        field = HogFunctionGlobalPropertiesField()
+        if expect_valid:
+            assert field.run_validation(data) == data
+        else:
+            with pytest.raises(ValidationError):
+                field.run_validation(data)
+
+    def test_malformed_group_is_a_field_error_not_an_exception(self):
+        serializer = HogFunctionFiltersSerializer(data={"properties": {"type": "OR", "values": [{"foo": "bar"}]}})
+        assert not serializer.is_valid()
+        assert "properties" in serializer.errors
 
 
 class TestTaskInputTypeValidation(SimpleTestCase):

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -3,9 +3,12 @@ import json
 import logging
 from typing import Any, Optional
 
+import pydantic
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
+
+from posthog.schema import PropertyGroupFilterValue
 
 from posthog.hogql import ast
 from posthog.hogql.compiler.bytecode import create_bytecode
@@ -845,6 +848,15 @@ class HogFunctionGlobalPropertiesField(serializers.Field):
                 raise ValidationError('Property group "type" must be "AND" or "OR"')
             if not isinstance(data.get("values", []), list):
                 raise ValidationError('Property group "values" must be a list')
+            # The compiler rebuilds this exact model, so a leaf it would choke on has to fail here
+            # as a field error — the transpiled path calls the compiler outside any guard, and a
+            # pydantic error escaping the serializer becomes a 500.
+            try:
+                PropertyGroupFilterValue(**data)
+            except pydantic.ValidationError as e:
+                first = e.errors()[0]
+                location = ".".join(str(part) for part in first["loc"])
+                raise ValidationError(f"Invalid property group at {location or 'root'}: {first['msg']}")
             return data
         raise ValidationError("properties must be a list of filters or a property group")
 

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -811,6 +811,47 @@ class InputsSerializer(serializers.DictField):
 DATA_WAREHOUSE_SOURCES = ("data-warehouse-table", "data-warehouse-view")
 
 
+@extend_schema_field(
+    {
+        "oneOf": [
+            {"type": "array", "items": {"type": "object", "additionalProperties": True}},
+            {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "enum": ["AND", "OR"]},
+                    "values": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
+                },
+                "required": ["type", "values"],
+            },
+        ]
+    }
+)
+class HogFunctionGlobalPropertiesField(serializers.Field):
+    """Global property filters applied to every event before it reaches the function.
+
+    Accepts either a flat list of filter objects (combined with AND — the shape every existing
+    destination uses) or a single property group ``{"type": "AND"|"OR", "values": [...]}`` so a
+    destination can combine conditions with OR. The compiler folds a group into the matching
+    And/Or expression; a flat list keeps the historical per-filter AND behavior.
+    """
+
+    def to_internal_value(self, data: Any) -> Any:
+        if isinstance(data, list):
+            if not all(isinstance(item, dict) for item in data):
+                raise ValidationError("Each property filter must be an object")
+            return data
+        if isinstance(data, dict):
+            if data.get("type") not in ("AND", "OR"):
+                raise ValidationError('Property group "type" must be "AND" or "OR"')
+            if not isinstance(data.get("values", []), list):
+                raise ValidationError('Property group "values" must be a list')
+            return data
+        raise ValidationError("properties must be a list of filters or a property group")
+
+    def to_representation(self, value: Any) -> Any:
+        return value
+
+
 class HogFunctionFiltersSerializer(serializers.Serializer):
     source = serializers.ChoiceField(
         choices=["events", "person-updates", *DATA_WAREHOUSE_SOURCES], required=False, default="events"
@@ -818,7 +859,7 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
     actions = serializers.ListField(child=serializers.DictField(), required=False)
     events = serializers.ListField(child=serializers.DictField(), required=False)
     data_warehouse = serializers.ListField(child=serializers.DictField(), required=False)
-    properties = serializers.ListField(child=serializers.DictField(), required=False)
+    properties = HogFunctionGlobalPropertiesField(required=False)
     bytecode = serializers.JSONField(required=False, allow_null=True)
     transpiled = serializers.JSONField(required=False)
     filter_test_accounts = serializers.BooleanField(required=False)

--- a/products/alerts/frontend/logic/alertsLogic.ts
+++ b/products/alerts/frontend/logic/alertsLogic.ts
@@ -257,9 +257,9 @@ export const alertsLogic = kea<alertsLogicType>([
                         if (!hogFunction.enabled) {
                             return counts
                         }
-                        const alertIdProperty = hogFunction.filters?.properties?.find(
-                            (property) => property.key === 'alert_id'
-                        )
+                        const alertIdProperty = Array.isArray(hogFunction.filters?.properties)
+                            ? hogFunction.filters.properties.find((property) => property.key === 'alert_id')
+                            : undefined
                         const alertId = alertIdProperty?.value
                         if (typeof alertId === 'string' && alertIds.has(alertId)) {
                             counts[alertId] = (counts[alertId] ?? 0) + 1

--- a/products/alerts/frontend/logic/insightAlertsLogic.ts
+++ b/products/alerts/frontend/logic/insightAlertsLogic.ts
@@ -276,9 +276,9 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
                         limit: 500,
                     })
                     return response.results.reduce<Record<string, number>>((counts, hogFunction) => {
-                        const alertIdProperty = hogFunction.filters?.properties?.find(
-                            (property) => property.key === 'alert_id'
-                        )
+                        const alertIdProperty = Array.isArray(hogFunction.filters?.properties)
+                            ? hogFunction.filters.properties.find((property) => property.key === 'alert_id')
+                            : undefined
                         const alertId = alertIdProperty?.value
                         if (typeof alertId === 'string' && alertIds.has(alertId)) {
                             counts[alertId] = (counts[alertId] ?? 0) + 1

--- a/products/cdp/frontend/generated/api.schemas.ts
+++ b/products/cdp/frontend/generated/api.schemas.ts
@@ -353,14 +353,19 @@ export type HogFunctionFiltersApiEventsItem = { [key: string]: unknown }
 
 export type HogFunctionFiltersApiDataWarehouseItem = { [key: string]: unknown }
 
-export type HogFunctionFiltersApiPropertiesItem = { [key: string]: unknown }
+export type HogFunctionFiltersApiProperties =
+    | { [key: string]: unknown }[]
+    | {
+          type: 'AND' | 'OR'
+          values: { [key: string]: unknown }[]
+      }
 
 export interface HogFunctionFiltersApi {
     source?: HogFunctionFiltersSourceEnumApi
     actions?: HogFunctionFiltersApiActionsItem[]
     events?: HogFunctionFiltersApiEventsItem[]
     data_warehouse?: HogFunctionFiltersApiDataWarehouseItem[]
-    properties?: HogFunctionFiltersApiPropertiesItem[]
+    properties?: HogFunctionFiltersApiProperties
     bytecode?: unknown
     transpiled?: unknown
     filter_test_accounts?: boolean

--- a/products/cdp/frontend/generated/api.zod.ts
+++ b/products/cdp/frontend/generated/api.zod.ts
@@ -130,7 +130,15 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             bytecode: zod.unknown().optional(),
             transpiled: zod.unknown().optional(),
             filter_test_accounts: zod.boolean().optional(),
@@ -240,7 +248,15 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         bytecode: zod.unknown().optional(),
                         transpiled: zod.unknown().optional(),
                         filter_test_accounts: zod.boolean().optional(),
@@ -393,7 +409,15 @@ export const HogFunctionsUpdateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             bytecode: zod.unknown().optional(),
             transpiled: zod.unknown().optional(),
             filter_test_accounts: zod.boolean().optional(),
@@ -503,7 +527,15 @@ export const HogFunctionsUpdateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         bytecode: zod.unknown().optional(),
                         transpiled: zod.unknown().optional(),
                         filter_test_accounts: zod.boolean().optional(),
@@ -656,7 +688,15 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             bytecode: zod.unknown().optional(),
             transpiled: zod.unknown().optional(),
             filter_test_accounts: zod.boolean().optional(),
@@ -766,7 +806,15 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         bytecode: zod.unknown().optional(),
                         transpiled: zod.unknown().optional(),
                         filter_test_accounts: zod.boolean().optional(),
@@ -923,7 +971,15 @@ export const HogFunctionsEnableBackfillsCreateBody = /* @__PURE__ */ zod.object(
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             bytecode: zod.unknown().optional(),
             transpiled: zod.unknown().optional(),
             filter_test_accounts: zod.boolean().optional(),
@@ -1039,7 +1095,15 @@ export const HogFunctionsEnableBackfillsCreateBody = /* @__PURE__ */ zod.object(
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         bytecode: zod.unknown().optional(),
                         transpiled: zod.unknown().optional(),
                         filter_test_accounts: zod.boolean().optional(),
@@ -1271,7 +1335,15 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                     events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                     data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod
+                        .union([
+                            zod.array(zod.record(zod.string(), zod.unknown())),
+                            zod.object({
+                                type: zod.enum(['AND', 'OR']),
+                                values: zod.array(zod.record(zod.string(), zod.unknown())),
+                            }),
+                        ])
+                        .optional(),
                     bytecode: zod.unknown().optional(),
                     transpiled: zod.unknown().optional(),
                     filter_test_accounts: zod.boolean().optional(),
@@ -1389,7 +1461,15 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -60,7 +60,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import log_activity_from_viewset
 from posthog.auth import InternalAPIAuthentication
-from posthog.cdp.filters import compile_filters_expr
+from posthog.cdp.filters import compile_filters_expr, iter_global_property_leaves
 from posthog.cdp.flag_gated_templates import FLAG_GATED_TEMPLATE_IDS, gated_template_enabled
 from posthog.cdp.validation import (
     DATA_WAREHOUSE_SOURCES,
@@ -761,11 +761,8 @@ def _normalize_slack_channel_filters(filters: dict) -> None:
     storing the picker's value verbatim compiles a filter that can never match. The frontend strips
     it too; this is here because the same dead filter is one API or MCP call away otherwise.
     """
-    properties = filters.get("properties")
-    if not isinstance(properties, list):
-        return
-    for prop in properties:
-        if not isinstance(prop, dict) or prop.get("key") != "channel":
+    for prop in iter_global_property_leaves(filters.get("properties")):
+        if prop.get("key") != "channel":
             continue
         value = prop.get("value")
         if isinstance(value, str):
@@ -1138,12 +1135,10 @@ class HogFlowActionSerializer(serializers.Serializer):
         # that for API/MCP callers. Static cohorts are exempt regardless of how they were built — their
         # membership is frozen and precalculated — matching the audience-picker exemption in
         # _build_cohort_dependency_graph in products/cohorts/backend/models/dependencies.py.
-        if not isinstance(properties, list):
-            return
         cohort_ids = [
             p["value"]
-            for p in properties
-            if isinstance(p, dict) and p.get("type") == "cohort" and p.get("value") is not None
+            for p in iter_global_property_leaves(properties)
+            if p.get("type") == "cohort" and p.get("value") is not None
         ]
         if not cohort_ids:
             return

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -2340,25 +2340,27 @@ class TestHogFlowAPI(APIBaseTest):
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
         assert response.status_code == 201, response.json()
 
-    def test_hog_flow_slack_trigger_stores_the_bare_channel_id(self):
+    @parameterized.expand([("flat_list", False), ("property_group", True)])
+    def test_hog_flow_slack_trigger_stores_the_bare_channel_id(self, _name, as_group):
         # The channel picker identifies a channel as `C123|#name`, but the event carries `C123`, so
         # storing the composite compiles a filter that never matches and the workflow never runs.
+        # The normalization must reach a channel condition inside a property group too.
+        channel_property = {
+            "key": "channel",
+            "value": ["C0ALERTS|#alerts"],
+            "operator": "exact",
+            "type": "event",
+        }
+        properties: list | dict = [channel_property]
+        if as_group:
+            properties = {"type": "OR", "values": properties}
         trigger_action = {
             "id": "trigger_node",
             "name": "trigger_1",
             "type": "trigger",
             "config": {
                 "type": "slack-message",
-                "filters": {
-                    "properties": [
-                        {
-                            "key": "channel",
-                            "value": ["C0ALERTS|#alerts"],
-                            "operator": "exact",
-                            "type": "event",
-                        }
-                    ]
-                },
+                "filters": {"properties": properties},
             },
         }
 
@@ -2366,7 +2368,8 @@ class TestHogFlowAPI(APIBaseTest):
 
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
         assert response.status_code == 201, response.json()
-        stored = response.json()["trigger"]["filters"]["properties"][0]["value"]
+        stored_properties = response.json()["trigger"]["filters"]["properties"]
+        stored = stored_properties["values"][0]["value"] if as_group else stored_properties[0]["value"]
         assert stored == ["C0ALERTS"]
 
     def test_hog_flow_data_warehouse_table_trigger_forces_exit_only_at_end(self):
@@ -2652,23 +2655,42 @@ class TestHogFlowAPI(APIBaseTest):
             filters = {"properties": properties}
         return Cohort.objects.create(team=self.team, name="c", filters=filters, is_static=static)
 
-    def _post_batch_with_cohort(self, cohort_id: int, *, status: str = "active", trigger_type: str = "batch", **extra):
+    def _post_batch_with_cohort(
+        self,
+        cohort_id: int,
+        *,
+        status: str = "active",
+        trigger_type: str = "batch",
+        as_group: bool = False,
+        **extra,
+    ):
+        properties: list | dict = [{"key": "id", "type": "cohort", "value": cohort_id, "operator": "in"}]
+        if as_group:
+            properties = {"type": "OR", "values": properties}
         trigger_action = {
             "id": "trigger_node",
             "name": "trigger_1",
             "type": "trigger",
             "config": {
                 "type": trigger_type,
-                "filters": {"properties": [{"key": "id", "type": "cohort", "value": cohort_id, "operator": "in"}]},
+                "filters": {"properties": properties},
             },
         }
         hog_flow = {"name": "Test Batch Flow", "status": status, "actions": [trigger_action]}
         return self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow, **extra)
 
-    @parameterized.expand(["batch", "schedule"])
-    def test_hog_flow_audience_rejects_behavioral_cohort(self, trigger_type: str):
+    @parameterized.expand(
+        [
+            ("batch", False),
+            ("schedule", False),
+            # Schedule audiences accept the OR/AND group shape (batch rejects any non-array
+            # properties upstream), so the guard must find a behavioral cohort inside a group too.
+            ("schedule", True),
+        ]
+    )
+    def test_hog_flow_audience_rejects_behavioral_cohort(self, trigger_type: str, as_group: bool):
         cohort = self._make_cohort(behavioral=True)
-        response = self._post_batch_with_cohort(cohort.pk, trigger_type=trigger_type)
+        response = self._post_batch_with_cohort(cohort.pk, trigger_type=trigger_type, as_group=as_group)
         assert response.status_code == 400, response.json()
         assert "behavior" in response.json()["detail"].lower()
 

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -87,14 +87,19 @@ export type HogFunctionFiltersApiEventsItem = { [key: string]: unknown }
 
 export type HogFunctionFiltersApiDataWarehouseItem = { [key: string]: unknown }
 
-export type HogFunctionFiltersApiPropertiesItem = { [key: string]: unknown }
+export type HogFunctionFiltersApiProperties =
+    | { [key: string]: unknown }[]
+    | {
+          type: 'AND' | 'OR'
+          values: { [key: string]: unknown }[]
+      }
 
 export interface HogFunctionFiltersApi {
     source?: HogFunctionFiltersSourceEnumApi
     actions?: HogFunctionFiltersApiActionsItem[]
     events?: HogFunctionFiltersApiEventsItem[]
     data_warehouse?: HogFunctionFiltersApiDataWarehouseItem[]
-    properties?: HogFunctionFiltersApiPropertiesItem[]
+    properties?: HogFunctionFiltersApiProperties
     bytecode?: unknown
     transpiled?: unknown
     filter_test_accounts?: boolean

--- a/products/workflows/frontend/generated/api.zod.ts
+++ b/products/workflows/frontend/generated/api.zod.ts
@@ -101,7 +101,15 @@ export const HogFlowTemplatesCreateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -223,7 +231,15 @@ export const HogFlowTemplatesUpdateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -356,7 +372,15 @@ export const HogFlowTemplatesPartialUpdateBody = /* @__PURE__ */ zod
                                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                     events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                     data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                    properties: zod
+                                        .union([
+                                            zod.array(zod.record(zod.string(), zod.unknown())),
+                                            zod.object({
+                                                type: zod.enum(['AND', 'OR']),
+                                                values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                            }),
+                                        ])
+                                        .optional(),
                                     bytecode: zod.unknown().optional(),
                                     transpiled: zod.unknown().optional(),
                                     filter_test_accounts: zod.boolean().optional(),
@@ -470,7 +494,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                        properties: zod
+                                            .union([
+                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                zod.object({
+                                                    type: zod.enum(['AND', 'OR']),
+                                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                }),
+                                            ])
+                                            .optional(),
                                         bytecode: zod.unknown().optional(),
                                         transpiled: zod.unknown().optional(),
                                         filter_test_accounts: zod.boolean().optional(),
@@ -574,7 +606,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -641,7 +681,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                             .array(zod.record(zod.string(), zod.unknown()))
                                                             .optional(),
                                                         properties: zod
-                                                            .array(zod.record(zod.string(), zod.unknown()))
+                                                            .union([
+                                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                zod.object({
+                                                                    type: zod.enum(['AND', 'OR']),
+                                                                    values: zod.array(
+                                                                        zod.record(zod.string(), zod.unknown())
+                                                                    ),
+                                                                }),
+                                                            ])
                                                             .optional(),
                                                         bytecode: zod.unknown().optional(),
                                                         transpiled: zod.unknown().optional(),
@@ -689,7 +737,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                                 .optional(),
                                                             properties: zod
-                                                                .array(zod.record(zod.string(), zod.unknown()))
+                                                                .union([
+                                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                    zod.object({
+                                                                        type: zod.enum(['AND', 'OR']),
+                                                                        values: zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                    }),
+                                                                ])
                                                                 .optional(),
                                                             bytecode: zod.unknown().optional(),
                                                             transpiled: zod.unknown().optional(),
@@ -825,7 +881,15 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                        properties: zod
+                                            .union([
+                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                zod.object({
+                                                    type: zod.enum(['AND', 'OR']),
+                                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                }),
+                                            ])
+                                            .optional(),
                                         bytecode: zod.unknown().optional(),
                                         transpiled: zod.unknown().optional(),
                                         filter_test_accounts: zod.boolean().optional(),
@@ -929,7 +993,15 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -996,7 +1068,15 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                                             .array(zod.record(zod.string(), zod.unknown()))
                                                             .optional(),
                                                         properties: zod
-                                                            .array(zod.record(zod.string(), zod.unknown()))
+                                                            .union([
+                                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                zod.object({
+                                                                    type: zod.enum(['AND', 'OR']),
+                                                                    values: zod.array(
+                                                                        zod.record(zod.string(), zod.unknown())
+                                                                    ),
+                                                                }),
+                                                            ])
                                                             .optional(),
                                                         bytecode: zod.unknown().optional(),
                                                         transpiled: zod.unknown().optional(),
@@ -1044,7 +1124,15 @@ export const HogFlowsUpdateBody = /* @__PURE__ */ zod
                                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                                 .optional(),
                                                             properties: zod
-                                                                .array(zod.record(zod.string(), zod.unknown()))
+                                                                .union([
+                                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                    zod.object({
+                                                                        type: zod.enum(['AND', 'OR']),
+                                                                        values: zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                    }),
+                                                                ])
                                                                 .optional(),
                                                             bytecode: zod.unknown().optional(),
                                                             transpiled: zod.unknown().optional(),
@@ -1185,7 +1273,15 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                        properties: zod
+                                            .union([
+                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                zod.object({
+                                                    type: zod.enum(['AND', 'OR']),
+                                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                }),
+                                            ])
+                                            .optional(),
                                         bytecode: zod.unknown().optional(),
                                         transpiled: zod.unknown().optional(),
                                         filter_test_accounts: zod.boolean().optional(),
@@ -1289,7 +1385,15 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -1356,7 +1460,15 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                                             .array(zod.record(zod.string(), zod.unknown()))
                                                             .optional(),
                                                         properties: zod
-                                                            .array(zod.record(zod.string(), zod.unknown()))
+                                                            .union([
+                                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                zod.object({
+                                                                    type: zod.enum(['AND', 'OR']),
+                                                                    values: zod.array(
+                                                                        zod.record(zod.string(), zod.unknown())
+                                                                    ),
+                                                                }),
+                                                            ])
                                                             .optional(),
                                                         bytecode: zod.unknown().optional(),
                                                         transpiled: zod.unknown().optional(),
@@ -1404,7 +1516,15 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                                 .optional(),
                                                             properties: zod
-                                                                .array(zod.record(zod.string(), zod.unknown()))
+                                                                .union([
+                                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                    zod.object({
+                                                                        type: zod.enum(['AND', 'OR']),
+                                                                        values: zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                    }),
+                                                                ])
                                                                 .optional(),
                                                             bytecode: zod.unknown().optional(),
                                                             transpiled: zod.unknown().optional(),
@@ -1789,7 +1909,15 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                             data_warehouse: zod
                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                 .optional(),
-                                            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                            properties: zod
+                                                .union([
+                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                    zod.object({
+                                                        type: zod.enum(['AND', 'OR']),
+                                                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                    }),
+                                                ])
+                                                .optional(),
                                             bytecode: zod.unknown().optional(),
                                             transpiled: zod.unknown().optional(),
                                             filter_test_accounts: zod.boolean().optional(),
@@ -1905,7 +2033,15 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                     events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                     data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                    properties: zod
+                                        .union([
+                                            zod.array(zod.record(zod.string(), zod.unknown())),
+                                            zod.object({
+                                                type: zod.enum(['AND', 'OR']),
+                                                values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                            }),
+                                        ])
+                                        .optional(),
                                     bytecode: zod.unknown().optional(),
                                     transpiled: zod.unknown().optional(),
                                     filter_test_accounts: zod.boolean().optional(),
@@ -1972,7 +2108,15 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                                 .optional(),
                                                             properties: zod
-                                                                .array(zod.record(zod.string(), zod.unknown()))
+                                                                .union([
+                                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                    zod.object({
+                                                                        type: zod.enum(['AND', 'OR']),
+                                                                        values: zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                    }),
+                                                                ])
                                                                 .optional(),
                                                             bytecode: zod.unknown().optional(),
                                                             transpiled: zod.unknown().optional(),
@@ -2020,7 +2164,17 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                                                     .array(zod.record(zod.string(), zod.unknown()))
                                                                     .optional(),
                                                                 properties: zod
-                                                                    .array(zod.record(zod.string(), zod.unknown()))
+                                                                    .union([
+                                                                        zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                        zod.object({
+                                                                            type: zod.enum(['AND', 'OR']),
+                                                                            values: zod.array(
+                                                                                zod.record(zod.string(), zod.unknown())
+                                                                            ),
+                                                                        }),
+                                                                    ])
                                                                     .optional(),
                                                                 bytecode: zod.unknown().optional(),
                                                                 transpiled: zod.unknown().optional(),
@@ -2428,7 +2582,15 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                        properties: zod
+                                            .union([
+                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                zod.object({
+                                                    type: zod.enum(['AND', 'OR']),
+                                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                }),
+                                            ])
+                                            .optional(),
                                         bytecode: zod.unknown().optional(),
                                         transpiled: zod.unknown().optional(),
                                         filter_test_accounts: zod.boolean().optional(),
@@ -2532,7 +2694,15 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -2599,7 +2769,15 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                                             .array(zod.record(zod.string(), zod.unknown()))
                                                             .optional(),
                                                         properties: zod
-                                                            .array(zod.record(zod.string(), zod.unknown()))
+                                                            .union([
+                                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                zod.object({
+                                                                    type: zod.enum(['AND', 'OR']),
+                                                                    values: zod.array(
+                                                                        zod.record(zod.string(), zod.unknown())
+                                                                    ),
+                                                                }),
+                                                            ])
                                                             .optional(),
                                                         bytecode: zod.unknown().optional(),
                                                         transpiled: zod.unknown().optional(),
@@ -2647,7 +2825,15 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
                                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                                 .optional(),
                                                             properties: zod
-                                                                .array(zod.record(zod.string(), zod.unknown()))
+                                                                .union([
+                                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                    zod.object({
+                                                                        type: zod.enum(['AND', 'OR']),
+                                                                        values: zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                    }),
+                                                                ])
                                                                 .optional(),
                                                             bytecode: zod.unknown().optional(),
                                                             transpiled: zod.unknown().optional(),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -40277,14 +40277,17 @@ export namespace Schemas {
 
     export type HogFunctionFiltersDataWarehouseItem = { [key: string]: unknown };
 
-    export type HogFunctionFiltersPropertiesItem = { [key: string]: unknown };
+    export type HogFunctionFiltersProperties = { [key: string]: unknown }[] | {
+      type: 'AND' | 'OR';
+      values: { [key: string]: unknown }[];
+    };
 
     export interface HogFunctionFilters {
       source?: HogFunctionFiltersSourceEnum;
       actions?: HogFunctionFiltersActionsItem[];
       events?: HogFunctionFiltersEventsItem[];
       data_warehouse?: HogFunctionFiltersDataWarehouseItem[];
-      properties?: HogFunctionFiltersPropertiesItem[];
+      properties?: HogFunctionFiltersProperties;
       bytecode?: unknown;
       transpiled?: unknown;
       filter_test_accounts?: boolean;

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -150,7 +150,15 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             filter_test_accounts: zod.boolean().optional(),
         })
         .optional()
@@ -248,7 +256,15 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         filter_test_accounts: zod.boolean().optional(),
                     })
                     .optional(),
@@ -403,7 +419,15 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             filter_test_accounts: zod.boolean().optional(),
         })
         .optional()
@@ -501,7 +525,15 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         filter_test_accounts: zod.boolean().optional(),
                     })
                     .optional(),
@@ -761,7 +793,15 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                     actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                     events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                     data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod
+                        .union([
+                            zod.array(zod.record(zod.string(), zod.unknown())),
+                            zod.object({
+                                type: zod.enum(['AND', 'OR']),
+                                values: zod.array(zod.record(zod.string(), zod.unknown())),
+                            }),
+                        ])
+                        .optional(),
                     bytecode: zod.unknown().optional(),
                     transpiled: zod.unknown().optional(),
                     filter_test_accounts: zod.boolean().optional(),
@@ -879,7 +919,15 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),

--- a/services/mcp/src/generated/error_tracking_alerts/api.ts
+++ b/services/mcp/src/generated/error_tracking_alerts/api.ts
@@ -150,7 +150,15 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             filter_test_accounts: zod.boolean().optional(),
         })
         .optional()
@@ -248,7 +256,15 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         filter_test_accounts: zod.boolean().optional(),
                     })
                     .optional(),
@@ -394,7 +410,15 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
             actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
             data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-            properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+            properties: zod
+                .union([
+                    zod.array(zod.record(zod.string(), zod.unknown())),
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(zod.record(zod.string(), zod.unknown())),
+                    }),
+                ])
+                .optional(),
             filter_test_accounts: zod.boolean().optional(),
         })
         .optional()
@@ -492,7 +516,15 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                        properties: zod
+                            .union([
+                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                zod.object({
+                                    type: zod.enum(['AND', 'OR']),
+                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                }),
+                            ])
+                            .optional(),
                         filter_test_accounts: zod.boolean().optional(),
                     })
                     .optional(),

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -121,7 +121,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                        properties: zod
+                                            .union([
+                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                zod.object({
+                                                    type: zod.enum(['AND', 'OR']),
+                                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                }),
+                                            ])
+                                            .optional(),
                                         bytecode: zod.unknown().optional(),
                                         transpiled: zod.unknown().optional(),
                                         filter_test_accounts: zod.boolean().optional(),
@@ -225,7 +233,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                 actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                 data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                properties: zod
+                                    .union([
+                                        zod.array(zod.record(zod.string(), zod.unknown())),
+                                        zod.object({
+                                            type: zod.enum(['AND', 'OR']),
+                                            values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                        }),
+                                    ])
+                                    .optional(),
                                 bytecode: zod.unknown().optional(),
                                 transpiled: zod.unknown().optional(),
                                 filter_test_accounts: zod.boolean().optional(),
@@ -292,7 +308,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                             .array(zod.record(zod.string(), zod.unknown()))
                                                             .optional(),
                                                         properties: zod
-                                                            .array(zod.record(zod.string(), zod.unknown()))
+                                                            .union([
+                                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                zod.object({
+                                                                    type: zod.enum(['AND', 'OR']),
+                                                                    values: zod.array(
+                                                                        zod.record(zod.string(), zod.unknown())
+                                                                    ),
+                                                                }),
+                                                            ])
                                                             .optional(),
                                                         bytecode: zod.unknown().optional(),
                                                         transpiled: zod.unknown().optional(),
@@ -340,7 +364,15 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
                                                                 .array(zod.record(zod.string(), zod.unknown()))
                                                                 .optional(),
                                                             properties: zod
-                                                                .array(zod.record(zod.string(), zod.unknown()))
+                                                                .union([
+                                                                    zod.array(zod.record(zod.string(), zod.unknown())),
+                                                                    zod.object({
+                                                                        type: zod.enum(['AND', 'OR']),
+                                                                        values: zod.array(
+                                                                            zod.record(zod.string(), zod.unknown())
+                                                                        ),
+                                                                    }),
+                                                                ])
                                                                 .optional(),
                                                             bytecode: zod.unknown().optional(),
                                                             transpiled: zod.unknown().optional(),
@@ -480,7 +512,15 @@ export const HogFlowsPartialUpdateBody = /* @__PURE__ */ zod
                                         actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
                                         data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
-                                        properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                                        properties: zod
+                                            .union([
+                                                zod.array(zod.record(zod.string(), zod.unknown())),
+                                                zod.object({
+                                                    type: zod.enum(['AND', 'OR']),
+                                                    values: zod.array(zod.record(zod.string(), zod.unknown())),
+                                                }),
+                                            ])
+                                            .optional(),
                                         bytecode: zod.unknown().optional(),
                                         transpiled: zod.unknown().optional(),
                                         filter_test_accounts: zod.boolean().optional(),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
@@ -59,14 +59,38 @@
                     "type": "boolean"
                 },
                 "properties": {
-                    "items": {
-                        "additionalProperties": {},
-                        "propertyNames": {
-                            "type": "string"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                    "type": "string"
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
                         },
-                        "type": "object"
-                    },
-                    "type": "array"
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["AND", "OR"],
+                                    "type": "string"
+                                },
+                                "values": {
+                                    "items": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["type", "values"],
+                            "type": "object"
+                        }
+                    ]
                 },
                 "source": {
                     "default": "events",
@@ -241,14 +265,38 @@
                                         "type": "boolean"
                                     },
                                     "properties": {
-                                        "items": {
-                                            "additionalProperties": {},
-                                            "propertyNames": {
-                                                "type": "string"
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "additionalProperties": {},
+                                                    "propertyNames": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
                                             },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "enum": ["AND", "OR"],
+                                                        "type": "string"
+                                                    },
+                                                    "values": {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": ["type", "values"],
+                                                "type": "object"
+                                            }
+                                        ]
                                     },
                                     "source": {
                                         "default": "events",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -206,14 +206,38 @@
                             "type": "boolean"
                         },
                         "properties": {
-                            "items": {
-                                "additionalProperties": {},
-                                "propertyNames": {
-                                    "type": "string"
+                            "anyOf": [
+                                {
+                                    "items": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
                                 },
-                                "type": "object"
-                            },
-                            "type": "array"
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "enum": ["AND", "OR"],
+                                            "type": "string"
+                                        },
+                                        "values": {
+                                            "items": {
+                                                "additionalProperties": {},
+                                                "propertyNames": {
+                                                    "type": "string"
+                                                },
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": ["type", "values"],
+                                    "type": "object"
+                                }
+                            ]
                         },
                         "source": {
                             "default": "events",
@@ -411,14 +435,38 @@
                                                 "type": "boolean"
                                             },
                                             "properties": {
-                                                "items": {
-                                                    "additionalProperties": {},
-                                                    "propertyNames": {
-                                                        "type": "string"
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
                                                     },
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
+                                                    {
+                                                        "properties": {
+                                                            "type": {
+                                                                "enum": ["AND", "OR"],
+                                                                "type": "string"
+                                                            },
+                                                            "values": {
+                                                                "items": {
+                                                                    "additionalProperties": {},
+                                                                    "propertyNames": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["type", "values"],
+                                                        "type": "object"
+                                                    }
+                                                ]
                                             },
                                             "source": {
                                                 "default": "events",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
@@ -65,14 +65,38 @@
                     "type": "boolean"
                 },
                 "properties": {
-                    "items": {
-                        "additionalProperties": {},
-                        "propertyNames": {
-                            "type": "string"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                    "type": "string"
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
                         },
-                        "type": "object"
-                    },
-                    "type": "array"
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["AND", "OR"],
+                                    "type": "string"
+                                },
+                                "values": {
+                                    "items": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["type", "values"],
+                            "type": "object"
+                        }
+                    ]
                 },
                 "source": {
                     "default": "events",
@@ -251,14 +275,38 @@
                                         "type": "boolean"
                                     },
                                     "properties": {
-                                        "items": {
-                                            "additionalProperties": {},
-                                            "propertyNames": {
-                                                "type": "string"
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "additionalProperties": {},
+                                                    "propertyNames": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
                                             },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "enum": ["AND", "OR"],
+                                                        "type": "string"
+                                                    },
+                                                    "values": {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": ["type", "values"],
+                                                "type": "object"
+                                            }
+                                        ]
                                     },
                                     "source": {
                                         "default": "events",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-create.json
@@ -59,14 +59,38 @@
                     "type": "boolean"
                 },
                 "properties": {
-                    "items": {
-                        "additionalProperties": {},
-                        "propertyNames": {
-                            "type": "string"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                    "type": "string"
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
                         },
-                        "type": "object"
-                    },
-                    "type": "array"
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["AND", "OR"],
+                                    "type": "string"
+                                },
+                                "values": {
+                                    "items": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["type", "values"],
+                            "type": "object"
+                        }
+                    ]
                 },
                 "source": {
                     "default": "events",
@@ -241,14 +265,38 @@
                                         "type": "boolean"
                                     },
                                     "properties": {
-                                        "items": {
-                                            "additionalProperties": {},
-                                            "propertyNames": {
-                                                "type": "string"
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "additionalProperties": {},
+                                                    "propertyNames": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
                                             },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "enum": ["AND", "OR"],
+                                                        "type": "string"
+                                                    },
+                                                    "values": {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": ["type", "values"],
+                                                "type": "object"
+                                            }
+                                        ]
                                     },
                                     "source": {
                                         "default": "events",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-partial-update.json
@@ -65,14 +65,38 @@
                     "type": "boolean"
                 },
                 "properties": {
-                    "items": {
-                        "additionalProperties": {},
-                        "propertyNames": {
-                            "type": "string"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                    "type": "string"
+                                },
+                                "type": "object"
+                            },
+                            "type": "array"
                         },
-                        "type": "object"
-                    },
-                    "type": "array"
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["AND", "OR"],
+                                    "type": "string"
+                                },
+                                "values": {
+                                    "items": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                            "type": "string"
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["type", "values"],
+                            "type": "object"
+                        }
+                    ]
                 },
                 "source": {
                     "default": "events",
@@ -251,14 +275,38 @@
                                         "type": "boolean"
                                     },
                                     "properties": {
-                                        "items": {
-                                            "additionalProperties": {},
-                                            "propertyNames": {
-                                                "type": "string"
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "additionalProperties": {},
+                                                    "propertyNames": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
                                             },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "enum": ["AND", "OR"],
+                                                        "type": "string"
+                                                    },
+                                                    "values": {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": ["type", "values"],
+                                                "type": "object"
+                                            }
+                                        ]
                                     },
                                     "source": {
                                         "default": "events",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create.json
@@ -64,14 +64,38 @@
                                                                 "type": "boolean"
                                                             },
                                                             "properties": {
-                                                                "items": {
-                                                                    "additionalProperties": {},
-                                                                    "propertyNames": {
-                                                                        "type": "string"
+                                                                "anyOf": [
+                                                                    {
+                                                                        "items": {
+                                                                            "additionalProperties": {},
+                                                                            "propertyNames": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
                                                                     },
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
+                                                                    {
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "enum": ["AND", "OR"],
+                                                                                "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                                "items": {
+                                                                                    "additionalProperties": {},
+                                                                                    "propertyNames": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "type": "array"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "values"],
+                                                                        "type": "object"
+                                                                    }
+                                                                ]
                                                             },
                                                             "source": {
                                                                 "default": "events",
@@ -147,14 +171,38 @@
                                                                     "type": "boolean"
                                                                 },
                                                                 "properties": {
-                                                                    "items": {
-                                                                        "additionalProperties": {},
-                                                                        "propertyNames": {
-                                                                            "type": "string"
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "items": {
+                                                                                "additionalProperties": {},
+                                                                                "propertyNames": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "object"
+                                                                            },
+                                                                            "type": "array"
                                                                         },
-                                                                        "type": "object"
-                                                                    },
-                                                                    "type": "array"
+                                                                        {
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "enum": ["AND", "OR"],
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "items": {
+                                                                                        "additionalProperties": {},
+                                                                                        "propertyNames": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": ["type", "values"],
+                                                                            "type": "object"
+                                                                        }
+                                                                    ]
                                                                 },
                                                                 "source": {
                                                                     "default": "events",
@@ -248,14 +296,38 @@
                                         "type": "boolean"
                                     },
                                     "properties": {
-                                        "items": {
-                                            "additionalProperties": {},
-                                            "propertyNames": {
-                                                "type": "string"
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "additionalProperties": {},
+                                                    "propertyNames": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
                                             },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "enum": ["AND", "OR"],
+                                                        "type": "string"
+                                                    },
+                                                    "values": {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": ["type", "values"],
+                                                "type": "object"
+                                            }
+                                        ]
                                     },
                                     "source": {
                                         "default": "events",
@@ -383,14 +455,38 @@
                                                 "type": "boolean"
                                             },
                                             "properties": {
-                                                "items": {
-                                                    "additionalProperties": {},
-                                                    "propertyNames": {
-                                                        "type": "string"
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
                                                     },
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
+                                                    {
+                                                        "properties": {
+                                                            "type": {
+                                                                "enum": ["AND", "OR"],
+                                                                "type": "string"
+                                                            },
+                                                            "values": {
+                                                                "items": {
+                                                                    "additionalProperties": {},
+                                                                    "propertyNames": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["type", "values"],
+                                                        "type": "object"
+                                                    }
+                                                ]
                                             },
                                             "source": {
                                                 "default": "events",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-update.json
@@ -53,14 +53,38 @@
                                                 "type": "boolean"
                                             },
                                             "properties": {
-                                                "items": {
-                                                    "additionalProperties": {},
-                                                    "propertyNames": {
-                                                        "type": "string"
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "additionalProperties": {},
+                                                            "propertyNames": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
                                                     },
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
+                                                    {
+                                                        "properties": {
+                                                            "type": {
+                                                                "enum": ["AND", "OR"],
+                                                                "type": "string"
+                                                            },
+                                                            "values": {
+                                                                "items": {
+                                                                    "additionalProperties": {},
+                                                                    "propertyNames": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["type", "values"],
+                                                        "type": "object"
+                                                    }
+                                                ]
                                             },
                                             "source": {
                                                 "default": "events",


### PR DESCRIPTION
## Problem

- A destination author who needs "match A **or** match B" cannot express it: global property filters combine only with AND, so they run two duplicate destinations, doubling maintenance and billed invocations.
- #79978 built this but the stale bot closed it before merge, and its ReviewHog review left two should-fix findings open. This PR revives it on current master and fixes both findings.

## Changes

- Destination filters show an **all / any** selector when there is more than one global property condition. Picking "any" combines them with OR. This reuses `AndOrFilterSelect`, the control feature flag release conditions use.
- Global properties store either the legacy flat list (always AND) or a single group `{"type": "AND" | "OR", "values": [...]}`. The UI writes the group shape only for OR, so existing destinations keep their shape and bytecode.
- Review fix: the filters serializer validates a group with the same pydantic model the compiler builds. A malformed leaf now returns a 400 field error instead of a 500 on the site destination/app path.
- Review fix: the survey notification test-send lookup keeps a group's operator instead of dropping grouped global filters, so the test invocation is not silently skipped.
- Consumer sweep: a shared `iter_global_property_leaves` helper lets workflow slack-channel normalization and the schedule-audience behavioral-cohort guard read leaves from either shape. Before, a group bypassed both. The cohort-guard bypass is the riskiest part of this diff; the generated-schema changes are mechanical (`hogli build:openapi`, no drift against master).

| Match all (existing behavior, flat list) | Match any (new, stored as an OR group) |
| --- | --- |
| ![filters-match-all](https://raw.githubusercontent.com/PostHog/pr-assets/14a3d490aea6946685825f966a874384c0018ac3/2026/08/d6b3b753-5a69-458d-96d1-931dff7c2d53.png) | ![filters-match-any](https://raw.githubusercontent.com/PostHog/pr-assets/a1aa2077a3242bc413d10abe7f565a49980ad642/2026/08/b0e91271-9e08-417f-ad8e-30a422ed1948.png) |

Rendered from a Storybook story of the destination scene with mocked data; the story itself is not committed.

## How did you test this code?

- `test_global_property_group_combines_with_or` (carried from #79978): compiles an OR group and an AND group and executes the bytecode. OR matches when one leaf matches, AND does not.
- New `TestHogFunctionGlobalPropertiesField` cases: a malformed group leaf fails as a field error, not an uncaught pydantic error; flat, group, and nested-group shapes pass unchanged.
- Extended hog flow tests: a behavioral cohort inside an OR group on a schedule audience is rejected (it bypassed the guard), and slack channel ids are normalized inside a group (they were skipped). Batch audiences already reject non-array properties upstream.
- New jest case: grouped global filters keep their OR operator in the survey notification last-response lookup (they were dropped).
- Run locally against Postgres and ClickHouse: `posthog/cdp/test/test_filters.py`, `posthog/cdp/test/test_validation.py`, `products/workflows/backend/api/test/test_hog_flow.py`, the affected jest suites, repo-wide mypy, `typescript:check`, and `hogli ci:preflight`.
- Both selector states were rendered headlessly from Storybook (screenshots above).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Revival of #79978 after the stale-bot close: its two commits were cherry-picked onto current master (two adjacency conflicts), then both ReviewHog findings were fixed here.
- The ReviewHog suggestion to sweep all `CyclotronJobFiltersType` consumers for array-only operations surfaced the two workflow helpers.
- Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Authored with Claude Code.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

