### PR TITLE
fix(workflows): sign cancel JWTs with a dedicated secret

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -1737,7 +1737,7 @@ describe('CDP API', () => {
         const mintCancelToken = (
             teamId: number,
             hogFlowId: string,
-            { secret = 'local-dev-workflows-reschedule-jwt', audience = 'posthog:workflows:cancel_invocations' } = {}
+            { secret = 'local-dev-workflows-cancel-jwt', audience = 'posthog:workflows:cancel_invocations' } = {}
         ) => jwt.sign({ team_id: teamId, hog_flow_id: hogFlowId }, secret, { audience, expiresIn: '2m' })
 
         // No hog flow row exists for this id: cancel deliberately skips the flow lookup so it
@@ -1789,12 +1789,22 @@ describe('CDP API', () => {
             ],
             ["another team's token", () => ({ Authorization: `Bearer ${mintCancelToken(team.id + 1, cancelFlowId)}` })],
             [
-                // The cancel purpose shares its signing key with reschedule_parked, so the audience
-                // is the only thing keeping a reschedule token out of cancel.
+                // Cancel and reschedule use separate keys now, so a reschedule-audience token is
+                // rejected on audience regardless of which key signed it.
                 'a reschedule-audience token',
                 () => ({
                     Authorization: `Bearer ${mintCancelToken(team.id, cancelFlowId, {
                         audience: 'posthog:workflows:reschedule_parked',
+                    })}`,
+                }),
+            ],
+            [
+                // The cancel key is dedicated: a cancel-audience token signed with the reschedule
+                // sweep's key must be rejected, or splitting the keys would buy no real isolation.
+                'a token signed with the reschedule key',
+                () => ({
+                    Authorization: `Bearer ${mintCancelToken(team.id, cancelFlowId, {
+                        secret: 'local-dev-workflows-reschedule-jwt',
                     })}`,
                 }),
             ],
@@ -1837,7 +1847,7 @@ describe('CDP API', () => {
             teamId: number,
             hogFlowId: string,
             {
-                secret = 'local-dev-workflows-reschedule-jwt',
+                secret = 'local-dev-workflows-cancel-jwt',
                 audience = 'posthog:workflows:cancel_batch',
                 batchJob = batchJobId,
             } = {}
@@ -1901,8 +1911,8 @@ describe('CDP API', () => {
                 }),
             ],
             [
-                // The batch purpose shares its signing key with the other workflows purposes, so
-                // the audience is the only thing keeping an invocations-cancel token out of here.
+                // The two cancel purposes share the cancel key, so the audience is the only thing
+                // keeping an invocations-cancel token out of the batch route.
                 'an invocations-cancel-audience token',
                 () => ({
                     Authorization: `Bearer ${mintBatchToken(team.id, batchFlowId, {

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -208,11 +208,11 @@ export class CdpApi {
         )
         this.cancelInvocationsJwt = new ScopedServiceJwt(
             PosthogJwtAudience.WORKFLOWS_CANCEL_INVOCATIONS,
-            config.WORKFLOWS_RESCHEDULE_JWT_SECRET || ''
+            config.WORKFLOWS_CANCEL_JWT_SECRET || ''
         )
         this.cancelBatchJwt = new ScopedServiceJwt(
             PosthogJwtAudience.WORKFLOWS_CANCEL_BATCH,
-            config.WORKFLOWS_RESCHEDULE_JWT_SECRET || ''
+            config.WORKFLOWS_CANCEL_JWT_SECRET || ''
         )
     }
 
@@ -1169,7 +1169,7 @@ export class CdpApi {
             }
             if (!this.cancelInvocationsJwt.enabled) {
                 return res.status(503).json({
-                    error: 'Workflows scoped auth not configured (WORKFLOWS_RESCHEDULE_JWT_SECRET unset)',
+                    error: 'Workflows scoped auth not configured (WORKFLOWS_CANCEL_JWT_SECRET unset)',
                 })
             }
 
@@ -1254,7 +1254,7 @@ export class CdpApi {
             }
             if (!this.cancelBatchJwt.enabled) {
                 return res.status(503).json({
-                    error: 'Workflows scoped auth not configured (WORKFLOWS_RESCHEDULE_JWT_SECRET unset)',
+                    error: 'Workflows scoped auth not configured (WORKFLOWS_CANCEL_JWT_SECRET unset)',
                 })
             }
 

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -179,6 +179,11 @@ export type CdpConfig = ClickhouseConfig & {
     // newest first (first signs, all verify). Deliberately NOT the fleet-wide INTERNAL_API_SECRET
     // (see .agents/security.md): empty in prod means the route fails closed until provisioned.
     WORKFLOWS_RESCHEDULE_JWT_SECRET: string
+    // Scoped JWT keys verifying Django's calls to the cancel routes (invocations/cancel and
+    // batch_jobs/:id/cancel). A dedicated key, separate from the reschedule sweep's above: the
+    // web tier mints cancels while the worker mints reschedules, so neither tier's key can forge
+    // the other's calls. Same comma-separated rotation and fail-closed-when-empty semantics.
+    WORKFLOWS_CANCEL_JWT_SECRET: string
     // Scoped JWT keys signing the workflow engine's task-create calls to Django, with the same
     // comma-separated rotation and fail-closed-when-empty semantics as the secret above.
     TASKS_CREATE_JWT_SECRET: string
@@ -338,6 +343,8 @@ export function getDefaultCdpConfig(): CdpConfig {
         // mass wake, so wakes are trickled (500k parked @ 200/s ≈ 42 min spread).
         // Dev/test default must match Django's (posthog/settings/data_stores.py).
         WORKFLOWS_RESCHEDULE_JWT_SECRET: isTestEnv() || isDevEnv() ? 'local-dev-workflows-reschedule-jwt' : '',
+        // Dev/test default must match Django's (posthog/settings/data_stores.py).
+        WORKFLOWS_CANCEL_JWT_SECRET: isTestEnv() || isDevEnv() ? 'local-dev-workflows-cancel-jwt' : '',
         // Dev/test default must match Django's (posthog/settings/data_stores.py).
         TASKS_CREATE_JWT_SECRET: isTestEnv() || isDevEnv() ? 'local-dev-tasks-create-jwt' : '',
         CYCLOTRON_NODE_RESCHEDULE_FLOOR_SECONDS: 600,

--- a/nodejs/src/common/api/middleware/internal-api-auth.ts
+++ b/nodejs/src/common/api/middleware/internal-api-auth.ts
@@ -30,9 +30,9 @@ const PUBLIC_PATH_PREFIXES = ['/public/', '/_health', '/_ready', '/_metrics', '/
 const SCOPED_AUTH_PATH_PATTERNS = [
     // CdpApi.postHogFlowRescheduleParked, verified against WORKFLOWS_RESCHEDULE_JWT_SECRET.
     /^\/api\/projects\/[^/]+\/hog_flows\/[^/]+\/reschedule_parked$/,
-    // CdpApi.postHogFlowCancelInvocations, verified against the same key, audience-pinned.
+    // CdpApi.postHogFlowCancelInvocations, verified against WORKFLOWS_CANCEL_JWT_SECRET, audience-pinned.
     /^\/api\/projects\/[^/]+\/hog_flows\/[^/]+\/invocations\/cancel$/,
-    // CdpApi.postHogFlowCancelBatchJob, verified against the same key, audience-pinned.
+    // CdpApi.postHogFlowCancelBatchJob, verified against WORKFLOWS_CANCEL_JWT_SECRET, audience-pinned.
     /^\/api\/projects\/[^/]+\/hog_flows\/[^/]+\/batch_jobs\/[^/]+\/cancel$/,
 ]
 

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -161,12 +161,13 @@ def reschedule_hog_flow_parked_jobs(
     )
 
 
-# Same signing key as reschedule_parked: every workflows route on the CDP API verifies against
-# WORKFLOWS_RESCHEDULE_JWT_SECRET, so the key already spans that one caller/callee surface. The
-# distinct audience still keeps a cancel token useless for reschedule (and vice versa).
+# Dedicated cancel key, distinct from reschedule_parked's: the scoped-JWT rule is one key per
+# caller/callee surface, and cancel mints from the web tier while reschedule mints from the
+# worker, so a leak of one tier's key can't forge the other's calls. The distinct audience
+# still keeps a cancel-invocations token useless for cancel-batch (and vice versa).
 WORKFLOWS_CANCEL_INVOCATIONS_JWT_PURPOSE = ScopedServiceJwtPurpose(
     audience=PosthogJwtAudience.WORKFLOWS_CANCEL_INVOCATIONS,
-    settings_name="WORKFLOWS_RESCHEDULE_JWT_SECRETS",
+    settings_name="WORKFLOWS_CANCEL_JWT_SECRETS",
     default_ttl=timedelta(minutes=2),
 )
 
@@ -176,14 +177,14 @@ def _mint_cancel_invocations_jwt(team_id: int, hog_flow_id: str) -> str:
     of this one team + workflow. Raises when unprovisioned so the call fails closed. Verified in
     the plugin server's CdpApi.postHogFlowCancelInvocations."""
     if not WORKFLOWS_CANCEL_INVOCATIONS_JWT_PURPOSE.enabled():
-        raise RuntimeError("WORKFLOWS_RESCHEDULE_JWT_SECRET is not configured — cannot cancel invocations")
+        raise RuntimeError("WORKFLOWS_CANCEL_JWT_SECRET is not configured — cannot cancel invocations")
     return WORKFLOWS_CANCEL_INVOCATIONS_JWT_PURPOSE.mint({"team_id": team_id, "hog_flow_id": hog_flow_id})
 
 
-# Same shared workflows signing key as the purposes above, on its own audience.
+# Same dedicated cancel key as cancel-invocations (both mint from the web tier), on its own audience.
 WORKFLOWS_CANCEL_BATCH_JWT_PURPOSE = ScopedServiceJwtPurpose(
     audience=PosthogJwtAudience.WORKFLOWS_CANCEL_BATCH,
-    settings_name="WORKFLOWS_RESCHEDULE_JWT_SECRETS",
+    settings_name="WORKFLOWS_CANCEL_JWT_SECRETS",
     default_ttl=timedelta(minutes=2),
 )
 
@@ -193,7 +194,7 @@ def _mint_cancel_batch_jwt(team_id: int, hog_flow_id: str, batch_job_id: str) ->
     this one batch run of this one team + workflow. Raises when unprovisioned so the call fails
     closed. Verified in the plugin server's CdpApi.postHogFlowCancelBatchJob."""
     if not WORKFLOWS_CANCEL_BATCH_JWT_PURPOSE.enabled():
-        raise RuntimeError("WORKFLOWS_RESCHEDULE_JWT_SECRET is not configured — cannot stop the batch run")
+        raise RuntimeError("WORKFLOWS_CANCEL_JWT_SECRET is not configured — cannot stop the batch run")
     return WORKFLOWS_CANCEL_BATCH_JWT_PURPOSE.mint(
         {"team_id": team_id, "hog_flow_id": hog_flow_id, "batch_job_id": batch_job_id}
     )

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -557,6 +557,17 @@ WORKFLOWS_RESCHEDULE_JWT_SECRETS = get_list(
     get_from_env("WORKFLOWS_RESCHEDULE_JWT_SECRET", "local-dev-workflows-reschedule-jwt" if DEBUG or TEST else "")
 )
 
+# Scoped JWT keys for the workflows cancel routes (invocations/cancel and batch_jobs/:id/cancel).
+# Web mints, the plugin server's cancel routes verify. A dedicated key per the scoped-JWT rule
+# (one key per caller/callee surface), so cancel from the web tier never carries the reschedule
+# sweep's key, and a leak of one can't forge the other. Comma-separated, newest first: the first
+# key signs, the plugin server verifies against all. Empty outside dev/test, so the cancel routes
+# fail closed until provisioned. The dev/test value must match the plugin server's default
+# (nodejs/src/cdp/config.ts).
+WORKFLOWS_CANCEL_JWT_SECRETS = get_list(
+    get_from_env("WORKFLOWS_CANCEL_JWT_SECRET", "local-dev-workflows-cancel-jwt" if DEBUG or TEST else "")
+)
+
 # Signs the tokens a workflow's "Create AI task" action calls back with. The dev/test value
 # must match the plugin server's minting default so local workflows work with no setup.
 TASKS_CREATE_JWT_SECRETS = get_list(


### PR DESCRIPTION
## Problem

- A leaked signing key from the web tier can forge the worker's reschedule-sweep calls, and a worker leak can forge cancels: all three workflows service JWTs share `WORKFLOWS_RESCHEDULE_JWT_SECRET`.
- The shared name is also an operational trap: cancel mints from the web tier, reschedule from the worker, so a cancel provisioning gap hides behind an env var named "reschedule". That gap shipped: cancel failed closed in production until PostHog/charts#14601.
- The scoped-JWT rule (`posthog/scoped_service_jwt.py`) is one key per caller/callee surface; the cancel purposes violated it.

## Changes

> [!WARNING]
> Deploy order: `WORKFLOWS_CANCEL_JWT_SECRET` must be provisioned in an environment (PostHog/charts#14601 wires it into the web tier and cdp-api) before this change reaches it. Until provisioning lands, cancels fail closed there.

- Cancel invocations and batch cancel now sign and verify with a dedicated `WORKFLOWS_CANCEL_JWT_SECRET`; the reschedule sweep keeps `WORKFLOWS_RESCHEDULE_JWT_SECRET`. A leak of one tier's key can no longer forge the other's calls.
- Missing-secret errors (Django mint and the Node 503s) now name the env var that is actually unset.
- Nothing user-visible changes when deploys are ordered as above; the two cancel audiences stay mutually exclusive as before.
- Mechanical: comment updates in the auth middleware and tests, dev/test defaults (`local-dev-workflows-cancel-jwt`) kept in Python/Node lockstep.

## How did you test this code?

- New Jest case: the cancel route rejects a cancel-audience token signed with the reschedule key — the isolation this split exists to provide; no existing case covered cross-key acceptance. Existing cancel cases re-mint with the dedicated dev key.
- Ran in the sandbox: `ruff check`/`format` (clean), plugin-server `tsc` (edited files clean; remaining errors are pre-existing unbuilt-workspace-package noise), `eslint` on the four edited files (clean).
- Not run: the Jest cdp-api suite and Python suites (sandbox has no built workspace deps or running stack); CI covers them. Python cancel API tests mock the CDP proxy above the mint, so they are unaffected.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal service-to-service auth configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in a PostHog Desktop task; assignee is the driving user (verified via `gh api user` this session). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Session decisions: one dedicated key for both cancel audiences (they mint from the same web tier; audiences already separate them) rather than a key per audience; provisioning wired ahead of time into PostHog/charts#14601 at the driver's direction, so this PR is merge-gated on that chart change syncing.
- Overlaps with #87789 on the mint-failure raise lines in `plugin_server_api.py`; whichever lands second rebases trivially.
