### PR TITLE
fix(tasks): stop pinning a PR head branch as a repo-less run's base

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -73,16 +73,23 @@ def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxBase
 
 
 def _resolve_protected_base_branch(ctx: TaskProcessingContext) -> str | None:
-    """The branch the agent must not commit directly onto (passed to the agent-server as --baseBranch).
+    """The run's base branch, passed to the agent-server as --baseBranch.
 
-    The task's working branch is normally the PR base it was started from, so protecting it is correct.
-    But when the working branch itself heads an open PR — e.g. a quick action started on an existing
-    posthog/* branch the agent is meant to update — the agent must commit *to* that branch, so the
-    protected base is the PR's own base instead. Without this the signed-commit guard refuses the very
-    branch the run needs to update. Best-effort: any failure falls back to the working branch.
+    The agent-server derives four things from it: the branch signed writes refuse, the `gh pr create`
+    base, the `git_signed_rewrite` rebase target, and the `git_signed_merge` source. So an unknown base
+    must stay unset rather than fall back to a guess.
+
+    The working branch is usually the base the run started from, but a resume carries forward the head
+    branch its predecessor pushed, and pinning a head branch refuses every signed write to the branch
+    the run exists to update. When the working branch heads an open PR, its own base is the answer. A
+    repo-less run cannot be checked and declares no base either, so it pins nothing and the
+    agent-server falls back to the remote default branch.
     """
     branch = ctx.branch
-    if not branch or not ctx.repository or not ctx.has_github_credentials:
+    if not branch or not ctx.repository:
+        return None
+
+    if not ctx.has_github_credentials:
         return branch
 
     try:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -324,12 +324,11 @@ def test_resolve_protected_base_branch(mocker, pr_base, branch, expected) -> Non
 
 
 def test_resolve_protected_base_skips_lookup_without_repository(mocker) -> None:
-    # Repo-less runs (e.g. Slack) must pass the branch through untouched, with no GitHub lookup.
     get = mocker.patch(
         "products.tasks.backend.temporal.process_task.activities.start_agent_server.Integration.objects.get",
     )
     context = _context(github_integration_id=42, repository=None, branch="some-branch")
-    assert _resolve_protected_base_branch(context) == "some-branch"
+    assert _resolve_protected_base_branch(context) is None
     get.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

A cloud task with no repository selected cannot commit anything on its second run: the agent is locked out of the very branch the task is about.

- `git_signed_commit`, `git_signed_merge` and `git_signed_rewrite` all refuse with "Refusing to commit directly to base branch", and raw `git commit` / `git push` are blocked in cloud runs.
- A run's `branch` field means "the branch this run works on". A resume inherits the head branch its predecessor pushed.
- `_resolve_protected_base_branch` hands that branch to the agent-server as `--baseBranch`, which is the branch signed writes refuse.
- The correction that substitutes the PR's real base (#65982) needs a repository, so a repo-less run skips it and keeps the head branch.

## Changes

- A repo-less run now sends no `--baseBranch`, so the agent-server protects the remote default branch instead of the branch the run sits on.
- A failed lookup or a missing credential still passes the declared branch through. `--baseBranch` also picks the `gh pr create` base, the `git_signed_rewrite` rebase target and the `git_signed_merge` source, so dropping it on an unknown would move where PRs open.
- The docstring now records those four consumers.
- The layer above this one stops the refusal for any pin that is really a PR head, whichever client sends it.
