### PR TITLE
fix(mcp): open a session when the credential lacks user:read

### DIFF
--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -1,6 +1,6 @@
 import { ApiClient } from '@/api/client'
 import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
-import { wrapError } from '@/lib/errors'
+import { findPostHogPermissionError, wrapError } from '@/lib/errors'
 import { getPostHogClient } from '@/lib/posthog'
 import {
     AnalyticsEvent,
@@ -148,6 +148,9 @@ export class RequestContext {
         }
         const userResult = await (await this.api()).users().me()
         if (!userResult.success) {
+            if (findPostHogPermissionError(userResult.error) && this.props.userHash) {
+                return this.props.userHash
+            }
             throw wrapError(`Failed to get user: ${userResult.error.message}`, userResult.error)
         }
         const distinctId = userResult.data.distinct_id as string

--- a/services/mcp/src/hono/request-utils.ts
+++ b/services/mcp/src/hono/request-utils.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { classifyAuthFailure, mapErrorToAuthResponse, validateBearerToken } from '@/lib/auth-errors'
+import { classifyAuthMethod } from '@/lib/auth-method'
 import { getPostHogClient } from '@/lib/posthog'
 import {
     type ClientInfo,
@@ -113,7 +114,7 @@ export async function authenticateAndParse(
 
 export function handleCatchError(error: unknown, props: RequestProperties): Response {
     console.error('[handleCatchError]', error)
-    const authResponse = mapErrorToAuthResponse(error)
+    const authResponse = mapErrorToAuthResponse(error, classifyAuthMethod(props.apiToken))
     if (authResponse) {
         const reason = authResponse.status === 403 ? 'insufficient_scope' : 'invalid_token'
         authFailuresTotal.inc({ reason })

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -4,6 +4,7 @@ import { hasScope } from '@/lib/api'
 import type { ScopedCache } from '@/lib/cache/ScopedCache'
 import {
     ErrorCode,
+    findPostHogPermissionError,
     MissingOrganizationContextError,
     MissingProjectContextError,
     PostHogApiError,
@@ -11,7 +12,7 @@ import {
 } from '@/lib/errors'
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
 import { getPostHogClient } from '@/lib/posthog'
-import { sanitizeHeaderValue } from '@/lib/utils'
+import { hash, sanitizeHeaderValue } from '@/lib/utils'
 import type { ApiUser } from '@/schema/api'
 import type { CachedOrg, CachedProject, CachedUser, State } from '@/tools/types'
 
@@ -113,7 +114,16 @@ export class StateManager {
         let _distinctId = await this._cache.get('distinctId')
 
         if (!_distinctId) {
-            const user = await this.getUser()
+            const user = await this.getUser().catch((error: unknown) => {
+                if (findPostHogPermissionError(error)) {
+                    return null
+                }
+                throw error
+            })
+
+            if (!user) {
+                return hash(this._api.config.apiToken)
+            }
 
             await this._cache.set('distinctId', user.distinct_id)
             _distinctId = user.distinct_id
@@ -136,8 +146,12 @@ export class StateManager {
         organizationId?: string
         projectId?: number
     }> {
-        const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([this.getApiKey(), this.getUser()])
-        const { organization: activeOrganization, team: activeTeam } = user
+        const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([
+            this.getApiKey(),
+            this.getUser().catch(() => null),
+        ])
+        const activeOrganization = user?.organization ?? null
+        const activeTeam = user?.team ?? null
 
         // Team-scoped key: prefer the active team if the scope allows it,
         // otherwise pick the first scoped team deterministically. The org is

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -30,6 +30,7 @@ export class StateManager {
     private _cache: ScopedCache<State>
     private _api: ApiClient
     private _user?: ApiUser
+    private _fallbackDistinctId?: string
     constructor(cache: ScopedCache<State>, api: ApiClient) {
         this._cache = cache
         this._api = api
@@ -122,7 +123,7 @@ export class StateManager {
             })
 
             if (!user) {
-                return hash(this._api.config.apiToken)
+                return this._getFallbackDistinctId()
             }
 
             await this._cache.set('distinctId', user.distinct_id)
@@ -130,6 +131,31 @@ export class StateManager {
         }
 
         return _distinctId
+    }
+
+    /**
+     * Stand-in distinct id for a credential that `users/@me` refuses. It is
+     * never written to the shared cache, so a credential that later gains
+     * `user:read` resolves its real distinct id on the next session.
+     *
+     * The value is held on the instance because `hash` is a deliberately slow
+     * PBKDF2 and runs synchronously. `getCachedOrFetchUser` resolves the
+     * distinct id before anything else, and the consent, entitlement, and
+     * environment-prompt paths each reach it, so recomputing the hash would
+     * block the event loop several times per request. A StateManager lives for
+     * one request, which is what keeps the value out of the shared cache.
+     *
+     * This must stay equal to `RequestProperties.userHash`, which hashes the
+     * same bearer token with the same function.
+     * `RequestContext.resolveDistinctId` falls back to that value, and
+     * pre-session events such as `$mcp_auth_failed` are already attributed to
+     * it.
+     */
+    private _getFallbackDistinctId(): string {
+        if (!this._fallbackDistinctId) {
+            this._fallbackDistinctId = hash(this._api.config.apiToken)
+        }
+        return this._fallbackDistinctId
     }
 
     /**
@@ -148,6 +174,11 @@ export class StateManager {
     }> {
         const [{ scoped_organizations, scoped_teams }, user] = await Promise.all([
             this.getApiKey(),
+            // Any failure resolves to no active org or team, because this method must
+            // not throw. An outage does not become a working session through this
+            // path: `RequestContext.resolveDistinctId` makes the same user call on
+            // every request and tolerates only a refused scope, so a transient
+            // failure still fails the session there.
             this.getUser().catch(() => null),
         ])
         const activeOrganization = user?.organization ?? null
@@ -340,7 +371,14 @@ export class StateManager {
             ])
             return data as State[D]
         } catch (error) {
-            this._reportException(error, `get_or_fetch_${opts.name}`)
+            // A refused scope is an expected state for a narrowed credential, not a
+            // service bug, so keep it out of error tracking for the same reason
+            // `_isRecoverableNotFound` exists. Without this guard, every request from
+            // a credential that cannot read `users/@me` reports one exception for each
+            // cached entity it touches.
+            if (!findPostHogPermissionError(error)) {
+                this._reportException(error, `get_or_fetch_${opts.name}`)
+            }
             await this._cache.set(opts.fetchedAtKey, Date.now() as State[F]).catch(() => {})
             return cached
         }

--- a/services/mcp/src/lib/auth-errors.ts
+++ b/services/mcp/src/lib/auth-errors.ts
@@ -5,6 +5,7 @@
 // that — permission errors, known error-code mappings, missing/invalid token responses —
 // is identical and lives here.
 
+import type { McpAuthMethod } from '@/lib/auth-method'
 import type { CloudRegion } from '@/tools/types'
 
 import {
@@ -19,10 +20,10 @@ import { getPublicUrl } from './routing'
 
 // Map a thrown error to the appropriate auth response, or null if not auth-related.
 // Callers handle the null case (typically by emitting observability + returning 500).
-export function mapErrorToAuthResponse(error: unknown): Response | null {
+export function mapErrorToAuthResponse(error: unknown, authMethod?: McpAuthMethod): Response | null {
     const permissionError = findPostHogPermissionError(error)
     if (permissionError) {
-        return new Response(formatPermissionErrorMessage(permissionError), {
+        return new Response(formatPermissionErrorMessage(permissionError, authMethod), {
             status: 403,
             headers: {
                 'Content-Type': 'text/plain; charset=utf-8',

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -1,5 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
+import type { McpAuthMethod } from '@/lib/auth-method'
 import { getPostHogClient } from '@/lib/posthog'
 import { getToolRecoveryHint } from '@/lib/tool-error-hints'
 import { sanitizeHeaderValue } from '@/lib/utils'
@@ -305,17 +306,41 @@ export function wrapError(message: string, cause: unknown): Error {
 
 const PERSONAL_API_KEY_DOCS_URL = 'https://posthog.com/docs/api#how-to-authenticate-with-the-posthog-api'
 
-export function formatPermissionErrorMessage(error: PostHogPermissionError): string {
+function missingScopeGuidance(missingScope: string, authMethod: McpAuthMethod | undefined): string[] {
+    if (authMethod === 'oauth') {
+        return [
+            `Your connection is missing the '${missingScope}' scope.`,
+            '',
+            `To fix: reconnect PostHog in your MCP client and leave '${missingScope}' selected on the permissions screen. If the connection still appears in PostHog under Settings → Connected applications, revoke it there first so you are prompted again.`,
+        ]
+    }
+    if (authMethod === 'personal_api_key') {
+        return [
+            `Your personal API key is missing the '${missingScope}' scope.`,
+            '',
+            `To fix: edit the key in PostHog (Settings → Personal API keys) and add the '${missingScope}' scope. Alternatively, select the "MCP Server" scope preset, which includes every scope the MCP needs.`,
+            '',
+            `See: ${PERSONAL_API_KEY_DOCS_URL}`,
+        ]
+    }
+    return [
+        `Your credential is missing the '${missingScope}' scope.`,
+        '',
+        `To fix: if you are using a personal API key, edit it in PostHog (Settings → Personal API keys) and add the '${missingScope}' scope, or select the "MCP Server" scope preset. If you connected with OAuth, reconnect and leave '${missingScope}' selected on the permissions screen.`,
+        '',
+        `See: ${PERSONAL_API_KEY_DOCS_URL}`,
+    ]
+}
+
+export function formatPermissionErrorMessage(error: PostHogPermissionError, authMethod?: McpAuthMethod): string {
     const callTarget = error.method && error.url ? `${error.method} ${error.url}` : 'this MCP request'
     if (error.missingScope) {
         return [
             `Missing PostHog API scope: '${error.missingScope}'`,
             '',
-            `Your Personal API key is missing the '${error.missingScope}' scope, which is required to call ${callTarget}.`,
+            `The call to ${callTarget} was rejected.`,
             '',
-            `To fix: edit the Personal API key in PostHog (User settings → Personal API keys) and add the '${error.missingScope}' scope. Alternatively, select the "MCP Server" scope preset which includes every scope the MCP needs.`,
-            '',
-            `See: ${PERSONAL_API_KEY_DOCS_URL}`,
+            ...missingScopeGuidance(error.missingScope, authMethod),
         ].join('\n')
     }
 

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/api/client', () => ({
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
 import { RequestContext } from '@/hono/request-context'
+import { PostHogPermissionError } from '@/lib/errors'
 import type { RequestProperties } from '@/lib/request-properties'
 
 import { makeRedisRateLimitStubs } from './helpers/redis-rate-limit-stubs'
@@ -162,6 +163,23 @@ describe('RequestContext', () => {
             const ctx = new RequestContext(fakeRedis(), env, makeProps())
 
             await expect(ctx.getDistinctId()).rejects.toThrow('Failed to get user')
+        })
+
+        it('falls back to the token hash when the user lookup is refused for a missing scope', async () => {
+            mockMe.mockResolvedValue({
+                success: false,
+                error: new PostHogPermissionError({
+                    detail: "API key missing required scope 'user:read'",
+                    missingScope: 'user:read',
+                    url: 'https://us.posthog.com/api/users/@me/',
+                    method: 'GET',
+                }),
+            })
+            const redis = fakeRedis()
+            const ctx = new RequestContext(redis, env, makeProps())
+
+            await expect(ctx.getDistinctId()).resolves.toBe('test-user')
+            await expect(redis.get('mcp:token:test-user:distinctId')).resolves.toBeNull()
         })
     })
 

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ApiClient } from '@/api/client'
 import { MemoryCache } from '@/lib/cache/MemoryCache'
-import { PostHogApiError } from '@/lib/errors'
+import { PostHogApiError, PostHogPermissionError } from '@/lib/errors'
 import { StateManager } from '@/lib/StateManager'
+import { hash } from '@/lib/utils'
 import type { ApiRedactedPersonalApiKey, ApiUser } from '@/schema/api'
 import type { State } from '@/tools/types'
 
@@ -78,6 +79,47 @@ describe('StateManager', () => {
             expect(result).toBe('distinct-123')
             expect(await cache.get('distinctId')).toBe('distinct-123')
             expect(getUserSpy).toHaveBeenCalledOnce()
+        })
+
+        it('falls back to the token hash and caches nothing when the user lookup is refused', async () => {
+            const apiToken = 'phx_lacks_user_read'
+            stateManager = new StateManager(cache, {
+                config: { apiToken },
+                users: () => ({
+                    me: async () => ({
+                        success: false,
+                        error: new PostHogPermissionError({
+                            detail: "API key missing required scope 'user:read'",
+                            missingScope: 'user:read',
+                            url: 'https://us.posthog.com/api/users/@me/',
+                            method: 'GET',
+                        }),
+                    }),
+                }),
+            } as unknown as ApiClient)
+
+            await expect(stateManager.getDistinctId()).resolves.toBe(hash(apiToken))
+            expect(await cache.get('distinctId')).toBeUndefined()
+        })
+
+        it('still throws when the user lookup fails for a reason other than scope', async () => {
+            stateManager = new StateManager(cache, {
+                config: { apiToken: 'phx_test' },
+                users: () => ({
+                    me: async () => ({
+                        success: false,
+                        error: new PostHogApiError({
+                            status: 503,
+                            statusText: 'Service Unavailable',
+                            body: 'upstream is down',
+                            url: 'https://us.posthog.com/api/users/@me/',
+                            method: 'GET',
+                        }),
+                    }),
+                }),
+            } as unknown as ApiClient)
+
+            await expect(stateManager.getDistinctId()).rejects.toThrow('Failed to get user')
         })
     })
 
@@ -157,6 +199,29 @@ describe('StateManager', () => {
             expect(result.projectId).toBe(123)
             expect(result.organizationId).toBeUndefined()
             expect(await cache.get('projectId')).toBe('123')
+        })
+
+        it.each([
+            {
+                name: 'resolves no project for an unscoped key when the user lookup is refused',
+                apiKey: mockApiKey,
+                expectedProjectId: undefined,
+                expectedOrganizationId: undefined,
+            },
+            {
+                name: 'still resolves the first scoped team when the user lookup is refused',
+                apiKey: { ...mockApiKey, scoped_teams: [123, 789] },
+                expectedProjectId: 123,
+                expectedOrganizationId: undefined,
+            },
+        ])('$name', async ({ apiKey, expectedProjectId, expectedOrganizationId }) => {
+            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(apiKey)
+            vi.spyOn(stateManager, 'getUser').mockRejectedValue(new Error('Failed to get user'))
+
+            const result = await stateManager.setDefaultOrganizationAndProject()
+
+            expect(result.projectId).toBe(expectedProjectId)
+            expect(result.organizationId).toBe(expectedOrganizationId)
         })
 
         it("should use user's active org and team when no scoped restrictions", async () => {
@@ -847,6 +912,32 @@ describe('StateManager', () => {
 
             await stateManager.getOrFetchGroupTypes(projectId)
             expect(getGroupTypes).toHaveBeenCalledTimes(2)
+        })
+
+        it.each([
+            {
+                name: 'keeps a refused scope out of error tracking',
+                error: new PostHogPermissionError({
+                    detail: "API key missing required scope 'group:read'",
+                    missingScope: 'group:read',
+                    url: 'https://us.posthog.com/api/projects/42/groups_types/',
+                    method: 'GET',
+                }),
+                expectedReports: 0,
+            },
+            {
+                name: 'still reports an unexpected failure to error tracking',
+                error: new Error('API error'),
+                expectedReports: 1,
+            },
+        ])('$name', async ({ error, expectedReports }) => {
+            const reportException = vi.spyOn(stateManager as any, '_reportException').mockImplementation(() => {})
+            const mockApi = stateManager as any
+            mockApi._api = { getGroupTypes: vi.fn().mockRejectedValue(error) }
+
+            await expect(stateManager.getOrFetchGroupTypes(projectId)).resolves.toBeUndefined()
+
+            expect(reportException).toHaveBeenCalledTimes(expectedReports)
         })
 
         it('should return undefined (not stale data) when fetch succeeds then later fails', async () => {

--- a/services/mcp/tests/unit/permission-errors.test.ts
+++ b/services/mcp/tests/unit/permission-errors.test.ts
@@ -72,6 +72,33 @@ describe('formatPermissionErrorMessage', () => {
         expect(text).toContain('GET https://us.posthog.com/api/users/@me/')
     })
 
+    it.each([
+        {
+            name: 'tells an OAuth client to reconnect',
+            authMethod: 'oauth' as const,
+            expected: 'reconnect PostHog in your MCP client',
+            notExpected: 'personal API key',
+        },
+        {
+            name: 'tells a personal API key holder to edit the key',
+            authMethod: 'personal_api_key' as const,
+            expected: 'Settings → Personal API keys',
+            notExpected: 'reconnect PostHog in your MCP client',
+        },
+    ])('$name', ({ authMethod, expected, notExpected }) => {
+        const error = new PostHogPermissionError({
+            detail: "API key missing required scope 'user:read'",
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        const text = formatPermissionErrorMessage(error, authMethod)
+
+        expect(text).toContain(expected)
+        expect(text).not.toContain(notExpected)
+    })
+
     it('falls back to generic remediation when no scope is parsed', () => {
         const error = new PostHogPermissionError({
             detail: 'team access denied',


### PR DESCRIPTION
## Problem

Anyone whose PostHog credential lacks the `user:read` scope cannot open an MCP session at all, in any client.

- The session bootstrap calls `GET /api/users/@me/`, which requires `user:read`.
- That scope is optional on the OAuth consent screen and in the personal API key picker, so a narrowed read-only credential is easy to build and never works.
- The client reports a generic authorization failure. Nothing names the missing scope.
- Only people who narrow scopes row by row hit this. The `mcp_server` key preset and the consent screen's read-only bulk action both keep `user:read`, so most users never see it.

## Changes

- A session now opens when the user lookup is refused, with the tool catalog filtered to the granted scopes.
- An unscoped credential resolves no default project, so the agent calls `switch-project` first. Credentials with organization or project scoping still resolve a project.
- Two resolvers call `users/@me` on every request, and both now fall back to the token hash. `RequestContext.resolveDistinctId` and `StateManager.getDistinctId` had to be fixed together, because either one throwing kills the session.
- The token hash already identifies the same credential on pre-session events such as `$mcp_auth_failed`, so an affected session attributes to the person it always did.
- Neither fallback is written to the shared cache, so a later grant including `user:read` resolves the real distinct id. `StateManager` holds it on the request instead, because the hash is a deliberately slow PBKDF2 that the consent, entitlement, and environment-prompt paths would each recompute.
- A refused scope no longer reaches error tracking. Every cached entity lookup reported one exception, so one request from an affected credential reported several.
- Only permission errors trigger either fallback. A 5xx or a network failure still fails the session, so an outage cannot look like a working session.
- `_getDefaultOrganizationAndProject` now honors the "never throws" contract in its own docstring, which it broke by awaiting the user lookup unguarded. It catches broadly on purpose, and `getApiKey` in the same call stays uncaught so a genuine outage still fails the session.
- The missing-scope error names the remedy that fits the credential. An OAuth user is told to reconnect instead of editing a personal API key that does not exist.
- Mechanical: `mapErrorToAuthResponse` takes an optional auth method, and `handleCatchError` supplies it from the request token.

> [!WARNING]
> This changes behavior for existing credentials without `user:read`. They move from a failed connection to a working session that has no default project. Worth a second opinion from the MCP owner on whether degraded beats failing here.

No user-visible UI changed, so there are no screenshots.

## How did you test this code?

Automated tests only. No manual testing against a running MCP server.

- `request-context.test.ts` gains one case: a refused user lookup returns the token hash and caches nothing. It catches both a revert of the fallback and a widening of the catch that would swallow outages. The existing "throws when API returns an error" case still guards the non-permission path.
- `StateManager.test.ts` gains the same pair for the second resolver, driven through a stub `users/@me` so the real wrap and unwrap of the permission error runs. Nothing covered this call site before.
- `StateManager.test.ts` also covers the default project for a refused user lookup, with and without team scoping. That is the behavior the warning above describes.
- `StateManager.test.ts` covers both directions of the error-tracking guard, so a permission error stays out and an unexpected failure still reports.
- `permission-errors.test.ts` gains two cases: the OAuth message never mentions a personal API key, and the key message never says "reconnect". No existing test covered credential-specific guidance.

Not checked: a live MCP session against a running server, and the no-default-project path end to end.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `/writing-ui-components`.

The change started as a warning on the OAuth consent screen next to the error copy fix. That warning was cut for two reasons. It cannot fire for clients that send an explicit `scope` list, because the backend only builds the MCP consent context when `scope` is absent. It also does nothing for personal API keys, which fail the same way with no consent screen involved. Making the bootstrap tolerant fixes both credential types at once, so the consent-screen work was dropped rather than extended.

A later review pass added the per-request memo on the `StateManager` fallback, the error-tracking guard, and the `StateManager` test coverage. Git history confirms the `users/@me` dependency is not a recent regression. `RequestContext.resolveDistinctId` has thrown on it since the hono server landed, and the equivalent `StateManager` code predates that. What is recent is `$mcp_auth_failed`, which made the failure visible.

Public artifact: the investigation began from a support ticket. No customer conversation, identifier, or operational metric appears in the code, the tests, the commit message, or this description.
