### PR TITLE
feat(flags): show approval state on scheduled flag changes

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2401,10 +2401,7 @@ const api = {
         ): Promise<CountedPaginatedResponse<ScheduledChangeType>> {
             return await new ApiRequest().featureFlagScheduledChanges(teamId, featureFlagId).get()
         },
-        async createScheduledChange(
-            teamId: TeamType['id'],
-            data: any
-        ): Promise<{ scheduled_change: ScheduledChangeType }> {
+        async createScheduledChange(teamId: TeamType['id'], data: any): Promise<ScheduledChangeType> {
             return await new ApiRequest().featureFlagCreateScheduledChange(teamId).create({ data })
         },
         async deleteScheduledChange(

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.test.tsx
@@ -11,6 +11,7 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import {
     FeatureFlagType,
+    RecurrenceInterval,
     ScheduledChangeModels,
     ScheduledChangeOperationType,
     ScheduledChangeRequestState,
@@ -225,6 +226,29 @@ describe('FeatureFlagSchedule', () => {
             expect(await screen.findByText(expectedTag)).toBeInTheDocument()
             expect(screen.queryByText('Active & upcoming')).not.toBeInTheDocument()
         })
+
+        it.each([
+            { state: ScheduledChangeRequestState.Rejected, expectedTag: 'Rejected' },
+            { state: ScheduledChangeRequestState.Expired, expectedTag: 'Approval expired' },
+        ])(
+            'keeps a recurring schedule with a $state approval active but tags it $expectedTag',
+            async ({ state, expectedTag }) => {
+                useMocks({
+                    get: schedulesMock([
+                        makeScheduledChange({
+                            is_recurring: true,
+                            recurrence_interval: RecurrenceInterval.Daily,
+                            change_request: { id: 'cr-recurring', state },
+                        }),
+                    ]),
+                })
+                renderWithSchedules()
+
+                expect(await screen.findByText(expectedTag)).toBeInTheDocument()
+                expect(screen.getByText('Active & upcoming')).toBeInTheDocument()
+                expect(screen.queryByText(/^History \(/)).not.toBeInTheDocument()
+            }
+        )
 
         it('shows the failure reason as visible text on an errored schedule', async () => {
             const failureReason = 'Feature flag not found (will retry automatically, 2 attempts remaining)'

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.test.tsx
@@ -247,6 +247,8 @@ describe('FeatureFlagSchedule', () => {
                 expect(await screen.findByText(expectedTag)).toBeInTheDocument()
                 expect(screen.getByText('Active & upcoming')).toBeInTheDocument()
                 expect(screen.queryByText(/^History \(/)).not.toBeInTheDocument()
+                // The link is the way to unblock a stalled recurring schedule.
+                expect(screen.getByText('View approval request')).toBeInTheDocument()
             }
         )
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.test.tsx
@@ -1,13 +1,21 @@
+import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_PROJECT } from 'lib/api.mock'
+
 import '@testing-library/jest-dom'
 
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { BindLogic, Provider } from 'kea'
 
 import { dayjs } from 'lib/dayjs'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { FeatureFlagType, ScheduledChangeOperationType } from '~/types'
+import {
+    FeatureFlagType,
+    ScheduledChangeModels,
+    ScheduledChangeOperationType,
+    ScheduledChangeRequestState,
+    ScheduledChangeType,
+} from '~/types'
 
 import { NEW_FLAG, featureFlagLogic } from './featureFlagLogic'
 import FeatureFlagSchedule from './FeatureFlagSchedule'
@@ -148,6 +156,84 @@ describe('FeatureFlagSchedule', () => {
         renderSchedule(featureFlag, ScheduledChangeOperationType.UpdateVariants)
 
         expect(screen.getByText(new RegExp(expectedText))).toBeInTheDocument()
+    })
+
+    describe('approval visibility', () => {
+        const makeScheduledChange = (overrides: Partial<ScheduledChangeType>): ScheduledChangeType => ({
+            id: 1,
+            team_id: MOCK_DEFAULT_PROJECT.id,
+            record_id: 1,
+            model_name: ScheduledChangeModels.FeatureFlag,
+            payload: { operation: ScheduledChangeOperationType.UpdateStatus, value: true },
+            scheduled_at: '2030-01-01T00:00:00Z',
+            executed_at: null,
+            failure_reason: null,
+            created_at: '2026-01-01T00:00:00Z',
+            created_by: MOCK_DEFAULT_BASIC_USER,
+            is_recurring: false,
+            recurrence_interval: null,
+            cron_expression: null,
+            last_executed_at: null,
+            end_date: null,
+            change_request: null,
+            ...overrides,
+        })
+
+        // useMocks trips the hooks naming lint inside named helpers, so each test registers
+        // its own mock before calling this.
+        const renderWithSchedules = (): void => {
+            renderSchedule(
+                buildFeatureFlag({ active: false, rolloutPercentage: 100 }),
+                ScheduledChangeOperationType.UpdateStatus
+            )
+            act(() => {
+                featureFlagLogic(logicProps).actions.loadScheduledChanges()
+            })
+        }
+
+        const schedulesMock = (
+            schedules: ScheduledChangeType[]
+        ): Record<string, () => [number, { results: ScheduledChangeType[] }]> => ({
+            [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/scheduled_changes`]: () => [200, { results: schedules }],
+        })
+
+        it('shows the Needs approval tag and an approval link for a pending gated schedule', async () => {
+            useMocks({
+                get: schedulesMock([
+                    makeScheduledChange({
+                        change_request: { id: 'cr-pending', state: ScheduledChangeRequestState.Pending },
+                    }),
+                ]),
+            })
+            renderWithSchedules()
+
+            expect(await screen.findByText('Needs approval')).toBeInTheDocument()
+            const link = screen.getByText('View approval request').closest('a')
+            // The router prefixes links with the current project path, so match the suffix only.
+            expect(link?.getAttribute('href')).toMatch(/\/approvals\/cr-pending$/)
+        })
+
+        it.each([
+            { state: ScheduledChangeRequestState.Rejected, expectedTag: 'Rejected' },
+            { state: ScheduledChangeRequestState.Expired, expectedTag: 'Approval expired' },
+        ])('lists a $state one-time schedule in history with a $expectedTag tag', async ({ state, expectedTag }) => {
+            useMocks({ get: schedulesMock([makeScheduledChange({ change_request: { id: 'cr-denied', state } })]) })
+            renderWithSchedules()
+
+            fireEvent.click(await screen.findByText('History (1)'))
+
+            expect(await screen.findByText(expectedTag)).toBeInTheDocument()
+            expect(screen.queryByText('Active & upcoming')).not.toBeInTheDocument()
+        })
+
+        it('shows the failure reason as visible text on an errored schedule', async () => {
+            const failureReason = 'Feature flag not found (will retry automatically, 2 attempts remaining)'
+            useMocks({ get: schedulesMock([makeScheduledChange({ failure_reason: failureReason })]) })
+            renderWithSchedules()
+
+            expect(await screen.findByText('Error')).toBeInTheDocument()
+            expect(screen.getByText(failureReason)).toBeVisible()
+        })
     })
 
     it.each([

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -204,7 +204,7 @@ function ScheduleStatusTag({ scheduledChange }: { scheduledChange: ScheduledChan
                 text: 'Needs approval',
                 tooltip: 'This change will be skipped if it is not approved before the scheduled time.',
             }
-        } else if (denied) {
+        } else if (denied && is_recurring) {
             // A denied request on a recurring schedule is not terminal: the sweep skips the next
             // occurrence and requests a fresh approval for the one after, so the row stays active
             // but the tag must not read as a plain "Recurring" that will run.

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -171,20 +171,19 @@ function ScheduleStatusTag({ scheduledChange }: { scheduledChange: ScheduledChan
     const tz = currentTeam?.timezone || 'UTC'
 
     function getStatus(): { type: LemonTagType; text: string; tooltip?: string } {
+        const rejected = change_request?.state === ScheduledChangeRequestState.Rejected
+        const denied = rejected || change_request?.state === ScheduledChangeRequestState.Expired
+        const deniedText = rejected ? 'Rejected' : 'Approval expired'
+        const deniedCause = rejected ? 'The approval request was rejected' : 'The approval request expired'
+
         if (failure_reason) {
             return { type: 'danger', text: 'Error' }
         } else if (isScheduleDeniedApproval(scheduledChange)) {
-            return change_request?.state === ScheduledChangeRequestState.Rejected
-                ? {
-                      type: 'danger',
-                      text: 'Rejected',
-                      tooltip: 'The approval request was rejected, so this change will not be applied.',
-                  }
-                : {
-                      type: 'danger',
-                      text: 'Approval expired',
-                      tooltip: 'The approval request expired, so this change will not be applied.',
-                  }
+            return {
+                type: 'danger',
+                text: deniedText,
+                tooltip: `${deniedCause}, so this change will not be applied.`,
+            }
         } else if (executed_at) {
             const executedAt = dayjs(executed_at)
             const tzShort = shortTimeZone(tz, executedAt.toDate()) ?? tz
@@ -204,6 +203,15 @@ function ScheduleStatusTag({ scheduledChange }: { scheduledChange: ScheduledChan
                 type: 'warning',
                 text: 'Needs approval',
                 tooltip: 'This change will be skipped if it is not approved before the scheduled time.',
+            }
+        } else if (denied) {
+            // A denied request on a recurring schedule is not terminal: the sweep skips the next
+            // occurrence and requests a fresh approval for the one after, so the row stays active
+            // but the tag must not read as a plain "Recurring" that will run.
+            return {
+                type: 'danger',
+                text: deniedText,
+                tooltip: `${deniedCause}, so the next occurrence will be skipped. A new approval request will be created for the following occurrence.`,
             }
         } else if (is_recurring) {
             return { type: 'highlight', text: 'Recurring' }

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -40,12 +40,14 @@ import {
     MultivariateFlagVariant,
     RecurrenceInterval,
     ScheduledChangeOperationType,
+    ScheduledChangeRequestState,
     ScheduledChangeType,
 } from '~/types'
 
 import {
     featureFlagLogic,
     hasZeroRollout,
+    isScheduleDeniedApproval,
     PAIRED_PRESETS,
     validateFeatureFlagVariantKey,
     validateVariantRolloutSum,
@@ -164,13 +166,25 @@ const RECURRING_SUPPORTED_OPERATIONS = new Set([
 // --- Schedule card for the list view ---
 
 function ScheduleStatusTag({ scheduledChange }: { scheduledChange: ScheduledChangeType }): JSX.Element {
-    const { executed_at, failure_reason, is_recurring } = scheduledChange
+    const { executed_at, failure_reason, is_recurring, change_request } = scheduledChange
     const { currentTeam } = useValues(teamLogic)
     const tz = currentTeam?.timezone || 'UTC'
 
     function getStatus(): { type: LemonTagType; text: string; tooltip?: string } {
         if (failure_reason) {
-            return { type: 'danger', text: 'Error', tooltip: `Failed: ${failure_reason}` }
+            return { type: 'danger', text: 'Error' }
+        } else if (isScheduleDeniedApproval(scheduledChange)) {
+            return change_request?.state === ScheduledChangeRequestState.Rejected
+                ? {
+                      type: 'danger',
+                      text: 'Rejected',
+                      tooltip: 'The approval request was rejected, so this change will not be applied.',
+                  }
+                : {
+                      type: 'danger',
+                      text: 'Approval expired',
+                      tooltip: 'The approval request expired, so this change will not be applied.',
+                  }
         } else if (executed_at) {
             const executedAt = dayjs(executed_at)
             const tzShort = shortTimeZone(tz, executedAt.toDate()) ?? tz
@@ -184,6 +198,12 @@ function ScheduleStatusTag({ scheduledChange }: { scheduledChange: ScheduledChan
                 type: 'warning',
                 text: 'Paused',
                 tooltip: 'Recurring schedule is paused. It will not execute until resumed.',
+            }
+        } else if (change_request?.state === ScheduledChangeRequestState.Pending) {
+            return {
+                type: 'warning',
+                text: 'Needs approval',
+                tooltip: 'This change will be skipped if it is not approved before the scheduled time.',
             }
         } else if (is_recurring) {
             return { type: 'highlight', text: 'Recurring' }
@@ -342,6 +362,19 @@ function ScheduleCard({
                 <div className="text-xs text-muted">
                     <ScheduleTiming scheduledChange={scheduledChange} />
                 </div>
+                {scheduledChange.failure_reason && (
+                    <div className="text-xs text-danger">{scheduledChange.failure_reason}</div>
+                )}
+                {scheduledChange.change_request && (
+                    <div className="text-xs">
+                        <Link
+                            to={urls.approval(scheduledChange.change_request.id)}
+                            data-attr="scheduled-change-view-approval-request"
+                        >
+                            View approval request
+                        </Link>
+                    </div>
+                )}
                 <div className="flex items-center gap-1.5 text-xs text-muted">
                     {scheduledChange.created_by && (
                         <>

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1986,6 +1986,13 @@ describe('featureFlagLogic', () => {
                                     recurrence_interval: RecurrenceInterval.Daily,
                                     change_request: { id: 'cr-4', state: ScheduledChangeRequestState.Expired },
                                 }),
+                                // An executed row pins how denied rows interleave with real history:
+                                // executed first, never-executed denied rows after.
+                                makeScheduledChange({
+                                    id: 5,
+                                    scheduled_at: '2025-12-01T00:00:00Z',
+                                    executed_at: '2025-12-01T00:00:00Z',
+                                }),
                             ],
                         },
                     ],
@@ -1997,8 +2004,32 @@ describe('featureFlagLogic', () => {
 
             await expectLogic(logic).toMatchValues({
                 activeSchedules: [partial({ id: 3 }), partial({ id: 4 })],
-                completedSchedules: [partial({ id: 2 }), partial({ id: 1 })],
+                completedSchedules: [partial({ id: 5 }), partial({ id: 2 }), partial({ id: 1 })],
             })
+        })
+
+        it.each([
+            {
+                name: 'gated create toasts pending approval',
+                change_request: { id: 'cr-toast', state: ScheduledChangeRequestState.Pending },
+                expectedMessage:
+                    'Change scheduled - pending approval. It will be skipped if not approved before the scheduled time.',
+            },
+            {
+                name: 'ungated create toasts plain success',
+                change_request: null,
+                expectedMessage: 'Change scheduled successfully',
+            },
+        ])('$name', async ({ change_request, expectedMessage }) => {
+            useMocks({ get: { [schedulesUrl]: () => [200, { results: [] }] } })
+            // The success listener reports to eventUsageLogic, but featureFlagLogic does not mount it via connect().
+            eventUsageLogic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.createScheduledChangeSuccess(makeScheduledChange({ change_request }))
+            }).toFinishAllListeners()
+
+            expect(lemonToast.success).toHaveBeenCalledWith(expectedMessage)
         })
 
         it('orders completed changes most-recent first', async () => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -29,8 +29,10 @@ import {
     OrganizationFeatureFlag,
     PropertyFilterType,
     PropertyOperator,
+    RecurrenceInterval,
     ScheduledChangeModels,
     ScheduledChangeOperationType,
+    ScheduledChangeRequestState,
     ScheduledChangeType,
 } from '~/types'
 import { FeatureFlagFilters } from '~/types'
@@ -1908,6 +1910,7 @@ describe('featureFlagLogic', () => {
             cron_expression: null,
             last_executed_at: null,
             end_date: null,
+            change_request: null,
             ...overrides,
         })
 
@@ -1954,6 +1957,47 @@ describe('featureFlagLogic', () => {
 
             await expectLogic(logic).toMatchValues({
                 activeSchedules: expectedIds.map((id) => partial({ id })),
+            })
+        })
+
+        it('moves one-time schedules with a rejected or expired approval to history, keeps others active', async () => {
+            useMocks({
+                get: {
+                    [schedulesUrl]: () => [
+                        200,
+                        {
+                            results: [
+                                makeScheduledChange({
+                                    id: 1,
+                                    change_request: { id: 'cr-1', state: ScheduledChangeRequestState.Rejected },
+                                }),
+                                makeScheduledChange({
+                                    id: 2,
+                                    change_request: { id: 'cr-2', state: ScheduledChangeRequestState.Expired },
+                                }),
+                                makeScheduledChange({
+                                    id: 3,
+                                    change_request: { id: 'cr-3', state: ScheduledChangeRequestState.Pending },
+                                }),
+                                // A recurring schedule re-gates each occurrence, so a denied request is not terminal.
+                                makeScheduledChange({
+                                    id: 4,
+                                    is_recurring: true,
+                                    recurrence_interval: RecurrenceInterval.Daily,
+                                    change_request: { id: 'cr-4', state: ScheduledChangeRequestState.Expired },
+                                }),
+                            ],
+                        },
+                    ],
+                },
+            })
+            await expectLogic(logic, () => {
+                logic.actions.loadScheduledChanges()
+            }).toDispatchActions(['loadScheduledChangesSuccess'])
+
+            await expectLogic(logic).toMatchValues({
+                activeSchedules: [partial({ id: 3 }), partial({ id: 4 })],
+                completedSchedules: [partial({ id: 2 }), partial({ id: 1 })],
             })
         })
 

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -3416,8 +3416,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             }
 
             // Create the enable schedule first
+            let enableSchedule: ScheduledChangeType
             try {
-                await api.featureFlags.createScheduledChange(currentProjectId, {
+                enableSchedule = await api.featureFlags.createScheduledChange(currentProjectId, {
                     ...basePayload,
                     payload: { operation: ScheduledChangeOperationType.UpdateStatus, value: true },
                     cron_expression: enableCron,
@@ -3429,8 +3430,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             }
 
             // Create the disable schedule
+            let disableSchedule: ScheduledChangeType
             try {
-                await api.featureFlags.createScheduledChange(currentProjectId, {
+                disableSchedule = await api.featureFlags.createScheduledChange(currentProjectId, {
                     ...basePayload,
                     payload: { operation: ScheduledChangeOperationType.UpdateStatus, value: false },
                     cron_expression: disableCron,
@@ -3446,7 +3448,16 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             }
 
             // Both succeeded
-            lemonToast.success('Paired schedules created')
+            const pairIsPendingApproval = [enableSchedule, disableSchedule].some(
+                (schedule) => schedule?.change_request?.state === ScheduledChangeRequestState.Pending
+            )
+            if (pairIsPendingApproval) {
+                lemonToast.success(
+                    'Paired schedules created - pending approval. Schedules that are not approved before their scheduled time will be skipped.'
+                )
+            } else {
+                lemonToast.success('Paired schedules created')
+            }
             resetScheduleForm()
             eventUsageLogic.actions.reportFeatureFlagScheduleSuccess()
         },

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -81,6 +81,7 @@ import {
     RecordingUniversalFilters,
     RecurrenceInterval,
     ScheduledChangeOperationType,
+    ScheduledChangeRequestState,
     ScheduledChangeType,
     Survey,
     SurveyQuestionType,
@@ -302,6 +303,19 @@ export function byExecutedAt(a: ScheduledChangeType, b: ScheduledChangeType): nu
         return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms
     }
     return epoch(b) - epoch(a) || b.id - a.id
+}
+
+// A one-time schedule whose approval request was rejected or expired will never apply: the
+// applier skips it at fire time. It reads as terminal in the UI and sorts with history.
+// Recurring schedules are excluded because each occurrence is re-gated with a fresh request.
+export function isScheduleDeniedApproval(sc: ScheduledChangeType): boolean {
+    return (
+        !sc.is_recurring &&
+        !sc.recurrence_interval &&
+        !sc.cron_expression &&
+        (sc.change_request?.state === ScheduledChangeRequestState.Rejected ||
+            sc.change_request?.state === ScheduledChangeRequestState.Expired)
+    )
 }
 
 export const PAIRED_PRESETS: Record<Exclude<PairedPresetKey, 'custom_pair'>, PairedPresetDefinition> = {
@@ -994,18 +1008,10 @@ export interface featureFlagLogicActions {
         errorObject?: any
     }
     createScheduledChangeSuccess: (
-        scheduledChange:
-            | {
-                  scheduled_change: ScheduledChangeType
-              }
-            | undefined,
+        scheduledChange: ScheduledChangeType | undefined,
         payload?: any
     ) => {
-        scheduledChange:
-            | {
-                  scheduled_change: ScheduledChangeType
-              }
-            | undefined
+        scheduledChange: ScheduledChangeType | undefined
         payload?: any
     }
     createStaticCohort: () => any
@@ -3878,7 +3884,13 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
         },
         createScheduledChangeSuccess: ({ scheduledChange }) => {
             if (scheduledChange) {
-                lemonToast.success('Change scheduled successfully')
+                if (scheduledChange.change_request?.state === ScheduledChangeRequestState.Pending) {
+                    lemonToast.success(
+                        'Change scheduled - pending approval. It will be skipped if not approved before the scheduled time.'
+                    )
+                } else {
+                    lemonToast.success('Change scheduled successfully')
+                }
                 actions.setScheduleDateMarker(null)
                 actions.setSchedulePayload(NEW_FLAG.filters, NEW_FLAG.active, {}, null, null)
                 actions.setIsRecurring(false)
@@ -4437,13 +4449,18 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             (s) => [s.scheduledChanges],
             (scheduledChanges: ScheduledChangeType[]) =>
                 scheduledChanges.filter(
-                    (sc) => !sc.is_recurring && !sc.recurrence_interval && !sc.cron_expression && !sc.executed_at
+                    (sc) =>
+                        !sc.is_recurring &&
+                        !sc.recurrence_interval &&
+                        !sc.cron_expression &&
+                        !sc.executed_at &&
+                        !isScheduleDeniedApproval(sc)
                 ),
         ],
         completedSchedules: [
             (s) => [s.scheduledChanges],
             (scheduledChanges: ScheduledChangeType[]) =>
-                scheduledChanges.filter((sc) => !!sc.executed_at).sort(byExecutedAt),
+                scheduledChanges.filter((sc) => !!sc.executed_at || isScheduleDeniedApproval(sc)).sort(byExecutedAt),
         ],
         activeSchedules: [
             (s) => [s.activeRecurringSchedules, s.pausedRecurringSchedules, s.upcomingOneTimeSchedules],

--- a/frontend/src/scenes/feature-flags/featureFlagScheduleEditLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagScheduleEditLogic.test.ts
@@ -24,6 +24,7 @@ describe('featureFlagScheduleEditLogic', () => {
         recurrence_interval: null,
         cron_expression: '30 14 * * *',
         last_executed_at: null,
+        change_request: null,
     }
 
     afterEach(() => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4615,6 +4615,22 @@ export type ScheduledChangePayload =
           }
       }
 
+// Keep in sync with products/approvals/backend/models.py ChangeRequestState
+export enum ScheduledChangeRequestState {
+    Pending = 'pending',
+    Approved = 'approved',
+    Applied = 'applied',
+    Rejected = 'rejected',
+    Expired = 'expired',
+    Failed = 'failed',
+}
+
+/** Summary of the approval change request gating a scheduled change. */
+export interface ScheduledChangeRequestSummary {
+    id: string
+    state: ScheduledChangeRequestState
+}
+
 export interface ScheduledChangeType {
     id: number
     team_id: number
@@ -4631,6 +4647,8 @@ export interface ScheduledChangeType {
     cron_expression: string | null
     last_executed_at: string | null
     end_date: string | null
+    /** Null when the change is not gated on approval. */
+    change_request: ScheduledChangeRequestSummary | null
 }
 
 export interface PrevalidatedInvite {

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -627,6 +627,8 @@ SPECTACULAR_SETTINGS = {
         "IngestionWarningSeverityEnum": "posthog.api.ingestion_warnings_v2.INGESTION_WARNING_SEVERITIES",
         "BillingAlertMetricEnum": "products.billing_alerts.backend.models.BillingAlertConfiguration.Metric",
         "BillingAlertStateEnum": "products.billing_alerts.backend.models.BillingAlertConfiguration.State",
+        # Shared by ChangeRequest.state and ChangeRequestSummary.state (same choice set).
+        "ChangeRequestStateEnum": "products.approvals.backend.models.ChangeRequestState",
         # Disambiguates from the same-valued inline enum on the signals LogsAlertStateChangeSignalExtra contract.
         "LogsAlertThresholdOperatorEnum": "products.logs.backend.models.LogsAlertConfiguration.ThresholdOperator",
         # Shared by _LogsGroupByBody.groupBySource and _LogsGroupByDimension.source (labels == values).

--- a/products/approvals/backend/serializers.py
+++ b/products/approvals/backend/serializers.py
@@ -4,7 +4,31 @@ from rest_framework import serializers
 from posthog.api.shared import UserBasicSerializer
 
 from products.access_control.backend.models.role import Role
-from products.approvals.backend.models import Approval, ApprovalPolicy, ChangeRequest
+from products.approvals.backend.models import Approval, ApprovalPolicy, ChangeRequest, ChangeRequestState
+
+
+class ChangeRequestSummarySerializer(serializers.ModelSerializer):
+    """Minimal read-only ChangeRequest shape for embedding on resources gated by an approval,
+    e.g. the scheduled change that carries it. Exposes just enough to show the approval state
+    and link to the change request."""
+
+    id = serializers.UUIDField(
+        read_only=True,
+        help_text="ID of the approval change request. Use it to link to the change request in the UI.",
+    )
+    state = serializers.ChoiceField(
+        choices=ChangeRequestState.choices,
+        read_only=True,
+        help_text=(
+            "Current approval state: 'pending' (awaiting approval), 'approved' (awaiting application), "
+            "'applied', 'rejected', 'expired', or 'failed'."
+        ),
+    )
+
+    class Meta:
+        model = ChangeRequest
+        fields = ["id", "state"]
+        read_only_fields = ["id", "state"]
 
 
 class ChangeRequestSerializer(serializers.ModelSerializer):

--- a/products/feature_flags/backend/api/scheduled_change.py
+++ b/products/feature_flags/backend/api/scheduled_change.py
@@ -14,6 +14,7 @@ from posthog.api.shared import UserBasicSerializer
 from products.approvals.backend.mixins import ApprovalHandlingMixin
 from products.approvals.backend.models import ChangeRequest, ChangeRequestState
 from products.approvals.backend.scheduled_changes import gate_scheduled_change
+from products.approvals.backend.serializers import ChangeRequestSummarySerializer
 from products.feature_flags.backend.api.feature_flag import CanEditFeatureFlag
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.feature_flags.backend.models.scheduled_change import ScheduledChange
@@ -45,6 +46,14 @@ def _gate_scheduled_change_at_creation(
 class ScheduledChangeSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     failure_reason = serializers.SerializerMethodField()
+    change_request = ChangeRequestSummarySerializer(
+        read_only=True,
+        allow_null=True,
+        help_text=(
+            "Summary of the approval change request gating this scheduled change. Null when no approval "
+            "policy applies. The change only applies at its scheduled time if the request is approved by then."
+        ),
+    )
 
     record_id = serializers.CharField(
         max_length=200,
@@ -101,6 +110,7 @@ class ScheduledChangeSerializer(serializers.ModelSerializer):
             "last_executed_at",
             "end_date",
             "timezone",
+            "change_request",
         ]
         read_only_fields = [
             "id",
@@ -110,6 +120,7 @@ class ScheduledChangeSerializer(serializers.ModelSerializer):
             "last_executed_at",
             "executed_at",
             "timezone",
+            "change_request",
         ]
 
     def get_failure_reason(self, obj: ScheduledChange) -> str | None:
@@ -359,7 +370,8 @@ class ScheduledChangeViewSet(ApprovalHandlingMixin, TeamAndOrgViewSetMixin, view
 
     scope_object = "feature_flag"
     serializer_class = ScheduledChangeSerializer
-    queryset = ScheduledChange.objects.all()
+    # select_related keeps the serializer's nested change_request and created_by from N+1-ing list responses.
+    queryset = ScheduledChange.objects.select_related("change_request", "created_by").all()
 
     @extend_schema(
         parameters=[

--- a/products/feature_flags/backend/api/test/test_scheduled_change.py
+++ b/products/feature_flags/backend/api/test/test_scheduled_change.py
@@ -1,7 +1,11 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import serializers, status
@@ -13,6 +17,7 @@ from posthog.models import User
 from posthog.models.organization import OrganizationMembership
 
 from products.access_control.backend.models.access_control import AccessControl
+from products.approvals.backend.models import ApprovalPolicy, ChangeRequest, ChangeRequestState
 from products.feature_flags.backend.api.scheduled_change import ScheduledChangeSerializer
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.feature_flags.backend.models.scheduled_change import ScheduledChange
@@ -48,6 +53,7 @@ class TestScheduledChange(APIBaseTest):
         assert response_data["record_id"] == str(feature_flag.id)
         assert response_data["payload"] == payload
         assert response_data["created_by"]["id"] == self.user.id
+        assert response_data["change_request"] is None
 
     def test_cannot_create_scheduled_change_without_feature_flag_edit_permission(self):
         """Test that users without edit permissions cannot create scheduled changes for feature flags"""
@@ -665,6 +671,88 @@ class TestScheduledChange(APIBaseTest):
         )
         assert scheduled_change.scheduled_at == original_scheduled_at, (
             f"scheduled_at changed to {scheduled_change.scheduled_at} (status={response.status_code})"
+        )
+
+
+class TestScheduledChangeApprovalVisibility(APIBaseTest):
+    def _gated_schedule(self, key: str, state: str) -> ScheduledChange:
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key=key, name=key, active=False)
+        change_request = ChangeRequest.objects.create(
+            team=self.team,
+            organization=self.organization,
+            action_key="feature_flag.enable",
+            resource_type="feature_flag",
+            resource_id=str(flag.id),
+            intent={},
+            intent_display={},
+            policy_snapshot={},
+            state=state,
+            expires_at=timezone.now() + timedelta(days=14),
+            created_by=self.user,
+        )
+        return ScheduledChange.objects.create(
+            team=self.team,
+            record_id=str(flag.id),
+            model_name="FeatureFlag",
+            payload={"operation": "update_status", "value": True},
+            scheduled_at=datetime(2030, 1, 15, 9, 0, 0, tzinfo=UTC),
+            created_by=self.user,
+            change_request=change_request,
+        )
+
+    @patch("products.approvals.backend.decorators._is_approvals_enabled", return_value=True)
+    def test_gated_create_returns_pending_change_request_summary(self, _mock_enabled):
+        ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key="feature_flag.enable",
+            conditions={},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="gated-create-flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+            active=False,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/scheduled_changes/",
+            data={
+                "record_id": str(flag.id),
+                "model_name": "FeatureFlag",
+                "payload": {"operation": "update_status", "value": True},
+                "scheduled_at": "2030-01-15T09:00:00Z",
+            },
+        )
+
+        response_data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+        bound = ScheduledChange.objects.get(id=response_data["id"]).change_request
+        assert bound is not None
+        assert response_data["change_request"] == {"id": str(bound.id), "state": ChangeRequestState.PENDING}
+
+    def test_list_serializes_change_request_states_without_per_row_queries(self):
+        self._gated_schedule("gated-0", ChangeRequestState.EXPIRED)
+        url = f"/api/projects/{self.team.id}/scheduled_changes/"
+
+        self.client.get(url)  # warm per-session caches so both captures compare like for like
+        with CaptureQueriesContext(connection) as one_row:
+            assert self.client.get(url).status_code == status.HTTP_200_OK
+
+        self._gated_schedule("gated-1", ChangeRequestState.REJECTED)
+        self._gated_schedule("gated-2", ChangeRequestState.PENDING)
+        with CaptureQueriesContext(connection) as three_rows:
+            response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        states = {row["change_request"]["state"] for row in response.json()["results"]}
+        assert states == {"expired", "rejected", "pending"}
+        assert len(three_rows) == len(one_row), (
+            f"listing 3 gated schedules ran {len(three_rows)} queries vs {len(one_row)} for 1: "
+            "the change_request summary is querying per row instead of using select_related"
         )
 
 

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -1616,6 +1616,44 @@ export const ScheduledChangeRecurrenceIntervalEnumApi = {
     Yearly: 'yearly',
 } as const
 
+/**
+ * * `pending` - Pending
+ * * `approved` - Approved (awaiting application)
+ * * `applied` - Applied
+ * * `rejected` - Rejected
+ * * `expired` - Expired
+ * * `failed` - Failed to apply
+ */
+export type ChangeRequestStateEnumApi = (typeof ChangeRequestStateEnumApi)[keyof typeof ChangeRequestStateEnumApi]
+
+export const ChangeRequestStateEnumApi = {
+    Pending: 'pending',
+    Approved: 'approved',
+    Applied: 'applied',
+    Rejected: 'rejected',
+    Expired: 'expired',
+    Failed: 'failed',
+} as const
+
+/**
+ * Minimal read-only ChangeRequest shape for embedding on resources gated by an approval,
+ * e.g. the scheduled change that carries it. Exposes just enough to show the approval state
+ * and link to the change request.
+ */
+export interface ChangeRequestSummaryApi {
+    /** ID of the approval change request. Use it to link to the change request in the UI. */
+    readonly id: string
+    /** Current approval state: 'pending' (awaiting approval), 'approved' (awaiting application), 'applied', 'rejected', 'expired', or 'failed'.
+     *
+     * * `pending` - Pending
+     * * `approved` - Approved (awaiting application)
+     * * `applied` - Applied
+     * * `rejected` - Rejected
+     * * `expired` - Expired
+     * * `failed` - Failed to apply */
+    readonly state: ChangeRequestStateEnumApi
+}
+
 export interface ScheduledChangeApi {
     readonly id: number
     readonly team_id: number
@@ -1665,6 +1703,8 @@ export interface ScheduledChangeApi {
     end_date?: string | null
     /** @nullable */
     readonly timezone: string | null
+    /** Summary of the approval change request gating this scheduled change. Null when no approval policy applies. The change only applies at its scheduled time if the request is approved by then. */
+    readonly change_request: ChangeRequestSummaryApi | null
 }
 
 export interface PaginatedScheduledChangeListApi {
@@ -1725,6 +1765,8 @@ export interface PatchedScheduledChangeApi {
     end_date?: string | null
     /** @nullable */
     readonly timezone?: string | null
+    /** Summary of the approval change request gating this scheduled change. Null when no approval policy applies. The change only applies at its scheduled time if the request is approved by then. */
+    readonly change_request?: ChangeRequestSummaryApi | null
 }
 
 export type FeatureFlagsStaffCacheListParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16748,6 +16748,25 @@ export namespace Schemas {
     }
 
     /**
+     * Minimal read-only ChangeRequest shape for embedding on resources gated by an approval,
+     * e.g. the scheduled change that carries it. Exposes just enough to show the approval state
+     * and link to the change request.
+     */
+    export interface ChangeRequestSummary {
+      /** ID of the approval change request. Use it to link to the change request in the UI. */
+      readonly id: string;
+      /** Current approval state: 'pending' (awaiting approval), 'approved' (awaiting application), 'applied', 'rejected', 'expired', or 'failed'.
+       *
+       * * `pending` - Pending
+       * * `approved` - Approved (awaiting application)
+       * * `applied` - Applied
+       * * `rejected` - Rejected
+       * * `expired` - Expired
+       * * `failed` - Failed to apply */
+      readonly state: ChangeRequestStateEnum;
+    }
+
+    /**
      * * `manual` - Manual
      */
     export type ChangeSourceEnum = typeof ChangeSourceEnum[keyof typeof ChangeSourceEnum];
@@ -54565,6 +54584,8 @@ export namespace Schemas {
       end_date?: string | null;
       /** @nullable */
       readonly timezone: string | null;
+      /** Summary of the approval change request gating this scheduled change. Null when no approval policy applies. The change only applies at its scheduled time if the request is approved by then. */
+      readonly change_request: ChangeRequestSummary | null;
     }
 
     export interface PaginatedScheduledChangeList {
@@ -63910,6 +63931,8 @@ export namespace Schemas {
       end_date?: string | null;
       /** @nullable */
       readonly timezone?: string | null;
+      /** Summary of the approval change request gating this scheduled change. Null when no approval policy applies. The change only applies at its scheduled time if the request is approved by then. */
+      readonly change_request?: ChangeRequestSummary | null;
     }
 
     export interface PatchedSchemaPropertyGroup {


### PR DESCRIPTION
## Problem

- A scheduled flag change that is waiting on approval shows the same "Scheduled" tag as one that will fire, so nobody knows to act before the deadline.
- If the fire window passes unapproved, the applier expires the request and skips the change - and the card then shows "Complete".
- A rejected change stays in "Active & upcoming" looking like it will run.
- The cause: the scheduled changes API omits the `change_request` binding, so the frontend cannot tell these states apart.

## Changes

| Before (master) | After |
| --- | --- |
| ![scheduled-changes-approval-before](https://raw.githubusercontent.com/PostHog/pr-assets/ca64dbbf8cc0900c6f8bbf6397bec8445fdc5329/2026/08/b798c1c2-8852-43eb-9dbb-f3d34f152255.png) | ![scheduled-changes-approval-after](https://raw.githubusercontent.com/PostHog/pr-assets/e74b92ac77eda588d88efe134e219d66f82cbc73/2026/08/c5d56a0d-b9c4-4cf7-9eb0-1159300da1a5.png) |

- Schedule cards now show the approval state: "Needs approval" while pending, "Rejected" and "Approval expired" when the change will not or did not run.
- Cards with an approval request link to it ("View approval request"), so an approver can act from the Schedule tab.
- Denied one-time schedules move out of "Active & upcoming" into History. Recurring schedules stay, because each occurrence re-gates with a fresh request.
- Errored cards show the failure and retry text visibly ("will retry automatically, 2 attempts remaining") instead of tooltip-only.
- The creation toast says the change is pending approval when scheduling created an approval request.
- No applier change: the skip path already stamps `executed_at`, so all states derive client-side from the newly exposed request state.
- Mechanical: `ScheduledChangeSerializer` gains a read-only nested `change_request` summary (id + state) with `select_related`; regenerated OpenAPI and MCP types; the handwritten `createScheduledChange` return type in `lib/api.ts` now matches the actual DRF response.

## How did you test this code?

- Backend tests: a gated create returns the pending summary and an ungated one returns null; a query-count test fails if the summary starts N+1-ing.
- Frontend tests: the denied-schedule reclassification (including the recurring exclusion), the three new tag states, the approval link, and the visible failure text - none of these states were rendered, or tested, before.
- Screenshots above come from local dev seeded with invented pending/rejected/expired/errored rows.
- Not run: the full CI matrix (draft PR).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - approval-gated scheduling behavior is unchanged; only its visibility improves.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigated and specified in a Claude Code session; implemented by a spawned Claude Code agent in a separate worktree from a written brief; screenshots and PR by the main session.
- Skills invoked across the sessions: /improving-drf-endpoints, /writing-ui-components, /writing-user-facing-copy, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decision recorded during the session: an OpenAPI enum-name collision on the new `state` field was resolved with an `ENUM_NAME_OVERRIDES` entry rather than renaming the field.
- All seeded demo data is invented; nothing in the diff or this description derives from customer material.
