### PR TITLE
feat(error-tracking): overlay recent issue state

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -80,6 +80,7 @@ from posthog.hogql.database.schema.error_tracking_issue_fingerprint_overrides im
     ErrorTrackingIssueFingerprintOverridesTable,
     RawErrorTrackingIssueFingerprintOverridesTable,
 )
+from posthog.hogql.database.schema.error_tracking_recent_issue_state import ErrorTrackingRecentIssueStateTable
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.exchange_rate import ExchangeRateTable
 from posthog.hogql.database.schema.experiment_exposures_preaggregated import ExperimentExposuresPreaggregatedTable
@@ -429,6 +430,11 @@ def _construct_database_root_node(*, include_posthog_tables: bool) -> TableNode:
                     "error_tracking_fingerprint_issue_state": TableNode(
                         name="error_tracking_fingerprint_issue_state",
                         table=ErrorTrackingFingerprintIssueStateTable(),
+                    ),
+                    "error_tracking_recent_issue_state": TableNode(
+                        name="error_tracking_recent_issue_state",
+                        table=ErrorTrackingRecentIssueStateTable(),
+                        hidden=True,
                     ),
                     "web_overview_preaggregated": TableNode(
                         name="web_overview_preaggregated", table=WebOverviewPreaggregatedTable()

--- a/posthog/hogql/database/schema/error_tracking_recent_issue_state.py
+++ b/posthog/hogql/database/schema/error_tracking_recent_issue_state.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any
 from posthog.hogql import ast
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
-    DateTimeDatabaseField,
     FieldOrTable,
     IntegerDatabaseField,
     LazyTable,
@@ -45,11 +44,6 @@ RECENT_ISSUE_STATE_FIELDS: dict[str, FieldOrTable] = {
     "assigned_role_id": UUIDDatabaseField(
         name="assigned_role_id", nullable=True, description="Currently assigned role, if any."
     ),
-    "state_updated_at": DateTimeDatabaseField(
-        name="state_updated_at",
-        nullable=False,
-        description="Server timestamp for the authoritative state change.",
-    ),
     "is_present": BooleanDatabaseField(
         name="is_present",
         nullable=False,
@@ -66,7 +60,6 @@ RECENT_ISSUE_STATE_EXTERNAL_STRUCTURE: list[tuple[str, str]] = [
     ("issue_description", "Nullable(String)"),
     ("assigned_user_id", "Nullable(Int64)"),
     ("assigned_role_id", "Nullable(UUID)"),
-    ("state_updated_at", "DateTime64(6, 'UTC')"),
     ("is_present", "UInt8"),
 ]
 

--- a/posthog/hogql/database/schema/error_tracking_recent_issue_state.py
+++ b/posthog/hogql/database/schema/error_tracking_recent_issue_state.py
@@ -1,0 +1,122 @@
+from typing import TYPE_CHECKING, Any
+
+from posthog.hogql import ast
+from posthog.hogql.database.models import (
+    BooleanDatabaseField,
+    DateTimeDatabaseField,
+    FieldOrTable,
+    IntegerDatabaseField,
+    LazyTable,
+    LazyTableToAdd,
+    StringDatabaseField,
+    Table,
+    TableNode,
+    UUIDDatabaseField,
+)
+
+if TYPE_CHECKING:
+    from posthog.hogql.context import HogQLContext
+
+RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY = "error_tracking_recent_issue_state"
+RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME = "__ph_error_tracking_recent_issue_state"
+
+RECENT_ISSUE_STATE_FIELDS: dict[str, FieldOrTable] = {
+    "team_id": IntegerDatabaseField(
+        name="team_id", nullable=False, description="Team that owns the error tracking issue."
+    ),
+    "issue_id": UUIDDatabaseField(
+        name="issue_id", nullable=False, description="Identifier of the recently changed error tracking issue."
+    ),
+    "issue_status": StringDatabaseField(
+        name="issue_status", nullable=False, description="Authoritative status stored in Postgres."
+    ),
+    "issue_name": StringDatabaseField(
+        name="issue_name", nullable=True, description="Authoritative issue name stored in Postgres."
+    ),
+    "issue_description": StringDatabaseField(
+        name="issue_description", nullable=True, description="Authoritative issue description stored in Postgres."
+    ),
+    "assigned_user_id": IntegerDatabaseField(
+        name="assigned_user_id", nullable=True, description="Currently assigned user, if any."
+    ),
+    "assigned_role_id": UUIDDatabaseField(
+        name="assigned_role_id", nullable=True, description="Currently assigned role, if any."
+    ),
+    "state_updated_at": DateTimeDatabaseField(
+        name="state_updated_at",
+        nullable=False,
+        description="Server timestamp for the authoritative state change.",
+    ),
+    "is_present": BooleanDatabaseField(
+        name="is_present",
+        nullable=False,
+        description="Whether an authoritative row exists, including when its nullable values are cleared.",
+    ),
+}
+
+RECENT_ISSUE_STATE_EXTERNAL_STRUCTURE: list[tuple[str, str]] = [
+    ("team_id", "Int64"),
+    ("issue_id", "UUID"),
+    ("issue_status", "String"),
+    ("issue_name", "Nullable(String)"),
+    ("issue_description", "Nullable(String)"),
+    ("assigned_user_id", "Nullable(Int64)"),
+    ("assigned_role_id", "Nullable(UUID)"),
+    ("state_updated_at", "DateTime64(6, 'UTC')"),
+    ("is_present", "UInt8"),
+]
+
+
+class _ErrorTrackingRecentIssueStateExternalTable(Table):
+    description: str = "Query-scoped authoritative state for recently changed error tracking issues."
+    fields: dict[str, FieldOrTable] = RECENT_ISSUE_STATE_FIELDS
+
+    def to_printed_clickhouse(self, context: "HogQLContext") -> str:
+        return RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME
+
+    def to_printed_hogql(self) -> str:
+        return RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME
+
+
+class ErrorTrackingRecentIssueStateTable(LazyTable):
+    description: str = "Recent Postgres issue state used to cover ClickHouse synchronization delay."
+    fields: dict[str, FieldOrTable] = RECENT_ISSUE_STATE_FIELDS
+
+    def lazy_select(
+        self,
+        table_to_add: LazyTableToAdd,
+        context: "HogQLContext",
+        node: ast.SelectQuery,
+    ) -> ast.SelectQuery:
+        rows: list[dict[str, Any]] = context.data_to_ingest.get(RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY) or []
+        context.external_tables[RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME] = {
+            "name": RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME,
+            "structure": RECENT_ISSUE_STATE_EXTERNAL_STRUCTURE,
+            "data": rows,
+        }
+        if context.database is not None:
+            context.database.tables.add_child(
+                TableNode(
+                    name=RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME,
+                    table=_ErrorTrackingRecentIssueStateExternalTable(),
+                    hidden=True,
+                ),
+                table_conflict_mode="override",
+                children_conflict_mode="override",
+            )
+
+        selected_fields = set(table_to_add.fields_accessed) | {"team_id"}
+        return ast.SelectQuery(
+            select=[
+                ast.Field(chain=[field_name])
+                for field_name in RECENT_ISSUE_STATE_FIELDS
+                if field_name in selected_fields
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=[RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME])),
+        )
+
+    def to_printed_clickhouse(self, context: "HogQLContext") -> str:
+        return RECENT_ISSUE_STATE_EXTERNAL_TABLE_NAME
+
+    def to_printed_hogql(self) -> str:
+        return "error_tracking_recent_issue_state"

--- a/posthog/hogql/database/schema/error_tracking_recent_issue_state.py
+++ b/posthog/hogql/database/schema/error_tracking_recent_issue_state.py
@@ -30,6 +30,9 @@ RECENT_ISSUE_STATE_FIELDS: dict[str, FieldOrTable] = {
     "issue_status": StringDatabaseField(
         name="issue_status", nullable=False, description="Authoritative status stored in Postgres."
     ),
+    "issue_severity": StringDatabaseField(
+        name="issue_severity", nullable=True, description="Authoritative severity stored in Postgres."
+    ),
     "issue_name": StringDatabaseField(
         name="issue_name", nullable=True, description="Authoritative issue name stored in Postgres."
     ),
@@ -58,6 +61,7 @@ RECENT_ISSUE_STATE_EXTERNAL_STRUCTURE: list[tuple[str, str]] = [
     ("team_id", "Int64"),
     ("issue_id", "UUID"),
     ("issue_status", "String"),
+    ("issue_severity", "Nullable(String)"),
     ("issue_name", "Nullable(String)"),
     ("issue_description", "Nullable(String)"),
     ("assigned_user_id", "Nullable(Int64)"),

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -243,7 +243,7 @@ class ErrorTrackingQueryBuilder:
 
     def _issue_state_expr(self, field_name: str) -> ast.Expr:
         clickhouse_state = ast.Field(chain=["fp_state", field_name])
-        if not self.include_recent_issue_state or field_name in {"issue_id", "issue_severity", "first_seen"}:
+        if not self.include_recent_issue_state or field_name in {"issue_id", "first_seen"}:
             return clickhouse_state
         return ast.Call(
             name="if",
@@ -483,9 +483,7 @@ class ErrorTrackingQueryBuilder:
         exprs: list[ast.Expr] = [
             ast.Alias(alias="id", expr=ast.Field(chain=["fp_state", "issue_id"])),
             ast.Alias(alias="status", expr=ast.Call(name="any", args=[self._issue_state_expr("issue_status")])),
-            ast.Alias(
-                alias="severity", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_severity"])])
-            ),
+            ast.Alias(alias="severity", expr=ast.Call(name="any", args=[self._issue_state_expr("issue_severity")])),
             ast.Alias(alias="name", expr=ast.Call(name="any", args=[self._issue_state_expr("issue_name")])),
             ast.Alias(
                 alias="description",

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -211,11 +211,17 @@ class ErrorTrackingQueryBuilder:
     # Optimized two-pass shape
     # ---------------------------------------------------------------------
 
-    def _fingerprint_state_join(self, fingerprint_hash: ast.Expr) -> ast.JoinExpr:
+    def _fingerprint_state_join(
+        self,
+        fingerprint_hash: ast.Expr,
+        *,
+        join_type: str = "INNER JOIN",
+        fallback_issue_id: ast.Expr | None = None,
+    ) -> ast.JoinExpr:
         fingerprint_state_join = ast.JoinExpr(
             table=ast.Field(chain=["posthog", "error_tracking_fingerprint_issue_state"]),
             alias="fp_state",
-            join_type="INNER JOIN",
+            join_type=join_type,
             constraint=ast.JoinConstraint(
                 expr=ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
@@ -226,6 +232,16 @@ class ErrorTrackingQueryBuilder:
             ),
         )
         if self.include_recent_issue_state:
+            issue_id_expr: ast.Expr = ast.Field(chain=["fp_state", "issue_id"])
+            if fallback_issue_id is not None:
+                issue_id_expr = ast.Call(
+                    name="if",
+                    args=[
+                        ast.Call(name="isNotNull", args=[ast.Field(chain=["fp_state", "issue_id"])]),
+                        ast.Field(chain=["fp_state", "issue_id"]),
+                        fallback_issue_id,
+                    ],
+                )
             fingerprint_state_join.next_join = ast.JoinExpr(
                 table=ast.Field(chain=["posthog", "error_tracking_recent_issue_state"]),
                 alias="recent_state",
@@ -233,7 +249,7 @@ class ErrorTrackingQueryBuilder:
                 constraint=ast.JoinConstraint(
                     expr=ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["fp_state", "issue_id"]),
+                        left=issue_id_expr,
                         right=ast.Field(chain=["recent_state", "issue_id"]),
                     ),
                     constraint_type="ON",
@@ -255,8 +271,6 @@ class ErrorTrackingQueryBuilder:
         )
 
     def _legacy_issue_state_expr(self, field_name: str) -> ast.Expr:
-        if self.include_recent_issue_state:
-            return self._issue_state_expr(field_name)
         event_field_name = {
             "issue_id": "issue_id",
             "issue_status": "issue_status",
@@ -267,7 +281,32 @@ class ErrorTrackingQueryBuilder:
             "assigned_role_id": "issue_assigned_role_id",
             "first_seen": "issue_first_seen",
         }[field_name]
-        return ast.Field(chain=["e", event_field_name])
+        event_state = ast.Field(chain=["e", event_field_name])
+        if not self.include_recent_issue_state:
+            return event_state
+        if field_name == "issue_id":
+            event_state = ast.Field(chain=["e", "event_issue_id"])
+        elif field_name == "first_seen":
+            event_state = ast.Field(chain=["e", "timestamp"])
+
+        fingerprint_state = ast.Call(
+            name="if",
+            args=[
+                ast.Call(name="isNotNull", args=[ast.Field(chain=["fp_state", "issue_id"])]),
+                ast.Field(chain=["fp_state", field_name]),
+                event_state,
+            ],
+        )
+        if field_name in {"issue_id", "first_seen"}:
+            return fingerprint_state
+        return ast.Call(
+            name="if",
+            args=[
+                ast.Field(chain=["recent_state", "is_present"]),
+                ast.Field(chain=["recent_state", field_name]),
+                fingerprint_state,
+            ],
+        )
 
     def _build_query_optimized(self) -> ast.SelectQuery:
         inner = self._build_inner_query()
@@ -577,7 +616,11 @@ class ErrorTrackingQueryBuilder:
     def _build_query_legacy(self) -> ast.SelectQuery:
         select_from = ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e")
         if self.include_recent_issue_state:
-            select_from.next_join = self._fingerprint_state_join(_fingerprint_hash_expr())
+            select_from.next_join = self._fingerprint_state_join(
+                _fingerprint_hash_expr(),
+                join_type="LEFT OUTER JOIN",
+                fallback_issue_id=ast.Field(chain=["e", "event_issue_id"]),
+            )
         return ast.SelectQuery(
             select=self._select_expressions_legacy(),
             select_from=select_from,

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -126,11 +126,19 @@ class ErrorTrackingQueryBuilder:
       mixed-OR semantics across the events/issue boundary.
     """
 
-    def __init__(self, query: ErrorTrackingQuery, team: Team, date_from: datetime.datetime, date_to: datetime.datetime):
+    def __init__(
+        self,
+        query: ErrorTrackingQuery,
+        team: Team,
+        date_from: datetime.datetime,
+        date_to: datetime.datetime,
+        include_recent_issue_state: bool = False,
+    ):
         self.query = query
         self.team = team
         self.date_from = date_from
         self.date_to = date_to
+        self.include_recent_issue_state = include_recent_issue_state
 
     def build_query(self) -> ast.SelectQuery:
         if self._needs_legacy_shape():
@@ -203,6 +211,64 @@ class ErrorTrackingQueryBuilder:
     # Optimized two-pass shape
     # ---------------------------------------------------------------------
 
+    def _fingerprint_state_join(self, fingerprint_hash: ast.Expr) -> ast.JoinExpr:
+        fingerprint_state_join = ast.JoinExpr(
+            table=ast.Field(chain=["posthog", "error_tracking_fingerprint_issue_state"]),
+            alias="fp_state",
+            join_type="INNER JOIN",
+            constraint=ast.JoinConstraint(
+                expr=ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=fingerprint_hash,
+                    right=ast.Field(chain=["fp_state", "fp_hash"]),
+                ),
+                constraint_type="ON",
+            ),
+        )
+        if self.include_recent_issue_state:
+            fingerprint_state_join.next_join = ast.JoinExpr(
+                table=ast.Field(chain=["posthog", "error_tracking_recent_issue_state"]),
+                alias="recent_state",
+                join_type="LEFT OUTER JOIN",
+                constraint=ast.JoinConstraint(
+                    expr=ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["fp_state", "issue_id"]),
+                        right=ast.Field(chain=["recent_state", "issue_id"]),
+                    ),
+                    constraint_type="ON",
+                ),
+            )
+        return fingerprint_state_join
+
+    def _issue_state_expr(self, field_name: str) -> ast.Expr:
+        clickhouse_state = ast.Field(chain=["fp_state", field_name])
+        if not self.include_recent_issue_state or field_name in {"issue_id", "issue_severity", "first_seen"}:
+            return clickhouse_state
+        return ast.Call(
+            name="if",
+            args=[
+                ast.Field(chain=["recent_state", "is_present"]),
+                ast.Field(chain=["recent_state", field_name]),
+                clickhouse_state,
+            ],
+        )
+
+    def _legacy_issue_state_expr(self, field_name: str) -> ast.Expr:
+        if self.include_recent_issue_state:
+            return self._issue_state_expr(field_name)
+        event_field_name = {
+            "issue_id": "issue_id",
+            "issue_status": "issue_status",
+            "issue_severity": "issue_severity",
+            "issue_name": "issue_name",
+            "issue_description": "issue_description",
+            "assigned_user_id": "issue_assigned_user_id",
+            "assigned_role_id": "issue_assigned_role_id",
+            "first_seen": "issue_first_seen",
+        }[field_name]
+        return ast.Field(chain=["e", event_field_name])
+
     def _build_query_optimized(self) -> ast.SelectQuery:
         inner = self._build_inner_query()
         outer_where_exprs = self._outer_where_exprs()
@@ -211,19 +277,7 @@ class ErrorTrackingQueryBuilder:
             select_from=ast.JoinExpr(
                 table=inner,
                 alias="ev",
-                next_join=ast.JoinExpr(
-                    table=ast.Field(chain=["posthog", "error_tracking_fingerprint_issue_state"]),
-                    alias="fp_state",
-                    join_type="INNER JOIN",
-                    constraint=ast.JoinConstraint(
-                        expr=ast.CompareOperation(
-                            op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=["ev", "fp_hash"]),
-                            right=ast.Field(chain=["fp_state", "fp_hash"]),
-                        ),
-                        constraint_type="ON",
-                    ),
-                ),
+                next_join=self._fingerprint_state_join(ast.Field(chain=["ev", "fp_hash"])),
             ),
             where=ast.And(exprs=outer_where_exprs) if outer_where_exprs else None,
             group_by=[ast.Field(chain=["id"])],
@@ -428,22 +482,22 @@ class ErrorTrackingQueryBuilder:
         # merged fingerprints to preserve the earliest-known-first-seen.
         exprs: list[ast.Expr] = [
             ast.Alias(alias="id", expr=ast.Field(chain=["fp_state", "issue_id"])),
-            ast.Alias(alias="status", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_status"])])),
+            ast.Alias(alias="status", expr=ast.Call(name="any", args=[self._issue_state_expr("issue_status")])),
             ast.Alias(
                 alias="severity", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_severity"])])
             ),
-            ast.Alias(alias="name", expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_name"])])),
+            ast.Alias(alias="name", expr=ast.Call(name="any", args=[self._issue_state_expr("issue_name")])),
             ast.Alias(
                 alias="description",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "issue_description"])]),
+                expr=ast.Call(name="any", args=[self._issue_state_expr("issue_description")]),
             ),
             ast.Alias(
                 alias="assignee_user_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "assigned_user_id"])]),
+                expr=ast.Call(name="any", args=[self._issue_state_expr("assigned_user_id")]),
             ),
             ast.Alias(
                 alias="assignee_role_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["fp_state", "assigned_role_id"])]),
+                expr=ast.Call(name="any", args=[self._issue_state_expr("assigned_role_id")]),
             ),
             ast.Alias(
                 alias="first_seen",
@@ -493,7 +547,7 @@ class ErrorTrackingQueryBuilder:
             exprs.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["fp_state", "issue_status"]),
+                    left=self._issue_state_expr("issue_status"),
                     right=ast.Constant(value=self.query.status),
                 )
             )
@@ -503,7 +557,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["fp_state", "assigned_user_id"]),
+                        left=self._issue_state_expr("assigned_user_id"),
                         right=ast.Constant(value=self.query.assignee.id),
                     )
                 )
@@ -511,7 +565,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["fp_state", "assigned_role_id"]),
+                        left=self._issue_state_expr("assigned_role_id"),
                         right=ast.Constant(value=str(self.query.assignee.id)),
                     )
                 )
@@ -523,9 +577,12 @@ class ErrorTrackingQueryBuilder:
     # ---------------------------------------------------------------------
 
     def _build_query_legacy(self) -> ast.SelectQuery:
+        select_from = ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e")
+        if self.include_recent_issue_state:
+            select_from.next_join = self._fingerprint_state_join(_fingerprint_hash_expr())
         return ast.SelectQuery(
             select=self._select_expressions_legacy(),
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e"),
+            select_from=select_from,
             where=ast.And(exprs=self._where_exprs_legacy()),
             group_by=[ast.Field(chain=["id"])],
             order_by=[ast.OrderExpr(expr=ast.Field(chain=[self.query.orderBy]), order=order_direction(self.query))],
@@ -533,25 +590,29 @@ class ErrorTrackingQueryBuilder:
 
     def _select_expressions_legacy(self) -> list[ast.Expr]:
         exprs: list[ast.Expr] = [
-            ast.Alias(alias="id", expr=ast.Field(chain=["e", "issue_id"])),
-            ast.Alias(alias="status", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_status"])])),
-            ast.Alias(alias="severity", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_severity"])])),
-            ast.Alias(alias="name", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_name"])])),
+            ast.Alias(alias="id", expr=self._legacy_issue_state_expr("issue_id")),
+            ast.Alias(alias="status", expr=ast.Call(name="any", args=[self._legacy_issue_state_expr("issue_status")])),
             ast.Alias(
-                alias="description", expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_description"])])
+                alias="severity",
+                expr=ast.Call(name="any", args=[self._legacy_issue_state_expr("issue_severity")]),
+            ),
+            ast.Alias(alias="name", expr=ast.Call(name="any", args=[self._legacy_issue_state_expr("issue_name")])),
+            ast.Alias(
+                alias="description",
+                expr=ast.Call(name="any", args=[self._legacy_issue_state_expr("issue_description")]),
             ),
             ast.Alias(
                 alias="assignee_user_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_assigned_user_id"])]),
+                expr=ast.Call(name="any", args=[self._legacy_issue_state_expr("assigned_user_id")]),
             ),
             ast.Alias(
                 alias="assignee_role_id",
-                expr=ast.Call(name="any", args=[ast.Field(chain=["e", "issue_assigned_role_id"])]),
+                expr=ast.Call(name="any", args=[self._legacy_issue_state_expr("assigned_role_id")]),
             ),
             ast.Alias(alias="last_seen", expr=ast.Call(name="max", args=[ast.Field(chain=["e", "timestamp"])])),
             ast.Alias(
                 alias="first_seen",
-                expr=ast.Call(name="min", args=[ast.Field(chain=["e", "issue_first_seen"])]),
+                expr=ast.Call(name="min", args=[self._legacy_issue_state_expr("first_seen")]),
             ),
             ast.Alias(alias="function", expr=innermost_frame_attribute("$exception_functions")),
             ast.Alias(alias="source", expr=innermost_frame_attribute("$exception_sources")),
@@ -650,7 +711,7 @@ class ErrorTrackingQueryBuilder:
                 left=ast.Field(chain=["e", "event"]),
                 right=ast.Constant(value="$exception"),
             ),
-            ast.Call(name="isNotNull", args=[ast.Field(chain=["e", "issue_id"])]),
+            ast.Call(name="isNotNull", args=[self._legacy_issue_state_expr("issue_id")]),
             ast.Placeholder(expr=ast.Field(chain=["filters"])),
         ]
 
@@ -676,7 +737,7 @@ class ErrorTrackingQueryBuilder:
             exprs.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["e", "issue_id"]),
+                    left=self._legacy_issue_state_expr("issue_id"),
                     right=ast.Constant(value=self.query.issueId),
                 )
             )
@@ -706,7 +767,7 @@ class ErrorTrackingQueryBuilder:
             exprs.append(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["e", "issue_status"]),
+                    left=self._legacy_issue_state_expr("issue_status"),
                     right=ast.Constant(value=self.query.status),
                 )
             )
@@ -716,7 +777,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["e", "issue_assigned_user_id"]),
+                        left=self._legacy_issue_state_expr("assigned_user_id"),
                         right=ast.Constant(value=self.query.assignee.id),
                     )
                 )
@@ -724,7 +785,7 @@ class ErrorTrackingQueryBuilder:
                 exprs.append(
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["e", "issue_assigned_role_id"]),
+                        left=self._legacy_issue_state_expr("assigned_role_id"),
                         right=ast.Constant(value=str(self.query.assignee.id)),
                     )
                 )
@@ -818,19 +879,19 @@ class ErrorTrackingQueryBuilder:
     def _issue_property_to_ast(self, prop: ErrorTrackingIssueFilter) -> ast.Expr | None:
         key = "description" if prop.key == "issue_description" else prop.key
 
-        field_chain_map: dict[str, list[str | int]] = {
-            "name": ["e", "issue_name"],
-            "description": ["e", "issue_description"],
-            "status": ["e", "issue_status"],
-            "severity": ["e", "issue_severity"],
-            "first_seen": ["e", "issue_first_seen"],
+        field_name_map: dict[str, str] = {
+            "name": "issue_name",
+            "description": "issue_description",
+            "status": "issue_status",
+            "severity": "issue_severity",
+            "first_seen": "first_seen",
         }
 
-        field_chain = field_chain_map.get(key)
-        if field_chain is None:
+        field_name = field_name_map.get(key)
+        if field_name is None:
             return None
 
-        field = ast.Field(chain=field_chain)
+        field = self._legacy_issue_state_expr(field_name)
         value = prop.value
         operator = prop.operator
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -7,6 +7,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.schema.error_tracking_fingerprint_issue_state import PENDING_UPDATES_HOGQL_CONTEXT_KEY
+from posthog.hogql.database.schema.error_tracking_recent_issue_state import RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
@@ -18,6 +19,11 @@ from posthog.utils import relative_date_parse
 from products.error_tracking.backend.hogql_queries.access import ErrorTrackingQueryRunnerAccessMixin
 from products.error_tracking.backend.hogql_queries.error_tracking_query_builder import ErrorTrackingQueryBuilder
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import validate_uuid_param
+from products.error_tracking.backend.hogql_queries.issue_state_overlay import (
+    RecentIssueState,
+    latest_issue_state_watermark,
+    load_recent_issue_states,
+)
 
 
 class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQueryRunner[ErrorTrackingQueryResponse]):
@@ -27,7 +33,7 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
     date_from: datetime.datetime
     date_to: datetime.datetime
 
-    CACHE_VERSION = 3
+    CACHE_VERSION = 4
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -61,6 +67,8 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
     def get_cache_payload(self) -> dict:
         payload = super().get_cache_payload()
         payload["error_tracking_cache_version"] = self.CACHE_VERSION
+        watermark = latest_issue_state_watermark(self.team.pk)
+        payload["error_tracking_issue_state_watermark"] = watermark.isoformat() if watermark is not None else None
         return payload
 
     @classmethod
@@ -88,32 +96,46 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
 
     MAX_PENDING_FINGERPRINT_ISSUE_STATE_UPDATES = 50
 
-    def _hogql_context(self) -> HogQLContext:
+    def _hogql_context(self, recent_issue_states: list[RecentIssueState] | None = None) -> HogQLContext:
         ctx = HogQLContext(team_id=self.team.pk, team=self.team, user=self.user, enable_select_queries=True)
         raw = (self.query.pendingFingerprintIssueStateUpdates or [])[: self.MAX_PENDING_FINGERPRINT_ISSUE_STATE_UPDATES]
         if raw:
             ctx.data_to_ingest[PENDING_UPDATES_HOGQL_CONTEXT_KEY] = [row.model_dump(mode="json") for row in raw]
+        if recent_issue_states:
+            ctx.data_to_ingest[RECENT_ISSUE_STATE_HOGQL_CONTEXT_KEY] = [
+                state.as_external_table_row() for state in recent_issue_states
+            ]
         return ctx
 
     def _calculate(self):
+        with self.timings.measure("error_tracking_query_recent_issue_state"):
+            recent_issue_states = load_recent_issue_states(self.team.pk)
+        context = self._hogql_context(recent_issue_states)
+        builder = ErrorTrackingQueryBuilder(
+            self.query,
+            self.team,
+            self.date_from,
+            self.date_to,
+            include_recent_issue_state=bool(recent_issue_states),
+        )
         with self.timings.measure("error_tracking_query_hogql_execute"):
             query_result = self.paginator.execute_hogql_query(
-                query=self._builder.build_query(),
+                query=builder.build_query(),
                 team=self.team,
                 query_type="ErrorTrackingQuery",
                 timings=self.timings,
                 modifiers=self.modifiers,
                 limit_context=self.limit_context,
-                filters=self._builder.hogql_filters(),
+                filters=builder.hogql_filters(),
                 user=self.user,
-                context=self._hogql_context(),
+                context=context,
             )
 
         columns, results = self._attach_events(query_result.columns or [], query_result.results)
 
         return ErrorTrackingQueryResponse(
             columns=columns,
-            results=self._builder.process_results(columns, results),
+            results=builder.process_results(columns, results),
             timings=query_result.timings,
             hogql=query_result.hogql,
             modifiers=self.modifiers,

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -74,10 +74,7 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
     def get_cache_payload(self) -> dict:
         payload = super().get_cache_payload()
         payload["error_tracking_cache_version"] = self.CACHE_VERSION
-        # This read runs on the cache-key path, before any cache lookup, and hits primary Postgres.
-        # Under connection-pool saturation it can time out (OperationalError); degrade to a stable
-        # "unavailable" marker instead of 500-ing a request whose result may already be cached.
-        # Mirrors AnalyticsQueryRunner._products_modifiers_for_cache.
+        # Use a stable marker when the primary read fails so an existing cached result can still load.
         try:
             watermark = latest_issue_state_watermark(self.team.pk)
         except OperationalError:
@@ -126,8 +123,7 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
 
     def _calculate(self):
         with self.timings.measure("error_tracking_query_recent_issue_state"):
-            # The overlay layers fresh Postgres state onto ClickHouse results. If the primary read
-            # fails, run without the overlay rather than failing the whole query.
+            # Keep ClickHouse available when the primary read fails.
             try:
                 recent_issue_states = load_recent_issue_states(self.team.pk)
             except OperationalError:

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -1,6 +1,10 @@
 import datetime
 from zoneinfo import ZoneInfo
 
+from django.db import OperationalError
+
+import structlog
+
 from posthog.schema import CachedErrorTrackingQueryResponse, ErrorTrackingQuery, ErrorTrackingQueryResponse
 
 from posthog.hogql import ast
@@ -20,10 +24,13 @@ from products.error_tracking.backend.hogql_queries.access import ErrorTrackingQu
 from products.error_tracking.backend.hogql_queries.error_tracking_query_builder import ErrorTrackingQueryBuilder
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import validate_uuid_param
 from products.error_tracking.backend.hogql_queries.issue_state_overlay import (
+    RECENT_ISSUE_STATE_OVERLAY_UNAVAILABLE,
     RecentIssueState,
     latest_issue_state_watermark,
     load_recent_issue_states,
 )
+
+logger = structlog.get_logger(__name__)
 
 
 class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQueryRunner[ErrorTrackingQueryResponse]):
@@ -67,8 +74,18 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
     def get_cache_payload(self) -> dict:
         payload = super().get_cache_payload()
         payload["error_tracking_cache_version"] = self.CACHE_VERSION
-        watermark = latest_issue_state_watermark(self.team.pk)
-        payload["error_tracking_issue_state_watermark"] = watermark.isoformat() if watermark is not None else None
+        # This read runs on the cache-key path, before any cache lookup, and hits primary Postgres.
+        # Under connection-pool saturation it can time out (OperationalError); degrade to a stable
+        # "unavailable" marker instead of 500-ing a request whose result may already be cached.
+        # Mirrors AnalyticsQueryRunner._products_modifiers_for_cache.
+        try:
+            watermark = latest_issue_state_watermark(self.team.pk)
+        except OperationalError:
+            logger.warning("error_tracking_issue_state_watermark_unavailable", team_id=self.team.pk, exc_info=True)
+            RECENT_ISSUE_STATE_OVERLAY_UNAVAILABLE.labels(read="watermark").inc()
+            payload["error_tracking_issue_state_watermark"] = "unavailable"
+        else:
+            payload["error_tracking_issue_state_watermark"] = watermark.isoformat() if watermark is not None else None
         return payload
 
     @classmethod
@@ -109,7 +126,14 @@ class ErrorTrackingQueryRunner(ErrorTrackingQueryRunnerAccessMixin, AnalyticsQue
 
     def _calculate(self):
         with self.timings.measure("error_tracking_query_recent_issue_state"):
-            recent_issue_states = load_recent_issue_states(self.team.pk)
+            # The overlay layers fresh Postgres state onto ClickHouse results. If the primary read
+            # fails, run without the overlay rather than failing the whole query.
+            try:
+                recent_issue_states = load_recent_issue_states(self.team.pk)
+            except OperationalError:
+                logger.warning("error_tracking_recent_issue_states_unavailable", team_id=self.team.pk, exc_info=True)
+                RECENT_ISSUE_STATE_OVERLAY_UNAVAILABLE.labels(read="recent_states").inc()
+                recent_issue_states = []
         context = self._hogql_context(recent_issue_states)
         builder = ErrorTrackingQueryBuilder(
             self.query,

--- a/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
+++ b/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
@@ -1,0 +1,102 @@
+import datetime
+from uuid import UUID
+
+from django.db import DEFAULT_DB_ALIAS
+from django.utils import timezone
+
+from prometheus_client import Histogram
+
+from posthog.dataclasses import frozen
+
+from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueAssignment
+
+RECENT_ISSUE_STATE_WINDOW = datetime.timedelta(seconds=60)
+
+RECENT_ISSUE_STATE_ROW_COUNT = Histogram(
+    "error_tracking_recent_issue_state_row_count",
+    "Number of recent Postgres issue-state rows sent with an error tracking query",
+    buckets=(0, 1, 5, 10, 25, 50, 100, 250, 500, 1000, float("inf")),
+)
+
+
+@frozen
+class RecentIssueState:
+    team_id: int
+    issue_id: UUID
+    issue_status: str
+    issue_name: str | None
+    issue_description: str | None
+    assigned_user_id: int | None
+    assigned_role_id: UUID | None
+    state_updated_at: datetime.datetime
+
+    def as_external_table_row(self) -> dict[str, object]:
+        return {
+            "team_id": self.team_id,
+            "issue_id": self.issue_id,
+            "issue_status": self.issue_status,
+            "issue_name": self.issue_name,
+            "issue_description": self.issue_description,
+            "assigned_user_id": self.assigned_user_id,
+            "assigned_role_id": self.assigned_role_id,
+            "state_updated_at": self.state_updated_at,
+            "is_present": True,
+        }
+
+
+def latest_issue_state_watermark(team_id: int) -> datetime.datetime | None:
+    return (
+        ErrorTrackingIssue.objects.using(DEFAULT_DB_ALIAS)
+        .filter(team_id=team_id, state_updated_at__isnull=False)
+        .order_by("-state_updated_at")
+        .values_list("state_updated_at", flat=True)
+        .first()
+    )
+
+
+def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | None = None) -> list[RecentIssueState]:
+    threshold = (current_time or timezone.now()) - RECENT_ISSUE_STATE_WINDOW
+    issues = (
+        ErrorTrackingIssue.objects.using(DEFAULT_DB_ALIAS)
+        .filter(team_id=team_id, state_updated_at__gte=threshold)
+        .select_related("assignment")
+        .only(
+            "id",
+            "team_id",
+            "status",
+            "name",
+            "description",
+            "state_updated_at",
+            "assignment__user_id",
+            "assignment__role_id",
+        )
+    )
+
+    recent_states: list[RecentIssueState] = []
+    for issue in issues:
+        try:
+            assignment = issue.assignment
+        except ErrorTrackingIssueAssignment.DoesNotExist:
+            assigned_user_id = None
+            assigned_role_id = None
+        else:
+            assigned_user_id = assignment.user_id
+            assigned_role_id = assignment.role_id
+
+        if issue.state_updated_at is None:
+            continue
+        recent_states.append(
+            RecentIssueState(
+                team_id=issue.team_id,
+                issue_id=issue.id,
+                issue_status=issue.status,
+                issue_name=issue.name,
+                issue_description=issue.description,
+                assigned_user_id=assigned_user_id,
+                assigned_role_id=assigned_role_id,
+                state_updated_at=issue.state_updated_at,
+            )
+        )
+
+    RECENT_ISSUE_STATE_ROW_COUNT.observe(len(recent_states))
+    return recent_states

--- a/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
+++ b/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
@@ -12,6 +12,12 @@ from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrac
 
 RECENT_ISSUE_STATE_WINDOW = datetime.timedelta(seconds=60)
 
+# The bulk mutation endpoint does not cap how many issues one request changes, and every changed
+# issue is loaded and sent as an external-table row on each forced refresh for the whole window.
+# Bound that payload. When a mutation touches more issues than this, skip the overlay and fall back
+# to ClickHouse state rather than materialize and ship an unbounded row list.
+MAX_RECENT_ISSUE_STATES = 100
+
 RECENT_ISSUE_STATE_ROW_COUNT = Histogram(
     "error_tracking_recent_issue_state_row_count",
     "Number of recent Postgres issue-state rows sent with an error tracking query",
@@ -72,7 +78,7 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
             "state_updated_at",
             "assignment__user_id",
             "assignment__role_id",
-        )
+        )[: MAX_RECENT_ISSUE_STATES + 1]
     )
 
     recent_states: list[RecentIssueState] = []
@@ -103,4 +109,6 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
         )
 
     RECENT_ISSUE_STATE_ROW_COUNT.observe(len(recent_states))
+    if len(recent_states) > MAX_RECENT_ISSUE_STATES:
+        return []
     return recent_states

--- a/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
+++ b/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from django.db import DEFAULT_DB_ALIAS
 from django.utils import timezone
 
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 
 from posthog.dataclasses import frozen
 
@@ -22,6 +22,14 @@ RECENT_ISSUE_STATE_ROW_COUNT = Histogram(
     "error_tracking_recent_issue_state_row_count",
     "Number of recent Postgres issue-state rows sent with an error tracking query",
     buckets=(0, 1, 5, 10, 25, 50, 100, 250, 500, 1000, float("inf")),
+)
+
+# These reads pin to the primary (read-after-write freshness), so they cannot fall back to a replica.
+# When the primary times out, the query degrades without the overlay; count each degraded read here.
+RECENT_ISSUE_STATE_OVERLAY_UNAVAILABLE = Counter(
+    "error_tracking_recent_issue_state_overlay_unavailable_total",
+    "Times an error tracking overlay Postgres read failed and the query ran without the overlay",
+    ["read"],
 )
 
 

--- a/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
+++ b/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
@@ -24,6 +24,7 @@ class RecentIssueState:
     team_id: int
     issue_id: UUID
     issue_status: str
+    issue_severity: str | None
     issue_name: str | None
     issue_description: str | None
     assigned_user_id: int | None
@@ -35,6 +36,7 @@ class RecentIssueState:
             "team_id": self.team_id,
             "issue_id": self.issue_id,
             "issue_status": self.issue_status,
+            "issue_severity": self.issue_severity,
             "issue_name": self.issue_name,
             "issue_description": self.issue_description,
             "assigned_user_id": self.assigned_user_id,
@@ -64,6 +66,7 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
             "id",
             "team_id",
             "status",
+            "severity",
             "name",
             "description",
             "state_updated_at",
@@ -90,6 +93,7 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
                 team_id=issue.team_id,
                 issue_id=issue.id,
                 issue_status=issue.status,
+                issue_severity=issue.severity,
                 issue_name=issue.name,
                 issue_description=issue.description,
                 assigned_user_id=assigned_user_id,

--- a/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
+++ b/products/error_tracking/backend/hogql_queries/issue_state_overlay.py
@@ -12,16 +12,14 @@ from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrac
 
 RECENT_ISSUE_STATE_WINDOW = datetime.timedelta(seconds=60)
 
-# The bulk mutation endpoint does not cap how many issues one request changes, and every changed
-# issue is loaded and sent as an external-table row on each forced refresh for the whole window.
-# Bound that payload. When a mutation touches more issues than this, skip the overlay and fall back
-# to ClickHouse state rather than materialize and ship an unbounded row list.
+# The bulk endpoint has no issue count limit, so skip the overlay instead of sending an unbounded
+# external table when many issues change within one window.
 MAX_RECENT_ISSUE_STATES = 100
 
 RECENT_ISSUE_STATE_ROW_COUNT = Histogram(
     "error_tracking_recent_issue_state_row_count",
-    "Number of recent Postgres issue-state rows sent with an error tracking query",
-    buckets=(0, 1, 5, 10, 25, 50, 100, 250, 500, 1000, float("inf")),
+    "Number of recent Postgres issue-state rows loaded before applying the external-table limit",
+    buckets=(0, 1, 5, 10, 25, 50, 100, 101, float("inf")),
 )
 
 # These reads pin to the primary (read-after-write freshness), so they cannot fall back to a replica.
@@ -43,7 +41,6 @@ class RecentIssueState:
     issue_description: str | None
     assigned_user_id: int | None
     assigned_role_id: UUID | None
-    state_updated_at: datetime.datetime
 
     def as_external_table_row(self) -> dict[str, object]:
         return {
@@ -55,7 +52,6 @@ class RecentIssueState:
             "issue_description": self.issue_description,
             "assigned_user_id": self.assigned_user_id,
             "assigned_role_id": self.assigned_role_id,
-            "state_updated_at": self.state_updated_at,
             "is_present": True,
         }
 
@@ -83,7 +79,6 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
             "severity",
             "name",
             "description",
-            "state_updated_at",
             "assignment__user_id",
             "assignment__role_id",
         )[: MAX_RECENT_ISSUE_STATES + 1]
@@ -100,8 +95,6 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
             assigned_user_id = assignment.user_id
             assigned_role_id = assignment.role_id
 
-        if issue.state_updated_at is None:
-            continue
         recent_states.append(
             RecentIssueState(
                 team_id=issue.team_id,
@@ -112,7 +105,6 @@ def load_recent_issue_states(team_id: int, *, current_time: datetime.datetime | 
                 issue_description=issue.description,
                 assigned_user_id=assigned_user_id,
                 assigned_role_id=assigned_role_id,
-                state_updated_at=issue.state_updated_at,
             )
         )
 

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -888,6 +888,47 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
 
         self.assertEqual([result["id"] for result in results], [self.issue_id_one])
 
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_issue_state_keeps_legacy_events_without_fingerprint_state(self):
+        issue_id = "01936e80-f594-7a2e-8545-7bcb491aa620"
+        ErrorTrackingIssue.objects.create(
+            id=issue_id,
+            team=self.team,
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            severity=ErrorTrackingIssue.Severity.CRITICAL,
+            name="Recent unmapped issue",
+            state_updated_at=now(),
+        )
+        _create_event(
+            distinct_id="unmapped-fingerprint-user",
+            event="$exception",
+            team=self.team,
+            properties={
+                "$exception_issue_id": issue_id,
+                "$exception_fingerprint": "fingerprint_without_clickhouse_state",
+            },
+        )
+        flush_persons_and_events()
+
+        results = self._calculate(
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    PropertyGroupFilterValue(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            ErrorTrackingIssueFilter(
+                                key="name", value=["Recent unmapped issue"], operator=PropertyOperator.EXACT
+                            )
+                        ],
+                    )
+                ],
+            )
+        )["results"]
+
+        self.assertEqual([result["id"] for result in results], [issue_id])
+        self.assertEqual(results[0]["severity"], ErrorTrackingIssue.Severity.CRITICAL)
+
     @parameterized.expand(
         [
             ("exact", PropertyOperator.EXACT, ErrorTrackingIssue.Severity.HIGH, (issue_id_one,)),

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -38,6 +38,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client import sync_execute
 from posthog.constants import AvailableFeature
+from posthog.models import Team
 from posthog.models.utils import uuid7
 from posthog.rbac.user_access_control import UserAccessControlError
 
@@ -57,6 +58,7 @@ from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_u
 from products.error_tracking.backend.hogql_queries.error_tracking_similar_issues_query_runner import (
     ErrorTrackingSimilarIssuesQueryRunner,
 )
+from products.error_tracking.backend.hogql_queries.issue_state_overlay import load_recent_issue_states
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -368,6 +370,37 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         self.assertTrue(runner.query.withAggregations)
 
     @freeze_time("2022-01-10T12:11:00")
+    def test_cache_payload_keeps_latest_issue_state_watermark_after_overlay_expiry(self):
+        query = ErrorTrackingQuery(
+            kind="ErrorTrackingQuery",
+            dateRange=DateRange(date_from="all"),
+            orderBy="last_seen",  # pyright: ignore[reportArgumentType]
+            volumeResolution=1,
+        )
+        initial_payload = ErrorTrackingQueryRunner(
+            team=self.team, query=query.model_copy(deep=True)
+        ).get_cache_payload()
+        mutation_timestamp = now() - timedelta(seconds=61)
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=mutation_timestamp)
+
+        mutated_payload = ErrorTrackingQueryRunner(
+            team=self.team, query=query.model_copy(deep=True)
+        ).get_cache_payload()
+        with freeze_time("2022-01-10T12:13:00"):
+            expired_payload = ErrorTrackingQueryRunner(
+                team=self.team, query=query.model_copy(deep=True)
+            ).get_cache_payload()
+
+        self.assertNotEqual(
+            initial_payload["error_tracking_issue_state_watermark"],
+            mutated_payload["error_tracking_issue_state_watermark"],
+        )
+        self.assertEqual(
+            mutated_payload["error_tracking_issue_state_watermark"],
+            expired_payload["error_tracking_issue_state_watermark"],
+        )
+
+    @freeze_time("2022-01-10T12:11:00")
     def test_missing_date_from_defaults_to_seven_days(self):
         # A missing date_from must default to a bounded 7-day window, not all-time.
         date_from = ErrorTrackingQueryRunner.parse_relative_date_from(None)
@@ -595,22 +628,89 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
     @freeze_time("2022-01-10T12:11:00")
     def test_status(self):
         resolved_issue = ErrorTrackingIssue.objects.get(id=self.issue_id_one)
-        resolved_issue.status = ErrorTrackingIssue.Status.RESOLVED
-        resolved_issue.save()
-        # re-sync after status change
+        resolved_issue.description = "Stale description"
+        resolved_issue.save(update_fields=["description"])
         sync_issues_to_clickhouse(issue_ids=[self.issue_id_one], team_id=self.team.pk)
+
+        resolved_issue.status = ErrorTrackingIssue.Status.RESOLVED
+        resolved_issue.name = "Updated TypeError"
+        resolved_issue.description = None
+        resolved_issue.state_updated_at = now()
+        resolved_issue.save(update_fields=["status", "name", "description", "state_updated_at"])
 
         results = self._calculate(status="active")["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_three, self.issue_id_two])
 
-        results = self._calculate(status="resolved")["results"]
+        results = self._calculate(status="resolved", issueId=self.issue_id_one)["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_one])
+        self.assertEqual(results[0]["status"], ErrorTrackingIssue.Status.RESOLVED)
+        self.assertEqual(results[0]["name"], "Updated TypeError")
+        self.assertIsNone(results[0]["description"])
 
         results = self._calculate()["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_three, self.issue_id_two, self.issue_id_one])
 
         results = self._calculate(status="all")["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_three, self.issue_id_two, self.issue_id_one])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_expired_postgres_state_uses_clickhouse_state(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            state_updated_at=now() - timedelta(seconds=61),
+        )
+
+        active_response = self._calculate(status="active")
+        self.assertIn(self.issue_id_one, [result["id"] for result in active_response["results"]])
+        self.assertNotIn("error_tracking_recent_issue_state", active_response["hogql"])
+
+        resolved_results = self._calculate(status="resolved")["results"]
+        self.assertNotIn(self.issue_id_one, [result["id"] for result in resolved_results])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_issue_state_is_scoped_to_team(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(state_updated_at=now())
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        other_issue = ErrorTrackingIssue.objects.create(
+            team=other_team,
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            state_updated_at=now(),
+        )
+
+        with self.assertNumQueries(1):
+            recent_states = load_recent_issue_states(self.team.pk)
+
+        self.assertEqual(
+            [state.issue_id for state in recent_states], [ErrorTrackingIssue.objects.get(id=self.issue_id_one).id]
+        )
+        self.assertNotIn(other_issue.id, [state.issue_id for state in recent_states])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_issue_state_applies_to_more_than_fifty_fingerprints(self):
+        for index in range(50):
+            fingerprint = f"additional-fingerprint-{index}"
+            ErrorTrackingIssueFingerprintV2.objects.create(
+                team=self.team,
+                issue_id=self.issue_id_one,
+                fingerprint=fingerprint,
+            )
+            _create_event(
+                distinct_id=self.distinct_id_one,
+                event="$exception",
+                team=self.team,
+                properties={"$exception_issue_id": self.issue_id_one, "$exception_fingerprint": fingerprint},
+            )
+        sync_issues_to_clickhouse(issue_ids=[self.issue_id_one], team_id=self.team.pk)
+        flush_persons_and_events()
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(
+            status=ErrorTrackingIssue.Status.RESOLVED,
+            state_updated_at=now(),
+        )
+
+        results = self._calculate(status="resolved", withAggregations=True)["results"]
+
+        self.assertEqual([result["id"] for result in results], [self.issue_id_one])
+        self.assertEqual(results[0]["aggregations"]["occurrences"], 52)
 
     @freeze_time("2022-01-10T12:11:00")
     @snapshot_clickhouse_queries
@@ -657,9 +757,7 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         )
         flush_persons_and_events()
         ErrorTrackingIssueAssignment.objects.create(issue_id=issue_id, user=self.user, team=self.team)
-        # re-sync with a newer version so the assignment wins argMax over the create-time row
-        with freeze_time("2022-01-10T12:11:05"):
-            sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+        ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now())
 
         results = self._calculate(assignee={"type": "user", "id": self.user.pk})["results"]
         self.assertEqual([x["id"] for x in results], [issue_id])
@@ -675,18 +773,13 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         flush_persons_and_events()
         role = Role.objects.create(name="Test Team", organization=self.organization)
         ErrorTrackingIssueAssignment.objects.create(issue_id=issue_id, role=role, team=self.team)
-        # re-sync with a newer version so the assignment wins argMax over the create-time row
-        with freeze_time("2022-01-10T12:11:05"):
-            sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+        ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now())
 
         results = self._calculate(assignee={"type": "role", "id": str(role.id)})["results"]
         self.assertEqual([x["id"] for x in results], [issue_id])
 
     @freeze_time("2022-01-10T12:11:00")
     def test_unassignment_clears_assignee(self):
-        # Reproduces argMax(field, version) NULL-skip behavior: writing a newer
-        # row with assigned_user_id=NULL must not let the query return the prior
-        # non-NULL user_id.
         issue_id = "e9ac529f-ac1c-4a96-bd3a-107034368d64"
         self.create_events_and_issue(
             issue_id=issue_id, fingerprint="unassign_issue_fingerprint", distinct_ids=[self.distinct_id_one]
@@ -697,14 +790,14 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         with freeze_time("2022-01-10T12:11:01"):
             sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
 
-        assignment.delete()
         with freeze_time("2022-01-10T12:11:02"):
-            sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+            assignment.delete()
+            ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now())
 
-        results = self._calculate()["results"]
-        matching = [r for r in results if r["id"] == issue_id]
-        self.assertEqual(len(matching), 1)
-        self.assertIsNone(matching[0]["assignee"])
+            results = self._calculate()["results"]
+            matching = [r for r in results if r["id"] == issue_id]
+            self.assertEqual(len(matching), 1)
+            self.assertIsNone(matching[0]["assignee"])
 
     @freeze_time("2022-01-10T12:11:00")
     @snapshot_clickhouse_queries
@@ -725,6 +818,31 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
             )
         )["results"]
         self.assertEqual(len(results), 1)
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_issue_state_applies_before_issue_filters(self):
+        ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(
+            name="Updated TypeError",
+            state_updated_at=now(),
+        )
+
+        results = self._calculate(
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    PropertyGroupFilterValue(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            ErrorTrackingIssueFilter(
+                                key="name", value=["Updated TypeError"], operator=PropertyOperator.EXACT
+                            ),
+                        ],
+                    )
+                ],
+            )
+        )["results"]
+
+        self.assertEqual([result["id"] for result in results], [self.issue_id_one])
 
     @parameterized.expand(
         [

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -405,9 +405,6 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         )
 
     def test_cache_payload_degrades_when_watermark_read_fails(self):
-        # A primary-Postgres pool timeout while reading the issue-state watermark runs on the
-        # cache-key path and must not 500 a request whose result may already be cached; the marker
-        # degrades to a stable "unavailable" instead.
         query = ErrorTrackingQuery(
             kind="ErrorTrackingQuery",
             dateRange=DateRange(date_from="all"),
@@ -650,24 +647,29 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
     @freeze_time("2022-01-10T12:11:00")
     def test_status(self):
         resolved_issue = ErrorTrackingIssue.objects.get(id=self.issue_id_one)
+        resolved_issue.status = ErrorTrackingIssue.Status.RESOLVED
         resolved_issue.description = "Stale description"
         resolved_issue.severity = ErrorTrackingIssue.Severity.LOW
-        resolved_issue.save(update_fields=["description", "severity"])
+        resolved_issue.save(update_fields=["status", "description", "severity"])
         sync_issues_to_clickhouse(issue_ids=[self.issue_id_one], team_id=self.team.pk)
 
-        resolved_issue.status = ErrorTrackingIssue.Status.RESOLVED
+        clickhouse_results = self._calculate(status="resolved", issueId=self.issue_id_one)["results"]
+        self.assertEqual([result["id"] for result in clickhouse_results], [self.issue_id_one])
+        self.assertEqual(clickhouse_results[0]["status"], ErrorTrackingIssue.Status.RESOLVED)
+
+        resolved_issue.status = ErrorTrackingIssue.Status.ACTIVE
         resolved_issue.severity = ErrorTrackingIssue.Severity.CRITICAL
         resolved_issue.name = "Updated TypeError"
         resolved_issue.description = None
         resolved_issue.state_updated_at = now()
         resolved_issue.save(update_fields=["status", "severity", "name", "description", "state_updated_at"])
 
-        results = self._calculate(status="active")["results"]
-        self.assertEqual([r["id"] for r in results], [self.issue_id_three, self.issue_id_two])
+        results = self._calculate(status="resolved")["results"]
+        self.assertNotIn(self.issue_id_one, [result["id"] for result in results])
 
-        results = self._calculate(status="resolved", issueId=self.issue_id_one)["results"]
+        results = self._calculate(status="active", issueId=self.issue_id_one)["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_one])
-        self.assertEqual(results[0]["status"], ErrorTrackingIssue.Status.RESOLVED)
+        self.assertEqual(results[0]["status"], ErrorTrackingIssue.Status.ACTIVE)
         self.assertEqual(results[0]["severity"], ErrorTrackingIssue.Severity.CRITICAL)
         self.assertEqual(results[0]["name"], "Updated TypeError")
         self.assertIsNone(results[0]["description"])
@@ -800,6 +802,12 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         results = self._calculate(assignee={"type": "user", "id": self.user.pk})["results"]
         self.assertEqual([x["id"] for x in results], [issue_id])
 
+        with freeze_time("2022-01-10T12:11:05"):
+            sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+            ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now() - timedelta(seconds=61))
+            results = self._calculate(assignee={"type": "user", "id": self.user.pk})["results"]
+        self.assertEqual([x["id"] for x in results], [issue_id])
+
     @freeze_time("2022-01-10T12:11:00")
     def test_role_assignee(self):
         issue_id = "e9ac529f-ac1c-4a96-bd3a-107034368d64"
@@ -814,6 +822,12 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now())
 
         results = self._calculate(assignee={"type": "role", "id": str(role.id)})["results"]
+        self.assertEqual([x["id"] for x in results], [issue_id])
+
+        with freeze_time("2022-01-10T12:11:05"):
+            sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+            ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now() - timedelta(seconds=61))
+            results = self._calculate(assignee={"type": "role", "id": str(role.id)})["results"]
         self.assertEqual([x["id"] for x in results], [issue_id])
 
     @freeze_time("2022-01-10T12:11:00")
@@ -836,6 +850,14 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
             matching = [r for r in results if r["id"] == issue_id]
             self.assertEqual(len(matching), 1)
             self.assertIsNone(matching[0]["assignee"])
+
+        with freeze_time("2022-01-10T12:11:03"):
+            sync_issues_to_clickhouse(issue_ids=[issue_id], team_id=self.team.pk)
+            ErrorTrackingIssue.objects.filter(id=issue_id).update(state_updated_at=now() - timedelta(seconds=61))
+            results = self._calculate()["results"]
+        matching = [r for r in results if r["id"] == issue_id]
+        self.assertEqual(len(matching), 1)
+        self.assertIsNone(matching[0]["assignee"])
 
     @freeze_time("2022-01-10T12:11:00")
     @snapshot_clickhouse_queries

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -629,14 +629,16 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
     def test_status(self):
         resolved_issue = ErrorTrackingIssue.objects.get(id=self.issue_id_one)
         resolved_issue.description = "Stale description"
-        resolved_issue.save(update_fields=["description"])
+        resolved_issue.severity = ErrorTrackingIssue.Severity.LOW
+        resolved_issue.save(update_fields=["description", "severity"])
         sync_issues_to_clickhouse(issue_ids=[self.issue_id_one], team_id=self.team.pk)
 
         resolved_issue.status = ErrorTrackingIssue.Status.RESOLVED
+        resolved_issue.severity = ErrorTrackingIssue.Severity.CRITICAL
         resolved_issue.name = "Updated TypeError"
         resolved_issue.description = None
         resolved_issue.state_updated_at = now()
-        resolved_issue.save(update_fields=["status", "name", "description", "state_updated_at"])
+        resolved_issue.save(update_fields=["status", "severity", "name", "description", "state_updated_at"])
 
         results = self._calculate(status="active")["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_three, self.issue_id_two])
@@ -644,6 +646,7 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         results = self._calculate(status="resolved", issueId=self.issue_id_one)["results"]
         self.assertEqual([r["id"] for r in results], [self.issue_id_one])
         self.assertEqual(results[0]["status"], ErrorTrackingIssue.Status.RESOLVED)
+        self.assertEqual(results[0]["severity"], ErrorTrackingIssue.Severity.CRITICAL)
         self.assertEqual(results[0]["name"], "Updated TypeError")
         self.assertIsNone(results[0]["description"])
 
@@ -823,6 +826,7 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
     def test_recent_issue_state_applies_before_issue_filters(self):
         ErrorTrackingIssue.objects.filter(id=self.issue_id_one).update(
             name="Updated TypeError",
+            severity=ErrorTrackingIssue.Severity.CRITICAL,
             state_updated_at=now(),
         )
 
@@ -835,6 +839,11 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
                         values=[
                             ErrorTrackingIssueFilter(
                                 key="name", value=["Updated TypeError"], operator=PropertyOperator.EXACT
+                            ),
+                            ErrorTrackingIssueFilter(
+                                key="severity",
+                                value=ErrorTrackingIssue.Severity.CRITICAL,
+                                operator=PropertyOperator.EXACT,
                             ),
                         ],
                     )

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -58,7 +58,10 @@ from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_u
 from products.error_tracking.backend.hogql_queries.error_tracking_similar_issues_query_runner import (
     ErrorTrackingSimilarIssuesQueryRunner,
 )
-from products.error_tracking.backend.hogql_queries.issue_state_overlay import load_recent_issue_states
+from products.error_tracking.backend.hogql_queries.issue_state_overlay import (
+    MAX_RECENT_ISSUE_STATES,
+    load_recent_issue_states,
+)
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -687,6 +690,19 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
             [state.issue_id for state in recent_states], [ErrorTrackingIssue.objects.get(id=self.issue_id_one).id]
         )
         self.assertNotIn(other_issue.id, [state.issue_id for state in recent_states])
+
+    @freeze_time("2022-01-10T12:11:00")
+    def test_recent_issue_state_skips_overlay_when_bound_exceeded(self):
+        ErrorTrackingIssue.objects.bulk_create(
+            ErrorTrackingIssue(team=self.team, status=ErrorTrackingIssue.Status.RESOLVED, state_updated_at=now())
+            for _ in range(MAX_RECENT_ISSUE_STATES)
+        )
+        self.assertEqual(len(load_recent_issue_states(self.team.pk)), MAX_RECENT_ISSUE_STATES)
+
+        ErrorTrackingIssue.objects.create(
+            team=self.team, status=ErrorTrackingIssue.Status.RESOLVED, state_updated_at=now()
+        )
+        self.assertEqual(load_recent_issue_states(self.team.pk), [])
 
     @freeze_time("2022-01-10T12:11:00")
     def test_recent_issue_state_applies_to_more_than_fifty_fingerprints(self):

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -12,8 +12,9 @@ from posthog.test.base import (
     flush_persons_and_events,
     snapshot_clickhouse_queries,
 )
-from unittest import TestCase
+from unittest import TestCase, mock
 
+from django.db import OperationalError
 from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
@@ -402,6 +403,24 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
             mutated_payload["error_tracking_issue_state_watermark"],
             expired_payload["error_tracking_issue_state_watermark"],
         )
+
+    def test_cache_payload_degrades_when_watermark_read_fails(self):
+        # A primary-Postgres pool timeout while reading the issue-state watermark runs on the
+        # cache-key path and must not 500 a request whose result may already be cached; the marker
+        # degrades to a stable "unavailable" instead.
+        query = ErrorTrackingQuery(
+            kind="ErrorTrackingQuery",
+            dateRange=DateRange(date_from="all"),
+            orderBy="last_seen",  # pyright: ignore[reportArgumentType]
+            volumeResolution=1,
+        )
+        with mock.patch(
+            "products.error_tracking.backend.hogql_queries.error_tracking_query_runner.latest_issue_state_watermark",
+            side_effect=OperationalError("query_wait_timeout"),
+        ):
+            payload = ErrorTrackingQueryRunner(team=self.team, query=query).get_cache_payload()
+
+        self.assertEqual(payload["error_tracking_issue_state_watermark"], "unavailable")
 
     @freeze_time("2022-01-10T12:11:00")
     def test_missing_date_from_defaults_to_seven_days(self):

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -133,9 +133,7 @@ class ErrorTrackingIssue(UUIDTModel):
             )
             ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=existing_source_issue_ids).delete()
 
-            # A merge changes the target's composition and deletes the source rows. Stamp the target
-            # so the team state watermark stays monotonic: a deleted source that held the previous
-            # maximum can no longer move the watermark backward and re-validate a pre-merge cache entry.
+            # Stamp the surviving row so deleting the latest source cannot move the cache watermark backward.
             ErrorTrackingIssue.objects.filter(team_id=team_id, id=target_issue_id).update(
                 state_updated_at=timezone.now()
             )

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
+from django.utils import timezone
 
 import structlog
 from django_deprecate_fields import deprecate_field
@@ -131,6 +132,13 @@ class ErrorTrackingIssue(UUIDTModel):
                 team_id=team_id, target_issue_id=target_issue_id, source_issue_ids=existing_source_issue_ids
             )
             ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=existing_source_issue_ids).delete()
+
+            # A merge changes the target's composition and deletes the source rows. Stamp the target
+            # so the team state watermark stays monotonic: a deleted source that held the previous
+            # maximum can no longer move the watermark backward and re-validate a pre-merge cache entry.
+            ErrorTrackingIssue.objects.filter(team_id=team_id, id=target_issue_id).update(
+                state_updated_at=timezone.now()
+            )
 
             _sync_error_tracking_issue_changes_on_commit(
                 team_id=team_id, issue_ids=[target_issue_id], overrides=overrides

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -15,6 +15,7 @@ from parameterized import parameterized
 
 from posthog.models import Team, User
 
+from products.error_tracking.backend.hogql_queries.issue_state_overlay import latest_issue_state_watermark
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -57,6 +58,25 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
 
         # deletes issue one
         assert ErrorTrackingIssue.objects.count() == 1
+
+    def test_merge_keeps_state_watermark_monotonic(self):
+        # The watermark is derived as the maximum state_updated_at over live issue rows. A merge
+        # deletes the source rows, so a deleted source that held the maximum must not drag the
+        # watermark backward and re-validate a pre-merge cache entry. Merging stamps the target.
+        target = self.create_issue(["fingerprint_target"])
+        source = self.create_issue(["fingerprint_source"])
+
+        source_stamp = datetime(2022, 1, 10, 12, 0, tzinfo=UTC)
+        ErrorTrackingIssue.objects.filter(id=source.id).update(state_updated_at=source_stamp)
+        assert latest_issue_state_watermark(self.team.id) == source_stamp
+
+        with freeze_time("2022-01-10T12:05:00"):
+            assert target.merge(issue_ids=[source.id]) == ErrorTrackingIssueMergeResult.MERGED
+
+        target.refresh_from_db()
+        assert target.state_updated_at == datetime(2022, 1, 10, 12, 5, tzinfo=UTC)
+        watermark = latest_issue_state_watermark(self.team.id)
+        assert watermark is not None and watermark >= source_stamp
 
     def test_merge_multiple_times(self):
         issue_one = self.create_issue(["fingerprint_one"])

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -60,9 +60,6 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         assert ErrorTrackingIssue.objects.count() == 1
 
     def test_merge_keeps_state_watermark_monotonic(self):
-        # The watermark is derived as the maximum state_updated_at over live issue rows. A merge
-        # deletes the source rows, so a deleted source that held the maximum must not drag the
-        # watermark backward and re-validate a pre-merge cache entry. Merging stamps the target.
         target = self.create_issue(["fingerprint_target"])
         source = self.create_issue(["fingerprint_source"])
 


### PR DESCRIPTION
## Problem

Error tracking users can briefly see stale issue status, severity, and assignments after a mutation.

ClickHouse receives issue state asynchronously. The current workaround sends client-generated rows for each fingerprint and caps them at 50.nnFollow-up: #87950 removes those client rows after production validation.

### Before

```mermaid
flowchart LR
    A[Issue mutation] --> B[Frontend fetches fingerprints]
    B --> C[Pending row per fingerprint]
    C --> D[ClickHouse UNION ALL and argMax]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D phRed;
```

## Changes

- Issue queries now use recent Postgres status, severity, and assignments while ClickHouse catches up.
- The query sends one temporary external row per issue and joins it by issue ID before filtering.
- An explicit presence field preserves cleared descriptions, severities, and assignments.
- The durable team watermark invalidates cached results without reverting after the 60-second overlay window.
- The existing fingerprint pending rows remain available for merge and split mapping lag.
- Nothing changes visually outside the corrected issue state.

### After

```mermaid
flowchart LR
    A[Issue mutation] --> B[Postgres state timestamp]
    B --> C[Query loads recent issue state]
    C --> D[ClickHouse external overlay by issue ID]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D phRed;
```

## How did you test this code?

- Added regressions for stale status, severity, detail projection, assignment, unassignment, expiry, team isolation, issues with 51 fingerprints, and unmapped legacy events.
- Added a regression for durable cache watermark behavior after overlay expiry.
- Ran targeted Ruff formatting and lint checks.
- Ran the repository-wide mypy check.
- Compiled optimized and legacy HogQL shapes with severity overrides and verified external-table registration.
- Ran focused ClickHouse query regressions successfully.
- The focused API test is blocked locally by an unrelated Pydantic v1 metaclass conflict during URL import.
- Not run: `hogli ci:preflight` because it requires Git metadata unavailable in this Jujutsu workspace.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This changes internal read-after-write consistency without changing an API or documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the approved issue-state overlay design. The implementation uses the existing fingerprint overlay only for mapping changes.

Skills invoked: `/error-tracking`, `/writing-tests`, `/writing-code-comments`, `/writing-dataclasses`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

The committed tests and identifiers use repository fixtures and invented values. No private customer material informed the change.