### PR TITLE
fix(adobe_commerce): keep admin token retry noise out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/adobe_commerce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/adobe_commerce.py
@@ -72,6 +72,10 @@ HOST_NOT_ALLOWED_ERROR = "Adobe Commerce store URL is not allowed"
 INCOMPLETE_CREDENTIALS_ERROR = "Adobe Commerce credentials are incomplete"
 HTTPS_REQUIRED_ERROR = "Adobe Commerce store URL must use HTTPS"
 PAGINATION_LIMIT_ERROR = "Adobe Commerce pagination did not terminate"
+# Reached only after the tracked session's own transport-level retries for 429/5xx are exhausted
+# (see `_mint`), so this is self-recovering — matched by `AdobeCommerceSource.get_retryable_errors`
+# to keep it out of error tracking. The status code is left out of the constant since it varies.
+ADMIN_TOKEN_RETRYABLE_ERROR = "Adobe Commerce admin token request failed (retryable)"
 
 # A store code is a Magento code: letters, digits and underscores, starting with a letter.
 _STORE_CODE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
@@ -369,9 +373,7 @@ class AdobeCommerceTokenManager:
 
         try:
             if response.status_code == 429 or response.status_code >= 500:
-                raise AdobeCommerceRetryableError(
-                    f"Adobe Commerce admin token request failed (retryable): status={response.status_code}"
-                )
+                raise AdobeCommerceRetryableError(f"{ADMIN_TOKEN_RETRYABLE_ERROR}: status={response.status_code}")
             # A 3xx is not an error status, so refuse it explicitly rather than following it to a
             # potentially internal Location.
             if response.is_redirect or response.is_permanent_redirect:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/source.py
@@ -12,6 +12,7 @@ from posthog.schema import (
 )
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.adobe_commerce.adobe_commerce import (
+    ADMIN_TOKEN_RETRYABLE_ERROR,
     HOST_NOT_ALLOWED_ERROR,
     HTTPS_REQUIRED_ERROR,
     INCOMPLETE_CREDENTIALS_ERROR,
@@ -167,6 +168,12 @@ class AdobeCommerceSource(ResumableSource[AdobeCommerceSourceConfig, AdobeCommer
             INCOMPLETE_CREDENTIALS_ERROR: "Adobe Commerce credentials are incomplete. Please re-enter them and reconnect.",
             PAGINATION_LIMIT_ERROR: "Adobe Commerce kept returning pages without signalling the end of the collection. This usually means the store's REST API is misconfigured — check the store URL and store code.",
         }
+
+    def get_retryable_errors(self) -> set[str]:
+        # The admin token exchange already retries 429/5xx at the transport level (the tracked
+        # session); this is only raised once that budget is exhausted, and re-minting later
+        # recovers on its own. Keep it out of error tracking rather than paging it as a bug.
+        return {ADMIN_TOKEN_RETRYABLE_ERROR}
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.adobe_commerce.canonical_descriptions import (  # noqa: PLC0415

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/tests/test_adobe_commerce_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/tests/test_adobe_commerce_source.py
@@ -109,6 +109,17 @@ class TestAdobeCommerceSource:
     def test_non_retryable_errors_ignore_transient(self, _name: str, unrelated_error: str) -> None:
         assert not any(key in unrelated_error for key in self.source.get_non_retryable_errors())
 
+    @parameterized.expand(
+        [
+            ("server_error", "Adobe Commerce admin token request failed (retryable): status=500"),
+            ("rate_limited", "Adobe Commerce admin token request failed (retryable): status=429"),
+        ]
+    )
+    def test_retryable_errors_match_admin_token_failures(self, _name: str, observed_error: str) -> None:
+        # The admin token exchange only raises this once its own transport-level retries for
+        # 429/5xx are exhausted, so it's self-recovering — it must stay out of error tracking.
+        assert any(key in observed_error for key in self.source.get_retryable_errors())
+
     @mock.patch(f"{_MODULE}.adobe_commerce_source")
     def test_source_for_pipeline_plumbs_incremental_inputs(self, mock_source: mock.MagicMock) -> None:
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

The AdobeCommerce data-warehouse source pages an error-tracking issue for a transient, self-recovering failure: [AdobeCommerceRetryableError](https://us.posthog.com/project/2/error_tracking/01a0344b-ea5d-72a2-8be0-c816eab186ee) ("Adobe Commerce admin token request failed (retryable): status=500").

The admin token exchange in `_mint` already retries 429/5xx at the transport level via the tracked HTTP session. Once that budget is exhausted, it raises `AdobeCommerceRetryableError` and Temporal retries the whole import activity — the token is re-minted on the next attempt and the sync recovers on its own. `AdobeCommerceSource` never overrode `get_retryable_errors()`, so this self-recovering error fell through to the default path (`logger.aexception` + raw re-raise), which reports it to error tracking as a bug on every occurrence.

## Changes

- Adds `AdobeCommerceSource.get_retryable_errors()`, matching the source's existing `ADMIN_TOKEN_RETRYABLE_ERROR` message, so `_handle_import_error` logs it as a warning and re-raises it as a non-reported error instead of paging it.
- Extracts the message into a shared `ADMIN_TOKEN_RETRYABLE_ERROR` constant instead of an inline f-string, mirroring the pattern already used by `HOST_NOT_ALLOWED_ERROR`/`PAGINATION_LIMIT_ERROR` and other sources (e.g. `GoogleAnalyticsSource.get_retryable_errors`).
- No behavior change to retries, backoff, or timeouts — only how the already-retryable failure is classified for error tracking.

## How did you test this code?

Added 2 parameterized cases to `test_adobe_commerce_source.py` asserting the 429/500 admin-token-retryable messages match `get_retryable_errors()` — guards against this self-recovering failure silently dropping out of the retryable set again.

Ran locally:
- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/adobe_commerce/` — 131 passed
- `ruff check` / `ruff format --check` on the touched files — clean
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean

Not run: a live sync against Adobe Commerce (no test store available in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in `adobe_commerce.py`. Read the source and the shared `get_retryable_errors()` convention documented in `products/warehouse_sources/backend/temporal/data_imports/sources/README.md` and already used by other sources for the same class of self-recovering failure. No open human-authored PR addresses this.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*