### PR TITLE
feat(insights): quill legend and position option for SQL pie charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3025,17 +3025,21 @@ snapshots:
     insights-sqlbargraph--stacked-bar-with-negative-values--light:
         hash: v1.k794b7964.e9f32e35e60194c76df1aad0e7963ca99bc76d2b6099437c5e679c4959feb976.3DeROLuvQPwEHmWPIxoY7SxfXAcAgX6gufInnDLnBh0
     insights-sqlpiegraph--breakdown-colors--dark:
-        hash: v1.k794b7964.459b2f2dad813b806560c40f292c41503482dcc864756aa5c27e936ef6ad5890.35VUrVQBDx9LxDWhN1L1896BV62m-OhK3d4ujQHrU5o
+        hash: v1.k794b7964.01928cb0ffb1554a01ffae8f214773557e22647fea676e40007a7803cec0af32.fk7qZ2CtcV_Ouq_6xOxJ7wqRdxmck-P18wvqRq1jLsc
     insights-sqlpiegraph--breakdown-colors--light:
-        hash: v1.k794b7964.85b6dc31bdb8ee361f89ab6c8b1df6c435e3e4b791fa982094ebd01a63b52cb7.LT735atGhIw513Hxuiqlqy2j0mRrsSlK5e__FssLlXo
+        hash: v1.k794b7964.2cdd1a0340ad18c1befb63f45f3019c9d169662d43abcf546087a6c076f04027.ZPiiGjgoY84m-UC9HiDkqnea5U12qN7NM0ijyMmK11M
     insights-sqlpiegraph--default--dark:
         hash: v1.k794b7964.5d9407311260cf6d60e52217801013baf5523971043d3a384399661606956094.gY3eS5hEKko3Uw025q_K8VD0OY4XUOo6iNkvdlzwrnA
     insights-sqlpiegraph--default--light:
         hash: v1.k794b7964.cb8ad5af06a0440258a2aad8b7a5531e83bed58ee3e1dfe019e9fcb549569b96.n6v4Nqqfp1KvW3ouAH4u2gEwzMI3eDb3hA3y2hHbBxY
+    insights-sqlpiegraph--legend-at-bottom--dark:
+        hash: v1.k794b7964.c47d48ad6a252d8a5dfc135b3d269bc028523df242a7b79c5b96d9d111ae0376._DhCXEiBO9wMl5fx3iWvB8BVIaxe19bUBzUQb55bkAo
+    insights-sqlpiegraph--legend-at-bottom--light:
+        hash: v1.k794b7964.edbf042650a6322573f4e64763cd4409162aca5fce5a35b2a51689d0b45a3867.KCSWIbrsWY4EZKnAeZHXdZXnZLEs0_oT1CnSBS-PmQE
     insights-sqlpiegraph--with-legend--dark:
-        hash: v1.k794b7964.41dfc4667fa9189fe499758412992668a572450ccd8efd81ebc5da0721e0a13f.IxIdKXrKk6F9AAvA7ZrkyjwOwobtpWR6PuJgvv_oSpo
+        hash: v1.k794b7964.d15af2bc969e9e442db3d5520d7b4c26a29f82dd001f9a3656da9cb838cd904e.HU5scx_5_NP2zMcUStE930Oaa1UgjhjHkEOUjAZ-u3w
     insights-sqlpiegraph--with-legend--light:
-        hash: v1.k794b7964.334268e3aeef84633d540830a5e1394e55a407118286053925f00e6eb378d806.zeqHqcf7h1Nihj7cEGiafCUbASLAmCZ28Z1xngTBl-0
+        hash: v1.k794b7964.e03eea04875a2046ced662098279559de6cfedb493840f3badf759e1a61a329b.Zkyv5NwjRftokqgfRfDPoMH62IXHvXLwEiQNGVkkoug
     insights-sqlscattergraph--default--dark:
         hash: v1.k794b7964.5ca16c3fa53c4fa08dfd7c540a2a6dda5ce63b1f9ebcb0e604a4f13e32c17af5.BC1sKBXJftn3jhHnOKFddv2XmlLtCTyZSfPw9c2yt_4
     insights-sqlscattergraph--default--light:

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBoxPlot.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBoxPlot.test.tsx
@@ -63,7 +63,7 @@ describe('SqlBoxPlot', () => {
         cleanup()
     })
 
-    it('renders grouped boxes with the standard axis defaults', async () => {
+    it('renders grouped boxes with the standard axis defaults and selected legend position', async () => {
         render(
             <SqlBoxPlot
                 rows={[
@@ -71,7 +71,7 @@ describe('SqlBoxPlot', () => {
                     ['Mon', 'Paid', 7, 8, 9, 10, 11, 12],
                 ]}
                 columns={columns}
-                chartSettings={chartSettings}
+                chartSettings={{ ...chartSettings, showLegend: true, legendPosition: 'bottom' }}
                 analyticsKey="grouped-test"
             />
         )
@@ -87,6 +87,7 @@ describe('SqlBoxPlot', () => {
             config: {
                 showGrid: true,
                 showAxisLines: { x: true, y: true },
+                legend: { show: true, position: 'bottom' },
             },
         })
     })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBoxPlot.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBoxPlot.tsx
@@ -67,7 +67,7 @@ export const SqlBoxPlot = ({
                 y: chartSettings.showYAxisBorder ?? true,
             },
             tooltip: { pinnable: true, placement: 'cursor' },
-            legend: { show: chartSettings.showLegend ?? false, position: 'top' },
+            legend: { show: chartSettings.showLegend ?? false, position: chartSettings.legendPosition ?? 'top' },
         }),
         [chartSettings, yAxisSettings]
     )

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.stories.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.stories.tsx
@@ -76,6 +76,16 @@ export const WithLegend: Story = {
         }),
 }
 
+export const LegendAtBottom: Story = {
+    render: () =>
+        render({
+            xData,
+            yData: singleSeries,
+            visualizationType: ChartDisplayType.ActionsPie,
+            chartSettings: { ...baseSettings, showLegend: true, legendPosition: 'bottom' },
+        }),
+}
+
 export const BreakdownColors: Story = {
     render: () =>
         render({

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
@@ -149,13 +149,13 @@ describe('SqlPieGraph', () => {
         expect(sliceLabelLines()).toEqual([])
     })
 
-    it('renders the side legend with per-slice values and shares', () => {
-        // The legend is plain DOM (rendered for both responsive layouts), so it needs no canvas paint.
+    it("renders quill's legend with one row per slice", () => {
+        // The legend is plain DOM outside the canvas, so it needs no canvas paint.
         render(<SqlPieGraph {...baseProps({ showLegend: true }, [60, 40, 0, 0])} />)
 
-        expect(screen.getAllByText('alpha').length).toBeGreaterThan(0)
-        expect(screen.getAllByText('60.0%').length).toBeGreaterThan(0)
-        expect(screen.getAllByText('40.0%').length).toBeGreaterThan(0)
+        expect(document.querySelector('[data-attr="hog-chart-pie-legend"]')).toBeInTheDocument()
+        expect(screen.getByText('alpha')).toBeInTheDocument()
+        expect(screen.getByText('beta')).toBeInTheDocument()
     })
 
     it('shows the empty state when there are no positive values', () => {
@@ -180,10 +180,10 @@ describe('SqlPieGraph', () => {
             />
         )
 
-        const swatchColors = Array.from(document.querySelectorAll<HTMLElement>('.LemonColorGlyph')).map(
-            (el) => el.style.color
-        )
-        expect(screen.getAllByText('first').length).toBeGreaterThan(0)
+        const swatchColors = Array.from(
+            document.querySelectorAll<HTMLElement>('[data-attr="hog-chart-pie-legend"] span[aria-hidden="true"]')
+        ).map((el) => el.style.backgroundColor)
+        expect(screen.getByText('first')).toBeInTheDocument()
         expect(swatchColors).toContain('rgb(170, 0, 0)')
         expect(swatchColors).toContain('rgb(0, 170, 0)')
     })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
@@ -156,6 +157,28 @@ describe('SqlPieGraph', () => {
         expect(document.querySelector('[data-attr="hog-chart-pie-legend"]')).toBeInTheDocument()
         expect(screen.getByText('alpha')).toBeInTheDocument()
         expect(screen.getByText('beta')).toBeInTheDocument()
+    })
+
+    it('restores all slices when the legend is hidden after isolating one', async () => {
+        const chartSettings: ChartSettings = { showLegend: true, pie: { sliceContent: 'labels', showTotal: true } }
+        const { rerender } = render(<SqlPieGraph {...baseProps(chartSettings, [60, 40, 0, 0])} />)
+        const user = userEvent.setup()
+
+        await waitForSlices()
+        await user.click(within(document.querySelector('[data-attr="hog-chart-pie-legend"]')!).getByText('alpha'))
+
+        await waitFor(() => {
+            expect(sliceLabelLines()).toEqual([['alpha']])
+            expect(screen.getByText('60')).toBeInTheDocument()
+        })
+
+        rerender(<SqlPieGraph {...baseProps({ ...chartSettings, showLegend: false }, [60, 40, 0, 0])} />)
+
+        await waitFor(() => {
+            expect(document.querySelector('[data-attr="hog-chart-pie-legend"]')).not.toBeInTheDocument()
+            expect(sliceLabelLines()).toEqual([['alpha'], ['beta']])
+            expect(screen.getByText('100')).toBeInTheDocument()
+        })
     })
 
     it('shows the empty state when there are no positive values', () => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
-import { LemonColorGlyph } from '@posthog/lemon-ui'
-import { PieChart, TooltipSurface, TooltipSwatch } from '@posthog/quill-charts'
-import type { PieChartConfig, TooltipContext } from '@posthog/quill-charts'
+import { ChartLegend, PieChart, TooltipSurface, TooltipSwatch, useChartLegend } from '@posthog/quill-charts'
+import type { ChartLegendConfig, PieChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { useChartTheme } from 'lib/charts/hooks'
+import { useChartLegendSeriesMenu } from 'lib/components/ChartLegendSeriesMenu/useChartLegendSeriesMenu'
 
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
 
@@ -16,8 +16,10 @@ import { buildPieSeries, buildPieSlices, formatPieSliceCount } from './sqlPieGra
 const handleChartError = makeChartErrorHandler('sql-pie-chart')
 
 /**
- * SQL pie graph on @posthog/quill-charts' {@link PieChart}. The chart core lives in quill; the
- * aggregation total and side legend stay here as chrome.
+ * SQL pie graph on @posthog/quill-charts' {@link PieChart}. The chart core and the legend are
+ * quill's; the aggregation total stays here as chrome. The legend is driven from here rather than
+ * through `config.legend` so the total sits in the layout's chart slot, centered under the pie
+ * instead of under the pie-plus-legend pair.
  */
 export const SqlPieGraph = ({
     xData,
@@ -31,7 +33,14 @@ export const SqlPieGraph = ({
     const slices = useMemo(() => buildPieSlices(xData, yData), [xData, yData])
     const formattingSettings = yData[0]?.settings
     const series = useMemo(() => buildPieSeries(slices), [slices])
-    const total = useMemo(() => slices.reduce((sum, slice) => sum + slice.value, 0), [slices])
+
+    // Toggled-off slices aren't persisted (SQL insights have nowhere to save them), but the legend
+    // is controlled anyway so the total and the tooltip shares track the slices actually drawn.
+    const [hiddenKeys, setHiddenKeys] = useState<string[]>([])
+    const total = useMemo(
+        () => series.reduce((sum, s) => (hiddenKeys.includes(s.key) ? sum : sum + (s.data[0] ?? 0)), 0),
+        [series, hiddenKeys]
+    )
 
     const showLegend = chartSettings.showLegend ?? false
     // Unset means an existing chart from before the labels option — keep showing values. New pies
@@ -47,8 +56,26 @@ export const SqlPieGraph = ({
         [formattingSettings]
     )
 
+    const legendRenderItem = useChartLegendSeriesMenu({ surface: 'sql', seriesCount: series.length })
+
+    const legendConfig: ChartLegendConfig = useMemo(
+        () => ({
+            show: showLegend,
+            position: chartSettings.legendPosition ?? 'right',
+            interactive: true,
+            hiddenKeys,
+            onToggleSeries: (key: string) =>
+                setHiddenKeys((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key])),
+            onSetHiddenSeries: setHiddenKeys,
+            renderItem: legendRenderItem,
+        }),
+        [showLegend, chartSettings.legendPosition, hiddenKeys, legendRenderItem]
+    )
+
+    const { visibleSeries, legendProps } = useChartLegend(series, theme, legendConfig)
+
     // `isPercent` makes the chart render on-slice values and tooltips as a share of the total; the
-    // total below the chart and the absolute legend line keep using the raw value formatter.
+    // total below the chart keeps using the raw value formatter.
     // Labels sit toward the rim (on the wider part of each wedge) and skip slices under 10% so a
     // long tail of thin slices doesn't pile labels up at the center.
     const pieConfig: PieChartConfig = useMemo(
@@ -91,83 +118,40 @@ export const SqlPieGraph = ({
         )
     }
 
-    const chart = (
-        <PieChart
-            series={series}
-            theme={theme}
-            config={pieConfig}
-            tooltip={renderTooltip}
-            valueFormatter={absoluteFormatter}
-            dataAttr="sql-pie-chart"
-            onError={handleChartError}
-        />
-    )
-
     const totalDisplay = showPieTotal ? (
         <div className="pt-4 text-center shrink-0">
             <div className="text-5xl font-bold">{absoluteFormatter(total)}</div>
         </div>
     ) : null
 
-    const legend = showLegend ? (
-        <div className="w-full xl:w-80 shrink-0 border border-border rounded bg-surface-secondary overflow-visible xl:overflow-auto">
-            <div className="divide-y divide-border">
-                {slices.map((slice) => {
-                    const percent = total > 0 ? ((slice.value / total) * 100).toFixed(1) : '0.0'
-
-                    return (
-                        <div key={slice.label} className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
-                            <div className="flex items-center gap-2 min-w-0">
-                                <LemonColorGlyph color={slice.color} className="shrink-0" />
-                                <span className="truncate">{slice.label}</span>
-                            </div>
-                            <div className="text-right shrink-0">
-                                <div className="font-semibold">
-                                    {asPercent ? `${percent}%` : absoluteFormatter(slice.value)}
-                                </div>
-                                <div className="text-xs text-secondary">
-                                    {asPercent ? absoluteFormatter(slice.value) : `${percent}%`}
-                                </div>
-                            </div>
-                        </div>
-                    )
-                })}
-            </div>
-        </div>
-    ) : null
+    // A side legend narrows the chart column, so the total belongs inside it to stay centered under
+    // the pie. A top/bottom legend leaves the column full-width, and the total goes below both.
+    const legendAtSide = legendProps.show && (legendProps.position === 'left' || legendProps.position === 'right')
 
     return (
         <div
-            className={clsx(className, 'rounded bg-surface-primary flex flex-1 p-4 gap-4', {
+            className={clsx(className, 'rounded bg-surface-primary flex flex-col flex-1 min-h-0 p-4', {
                 'h-[60vh]': presetChartHeight,
                 'h-full': !presetChartHeight,
             })}
         >
-            {!showLegend ? (
-                <div className="flex flex-1 min-h-0">
-                    <div className="flex flex-1 flex-col min-h-0">
-                        <div className="flex flex-col flex-1 min-h-[18rem]">{chart}</div>
-                        {totalDisplay}
-                    </div>
+            <ChartLegend {...legendProps} legendDataAttr="hog-chart-pie-legend">
+                {/* min-h-0, not a fixed floor: in a short panel the pie has to shrink, or its box
+                    runs over the legend and the total below it. */}
+                <div className="flex flex-col flex-1 min-h-0">
+                    <PieChart
+                        series={visibleSeries}
+                        theme={theme}
+                        config={pieConfig}
+                        tooltip={renderTooltip}
+                        valueFormatter={absoluteFormatter}
+                        dataAttr="sql-pie-chart"
+                        onError={handleChartError}
+                    />
                 </div>
-            ) : (
-                <>
-                    <div className="flex flex-col gap-4 w-full xl:hidden">
-                        <div className="flex flex-col">
-                            <div className="flex flex-col h-[18rem]">{chart}</div>
-                            {totalDisplay}
-                        </div>
-                        {legend}
-                    </div>
-                    <div className="hidden xl:flex flex-1 gap-4 min-h-0">
-                        <div className="flex flex-1 flex-col min-h-0">
-                            <div className="flex flex-col flex-1 min-h-[18rem]">{chart}</div>
-                            {totalDisplay}
-                        </div>
-                        {legend}
-                    </div>
-                </>
-            )}
+                {legendAtSide && totalDisplay}
+            </ChartLegend>
+            {!legendAtSide && totalDisplay}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
@@ -37,12 +37,13 @@ export const SqlPieGraph = ({
     // Toggled-off slices aren't persisted (SQL insights have nowhere to save them), but the legend
     // is controlled anyway so the total and the tooltip shares track the slices actually drawn.
     const [hiddenKeys, setHiddenKeys] = useState<string[]>([])
+    const showLegend = chartSettings.showLegend ?? false
+    const visibleHiddenKeySet = useMemo(() => new Set(showLegend ? hiddenKeys : []), [showLegend, hiddenKeys])
     const total = useMemo(
-        () => series.reduce((sum, s) => (hiddenKeys.includes(s.key) ? sum : sum + (s.data[0] ?? 0)), 0),
-        [series, hiddenKeys]
+        () => series.reduce((sum, s) => (visibleHiddenKeySet.has(s.key) ? sum : sum + (s.data[0] ?? 0)), 0),
+        [series, visibleHiddenKeySet]
     )
 
-    const showLegend = chartSettings.showLegend ?? false
     // Unset means an existing chart from before the labels option — keep showing values. New pies
     // are stamped with 'labels' when the type is picked (see dataVisualizationLogic).
     const sliceContent = chartSettings.pie?.sliceContent ?? 'values'
@@ -63,7 +64,7 @@ export const SqlPieGraph = ({
             show: showLegend,
             position: chartSettings.legendPosition ?? 'right',
             interactive: true,
-            hiddenKeys,
+            hiddenKeys: showLegend ? hiddenKeys : [],
             onToggleSeries: (key: string) =>
                 setHiddenKeys((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key])),
             onSetHiddenSeries: setHiddenKeys,

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -718,6 +718,18 @@ describe('sqlLineGraphAdapter', () => {
             expect(config.legend).toEqual({ show: expected, position: 'top', interactive: true })
         })
 
+        it.each([
+            ['defaults to the top', undefined, 'top'],
+            ['follows legendPosition', 'bottom', 'bottom'],
+        ] as const)('%s for the legend position', (_name, legendPosition, expected) => {
+            const config = buildLineChartConfig({
+                xData: dateXData,
+                chartSettings: { showLegend: true, legendPosition },
+                timezone: 'UTC',
+            })
+            expect(config.legend?.position).toBe(expected)
+        })
+
         it('forwards legendRenderItem, which carries the row right-click menu', () => {
             const legendRenderItem = jest.fn()
             const config = buildLineChartConfig({

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -377,7 +377,12 @@ function buildLegendConfig(
 ): ChartLegendConfig {
     // No `hiddenKeys`, so the legend is uncontrolled: quill owns which series are toggled off, and
     // isolating a series works without SQL charts having to persist anything.
-    return { show: chartSettings.showLegend ?? false, position: 'top', interactive: true, renderItem }
+    return {
+        show: chartSettings.showLegend ?? false,
+        position: chartSettings.legendPosition ?? 'top',
+        interactive: true,
+        renderItem,
+    }
 }
 
 /** The X/Y axis-border toggles map onto quill's per-edge axis lines — undefined when both are on

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlScatterGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlScatterGraphAdapter.ts
@@ -102,7 +102,11 @@ export function buildScatterConfig({
         },
         showGrid: yAxisSettings?.showGridLines ?? true,
         showBestFit: chartSettings.scatter?.showBestFit ?? false,
-        legend: { show: chartSettings.showLegend ?? false, position: 'top', interactive: true },
+        legend: {
+            show: chartSettings.showLegend ?? false,
+            position: chartSettings.legendPosition ?? 'top',
+            interactive: true,
+        },
         tooltip: {
             xFormatter: (value: number): string => value.toLocaleString(),
             yFormatter: (value: number, point): string => formatSqlSeriesValue(value, point.meta?.settings),

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -30,6 +30,13 @@ const PIE_VALUE_DISPLAY_OPTIONS: { value: 'absolute' | 'percentage'; label: stri
     { value: 'percentage', label: 'Percentage' },
 ]
 
+const LEGEND_POSITION_OPTIONS: { value: 'top' | 'bottom' | 'left' | 'right'; label: string }[] = [
+    { value: 'top', label: 'Top' },
+    { value: 'bottom', label: 'Bottom' },
+    { value: 'left', label: 'Left' },
+    { value: 'right', label: 'Right' },
+]
+
 const LINE_STYLE_OPTIONS: { value: 'smooth' | 'linear'; label: string }[] = [
     { value: 'smooth', label: 'Smooth' },
     { value: 'linear', label: 'Straight' },
@@ -142,6 +149,21 @@ export const DisplayTab = (): JSX.Element => {
                                         updateChartSettings({ showLegend: value })
                                     }}
                                 />
+                                <div className="flex flex-col gap-1">
+                                    <LemonLabel>Legend position</LemonLabel>
+                                    <LemonSelect
+                                        className="w-full"
+                                        value={chartSettings.legendPosition ?? (isPieChart ? 'right' : 'top')}
+                                        options={LEGEND_POSITION_OPTIONS}
+                                        disabledReason={
+                                            chartSettings.showLegend
+                                                ? undefined
+                                                : 'Turn the legend on to set its position'
+                                        }
+                                        onChange={(value) => updateChartSettings({ legendPosition: value })}
+                                        fullWidth
+                                    />
+                                </div>
                                 {isBoxPlot && (
                                     <LemonSwitch
                                         className="flex-1 w-full"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16485,6 +16485,11 @@
                 "leftYAxisSettings": {
                     "$ref": "#/definitions/YAxisSettings"
                 },
+                "legendPosition": {
+                    "description": "Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest.",
+                    "enum": ["top", "bottom", "left", "right"],
+                    "type": "string"
+                },
                 "pie": {
                     "$ref": "#/definitions/PieChartSettings"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1400,6 +1400,8 @@ export interface ChartSettings {
     showYAxisBorder?: boolean
     showLegend?: boolean
     showAnnotations?: boolean
+    /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
+    legendPosition?: 'top' | 'bottom' | 'left' | 'right'
     showValuesOnSeries?: boolean
     // Deprecated: superseded by `pie.showTotal`. Retained so pre-existing pie-chart insights still
     // validate (ChartSettings is `extra="forbid"`). Read as a fallback in the pie chart components.

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -15566,6 +15566,13 @@ class ChartSettings(BaseModel):
     goalLines: list[GoalLine] | None = None
     heatmap: HeatmapSettings | None = None
     leftYAxisSettings: YAxisSettings | None = None
+    legendPosition: LegendPosition | None = Field(
+        default=None,
+        description=(
+            "Where the legend sits relative to the chart. Unset falls back per chart"
+            " type: right for pie, top for the rest."
+        ),
+    )
     pie: PieChartSettings | None = None
     resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(
         default=None,

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -695,6 +695,13 @@ class ChartDisplayType(StrEnum):
     SCATTER_PLOT = "ScatterPlot"
 
 
+class LegendPosition(StrEnum):
+    TOP = "top"
+    BOTTOM = "bottom"
+    LEFT = "left"
+    RIGHT = "right"
+
+
 class Curve(StrEnum):
     LINEAR = "linear"
     SMOOTH = "smooth"
@@ -2784,13 +2791,6 @@ class FunnelVizType(StrEnum):
     TIME_TO_CONVERT = "time_to_convert"
     TRENDS = "trends"
     FLOW = "flow"
-
-
-class LegendPosition(StrEnum):
-    TOP = "top"
-    BOTTOM = "bottom"
-    LEFT = "left"
-    RIGHT = "right"
 
 
 class Position(StrEnum):

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8980,6 +8980,8 @@ export interface ChartSettingsApi {
     goalLines?: GoalLineApi[] | null
     heatmap?: HeatmapSettingsApi | null
     leftYAxisSettings?: YAxisSettingsApi | null
+    /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
+    legendPosition?: LegendPositionApi | null
     pie?: PieChartSettingsApi | null
     /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
     resultCustomizations?: ChartSettingsApiResultCustomizations

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -8035,6 +8035,8 @@ export interface ChartSettingsApi {
     goalLines?: GoalLineApi[] | null
     heatmap?: HeatmapSettingsApi | null
     leftYAxisSettings?: YAxisSettingsApi | null
+    /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
+    legendPosition?: LegendPositionApi | null
     pie?: PieChartSettingsApi | null
     /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
     resultCustomizations?: ChartSettingsApiResultCustomizations

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8793,6 +8793,8 @@ export namespace Schemas {
       goalLines?: GoalLine[] | null;
       heatmap?: HeatmapSettings | null;
       leftYAxisSettings?: YAxisSettings | null;
+      /** Where the legend sits relative to the chart. Unset falls back per chart type: right for pie, top for the rest. */
+      legendPosition?: LegendPosition | null;
       pie?: PieChartSettings | null;
       /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
       resultCustomizations?: ChartSettingsResultCustomizations;


### PR DESCRIPTION
## Problem

A SQL insight shown as a pie chart drew a legend that looks like nothing else in PostHog: a bordered panel of rows, each with a value and a share of the total. Every other chart shows the compact quill legend. The panel shipped with the first SQL pie chart and stayed behind when that chart moved onto quill-charts, which took over only the plot.

SQL charts also had no way to move the legend, an option trends charts already offer.

## Changes

- A SQL pie chart now shows the same legend as every other chart. Clicking a row isolates that slice, ⌘-clicking adds or removes one, and right-clicking opens the series menu.
- The total under the pie follows the visible slices, so hiding one updates it.
- **Legend position** is now a setting on every SQL chart, under "Show legend" in the Display tab.
- Existing charts stay where they are: the fallback is right for pie, top for line, bar, combo, and scatter.
- The pie shrinks when the panel is short, instead of overlapping the legend and total below it.
- The legend is built in `SqlPieGraph` with `useChartLegend` and quill's `ChartLegend` rather than passed as `config.legend`. That puts the total inside the legend layout's chart slot, so a side legend leaves it centered under the pie.
- Mechanical: regenerated query schema and API types for the new `legendPosition` field.

Before, and after with the legend right and bottom:

![pr-before](https://raw.githubusercontent.com/PostHog/pr-assets/d76c7839573cf0ec3fb77d2c052cc3805e3fb1da/2026/08/6146af10-e24c-45a5-b491-d0bc426dd706.png)

![pr-after-right](https://raw.githubusercontent.com/PostHog/pr-assets/9056557b852394a46143c61a357ff574ecd625f0/2026/08/8e523a4e-3f73-40b5-af28-9f5aa90fe4a0.png)

![pr-after-bottom](https://raw.githubusercontent.com/PostHog/pr-assets/d1100518e5e9027c9e621fc9e51caeae351c5620/2026/08/e2017da6-a07e-4819-8b5a-f30b61ab8c25.png)

## How did you test this code?

Two jest changes, both in existing suites:

- `SqlPieGraph.test.tsx` asserted on the old panel's markup, including its `LemonColorGlyph` swatches. It now reads quill's legend rows, so a silent fall back to a hand-rolled legend fails the suite.
- `sqlLineGraphAdapter.test.ts` gains a parameterized case that the legend position defaults to top and follows `legendPosition`. It catches a future edit that hardcodes the position again.

Storybook covers the layouts: `LegendAtBottom` is new, and `WithLegend` plus `BreakdownColors` change. Their snapshot baselines need regenerating.

Checked by hand in the local app, on a SQL insight with seven slices:

- Isolating a slice from the legend dropped the total from 132,913 to 76,424.
- With the legend right, the pie canvas and the total shared a center (x=667 for both).
- At a 720px viewport with the legend at the bottom, the pie, legend, and total occupied 408-568, 576-612, and 628-676 with no overlap.

Not checked: side legends on the SQL line, bar, and scatter charts, which the new setting also reaches. Trends renders those positions already, so quill owns that layout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The setting matches the trends legend option, which the docs do not enumerate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) in an interactive session with @sampennington, who spotted the odd legend on a dashboard and asked where it came from.

Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`, and the local `storyshot` and `test` skills for the Storybook and live-app checks.

The first attempt passed `config.legend` to `PieChart`, which is how the trends pie does it. That centered the total across the pie and the legend together, so it no longer lined up with the pie. Driving the legend from the wrapper fixed the alignment and made the bottom-legend order (pie, legend, total) explicit. The fixed `min-h-[18rem]` on the chart wrapper came from the old layout and had to go, since it made the pie overlap the legend in a short panel.

These changes started on the branch of #86525 and moved here, so that PR stays about the donut chart type.
