### PR TITLE
chore(batch-exports): remove deprecated stage result patch

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -186,12 +186,6 @@ async def _stage_batch_export_data(
         batch_export_schema=batch_export_inputs.batch_export_schema,
         destination_default_fields=batch_export_inputs.destination_default_fields,
     )
-    # All workers now run the `InternalStageResult` path, so the pre-patch bare-string
-    # branch is gone. `deprecate_patch` keeps the marker compatible for any execution
-    # still in flight that recorded it.
-    # See https://docs.temporal.io/develop/python/workflows/versioning#deprecated-patches
-    # TODO: delete this call once those histories have drained.
-    workflow.deprecate_patch("batch-exports-stage-result")
     return await workflow.execute_activity(
         insert_into_internal_stage_activity,
         stage_inputs,


### PR DESCRIPTION
## Problem

A Temporal patch marker is left in our code that no longer guards anything. [#78766](https://github.com/PostHog/posthog/pull/78766) left `deprecate_patch` in place as the middle step of Temporal's [three-step patch lifecycle](https://docs.temporal.io/develop/python/workflows/versioning), with a TODO to delete it once the affected histories drained. They have drained, so it is safe to clean up.

## Changes

- The `workflow.deprecate_patch("batch-exports-stage-result")` call and its comment come out of `_stage_batch_export_data`. Nothing else changes.


## How did you test this code?

https://github.com/PostHog/posthog/pull/78766 was merged more than a week ago, so it should be safe to clean up the marker as there are no workflows still running from before that time.

Claude also checked this using the `temporal` CLI against `prod-us` and `prod-eu` and confirmed there is no execution carrying the marker is still open in either production namespace.


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus 5). Skills invoked: `/create-pr`, and `/writing-pr-descriptions` and `/debugging-temporal-cloud-workflows` for the drain queries.
- I asked what was left to finish the cleanup. Claude checked production rather than assuming a drain window, which is what established the gate was met.