### PR TITLE
fix(desktop): allow signed writes to a branch that heads an open PR

### DIFF
--- a/products/desktop/packages/git/src/signed-commit.test.ts
+++ b/products/desktop/packages/git/src/signed-commit.test.ts
@@ -2,7 +2,15 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   assertNotBehindRemote,
   behindRemoteError,
@@ -13,6 +21,7 @@ import {
   operationInProgressError,
   parseRawDiffZ,
   type RawDiffEntry,
+  resolveWriteBase,
   splitCommitMessage,
 } from "./signed-commit";
 
@@ -496,5 +505,175 @@ describe("assertNotBehindRemote", () => {
     await expect(
       assertNotBehindRemote({ cwd: agent, token: "x" }, "main", tip),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("resolveWriteBase", () => {
+  const dirs: string[] = [];
+  const run = (cwd: string, ...args: string[]) =>
+    execFileSync("git", args, { cwd, encoding: "utf8" });
+
+  function tmp(label: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), `posthog-${label}-`));
+    dirs.push(dir);
+    return dir;
+  }
+
+  // A clone whose origin/HEAD resolves, so the default-branch refusal is live.
+  function repoWithDefaultBranch(): string {
+    const remote = tmp("wb-remote");
+    execFileSync("git", ["init", "--bare", "--initial-branch", "main", remote]);
+    const clone = tmp("wb-clone");
+    run(clone, "init", "--initial-branch", "main");
+    run(clone, "config", "user.email", "e2e@posthog.com");
+    run(clone, "config", "user.name", "e2e");
+    writeFileSync(path.join(clone, "a.txt"), "a\n");
+    run(clone, "add", "a.txt");
+    run(clone, "commit", "-m", "init");
+    run(clone, "remote", "add", "origin", remote);
+    run(clone, "push", "origin", "main");
+    run(clone, "remote", "set-head", "origin", "main");
+    return clone;
+  }
+
+  let cwd: string;
+  beforeAll(() => {
+    cwd = repoWithDefaultBranch();
+  });
+  afterAll(() => {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  });
+
+  const ctx = (baseBranch: string, dir?: string) => ({
+    cwd: dir ?? cwd,
+    token: "token",
+    baseBranch,
+  });
+  const gh = (stdout: string, exitCode = 0, stderr = "") =>
+    vi.fn().mockResolvedValue({ stdout, stderr, exitCode });
+  const pr = (baseRefName: string, isCrossRepository = false) => ({
+    baseRefName,
+    isCrossRepository,
+  });
+
+  it("replaces a pin that heads an open PR with the PR's own base", async () => {
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature"),
+        "posthog/feature",
+        gh(JSON.stringify([pr("main")])),
+      ),
+    ).resolves.toBe("main");
+  });
+
+  it("keeps a pin that heads an open PR against a non-default base", async () => {
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature"),
+        "posthog/feature",
+        gh(JSON.stringify([pr("release/1")])),
+      ),
+    ).resolves.toBe("release/1");
+  });
+
+  it("ignores fork pull requests that share the head branch name", async () => {
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature"),
+        "posthog/feature",
+        gh(JSON.stringify([pr("release/1", true)])),
+      ),
+    ).rejects.toThrow("no open pull request heads it");
+  });
+
+  it("refuses when the branch heads open PRs with different bases", async () => {
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature"),
+        "posthog/feature",
+        gh(JSON.stringify([pr("main"), pr("release/1")])),
+      ),
+    ).rejects.toThrow("open pull requests with different bases");
+  });
+
+  it("allows several open PRs that agree on the base", async () => {
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature"),
+        "posthog/feature",
+        gh(JSON.stringify([pr("main"), pr("main")])),
+      ),
+    ).resolves.toBe("main");
+  });
+
+  it("refuses when no open PR heads the pinned branch", async () => {
+    await expect(
+      resolveWriteBase(ctx("posthog/feature"), "posthog/feature", gh("[]")),
+    ).rejects.toThrow("no open pull request heads it");
+  });
+
+  it("names the lookup failure instead of blaming the branch", async () => {
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature"),
+        "posthog/feature",
+        gh("", 1, "gh: not authenticated"),
+      ),
+    ).rejects.toThrow(
+      "its open pull requests could not be looked up: gh: not authenticated",
+    );
+  });
+
+  it("retries a transient lookup failure", async () => {
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", stderr: "HTTP 502", exitCode: 1 })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([pr("main")]),
+        stderr: "",
+        exitCode: 0,
+      });
+    await expect(
+      resolveWriteBase(ctx("posthog/feature"), "posthog/feature", exec),
+    ).resolves.toBe("main");
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the pin and skips the lookup when the branch differs", async () => {
+    const exec = gh("[]");
+    await expect(
+      resolveWriteBase(ctx("main"), "posthog/feature", exec),
+    ).resolves.toBe("main");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("refuses the remote default branch even when a PR heads it", async () => {
+    const exec = gh(JSON.stringify([pr("release/1")]));
+    await expect(resolveWriteBase(ctx("main"), "main", exec)).rejects.toThrow(
+      "it is the repository's default branch",
+    );
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("refuses the default branch when the pin names another branch", async () => {
+    const exec = gh(JSON.stringify([pr("release/1")]));
+    await expect(
+      resolveWriteBase(ctx("develop"), "main", exec),
+    ).rejects.toThrow("it is the repository's default branch");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("refuses when origin/HEAD cannot name the default branch", async () => {
+    const headless = tmp("wb-headless");
+    run(headless, "init", "--initial-branch", "main");
+    const exec = gh(JSON.stringify([pr("release/1")]));
+    await expect(
+      resolveWriteBase(
+        ctx("posthog/feature", headless),
+        "posthog/feature",
+        exec,
+      ),
+    ).rejects.toThrow("default branch could not be determined");
+    expect(exec).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/git/src/signed-commit.ts
+++ b/products/desktop/packages/git/src/signed-commit.ts
@@ -26,6 +26,7 @@ const DEFAULT_MAX_PAYLOAD_BYTES = 35 * 1024 * 1024;
 const MAX_GIT_BUFFER = 256 * 1024 * 1024;
 // Per-attempt cap for the GraphQL commit call; retried with backoff on timeout.
 const GH_GRAPHQL_TIMEOUT_MS = 30_000;
+const GH_PR_LOOKUP_TIMEOUT_MS = 4_000;
 
 export interface SignedCommitCtx {
   /** Working directory of the clone. */
@@ -197,11 +198,11 @@ export async function resolveRepoNameWithOwner(cwd: string): Promise<string> {
   return `${parsed.owner}/${parsed.repo}`;
 }
 
-async function resolveBaseBranch(ctx: SignedCommitCtx): Promise<string | null> {
-  if (ctx.baseBranch) return ctx.baseBranch;
-  // Fall back to the remote's default branch so the guard still fires when no
-  // explicit base is supplied. Best-effort: a clone without origin/HEAD just
-  // leaves the guard inactive rather than failing the commit.
+// Best-effort: a clone without origin/HEAD leaves the default-branch refusal
+// inactive rather than failing the commit.
+async function remoteDefaultBranch(
+  ctx: SignedCommitCtx,
+): Promise<string | null> {
   const r = await runGit(
     ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
     ctx.cwd,
@@ -215,24 +216,111 @@ async function resolveBaseBranch(ctx: SignedCommitCtx): Promise<string | null> {
   );
 }
 
+// Fork rows are dropped: `--head` matches a fork's head ref too, and the signed
+// write always lands on the origin repository, never on the fork.
+async function openPrBaseForHead(
+  ctx: SignedCommitCtx,
+  branch: string,
+  exec: typeof execGh = execGh,
+): Promise<{ bases: string[]; error: string | null }> {
+  const res = await execGhWithRetry(
+    [
+      "pr",
+      "list",
+      "--head",
+      branch,
+      "--state",
+      "open",
+      "--limit",
+      "20",
+      "--json",
+      "baseRefName,isCrossRepository",
+    ],
+    {
+      cwd: ctx.cwd,
+      env: ghTokenEnv(ctx.token),
+      timeoutMs: GH_PR_LOOKUP_TIMEOUT_MS,
+    },
+    { maxAttempts: 2, backoffMs: 250 },
+    exec,
+  );
+  if (res.exitCode !== 0) {
+    return { bases: [], error: res.stderr.trim() || res.error || "gh failed" };
+  }
+  try {
+    const rows = JSON.parse(res.stdout) as {
+      baseRefName?: string;
+      isCrossRepository?: boolean;
+    }[];
+    const bases = rows
+      .filter((row) => row.isCrossRepository !== true)
+      .map((row) => row.baseRefName)
+      .filter((base): base is string => !!base);
+    return { bases: [...new Set(bases)], error: null };
+  } catch {
+    return { bases: [], error: `unreadable gh output: ${res.stdout.trim()}` };
+  }
+}
+
+function refuseBaseWrite(branch: string, because: string): Error {
+  return new Error(
+    `Refusing to commit directly to base branch '${branch}' (${because}). ` +
+      `Pass a 'branch' name prefixed with posthog/.`,
+  );
+}
+
+/**
+ * The base branch for a write to `branch`; throws when the write is refused.
+ * A caller-supplied base can be a head branch the run has to update, so GitHub
+ * decides and the PR's own base replaces the pin for the whole operation. The
+ * repository's default branch is refused whatever the caller passed.
+ */
+export async function resolveWriteBase(
+  ctx: SignedCommitCtx,
+  branch: string,
+  exec: typeof execGh = execGh,
+): Promise<string | null> {
+  const remoteDefault = await remoteDefaultBranch(ctx);
+  if (branch === remoteDefault) {
+    throw refuseBaseWrite(branch, "it is the repository's default branch");
+  }
+
+  const base = ctx.baseBranch ?? remoteDefault;
+  if (!base || branch !== base) return base;
+
+  if (!remoteDefault) {
+    throw refuseBaseWrite(
+      branch,
+      "the repository's default branch could not be determined",
+    );
+  }
+
+  const { bases, error } = await openPrBaseForHead(ctx, branch, exec);
+  if (error) {
+    throw refuseBaseWrite(
+      branch,
+      `its open pull requests could not be looked up: ${error}`,
+    );
+  }
+  const candidates = bases.filter((candidate) => candidate !== branch);
+  if (candidates.length === 0) {
+    throw refuseBaseWrite(branch, "no open pull request heads it");
+  }
+  if (candidates.length > 1) {
+    throw refuseBaseWrite(
+      branch,
+      `it heads open pull requests with different bases (${candidates.join(", ")})`,
+    );
+  }
+  return candidates[0];
+}
+
 async function resolveBranchName(
   ctx: SignedCommitCtx,
   input: SignedCommitInput,
 ): Promise<string> {
-  const branch = input.branch
-    ? input.branch.replace(/^refs\/heads\//, "")
-    : await resolveCurrentBranch(ctx);
-
-  // Guard both paths: an explicit `branch: "main"` must be refused the same as
-  // landing on the base branch implicitly via HEAD.
-  const baseBranch = await resolveBaseBranch(ctx);
-  if (baseBranch && branch === baseBranch) {
-    throw new Error(
-      `Refusing to commit directly to base branch '${baseBranch}'. ` +
-        `Pass a 'branch' name prefixed with posthog/.`,
-    );
-  }
-  return branch;
+  if (input.branch) return input.branch.replace(/^refs\/heads\//, "");
+  return resolveCurrentBranch(ctx);
 }
 
 async function resolveCurrentBranch(ctx: SignedCommitCtx): Promise<string> {
@@ -576,6 +664,7 @@ async function assertNoBaseLeak(
   ctx: SignedCommitCtx,
   branch: string,
   tip: string,
+  base: string | null,
 ): Promise<void> {
   const skip = (reason: string) => {
     process.stderr.write(
@@ -583,7 +672,6 @@ async function assertNoBaseLeak(
     );
   };
 
-  const base = await resolveBaseBranch(ctx);
   if (!base || base === branch) return;
 
   const fetched = await runGit(["fetch", "--no-tags", "origin", base], ctx.cwd);
@@ -839,6 +927,7 @@ export async function createSignedCommit(
     resolveRepoNameWithOwner(ctx.cwd),
     resolveBranchName(ctx, input),
   ]);
+  const writeBase = await resolveWriteBase(ctx, branch);
 
   if (input.paths && input.paths.length > 0) {
     const r = await runGit(["add", "--", ...input.paths], ctx.cwd);
@@ -880,7 +969,7 @@ export async function createSignedCommit(
     );
   }
 
-  await assertNoBaseLeak(ctx, branch, tip);
+  await assertNoBaseLeak(ctx, branch, tip, writeBase);
 
   const body = [input.body, buildPostHogTrailers(ctx.taskId).join("\n")]
     .filter(Boolean)
@@ -954,7 +1043,7 @@ export async function createSignedRewrite(
     );
   }
 
-  const baseBranch = await resolveBaseBranch(ctx);
+  const baseBranch = await resolveWriteBase(ctx, branch);
   if (baseBranch) {
     await runGit(["fetch", "--no-tags", "origin", baseBranch], ctx.cwd);
   }
@@ -1125,7 +1214,8 @@ export async function createSignedMerge(
     resolveBranchName(ctx, { message: "", branch: input.branch }),
   ]);
 
-  const base = input.base ?? (await resolveBaseBranch(ctx));
+  const writeBase = await resolveWriteBase(ctx, branch);
+  const base = input.base ?? writeBase;
   if (!base) {
     throw new Error(
       "Could not determine the base branch — pass `base` explicitly (e.g. master).",


### PR DESCRIPTION
## Problem

A signed git tool refuses to write to a branch that heads an open PR, whenever the harness pins that branch as the run's base. The agent then has no way to write at all.

- `git_signed_commit`, `git_signed_merge` and `git_signed_rewrite` share the guard, and raw `git commit` / `git push` are blocked in cloud runs.
- The layer below stops the backend sending that pin for a repo-less run. Another client, or a base lookup that fails, still can.

## Changes

- The guard asks GitHub whether the pinned branch heads an open PR. If it does, the write proceeds and the PR's own base becomes the base.
- The refusal stands for the remote default branch, and for a pinned base that heads no open PR.
- The `origin/HEAD` fallback is exempt, so only a caller-supplied pin can be overridden. A repo's default branch is never a branch a run should commit onto.
- The lookup runs only where the guard would have thrown, so a normal commit pays nothing.
- One retry on a transient `gh` failure, at 4s per attempt. Without it a single 502 refuses a commit the run exists to make.

