### PR TITLE
chore(cohorts): make the cohort membership consumer's source configurable

### DIFF
--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -1,5 +1,6 @@
 import {
     KAFKA_APP_METRICS_2,
+    KAFKA_COHORT_MEMBERSHIP_CHANGED,
     KAFKA_EVENTS_JSON,
     KAFKA_HOG_INVOCATION_RESULTS,
     KAFKA_LOG_ENTRIES,
@@ -51,6 +52,14 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: string
     CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
     CDP_LEGACY_EVENT_CONSUMER_INCLUDE_WEBHOOKS: boolean
+
+    /**
+     * Source of cohort membership changes persisted to the `cohort_membership` table.
+     * Set per deployment so the consumer can follow the producer between Kafka clusters
+     * and topics without a code change.
+     */
+    CDP_COHORT_MEMBERSHIP_CONSUMER_GROUP_ID: string
+    CDP_COHORT_MEMBERSHIP_CONSUMER_TOPIC: string
 
     CDP_CYCLOTRON_BATCH_DELAY_MS: number
     CDP_CYCLOTRON_HEARTBEAT_INTERVAL_MS: number
@@ -226,6 +235,9 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
         CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,
         CDP_LEGACY_EVENT_CONSUMER_INCLUDE_WEBHOOKS: false,
+
+        CDP_COHORT_MEMBERSHIP_CONSUMER_GROUP_ID: 'cdp-cohort-membership-consumer',
+        CDP_COHORT_MEMBERSHIP_CONSUMER_TOPIC: KAFKA_COHORT_MEMBERSHIP_CHANGED,
 
         CDP_CYCLOTRON_BATCH_DELAY_MS: 50,
         CDP_CYCLOTRON_HEARTBEAT_INTERVAL_MS: 10000,

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.ts
@@ -1,14 +1,13 @@
 import { Message } from 'node-rdkafka'
 import { z } from 'zod'
 
-import { KAFKA_COHORT_MEMBERSHIP_CHANGED } from '~/common/config/kafka-topics'
 import { KafkaConsumerInterface, createKafkaConsumer } from '~/common/kafka/consumer'
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 import { PostgresUse } from '~/common/utils/db/postgres'
 import { parseJSON } from '~/common/utils/json-parse'
 import { logger } from '~/common/utils/logger'
 
-import { HealthCheckResult } from '../../types'
+import { HealthCheckResult, PluginsServerConfig } from '../../types'
 import { CdpConsumerBase, CdpConsumerBaseConfig, CdpConsumerBaseDeps } from './cdp-base.consumer'
 
 // Zod schema for validation
@@ -22,15 +21,18 @@ const CohortMembershipChangeSchema = z.object({
 
 export type CohortMembershipChange = z.infer<typeof CohortMembershipChangeSchema>
 
-export class CdpCohortMembershipConsumer extends CdpConsumerBase {
+export type CdpCohortMembershipConsumerConfig = CdpConsumerBaseConfig &
+    Pick<PluginsServerConfig, 'CDP_COHORT_MEMBERSHIP_CONSUMER_GROUP_ID' | 'CDP_COHORT_MEMBERSHIP_CONSUMER_TOPIC'>
+
+export class CdpCohortMembershipConsumer extends CdpConsumerBase<CdpCohortMembershipConsumerConfig> {
     protected name = 'CdpCohortMembershipConsumer'
     private kafkaConsumer: KafkaConsumerInterface
 
-    constructor(config: CdpConsumerBaseConfig, deps: CdpConsumerBaseDeps) {
+    constructor(config: CdpCohortMembershipConsumerConfig, deps: CdpConsumerBaseDeps) {
         super(config, deps)
         this.kafkaConsumer = createKafkaConsumer({
-            groupId: 'cdp-cohort-membership-consumer',
-            topic: KAFKA_COHORT_MEMBERSHIP_CHANGED,
+            groupId: config.CDP_COHORT_MEMBERSHIP_CONSUMER_GROUP_ID,
+            topic: config.CDP_COHORT_MEMBERSHIP_CONSUMER_TOPIC,
         })
     }
 

--- a/nodejs/src/common/config/kafka-topics.ts
+++ b/nodejs/src/common/config/kafka-topics.ts
@@ -82,6 +82,8 @@ export const KAFKA_CDP_FUNCTION_OVERFLOW = `${prefix}cdp_function_overflow${suff
 export const KAFKA_CDP_INTERNAL_EVENTS = `${prefix}cdp_internal_events${suffix}`
 export const KAFKA_CDP_CLICKHOUSE_BEHAVIORAL_COHORTS_MATCHES = `${prefix}clickhouse_behavioral_cohorts_matches${suffix}`
 export const KAFKA_COHORT_MEMBERSHIP_CHANGED = `${prefix}cohort_membership_changed${suffix}`
+// Membership changes emitted by the cohort-stream-processor (Rust) on the realtime path.
+export const KAFKA_COHORT_MEMBERSHIP_CHANGED_SHADOW = `${prefix}cohort_membership_changed_shadow${suffix}`
 // Cross-partition merge protocol trigger consumed by the cohort-stream-processor (Rust).
 export const KAFKA_PERSON_MERGE_EVENTS = `${prefix}person_merge_events${suffix}`
 

--- a/posthog/kafka_client/routing.py
+++ b/posthog/kafka_client/routing.py
@@ -31,7 +31,6 @@ from posthog.kafka_client.topics import (
     KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS,
     KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
     KAFKA_CLICKHOUSE_TOPHOG,
-    KAFKA_COHORT_MEMBERSHIP_CHANGED,
     KAFKA_DOCUMENT_EMBEDDING_RESULTS_TOPIC,
     KAFKA_DOCUMENT_EMBEDDINGS_INPUT_TOPIC,
     KAFKA_DOCUMENT_EMBEDDINGS_TOPIC,
@@ -100,8 +99,6 @@ _DEFAULT_TOPIC_ROUTING: dict[str, KafkaClusterProfile] = {
     # warpstream-cyclotron named collection, so a Django producer has to target
     # the same cluster the CDP workers produce to or the rows never arrive.
     KAFKA_HOG_INVOCATION_RESULTS: KafkaClusterProfile.CYCLOTRON,
-    # --- CALCULATED_EVENTS (Warpstream calculated-events) ---
-    KAFKA_COHORT_MEMBERSHIP_CHANGED: KafkaClusterProfile.CALCULATED_EVENTS,
     # --- REPLAY (Session replay) ---
     KAFKA_CLICKHOUSE_SESSION_RECORDING_EVENTS: KafkaClusterProfile.REPLAY,
     KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS: KafkaClusterProfile.REPLAY,

--- a/posthog/settings/kafka.py
+++ b/posthog/settings/kafka.py
@@ -217,5 +217,5 @@ KAFKA_BASE64_KEYS: bool = get_from_env("KAFKA_BASE64_KEYS", False, type_cast=str
 
 # Per-topic overrides for the kafka_client.routing map. Comma-separated
 # "topic=profile" entries; merged over the code-level defaults at lookup time.
-# Example: "cohort_membership_changed=calculated_events"
+# Example: "cdp_internal_events=cyclotron"
 KAFKA_TOPIC_ROUTING_OVERRIDES: str = os.getenv("KAFKA_TOPIC_ROUTING_OVERRIDES", "") or ""


### PR DESCRIPTION
## Problem

The `cdp-cohort-membership` consumer is the only writer to the Postgres `cohort_membership` table, and that table is what the feature-flags realtime cohort read path queries (`rust/feature-flags/src/cohorts/membership/realtime_provider.rs`). The new Rust `cohort-stream-processor` only produces membership changes to Kafka; nothing else persists them.

#79808 proposed deleting the consumer as part of decommissioning the `warpstream-calculated-events` cluster. That would remove the sink the realtime behavioral cohorts path needs, so it is closed in favour of this PR: retire the cluster, keep the consumer.

The consumer's topic was hardcoded, so it could not follow its producer to a different cluster and topic without a code change.

Refs #82624

## Changes

- The cohort membership consumer's Kafka source is now set per deployment via `CDP_COHORT_MEMBERSHIP_CONSUMER_TOPIC` and `CDP_COHORT_MEMBERSHIP_CONSUMER_GROUP_ID`, following the existing `CDP_LEGACY_EVENT_CONSUMER_*` pattern. Defaults match today's behaviour, so nothing changes until a deployment sets them.
- Mechanical: added the `cohort_membership_changed_shadow` topic constant, and dropped the `cohort_membership_changed` entry from the Django Kafka routing map — no Python producer remains and it pointed at the cluster being destroyed.

## How did you test this code?

- `npx tsc --noEmit` in `nodejs/`: no errors in any file this PR touches. The remaining errors are pre-existing and come from unbuilt workspace packages (`@posthog/hogvm`, `@posthog/replay-anonymizer`).
- `ruff check` and `ruff format --check` on the two changed Python files: clean.
- No new tests. The existing `cdp-cohort-membership.consumer.test.ts` already builds the consumer from config and produces to the resulting topic, so a hardcoded or mis-wired topic fails it.
- Not done: no manual or cluster testing, and the Jest and Python suites were not run locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop). No repo skills were invoked.

The starting point was a review of #82624's plan rather than a code change: tracing every reader and writer of the Postgres `cohort_membership` table showed the consumer is load-bearing for the realtime path, not dead weight. The alternative of leaving the topic hardcoded and repointing only the brokers was rejected — the producer writes to a different topic name, so the consumer needs both.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
