### PR TITLE
fix(data-catalog): surface view certifications in information_schema

### DIFF
--- a/posthog/api/test/__snapshots__/test_element.ambr
+++ b/posthog/api/test/__snapshots__/test_element.ambr
@@ -614,13 +614,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1519,6 +1519,7 @@ class Database(BaseModel):
 
         with timings.measure("data_warehouse_saved_query", emit_span=True):
             saved_queries: list[DataWarehouseSavedQuery] = []
+            all_saved_queries: list[DataWarehouseSavedQuery] = []
             # Direct-connection queries do not expose saved queries.
             if not is_direct_query:
                 with timings.measure("select"):
@@ -1530,9 +1531,12 @@ class Database(BaseModel):
                         .select_related("table", "managed_viewset", "created_by")
                         # credential attached in bulk below, not joined per row
                     )
-                    if not is_managed_viewset_enabled:
-                        queryset = queryset.filter(managed_viewset__isnull=True)
-                    saved_queries = list(queryset)
+                    all_saved_queries = list(queryset)
+                    saved_queries = (
+                        all_saved_queries
+                        if is_managed_viewset_enabled
+                        else [sq for sq in all_saved_queries if sq.managed_viewset_id is None]
+                    )
 
         with timings.measure("endpoint_saved_query", emit_span=True):
             endpoint_saved_queries: list[DataWarehouseSavedQuery] = []
@@ -1566,7 +1570,7 @@ class Database(BaseModel):
         # Exclude that private storage table so the view owns access control, even after a rename.
         backing_table_ids = {
             sq.table_id
-            for sq in (*saved_queries, *endpoint_saved_queries)
+            for sq in (*all_saved_queries, *endpoint_saved_queries)
             if sq.table_id is not None and sq.table is not None and sq.folder_path in sq.table.url_pattern
         }
 

--- a/posthog/hogql/database/schema/information_schema.py
+++ b/posthog/hogql/database/schema/information_schema.py
@@ -14,6 +14,7 @@ semantic layers — fetched lazily only when these tables are queried.
 """
 
 import json
+import uuid
 import hashlib
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional
@@ -173,9 +174,11 @@ def _classify_table(name: str, table: Table, warehouse: set[str], views: set[str
         return "information_schema", "information_schema"
     if name.startswith("system."):
         return "system", "system"
+    if isinstance(table, SavedQuery):
+        return "view", "views"
     if name in warehouse:
         return "data_warehouse", "warehouse"
-    if name in views or isinstance(table, SavedQuery):
+    if name in views:
         return "view", "views"
     return "posthog", "public"
 
@@ -207,25 +210,26 @@ class _CollectedRelationship(NamedTuple):
 class _WarehouseMetadata(NamedTuple):
     row_counts: dict[str, Optional[int]]
     view_row_counts: dict[str, Optional[int]]
-    materialized_view_ids: dict[str, str]
+    saved_query_ids_by_name: dict[str, str]
     column_stats: dict[tuple[str, str], _ColumnStats]
 
 
 def _warehouse_metadata(team_id: Optional[int]) -> _WarehouseMetadata:
     """Lazily load warehouse row counts and column statistics for the team.
 
-    Returns `(row_counts, view_row_counts, materialized_view_ids, column_stats)`. The view IDs retain
-    saved-query identity when a materialized view resolves to its backing warehouse table. Only runs
-    when an information_schema table is actually queried, so it never touches the hot
-    `create_hogql_database` path. Mirrors how `serialize_database` sources counts so the catalog and
-    the SQL-editor schema agree.
+    Returns `(row_counts, view_row_counts, saved_query_ids_by_name, column_stats)`. The name→id map
+    covers every live saved query, so a view keeps its saved-query identity even when the catalog
+    object resolves to something else (a materialized backing table, or a revenue-analytics view
+    whose `id` is not a saved-query id). Only runs when an information_schema table is actually
+    queried, so it never touches the hot `create_hogql_database` path. Mirrors how
+    `serialize_database` sources counts so the catalog and the SQL-editor schema agree.
     """
     row_counts: dict[str, Optional[int]] = {}
     view_row_counts: dict[str, Optional[int]] = {}
-    materialized_view_ids: dict[str, str] = {}
+    saved_query_ids_by_name: dict[str, str] = {}
     column_stats: dict[tuple[str, str], _ColumnStats] = {}
     if team_id is None:
-        return _WarehouseMetadata(row_counts, view_row_counts, materialized_view_ids, column_stats)
+        return _WarehouseMetadata(row_counts, view_row_counts, saved_query_ids_by_name, column_stats)
 
     # Inline imports: keeps the products dependency off the hogql import path (avoids an import
     # cycle, since products import hogql) and off every non-information_schema query.
@@ -251,13 +255,15 @@ def _warehouse_metadata(team_id: Optional[int]) -> _WarehouseMetadata:
             ):
                 row_counts[table_name] = row_count
             # Views carry their row count on the materialized backing table (`saved_query.table`).
-            for view_id, view_name, row_count in (
+            for view_id, view_name, table_id, row_count in (
                 DataWarehouseSavedQuery.objects.exclude(deleted=True)
-                .filter(team_id=team_id, table__isnull=False)
-                .values_list("id", "name", "table__row_count")
+                .filter(team_id=team_id)
+                .order_by("created_at")
+                .values_list("id", "name", "table_id", "table__row_count")
             ):
-                view_row_counts[view_name] = row_count
-                materialized_view_ids[view_name] = str(view_id)
+                if table_id is not None:
+                    view_row_counts[view_name] = row_count
+                saved_query_ids_by_name[view_name] = str(view_id)
             # Per-column profiling stats (keyed by table UUID + column). Only the columns that have been
             # profiled appear; everything else stays absent (NULL in the catalog).
             for stats in list_column_statistics(team_id):
@@ -272,7 +278,7 @@ def _warehouse_metadata(team_id: Optional[int]) -> _WarehouseMetadata:
         logger.exception("information_schema: failed to load warehouse metadata", team_id=team_id)
         return _WarehouseMetadata({}, {}, {}, {})
 
-    return _WarehouseMetadata(row_counts, view_row_counts, materialized_view_ids, column_stats)
+    return _WarehouseMetadata(row_counts, view_row_counts, saved_query_ids_by_name, column_stats)
 
 
 def _unwrap(expr: ast.Expr) -> ast.Expr:
@@ -468,7 +474,7 @@ class _Introspection:
         warehouse_metadata = _warehouse_metadata(context.team_id)
         self.row_counts = warehouse_metadata.row_counts
         self.view_row_counts = warehouse_metadata.view_row_counts
-        self.materialized_view_ids = warehouse_metadata.materialized_view_ids
+        self.saved_query_ids_by_name = warehouse_metadata.saved_query_ids_by_name
         self.column_stats = warehouse_metadata.column_stats
         self.table_descriptions = TableDescriptions.load(context.team_id)
         self._collected: Optional[_CollectedCatalog] = None
@@ -570,7 +576,7 @@ class _Introspection:
             table_type, table_schema = _classify_table(name, table, self.warehouse, self.views)
             row_count = self._row_count(name, table, table_type)
             table_rows.append([name, table_schema, name, table_type, self._table_description(table), row_count])
-            certification_keys.append(_certification_key(name, table, table_type, self.materialized_view_ids))
+            certification_keys.append(_certification_key(name, table, table_type, self.saved_query_ids_by_name))
 
             self._collect_fields(
                 name,
@@ -596,7 +602,7 @@ class _Introspection:
             return self._data_catalog_enriched_table_rows
 
         table_rows = self.table_rows()
-        certifications = _catalog_certifications(self.context, self.allowed_tables)
+        certifications = _catalog_certifications(self.context, self._table_certification_keys)
         # Match each certification to the introspected row by that resource's own id (warehouse table
         # id / saved-query id), not its name: warehouse table names are not unique per team, so a
         # name-keyed lookup could show one table's certification on a same-named sibling.
@@ -1199,7 +1205,7 @@ def _data_quality_health(context: "HogQLContext", allowed: Optional[frozenset[st
 
 
 def _certification_key(
-    table_name: str, table: Table, table_type: str, materialized_view_ids: dict[str, str]
+    table_name: str, table: Table, table_type: str, saved_query_ids_by_name: dict[str, str]
 ) -> Optional[_CertificationKey]:
     """Certification lookup key `(table_type, resource_id)` for an introspected table, or None.
 
@@ -1212,20 +1218,31 @@ def _certification_key(
         table_id = getattr(table, "table_id", None)
         return ("data_warehouse", str(table_id)) if table_id else None
     if table_type == "view":
-        saved_query_id = getattr(table, "id", None) or materialized_view_ids.get(table_name)
-        return ("view", str(saved_query_id)) if saved_query_id else None
+        saved_query_id = saved_query_ids_by_name.get(table_name) or getattr(table, "id", None)
+        return ("view", str(saved_query_id)) if saved_query_id and _is_uuid(str(saved_query_id)) else None
     return None
 
 
-def _catalog_certifications(context: "HogQLContext", allowed: Optional[frozenset[str]]) -> dict[tuple[str, str], str]:
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _catalog_certifications(
+    context: "HogQLContext", keys: Optional[list[Optional[_CertificationKey]]]
+) -> dict[_CertificationKey, str]:
     """Map each certified/deprecated resource to its certification status (fail-soft).
 
     Keyed by `(table_type, resource_id)` — a warehouse table cert keys on `("data_warehouse",
     str(table_id))`, a view cert on `("view", str(saved_query_id))`. Keying by the resource's own id
     (not its name) is required because `(team, name)` is not unique on `DataWarehouseTable`: two live
     tables can share a name yet each carry its own certification, and a name-keyed lookup would let one
-    clobber the other. Soft-deleted targets are excluded (their marks read as absent). `allowed` still
-    filters by name to trim the query to the pushed-down set.
+    clobber the other. `keys` — the certification keys of the introspected rows — bounds the query to
+    the exact resources being returned; a name-based bound would miss certs behind the dotted catalog
+    aliases. `None` means unbounded. Soft-deleted targets are excluded (their marks read as absent).
     """
     team_id = context.team_id
     if team_id is None or not _can_read_catalog(context):
@@ -1233,9 +1250,17 @@ def _catalog_certifications(context: "HogQLContext", allowed: Optional[frozenset
     from products.data_catalog.backend.facade.enums import CertificationStatus  # noqa: PLC0415
     from products.data_catalog.backend.facade.models import TableCertification  # noqa: PLC0415
 
+    table_ids: Optional[set[str]] = None
+    view_ids: Optional[set[str]] = None
+    if keys is not None:
+        table_ids = {key[1] for key in keys if key is not None and key[0] == "data_warehouse"}
+        view_ids = {key[1] for key in keys if key is not None and key[0] == "view"}
+        if not table_ids and not view_ids:
+            return {}
+
     record_catalog_read("tables")
     try:
-        result: dict[tuple[str, str], str] = {}
+        result: dict[_CertificationKey, str] = {}
         certs = TableCertification.objects.for_team(team_id).filter(
             status__in=(CertificationStatus.CERTIFIED, CertificationStatus.DEPRECATED)
         )
@@ -1245,9 +1270,10 @@ def _catalog_certifications(context: "HogQLContext", allowed: Optional[frozenset
             .exclude(table__external_data_source__deleted=True)
         )
         view_certs = certs.filter(saved_query__isnull=False).exclude(saved_query__deleted=True)
-        if allowed is not None:
-            table_certs = table_certs.filter(table__name__in=allowed)
-            view_certs = view_certs.filter(saved_query__name__in=allowed)
+        if table_ids is not None:
+            table_certs = table_certs.filter(table_id__in=table_ids)
+        if view_ids is not None:
+            view_certs = view_certs.filter(saved_query_id__in=view_ids)
         for table_id, status in table_certs.values_list("table_id", "status"):
             result[("data_warehouse", str(table_id))] = status
         for saved_query_id, status in view_certs.values_list("saved_query_id", "status"):

--- a/posthog/hogql/database/schema/test/test_information_schema.py
+++ b/posthog/hogql/database/schema/test/test_information_schema.py
@@ -1,14 +1,20 @@
+import uuid
+
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 from django.apps import apps
+from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
+from posthog.hogql.database.models import SavedQuery
 from posthog.hogql.database.schema.information_schema import (
     _bound_table_names,
+    _certification_key,
+    _classify_table,
     _pushdown_table_filter,
     _warehouse_metadata,
 )
@@ -160,6 +166,34 @@ class TestWarehouseMetadata(APIBaseTest):
         self._table("shared", 7)
         metadata = _warehouse_metadata(self.team.id)
         assert metadata.row_counts["shared"] == 7
+
+    def test_saved_query_id_map_covers_non_materialized_views(self):
+        view = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="plain_view", query={"query": "SELECT 1"}, columns={}
+        )
+        metadata = _warehouse_metadata(self.team.id)
+        assert metadata.saved_query_ids_by_name["plain_view"] == str(view.id)
+        assert "plain_view" not in metadata.view_row_counts
+
+
+class TestCertificationKey(SimpleTestCase):
+    def test_view_key_prefers_db_saved_query_id_over_object_id(self) -> None:
+        saved_query_id = str(uuid.uuid4())
+        view = SavedQuery(id=str(uuid.uuid4()), name="stripe.mrr_revenue_view", query="select 1", fields={})
+        key = _certification_key("stripe.mrr_revenue_view", view, "view", {"stripe.mrr_revenue_view": saved_query_id})
+        assert key == ("view", saved_query_id)
+
+    def test_view_with_name_shaped_id_and_no_saved_query_has_no_key(self) -> None:
+        name = "revenue_analytics.events.mrr_revenue_view"
+        view = SavedQuery(id=name, name=name, query="select 1", fields={})
+        assert _certification_key(name, view, "view", {}) is None
+
+    def test_resolved_view_classifies_as_view_even_when_a_warehouse_table_shares_its_name(self) -> None:
+        view = SavedQuery(id=str(uuid.uuid4()), name="stripe.mrr_revenue_view", query="select 1", fields={})
+        assert _classify_table("stripe.mrr_revenue_view", view, {"stripe.mrr_revenue_view"}, set()) == (
+            "view",
+            "views",
+        )
 
 
 class TestInformationSchema(ClickhouseTestMixin, APIBaseTest):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -124,13 +124,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -626,13 +625,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -1096,13 +1096,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -725,13 +725,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -1560,13 +1559,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -2392,13 +2390,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -3224,13 +3221,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -4059,13 +4055,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -4894,13 +4889,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -5729,13 +5723,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -6109,13 +6102,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -6963,13 +6955,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -7865,13 +7856,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -8750,13 +8740,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -9788,13 +9777,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -10489,13 +10477,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -11362,13 +11349,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -12261,13 +12247,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -13140,13 +13125,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -13342,13 +13326,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---
@@ -14170,13 +14153,12 @@
          "posthog_datawarehousemanagedviewset"."team_id",
          "posthog_datawarehousemanagedviewset"."kind"
   FROM "posthog_datawarehousesavedquery"
-  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_datawarehousesavedquery"."created_by_id" = "posthog_user"."id")
   LEFT OUTER JOIN "posthog_datawarehousetable" ON ("posthog_datawarehousesavedquery"."table_id" = "posthog_datawarehousetable"."id")
+  LEFT OUTER JOIN "posthog_datawarehousemanagedviewset" ON ("posthog_datawarehousesavedquery"."managed_viewset_id" = "posthog_datawarehousemanagedviewset"."id")
   WHERE ("posthog_datawarehousesavedquery"."team_id" = 99999
          AND NOT ("posthog_datawarehousesavedquery"."deleted"
-                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL)
-         AND "posthog_datawarehousesavedquery"."managed_viewset_id" IS NULL)
+                  AND "posthog_datawarehousesavedquery"."deleted" IS NOT NULL))
   ORDER BY "posthog_datawarehousesavedquery"."name" ASC
   '''
 # ---

--- a/products/data_catalog/backend/tests/test_information_schema.py
+++ b/products/data_catalog/backend/tests/test_information_schema.py
@@ -37,11 +37,11 @@ from products.data_catalog.backend.logic.metrics import upsert_metric
 from products.data_catalog.backend.logic.relationships import accept_proposal, propose_relationship, reject_proposal
 from products.data_catalog.backend.models import RelationshipProposal, TableCertification
 from products.data_catalog.backend.models.metric import Metric
-from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+from products.data_modeling.backend.facade.models import DataWarehouseManagedViewSet, DataWarehouseSavedQuery
 from products.data_tools.backend.facade.models import DataWarehouseJoin
 from products.product_analytics.backend.facade.models import Insight
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSource
-from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind, ExternalDataSourceType
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -343,25 +343,70 @@ class TestInformationSchemaCertificationsAndRelationships(ClickhouseTestMixin, A
         )
         assert response.results == [(expected,)]
 
-    def test_materialized_view_keeps_its_certification(self) -> None:
-        backing_table = self._create_warehouse_table("materialized_revenue_backing")
+    @parameterized.expand([("materialized", True), ("plain", False)])
+    def test_view_keeps_its_certification(self, _name: str, materialized: bool) -> None:
+        backing_table = self._create_warehouse_table("certified_view_backing") if materialized else None
         view = DataWarehouseSavedQuery.objects.create(
             team=self.team,
-            name="materialized_revenue",
+            name="certified_view",
             query={"kind": "HogQLQuery", "query": "select 1"},
             columns=_COLUMNS,
             table=backing_table,
-            is_materialized=True,
+            is_materialized=materialized,
         )
         certify(propose_certification(team=self.team, user=self.user, saved_query_id=str(view.id)), self.user)
 
         response = execute_hogql_query(
             "SELECT table_type, certification FROM system.information_schema.tables "
-            "WHERE table_name = 'materialized_revenue'",
+            "WHERE table_name = 'certified_view'",
             team=self.team,
             context=self._context(),
         )
         assert response.results == [("view", "certified")]
+
+    def test_managed_view_backing_table_is_hidden_when_viewset_flag_is_off(self) -> None:
+        viewset = DataWarehouseManagedViewSet.objects.create(
+            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
+        )
+        view = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="stripe.mrr_revenue_view",
+            query={"kind": "HogQLQuery", "query": "select 1"},
+            columns=_COLUMNS,
+            managed_viewset=viewset,
+            is_materialized=True,
+        )
+        view.table = DataWarehouseTable.objects.create(
+            name=view.name, format="Parquet", team=self.team, url_pattern=view.url_pattern, columns=_COLUMNS
+        )
+        view.save()
+
+        response = execute_hogql_query(
+            "SELECT table_name, table_type FROM system.information_schema.tables "
+            "WHERE table_name = 'stripe.mrr_revenue_view'",
+            team=self.team,
+            context=self._context(),
+        )
+        assert response.results == []
+
+    def test_certification_is_found_under_the_dotted_catalog_name(self) -> None:
+        source = ExternalDataSource.objects.create(team=self.team, source_type=ExternalDataSourceType.STRIPE)
+        table = DataWarehouseTable.objects.create(
+            name="stripe_charge",
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            url_pattern="s3://bucket/stripe_charge",
+            columns=_COLUMNS,
+        )
+        certify(propose_certification(team=self.team, user=self.user, table_id=str(table.id)), self.user)
+
+        response = execute_hogql_query(
+            "SELECT certification FROM system.information_schema.tables WHERE table_name = 'stripe.charge'",
+            team=self.team,
+            context=self._context(),
+        )
+        assert response.results == [("certified",)]
 
     def test_view_certification_does_not_bleed_onto_same_name_table(self) -> None:
         # A warehouse table and a view can share a name; each certification belongs to exactly one of


### PR DESCRIPTION
## Problem

A user who deprecates a warehouse view gets no warning when an agent queries that view later. `SELECT certification FROM system.information_schema.tables` returns NULL for every row, so agents build reports on deprecated data.

Three read-path defects cause this:

- Revenue and managed views are listed twice and classified as `data_warehouse` instead of `view`. The misclassified row looks up its mark with a key that does not exist, so the result is always NULL.
- A revenue view object carries the id of its source table, not of its saved query. The mark is stored against the saved query, so the lookup never matches.
- `WHERE table_name = 'stripe.charge'` narrows the mark query by the dotted catalog name, but the stored table name is `stripe_charge`. Equality lookups drop the mark.

## Changes

- Deprecated and certified marks now show in the `certification` column for managed views, revenue views, and dotted catalog names.
- The duplicate `data_warehouse` rows for managed views disappear: the backing-table exclusion now covers saved queries that the `managed-viewsets` flag hides (`backing_table_ids` builds from all saved queries).
- `_classify_table` classifies by the object the name resolves to, so a resolved view is a `view` even when a warehouse table shares its name.
- `_certification_key` resolves a view's saved-query id from a database name→id map first, and falls back to the object's own id. Ids that are not UUIDs produce no key.
- `_catalog_certifications` filters by resource ids taken from the introspected rows instead of by name.
- Mechanical: rename `materialized_view_ids` to `saved_query_ids_by_name`, extend that map to non-materialized saved queries, regenerate one SQL snapshot.

Nothing visible changes for tables that already showed their marks.

## How did you test this code?

- New test: a managed view's backing table is hidden when the flag is off. Catches the leak that created the duplicate misclassified rows.
- New test: `WHERE table_name = 'stripe.charge'` finds a mark stored against `stripe_charge`. Fails without the resource-id filter.
- New unit tests: `_certification_key` prefers the map over a bogus object id, and ignores name-shaped ids; `_classify_table` prefers the resolved view.
- Extended test: a plain (non-materialized) view keeps its mark, guarding the lookup reorder.
- Ran locally: the data catalog information_schema suite, the hogql schema suites, `test_database.py`, and repo-wide mypy.
- Not run: a live end-to-end check against a real Stripe source in the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - the certification column keeps its documented behavior; it now populates correctly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a bug report: an agent used a deprecated revenue view for an ARR question because the catalog returned NULL certifications. Skills invoked: /writing-tests, /stacking-prs, /writing-pr-descriptions, /django-migrations (a data migration was drafted, then dropped when existing tests showed marks are environment-scoped by design). The session also fixed the write/read scope mismatch in the next PR of this stack.
