### PR TITLE
fix(replay-vision): make the scanner digest summarize its window

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/scannerScout.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScout.ts
@@ -82,12 +82,19 @@ interface ScoutFocus {
     quiet: string
     priority: string
     skip: string
+    /** Replaces the default report shape. A watcher reports an exception, so its default is a
+     * takeaway and at most three bullets; a digest summarizes the window whether or not anything
+     * crossed a bar, and that does not fit in three bullets. */
+    shape?: string
 }
 
 /** Every template shares this scaffolding — how to orient, dedupe, file, and handle untrusted
  * observation text — and differs only in what it reads and what it considers report-worthy. The
  * scanner id is the sole baked-in context; the scanner's name, type, and prompt are read live via
  * `vision-scanners-get`, so editing the scanner never requires touching the scout. */
+const DEFAULT_REPORT_SHAPE = `- Open with the takeaway in one line, then at most three bullets ordered by impact.
+- Each bullet: what changed, with only the numbers needed to judge it; why it matters; the evidence-backed cause or best next investigation; and the specific next action.`
+
 function buildScoutBody(scannerId: string, focus: ScoutFocus): string {
     return `# ${focus.heading}
 
@@ -130,18 +137,17 @@ ${focus.skip}
 Every successful run leaves exactly one report for the date, and it is the digest: never one report per finding, and never a run that files nothing.
 
 Title it \`<your scout name>: YYYY-MM-DD\`, dating it with the run's date in the project timezone. Your scout name is your own \`skill_name\` with the \`signals-scout-\` prefix dropped, dashes turned into spaces, and the first letter capitalized: \`signals-scout-checkout-trend-watch\` titles as \`Checkout trend watch: 2026-01-31\`. It already carries the scanner, so nothing else has to, and it is what keeps two scouts from writing the same title, which matters because of the next line.
-Before writing, \`inbox-reports-list\` and compare titles exactly: if today's title already exists, \`scout-edit-report\` it rather than authoring a second one. Otherwise \`scout-emit-report\`. Never two reports for the same date, and never a second emit later in the same run — each one delivers again.
+Before writing, find your own report by pointer, never by title: \`scout-scratchpad-search\` for \`${scannerId}:report:<today>\` and \`inbox-reports-retrieve\` the id it holds. Edit that report if it exists; otherwise \`scout-emit-report\` and stash the new id under \`${scannerId}:report:<today>\`. A title match is not proof the report is yours — several scouts watch this scanner, and more than one of them titles its report after the scanner, so matching on title edits another scout's report and leaves yours unwritten. Never two reports for the same date from you, and never a second emit later in the same run — each one delivers again.
 
 Write the report so it stands alone for a reader with no prior context:
 
-- Open with the takeaway in one line, then at most three bullets ordered by impact.
-- Each bullet: what changed, with only the numbers needed to judge it; why it matters; the evidence-backed cause or best next investigation; and the specific next action.
+${focus.shape ?? DEFAULT_REPORT_SHAPE}
 - Ground every claim in observations you actually read, as real markdown links to the recording: \`[what it shows](/project/<project_id>/replay/<session_id>?t=<seconds>)\`, so the link opens on the moment being claimed. A bare \`[obs 3]\` is not a link and leaves the reader nowhere to go. Two or three per bullet is plenty; link the clearest cases, not every one.
 - Link what another scout already reported rather than restating it: \`[already documented](/project/<project_id>/inbox/<report_id>)\`, taking the id from \`inbox-reports-list\`. Several scouts watch this scanner and read the same window, so without the link one finding gets filed three times.
 - Close with what you checked, and name anything you could not cover and why.
 
 When nothing clears the bar, still file the report, with the verdict \`Nothing notable\` and a short coverage line ("42 observations across 30 sessions, distributions steady"). ${focus.priority}
-These are watcher findings: \`repository=NO_REPO\`. Set \`actionability\` by what the report asks of its reader. \`requires_human_input\` only when someone has to decide or act on what you found: it lands in the inbox awaiting input, and a digest that reports a quiet day does not belong in that queue. Otherwise \`immediately_actionable\`, which surfaces the report without asking anything of anyone. Never \`not_actionable\`: it suppresses the report, which empties the scanner's digest card and stops delivery, so a quiet day reads as a run that never happened. After writing, keep a \`report:\` scratchpad pointer so the next run finds today's report instead of duplicating it.
+These are watcher findings: \`repository=NO_REPO\`. Set \`actionability\` by what the report asks of its reader. \`requires_human_input\` only when someone has to decide or act on what you found: it lands in the inbox awaiting input, and a digest that reports a quiet day does not belong in that queue. Otherwise \`immediately_actionable\`, which surfaces the report without asking anything of anyone. Never \`not_actionable\`: it suppresses the report, which empties the scanner's digest card and stops delivery, so a quiet day reads as a run that never happened. After writing, stash the report id under \`${scannerId}:report:<today>\` — that pointer, not the title, is how the next run finds this report.
 
 ## Charts, when the shape is the point
 
@@ -230,15 +236,22 @@ export function scannerScoutTemplates(
                 role: 'You write the daily digest for one Replay Vision scanner: read what it observed since your last run and report what a product team should know.',
                 reads: `- \`vision-scanners-observations-stats\` and \`vision-scanners-observations-list\` (scanner_id \`${scannerId}\`) — the primary read: what the scanner saw in the window, and how its outcomes are distributed.
 - \`execute-sql\` over \`$recording_observed\` for counts and distributions across the window when the stats endpoint doesn't answer the question.`,
-                notable: `Judge the window against the scanner's own baseline, not an absolute bar:
+                notable: `Every run summarizes the window. There is no bar to clear: a reader opens a
+digest to learn what the scanner saw, so describe the window whether or not anything changed.
 
+Lead the summary with whatever the window is actually about, and lean on:
+
+- The themes the observations fall into, and roughly how much of the window each accounts for.
 - A friction theme, complaint, or failure mode recurring across several distinct sessions.
 - A verdict rate, score distribution, or tag mix stepping away from the scanner's prior weeks.
 - A single session severe enough that the team should watch the recording today.`,
-                quiet: 'Routine volume, steady distributions, happy-path summaries, and one mild low-score session are baseline. A quiet window is a normal outcome, and still files its digest: verdict `Nothing notable`, plus what you checked.',
+                quiet: 'A window where nothing changed still has content: what users did, which themes dominated, and how the distribution sat against prior weeks. Say plainly that nothing stood out, then summarize the window anyway. `Nothing notable` on its own is not a digest.',
                 skip: `- Anything the scanner's own per-session signals already pushed to the inbox.
-- A theme resting on one or two observations; say so rather than inflating it into a trend.
 - Observations whose own signals contradict the claim (a session marked \`friction: none\` is never evidence of an error).`,
+                shape: `- Open with a two or three sentence read on the window: what users were doing, and what stood out.
+- Then a short section per theme, each a heading and two to four bullets. Order them by how much of the window they cover, and say roughly how many sessions each rests on.
+- A theme resting on one or two observations is worth a sentence, not a section: say how thin it is rather than inflating it or dropping it.
+- Close with "What to look at": the few things worth someone's time, each naming the action.`,
                 priority: 'Priority P3 by default; P2 when a severe problem is spreading.',
             }),
         },

--- a/products/replay_vision/frontend/replay_scanners/scannerScout.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScout.ts
@@ -82,6 +82,9 @@ interface ScoutFocus {
     quiet: string
     priority: string
     skip: string
+    /** Replaces the default quiet-window verdict. A watcher's quiet run is a one-line "nothing
+     * crossed the bar"; a digest has no bar to clear, so that line contradicts its own shape. */
+    quietVerdict?: string
     /** Replaces the default report shape. A watcher reports an exception, so its default is a
      * takeaway and at most three bullets; a digest summarizes the window whether or not anything
      * crossed a bar, and that does not fit in three bullets. */
@@ -92,6 +95,9 @@ interface ScoutFocus {
  * observation text — and differs only in what it reads and what it considers report-worthy. The
  * scanner id is the sole baked-in context; the scanner's name, type, and prompt are read live via
  * `vision-scanners-get`, so editing the scanner never requires touching the scout. */
+const DEFAULT_QUIET_VERDICT =
+    'When nothing clears the bar, still file the report, with the verdict `Nothing notable` and a short coverage line ("42 observations across 30 sessions, distributions steady").'
+
 const DEFAULT_REPORT_SHAPE = `- Open with the takeaway in one line, then at most three bullets ordered by impact.
 - Each bullet: what changed, with only the numbers needed to judge it; why it matters; the evidence-backed cause or best next investigation; and the specific next action.`
 
@@ -137,7 +143,7 @@ ${focus.skip}
 Every successful run leaves exactly one report for the date, and it is the digest: never one report per finding, and never a run that files nothing.
 
 Title it \`<your scout name>: YYYY-MM-DD\`, dating it with the run's date in the project timezone. Your scout name is your own \`skill_name\` with the \`signals-scout-\` prefix dropped, dashes turned into spaces, and the first letter capitalized: \`signals-scout-checkout-trend-watch\` titles as \`Checkout trend watch: 2026-01-31\`. It already carries the scanner, so nothing else has to, and it is what keeps two scouts from writing the same title, which matters because of the next line.
-Before writing, find your own report by pointer, never by title: \`scout-scratchpad-search\` for \`${scannerId}:report:<today>\` and \`inbox-reports-retrieve\` the id it holds. Edit that report if it exists; otherwise \`scout-emit-report\` and stash the new id under \`${scannerId}:report:<today>\`. A title match is not proof the report is yours — several scouts watch this scanner, and more than one of them titles its report after the scanner, so matching on title edits another scout's report and leaves yours unwritten. Never two reports for the same date from you, and never a second emit later in the same run — each one delivers again.
+Before writing, find your own report by pointer, never by title: \`scout-scratchpad-search\` for \`${scannerId}:report:<your skill_name>:<today>\` and \`inbox-reports-retrieve\` the id it holds. Edit that report if it exists; otherwise \`scout-emit-report\` and stash the new id under \`${scannerId}:report:<your skill_name>:<today>\`. A title match is not proof the report is yours — several scouts watch this scanner, and more than one of them titles its report after the scanner, so matching on title edits another scout's report and leaves yours unwritten. Never two reports for the same date from you, and never a second emit later in the same run — each one delivers again.
 
 Write the report so it stands alone for a reader with no prior context:
 
@@ -146,8 +152,8 @@ ${focus.shape ?? DEFAULT_REPORT_SHAPE}
 - Link what another scout already reported rather than restating it: \`[already documented](/project/<project_id>/inbox/<report_id>)\`, taking the id from \`inbox-reports-list\`. Several scouts watch this scanner and read the same window, so without the link one finding gets filed three times.
 - Close with what you checked, and name anything you could not cover and why.
 
-When nothing clears the bar, still file the report, with the verdict \`Nothing notable\` and a short coverage line ("42 observations across 30 sessions, distributions steady"). ${focus.priority}
-These are watcher findings: \`repository=NO_REPO\`. Set \`actionability\` by what the report asks of its reader. \`requires_human_input\` only when someone has to decide or act on what you found: it lands in the inbox awaiting input, and a digest that reports a quiet day does not belong in that queue. Otherwise \`immediately_actionable\`, which surfaces the report without asking anything of anyone. Never \`not_actionable\`: it suppresses the report, which empties the scanner's digest card and stops delivery, so a quiet day reads as a run that never happened. After writing, stash the report id under \`${scannerId}:report:<today>\` — that pointer, not the title, is how the next run finds this report.
+${focus.quietVerdict ?? DEFAULT_QUIET_VERDICT} ${focus.priority}
+These are watcher findings: \`repository=NO_REPO\`. Set \`actionability\` by what the report asks of its reader. \`requires_human_input\` only when someone has to decide or act on what you found: it lands in the inbox awaiting input, and a digest that reports a quiet day does not belong in that queue. Otherwise \`immediately_actionable\`, which surfaces the report without asking anything of anyone. Never \`not_actionable\`: it suppresses the report, which empties the scanner's digest card and stops delivery, so a quiet day reads as a run that never happened. After writing, stash the report id under \`${scannerId}:report:<your skill_name>:<today>\` — that pointer, not the title, is how the next run finds this report.
 
 ## Charts, when the shape is the point
 
@@ -248,6 +254,8 @@ Lead the summary with whatever the window is actually about, and lean on:
                 quiet: 'A window where nothing changed still has content: what users did, which themes dominated, and how the distribution sat against prior weeks. Say plainly that nothing stood out, then summarize the window anyway. `Nothing notable` on its own is not a digest.',
                 skip: `- Anything the scanner's own per-session signals already pushed to the inbox.
 - Observations whose own signals contradict the claim (a session marked \`friction: none\` is never evidence of an error).`,
+                quietVerdict:
+                    'A digest has no bar to clear, so it never files a bare verdict. Say in the opening line that nothing stood out, then summarize the window as below.',
                 shape: `- Open with a two or three sentence read on the window: what users were doing, and what stood out.
 - Then a short section per theme, each a heading and two to four bullets. Order them by how much of the window they cover, and say roughly how many sessions each rests on.
 - A theme resting on one or two observations is worth a sentence, not a section: say how thin it is rather than inflating it or dropping it.


### PR DESCRIPTION
## Problem

A scanner's daily digest reports that nothing happened. Its whole body is a `Nothing notable` verdict, a line saying the success rate sat near baseline, and a line naming the window it read. The scanner saw 148 sessions in that window.

The legacy digest read the same scanner and the same day and produced five themed sections, roughly how much of the window each covered, and four things worth someone's time.

The cause is framing. The digest template was built on the same scaffolding as trend watch and new issue watch, which are watchers: they carry a notability bar and stay quiet until something crosses it. That is right for a watcher and wrong for a digest, and it is worse on a summarizer scanner, which has no verdict rates to trend. The shared report shape compounds it by capping a report at a takeaway and three bullets, which cannot hold a themed summary.

A second scout on that scanner then made it worse. Both titled their report after the scanner, the second matched the first's title, and it edited that report instead of filing its own. One report, one scout's work lost, no error anywhere.

## Changes

- A digest now says what the scanner saw, every run. The notability bar becomes what to lean on rather than what to qualify for, and the themes in the window come first.
- A quiet window still gets a summary. Reporting that nothing changed is a line, not the whole report.
- A digest is no longer capped at three bullets: it opens with a read on the window, then a section per theme ordered by coverage and saying how many sessions each rests on, then what to look at. `ScoutFocus.shape` carries this; every other template keeps the watcher shape it had.
- A scout finds its own report by the scratchpad pointer it wrote, not by matching a title. A title match is not proof the report is yours, and the failure is silent: the scout edits a sibling's report and files nothing of its own.

The pointer is what the Signals harness prompt already calls the durable record of "I filed this", saying to re-find by it "never by remembering the exact title". This template was doing the thing that prompt warns against.

> [!NOTE]
> Prompts are fixed when a scout is created, so this reaches scouts created after it deploys and changes nothing for existing ones.

## How did you test this code?

Rendered the reworked template and ran it against the scanner from the Problem section, over the same 24-hour window the legacy digest read: 149 observations, 149 recordings. It produced a three-section themed summary with per-theme session counts, timestamped replay links, and a "what to look at" close, and it reached both themes the legacy digest found plus two Inbox interactions the legacy digest missed. It also stated where its evidence was thin, which the legacy digest does not.

The dedupe change is not verified in a run. The collision it fixes was reproduced before the change (two scouts, one report, the second wrote nothing), but confirming the pointer path needs two scouts filing on the same scanner and day, which is a slower loop than this PR waited for.

No new tests. Both changes are prose inside a prompt template, where asserting that a template contains a sentence breaks on any rewording and proves nothing about what a model does with it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @TueHaulund. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`, `/toolbox-access`.

Both changes came from running the legacy digest and a scout digest against one scanner and reading them side by side, rather than from review.

**Public artifact:** nothing here came from a customer conversation, ticket, or log.
