### PR TITLE
fix(experiments): add absolute floor to precompute canary correctness check

### DIFF
--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -9,7 +9,10 @@ scan (``PrecomputationMode.DIRECT``). Two checks per metric:
   counts are held to the strict tolerance. Retention resolves both of its numbers from metric events, so
   both get the loose tolerance.
 - correctness (B vs C): the precomputed read must agree with the events table within a loose tolerance that
-  covers live ingestion between the cache writes and the direct scan.
+  covers live ingestion between the cache writes and the direct scan. Deviations also need to clear an
+  absolute per-variant difference (``MIN_CORRECTNESS_DELTA``), because on sparse metrics a handful of
+  users' worth of expected live-vs-frozen drift (person merges, late-arriving events) exceeds any
+  relative tolerance.
 
 The bug class this guards (multi-node ClickHouse read-your-writes, see
 ``products/analytics_platform/backend/lazy_computation/CONSISTENCY.md``) cannot be reproduced in dev/CI
@@ -85,6 +88,12 @@ STRICT_TOLERANCE = 0.001
 # Precomputed-vs-direct (and mean-metric sums, which join live values) legitimately drift by the few minutes
 # of ingestion between the cache writes and the comparison read.
 LOOSE_TOLERANCE = 0.02
+
+# Correctness deviations below this absolute per-variant difference don't count. Frozen snapshots
+# legitimately drift from the live scan by a handful of users' events (post-freeze person merges,
+# late-arriving events), and on a sparse metric (tens of conversions over millions of exposures) that
+# handful already exceeds any relative tolerance and would page as the run's worst divergence.
+MIN_CORRECTNESS_DELTA = 100.0
 
 # Below this, a single user moves a variant by more than the strict tolerance and comparison is meaningless.
 MIN_EXPOSURES_PER_VARIANT = 100
@@ -237,12 +246,16 @@ def relative_deviation(a: float, b: float) -> float:
     return abs(a - b) / max(abs(a), abs(b), 1.0)
 
 
-def _max_deviation(run_x: CanaryRunSnapshot, run_y: CanaryRunSnapshot) -> float:
+def _max_deviation(run_x: CanaryRunSnapshot, run_y: CanaryRunSnapshot, min_delta: float = 0.0) -> float:
     deviations = [0.0]
     for key, stats_x in run_x.variants.items():
         stats_y = run_y.variants[key]
-        deviations.append(relative_deviation(stats_x.sum, stats_y.sum))
-        deviations.append(relative_deviation(stats_x.number_of_samples, stats_y.number_of_samples))
+        for value_x, value_y in (
+            (stats_x.sum, stats_y.sum),
+            (stats_x.number_of_samples, stats_y.number_of_samples),
+        ):
+            if abs(value_x - value_y) > min_delta:
+                deviations.append(relative_deviation(value_x, value_y))
     return max(deviations)
 
 
@@ -291,7 +304,7 @@ def evaluate_canary_runs(
         )
 
     stability_deviation = _max_deviation(run_a, run_b)
-    correctness_deviation = _max_deviation(run_b, run_c)
+    correctness_deviation = _max_deviation(run_b, run_c, min_delta=MIN_CORRECTNESS_DELTA)
     diverged = _stability_violated(metric_type, run_a, run_b) or correctness_deviation > LOOSE_TOLERANCE
 
     return CanaryVerdict(

--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -9,10 +9,10 @@ scan (``PrecomputationMode.DIRECT``). Two checks per metric:
   counts are held to the strict tolerance. Retention resolves both of its numbers from metric events, so
   both get the loose tolerance.
 - correctness (B vs C): the precomputed read must agree with the events table within a loose tolerance that
-  covers live ingestion between the cache writes and the direct scan. Deviations also need to clear an
-  absolute per-variant difference (``MIN_CORRECTNESS_DELTA``), because on sparse metrics a handful of
-  users' worth of expected live-vs-frozen drift (person merges, late-arriving events) exceeds any
-  relative tolerance.
+  covers live ingestion between the cache writes and the direct scan. Sum deviations also need to clear
+  an absolute per-variant difference (``MIN_CORRECTNESS_SUM_DELTA``), because on sparse metrics a handful
+  of users' worth of expected live-vs-frozen drift (person merges, late-arriving events) exceeds any
+  relative tolerance. Exposure counts are never floored.
 
 The bug class this guards (multi-node ClickHouse read-your-writes, see
 ``products/analytics_platform/backend/lazy_computation/CONSISTENCY.md``) cannot be reproduced in dev/CI
@@ -89,11 +89,14 @@ STRICT_TOLERANCE = 0.001
 # of ingestion between the cache writes and the comparison read.
 LOOSE_TOLERANCE = 0.02
 
-# Correctness deviations below this absolute per-variant difference don't count. Frozen snapshots
+# Correctness sum deviations below this absolute per-variant difference don't count. Frozen snapshots
 # legitimately drift from the live scan by a handful of users' events (post-freeze person merges,
 # late-arriving events), and on a sparse metric (tens of conversions over millions of exposures) that
 # handful already exceeds any relative tolerance and would page as the run's worst divergence.
-MIN_CORRECTNESS_DELTA = 100.0
+# The floor is in raw metric units and deliberately conservative: it only mutes differences below 100
+# units, so value-sum metrics with large units still page on relative drift alone. It never applies to
+# exposure counts, which are in users and where a beyond-tolerance divergence is always worth paging on.
+MIN_CORRECTNESS_SUM_DELTA = 100.0
 
 # Below this, a single user moves a variant by more than the strict tolerance and comparison is meaningless.
 MIN_EXPOSURES_PER_VARIANT = 100
@@ -246,16 +249,13 @@ def relative_deviation(a: float, b: float) -> float:
     return abs(a - b) / max(abs(a), abs(b), 1.0)
 
 
-def _max_deviation(run_x: CanaryRunSnapshot, run_y: CanaryRunSnapshot, min_delta: float = 0.0) -> float:
+def _max_deviation(run_x: CanaryRunSnapshot, run_y: CanaryRunSnapshot, min_sum_delta: float = 0.0) -> float:
     deviations = [0.0]
     for key, stats_x in run_x.variants.items():
         stats_y = run_y.variants[key]
-        for value_x, value_y in (
-            (stats_x.sum, stats_y.sum),
-            (stats_x.number_of_samples, stats_y.number_of_samples),
-        ):
-            if abs(value_x - value_y) > min_delta:
-                deviations.append(relative_deviation(value_x, value_y))
+        if abs(stats_x.sum - stats_y.sum) > min_sum_delta:
+            deviations.append(relative_deviation(stats_x.sum, stats_y.sum))
+        deviations.append(relative_deviation(stats_x.number_of_samples, stats_y.number_of_samples))
     return max(deviations)
 
 
@@ -304,7 +304,7 @@ def evaluate_canary_runs(
         )
 
     stability_deviation = _max_deviation(run_a, run_b)
-    correctness_deviation = _max_deviation(run_b, run_c, min_delta=MIN_CORRECTNESS_DELTA)
+    correctness_deviation = _max_deviation(run_b, run_c, min_sum_delta=MIN_CORRECTNESS_SUM_DELTA)
     diverged = _stability_violated(metric_type, run_a, run_b) or correctness_deviation > LOOSE_TOLERANCE
 
     return CanaryVerdict(

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -49,6 +49,7 @@ def _snapshot(label: str, variants: dict[str, tuple[float, int]], is_precomputed
 
 
 _BASE = {"control": (1000.0, 10000), "test": (1100.0, 10000)}
+_SPARSE = {"control": (27.0, 500000), "test": (13555.0, 500000)}
 
 
 class TestRelativeDeviation:
@@ -143,6 +144,16 @@ class TestEvaluateCanaryRuns:
                 {"control": (1300.0, 10000), "test": (1100.0, 10000)},  # 23% — the incident signature
                 OUTCOME_DIVERGENCE,
             ),
+            (
+                # 27% relative on the control sum, but only 10 events apart: expected live-vs-frozen drift
+                # on a sparse metric, not a divergence.
+                "sparse_metric_gap_below_absolute_floor_passes",
+                "funnel",
+                _SPARSE,
+                _SPARSE,
+                {"control": (37.0, 499000), "test": (13571.0, 499000)},
+                OUTCOME_PASS,
+            ),
         ]
     )
     def test_outcomes(self, _name, metric_type, a, b, c, expected):
@@ -193,10 +204,18 @@ class TestEvaluateCanaryRuns:
         assert verdict.outcome == OUTCOME_SKIPPED
 
     def test_deviations_are_reported_on_pass(self):
-        c = {"control": (1010.0, 10000), "test": (1100.0, 10000)}
-        verdict = evaluate_canary_runs("funnel", _snapshot("a", _BASE), _snapshot("b", _BASE), _snapshot("c", c))
+        base = {"control": (100000.0, 10000), "test": (110000.0, 10000)}
+        c = {"control": (101500.0, 10000), "test": (110000.0, 10000)}  # 1.5% < 2%, 1500 events > floor
+        verdict = evaluate_canary_runs("funnel", _snapshot("a", base), _snapshot("b", base), _snapshot("c", c))
+        assert verdict.outcome == OUTCOME_PASS
         assert verdict.stability_deviation == 0.0
-        assert verdict.correctness_deviation == pytest.approx(0.01, rel=0.05)
+        assert verdict.correctness_deviation == pytest.approx(1500 / 101500)
+
+    def test_sub_floor_correctness_wiggle_is_not_reported(self):
+        c = {"control": (1010.0, 10000), "test": (1100.0, 10000)}  # 1% relative, but only 10 events
+        verdict = evaluate_canary_runs("funnel", _snapshot("a", _BASE), _snapshot("b", _BASE), _snapshot("c", c))
+        assert verdict.outcome == OUTCOME_PASS
+        assert verdict.correctness_deviation == 0.0
 
 
 def _inline_metric(metric_type: str) -> dict:

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -154,6 +154,16 @@ class TestEvaluateCanaryRuns:
                 {"control": (37.0, 499000), "test": (13571.0, 499000)},
                 OUTCOME_PASS,
             ),
+            (
+                # Exposure counts are never floored: 90 users is under MIN_CORRECTNESS_SUM_DELTA, but a
+                # beyond-tolerance exposure-set divergence on a small experiment must still page.
+                "small_experiment_exposure_drift_beyond_tolerance_diverges",
+                "funnel",
+                {"control": (500.0, 3000), "test": (500.0, 3000)},
+                {"control": (500.0, 3000), "test": (500.0, 3000)},
+                {"control": (500.0, 3090), "test": (500.0, 3000)},
+                OUTCOME_DIVERGENCE,
+            ),
         ]
     )
     def test_outcomes(self, _name, metric_type, a, b, c, expected):


### PR DESCRIPTION
## Problem

The precompute canary's correctness check uses a relative tolerance only. On a sparse metric, a gap of a few events between the precomputed and the live read exceeds any relative tolerance, so expected live-vs-frozen drift (person merges after a window froze, late-arriving events) pages as a divergence. Most of the divergences flagged in the last week were this shape - the worst, reported at 27%, was a 10-conversion gap on an experiment with millions of exposures.

## Changes

- A correctness sum deviation now only counts when the per-variant difference also exceeds 100 (`MIN_CORRECTNESS_SUM_DELTA`).
- Exposure counts are never floored: a beyond-tolerance exposure-set divergence pages regardless of experiment size, and every false positive observed so far was sum-driven.
- The floor is applied where deviations are computed, so the verdict, the Slack alert, the divergence log, and the Prometheus gauge report the same number.
- The stability check is unchanged.

No user-visible changes; this only affects canary alerting.

## How did you test this code?

- New parameterized case with last week's false-positive shape (a 10-event gap at 27% relative on a sparse funnel) - catches the floor being removed.
- New parameterized case with a 3% exposure-count divergence of only 90 users - catches the floor being extended to exposure counts, which would hide real cache breaks on small experiments.
- New `test_sub_floor_correctness_wiggle_is_not_reported` - catches sub-floor drift leaking back into the reported deviation and the Prometheus gauge.
- Ran `products/experiments/backend/temporal/test_canary_logic.py` locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - the canary runbook lives in the module docstring, updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code after a root-cause investigation of last week's canary divergences (Loki divergence logs via the Grafana MCP). Skills invoked: analyzing-experiment-precompute-canary, writing-tests, writing-code-comments, writing-pr-descriptions. Design choices: the floor sits inside `_max_deviation` rather than in a separate verdict check, so sub-floor wiggles are excluded from every reporting surface at once instead of passing the verdict while still inflating the gauge. The floor was initially applied to both sums and exposure counts; scoped to sums only after review, since a 100-user floor could hide a genuine exposure-set break on a small experiment.