### PR TITLE
feat(onboarding): restore the data sources step in self-driving onboarding

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6337,7 +6337,7 @@ snapshots:
     scenes-app-experiments--experiment-frequentist-two-variants--light:
         hash: v1.k794b7964.ec64583fd2debf87822296f1c9fc10e73c1c6b7e31fe55f0ca974d3920f8bd14.Ch64gBgjo0wR0Ypvkhap6047UPjXBaWSQCNoKDOiNHc
     scenes-app-experiments--experiment-stopped-with-conclusion--dark:
-        hash: v1.k794b7964.37e8127d5a33175889cf1da00e80998b1858fd3713fe5c0c1ec42ff0bb1da220.oIA6fAIpYfvfCAh_6TQs-uqDeMEONwTb3luZF1rzBs4
+        hash: v1.k794b7964.e347bbe9e217d7cbd915b09b362a9d995285c1f6492229235ce3dcef74e49f30.5xV99CaEDXp-xFACHoS4M9vQ6zFGOjestb-iW79F5Q4
     scenes-app-experiments--experiment-stopped-with-conclusion--light:
         hash: v1.k794b7964.793a4b6109b2c0ab65b07d9eaefd1c8862f12bfc7f33b2f452ad20044396b2a7.6B0Meq7yO75vBEoBmuP2dNl2oKTugzzr_IKTcJHhEi0
     scenes-app-experiments--experiment-with-funnel-metric--dark:

--- a/frontend/src/scenes/onboarding/onboardingEventUsageLogic.ts
+++ b/frontend/src/scenes/onboarding/onboardingEventUsageLogic.ts
@@ -12,6 +12,7 @@ export type SelfDrivingOnboardingStepId =
     | 'goals'
     | 'tools'
     | 'install'
+    | 'sources'
     | 'authorized-urls'
     | 'ai-observability'
     | 'billing'

--- a/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
@@ -27,6 +27,7 @@ import { AIObservabilityStep } from './steps/AIObservabilityStep'
 import { AuthorizedUrlsStep } from './steps/AuthorizedUrlsStep'
 import { BillingStep } from './steps/BillingStep'
 import { InstallStep } from './steps/InstallStep'
+import { SourcesStep } from './steps/SourcesStep'
 import { ToolsStep } from './steps/ToolsStep'
 import { UseCasesStep } from './steps/UseCasesStep'
 import { WelcomeStep } from './steps/WelcomeStep'
@@ -85,6 +86,17 @@ function buildSteps(useCase: OnboardingUseCaseKey | null): StepDef[] {
         // finish line without. These steps render their own action zone, so the footer Continue is
         // suppressed.
         ...(resolveSetup(useCase).extraSteps ?? []).map((id) => EXTRA_STEPS[id]),
+        // Shown to every goal: ad platforms (Google Ads, Meta Ads) and other warehouse sources
+        // have no other onboarding surface, and connecting one is what makes cross-source
+        // insights possible later.
+        {
+            id: 'sources',
+            title: 'Connect your data',
+            Content: SourcesStep,
+            skippable: true,
+            hideContinue: true,
+            maxWidth: 'max-w-3xl',
+        },
         {
             id: 'billing',
             title: 'Pick a plan',

--- a/frontend/src/scenes/onboarding/self-driving/steps/SourcesStep.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/steps/SourcesStep.tsx
@@ -1,0 +1,18 @@
+import { InlineSourceSetup } from 'products/data_warehouse/frontend/shared/components/InlineSourceSetup'
+
+/**
+ * Featured data warehouse sources (Stripe, ad platforms, Postgres, GitHub, ...) with the full
+ * catalog behind an expand. Connecting a source is the step's primary action; the footer only
+ * offers Skip. Ad platforms have no other onboarding surface, so this step is their entry point.
+ */
+export function SourcesStep({ onContinue }: { onContinue: () => void }): JSX.Element {
+    return (
+        <InlineSourceSetup
+            onComplete={onContinue}
+            featured
+            showWizard
+            autoConfigureTables
+            subtitle="Link sources like Stripe, Google Ads, and Postgres to query them alongside your product data. You can always connect more sources later."
+        />
+    )
+}


### PR DESCRIPTION
## Problem

- New users lost the only onboarding surface that offered warehouse sources when the self-driving flow replaced the old one (#75697): the old flow's sources step, which led with featured connectors like Google Ads, Meta Ads, and Stripe, was deleted without a replacement.
- Ad platforms have no other entry point: nothing in the goals step, the tools step, or the sidebar routes a new user toward connecting them.
- Since the change, first-time source connections per week fell roughly 15% while signups stayed flat, concentrated in ad platforms, Stripe, and GitHub.

## Changes

- Adds a skippable "Connect your data" step to the self-driving flow, after install and any goal-specific steps, before billing.
- The step reuses `InlineSourceSetup` (featured sources, full catalog behind expand, agent fast path, one-click table config), the same component the legacy flow's sources step still uses.
- Shown for every goal, matching the old flow. Connecting a source advances; the footer offers "Skip for now".
- Selecting an ad connector in the picker already registers the marketing analytics product intent, so the sidebar entry to Marketing analytics follows from this step without extra wiring.

No screenshot: I (Claude) made this change without a running app in the session. The step renders the same source grid as the legacy onboarding's "Connect your data for better insights" step, inside the self-driving card.

## How did you test this code?

- Typecheck and `hogli ci:preflight --fix` pass locally.
- No new tests: the change is declarative step config rendering an existing, already-exercised component. The existing self-driving onboarding story picks up the new step in Visual Review.
- Not run: the Storybook render locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in a session driven by Tom Owers, following an analytics investigation into declining new-source counts that traced the drop to this removed onboarding surface.
- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- The alternative considered was a marketing-specific goal in the goals step; restoring the general sources step covers the same ad sources plus the Stripe and GitHub losses, with less product surface.
