### PR TITLE
fix(data-catalog): keep certification reads environment-scoped

### DIFF
--- a/products/data_catalog/backend/logic/certifications.py
+++ b/products/data_catalog/backend/logic/certifications.py
@@ -124,7 +124,7 @@ def propose_certification(
     else:
         target_saved_query = _resolve_saved_query(team, saved_query_id, view_name)
 
-    certifications = TableCertification.objects.for_team(team.id, canonical=True)
+    certifications = TableCertification.objects.for_team(team.id)
     existing = certifications.filter(table=target_table, saved_query=target_saved_query).first()
     if existing is not None:
         raise _duplicate_target_conflict(existing)
@@ -186,7 +186,7 @@ def revoke_certification(cert: TableCertification, user: Optional[User], request
 def certifications_for_team(team: Team) -> QuerySet[TableCertification]:
     """Certifications whose target is not soft-deleted, newest first."""
     return (
-        TableCertification.objects.for_team(team.id, canonical=True)
+        TableCertification.objects.for_team(team.id)
         .exclude(table__deleted=True)
         .exclude(table__external_data_source__deleted=True)
         .exclude(saved_query__deleted=True)

--- a/products/data_catalog/backend/models/certification.py
+++ b/products/data_catalog/backend/models/certification.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from posthog.models.scoping.manager import TeamScopedManager
+from posthog.models.scoping.manager import EnvironmentScopedManager
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
 
 from ..facade.enums import CertificationStatus
@@ -14,7 +14,7 @@ class TableCertification(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     API reads exclude the row rather than cascading.
     """
 
-    objects = TeamScopedManager()
+    objects = EnvironmentScopedManager()
 
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, db_constraint=False)
     created_by = models.ForeignKey(

--- a/products/data_catalog/backend/tests/test_information_schema.py
+++ b/products/data_catalog/backend/tests/test_information_schema.py
@@ -389,6 +389,28 @@ class TestInformationSchemaCertificationsAndRelationships(ClickhouseTestMixin, A
         )
         assert response.results == []
 
+    def test_child_environment_sees_its_own_certification(self) -> None:
+        child_team = Team.objects.create(
+            organization=self.organization, project=self.project, parent_team=self.team, name="Child environment"
+        )
+        table = DataWarehouseTable.objects.create(
+            name="env_revenue",
+            format="Parquet",
+            team=child_team,
+            url_pattern="s3://bucket/env_revenue",
+            columns=_COLUMNS,
+        )
+        deprecate(propose_certification(team=child_team, user=self.user, table_id=str(table.id)), self.user)
+
+        database = Database.create_for(team=child_team, user=self.user)
+        context = HogQLContext(team=child_team, team_id=child_team.pk, database=database)
+        response = execute_hogql_query(
+            "SELECT certification FROM system.information_schema.tables WHERE table_name = 'env_revenue'",
+            team=child_team,
+            context=context,
+        )
+        assert response.results == [("deprecated",)]
+
     def test_certification_is_found_under_the_dotted_catalog_name(self) -> None:
         source = ExternalDataSource.objects.create(team=self.team, source_type=ExternalDataSourceType.STRIPE)
         table = DataWarehouseTable.objects.create(


### PR DESCRIPTION
## Problem

A user who certifies or deprecates a warehouse table inside a non-default environment never sees that mark in the data catalog. `SELECT certification FROM system.information_schema.tables` returns NULL for them, even though the REST API lists the mark correctly.

Writes and reads disagree about which team id a mark belongs to:

- `propose_certification` stores the mark under the environment's own team id.
- The catalog read resolves the team id to the parent project id first, so it looks for the mark under an id that was never written.

Two existing tests, `test_proposal_stays_in_the_requested_environment` and `test_certifications_are_isolated_between_project_environments`, show the write side is deliberate: a mark belongs to one environment, like the warehouse table it points at.

Builds on #87825, which fixes the three other reasons the column read NULL.

## Changes

- Marks made in a non-default environment now appear in that environment's catalog reads.
- `TableCertification` moves from `TeamScopedManager` to `EnvironmentScopedManager`, so `for_team()` filters by the literal environment id everywhere and never resolves to the parent project.
- The logic layer drops its `canonical=True` arguments, which existed only to opt out of that resolution.
- No migration: stored rows already hold the environment id the reads now use.

Projects without extra environments see no change, because the environment id and the project id are the same there.

## How did you test this code?

- New test: a child environment's own deprecation shows as `deprecated` in `system.information_schema.tables`. It returns NULL before this change.
- The two environment tests named above still pass unchanged, which confirms the write side and the API reads keep their behavior.
- Ran locally: the data catalog certification and information_schema suites, plus repo-wide mypy.
- Not run: a live check in a multi-environment project in the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-tests, /django-migrations, /stacking-prs, /writing-pr-descriptions.

The first plan for this layer canonicalized the write path to the parent project id and added a data migration to move existing rows. Reading the two environment tests showed that inverts a deliberate design, so the migration was dropped and the read side moved to the literal id instead. That also removed the need to touch stored data.
