### PR TITLE
fix(desktop): make space sidebar tab switches atomic

### DIFF
--- a/products/desktop/packages/ui/src/features/browser-tabs/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/browser-tabs/AGENTS.md
@@ -247,7 +247,9 @@ retarget its originating background tab as described below. `railHistoryStore`
   still settled. That transient pairing lets the navigation effect write the
   outgoing href into the selected tab. Selection only pushes the target's
   tagged history entry; that settled entry drives view-state restore,
-  activation, and durable focus through the navigation effect.
+  activation, and durable focus through the navigation effect. The sidebar may
+  project the tagged target's stored `viewState` while navigation is pending,
+  but that projection is render-only and must not write either store.
 - **The effect reconciles SETTLED state only (`settledLocation.ts`).** During a
   pending navigation the router's `location` is already the destination while
   `resolvedLocation` (and `matches`, and so `params` / `railPane`) still describe

--- a/products/desktop/packages/ui/src/features/browser-tabs/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/browser-tabs/AGENTS.md
@@ -249,7 +249,8 @@ retarget its originating background tab as described below. `railHistoryStore`
   tagged history entry; that settled entry drives view-state restore,
   activation, and durable focus through the navigation effect. The sidebar may
   project the tagged target's stored `viewState` while navigation is pending,
-  but that projection is render-only and must not write either store.
+  but that projection is render-only: it must not write stores or trigger
+  visibility side effects such as marking the projected space seen.
 - **The effect reconciles SETTLED state only (`settledLocation.ts`).** During a
   pending navigation the router's `location` is already the destination while
   `resolvedLocation` (and `matches`, and so `params` / `railPane`) still describe

--- a/products/desktop/packages/ui/src/features/browser-tabs/usePendingTabViewState.ts
+++ b/products/desktop/packages/ui/src/features/browser-tabs/usePendingTabViewState.ts
@@ -2,12 +2,17 @@ import { primaryWindow, type TabViewState } from "@posthog/shared";
 import { useRouterState } from "@tanstack/react-router";
 import { useTabsSnapshot } from "./useBrowserTabs";
 
+type PendingTabViewState = {
+  isPending: boolean;
+  viewState: TabViewState | null;
+};
+
 /**
  * The destination tab's sidebar state while its route is still settling.
  * Rendering may follow the in-flight history tag immediately, but durable tab
  * focus and the window-global sidebar stores remain settled-navigation writes.
  */
-export function usePendingTabViewState(): TabViewState | null {
+export function usePendingTabViewState(): PendingTabViewState {
   const snapshot = useTabsSnapshot();
   const historyTabId = useRouterState({
     select: (state) => state.location.state.tabId,
@@ -15,11 +20,14 @@ export function usePendingTabViewState(): TabViewState | null {
   const window = primaryWindow(snapshot);
 
   if (!window || !historyTabId || historyTabId === window.activeTabId) {
-    return null;
+    return { isPending: false, viewState: null };
   }
 
   const target = snapshot.tabs.find(
     (tab) => tab.id === historyTabId && tab.windowId === window.id,
   );
-  return target?.viewState ?? null;
+  return {
+    isPending: target !== undefined,
+    viewState: target?.viewState ?? null,
+  };
 }

--- a/products/desktop/packages/ui/src/features/browser-tabs/usePendingTabViewState.ts
+++ b/products/desktop/packages/ui/src/features/browser-tabs/usePendingTabViewState.ts
@@ -1,0 +1,25 @@
+import { primaryWindow, type TabViewState } from "@posthog/shared";
+import { useRouterState } from "@tanstack/react-router";
+import { useTabsSnapshot } from "./useBrowserTabs";
+
+/**
+ * The destination tab's sidebar state while its route is still settling.
+ * Rendering may follow the in-flight history tag immediately, but durable tab
+ * focus and the window-global sidebar stores remain settled-navigation writes.
+ */
+export function usePendingTabViewState(): TabViewState | null {
+  const snapshot = useTabsSnapshot();
+  const historyTabId = useRouterState({
+    select: (state) => state.location.state.tabId,
+  });
+  const window = primaryWindow(snapshot);
+
+  if (!window || !historyTabId || historyTabId === window.activeTabId) {
+    return null;
+  }
+
+  const target = snapshot.tabs.find(
+    (tab) => tab.id === historyTabId && tab.windowId === window.id,
+  );
+  return target?.viewState ?? null;
+}

--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -74,7 +74,10 @@ changing breadcrumbs, canvas naming, or the canvas generation harness. The root
   stay mounted — the offscreen one is `inert` — so the slide has something to
   slide and returning to the list doesn't rebuild every row. A two-finger
   horizontal swipe moves between them (`useChannelPaneSwipe`, wheel `deltaX`
-  accumulated per gesture and locked until the wheel goes quiet).
+  accumulated per gesture and locked until the wheel goes quiet). The track
+  animates only for a space-row click or the back row; tab restoration, route
+  sync, hotkeys, rail restoration, and swipes snap directly to their pane so
+  unrelated navigation never moves the sidebar across the reader.
 - In the list, "Starred"/"Spaces" are headings above lightly indented rows. The
   private "personal" row leads the Starred section and takes the same inset as the
   spaces beside it. It is the one row that carries a glyph: the lock is the only

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.test.tsx
@@ -50,7 +50,10 @@ describe("ChannelBackRow", () => {
     vi.clearAllMocks();
     mocks.channels = [ME, ENG];
     mocks.isLoading = false;
-    useChannelPaneStore.setState({ pane: "channel" });
+    useChannelPaneStore.setState({
+      pane: "channel",
+      animateTransition: false,
+    });
   });
 
   it("names the channel you're in", () => {
@@ -65,6 +68,7 @@ describe("ChannelBackRow", () => {
     await user.click(screen.getByRole("button", { name: "Back to spaces" }));
 
     expect(useChannelPaneStore.getState().pane).toBe("list");
+    expect(useChannelPaneStore.getState().animateTransition).toBe(true);
   });
 
   // #me can't be starred, so its well is empty — but the well is still there,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
@@ -83,7 +83,7 @@ export function ChannelBackRow({ channelId }: { channelId: string }) {
                   surface: "sidebar",
                   channel_id: channelId,
                 });
-                showChannelList();
+                showChannelList({ animate: true });
               }}
               // Quill's own height and radius, so this reads as one of the rows
               // under it rather than a control sitting on top. The right padding

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -235,6 +235,7 @@ describe("ChannelsList", () => {
     await user.click(screen.getByText("engineering"));
 
     expect(useCurrentChannelStore.getState().currentChannelId).toBe(ENG.id);
+    expect(useChannelPaneStore.getState().animateTransition).toBe(true);
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -1319,7 +1319,7 @@ function useOpenPersonalChannel(): {
   const openPersonalChannel = () => {
     const channelId = ensureChannelId();
     if (!channelId) return;
-    showChannelPane();
+    showChannelPane({ animate: true });
     setCurrentChannel(channelId);
     if (!spacesLayout) {
       void navigate({ to: "/spaces/$channelId", params: { channelId } });
@@ -1344,7 +1344,7 @@ function useOpenChannel(): (channel: Channel) => void {
       surface: "sidebar",
       channel_id: channel.id,
     });
-    showChannelPane();
+    showChannelPane({ animate: true });
     setCurrentChannel(channel.id);
     if (!spacesLayout) {
       void navigate({

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.test.tsx
@@ -134,6 +134,60 @@ const ENG = {
   starred: false,
 };
 
+function setPendingTabSwitch({
+  href,
+  viewState,
+  channelId,
+}: {
+  href: string;
+  viewState: { listOpen: boolean; spaceId: string | null };
+  channelId: string | null;
+}): void {
+  mocks.historyTabId = "target-tab";
+  browserTabsStore.getState().setSnapshot({
+    windows: [
+      {
+        id: "window-1",
+        isPrimary: true,
+        bounds: null,
+        activeTabId: "channel-tab",
+      },
+    ],
+    tabs: [
+      {
+        id: "channel-tab",
+        windowId: "window-1",
+        href: `/spaces/${ENG.id}`,
+        viewState: { listOpen: false, spaceId: ENG.id },
+        dashboardId: null,
+        taskId: null,
+        channelId: ENG.id,
+        channelSection: null,
+        appView: null,
+        position: 1_000,
+        scrollState: null,
+        createdAt: 1,
+        lastActiveAt: 1,
+      },
+      {
+        id: "target-tab",
+        windowId: "window-1",
+        href,
+        viewState,
+        dashboardId: null,
+        taskId: null,
+        channelId,
+        channelSection: null,
+        appView: null,
+        position: 2_000,
+        scrollState: null,
+        createdAt: 2,
+        lastActiveAt: 2,
+      },
+    ],
+  });
+}
+
 describe("ChannelsSidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -205,54 +259,30 @@ describe("ChannelsSidebar", () => {
 
     it("shows an in-flight tab's list before its route settles", () => {
       mocks.routeChannelId = ENG.id;
-      mocks.historyTabId = "root-tab";
-      browserTabsStore.getState().setSnapshot({
-        windows: [
-          {
-            id: "window-1",
-            isPrimary: true,
-            bounds: null,
-            activeTabId: "channel-tab",
-          },
-        ],
-        tabs: [
-          {
-            id: "channel-tab",
-            windowId: "window-1",
-            href: `/spaces/${ENG.id}`,
-            viewState: { listOpen: false, spaceId: ENG.id },
-            dashboardId: null,
-            taskId: null,
-            channelId: ENG.id,
-            channelSection: null,
-            appView: null,
-            position: 1_000,
-            scrollState: null,
-            createdAt: 1,
-            lastActiveAt: 1,
-          },
-          {
-            id: "root-tab",
-            windowId: "window-1",
-            href: "/spaces",
-            viewState: { listOpen: true, spaceId: ENG.id },
-            dashboardId: null,
-            taskId: null,
-            channelId: null,
-            channelSection: null,
-            appView: null,
-            position: 2_000,
-            scrollState: null,
-            createdAt: 2,
-            lastActiveAt: 2,
-          },
-        ],
+      setPendingTabSwitch({
+        href: "/spaces",
+        viewState: { listOpen: true, spaceId: ENG.id },
+        channelId: null,
       });
 
       renderSidebar();
 
       expect(listIsInteractive()).toBe(true);
       expect(useChannelPaneStore.getState().pane).toBe("channel");
+    });
+
+    it("does not mark an in-flight tab's channel seen", () => {
+      mocks.routeChannelId = ENG.id;
+      setPendingTabSwitch({
+        href: `/spaces/${ME.id}`,
+        viewState: { listOpen: false, spaceId: ME.id },
+        channelId: ME.id,
+      });
+
+      renderSidebar();
+
+      expect(screen.getByTestId("channel-sidebar").textContent).toBe(ME.id);
+      expect(mocks.markChannelSeen).toHaveBeenLastCalledWith(undefined);
     });
 
     it("marks a channel seen only while its pane is visible", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.test.tsx
@@ -1,3 +1,4 @@
+import { browserTabsStore } from "@posthog/core/browser-tabs/browserTabsStore";
 import { Theme } from "@radix-ui/themes";
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   routeChannelId: undefined as string | undefined,
   fullPath: "/spaces/$channelId",
   markChannelSeen: vi.fn(),
+  historyTabId: undefined as string | undefined,
 }));
 
 vi.mock("@posthog/ui/shell/analytics", () => ({
@@ -87,8 +89,15 @@ vi.mock("@tanstack/react-router", () => ({
   useRouterState: ({
     select,
   }: {
-    select: (s: { matches: { fullPath: string }[] }) => unknown;
-  }) => select({ matches: [{ fullPath: mocks.fullPath }] }),
+    select: (s: {
+      matches: { fullPath: string }[];
+      location: { state: { tabId?: string } };
+    }) => unknown;
+  }) =>
+    select({
+      matches: [{ fullPath: mocks.fullPath }],
+      location: { state: { tabId: mocks.historyTabId } },
+    }),
 }));
 
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
@@ -136,8 +145,13 @@ describe("ChannelsSidebar", () => {
     mocks.track.mockClear();
     mocks.routeChannelId = undefined;
     mocks.fullPath = "/spaces/$channelId/";
+    mocks.historyTabId = undefined;
+    browserTabsStore.getState().setSnapshot({ windows: [], tabs: [] });
     useCurrentChannelStore.setState({ currentChannelId: null });
-    useChannelPaneStore.setState({ pane: "channel" });
+    useChannelPaneStore.setState({
+      pane: "channel",
+      animateTransition: false,
+    });
     // hasUserSetOpen pins `open`, so the auto-open effect (which sees no
     // workspaces in this harness) can't collapse it out from under the tests.
     useSidebarStore.setState({
@@ -187,6 +201,58 @@ describe("ChannelsSidebar", () => {
 
       expect(listIsInteractive()).toBe(true);
       expect(useCurrentChannelStore.getState().currentChannelId).toBe(ENG.id);
+    });
+
+    it("shows an in-flight tab's list before its route settles", () => {
+      mocks.routeChannelId = ENG.id;
+      mocks.historyTabId = "root-tab";
+      browserTabsStore.getState().setSnapshot({
+        windows: [
+          {
+            id: "window-1",
+            isPrimary: true,
+            bounds: null,
+            activeTabId: "channel-tab",
+          },
+        ],
+        tabs: [
+          {
+            id: "channel-tab",
+            windowId: "window-1",
+            href: `/spaces/${ENG.id}`,
+            viewState: { listOpen: false, spaceId: ENG.id },
+            dashboardId: null,
+            taskId: null,
+            channelId: ENG.id,
+            channelSection: null,
+            appView: null,
+            position: 1_000,
+            scrollState: null,
+            createdAt: 1,
+            lastActiveAt: 1,
+          },
+          {
+            id: "root-tab",
+            windowId: "window-1",
+            href: "/spaces",
+            viewState: { listOpen: true, spaceId: ENG.id },
+            dashboardId: null,
+            taskId: null,
+            channelId: null,
+            channelSection: null,
+            appView: null,
+            position: 2_000,
+            scrollState: null,
+            createdAt: 2,
+            lastActiveAt: 2,
+          },
+        ],
+      });
+
+      renderSidebar();
+
+      expect(listIsInteractive()).toBe(true);
+      expect(useChannelPaneStore.getState().pane).toBe("channel");
     });
 
     it("marks a channel seen only while its pane is visible", () => {
@@ -240,7 +306,7 @@ describe("ChannelsSidebar", () => {
       mocks.routeChannelId = ENG.id;
       const { rerender } = renderSidebar();
       act(() => {
-        showChannelList(ENG.id);
+        showChannelList({ keepForRoute: ENG.id });
       });
       expect(listIsInteractive()).toBe(true);
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -67,17 +67,21 @@ function ChannelPanes({
   channelId,
   showList,
   sidebarVisible,
+  pendingTabSwitch,
 }: {
   channelId: string | null;
   showList: boolean;
   sidebarVisible: boolean;
+  pendingTabSwitch: boolean;
 }) {
   // Mark the channel seen only while a reader can see its pane: this pane is
   // the one showing (not the list) and the sidebar is on screen. A collapsed
   // sidebar keeps both panes mounted, so without the visibility gate a mention
   // landing behind it would clear the unread emphasis nobody saw.
   const visibleChannelId =
-    !showList && sidebarVisible ? (channelId ?? undefined) : undefined;
+    !pendingTabSwitch && !showList && sidebarVisible
+      ? (channelId ?? undefined)
+      : undefined;
   useMarkChannelSeen(visibleChannelId);
   const animateTransition = useChannelPaneStore(
     (state) => state.animateTransition,
@@ -200,7 +204,8 @@ export function ChannelsSidebar() {
   const selectedActivityId = useActivitySelection()?.id;
   const { feedId } = useParams({ strict: false });
   const pane = useChannelPaneStore((s) => s.pane);
-  const pendingTabViewState = usePendingTabViewState();
+  const { isPending: pendingTabSwitch, viewState: pendingTabViewState } =
+    usePendingTabViewState();
   const presentedChannelId =
     pendingTabViewState?.spaceId !== undefined
       ? pendingTabViewState.spaceId
@@ -259,6 +264,7 @@ export function ChannelsSidebar() {
                 channelId={presentedChannelId}
                 showList={showList}
                 sidebarVisible={open || peek}
+                pendingTabSwitch={pendingTabSwitch}
               />
             )
           ) : bodyChannelsWorld ? (

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -1,6 +1,7 @@
 import { ArchiveIcon } from "@phosphor-icons/react";
 import { cn, Separator } from "@posthog/quill";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { usePendingTabViewState } from "@posthog/ui/features/browser-tabs/usePendingTabViewState";
 import { ActivityFeedList } from "@posthog/ui/features/canvas/components/ActivityFeedList";
 import { ChannelItemPreviewCardProvider } from "@posthog/ui/features/canvas/components/ChannelItemHoverCard";
 import { ChannelSidebar } from "@posthog/ui/features/canvas/components/ChannelSidebar";
@@ -78,6 +79,12 @@ function ChannelPanes({
   const visibleChannelId =
     !showList && sidebarVisible ? (channelId ?? undefined) : undefined;
   useMarkChannelSeen(visibleChannelId);
+  const animateTransition = useChannelPaneStore(
+    (state) => state.animateTransition,
+  );
+  const finishTransition = useChannelPaneStore(
+    (state) => state.finishTransition,
+  );
   const panesRef = useRef<HTMLDivElement | null>(null);
   useChannelPaneSwipe(panesRef, {
     // With no channel to slide to, the list is all there is — leave the gesture
@@ -90,8 +97,13 @@ function ChannelPanes({
   return (
     <div ref={panesRef} className="min-h-0 flex-1 overflow-hidden">
       <div
+        onTransitionEnd={(event) => {
+          if (event.currentTarget === event.target) finishTransition();
+        }}
         className={cn(
-          "flex h-full w-[200%] transition-transform duration-200 ease-out motion-reduce:transition-none",
+          "flex h-full w-[200%]",
+          animateTransition &&
+            "transition-transform duration-200 ease-out motion-reduce:transition-none",
           showList ? "translate-x-0" : "-translate-x-1/2",
         )}
       >
@@ -188,7 +200,14 @@ export function ChannelsSidebar() {
   const selectedActivityId = useActivitySelection()?.id;
   const { feedId } = useParams({ strict: false });
   const pane = useChannelPaneStore((s) => s.pane);
-  const showList = pane === "list" || currentChannelId == null;
+  const pendingTabViewState = usePendingTabViewState();
+  const presentedChannelId =
+    pendingTabViewState?.spaceId !== undefined
+      ? pendingTabViewState.spaceId
+      : currentChannelId;
+  const showList =
+    (pendingTabViewState?.listOpen ?? pane === "list") ||
+    presentedChannelId == null;
 
   return (
     <ResizableSidebar
@@ -237,7 +256,7 @@ export function ChannelsSidebar() {
               <TaskFeedPane feedId={feedId} className="min-h-0 flex-1" />
             ) : (
               <ChannelPanes
-                channelId={currentChannelId}
+                channelId={presentedChannelId}
                 showList={showList}
                 sidebarVisible={open || peek}
               />

--- a/products/desktop/packages/ui/src/features/canvas/components/railDestinations.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/railDestinations.ts
@@ -83,7 +83,7 @@ export function showSpaces(): void {
     navigateToSpaces();
     return;
   }
-  showChannelList(channelId);
+  showChannelList({ keepForRoute: channelId });
   navigateToChannel(channelId);
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/stores/channelPaneStore.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/channelPaneStore.test.ts
@@ -1,11 +1,15 @@
 import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/currentChannelStore";
 import { beforeEach, describe, expect, it } from "vitest";
-import { applyTabViewState } from "./channelPaneStore";
+import { applyTabViewState, useChannelPaneStore } from "./channelPaneStore";
 
 describe("applyTabViewState", () => {
   beforeEach(() => {
     useCurrentChannelStore.setState({
       currentChannelId: "space-from-prev-tab",
+    });
+    useChannelPaneStore.setState({
+      pane: "channel",
+      animateTransition: true,
     });
   });
 
@@ -21,5 +25,21 @@ describe("applyTabViewState", () => {
     applyTabViewState({ spaceId });
 
     expect(useCurrentChannelStore.getState().currentChannelId).toBe(expected);
+    expect(useChannelPaneStore.getState().animateTransition).toBe(false);
   });
+
+  it.each([
+    ["list", true, "list"],
+    ["channel", false, "channel"],
+  ] as const)(
+    "restores the %s pane without animating",
+    (_name, listOpen, expectedPane) => {
+      applyTabViewState({ listOpen, spaceId: "space-b" });
+
+      expect(useChannelPaneStore.getState()).toMatchObject({
+        pane: expectedPane,
+        animateTransition: false,
+      });
+    },
+  );
 });

--- a/products/desktop/packages/ui/src/features/canvas/stores/channelPaneStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/channelPaneStore.ts
@@ -13,15 +13,29 @@ type ChannelPane = "list" | "channel";
 
 interface ChannelPaneState {
   pane: ChannelPane;
-  setPane: (pane: ChannelPane) => void;
+  animateTransition: boolean;
+  setPane: (pane: ChannelPane, animateTransition?: boolean) => void;
+  finishTransition: () => void;
 }
 
 export const useChannelPaneStore = create<ChannelPaneState>()((set) => ({
   // A scoped channel is the resting state, so a cold start lands on the channel
   // rather than sliding away from it.
   pane: "channel",
-  setPane: (pane) => set({ pane }),
+  animateTransition: false,
+  setPane: (pane, animateTransition = false) =>
+    set({ pane, animateTransition }),
+  finishTransition: () => set({ animateTransition: false }),
 }));
+
+interface ShowChannelListOptions {
+  keepForRoute?: string;
+  animate?: boolean;
+}
+
+interface ShowChannelPaneOptions {
+  animate?: boolean;
+}
 
 /**
  * Keyed on the channel rather than consumed on first read so it survives a
@@ -51,15 +65,20 @@ export function clearKeepListForRoute(): void {
  * arriving at a channel pulls the slider to it, and the latch holds the list
  * across that navigation.
  */
-export function showChannelList(keepForRoute?: string): void {
+export function showChannelList({
+  keepForRoute,
+  animate = false,
+}: ShowChannelListOptions = {}): void {
   keepListForChannelId = keepForRoute ?? null;
-  useChannelPaneStore.getState().setPane("list");
+  useChannelPaneStore.getState().setPane("list", animate);
 }
 
 /** Slide to the channel pane — every channel entry point goes through here. */
-export function showChannelPane(): void {
+export function showChannelPane({
+  animate = false,
+}: ShowChannelPaneOptions = {}): void {
   keepListForChannelId = null;
-  useChannelPaneStore.getState().setPane("channel");
+  useChannelPaneStore.getState().setPane("channel", animate);
 }
 
 /**
@@ -76,11 +95,13 @@ export function applyTabViewState(view: {
   listOpen?: boolean;
   spaceId?: string | null;
 }): void {
+  useChannelPaneStore.getState().finishTransition();
   // A stored null explicitly clears the space; only an absent value is skipped.
   if (view.spaceId !== undefined) {
     useCurrentChannelStore.getState().setCurrentChannel(view.spaceId);
   }
   if (view.listOpen === undefined) return;
-  if (view.listOpen) showChannelList(view.spaceId ?? undefined);
-  else showChannelPane();
+  if (view.listOpen) {
+    showChannelList({ keepForRoute: view.spaceId ?? undefined });
+  } else showChannelPane();
 }

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -125,7 +125,7 @@ function App({ devToolbar }: AppProps) {
           spacesLayoutEnabledRef.current,
         );
         if (firstRun) {
-          showChannelList(firstRun.generalChannelId);
+          showChannelList({ keepForRoute: firstRun.generalChannelId });
           useSpaceTreeStore.getState().expandSpace(firstRun.generalChannelId);
         }
         router.history.replace(href);


### PR DESCRIPTION
## Problem

Switching browser tabs can briefly show another tab's space sidebar and animate the pane track, which makes navigation feel disorienting.

The independent tab model from #87734 exposes window-global sidebar state while the destination route settles.

## Changes

- Tab switches now snap directly to each tab's saved sidebar pane without playing the space-entry animation.
- Pending switches render the destination sidebar immediately, while durable state waits for the route to settle.
- Space-row entry and the back control retain the existing animation.
- The sidebar projects saved state instead of showing a loader because the destination state is already available.
- No screenshot: this timing-only change does not alter either resting sidebar state.

## How did you test this code?

- Added sidebar and pane-store regression coverage for animation intent and pending-tab projection.
- Ran the focused `@posthog/ui` Vitest suite and TypeScript check.
- Verified the rendered switch in Electron through CDP, including the pane class sequence.
- Ran `hogli ci:preflight --fix` against `origin/master`.
- Not run: Playwright E2E; the focused tests and live Electron check cover this interaction.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the browser-tabs and canvas architecture guides. No user-facing documentation changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the local shell, Electron CDP, and GitHub CLI. Skills invoked: `/diagnose`, `/posthog-desktop`, `/test-electron-app`, `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
