### PR TITLE
feat(warehouse-sources): scan synced tickets for zendesk ticket comments

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/datetime_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/datetime_utils.py
@@ -1,6 +1,8 @@
 from datetime import UTC, date, datetime
 from typing import Any
 
+from dateutil import parser as dateutil_parser
+
 
 def coerce_datetime_to_utc(value: Any) -> datetime | None:
     """Normalize a date/datetime-like value to a timezone-aware UTC datetime.
@@ -17,3 +19,18 @@ def coerce_datetime_to_utc(value: Any) -> datetime | None:
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value.astimezone(UTC)
+
+
+def parse_datetime_value(value: Any) -> datetime | None:
+    """Same as `coerce_datetime_to_utc`, but also parses a datetime written as a string.
+
+    An incremental watermark reaches a source as whatever the pipeline persisted, which is a
+    string for some sources and a datetime for others, so a caller that has to compare one
+    against a real datetime cannot assume either.
+    """
+    if isinstance(value, str):
+        try:
+            value = dateutil_parser.parse(value)
+        except (ValueError, TypeError, OverflowError):
+            return None
+    return coerce_datetime_to_utc(value)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
@@ -1,9 +1,11 @@
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Literal, Protocol
 
 import structlog
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.datetime_utils import parse_datetime_value
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
     RESTAPIConfig,
     rest_api_resources,
@@ -102,6 +104,7 @@ def build_dependent_resource(
     initial_paginator_state: dict[str, Any] | None = None,
     source_id: str | None = None,
     use_warehouse_parent: bool = False,
+    parent_snapshot_at: datetime | None = None,
 ) -> Iterable[Any]:
     parent_config = endpoint_configs[fanout.parent_name]
     child_config = endpoint_configs[child_endpoint]
@@ -251,4 +254,27 @@ def build_dependent_resource(
         initial_paginator_state=initial_paginator_state,
     )
     child_dlt_resource = next(r for r in resources if getattr(r, "name", None) == child_endpoint)
-    return child_dlt_resource.add_map(rename_parent_fields(fanout.parent_name, fanout.parent_field_renames))
+    child = child_dlt_resource.add_map(rename_parent_fields(fanout.parent_name, fanout.parent_field_renames))
+
+    # Capping belongs here rather than in the caller because only this function knows whether the
+    # run ended up on the warehouse parent: `warehouse_parent` is false when the table turned out
+    # to be unresolvable, and a caller reading its own config would still see "warehouse" and cap a
+    # live API response, dropping rows that path had no reason to hold back.
+    cursor_field = incremental_field or child_config.default_incremental_field
+    if warehouse_parent and parent_snapshot_at is not None and cursor_field:
+        child = child.add_filter(_not_newer_than(cursor_field, parent_snapshot_at))
+    return child
+
+
+def _not_newer_than(field: str, snapshot_at: datetime) -> Callable[[dict[str, Any]], bool]:
+    """Keep rows the parent snapshot could already account for.
+
+    A row without the field carries no recency signal and is kept, matching how the parent row
+    filter treats NULLs.
+    """
+
+    def _keep(row: dict[str, Any]) -> bool:
+        value = parse_datetime_value(row.get(field))
+        return value is None or value <= snapshot_at
+
+    return _keep

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
@@ -260,8 +260,15 @@ def build_dependent_resource(
     # run ended up on the warehouse parent: `warehouse_parent` is false when the table turned out
     # to be unresolvable, and a caller reading its own config would still see "warehouse" and cap a
     # live API response, dropping rows that path had no reason to hold back.
-    cursor_field = incremental_field or child_config.default_incremental_field
-    if warehouse_parent and parent_snapshot_at is not None and cursor_field:
+    if warehouse_parent and parent_snapshot_at is not None:
+        # `getattr` because a source that never merges can omit the field entirely, and the read
+        # has to stay off the path those sources take.
+        cursor_field = incremental_field or getattr(child_config, "default_incremental_field", None)
+        if not cursor_field:
+            raise ValueError(
+                f"'{child_endpoint}' asks for a parent snapshot cap but declares no incremental field to "
+                "cap on; capping nothing would let its watermark run past the snapshot"
+            )
         child = child.add_filter(_not_newer_than(cursor_field, parent_snapshot_at))
     return child
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -167,6 +167,56 @@ def test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing(tmp_pat
     assert pinned.version == v0
 
 
+class TestParentSnapshotCoversThrough(APIBaseTest):
+    def _schema_with_completed_job(self) -> tuple[Any, Any, Any, Any]:
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type="Sentry",
+            job_inputs={"auth_token": "token", "organization_slug": "acme"},
+        )
+        schema = ExternalDataSchema.objects.create(name="issues", team=self.team, source=source)
+        now = datetime.now(UTC)
+        started_at, finished_at = now - timedelta(hours=3), now - timedelta(hours=1)
+        job = ExternalDataJob.objects.create(
+            team=self.team,
+            pipeline=source,
+            schema=schema,
+            status="Completed",
+            workflow_id="wf-0",
+            finished_at=finished_at,
+        )
+        ExternalDataJob.objects.filter(id=job.id).update(created_at=started_at)
+        return source, schema, started_at, finished_at
+
+    def test_coverage_is_when_the_sync_started_not_when_it_finished(self) -> None:
+        source, _schema, started_at, finished_at = self._schema_with_completed_job()
+
+        covers_through = warehouse_parent.parent_snapshot_covers_through(self.team.pk, str(source.pk), "issues")
+
+        assert covers_through is not None
+        assert abs(covers_through - started_at) < timedelta(seconds=1)
+        assert covers_through < finished_at
+
+    def test_none_without_a_completed_sync(self) -> None:
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type="Sentry",
+            job_inputs={"auth_token": "token", "organization_slug": "acme"},
+        )
+        ExternalDataSchema.objects.create(name="issues", team=self.team, source=source)
+
+        assert warehouse_parent.parent_snapshot_covers_through(self.team.pk, str(source.pk), "issues") is None
+
+    def test_none_when_the_parent_schema_does_not_exist(self) -> None:
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type="Sentry",
+            job_inputs={"auth_token": "token", "organization_slug": "acme"},
+        )
+
+        assert warehouse_parent.parent_snapshot_covers_through(self.team.pk, str(source.pk), "issues") is None
+
+
 class TestSnapshotPinAsOf(APIBaseTest):
     def _schema_with_jobs(self, statuses: list[str], finished_at_hours_ago: float = 1.0) -> tuple[Any, dict[int, Any]]:
         """Jobs in the given order, oldest first, all finishing `finished_at_hours_ago` back."""

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
@@ -236,6 +236,44 @@ def try_resolve_parent_table(
         return None
 
 
+def parent_snapshot_covers_through(team_id: int, source_id: str, parent_name: str) -> dt.datetime | None:
+    """How far the parent's data is guaranteed complete, or None if it has never completed a sync.
+
+    A child that derives its next scan floor from its own rows has to cap what it emits at this
+    value, or the floor advances past parent changes the snapshot could not show it yet and they
+    are never scanned again.
+
+    This is when the parent's last completed sync *started*, not when it finished. A sync reads
+    each row at some point between those two, so a row read early carries the state it had then,
+    and a parent change landing later in the same sync may be missing from the snapshot entirely.
+    Only changes from before the sync started are guaranteed to be in it. `finished_at` is the
+    right stamp for picking a Delta version (see `_snapshot_pin_as_of`) and the wrong one for
+    coverage; they are different quantities.
+
+    Call this BEFORE resolving the table, never after. A sync completing between the two reads
+    then leaves the cap on the older job while the pinned snapshot holds the newer one, which errs
+    toward emitting too little. Reversing the order errs toward emitting rows the snapshot never
+    covered, which is the bug this exists to prevent.
+    """
+    try:
+        parent_schema = get_schema_if_exists(parent_name, team_id, uuid.UUID(source_id))
+    except (ValueError, AttributeError):
+        return None
+    if parent_schema is None:
+        return None
+    return (
+        ExternalDataJob.objects.filter(
+            team_id=team_id,
+            schema_id=parent_schema.id,
+            status=ExternalDataJob.Status.COMPLETED,
+            finished_at__isnull=False,
+        )
+        .order_by("-finished_at")
+        .values_list("created_at", flat=True)
+        .first()
+    )
+
+
 def _snapshot_pin_as_of(team_id: int, parent_schema_id: uuid.UUID) -> dt.datetime | None:
     """The timestamp to time-travel the parent table to, or None to read its latest version.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/settings.py
@@ -1,7 +1,7 @@
 """Zendesk source settings and constants"""
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
@@ -163,16 +163,33 @@ class ZendeskEndpointConfig:
     params: dict[str, Any] = field(default_factory=dict)
 
 
-# Parent that drives the `ticket_comments` fan-out. It is deliberately kept out of
-# `ZENDESK_ENDPOINTS` so it never becomes a schema of its own — tickets already sync through the
-# cursor incremental export.
-TICKET_COMMENTS_PARENT_NAME = "tickets_for_comments"
+# Parent that drives the `ticket_comments` fan-out. The name is the `tickets` schema's, because
+# that is how `_warehouse_parent_reuse_available` finds the parent to read from. The path is the
+# API-fallback walk, and stays on the plain list endpoint so a fallback run produces the row set it
+# has always produced.
+TICKET_COMMENTS_PARENT_NAME = "tickets"
 TICKET_COMMENTS_PARENT = ZendeskEndpointConfig(
     name=TICKET_COMMENTS_PARENT_NAME,
     path="/api/v2/tickets",
     data_selector="tickets",
     primary_key=["id"],
 )
+
+# A ticket's `updated_at` moves whenever a comment is added, redacted, or made private. Comments
+# carry no modification timestamp of their own, so this is the only field a scan can use to find
+# the tickets whose comments may have changed.
+TICKET_COMMENTS_PARENT_FILTER_FIELD = "updated_at"
+
+# Absorbs the offset between a comment's `created_at`, which is the child's watermark, and the
+# ticket `updated_at` the scan compares it against, so a comment written moments before the last
+# run finished is not stranded below the next run's floor.
+TICKET_COMMENTS_PARENT_LOOKBACK = timedelta(hours=1)
+
+# Zendesk archives a closed ticket around 120 days after it closes, and an archived ticket drops
+# out of `/api/v2/tickets` while staying in the incremental export the `tickets` schema syncs.
+# Scanning further back than that covers tickets the API path would never visit, which multiplies
+# the fan-out instead of shrinking it, so a run that far behind takes the API path.
+TICKET_COMMENTS_PARENT_MAX_CATCHUP = timedelta(days=120)
 
 # Parent endpoints referenced by `ZendeskEndpointConfig.fanout`, looked up by `fanout.parent_name`.
 FANOUT_PARENTS: dict[str, ZendeskEndpointConfig] = {TICKET_COMMENTS_PARENT_NAME: TICKET_COMMENTS_PARENT}
@@ -222,6 +239,10 @@ ZENDESK_ENDPOINTS: dict[str, ZendeskEndpointConfig] = {
             resolve_field="id",
             include_from_parent=["id"],
             parent_field_renames={"id": "ticket_id"},
+            # The row filter is per-run rather than static, so it is applied in `zendesk.py` where
+            # the watermark is known. Without one this scan would fan out over every ticket ever
+            # exported, so that code also drops the run to the API path when it cannot build one.
+            parent_source="warehouse",
         ),
     ),
     "group_memberships": ZendeskEndpointConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/source.py
@@ -14,6 +14,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.can
     CanonicalDescriptions,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    required_parents_from_endpoint_configs,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs, SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.zendesk import (
@@ -60,6 +63,9 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
             "403 Client Error: Forbidden for url": "Zendesk authentication failed. Please check your API token and subdomain.",
             "401 Client Error": "Zendesk authentication failed. Please check your API token and subdomain.",
         }
+
+    def get_required_parent_schemas(self, schema_name: str) -> list[str]:
+        return required_parents_from_endpoint_configs(ZENDESK_ENDPOINTS, schema_name)
 
     def get_schemas(
         self,
@@ -168,6 +174,8 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
             if inputs.should_use_incremental_field
             else None,
             incremental_field_name=inputs.incremental_field,
+            source_id=inputs.source_id,
+            use_warehouse_parent=inputs.fanout_warehouse_reuse,
         )
         # The original nine endpoints aren't in the declarative catalog; they keep the `id`
         # primary key and ascending sort they have always used.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -12,6 +12,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     JSONLinkPaginator,
     SinglePagePaginator,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ParentRowFilter
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.warehouse_parent import (
+    ParentTableRef,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.zendesk import (
     ZendeskSourceConfig,
@@ -21,6 +25,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.zendesk.se
     FANOUT_PARENTS,
     INCREMENTAL_ENDPOINTS,
     INCREMENTAL_FIELDS,
+    TICKET_COMMENTS_PARENT_LOOKBACK,
+    TICKET_COMMENTS_PARENT_MAX_CATCHUP,
     TICKET_COMMENTS_PARENT_NAME,
     ZENDESK_ENDPOINTS,
 )
@@ -537,13 +543,21 @@ class TestToZendeskIso8601:
         assert to_zendesk_iso8601(value) == expected
 
 
+_UNSET = object()
+
+
 class _FakeResource:
     def __init__(self, name: str) -> None:
         self.name = name
         self.maps: list[Any] = []
+        self.filters: list[Any] = []
 
     def add_map(self, fn: Any) -> "_FakeResource":
         self.maps.append(fn)
+        return self
+
+    def add_filter(self, fn: Any) -> "_FakeResource":
+        self.filters.append(fn)
         return self
 
 
@@ -605,6 +619,161 @@ class TestZendeskTicketCommentsFanout:
         row = child.maps[0]({f"_{TICKET_COMMENTS_PARENT_NAME}_id": 42, "id": 7, "body": "hi"})
 
         assert row == {"ticket_id": 42, "id": 7, "body": "hi"}
+
+
+class TestZendeskTicketCommentsWarehouseParent:
+    def _build(
+        self,
+        watermark: Any,
+        use_warehouse_parent: bool = True,
+        snapshot_at: Any = _UNSET,
+    ) -> tuple[Any, _FakeResource]:
+        child = _FakeResource("ticket_comments")
+        if snapshot_at is _UNSET:
+            snapshot_at = datetime.now(UTC)
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources",
+                return_value=[_FakeResource("tickets"), child],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.zendesk.zendesk.parent_snapshot_covers_through",
+                return_value=snapshot_at,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.warehouse_parent.resolve_parent_table_ref",
+                return_value=ParentTableRef(uri="s3://bucket/team_1/tickets", version=3),
+            ) as mock_resolve,
+        ):
+            zendesk_source(
+                subdomain="nibbles",
+                api_key="token",
+                email_address="user@example.com",
+                endpoint="ticket_comments",
+                team_id=1,
+                job_id="job-1",
+                db_incremental_field_last_value=watermark,
+                should_use_incremental_field=True,
+                source_id="source-1",
+                use_warehouse_parent=use_warehouse_parent,
+            )
+        return mock_resolve, child
+
+    def _resolve(self, watermark: Any, use_warehouse_parent: bool = True, snapshot_at: Any = _UNSET) -> Any:
+        return self._build(watermark, use_warehouse_parent, snapshot_at)[0]
+
+    def test_scans_tickets_bounded_by_the_child_watermark(self) -> None:
+        watermark = datetime.now(UTC) - timedelta(hours=6)
+
+        resolve = self._resolve(watermark)
+
+        assert resolve.call_args.args[2] == "tickets"
+        assert resolve.call_args.kwargs["required_columns"] == ["id"]
+        assert resolve.call_args.kwargs["row_filter"] == ParentRowFilter(
+            field="updated_at",
+            not_before=watermark - TICKET_COMMENTS_PARENT_LOOKBACK,
+        )
+
+    def test_clamps_a_watermark_that_sits_ahead_of_now(self) -> None:
+        resolve = self._resolve(datetime.now(UTC) + timedelta(days=1))
+
+        assert resolve.call_args.kwargs["row_filter"].not_before <= datetime.now(UTC) - TICKET_COMMENTS_PARENT_LOOKBACK
+
+    @pytest.mark.parametrize(
+        "watermark_factory",
+        [
+            pytest.param(lambda: None, id="no_watermark"),
+            pytest.param(lambda: "still syncing", id="unparseable_watermark"),
+            pytest.param(
+                lambda: datetime.now(UTC) - TICKET_COMMENTS_PARENT_MAX_CATCHUP - timedelta(days=1),
+                id="older_than_the_archive_window",
+            ),
+        ],
+    )
+    def test_takes_the_api_path_when_no_safe_floor_exists(self, watermark_factory: Any) -> None:
+        assert self._resolve(watermark_factory()).call_count == 0
+
+    def test_drops_comments_newer_than_the_parent_snapshot(self) -> None:
+        snapshot_at = datetime.now(UTC) - timedelta(hours=6)
+        _, child = self._build(datetime.now(UTC) - timedelta(hours=7), snapshot_at=snapshot_at)
+
+        keep = child.filters[0]
+
+        assert keep({"created_at": (snapshot_at - timedelta(minutes=1)).isoformat()}) is True
+        assert keep({"created_at": (snapshot_at + timedelta(minutes=1)).isoformat()}) is False
+        assert keep({"created_at": None}) is True
+
+    def test_emits_every_comment_on_the_api_path(self) -> None:
+        _, child = self._build(datetime.now(UTC) - timedelta(hours=6), use_warehouse_parent=False)
+
+        assert child.filters == []
+
+    def test_takes_the_api_path_without_a_completed_parent_sync(self) -> None:
+        assert self._resolve(datetime.now(UTC) - timedelta(hours=6), snapshot_at=None).call_count == 0
+
+    def test_no_cap_when_the_parent_table_cannot_be_resolved(self) -> None:
+        child = _FakeResource("ticket_comments")
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources",
+                return_value=[_FakeResource("tickets"), child],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.zendesk.zendesk.parent_snapshot_covers_through",
+                return_value=datetime.now(UTC) - timedelta(hours=6),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.warehouse_parent.try_resolve_parent_table",
+                return_value=None,
+            ),
+        ):
+            zendesk_source(
+                subdomain="nibbles",
+                api_key="token",
+                email_address="user@example.com",
+                endpoint="ticket_comments",
+                team_id=1,
+                job_id="job-1",
+                db_incremental_field_last_value=datetime.now(UTC) - timedelta(hours=7),
+                should_use_incremental_field=True,
+                source_id="source-1",
+                use_warehouse_parent=True,
+            )
+
+        assert child.filters == []
+
+    def test_takes_the_api_path_when_reuse_is_not_enabled_for_the_run(self) -> None:
+        watermark = datetime.now(UTC) - timedelta(hours=6)
+
+        assert self._resolve(watermark, use_warehouse_parent=False).call_count == 0
+
+
+class TestZendeskRequiredParentSchemas:
+    @pytest.mark.parametrize(
+        "schema_name,expected",
+        [
+            pytest.param("ticket_comments", ["tickets"], id="the_fanout_child"),
+            pytest.param("tickets", [], id="the_parent_itself"),
+            pytest.param("ticket_audits", [], id="a_plain_list_endpoint"),
+            pytest.param("users", [], id="an_original_export_endpoint"),
+        ],
+    )
+    def test_required_parent_schemas(self, schema_name: str, expected: list[str]) -> None:
+        assert ZendeskSource().get_required_parent_schemas(schema_name) == expected
+
+    def test_source_for_pipeline_forwards_the_source_and_the_reuse_decision(self) -> None:
+        config = ZendeskSourceConfig(subdomain="nibbles", api_key="token", email_address="user@example.com")
+        inputs = _source_inputs("ticket_comments")
+        inputs.fanout_warehouse_reuse = True
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.zendesk.source.zendesk_source",
+            return_value=SimpleNamespace(name="ticket_comments", column_hints=None),
+        ) as mock_source:
+            ZendeskSource().source_for_pipeline(config, inputs)
+
+        assert mock_source.call_args.kwargs["source_id"] == "source-1"
+        assert mock_source.call_args.kwargs["use_warehouse_parent"] is True
 
 
 class TestZendeskSchemas:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
@@ -1,5 +1,6 @@
 import re
 import base64
+import dataclasses
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Optional, cast
@@ -7,12 +8,14 @@ from typing import Any, Optional, cast
 from requests import Request, Response
 
 from products.warehouse_sources.backend.models.external_table_definitions import get_dlt_mapping_for_external_table
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.datetime_utils import parse_datetime_value
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
     RESTAPIConfig,
     rest_api_resource,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    DependentEndpointConfig,
     build_dependent_resource,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
@@ -26,9 +29,16 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     Endpoint,
     EndpointResource,
     IncrementalConfig,
+    ParentRowFilter,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.warehouse_parent import (
+    parent_snapshot_covers_through,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.zendesk.settings import (
     FANOUT_PARENTS,
+    TICKET_COMMENTS_PARENT_FILTER_FIELD,
+    TICKET_COMMENTS_PARENT_LOOKBACK,
+    TICKET_COMMENTS_PARENT_MAX_CATCHUP,
     ZENDESK_ENDPOINTS,
     ZendeskEndpointConfig,
 )
@@ -64,6 +74,36 @@ def zendesk_incremental_window(start_param: str, cursor_path: str) -> Incrementa
         "initial_value": ZENDESK_EPOCH_START,
         "convert": to_zendesk_iso8601,
     }
+
+
+def _bounded_fanout(fanout: DependentEndpointConfig, db_incremental_field_last_value: Any) -> DependentEndpointConfig:
+    """Bound a warehouse parent scan to the tickets whose comments may have changed.
+
+    The floor is the child's own watermark, so the scan covers exactly what the previous run did
+    not: a comment added, redacted, or made private since then moved its ticket's `updated_at`.
+
+    Two cases have no floor that is both safe and complete, and both take the parent-API path the
+    feature already falls back to. Without a watermark there is nothing to scan from. With a
+    watermark older than Zendesk's archive delay, a scan wide enough to cover the gap reaches
+    tickets `/api/v2/tickets` no longer lists, so it would fan out wider than the API path rather
+    than narrower.
+    """
+    if fanout.parent_source != "warehouse":
+        return fanout
+
+    now = datetime.now(UTC)
+    watermark = parse_datetime_value(db_incremental_field_last_value)
+    if watermark is None or watermark < now - TICKET_COMMENTS_PARENT_MAX_CATCHUP:
+        return dataclasses.replace(fanout, parent_source="api")
+
+    return dataclasses.replace(
+        fanout,
+        parent_row_filter=ParentRowFilter(
+            field=TICKET_COMMENTS_PARENT_FILTER_FIELD,
+            # A watermark ahead of now would floor the scan in the future and read nothing.
+            not_before=min(watermark, now) - TICKET_COMMENTS_PARENT_LOOKBACK,
+        ),
+    )
 
 
 def _fanout_incremental_config(config: ZendeskEndpointConfig) -> Callable[[str], IncrementalConfig | None]:
@@ -504,16 +544,33 @@ def zendesk_fanout_source(
     db_incremental_field_last_value: Optional[Any],
     should_use_incremental_field: bool = False,
     incremental_field_name: str | None = None,
+    source_id: str | None = None,
+    use_warehouse_parent: bool = False,
 ) -> Resource:
     """Fan out over a parent list endpoint, then page the child endpoint per parent row."""
     assert config.fanout is not None
-    parent = FANOUT_PARENTS[config.fanout.parent_name]
+    fanout = _bounded_fanout(config.fanout, db_incremental_field_last_value)
+
+    # How far the tickets snapshot is guaranteed complete. The comments fanned out below are
+    # fetched live, so emitting one past this point would carry this schema's watermark over
+    # ticket changes the snapshot could not show it, and the next run's floor would skip them for
+    # good. Capping defers those comments by one run instead, so nothing is lost. Read before
+    # `build_dependent_resource` pins the table, never after — see the helper's docstring. Without
+    # a completed parent sync there is no cap, so the run takes the API path, whose listing is
+    # live and needs none.
+    snapshot_at: datetime | None = None
+    if fanout.parent_source == "warehouse" and use_warehouse_parent:
+        snapshot_at = parent_snapshot_covers_through(team_id, source_id or "", fanout.parent_name)
+        if snapshot_at is None:
+            fanout = dataclasses.replace(fanout, parent_source="api")
+
+    parent = FANOUT_PARENTS[fanout.parent_name]
     return cast(
         Resource,
         build_dependent_resource(
             endpoint_configs={config.name: config, parent.name: parent},
             child_endpoint=config.name,
-            fanout=config.fanout,
+            fanout=fanout,
             client_config=client_config,
             path_format_values={},
             team_id=team_id,
@@ -531,6 +588,9 @@ def zendesk_fanout_source(
                 "paginator": paginator_for(config),
                 "data_selector": config.data_selector,
             },
+            source_id=source_id,
+            use_warehouse_parent=use_warehouse_parent,
+            parent_snapshot_at=snapshot_at,
         ),
     )
 
@@ -545,6 +605,8 @@ def zendesk_source(
     db_incremental_field_last_value: Optional[Any],
     should_use_incremental_field: bool = False,
     incremental_field_name: str | None = None,
+    source_id: str | None = None,
+    use_warehouse_parent: bool = False,
 ):
     client_config = zendesk_client_config(subdomain, api_key, email_address)
 
@@ -558,6 +620,8 @@ def zendesk_source(
             db_incremental_field_last_value,
             should_use_incremental_field,
             incremental_field_name,
+            source_id=source_id,
+            use_warehouse_parent=use_warehouse_parent,
         )
 
     config: RESTAPIConfig = {


### PR DESCRIPTION
## Problem

Syncing Zendesk `ticket_comments` costs about an hour per run on a large account, every run, and almost all of it is wasted.

- The sync lists every ticket in the account, then calls the comments endpoint once per ticket, whether or not anything changed.
- The listing is roughly 1% of that. The per-ticket calls are the cost, so the fix is to visit fewer tickets, not to fetch the list more cheaply.
- Nothing on a comment records when it last changed, so the sync cannot tell which tickets are worth revisiting.

Builds on #87284, which made the table merge rather than replace. Under `replace`, visiting fewer tickets would delete the comments left behind.

> [!NOTE]
> Inert on merge. Both `ticket_comments` schemas in the fleet are full refresh, which takes the API path regardless of the flag, and neither team is in the flag's team list. The Sentry half of this work was split into #88057, which does change a live path.

## Changes

- `ticket_comments` reads the `tickets` schema's synced table instead of re-listing tickets, scanning only tickets updated since its own watermark. A comment added, redacted, or made private moves its ticket's `updated_at`, so that window holds every ticket whose comments can have changed.
- A run caps what it emits at the point the parent snapshot is guaranteed complete, which is when the parent's last completed sync started. Without that, a comment fetched live carries the watermark past ticket changes the snapshot has not shown yet, and the next floor skips them for good. Rows past the cap are deferred by one run instead.
- The cap lives in `build_dependent_resource` rather than the caller, because that is the only place that knows whether the run reached the warehouse: the builder falls back internally, and a caller reading its own config would still see `warehouse` and cap a live API response.
- Four cases keep the parent-API path, so no account gets a narrower row set than today: no watermark; a watermark older than Zendesk's archive delay; no completed parent sync to cap against; and a parent that will not resolve.
- Mechanical: `source_id` and the per-run reuse decision are threaded from `SourceInputs` to the fan-out builder, `parent_snapshot_covers_through` is new in `warehouse_parent.py`, and `parse_datetime_value` moves the string-or-datetime watermark parse into `common/datetime_utils.py`.

Zendesk's archive bound: `/api/v2/tickets` excludes archived tickets, while the `tickets` table syncs as merge and never deletes, so it keeps tickets that were synced before they were archived. A scan reaching back past that delay would visit tickets the API path never does, widening the fan-out instead of narrowing it.

> [!NOTE]
> Not ready to enable. Zendesk's docs confirm that redaction updates the ticket, which is the load-bearing claim, but nothing here has been exercised against a real account.

## How did you test this code?

- `TestZendeskTicketCommentsWarehouseParent` asserts what reaches `resolve_parent_table_ref`, which is where an unbounded scan would show up: a fresh watermark produces the `updated_at` floor; a watermark ahead of now is clamped so the floor cannot land in the future and read nothing; and no watermark, an unparseable one, one past the archive window, an unresolvable table, and flag-off each take the API path uncapped.
- `test_drops_comments_newer_than_the_parent_snapshot` covers the cap; `test_no_cap_when_the_parent_table_cannot_be_resolved` covers the fallback.
- `TestParentSnapshotCoversThrough` pins that coverage is the sync's start and is strictly before its finish, which is the difference between deferring a row and losing it.
- `TestZendeskRequiredParentSchemas` is the blast radius a reviewer reads: `ticket_comments` declares `tickets`, everything else declares nothing. Its second case catches the failure mode where the config says warehouse, the run silently takes the API path, and the activity logs `parent_source="warehouse"` anyway.
- Every new case was confirmed to fail with the behavior it covers removed.
- Ran locally: Zendesk, Sentry, and shared fan-out suites, plus `uv run mypy --cache-fine-grained .` repo-wide.
- Not run: anything against a real Zendesk account, and the object-storage-backed webhook tests, which need a local object store this machine is not running.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Opus 5 in Claude Code. Skills invoked: `/converting-fanout-parents-to-warehouse`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Five P1 review findings landed on the combined branch, all one family: the cap leaking on its timestamp, on the read ordering against a completing parent sync, and on the API fallback. All are fixed here, and the Sentry half was split into #88057 so the production change gets reviewed on its own.
- The row filter is built per run rather than declared on the config, because the floor is the watermark. That is why `zendesk.py` rewrites the frozen fan-out config instead of `settings.py` carrying a `ParentRowFilter`.
- A comment on `TICKET_COMMENTS_PARENT_MAX_CATCHUP` still describes the archive mechanism as the export retaining archived tickets. The accumulation above is the accurate version; correcting the comment is a follow-up, deliberately not in this diff.
- The API-fallback parent deliberately stays on `/api/v2/tickets`. Bounding it too, by moving it to the incremental export, would cut the fallback path's cost as well, but it is a separate change to a separate endpoint.
