### PR TITLE
chore(capture): semgrep guard for the config resolution choke point

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -75,9 +75,11 @@ jobs:
                       go:
                         - 'livestream/**'
                         - '.github/workflows/ci-security.yaml'
+                      # Keep .semgrep/rules/rust aligned with semgrep-rust's --config list.
                       rust:
                         - 'cli/**'
                         - 'rust/**'
+                        - '.semgrep/rules/rust/**'
                         - '.github/workflows/ci-security.yaml'
                       js:
                         - 'frontend/**'
@@ -243,6 +245,7 @@ jobs:
                       --config p/security-audit
                       --config p/trailofbits
                       --config r/rust.lang.security
+                      --config .semgrep/rules/rust
                       --exclude-rule trailofbits.generic.curl-unencrypted-url.curl-unencrypted-url
                       --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
                       --exclude-rule trailofbits.rs.panic-in-function-returning-result.panic-in-function-returning-result

--- a/.semgrep/rules/rust/capture-config-via-config-resolution.rs
+++ b/.semgrep/rules/rust/capture-config-via-config-resolution.rs
@@ -1,0 +1,52 @@
+// Test cases for the capture-config-via-config-resolution rule.
+
+use envconfig::Envconfig;
+
+fn parses_config_directly() -> Config {
+    // ruleid: capture-config-via-config-resolution
+    Config::init_from_env().expect("Invalid configuration:")
+}
+
+fn parses_config_from_a_snapshot(env: &HashMap<String, String>) -> Config {
+    // ruleid: capture-config-via-config-resolution
+    envconfig::Envconfig::init_from_hashmap(env).unwrap()
+}
+
+fn parses_via_self() -> Result<Self, envconfig::Error> {
+    // ruleid: capture-config-via-config-resolution
+    Self::init_from_env()
+}
+
+fn parses_via_qualified_trait_syntax() -> Config {
+    // ruleid: capture-config-via-config-resolution
+    <Config as Envconfig>::init_from_env().unwrap()
+}
+
+fn resolves_through_the_choke_point() -> anyhow::Result<Config> {
+    // ok: capture-config-via-config-resolution
+    let resolved = crate::config_resolution::resolve(&std::env::vars().collect())?;
+    Ok(resolved.config().clone())
+}
+
+fn resolves_around_a_built_config(config: Config) -> anyhow::Result<Resolved> {
+    // ok: capture-config-via-config-resolution
+    crate::config_resolution::resolve_with_config(config, &std::env::vars().collect())
+}
+
+// Inline unit tests build configs directly on purpose.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(env: &HashMap<String, String>) -> Config {
+        // ok: capture-config-via-config-resolution
+        envconfig::Envconfig::init_from_hashmap(env).expect("test config")
+    }
+
+    #[test]
+    fn a_test_that_builds_its_own_config() {
+        // ok: capture-config-via-config-resolution
+        let config: Config = Config::init_from_env().unwrap();
+        assert!(!config.print_sink);
+    }
+}

--- a/.semgrep/rules/rust/capture-config-via-config-resolution.yaml
+++ b/.semgrep/rules/rust/capture-config-via-config-resolution.yaml
@@ -1,0 +1,47 @@
+rules:
+    - id: capture-config-via-config-resolution
+      message: |
+          capture config is being parsed straight from the environment.
+
+          Obtain it through `config_resolution::resolve(&env)` instead, and read the
+          result with `resolved.config()`.
+
+          `resolve` is the choke point that applies the emergency Kafka fallback
+          (`CAPTURE_ANALYTICS_KAFKA_EMERGENCY_FALLBACK`) to every broker address before
+          anything is built. An envconfig parse returns pre-fallback config, so a producer
+          built from it keeps pointing at the primary cluster while the switch is armed —
+          which is exactly the outage the switch exists for.
+
+          Test code that needs a hand-built `Config` should use
+          `config_resolution::resolve_with_config`, which is gated behind the `test-utils`
+          feature and still applies the fallback.
+
+          For a genuine exception, add
+          `// nosemgrep: capture-config-via-config-resolution -- <reason>` at the call site.
+      severity: ERROR
+      languages: [rust]
+      paths:
+          include:
+              - 'rust/capture/src/**'
+          exclude:
+              # The resolver itself: the one place allowed to parse the environment.
+              - 'rust/capture/src/config_resolution.rs'
+              # Test scaffolding, compiled only under `cfg(test)` or the
+              # `test-utils` feature, so it never builds a production producer.
+              - 'rust/capture/src/v1/test_utils.rs'
+      patterns:
+          - pattern-either:
+                - pattern: $X::init_from_env(...)
+                - pattern: $X::init_from_hashmap(...)
+                - pattern: <$T as $TRAIT>::init_from_env(...)
+                - pattern: <$T as $TRAIT>::init_from_hashmap(...)
+          # Inline unit tests build configs directly on purpose. Semgrep's Rust
+          # support does not match a metavariable module name here, so this
+          # relies on the crate's `mod tests` naming convention.
+          - pattern-not-inside: mod tests { ... }
+      metadata:
+          category: best-practice
+          subcategory:
+              - audit
+          technology:
+              - rust

--- a/rust/capture/src/v1/sinks/mod.rs
+++ b/rust/capture/src/v1/sinks/mod.rs
@@ -201,6 +201,7 @@ fn load_sink_config(name: SinkName, env: &HashMap<String, String>) -> anyhow::Re
         }
     }
 
+    // nosemgrep: capture-config-via-config-resolution -- the sink half of config_resolution::resolve, which applies the fallback to what this returns
     let kafka = kafka::config::Config::init_from_hashmap(&kafka_map)
         .map_err(|e| anyhow::anyhow!("kafka config: {e}"))?;
 


### PR DESCRIPTION
## Problem

Stacked on #86639, which makes `config_resolution::resolve` the single way capture obtains its config so the emergency Kafka fallback reaches every producer. That property holds today because the bypasses were removed by hand. Nothing stops the next person from adding `Config::init_from_env()` back into a startup path, and the failure is silent: capture boots fine, the switch reports armed, and one producer keeps writing to the cluster that is down.

This adds the lint that keeps the choke point closed.

## Changes

A local semgrep rule, `capture-config-via-config-resolution`, flags any envconfig entry point called under `rust/capture/src/` outside the resolver. Someone who reintroduces a direct parse gets told where to go instead, at review time rather than during an outage.

- **Matched call forms:** `$X::init_from_env(...)`, `$X::init_from_hashmap(...)`, and the qualified `<$T as $TRAIT>::…` spellings of both. `$X` covers `Config::`, `Self::`, and fully-qualified `envconfig::Envconfig::` prefixes.
- **Exempt by path:** `config_resolution.rs` (the resolver) and `v1/test_utils.rs` (test scaffolding, compiled only under `cfg(test)` or the `test-utils` feature).
- **Exempt by scope:** anything inside `mod tests`. Inline unit tests build configs directly on purpose, and path excludes cannot reach them because they live in the same files as production code.
- **One `nosemgrep`,** on the sink half of the resolver in `v1/sinks/mod.rs`, which parses its own env namespace by design and is only reachable through `resolve`.

Wired into the existing `semgrep-rust` job rather than `semgrep-devex`, because that job is the one that scans `rust/`. The `rust` paths-filter gains `.semgrep/rules/rust/**` so editing a rule reruns the job that enforces it, matching the alignment comments already in that filter block. `semgrep-test-rules` picks up the fixture with no change, since it already globs all of `.semgrep/`.

## Why this is stacked rather than part of #86639

The rule points every violation at `config_resolution::resolve`, which only exists on the branch below. Based on master it would name a module that isn't there. Keeping it separate also keeps a CI workflow edit out of the feature PR, so the two get reviewed by the people who care about each.

## How did you test this code?

Ran locally with the pinned CI image (`semgrep/semgrep:1.167.0`) and semgrep 1.168.0:

- `semgrep --test .semgrep/` — **47/47 rule tests pass**, including this rule's fixture. The fixture asserts four positive forms and four negatives: the two sanctioned resolver entry points, a test-mod helper, and a `#[test]` body.
- `semgrep --config .semgrep/rules/rust/ rust/` — **clean**, zero findings across the whole rust tree.
- **Caught-violation demo:** adding `envconfig::Envconfig::init_from_hashmap(&std::env::vars().collect())` to `rust/capture/src/server.rs` produced exactly one blocking finding at that line. Reverted after the check.
- Before the `nosemgrep` was added, the rule found the one real production caller (`v1/sinks/mod.rs:204`) and nothing else, which is how the exemption was chosen rather than assumed.

Also ran `bin/hogli lint:workflows` (8 checks across 127 workflows, all pass) and confirmed the rendered `semgrep ci` args parse to a single whitespace-split line. `cargo fmt --check` and `cargo check -p capture` still pass with the comment added.

Not tested: the job running against the semgrep registry packs, which needs network access to `semgrep.dev`. That path is unchanged by this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Repo skills invoked: `/authoring-ci-workflows` before the workflow edit, and `/writing-code-comments`.

Two findings worth flagging for review. Semgrep's Rust support does not match a metavariable module name in `pattern-not-inside`, so `mod $M { ... }` silently matches nothing while the literal `mod tests { ... }` works — the rule relies on the crate's naming convention, and the comment in the rule says so. And `nosemgrep` only suppresses from the line immediately above the finding, so the exemption's reason had to go on that one line rather than in a wrapped comment block.
