### PR TITLE
fix(alerts): stop retrying unavailable email alerts

### DIFF
--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -488,7 +488,7 @@ def add_alert_check(
     return alert_check, should_notify(outcome)
 
 
-def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> AlertCheck:
+def disable_invalid_alert(alert: AlertConfiguration, reason: str, *, notify_subscribers: bool = True) -> AlertCheck:
     """Auto-disable a misconfigured alert and email its subscribers.
 
     Used for configuration problems that make the alert unevaluable as set up — a deliberate,
@@ -509,7 +509,7 @@ def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> AlertCheck:
         state=AlertState.ERRORED,
         error={"message": reason},
     )
-    if targets_to_notify:
+    if targets_to_notify and notify_subscribers:
         deliveries = send_notifications_for_disabled(alert, reason, targets_to_notify)
         record_alert_delivery(alert, alert_check, deliveries)
     return alert_check

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -14,6 +14,7 @@ from posthog.schema import AlertState
 from posthog.hogql.errors import TableAccessDeniedError
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.email import is_email_available
 from posthog.errors import CH_TRANSIENT_ERRORS
 from posthog.exceptions_capture import capture_exception
 from posthog.query_creator_access import creator_access_revoked, report_creator_access_revoked
@@ -133,6 +134,14 @@ async def prepare_alert(inputs: PrepareAlertActivityInputs) -> PrepareAlertResul
                 insight_id=alert.insight_id,
             )
             return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.INSIGHT_DELETED)
+
+        # Email-backed alerts cannot deliver anything on instances without an email transport.
+        # Disable them before evaluation so the scheduler does not repeatedly retry delivery.
+        # Do not send the usual disabled-alert email: that would fail for the same reason.
+        if alert.get_subscribed_users_emails() and not is_email_available():
+            reason = "Email delivery is unavailable on this instance. Configure email before re-enabling this alert."
+            disable_invalid_alert(alert, reason, notify_subscribers=False)
+            return PrepareAlertResult(action=PrepareAction.AUTO_DISABLE, reason=reason)
 
         # Plan downgrade protection: entitlement-gated intervals must stop evaluating when the
         # org loses the feature (e.g. billing downgrade), since API validation only runs on writes.

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -327,6 +327,24 @@ class TestPrepareAlert:
         assert check.error is not None
         assert result.reason in check.error["message"]
 
+    async def test_auto_disable_email_alert_when_email_is_unavailable(self, alert_with_user) -> None:
+        with patch("posthog.temporal.alerts.activities.is_email_available", return_value=False):
+            env = ActivityEnvironment()
+            result = await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(alert_with_user.id)))
+
+        assert result.action == PrepareAction.AUTO_DISABLE
+        assert (
+            result.reason
+            == "Email delivery is unavailable on this instance. Configure email before re-enabling this alert."
+        )
+
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert_with_user.pk)
+        assert refreshed.enabled is False
+        assert refreshed.state == AlertState.ERRORED
+
+        check = await sync_to_async(AlertCheck.objects.get)(alert_configuration=refreshed)
+        assert check.error == {"message": result.reason}
+
     async def test_evaluate_for_valid_alert(self, alert) -> None:
         env = ActivityEnvironment()
         result = await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(alert.id)))


### PR DESCRIPTION
## Problem

Email-backed alerts can remain enabled on instances without an email transport. Each scheduled notification then fails with the same configuration error and is retried instead of being surfaced as an actionable alert configuration problem.

## Changes

- Automatically disable email-backed alerts when email delivery is unavailable.
- Record a clear error on the resulting alert check so the alert is visibly unsendable.
- Skip the disabled-alert email when email itself is unavailable.
- Add regression coverage for the prepare-time behavior.

## How did you test this code?

- `uv run ruff check posthog/temporal/alerts/activities.py posthog/tasks/alerts/utils.py posthog/temporal/tests/test_alerts_activities.py`
- `uv run ruff format --check posthog/temporal/alerts/activities.py posthog/tasks/alerts/utils.py posthog/temporal/tests/test_alerts_activities.py`
- The targeted pytest command was invoked, but this environment returned no test output; CI should run the regression test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app used the repository tools and the `querying-posthog-data` skill. The implementation uses the existing errored/disabled alert lifecycle and preserves the configured alert for re-enablement after email is configured.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1787554910958869?thread_ts=1787554910.958869&cid=C09BDQLM8KA)*