### PR TITLE
fix(cdp): surface AggregateError causes in fetch failure messages

### DIFF
--- a/nodejs/src/cdp/services/hog-executor-async.service.ts
+++ b/nodejs/src/cdp/services/hog-executor-async.service.ts
@@ -18,7 +18,7 @@ import type {
 } from '../types'
 import { createAddLogFunction, destinationE2eLagMsSummary } from '../utils'
 import { resolveAwsSigV4Credentials, signAwsRequest } from '../utils/aws-sigv4'
-import { cdpTrackedFetch, isFetchResponseRetriable } from '../utils/cdp-fetch'
+import { cdpTrackedFetch, fetchErrorDetail, isFetchResponseRetriable } from '../utils/cdp-fetch'
 import { createInvocationResult } from '../utils/invocation-utils'
 import { isNonFailureStatus } from '../utils/non-failure-status-codes'
 import { HogExecutorExecuteOptions, HogExecutorPreviousResult, HogExecutorService } from './hog-executor.service'
@@ -484,7 +484,7 @@ export class HogExecutorAsyncService {
             }.`
 
             if (fetchError) {
-                message += ` Error: ${fetchError.message}.`
+                message += ` Error: ${fetchErrorDetail(fetchError)}.`
             }
 
             if (willRetry) {
@@ -536,7 +536,7 @@ export class HogExecutorAsyncService {
             body: unknown
         } = {
             status: fetchResponse?.status ?? 500,
-            body: body ?? (fetchError ? `${fetchError.name}: ${fetchError.message}` : undefined),
+            body: body ?? (fetchError ? `${fetchError.name}: ${fetchErrorDetail(fetchError)}` : undefined),
         }
 
         // Finally we create the response object as the VM expects

--- a/nodejs/src/cdp/utils/cdp-fetch.test.ts
+++ b/nodejs/src/cdp/utils/cdp-fetch.test.ts
@@ -1,0 +1,30 @@
+import { fetchErrorDetail } from './cdp-fetch'
+
+describe('fetchErrorDetail', () => {
+    // Guards the unpacking of AggregateError causes: undici throws it with an empty message when
+    // every connection attempt fails, so falling back to `error.message` alone would turn a
+    // diagnosable per-address failure back into an opaque "AggregateError: ".
+    it.each([
+        [
+            'a plain error keeps its message',
+            new Error('connect ETIMEDOUT 10.0.0.1:443'),
+            'connect ETIMEDOUT 10.0.0.1:443',
+        ],
+        [
+            'an empty-message AggregateError surfaces its causes',
+            new AggregateError([
+                new Error('connect ECONNREFUSED 1.2.3.4:443'),
+                new Error('connect ENETUNREACH ::1:443'),
+            ]),
+            'connect ECONNREFUSED 1.2.3.4:443; connect ENETUNREACH ::1:443',
+        ],
+        [
+            'an AggregateError with a message appends its causes',
+            new AggregateError([new Error('boom')], 'All attempts failed'),
+            'All attempts failed (boom)',
+        ],
+        ['an AggregateError with no causes and no message stays empty', new AggregateError([]), ''],
+    ])('%s', (_name, error, expected) => {
+        expect(fetchErrorDetail(error)).toBe(expected)
+    })
+})

--- a/nodejs/src/cdp/utils/cdp-fetch.ts
+++ b/nodejs/src/cdp/utils/cdp-fetch.ts
@@ -80,6 +80,21 @@ export function isConnectionLevelError(error: any): boolean {
     )
 }
 
+// An AggregateError's own message is usually empty — undici throws it when every connection
+// attempt to a host fails, and the per-address reasons (ECONNREFUSED, ETIMEDOUT, ...) live in
+// `errors`. Without unpacking them, the customer-facing log reads "AggregateError: " with no way
+// to tell a DNS failure from a refused connection.
+export function fetchErrorDetail(error: Error): string {
+    const causes =
+        error instanceof AggregateError && error.errors.length > 0
+            ? error.errors.map((e) => (e instanceof Error ? e.message : String(e))).join('; ')
+            : ''
+    if (error.message && causes) {
+        return `${error.message} (${causes})`
+    }
+    return error.message || causes
+}
+
 // Attribution for a tracked fetch, so a blocked/refused request can be traced back to the
 // owning hog function and team. Optional because a few callers (push notifications, hog
 // transformations) hand `cdpTrackedFetch` to the Hog VM without an invocation in scope.


### PR DESCRIPTION
## Problem

When a destination's fetch fails at the connection level, the customer sees `Failed to post message to <destination>: 500: AggregateError: ` and nothing else. Undici throws `AggregateError` with an empty message when every connection attempt to a host fails; the per-address reasons live in `error.errors`, which we drop. A real support case (a Microsoft Teams destination whose Power Platform gateway refuses connections from one of our egress regions) was undiagnosable from the logs alone.

## Changes

- Customers now see the underlying connection errors, e.g. `AggregateError: connect ECONNREFUSED 1.2.3.4:443; connect ETIMEDOUT ...` instead of an empty `AggregateError: `, in both the retry log line and the synthetic 500 body the Hog VM receives.
- Mechanism: a `fetchErrorDetail` helper in `cdp-fetch.ts` that unpacks `AggregateError.errors`; output is unchanged for every error that already carries a message.

## How did you test this code?

- A parameterized unit test on the helper pins the four shapes: plain error, empty-message aggregate, aggregate with message, empty aggregate. No existing test covered the fallback body.
- Not run: an end-to-end fetch failure against a real unreachable host.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code while debugging a customer's failing Teams destination, where the empty error body hid an egress-level TCP refusal. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
