### PR TITLE
fix(warehouse-sources): coalesce rewrite batches independently of scan size

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -97,6 +97,12 @@ CHECKPOINT_INTERVAL_SECONDS = 30.0
 # that matters — the win comes from merging thousands of KB-sized batches, not from filling the cap.
 REWRITE_BUFFER_MAX_BYTES = DEFAULT_MAX_TABLE_BYTES // 2
 
+# Rows the coalescing buffer may hold before it commits. Deliberately not the scan batch size: one
+# number for both caps the buffer at a single batch, so nothing coalesces and every batch becomes its
+# own Delta commit. Each commit is a transaction-log write, so that puts a floor under throughput that
+# no table large enough to need repartitioning can finish above.
+REWRITE_BUFFER_MAX_ROWS = 50_000
+
 # Arrow's default 16-batch readahead keeps memory in flight that never reaches the coalescing buffer,
 # so no buffer budget bounds it. Fragment readahead is left at its default: serialising file reads
 # would cost the most on the many-small-files tables this module rewrites.
@@ -925,7 +931,7 @@ async def _rewrite_into_temp(
         # buffer plus the batch in hand, which `REWRITE_BUFFER_MAX_BYTES` budgets for.
         table_bytes = table_payload_bytes(partitioned_table)
         if buffered and (
-            buffered_rows + partitioned_table.num_rows > batch_size
+            buffered_rows + partitioned_table.num_rows > REWRITE_BUFFER_MAX_ROWS
             or buffered_bytes + table_bytes > REWRITE_BUFFER_MAX_BYTES
         ):
             await flush()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
@@ -670,7 +670,10 @@ class TestRewriteIntoTemp:
         # the deadline for the early reads and every later read is over it.
         clock = Mock(side_effect=itertools.chain([0.0] * 4, itertools.repeat(100.0)))
 
-        with patch.object(repartition_module, "time", Mock(monotonic=clock)):
+        with (
+            patch.object(repartition_module, "time", Mock(monotonic=clock)),
+            patch.object(repartition_module, "REWRITE_BUFFER_MAX_ROWS", 2),
+        ):
             with pytest.raises(RepartitionBudgetExceededError):
                 asyncio.run(
                     _rewrite_into_temp(
@@ -711,7 +714,10 @@ class TestRewriteIntoTemp:
 
         # Stop the first pass after the buffer has flushed once, so temp holds a partial prefix.
         clock = Mock(side_effect=itertools.chain([0.0] * 4, itertools.repeat(100.0)))
-        with patch.object(repartition_module, "time", Mock(monotonic=clock)):
+        with (
+            patch.object(repartition_module, "time", Mock(monotonic=clock)),
+            patch.object(repartition_module, "REWRITE_BUFFER_MAX_ROWS", 2),
+        ):
             with pytest.raises(RepartitionBudgetExceededError):
                 asyncio.run(
                     _rewrite_into_temp(
@@ -1702,9 +1708,12 @@ class TestClaimFencing:
         assert rows_written == 24
         assert ensure.await_count == 1
 
-    def test_rewrite_coalesces_batches_into_one_commit(self, tmp_path):
-        # Commits must scale with data size, not source file count: under one batch_size worth of
-        # rows the whole rewrite lands as a single commit, losing no rows.
+    @pytest.mark.parametrize("batch_size", [50_000, 2])
+    def test_rewrite_coalesces_batches_into_one_commit(self, batch_size, tmp_path):
+        # Commits must scale with data size, not source file count or scan batch count: under one
+        # buffer's worth of rows the whole rewrite lands as a single commit, losing no rows. A scan
+        # batch size the buffer bound is derived from would cap the buffer at one batch and commit
+        # per batch instead, which is a throughput floor, not just extra versions.
         rows = [(i, datetime.datetime(2024, 1 + (i % 12), 5)) for i in range(1, 37)]
         live = _write_month_partitioned(str(tmp_path / "live"), rows)
         assert len(measure_partition_bytes(live)) == 12
@@ -1719,7 +1728,7 @@ class TestClaimFencing:
                 temp_uri=temp_uri,
                 storage_options={},
                 target=target,
-                batch_size=50_000,
+                batch_size=batch_size,
                 logger=logger,
             )
         )
@@ -1727,7 +1736,8 @@ class TestClaimFencing:
         temp = deltalake.DeltaTable(temp_uri)
         assert rows_written == 36
         assert temp.to_pyarrow_dataset().count_rows() == 36
-        # Version 0 is the sole commit; one-per-source-file would leave version 11.
+        # Version 0 is the sole commit; one-per-source-file would leave version 11, and
+        # one-per-scan-batch would leave version 17 at batch_size=2.
         assert temp.version() == 0
 
     def test_rewrite_of_empty_source_writes_nothing(self, tmp_path):
@@ -1789,12 +1799,12 @@ class TestClaimFencing:
         assert temp.to_pyarrow_dataset().count_rows() == 24
         assert temp.version() > 0
 
-    def test_rewrite_never_buffers_beyond_batch_size(self, tmp_path):
+    def test_rewrite_never_buffers_beyond_its_row_bound(self, tmp_path):
         # Appending before the size check lets a nearly-full buffer take another full-sized batch, so
-        # peak memory reaches ~2x batch_size — a regression on the one-batch bound the rewrite held
-        # before it coalesced, in the module that exists because oversized in-memory data OOMs the
-        # worker. Four 6-row source files against batch_size=10 catch it: flushing after the append
-        # writes commits of 12 rows, flushing before it keeps every commit within the bound.
+        # peak memory reaches ~2x the bound, in the module that exists because oversized in-memory
+        # data OOMs the worker. Four 6-row source files against a 10-row bound catch it: flushing
+        # after the append writes commits of 12 rows, flushing before it keeps every commit within
+        # the bound.
         rows = [(i, datetime.datetime(2024, 1 + (i % 4), 5)) for i in range(1, 25)]
         live = _write_month_partitioned(str(tmp_path / "live"), rows)
         assert len(measure_partition_bytes(live)) == 4
@@ -1803,16 +1813,17 @@ class TestClaimFencing:
             partition_keys=["created_at"], trigger_reason="t", partition_mode="datetime", partition_format="day"
         )
         temp_uri = str(tmp_path / "temp")
-        rows_written, _ = asyncio.run(
-            _rewrite_into_temp(
-                old_delta=live,
-                temp_uri=temp_uri,
-                storage_options={},
-                target=target,
-                batch_size=10,
-                logger=logger,
+        with patch.object(repartition_module, "REWRITE_BUFFER_MAX_ROWS", 10):
+            rows_written, _ = asyncio.run(
+                _rewrite_into_temp(
+                    old_delta=live,
+                    temp_uri=temp_uri,
+                    storage_options={},
+                    target=target,
+                    batch_size=2,
+                    logger=logger,
+                )
             )
-        )
 
         temp = deltalake.DeltaTable(temp_uri)
         assert rows_written == 24


### PR DESCRIPTION
## Problem

A warehouse table being repartitioned rewrites about 18 times slower than it did last week, and the largest tables can no longer finish at all.

- The rewrite commits once per scan batch instead of once per buffer, at roughly 700 rows per commit.
- Each commit is a Delta transaction log write, so throughput fell from about 12,000 rows per second to about 700.
- A table large enough to need repartitioning cannot finish inside the activity budget at that rate, so it checkpoints and resumes for many more cycles than the retry cap allows.

The coalescing buffer takes its row bound from `batch_size`, which is also the Arrow scanner's batch size. The scanner emits exactly `batch_size` rows, so the buffer overflows on the second batch and can never hold more than one. Coalescing has always been a no-op. #86717 made it visible by lowering `DEFAULT_REPARTITION_BATCH_SIZE` from 50,000 to 1,000 to bound peak memory, which shrank every commit by the same factor.

## Changes

- The rewrite now commits once per buffer again, restoring the commit sizing that preceded #86717.
- `REWRITE_BUFFER_MAX_ROWS` bounds the buffer at 50,000 rows, separate from the scan batch size.
- The scan batch size stays at 1,000, so the memory bound that stopped the worker OOM kills is unchanged.
- `REWRITE_BUFFER_MAX_BYTES` is untouched and remains the real memory bound, since a row count says nothing about row width.

Nothing user-visible changes. The rewrite produces the same rows in the same order and writes fewer, larger commits.

> [!NOTE]
> A larger buffer means a rewrite that dies before filling it commits nothing, so an early death has no progress to checkpoint. At the restored throughput a full buffer takes a few seconds, so the exposure is small, but it is wider than it was at 1,000 rows.

## How did you test this code?

Automated only. No manual testing, and no verification against a production table.

- `test_rewrite_coalesces_batches_into_one_commit` gains a `batch_size=2` case. The existing case used `batch_size=50_000` against 36 rows, so the source never produced a second batch and the test could not observe the bug its name describes.
- Reverting the one-line fix fails the new case and passes the old one, which is why this shipped unnoticed.
- `test_rewrite_never_buffers_beyond_batch_size` becomes `test_rewrite_never_buffers_beyond_its_row_bound`. It guards a real property, that the buffer flushes before it appends so peak memory cannot reach twice the bound, and it now drives the bound that governs the buffer.
- Two deadline and resume tests drove a mid-stream flush through `batch_size`. They now patch `REWRITE_BUFFER_MAX_ROWS`. Both pass on master without this change, so neither was pre-existing breakage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while checking whether the checkpointing added in #87262 was letting stuck tables converge. It was: the attempt counter resets on progress and the resume path engages. The tables still could not finish, which pointed at throughput rather than at checkpointing.

The regression was identified by comparing the same table's progress logs across the two builds, using the log line number to tell the builds apart. Rows per commit fell from about 36,000 to about 1,000 between them.

Raising the scan batch size back to 50,000 would also restore throughput, but it would undo the memory bound that removed the worker OOM kills. Splitting the two bounds keeps both.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
