### PR TITLE
feat(desktop): ask new-session research prompts for a canvas

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/channelTaskSuggestions.ts
+++ b/products/desktop/packages/ui/src/features/canvas/channelTaskSuggestions.ts
@@ -1,11 +1,11 @@
 import {
   Bug,
-  ChartBar,
   ChartLine,
   ChatCircleText,
   Cube,
   CurrencyDollar,
   Flask,
+  SquaresFour,
   Wrench,
 } from "@phosphor-icons/react";
 import type { SuggestedPrompt } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
@@ -17,6 +17,9 @@ import type { SuggestedPrompt } from "@posthog/ui/features/task-detail/component
 // keeps its discovery suggestions. Card styling mirrors SuggestedTaskCard
 // (icon badge + title + description); the icon/color follow the same
 // `var(--<color>-N)` token scheme.
+//
+// The research prompts end by asking for a canvas, so the answer is a surface
+// the user can keep and share instead of chat history.
 export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
   {
     label: "Debug a user issue",
@@ -25,7 +28,7 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     color: "red",
     mode: "auto",
     prompt:
-      "Help me debug an issue a specific user is hitting. Pull their recent events, session replays, and errors, then figure out what went wrong.\n\n\nUser input:\n- Describe the user issue:\n- User identifier (distinct ID, email address, etc):",
+      "Help me debug an issue a specific user is hitting. Pull their recent events, session replays, and errors, then figure out what went wrong. Build a canvas that explains what you found and the evidence behind it.\n\n\nUser input:\n- Describe the user issue:\n- User identifier (distinct ID, email address, etc):",
   },
   {
     label: "Run a feature analysis",
@@ -34,7 +37,7 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     color: "blue",
     mode: "auto",
     prompt:
-      "Analyze how a feature is performing — adoption, engagement, and retention of users who use it vs. those who don't.\n\n\nUser input:\n- Feature to analyze:\n- Time period (optional):",
+      "Analyze how a feature is performing — adoption, engagement, and retention of users who use it vs. those who don't. Build a canvas that explains what you found, with the charts behind it.\n\n\nUser input:\n- Feature to analyze:\n- Time period (optional):",
   },
   {
     label: "Understand revenue patterns",
@@ -43,16 +46,16 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     color: "green",
     mode: "auto",
     prompt:
-      "Analyze our revenue trends — break it down over time, by plan, and by cohort, and call out notable changes and likely drivers.\n\n\nUser input:\n- What revenue question are you trying to answer:\n- Time period (optional):",
+      "Analyze our revenue trends — break it down over time, by plan, and by cohort, and call out notable changes and likely drivers. Build a canvas that explains what you found, with the charts behind it.\n\n\nUser input:\n- What revenue question are you trying to answer:\n- Time period (optional):",
   },
   {
-    label: "Summarize product usage",
-    description: "Top events, active users, and key funnels",
-    icon: ChartBar,
+    label: "Build a canvas",
+    description: "Research a question and explain the answer",
+    icon: SquaresFour,
     color: "violet",
     mode: "auto",
     prompt:
-      "Summarize how our product is being used — top events, active users, key funnels, and notable trends.\n\n\nUser input:\n- Product area or feature to focus on (optional):\n- Time period (optional):",
+      "Research a question about our product, then build a canvas that explains the answer. Include the charts that show it and short written context for what they mean.\n\n\nUser input:\n- What should the canvas explain:\n- Time period (optional):",
   },
   {
     label: "Summarize user & agent feedback",
@@ -61,7 +64,7 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     color: "amber",
     mode: "auto",
     prompt:
-      "Summarize recent user and support/agent feedback — surface the common themes, complaints, and requests.\n\n\nUser input:\n- Feedback source or topic to focus on:\n- Time period (optional):",
+      "Summarize recent user and support/agent feedback — surface the common themes, complaints, and requests. Build a canvas that explains the themes, with examples behind each one.\n\n\nUser input:\n- Feedback source or topic to focus on:\n- Time period (optional):",
   },
   {
     label: "Interpret experiment results",
@@ -70,7 +73,7 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     color: "purple",
     mode: "auto",
     prompt:
-      "Interpret the results of an experiment — explain what the metrics show, whether it's significant, and what to do next.\n\n\nUser input:\n- Experiment name or key:\n- What decision are you trying to make (optional):",
+      "Interpret the results of an experiment — explain what the metrics show, whether it's significant, and what to do next. Build a canvas that explains the result and your recommendation.\n\n\nUser input:\n- Experiment name or key:\n- What decision are you trying to make (optional):",
   },
   {
     label: "Fix a bug",


### PR DESCRIPTION
## Problem

Someone who starts a session from a research starter card on the new-session screen gets the answer as chat inside that session, so there is nothing to return to or share afterwards.

- The cards can start research, but none of them asks for a canvas, even though the agent can build one.
- Product usage already had a card, and it overlapped with the feature-analysis card next to it.

## Changes

- The "Summarize product usage" card becomes "Build a canvas". It researches a question and explains the answer on a canvas, and asks the user what the canvas should explain.
- The five remaining research cards now end their prompt by asking for a canvas that explains the findings.
- The two code cards, "Fix a bug" and "Build a new feature", are unchanged.
- Mechanical: the card's icon swaps to `SquaresFour`, which this app already uses for canvases and dashboards.

Nothing about the screen's layout changes. One card in the list shows a different label, description, and icon. The other seven look the same, so no screenshot would show anything a reader cannot get from the diff.

The prompts ask for a canvas rather than a notebook because a canvas can hold both the charts and the written context, and stays open in the space the session ran in.

## How did you test this code?

- `pnpm --filter @posthog/ui typecheck` and `biome check` on the changed file both pass.
- No automated tests cover this list, and none were added: the change is prompt copy in a data file, and a test asserting a string against itself catches no regression.
- Not run: the desktop app itself. This sandbox has no build of it, so the cards were not seen rendered.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop. The driver asked for a canvas-building card on the new-session screen and for the research prompts to ask for a canvas as well, and chose which card to replace.

Skills invoked: `/writing-user-facing-copy` and `/writing-pr-descriptions`. The copy skill caught an em-dash and a clever closing clause in the first drafts of the new prompt and the experiment prompt, which were rewritten as plain sentences.

The label went through "Build a canvas to explain something" before settling on "Build a canvas", so the description carries what gets explained instead of the label running long against the card's truncation.

No customer data, session material, or internal context is in this diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
