### PR TITLE
fix(aio): make a failed sentiment load recoverable

### DIFF
--- a/products/ai_observability/frontend/sentimentQueries.test.ts
+++ b/products/ai_observability/frontend/sentimentQueries.test.ts
@@ -1,4 +1,5 @@
 import api from 'lib/api'
+import { ApiError } from 'lib/api-error'
 
 import {
     fetchSentimentGenerationsPage,
@@ -281,5 +282,40 @@ describe('sentimentQueries', () => {
         expect(page.hasMore).toBe(false)
         expect(mockApi.queryHogQL).toHaveBeenCalledTimes(4)
         expect(mockApi.queryHogQL.mock.calls[2][0]).toContain('OFFSET 200')
+    })
+
+    it('stops walking candidates that never hydrate and reports there is more to load', async () => {
+        mockApi.queryHogQL.mockImplementation(((query: string) =>
+            Promise.resolve(
+                query.includes('evaluation_id')
+                    ? { columns: candidateColumns, results: candidateRows(200) }
+                    : { columns: generationColumns, results: [] }
+            )) as unknown as typeof api.queryHogQL)
+
+        const page = await fetchSentimentGenerationsPage(queryValues, 0)
+
+        expect(page.generations).toEqual([])
+        expect(page.hasMore).toBe(true)
+        // Five passes of two dependent queries each, rather than an open-ended chain
+        expect(mockApi.queryHogQL).toHaveBeenCalledTimes(10)
+    })
+
+    it('retries a transient query failure instead of failing the whole load', async () => {
+        mockApi.queryHogQL
+            .mockRejectedValueOnce(new ApiError('Queries are a little too busy right now', 503))
+            .mockResolvedValueOnce({ columns: candidateColumns, results: candidateRows(1) })
+            .mockResolvedValueOnce({ columns: generationColumns, results: [generationRow(0)] })
+
+        const page = await fetchSentimentGenerationsPage(queryValues, 0)
+
+        expect(page.generations).toHaveLength(1)
+        expect(mockApi.queryHogQL).toHaveBeenCalledTimes(3)
+    })
+
+    it('gives up immediately on a failure a retry cannot fix', async () => {
+        mockApi.queryHogQL.mockRejectedValue(new ApiError('Invalid query', 400))
+
+        await expect(fetchSentimentGenerationsPage(queryValues, 0)).rejects.toThrow('Invalid query')
+        expect(mockApi.queryHogQL).toHaveBeenCalledTimes(1)
     })
 })

--- a/products/ai_observability/frontend/sentimentQueries.ts
+++ b/products/ai_observability/frontend/sentimentQueries.ts
@@ -1,11 +1,28 @@
 import api from 'lib/api'
+import { isTransientServerError } from 'lib/api-error'
+import { retryWithBackoff } from 'lib/utils/async'
 
-import { ProductKey, type RefreshType } from '~/queries/schema/schema-general'
+import { ProductKey, type HogQLQueryResponse, type RefreshType } from '~/queries/schema/schema-general'
 import { escapeHogQLString, hogql } from '~/queries/utils'
 
 import { normalizeSentimentResult, type GenerationSentiment } from './sentimentResults'
 
 export const GENERATIONS_PAGE_SIZE = 200
+
+/**
+ * A page can need several passes when candidates don't hydrate, and each pass runs two dependent
+ * queries. Cap the passes so a poorly hydrating range can't fan out into an open-ended chain where
+ * any single timeout fails the whole load — the caller reports `hasMore` and the user pulls the rest.
+ */
+const MAX_FETCH_PASSES = 5
+
+/** These queries scan a lot, so a busy or briefly overloaded cluster is worth waiting out. */
+const TRANSIENT_QUERY_RETRY = {
+    maxAttempts: 3,
+    initialDelayMs: 500,
+    backoffMultiplier: 2,
+    shouldRetry: isTransientServerError,
+}
 
 export type SentimentCategory = 'negative' | 'positive'
 
@@ -155,6 +172,13 @@ function hasUsableInput(value: unknown): boolean {
     return value !== null && value !== undefined && value !== '' && value !== 'null'
 }
 
+/** Runs a sentiment query, waiting out a busy cluster instead of failing the whole load. */
+function querySentimentHogQL(
+    ...args: Parameters<typeof api.queryHogQL<unknown[][]>>
+): Promise<HogQLQueryResponse<unknown[][]>> {
+    return retryWithBackoff(() => api.queryHogQL<unknown[][]>(...args), TRANSIENT_QUERY_RETRY)
+}
+
 async function queryStoredGenerationSentiments(
     normalizedLookups: GenerationSentimentLookup[],
     source: SentimentQuerySource
@@ -166,7 +190,7 @@ async function queryStoredGenerationSentiments(
         return new Map()
     }
 
-    const response = await api.queryHogQL<unknown[][]>(
+    const response = await querySentimentHogQL(
         hogql`
             SELECT
                 trace_id,
@@ -286,7 +310,7 @@ async function fetchSentimentEvaluationCandidates(
         ? `AND properties.$ai_evaluation_id = ${escapeHogQLString(values.evaluationId)}`
         : ''
 
-    const response = await api.queryHogQL<unknown[][]>(
+    const response = await querySentimentHogQL(
         hogql`
             SELECT
                 evaluation_id,
@@ -359,7 +383,7 @@ async function hydrateSentimentGenerations(
         return new Map()
     }
 
-    const response = await api.queryHogQL<unknown[][]>(
+    const response = await querySentimentHogQL(
         hogql`
             SELECT
                 generation.uuid,
@@ -475,7 +499,13 @@ export async function fetchSentimentGenerationsPage(
     let rawCount = 0
     let hasMore = false
 
-    while (generations.length < GENERATIONS_PAGE_SIZE) {
+    for (let pass = 0; generations.length < GENERATIONS_PAGE_SIZE; pass++) {
+        if (pass >= MAX_FETCH_PASSES) {
+            // Every pass so far consumed a full batch, so there is more to walk — hand it to "Load more"
+            hasMore = true
+            break
+        }
+
         const candidates = await fetchSentimentEvaluationCandidates(values, offset + rawCount, refresh)
         if (candidates.length === 0) {
             break

--- a/products/ai_observability/frontend/tabs/AIObservabilitySentiment.tsx
+++ b/products/ai_observability/frontend/tabs/AIObservabilitySentiment.tsx
@@ -5,6 +5,7 @@ import { IconPlus, IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonSelect, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
 import { urls } from 'scenes/urls'
 
@@ -261,6 +262,29 @@ function SentimentControls(): JSX.Element {
     )
 }
 
+/** Shown when a load failed and there is nothing on screen to fall back to. */
+function SentimentLoadError({ detail }: { detail: string }): JSX.Element {
+    const { generationsLoading } = useValues(aiObservabilitySentimentLogic)
+    const { loadGenerations } = useActions(aiObservabilitySentimentLogic)
+
+    return (
+        <div className="flex flex-col items-center justify-center text-center py-20 text-muted">
+            <p className="text-lg font-medium mb-1 text-default">Couldn't load sentiment evaluation results</p>
+            <p className="text-sm max-w-xl mb-4">{detail}</p>
+            <LemonButton
+                type="primary"
+                icon={<IconRefresh />}
+                onClick={() => loadGenerations()}
+                loading={generationsLoading}
+                disabledReason={generationsLoading ? 'Loading results' : undefined}
+                data-attr="llma-sentiment-retry"
+            >
+                Try again
+            </LemonButton>
+        </div>
+    )
+}
+
 function SentimentEvaluationOnboarding(): JSX.Element {
     return (
         <div className="flex flex-col items-center justify-center text-center py-20 text-muted">
@@ -299,7 +323,7 @@ export function AIObservabilitySentiment(): JSX.Element {
         expandedCardIds,
         hasMore,
     } = useValues(aiObservabilitySentimentLogic)
-    const { loadMoreGenerations } = useActions(aiObservabilitySentimentLogic)
+    const { loadGenerations, loadMoreGenerations } = useActions(aiObservabilitySentimentLogic)
 
     if (sentimentEvaluationsLoading || !hasLoadedSentimentEvaluations) {
         return (
@@ -326,11 +350,8 @@ export function AIObservabilitySentiment(): JSX.Element {
                 <div className="flex items-center justify-center py-20">
                     <Spinner className="text-4xl" captureTime />
                 </div>
-            ) : generationsError ? (
-                <div className="text-center py-20 text-muted">
-                    <p className="text-lg font-medium mb-1">Failed to load generations</p>
-                    <p className="text-sm">There was an error fetching data. Try refreshing the page.</p>
-                </div>
+            ) : generationsError && generations.length === 0 ? (
+                <SentimentLoadError detail={generationsError} />
             ) : generations.length === 0 ? (
                 <div className="text-center py-20 text-muted">
                     <p className="text-lg font-medium mb-1">No sentiment evaluation results found</p>
@@ -349,6 +370,22 @@ export function AIObservabilitySentiment(): JSX.Element {
                 </div>
             ) : (
                 <>
+                    {generationsError && (
+                        <LemonBanner
+                            type="warning"
+                            className="mb-3"
+                            action={{
+                                children: 'Try again',
+                                onClick: () => loadGenerations(),
+                                disabledReason: generationsLoading ? 'Loading results' : undefined,
+                                'data-attr': 'llma-sentiment-retry',
+                            }}
+                        >
+                            Couldn't load the latest sentiment evaluation results, so these may be out of date.{' '}
+                            {generationsError}
+                        </LemonBanner>
+                    )}
+
                     {groupedSentimentCards.length > 0 && (
                         <div className="space-y-2">
                             {groupedSentimentCards.map((group: GroupedSentimentCard) => (

--- a/products/ai_observability/frontend/tabs/aiObservabilitySentimentLogic.test.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilitySentimentLogic.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { ApiError } from 'lib/api-error'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { emptySceneParams } from 'scenes/scenes'
 
@@ -133,5 +134,31 @@ describe('aiObservabilitySentimentLogic', () => {
         expect(logic!.values.hasSentimentEvaluations).toBe(true)
         expect(logic!.values.generations).toEqual([])
         expect(logic!.values.showSentimentEvaluationOnboarding).toBe(false)
+    })
+
+    it('keeps the rows already on screen and surfaces the error when a reload fails', async () => {
+        mockFetchSentimentGenerationsPage.mockResolvedValue({
+            generations: [generationWithSentiment],
+            rawCount: 1,
+            hasMore: false,
+        })
+        mountLogics()
+
+        await expectLogic(logic!, () => {
+            logic!.actions.activate()
+        }).toFinishAllListeners()
+
+        mockFetchSentimentGenerationsPage.mockRejectedValue(
+            new ApiError('Request failed', 504, undefined, {
+                detail: 'Query has hit the max execution time before completing.',
+            })
+        )
+
+        await expectLogic(logic!, () => {
+            logic!.actions.loadGenerations()
+        }).toFinishAllListeners()
+
+        expect(logic!.values.generationsError).toBe('Query has hit the max execution time before completing.')
+        expect(logic!.values.generations).toEqual([generationWithSentiment])
     })
 })

--- a/products/ai_observability/frontend/tabs/aiObservabilitySentimentLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilitySentimentLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
+import { ApiError } from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import type { LemonSelectOption } from 'lib/lemon-ui/LemonSelect'
 
@@ -136,6 +137,14 @@ function captureEngagementEvents(
     }
 }
 
+const GENERIC_LOAD_ERROR = 'Something went wrong while loading sentiment evaluation results.'
+
+/** The query API puts the useful text in `detail`; fall back to the loader's own message. */
+function describeLoadError(error: string, errorObject?: unknown): string {
+    const detail = errorObject instanceof ApiError ? errorObject.detail : null
+    return detail || error || GENERIC_LOAD_ERROR
+}
+
 let lastPageHasMore = false
 let nextGenerationsOffset = 0
 
@@ -158,7 +167,7 @@ export interface aiObservabilitySentimentLogicValues {
     evaluationOptions: LemonSelectOption<string | null>[]
     expandedCardIds: Set<string>
     generations: SentimentGeneration[]
-    generationsError: boolean
+    generationsError: string | null
     generationsLoading: boolean
     groupedSentimentCards: GroupedSentimentCard[]
     hasLoadedOnce: boolean
@@ -260,7 +269,7 @@ export interface aiObservabilitySentimentLogicMeta {
             hasLoadedOnce: boolean,
             generations: SentimentGeneration[],
             generationsLoading: boolean,
-            generationsError: boolean,
+            generationsError: string | null,
             hasMore: boolean
         ) => boolean
     }
@@ -362,11 +371,14 @@ export const aiObservabilitySentimentLogic = kea<aiObservabilitySentimentLogicTy
             },
         ],
         generationsError: [
-            false as boolean,
+            null as string | null,
             {
-                loadGenerations: () => false,
-                loadGenerationsFailure: () => true,
-                loadGenerationsSuccess: () => false,
+                loadGenerations: () => null,
+                loadGenerationsFailure: (_, { error, errorObject }) => describeLoadError(error, errorObject),
+                loadGenerationsSuccess: () => null,
+                loadMoreGenerations: () => null,
+                loadMoreGenerationsFailure: (_, { error, errorObject }) => describeLoadError(error, errorObject),
+                loadMoreGenerationsSuccess: () => null,
             },
         ],
     }),
@@ -531,7 +543,7 @@ export const aiObservabilitySentimentLogic = kea<aiObservabilitySentimentLogicTy
                 hasLoadedOnce: boolean,
                 generations: SentimentGeneration[],
                 generationsLoading: boolean,
-                generationsError: boolean,
+                generationsError: string | null,
                 hasMore: boolean
             ): boolean =>
                 hasLoadedSentimentEvaluations &&


### PR DESCRIPTION
## Problem

Anyone using the Sentiment tab in AI observability loses the whole panel when one query fails. The panel shows "Failed to load generations" with no retry button and no indication of what went wrong, so the only way forward is a full page reload.

The real error is not lost — the global kea loader handler toasts it and reports it to error tracking. But the toast is transient and the panel is not: what persists on screen is generic text that dead-ends. The loader reduces the error to a boolean, so the component cannot show the detail inline even though the detail is often directly actionable ("try a shorter date range or narrower filters"). Rows that were already loaded stay in the store but are hidden behind the error state.

Refs #58341

## Changes

- A failed load now keeps the rows already on screen and puts a warning banner above them with a "Try again" button, instead of blanking the panel.
- When nothing loaded, the error state shows what the query actually reported and offers a retry, so the actionable detail stays on screen instead of vanishing with the toast.
- A failed "Load more" is now reported the same way. It used to fail silently.
- The candidate fetch stops after a fixed number of passes and hands the rest to "Load more", so one page load can't chain an unbounded number of queries.
- Transient gateway failures are retried with backoff. Deterministic failures are deliberately not retried.

## How did you test this code?

Automated only — the dev stack wasn't brought up, so none of this was exercised in a browser. The failing states were reproduced against production by a reviewer, not by me.

Added Jest coverage for the three behaviors no existing test covered:
- `sentimentQueries.test.ts` — the fetch stops after the pass cap and reports `hasMore`, a transient failure is retried and then succeeds, and a client error fails immediately rather than being retried.
- `aiObservabilitySentimentLogic.test.ts` — a failed reload keeps the previously loaded rows and exposes the error detail.

`pnpm --filter=@posthog/frontend typescript:check` reports no errors in the touched files (the run has pre-existing quill module-resolution failures elsewhere, unrelated to this change).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus) working from a PostHog Signals inbox report. Repo guidance consulted: `frontend/src/CLAUDE.md`, `products/ai_observability/CLAUDE.md`, and the conventions for kea logics, user-facing copy, and tests.

**This PR is deliberately palliative and does not fix any root cause.** Reviewers should weigh it on that basis. Investigation alongside it identified two distinct underlying defects on this surface, neither addressed here:

1. The candidate query groups by a key that is already unique, so it builds a hash table over the whole window to deduplicate data that is not duplicated. That is what exhausts memory on large windows. Removing the grouping in favour of a bounded top-N would preserve the ranking users see today.
2. The hydration query targets the dedicated AI events table unconditionally, and fails outright when a project's test-account filter references a cohort or group property that table cannot resolve, or on deployments where the table is absent. The sibling function in the same file already implements a fallback to the standard events table for exactly this reason; the hydration path does not.

Two earlier hypotheses were checked and disproved rather than shipped: that the hydration query was slow for lack of a date bound (it is not — that table is ordered by trace id), and that the fast client errors were a cost-estimator rejection (they are query resolution failures, per error tracking). An earlier draft of this description claimed the failure was invisible to error tracking; that was wrong and has been corrected.

Nothing in this PR carries material from the agent session. Analytics behind the claims above is described qualitatively on purpose, as the repository is public.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
