### PR TITLE
fix(experiments): load history tab from experiment activity endpoint

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2669,6 +2669,16 @@ const api = {
         ): Promise<ActivityLogPaginatedResponse<ActivityLogItem>> {
             const scopes = Array.isArray(props.scope) ? [...props.scope] : [props.scope]
 
+            // The experiment activity endpoint merges in entries from the experiment's holdout
+            // and shared metrics, which the generic /activity_log scope+item_id filter can't express.
+            if (scopes.length === 1 && scopes[0] === ActivityScope.EXPERIMENT && props.id) {
+                return new ApiRequest()
+                    .experimentsDetail(props.id as number, projectId)
+                    .withAction('activity')
+                    .withQueryString(toParams({ page: page || 1, limit: ACTIVITY_PAGE_SIZE }))
+                    .get()
+            }
+
             // Opt into the new /activity_log API
             if (
                 [

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.experiment.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.experiment.test.tsx
@@ -1,0 +1,40 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+
+import { ActivityScope } from '~/types'
+
+import { makeTestSetup } from './activityLogLogic.test.setup'
+
+describe('the activity log logic', () => {
+    describe('humanizing experiments', () => {
+        // Guards the routing: a single experiment's activity must come from the experiment's
+        // own /activity endpoint (which merges holdout and shared-metric entries), not the
+        // generic /activity_log endpoint. If routing regresses, this mock is never hit and
+        // the log renders empty.
+        const experimentTestSetup = makeTestSetup(
+            ActivityScope.EXPERIMENT,
+            `/api/projects/${MOCK_TEAM_ID}/experiments/7/activity/`
+        )
+
+        it('fetches from the experiment activity endpoint and humanizes a launch', async () => {
+            const logic = await experimentTestSetup('my experiment', 'updated', [
+                {
+                    type: ActivityScope.EXPERIMENT,
+                    action: 'created',
+                    field: 'start_date',
+                    before: null,
+                    after: '2024-01-01T00:00:00Z',
+                },
+            ])
+
+            const actual = logic.values.humanizedActivity
+            const text = render(<>{actual[0].description}</>).container.textContent
+            expect(text).toContain('peter')
+            expect(text).toContain('launched experiment')
+            expect(text).toContain('my experiment')
+        })
+    })
+})


### PR DESCRIPTION
## Problem

The History tab on an experiment misses holdout and shared metric changes. It fetches from the generic activity log endpoint, which can only filter by the experiment's own id.

The experiment's `/activity` endpoint already merges those entries (with guards against id collisions), but only the public API used it.

## Changes

- The History tab now shows holdout and shared metric changes alongside the experiment's own history.
- Mechanical: `listLegacy` routes single-experiment activity to `/experiments/:id/activity`, following the existing per-scope branches. The scope-wide view on the experiments list page keeps the generic endpoint.
- No visual change to the component, same list UI with a different data source.

Design note: the generated `experimentsActivityRetrieve` client is not used here because importing a generated function into `lib/api.ts` would create a runtime import cycle (generated api imports the mutator, which imports `lib/api`). The file currently imports only generated types, so the branch uses its existing `ApiRequest` pattern instead.

## How did you test this code?

- New jest test (`activityLogLogic.experiment.test.tsx`) mounts the logic for a single experiment with only the experiment activity endpoint mocked. It catches a regression where routing reverts to the generic endpoint and merged entries silently vanish; no existing test pinned this routing.
- Ran the ActivityLog jest suite and the frontend typecheck locally.
- Not checked: the tab against a running backend.

Follow-ups:
- Merge linked feature flag changes (rollout, conditions, enable/disable) into the experiment activity endpoint.
- Log pause/resume as experiment activity.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /adopting-generated-api-types, /writing-tests, /writing-pr-descriptions. The session started as an assessment of the History feature; this is the first of three planned PRs (endpoint routing, then flag-change merging, then pause/resume logging).
