### PR TITLE
fix(error-tracking): overlay recent issue state

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -74,6 +74,7 @@ from posthog.hogql.database.schema.document_embeddings import (
 from posthog.hogql.database.schema.duckdb_table_functions import GenerateSeriesTable, RangeTable
 from posthog.hogql.database.schema.error_tracking_fingerprint_issue_state import (
     ErrorTrackingFingerprintIssueStateTable,
+    ErrorTrackingRecentIssueStateTable,
     RawErrorTrackingFingerprintIssueStateTable,
 )
 from posthog.hogql.database.schema.error_tracking_issue_fingerprint_overrides import (
@@ -423,6 +424,11 @@ def _construct_database_root_node(*, include_posthog_tables: bool) -> TableNode:
                     "error_tracking_fingerprint_issue_state": TableNode(
                         name="error_tracking_fingerprint_issue_state",
                         table=ErrorTrackingFingerprintIssueStateTable(),
+                    ),
+                    "error_tracking_recent_issue_state": TableNode(
+                        name="error_tracking_recent_issue_state",
+                        table=ErrorTrackingRecentIssueStateTable(),
+                        hidden=True,
                     ),
                     "web_overview_preaggregated": TableNode(
                         name="web_overview_preaggregated", table=WebOverviewPreaggregatedTable()

--- a/posthog/hogql/database/schema/error_tracking_fingerprint_issue_state.py
+++ b/posthog/hogql/database/schema/error_tracking_fingerprint_issue_state.py
@@ -5,6 +5,7 @@ from posthog.hogql.constants import HogQLQuerySettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
+    DANGEROUS_NoTeamIdCheckTable,
     DateTimeDatabaseField,
     FieldOrTable,
     IntegerDatabaseField,
@@ -13,12 +14,15 @@ from posthog.hogql.database.models import (
     LazyTableToAdd,
     StringDatabaseField,
     Table,
+    TableNode,
     UUIDDatabaseField,
 )
 from posthog.hogql.errors import ResolutionError
 
 # Key used to pass pending fingerprint-issue-state updates through HogQLContext.data_to_ingest.
 PENDING_UPDATES_HOGQL_CONTEXT_KEY = "error_tracking_fingerprints"
+RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY = "error_tracking_recent_issue_state"
+RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME = "__ph_error_tracking_recent_issue_state"
 
 ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_FIELDS: dict[str, FieldOrTable] = {
     "team_id": IntegerDatabaseField(name="team_id", nullable=False),
@@ -252,6 +256,84 @@ def _pending_update_select(row: dict[str, Any]):
     return ast.SelectQuery(
         select=[ast.Alias(alias=col, expr=column_exprs[col]) for col in _ISSUE_STATE_COLUMNS],
     )
+
+
+RECENT_ISSUE_STATE_FIELDS: dict[str, FieldOrTable] = {
+    "issue_id": UUIDDatabaseField(name="issue_id", nullable=False),
+    "issue_status": StringDatabaseField(name="issue_status", nullable=False),
+    "issue_name": StringDatabaseField(name="issue_name", nullable=True),
+    "issue_description": StringDatabaseField(name="issue_description", nullable=True),
+    "assigned_user_id": IntegerDatabaseField(name="assigned_user_id", nullable=True),
+    "assigned_role_id": UUIDDatabaseField(name="assigned_role_id", nullable=True),
+    "state_updated_at": DateTimeDatabaseField(name="state_updated_at", nullable=False),
+    "is_present": BooleanDatabaseField(name="is_present", nullable=False),
+}
+
+RECENT_ISSUE_STATE_STRUCTURE = [
+    ("issue_id", "UUID"),
+    ("issue_status", "String"),
+    ("issue_name", "Nullable(String)"),
+    ("issue_description", "Nullable(String)"),
+    ("assigned_user_id", "Nullable(Int64)"),
+    ("assigned_role_id", "Nullable(UUID)"),
+    ("state_updated_at", "DateTime64(6, 'UTC')"),
+    ("is_present", "UInt8"),
+]
+
+
+class _RecentIssueStateExternalTable(DANGEROUS_NoTeamIdCheckTable):
+    fields: dict[str, FieldOrTable] = RECENT_ISSUE_STATE_FIELDS
+
+    def to_printed_clickhouse(self, context):
+        return RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME
+
+    def to_printed_hogql(self):
+        return RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME
+
+
+class ErrorTrackingRecentIssueStateTable(LazyTable):
+    fields: dict[str, FieldOrTable] = RECENT_ISSUE_STATE_FIELDS
+
+    def lazy_select(
+        self,
+        table_to_add: LazyTableToAdd,
+        context: HogQLContext,
+        node: SelectQuery,
+    ):
+        from posthog.hogql import ast
+
+        database = context.database
+        if database is None:
+            raise ResolutionError("Database is not set")
+
+        rows = context.data_to_ingest.get(RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY) or []
+        if RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME not in context.external_tables:
+            context.external_tables[RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME] = {
+                "name": RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME,
+                "structure": RECENT_ISSUE_STATE_STRUCTURE,
+                "data": rows,
+            }
+            database.tables.add_child(
+                TableNode(
+                    name=RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME,
+                    table=_RecentIssueStateExternalTable(name=RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME),
+                    hidden=True,
+                ),
+                table_conflict_mode="override",
+                children_conflict_mode="override",
+            )
+
+        fields = list(table_to_add.fields_accessed)
+        return ast.SelectQuery(
+            select=[ast.Alias(alias=field, expr=ast.Field(chain=[field])) for field in fields],
+            select_from=ast.JoinExpr(table=ast.Field(chain=[RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME])),
+        )
+
+    def to_printed_clickhouse(self, context):
+        return RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME
+
+    def to_printed_hogql(self):
+        return "error_tracking_recent_issue_state"
 
 
 class RawErrorTrackingFingerprintIssueStateTable(Table):

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -126,11 +126,19 @@ class ErrorTrackingQueryBuilder:
       mixed-OR semantics across the events/issue boundary.
     """
 
-    def __init__(self, query: ErrorTrackingQuery, team: Team, date_from: datetime.datetime, date_to: datetime.datetime):
+    def __init__(
+        self,
+        query: ErrorTrackingQuery,
+        team: Team,
+        date_from: datetime.datetime,
+        date_to: datetime.datetime,
+        has_recent_issue_state: bool = False,
+    ):
         self.query = query
         self.team = team
         self.date_from = date_from
         self.date_to = date_to
+        self.has_recent_issue_state = has_recent_issue_state
 
     def build_query(self) -> ast.SelectQuery:
         if self._needs_legacy_shape():
@@ -199,6 +207,64 @@ class ErrorTrackingQueryBuilder:
             return any(self._tree_contains_issue_filter(child) for child in node.values)
         return False
 
+    def _effective_issue_field(self, field_name: str) -> ast.Expr:
+        clickhouse_field = ast.Field(chain=["fp_state", field_name])
+        if not self.has_recent_issue_state:
+            return clickhouse_field
+        return ast.Call(
+            name="if",
+            args=[
+                ast.Field(chain=["recent_issue_state", "is_present"]),
+                ast.Field(chain=["recent_issue_state", field_name]),
+                clickhouse_field,
+            ],
+        )
+
+    def _legacy_issue_field(self, field_name: str) -> ast.Expr:
+        if self.has_recent_issue_state:
+            return self._effective_issue_field(field_name)
+        event_field_names = {
+            "issue_id": "issue_id",
+            "issue_status": "issue_status",
+            "issue_name": "issue_name",
+            "issue_description": "issue_description",
+            "issue_severity": "issue_severity",
+            "assigned_user_id": "issue_assigned_user_id",
+            "assigned_role_id": "issue_assigned_role_id",
+            "first_seen": "issue_first_seen",
+        }
+        return ast.Field(chain=["e", event_field_names[field_name]])
+
+    def _fingerprint_state_join(self, left: ast.Expr) -> ast.JoinExpr:
+        fingerprint_state_join = ast.JoinExpr(
+            table=ast.Field(chain=["posthog", "error_tracking_fingerprint_issue_state"]),
+            alias="fp_state",
+            join_type="INNER JOIN",
+            constraint=ast.JoinConstraint(
+                expr=ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=left,
+                    right=ast.Field(chain=["fp_state", "fp_hash"]),
+                ),
+                constraint_type="ON",
+            ),
+        )
+        if self.has_recent_issue_state:
+            fingerprint_state_join.next_join = ast.JoinExpr(
+                table=ast.Field(chain=["posthog", "error_tracking_recent_issue_state"]),
+                alias="recent_issue_state",
+                join_type="LEFT OUTER JOIN",
+                constraint=ast.JoinConstraint(
+                    expr=ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["fp_state", "issue_id"]),
+                        right=ast.Field(chain=["recent_issue_state", "issue_id"]),
+                    ),
+                    constraint_type="ON",
+                ),
+            )
+        return fingerprint_state_join
+
     # ---------------------------------------------------------------------
     # Optimized two-pass shape
     # ---------------------------------------------------------------------
@@ -211,19 +277,7 @@ class ErrorTrackingQueryBuilder:
             select_from=ast.JoinExpr(
                 table=inner,
                 alias="ev",
-                next_join=ast.JoinExpr(
-                    table=ast.Field(chain=["posthog", "error_tracking_fingerprint_issue_state"]),
-                    alias="fp_state",
-                    join_type="INNER JOIN",
-                    constraint=ast.JoinConstraint(
-                        expr=ast.CompareOperation(
-                            op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=["ev", "fp_hash"]),
-                            right=ast.Field(chain=["fp_state", "fp_hash"]),
-                        ),
-                        constraint_type="ON",
-                    ),
-                ),
+                next_join=self._fingerprint_state_join(ast.Field(chain=["ev", "fp_hash"])),
             ),
             where=ast.And(exprs=outer_where_exprs) if outer_where_exprs else None,
             group_by=[ast.Field(chain=["id"])],
@@ -428,22 +482,22 @@ class ErrorTrackingQueryBuilder:
         # merged fingerprints to preserve the earliest-known-first-seen.
         exprs: list[ast.Expr] = [
             ast.Alias(alias="id", expr=ast.Field(chain=["fp_state", "issue_id"])),
-            ast.Alias(alias="status", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_status"])])),
+            ast.Alias(alias="status", expr=ast.Call(name="any", args=[self._effective_issue_field("issue_status")])),
             ast.Alias(
                 alias="severity", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_severity"])])
             ),
-            ast.Alias(alias="name", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_name"])])),
+            ast.Alias(alias="name", expr=ast.Call(name="any", args=[self._effective_issue_field("issue_name")])),
             ast.Alias(
                 alias="description",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_description"])]),
+                expr=ast.Call(name="any", args=[self._effective_issue_field("issue_description")]),
             ),
             ast.Alias(
                 alias="assignee_user_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "assigned_user_id"])]),
+                expr=ast.Call(name="any", args=[self._effective_issue_field("assigned_user_id")]),
             ),
             ast.Alias(
                 alias="assignee_role_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "assigned_role_id"])]),
+                expr=ast.Call(name="any", args=[self._effective_issue_field("assigned_role_id")]),
             ),
             ast.Alias(
                 alias="first_seen",
@@ -493,7 +547,7 @@ class ErrorTrackingQueryBuilder:
             exprs.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["fp_state", "issue_status"]),
+                    left=self._effective_issue_field("issue_status"),
                     right=ast.Constant(value=self.query.status),
                 )
             )
@@ -503,7 +557,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["fp_state", "assigned_user_id"]),
+                        left=self._effective_issue_field("assigned_user_id"),
                         right=ast.Constant(value=self.query.assignee.id),
                     )
                 )
@@ -511,7 +565,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["fp_state", "assigned_role_id"]),
+                        left=self._effective_issue_field("assigned_role_id"),
                         right=ast.Constant(value=str(self.query.assignee.id)),
                     )
                 )
@@ -523,9 +577,17 @@ class ErrorTrackingQueryBuilder:
     # ---------------------------------------------------------------------
 
     def _build_query_legacy(self) -> ast.SelectQuery:
+        select_from = ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e")
+        if self.has_recent_issue_state:
+            select_from.next_join = self._fingerprint_state_join(
+                ast.Call(
+                    name="cityHash64",
+                    args=[ast.Field(chain=["e", "properties", "$exception_fingerprint"])],
+                )
+            )
         return ast.SelectQuery(
             select=self._select_expressions_legacy(),
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e"),
+            select_from=select_from,
             where=ast.And(exprs=self._where_exprs_legacy()),
             group_by=[ast.Field(chain=["id"])],
             order_by=[ast.OrderExpr(expr=ast.Field(chain=[self.query.orderBy]), order=order_direction(self.query))],
@@ -533,25 +595,25 @@ class ErrorTrackingQueryBuilder:
 
     def _select_expressions_legacy(self) -> list[ast.Expr]:
         exprs: list[ast.Expr] = [
-            ast.Alias(alias="id", expr=ast.Field(chain=["e", "issue_id"])),
-            ast.Alias(alias="status", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_status"])])),
-            ast.Alias(alias="severity", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_severity"])])),
-            ast.Alias(alias="name", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_name"])])),
+            ast.Alias(alias="id", expr=self._legacy_issue_field("issue_id")),
+            ast.Alias(alias="status", expr=ast.Call(name="any", args=[self._legacy_issue_field("issue_status")])),
+            ast.Alias(alias="severity", expr=ast.Call(name="any", args=[self._legacy_issue_field("issue_severity")])),
+            ast.Alias(alias="name", expr=ast.Call(name="any", args=[self._legacy_issue_field("issue_name")])),
             ast.Alias(
-                alias="description", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_description"])])
+                alias="description", expr=ast.Call(name="any", args=[self._legacy_issue_field("issue_description")])
             ),
             ast.Alias(
                 alias="assignee_user_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_assigned_user_id"])]),
+                expr=ast.Call(name="any", args=[self._legacy_issue_field("assigned_user_id")]),
             ),
             ast.Alias(
                 alias="assignee_role_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_assigned_role_id"])]),
+                expr=ast.Call(name="any", args=[self._legacy_issue_field("assigned_role_id")]),
             ),
             ast.Alias(alias="last_seen", expr=ast.Call(name="max", args=[ast.Field(chain=["e", "timestamp"])])),
             ast.Alias(
                 alias="first_seen",
-                expr=ast.Call(name="min", args=[ast.Field(chain=["e", "issue_first_seen"])]),
+                expr=ast.Call(name="min", args=[self._legacy_issue_field("first_seen")]),
             ),
             ast.Alias(alias="function", expr=innermost_frame_attribute("$exception_functions")),
             ast.Alias(alias="source", expr=innermost_frame_attribute("$exception_sources")),
@@ -650,7 +712,7 @@ class ErrorTrackingQueryBuilder:
                 left=ast.Field(chain=["e", "event"]),
                 right=ast.Constant(value="$exception"),
             ),
-            ast.Call(name="isNotNull", args=[ast.Field(chain=["e", "issue_id"])]),
+            ast.Call(name="isNotNull", args=[self._legacy_issue_field("issue_id")]),
             ast.Placeholder(expr=ast.Field(chain=["filters"])),
         ]
 
@@ -676,7 +738,7 @@ class ErrorTrackingQueryBuilder:
             exprs.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["e", "issue_id"]),
+                    left=self._legacy_issue_field("issue_id"),
                     right=ast.Constant(value=self.query.issueId),
                 )
             )
@@ -706,7 +768,7 @@ class ErrorTrackingQueryBuilder:
             exprs.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["e", "issue_status"]),
+                    left=self._legacy_issue_field("issue_status"),
                     right=ast.Constant(value=self.query.status),
                 )
             )
@@ -716,7 +778,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["e", "issue_assigned_user_id"]),
+                        left=self._legacy_issue_field("assigned_user_id"),
                         right=ast.Constant(value=self.query.assignee.id),
                     )
                 )
@@ -724,7 +786,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["e", "issue_assigned_role_id"]),
+                        left=self._legacy_issue_field("assigned_role_id"),
                         right=ast.Constant(value=str(self.query.assignee.id)),
                     )
                 )
@@ -818,19 +880,17 @@ class ErrorTrackingQueryBuilder:
     def _issue_property_to_ast(self, prop: ErrorTrackingIssueFilter) -> ast.Expr | None:
         key = "description" if prop.key == "issue_description" else prop.key
 
-        field_chain_map: dict[str, list[str | int]] = {
-            "name": ["e", "issue_name"],
-            "description": ["e", "issue_description"],
-            "status": ["e", "issue_status"],
-            "severity": ["e", "issue_severity"],
-            "first_seen": ["e", "issue_first_seen"],
+        field_map: dict[str, ast.Expr] = {
+            "name": self._legacy_issue_field("issue_name"),
+            "description": self._legacy_issue_field("issue_description"),
+            "status": self._legacy_issue_field("issue_status"),
+            "severity": self._legacy_issue_field("issue_severity"),
+            "first_seen": self._legacy_issue_field("first_seen"),
         }
 
-        field_chain = field_chain_map.get(key)
-        if field_chain is None:
+        field = field_map.get(key)
+        if field is None:
             return None
-
-        field = ast.Field(chain=field_chain)
         value = prop.value
         operator = prop.operator
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -1,15 +1,25 @@
 import datetime
+from collections.abc import Sequence
+from uuid import UUID
 from zoneinfo import ZoneInfo
+
+from django.utils import timezone
+
+from prometheus_client import Histogram
 
 from posthog.schema import CachedErrorTrackingQueryResponse, ErrorTrackingQuery, ErrorTrackingQueryResponse
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.schema.error_tracking_fingerprint_issue_state import PENDING_UPDATES_HOGQL_CONTEXT_KEY
+from posthog.hogql.database.schema.error_tracking_fingerprint_issue_state import (
+    PENDING_UPDATES_HOGQL_CONTEXT_KEY,
+    RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY,
+)
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.dataclasses import frozen
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models.filters.mixins.utils import cached_property
@@ -18,6 +28,36 @@ from posthog.utils import relative_date_parse
 from products.error_tracking.backend.hogql_queries.access import ErrorTrackingQueryRunnerAccessMixin
 from products.error_tracking.backend.hogql_queries.error_tracking_query_builder import ErrorTrackingQueryBuilder
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import validate_uuid_param
+from products.error_tracking.backend.models import ErrorTrackingIssue
+
+RECENT_ISSUE_STATE_WINDOW = datetime.timedelta(seconds=60)
+ERROR_TRACKING_QUERY_RECENT_STATE_ROWS = Histogram(
+    "error_tracking_query_recent_state_rows",
+    "Number of recent authoritative issue-state rows sent with an Error Tracking query",
+)
+
+
+@frozen
+class RecentErrorTrackingIssueState:
+    issue_id: UUID
+    issue_status: str
+    issue_name: str | None
+    issue_description: str | None
+    assigned_user_id: int | None
+    assigned_role_id: UUID | None
+    state_updated_at: datetime.datetime
+
+    def as_external_row(self) -> dict[str, object]:
+        return {
+            "issue_id": self.issue_id,
+            "issue_status": self.issue_status,
+            "issue_name": self.issue_name,
+            "issue_description": self.issue_description,
+            "assigned_user_id": self.assigned_user_id,
+            "assigned_role_id": self.assigned_role_id,
+            "state_updated_at": self.state_updated_at,
+            "is_present": 1,
+        }
 
 
 class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQueryRunner[ErrorTrackingQueryResponse]):
@@ -27,7 +67,7 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
     date_from: datetime.datetime
     date_to: datetime.datetime
 
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -60,7 +100,16 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
 
     def get_cache_payload(self) -> dict:
         payload = super().get_cache_payload()
+        latest_state_updated_at = (
+            ErrorTrackingIssue.objects.filter(team_id=self.team.pk, state_updated_at__isnull=False)
+            .order_by("-state_updated_at")
+            .values_list("state_updated_at", flat=True)
+            .first()
+        )
         payload["error_tracking_cache_version"] = self.CACHE_VERSION
+        payload["error_tracking_state_updated_at"] = (
+            latest_state_updated_at.isoformat() if latest_state_updated_at is not None else None
+        )
         return payload
 
     @classmethod
@@ -88,32 +137,73 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
 
     MAX_PENDING_FINGERPRINT_ISSUE_STATE_UPDATES = 50
 
-    def _hogql_context(self) -> HogQLContext:
+    def _hogql_context(self, recent_issue_states: Sequence[RecentErrorTrackingIssueState] = ()) -> HogQLContext:
         ctx = HogQLContext(team_id=self.team.pk, team=self.team, user=self.user, enable_select_queries=True)
         raw = (self.query.pendingFingerprintIssueStateUpdates or [])[: self.MAX_PENDING_FINGERPRINT_ISSUE_STATE_UPDATES]
         if raw:
             ctx.data_to_ingest[PENDING_UPDATES_HOGQL_CONTEXT_KEY] = [row.model_dump(mode="json") for row in raw]
+        if recent_issue_states:
+            ctx.data_to_ingest[RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY] = [
+                state.as_external_row() for state in recent_issue_states
+            ]
         return ctx
 
+    def _recent_issue_states(self) -> list[RecentErrorTrackingIssueState]:
+        with self.timings.measure("error_tracking_query_recent_state_postgres"):
+            issues = list(
+                ErrorTrackingIssue.objects.filter(
+                    team_id=self.team.pk,
+                    state_updated_at__gte=timezone.now() - RECENT_ISSUE_STATE_WINDOW,
+                ).select_related("assignment")
+            )
+
+        states: list[RecentErrorTrackingIssueState] = []
+        for issue in issues:
+            assignment = getattr(issue, "assignment", None)
+            if issue.state_updated_at is None:
+                continue
+            states.append(
+                RecentErrorTrackingIssueState(
+                    issue_id=issue.id,
+                    issue_status=issue.status,
+                    issue_name=issue.name,
+                    issue_description=issue.description,
+                    assigned_user_id=assignment.user_id if assignment is not None else None,
+                    assigned_role_id=assignment.role_id if assignment is not None else None,
+                    state_updated_at=issue.state_updated_at,
+                )
+            )
+
+        ERROR_TRACKING_QUERY_RECENT_STATE_ROWS.observe(len(states))
+        return states
+
     def _calculate(self):
+        recent_issue_states = self._recent_issue_states()
+        builder = ErrorTrackingQueryBuilder(
+            self.query,
+            self.team,
+            self.date_from,
+            self.date_to,
+            has_recent_issue_state=bool(recent_issue_states),
+        )
         with self.timings.measure("error_tracking_query_hogql_execute"):
             query_result = self.paginator.execute_hogql_query(
-                query=self._builder.build_query(),
+                query=builder.build_query(),
                 team=self.team,
                 query_type="ErrorTrackingQuery",
                 timings=self.timings,
                 modifiers=self.modifiers,
                 limit_context=self.limit_context,
-                filters=self._builder.hogql_filters(),
+                filters=builder.hogql_filters(),
                 user=self.user,
-                context=self._hogql_context(),
+                context=self._hogql_context(recent_issue_states),
             )
 
         columns, results = self._attach_events(query_result.columns or [], query_result.results)
 
         return ErrorTrackingQueryResponse(
             columns=columns,
-            results=self._builder.process_results(columns, results),
+            results=builder.process_results(columns, results),
             timings=query_result.timings,
             hogql=query_result.hogql,
             modifiers=self.modifiers,

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
@@ -34,10 +35,18 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.schema.error_tracking_fingerprint_issue_state import (
+    RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME,
+    RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY,
+)
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client import sync_execute
 from posthog.constants import AvailableFeature
+from posthog.models.team import Team
 from posthog.models.utils import uuid7
 from posthog.rbac.user_access_control import UserAccessControlError
 
@@ -52,7 +61,10 @@ from products.error_tracking.backend.hogql_queries.error_tracking_issue_correlat
     ErrorTrackingIssueCorrelationQueryRunner,
 )
 from products.error_tracking.backend.hogql_queries.error_tracking_query_builder import ErrorTrackingQueryBuilder
-from products.error_tracking.backend.hogql_queries.error_tracking_query_runner import ErrorTrackingQueryRunner
+from products.error_tracking.backend.hogql_queries.error_tracking_query_runner import (
+    ErrorTrackingQueryRunner,
+    RecentErrorTrackingIssueState,
+)
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import search_tokenizer
 from products.error_tracking.backend.hogql_queries.error_tracking_similar_issues_query_runner import (
     ErrorTrackingSimilarIssuesQueryRunner,
@@ -611,6 +623,217 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
 
         results = self._calculate(status="all")["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_three, self.issue_id_two, self.issue_id_one])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_status_overrides_display_and_filtering(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            state_updated_at=now(),
+        )
+
+        results = self._calculate()["results"]
+        issue = next(result for result in results if result["id"] == self.issue_id_one)
+        self.assertEqual(issue["status"], ErrorTrackingIssue.Status.RESOLVED)
+        self.assertNotIn(self.issue_id_one, {result["id"] for result in self._calculate(status="active")["results"]})
+        self.assertEqual(
+            [result["id"] for result in self._calculate(status="resolved")["results"]],
+            [self.issue_id_one],
+        )
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_user_assignment_overrides_clickhouse(self):
+        ErrorTrackingIssueAssignment.objects.create(issue_id=self.issue_id_one, user=self.user, team=self.team)
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=now())
+
+        results = self._calculate(assignee={"type": "user", "id": self.user.pk})["results"]
+        self.assertEqual([result["id"] for result in results], [self.issue_id_one])
+        self.assertEqual(results[0]["assignee"], {"id": self.user.pk, "type": "user"})
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_role_assignment_overrides_clickhouse(self):
+        role = Role.objects.create(name="Overlay role", organization=self.organization)
+        ErrorTrackingIssueAssignment.objects.create(issue_id=self.issue_id_one, role=role, team=self.team)
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=now())
+
+        results = self._calculate(assignee={"type": "role", "id": str(role.id)})["results"]
+        self.assertEqual([result["id"] for result in results], [self.issue_id_one])
+        self.assertEqual(results[0]["assignee"], {"id": str(role.id), "type": "role"})
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_unassignment_overrides_clickhouse(self):
+        assignment = ErrorTrackingIssueAssignment.objects.create(
+            issue_id=self.issue_id_one,
+            user=self.user,
+            team=self.team,
+        )
+        sync_issues_to_clickhouse(issue_ids=[self.issue_id_one], team_id=self.team.pk)
+        assignment.delete()
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=now())
+
+        issue = next(result for result in self._calculate()["results"] if result["id"] == self.issue_id_one)
+        self.assertIsNone(issue["assignee"])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_null_description_overrides_clickhouse(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(description="stale description")
+        sync_issues_to_clickhouse(issue_ids=[self.issue_id_one], team_id=self.team.pk)
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(description=None, state_updated_at=now())
+
+        issue = next(result for result in self._calculate()["results"] if result["id"] == self.issue_id_one)
+        self.assertIsNone(issue["description"])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_state_older_than_overlay_window_does_not_override_clickhouse(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            state_updated_at=now() - timedelta(seconds=61),
+        )
+
+        issue = next(result for result in self._calculate()["results"] if result["id"] == self.issue_id_one)
+        self.assertEqual(issue["status"], ErrorTrackingIssue.Status.ACTIVE)
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_cache_watermark_remains_after_overlay_window_expires(self):
+        state_updated_at = now() - timedelta(seconds=61)
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=state_updated_at)
+        runner = ErrorTrackingQueryRunner(
+            team=self.team,
+            query=ErrorTrackingQuery(
+                kind="ErrorTrackingQuery",
+                dateRange=DateRange(date_from="all"),
+                orderBy="last_seen",
+                volumeResolution=1,
+            ),
+        )
+
+        self.assertEqual(runner.get_cache_payload()["error_tracking_state_updated_at"], state_updated_at.isoformat())
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_cache_payload_changes_when_state_watermark_advances(self):
+        runner = ErrorTrackingQueryRunner(
+            team=self.team,
+            query=ErrorTrackingQuery(
+                kind="ErrorTrackingQuery",
+                dateRange=DateRange(date_from="all"),
+                orderBy="last_seen",
+                volumeResolution=1,
+            ),
+        )
+        initial_payload = runner.get_cache_payload()
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=now())
+
+        self.assertNotEqual(initial_payload, runner.get_cache_payload())
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_issue_lookup_is_team_scoped(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=now())
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        other_issue = ErrorTrackingIssue.objects.create(team=other_team, state_updated_at=now())
+        runner = ErrorTrackingQueryRunner(
+            team=self.team,
+            query=ErrorTrackingQuery(
+                kind="ErrorTrackingQuery",
+                dateRange=DateRange(date_from="all"),
+                orderBy="last_seen",
+                volumeResolution=1,
+            ),
+        )
+
+        recent_issue_ids = {state.issue_id for state in runner._recent_issue_states()}
+        self.assertEqual(recent_issue_ids, {UUID(self.issue_id_one)})
+        self.assertNotIn(other_issue.id, recent_issue_ids)
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_issue_level_overlay_applies_to_more_than_fifty_fingerprints(self):
+        issue_id = "01936e83-5c2d-78f5-9237-13a5cbe7a190"
+        issue = ErrorTrackingIssue.objects.create(id=issue_id, team=self.team, status=ErrorTrackingIssue.Status.ACTIVE)
+        fingerprints = [f"many_fingerprints_{index}" for index in range(51)]
+        ErrorTrackingIssueFingerprintV2.objects.bulk_create(
+            [
+                ErrorTrackingIssueFingerprintV2(team=self.team, issue=issue, fingerprint=fingerprint)
+                for fingerprint in fingerprints
+            ]
+        )
+        for fingerprint in fingerprints:
+            _create_event(
+                distinct_id=self.distinct_id_one,
+                event="$exception",
+                team=self.team,
+                properties={"$exception_fingerprint": fingerprint},
+            )
+        sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+        flush_persons_and_events()
+        ErrorTrackingIssue.objects.filter(id=issue_id).update(
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            state_updated_at=now(),
+        )
+
+        result = self._calculate(issueId=issue_id, withAggregations=True)["results"][0]
+        self.assertEqual(result["status"], ErrorTrackingIssue.Status.RESOLVED)
+        self.assertEqual(result["aggregations"]["occurrences"], 51)
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_no_recent_state_uses_query_without_external_overlay(self):
+        response = self._calculate()
+
+        self.assertNotIn("error_tracking_recent_issue_state", response["hogql"])
+
+    def test_recent_state_external_table_preserves_schema_and_values(self):
+        issue_id = UUID(self.issue_id_one)
+        role_id = UUID("01936e83-f5c0-7e18-a166-20af1de09255")
+        state_updated_at = datetime(2025, 1, 2, 3, 4, 5, 678901, tzinfo=UTC)
+        state = RecentErrorTrackingIssueState(
+            issue_id=issue_id,
+            issue_status=ErrorTrackingIssue.Status.RESOLVED,
+            issue_name=None,
+            issue_description=None,
+            assigned_user_id=42,
+            assigned_role_id=role_id,
+            state_updated_at=state_updated_at,
+        )
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        context.data_to_ingest[RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY] = [state.as_external_row()]
+        sql, _ = prepare_and_print_ast(
+            parse_select(
+                "SELECT recent_issue_state.issue_id, recent_issue_state.issue_status, recent_issue_state.issue_name, "
+                "recent_issue_state.issue_description, recent_issue_state.assigned_user_id, "
+                "recent_issue_state.assigned_role_id, recent_issue_state.state_updated_at, "
+                "recent_issue_state.is_present FROM posthog.error_tracking_recent_issue_state AS recent_issue_state"
+            ),
+            context,
+            dialect="clickhouse",
+        )
+
+        table = context.external_tables[RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME]
+        self.assertIn(RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME, sql)
+        self.assertEqual(
+            table["structure"],
+            [
+                ("issue_id", "UUID"),
+                ("issue_status", "String"),
+                ("issue_name", "Nullable(String)"),
+                ("issue_description", "Nullable(String)"),
+                ("assigned_user_id", "Nullable(Int64)"),
+                ("assigned_role_id", "Nullable(UUID)"),
+                ("state_updated_at", "DateTime64(6, 'UTC')"),
+                ("is_present", "UInt8"),
+            ],
+        )
+        self.assertEqual(
+            table["data"],
+            [
+                {
+                    "issue_id": issue_id,
+                    "issue_status": ErrorTrackingIssue.Status.RESOLVED,
+                    "issue_name": None,
+                    "issue_description": None,
+                    "assigned_user_id": 42,
+                    "assigned_role_id": role_id,
+                    "state_updated_at": state_updated_at,
+                    "is_present": 1,
+                }
+            ],
+        )
 
     @freeze_time("2022-01-10T12:11:00")
     @snapshot_clickhouse_queries


### PR DESCRIPTION
## Problem

Error Tracking users can briefly see stale issue status, metadata, or assignment after an update.

## Changes

- Issue lists now use recent Postgres state before ClickHouse state reaches the denormalized table.
- The query applies one issue-level override after fingerprint state deduplicates, so all fingerprints use the same state.
- The query cache includes the latest issue-state timestamp for the current team.
- The query sends recent state as a typed external table and preserves intentional null values.
- The change adds timing and row-count metrics for the Postgres overlay lookup.

```mermaid
flowchart LR
classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
A[Issue mutation] --> B[(Postgres)]
A --> C[(ClickHouse fingerprint state)]
D[Issue list] --> C
class A,D phYellow;
class B,C phGray;
```

```mermaid
flowchart LR
classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
A[Issue mutation] --> B[(Postgres)]
A --> C[(ClickHouse fingerprint state)]
D[Issue list] --> B
B --> E[External overlay]
D --> C
C --> E
class A,D phYellow;
class B,C phGray;
class E phBlue;
```

## How did you test this code?

- Added query behavior cases for recent status, assignment, null values, cache watermarks, team isolation, and many fingerprints.
- Added an external-table schema case for nullable values, UUIDs, integers, and timestamps.
- Ran the focused query suite successfully before updating the branch base.
- A repeat run after the rebase hit local ClickHouse file-descriptor exhaustion.
- Ran Ruff, formatting, the dataclass invariant, and CI preflight.
- Not completed: repository-wide mypy. The command exceeded the local time limit.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. This is an internal consistency change with no public API change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was authored with pi and repository tooling. Skills invoked: `/writing-tests`, `/writing-dataclasses`, `/writing-code-comments`, and `/writing-pr-descriptions`. The implementation uses the existing query-scoped external-table lifecycle instead of persistent ClickHouse storage or generated SQL branches.
