### PR TITLE
feat(persons): measure person search latency

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -615,7 +615,8 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         }
         with slo_operation(
             spec=SloSpec(
-                distinct_id=request.user.distinct_id,
+                # `User.distinct_id` is nullable, so fall back to the team like the query service does.
+                distinct_id=request.user.distinct_id or str(team.uuid),
                 area=SloArea.ANALYTIC_PLATFORM,
                 operation=SloOperation.PERSONS_LIST,
                 team_id=team.pk,

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -5,6 +5,8 @@ import dataclasses
 from datetime import UTC, datetime
 from typing import Any, Optional, Union, cast  # noqa: UP035
 
+from django.conf import settings
+
 import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
@@ -67,6 +69,8 @@ from posthog.queries.actor_base_query import get_serialized_people
 from posthog.queries.properties_timeline import PropertiesTimeline
 from posthog.rate_limit import ClickHouseBurstRateThrottle, PersonalApiKeyRateThrottle, UserOrEmailRateThrottle
 from posthog.renderers import SafeJSONRenderer
+from posthog.slo.context import JsonValue, SloSpec, slo_operation
+from posthog.slo.types import SloArea, SloOperation
 from posthog.tasks.split_person import split_person
 from posthog.utils import (
     format_query_params_absolute_url,
@@ -595,38 +599,64 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             limit=filter.limit,
             offset=filter.offset,
         )
-        # Use .calculate() (not .run()) — it applies the limit/offset paginator but skips the
-        # insight-caching wrapper. With an id-only select there's no actor-column hydration, so
-        # we still hydrate the person objects ourselves via get_serialized_people.
-        actors_runner = ActorsQueryRunner(team=team, query=actors_query)
-        actor_ids = [row[0] for row in actors_runner.calculate().results]
-        with personhog_caller_tag("persons/list"):
-            serialized_actors = get_serialized_people(team, actor_ids)
+        include_total = "include_total" in request.GET
+        # This endpoint bypasses `QueryRunner.run()`, so nothing else measures how long it takes.
+        # The search path is the slow one, so the shape of the request is recorded alongside the
+        # duration. The search term itself is never recorded - it is user data.
+        slo_properties: dict[str, JsonValue] = {
+            "query_type": "ActorsQuery",
+            "has_search": bool(filter.search),
+            "has_properties": bool(person_properties),
+            "has_distinct_id": bool(filter.distinct_id),
+            "include_total": include_total,
+            "is_csv": is_csv_request,
+            "limit": filter.limit,
+            "offset": filter.offset,
+        }
+        with slo_operation(
+            spec=SloSpec(
+                distinct_id=request.user.distinct_id,
+                area=SloArea.ANALYTIC_PLATFORM,
+                operation=SloOperation.PERSONS_LIST,
+                team_id=team.pk,
+                sample_rate=settings.PERSONS_LIST_SLO_SAMPLE_RATE,
+            ),
+            properties=slo_properties,
+        ) as slo:
+            # Use .calculate() (not .run()) — it applies the limit/offset paginator but skips the
+            # insight-caching wrapper. With an id-only select there's no actor-column hydration, so
+            # we still hydrate the person objects ourselves via get_serialized_people.
+            actors_runner = ActorsQueryRunner(team=team, query=actors_query)
+            actor_ids = [row[0] for row in actors_runner.calculate().results]
+            with personhog_caller_tag("persons/list"):
+                serialized_actors = get_serialized_people(team, actor_ids)
 
-        restricted_person_properties = self.get_serializer_context().get("restricted_person_properties")
-        if restricted_person_properties:
-            for person_dict in serialized_actors:
-                properties = person_dict.get("properties")
-                if isinstance(properties, dict):
-                    person_dict["properties"] = {
-                        k: v for k, v in properties.items() if k not in restricted_person_properties
-                    }
+            restricted_person_properties = self.get_serializer_context().get("restricted_person_properties")
+            if restricted_person_properties:
+                for person_dict in serialized_actors:
+                    properties = person_dict.get("properties")
+                    if isinstance(properties, dict):
+                        person_dict["properties"] = {
+                            k: v for k, v in properties.items() if k not in restricted_person_properties
+                        }
 
-        _should_paginate = len(actor_ids) >= filter.limit
+            _should_paginate = len(actor_ids) >= filter.limit
 
-        # If the undocumented include_total param is set to true, we'll return the total count of people
-        # This is extra time and DB load, so we only do this when necessary, which is in PostHog 3000 navigation
-        # TODO: Use a more scalable solution before PostHog 3000 navigation is released, and remove this param
-        total_count: Optional[int] = None
-        if "include_total" in request.GET:
-            count_inner = actors_runner.to_query()
-            count_inner.limit = None
-            count_inner.offset = None
-            count_query = ast.SelectQuery(
-                select=[ast.Call(name="count", args=[])],
-                select_from=ast.JoinExpr(table=count_inner),
-            )
-            total_count = execute_hogql_query(count_query, team=team).results[0][0]
+            # If the undocumented include_total param is set to true, we'll return the total count of people
+            # This is extra time and DB load, so we only do this when necessary, which is in PostHog 3000 navigation
+            # TODO: Use a more scalable solution before PostHog 3000 navigation is released, and remove this param
+            total_count: Optional[int] = None
+            if include_total:
+                count_inner = actors_runner.to_query()
+                count_inner.limit = None
+                count_inner.offset = None
+                count_query = ast.SelectQuery(
+                    select=[ast.Call(name="count", args=[])],
+                    select_from=ast.JoinExpr(table=count_inner),
+                )
+                total_count = execute_hogql_query(count_query, team=team).results[0][0]
+
+            slo.tag(result_count=len(actor_ids))
 
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None
         previous_url = (

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -85,6 +85,32 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 1)
 
+    @parameterized.expand([("?search=another@gm", True), ("", False)])
+    def test_person_list_emits_slo_event(self, query: str, expected_has_search: bool) -> None:
+        _create_person(
+            team=self.team,
+            distinct_ids=["distinct_id"],
+            properties={"email": "another@gmail.com"},
+        )
+        flush_persons_and_events()
+
+        with mock.patch("posthog.slo.events.posthoganalytics.capture") as capture:
+            response = self.client.get(f"/api/person/{query}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        completed = [
+            call.kwargs["properties"]
+            for call in capture.call_args_list
+            if call.kwargs["event"] == "slo_operation_completed"
+            and call.kwargs["properties"]["operation"] == "persons_list"
+        ]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["has_search"], expected_has_search)
+        self.assertEqual(completed[0]["actor_type"], "person")
+        self.assertEqual(completed[0]["outcome"], "success")
+        self.assertEqual(completed[0]["result_count"], 1)
+        self.assertGreater(completed[0]["duration_ms"], 0)
+
     @also_test_with_materialized_columns(event_properties=["email"], person_properties=["email"])
     @snapshot_clickhouse_queries
     def test_search_person_id(self) -> None:

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -33,6 +33,7 @@ from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, ExecutionMode, QueryRunner, get_query_runner
 from posthog.hogql_queries.utils.person_display_name import person_display_name_property_exprs
 from posthog.models import User
+from posthog.slo.context import tag_current_slo
 
 
 class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
@@ -264,6 +265,10 @@ class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
         # `hogql_cohort_query._actors_query_from_source`) that invoke `to_query()` with
         # platform-constant select lists are not mis-attributed.
         tag_contains_user_hogql()
+        # Search is the expensive arm of an actors query, so the surrounding SLO event needs to
+        # separate it from a plain listing. Works for both entry points: `run()` opens a
+        # query-service SLO, `/api/persons/` opens a persons-list one.
+        tag_current_slo(has_search=bool(self.query.search), actor_type=self.strategy.field)
         try:
             self.calculating = True
             return self._calculate_internal()

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1145,6 +1145,12 @@ API_ENVIRONMENTS_SUNSET_DATE = get_from_env("API_ENVIRONMENTS_SUNSET_DATE", "202
 # Defaults to 1.0 under TEST so assertions on emitted SLO events are deterministic.
 QUERY_SERVICE_SLO_SAMPLE_RATE = get_from_env("QUERY_SERVICE_SLO_SAMPLE_RATE", 1.0 if TEST else 0.01, type_cast=float)
 
+# Persons list SLO sampling rate. That endpoint runs its ActorsQuery through `calculate()`,
+# not `run()`, so it emits no query-service SLO events at all. It is lower volume than the
+# query service and its slow tail is the point of the measurement, so it samples ten times
+# higher. Same weighting rule: divide counts by `properties.sample_rate`.
+PERSONS_LIST_SLO_SAMPLE_RATE = get_from_env("PERSONS_LIST_SLO_SAMPLE_RATE", 1.0 if TEST else 0.1, type_cast=float)
+
 ####
 # Livestream
 

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -16,6 +16,7 @@ class SloOperation(StrEnum):
     ALERT_CHECK = "alert_check"
     ALERT_DELIVERY = "alert_delivery"
     QUERY_SERVICE = "query_service"
+    PERSONS_LIST = "persons_list"
     DASHBOARD_WIDGET_DELIVERY = "dashboard_widget_delivery"
     PULSE_BRIEF_GENERATION = "pulse-brief-generation"
     SYNC_EVENTS_RETENTION = "sync_events_retention"


### PR DESCRIPTION
## Problem

Person search times out on large projects, and nobody can see how slow it is. The `/api/persons/` endpoint the cmd+K palette calls emits no latency telemetry at all.

That endpoint runs its ActorsQuery through `calculate()`, which skips the `QueryRunner.run()` path where SLO events come from. The query-service events that do exist cannot tell a search apart from a plain listing.

So there is nothing to measure the search work against, before or after.

Refs #43419

## Changes

- Person search latency becomes measurable. A `persons_list` SLO operation wraps the endpoint's query and hydration, and its `slo_operation_completed` event carries `duration_ms`.
- Actor query events now separate a search from a plain listing. `has_search` and `actor_type` are tagged on the actors query runner, so `/api/query/` gains the same split without a second call site.
- The search term is never recorded. Only the shape of the request: search, properties, distinct id, limit, offset, and whether a total was asked for.
- Sampling is 10%, set by `PERSONS_LIST_SLO_SAMPLE_RATE`. The query service samples at 1%, too thin for this endpoint's slow tail.
- Nothing user-visible changes. The endpoint returns the same response; the diff is an indentation move plus the instrumentation around it.

A separate `persons_list` operation, rather than reusing `query_service`, keeps a high-volume endpoint out of the query service's existing SLO numbers.

The dashboard tiles that read these events are not here. This PR emits the data; charting it lands separately.

## How did you test this code?

Added `test_person_list_emits_slo_event`, parameterized over a search and a plain listing. It catches the endpoint's query moving out of the SLO block, and `has_search` going untagged. Either one silently drops the measurement, and no existing test reads SLO events for this endpoint.

Not verified: behavior in production, and the sampling rate against real endpoint volume. The 10% default is an estimate.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code in a PostHog Desktop cloud task.
- Skills invoked: `/improving-drf-endpoints`, `/writing-pr-descriptions`.
- The session first surveyed what already measures actor query latency: the query-service SLO events, the frontend `query completed` event, and the `posthog_query_execution_duration_seconds` histogram. Each misses either the palette surface or the search dimension, which set the scope here.
- Reusing `query_service` for the endpoint was considered and dropped, for the reason given under Changes.
- A later revision dropped the terraform dashboard commit, on request, to keep this PR to the instrumentation.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
