### PR TITLE
fix(error-tracking): retire client state overlays

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1784,6 +1784,10 @@ snapshots:
         hash: v1.k794b7964.ba387f94bf7380934a79b9a58f19d27dbe5561163315728c3a2d813a747757f0.XpF43f3StaHvZq-5TpAo3Uw5ABra8ikrJrLcMaCFqlM
     components-product-empty-state--product-tours-needs-setup--light:
         hash: v1.k794b7964.bcb7662c9b7c8b359951611d5d8c707b752df3cf4b51d4b55db0031a895fbb1d.LLNYGfrenmzwrDMW0v_HX5rZG8y7Zh-H_GoHbWDymRU
+    components-product-empty-state--replay-vision-needs-setup--dark:
+        hash: v1.k794b7964.78d06d6c9f11d54919ad81abffe6a5d409dd1b4e7ba08a822a17485f8503617f.owccqODY_2d4-T-mAhHHfXx-rjYgbeohS0xVOLc5FXQ
+    components-product-empty-state--replay-vision-needs-setup--light:
+        hash: v1.k794b7964.251eee6169c98d22d57c361fdcf9747e16187d832d3ce775d93ce9418b67466a.QZzU0myILKJWAjynyGeUQybg5UwVqniqT1Q1TuT-jkE
     components-product-empty-state--skills-needs-setup--dark:
         hash: v1.k794b7964.7fb1bfe531cab39785cf3d98edc3fed01122cbe04f2fc10b23054648455ed423.VhFzyJUt9ckAydjv1P6BL83AKLhlKl3NRrb5fL1o2M8
     components-product-empty-state--skills-needs-setup--light:
@@ -2065,9 +2069,9 @@ snapshots:
     errortracking-contextdisplay--context-display-with-stacktrace--light:
         hash: v1.k794b7964.4647fc443f0df7cf2451a05f28fb95592b4c40e98d59ae289a5a3a2d54dba14f.y3p3Lw9_WVMCUVwR_8JJwjdkKaYBWgrJNzCa3e3Mu2I
     errortracking-exceptioncard--exception-card-all-events--dark:
-        hash: v1.k794b7964.d8eeeb2edea49238f843906636f535de9d9bb972dfdb7b0a7d4996e2c90b8a09.x8dkCzh5Nu2XxKwjMs6ab8KHxvQaP9toxjiu3Cd0dNs
+        hash: v1.k794b7964.1ecdd072724548b5b1479b571c4e71d939c63eec086577ca404887e1a847d77e.sDYzU0ZZuvsAFJHS8-T1Kw9lrA-Pi64kJtUX8oILYu0
     errortracking-exceptioncard--exception-card-all-events--light:
-        hash: v1.k794b7964.c83f4ab40ac186ee8872b9e051f8eb74be9fe70a1f257d853bbbb8372f2d6db2.my2kxuXPuZRq6U3hYpzKMZOQiYOVGgYTFrYo97sltlo
+        hash: v1.k794b7964.1f130e815e8ad575ae002b76862cb638dd37f70c7cc5171f917026e4fde7c04e.2aVA113FgaOPAEfpNsaCysOoMkbGQGlpdryxOIaDfbk
     errortracking-exceptioncard--exception-card-base--dark:
         hash: v1.k794b7964.3c350c23790195a5fc0dfb048f81f0a62dee7d84dab927e4b0fe318adce3443c.uWybQFWQBqnNXQnYT_PSKs0VNv5dVHNtDFIkDAa1Toc
     errortracking-exceptioncard--exception-card-base--light:
@@ -2749,29 +2753,29 @@ snapshots:
     insights-funneltrendstable--default--light:
         hash: v1.k794b7964.f4486460f4481d343ecf8e0890d94f8d4c3da70164008d53bc762b6900623bc1.MRfTllR3ODYt6mNxjI-nTmfYZk0V2cXLMRmUwbKFC1Q
     insights-insightseriestooltip--compare-to-previous-period--dark:
-        hash: v1.k794b7964.c678377bbf5032ac7eecc97fa759c8fc9e3c06b57ba16689210c912536a2db4e.gpyupEpCOehnsZYtAShrMscqqGEa5IzBVy3Zvin1AxY
+        hash: v1.k794b7964.87bb24ae627d7ae4349e3ff4ff140f845ac3f0e3443c94eb77ffa172237c303d.XbFd2fGd29VAUNDjyNUG9-m2P2N7zpe528qjdqdXBKE
     insights-insightseriestooltip--compare-to-previous-period--light:
-        hash: v1.k794b7964.fe66a9a81d1cfad2b31e17932f0aaa5951e386c66d15a2f72a3a06556aaeeaf1.-mMZ0ZBqw02XLGxkjNIzt9jbvc-CYe_lJP-seoien7w
+        hash: v1.k794b7964.887f50a8fb784402eb68bbcd7bc441a483a1cd9ed7b6b5e7ab25040cfab2837e.wdu0JxKXwmBvmClqjpilf6q1vPvufoVpIPWb629waSA
     insights-insightseriestooltip--compare-to-previous-period-with-breakdown--dark:
-        hash: v1.k794b7964.70573eaefe2caf1df8e9df7d06bcb0a5bfd792e111d6b27baa0a071db8c73dac.i8G5xtKkXf_02jXPVkKMZmd4prvg1wun6DRxKsWKsAk
+        hash: v1.k794b7964.ada5b19ef29ef4924c6a945e20bb8e0fe834ecddcf24cddc2ba4edc8fb328621.XEJcqQUCUHPRS0GWP8j5UYecf9sKP6SVwwJc0HSEFFE
     insights-insightseriestooltip--compare-to-previous-period-with-breakdown--light:
-        hash: v1.k794b7964.df3fc154dd774f23fb6c1e34ca61e15362ccdabc2cb1bd49773a924554ce4fd7.wK9NCJZpxlmZdvFUBEoWqe2_wY1Q89SlLMyujbJ3EMY
+        hash: v1.k794b7964.5587e7a896a9bc8e23e2aea1bbc90a81e5c1d76df5db3fc99a030488badcf96f.wIxEzm8vuXxLBqnPNUHn3vdlGn-0piukfsBP48Zf8pg
     insights-insightseriestooltip--long-series-name-with-breakdown--dark:
-        hash: v1.k794b7964.02efe0c272601d88771f746200a6ba7c0eafe4b4e5591b45a61da060b1da69bc.6YQtVQfdlEayGDy6dKw0Ek4vzGE5NexySwKlQd93Tqg
+        hash: v1.k794b7964.485977959af7e78f4b0336e816b4bafb8ad96e1190a574ee8a8229d1d30971f7.L4xNQeB80wWVuJ2IhRJkYvQfDkNTXVdT0pDvOsxD3Tc
     insights-insightseriestooltip--long-series-name-with-breakdown--light:
-        hash: v1.k794b7964.add03affe5e904b0e7e25dc02a64a2c4b5e8675a6fd248092c3c4f9ccd017270.v3DqkDMCZGO1wL2qcw9019f4gps6WY9qPwRe0SH7RZs
+        hash: v1.k794b7964.ab54b7f07f0c042ffe71895f14dda907d4c3e7877214e10c27d5424a01b2b6d7.Y5dt0GPeSpZvIz7V-AZz9JC54fL3uVO5wQH26Nj-Z_A
     insights-insightseriestooltip--multiple-formulas-with-breakdown--dark:
-        hash: v1.k794b7964.f03e00bd77e4d765859443dbbddaa1618b4076b61bc8c63889f3bb99a739a5cf.P42JfB5eDUppR3yGx6Ccd6hYnE77Lx5sp5T82YhM0eE
+        hash: v1.k794b7964.7a17448bbd7b31f1eaa50affed819fee4e295d2a4e7dd5826fd7718da52213ee.hMF1qjDD8qCjJ6mGw1V7hK0mVzT_kfFy1z2WWeJpPug
     insights-insightseriestooltip--multiple-formulas-with-breakdown--light:
-        hash: v1.k794b7964.970aa26fe9da77660c5bc38f9213cbd05cfb1795215334d134ebe41becb41b5d.r3t_NY_Li8xMbv7IeXx522a7eMsPVJ0L7mTt_HSxozc
+        hash: v1.k794b7964.3175d080a0e954a36b55ed3258de555f65ac953c275a89b3aad302c153060274.4YRMTzGzpb4JNcqvjyJqYyEXVdpttgvVughFo7fXFFM
     insights-insightseriestooltip--multiple-series-with-breakdown--dark:
-        hash: v1.k794b7964.5bfa549f548aa3568e46c0887ec1c25f993424a01d18d2a6c71e590188d7caa9.Q9ge6rM1Ga2_yDhVyt6lmUiIZO47K_Vd59aJtMp80T4
+        hash: v1.k794b7964.d03acd30d3bd10fea25ceadc18f658a3b68029c91594328e2ca29d9c086ccf2b.HuxAeDDZFVlAMrv4ma9Ur-Oxh3bXLyPu0HlQaWmxmN4
     insights-insightseriestooltip--multiple-series-with-breakdown--light:
-        hash: v1.k794b7964.30ae3fc7ed9ff096ac81d00301b82566ff20e97352d543c2031b18cf5906f103.6QForav35AQFQD35zPNU7WTPEPk4jtP7UJdcw3XGyEs
+        hash: v1.k794b7964.32f4f50be9cc7eb9564906b7bed5c6bbe0d0efc39fe52e4ec0ef8bc3c8725e29.YPPQ8tBkIfQHsr2RwFw4XJZdY3yiZOaQEADjS1OsN5s
     insights-insightseriestooltip--same-event-series-with-breakdown--dark:
-        hash: v1.k794b7964.8c5f1be7bda1d9688273349c73512afa7e1a7492245abd6f8f7d4c7f5cd8f3aa.f-Vpg6pjAL8o2lcVOlLw_5m7-RvNgHTlBkryFqeZ-8c
+        hash: v1.k794b7964.37a916ab8d2b3cb2df7b90980f9333ac107be063e02a336dbcba0aa998130a5a.Sypeo_xPZx7ObVi0fmODe1_QJzZXq0Jeo2YCijOt1dc
     insights-insightseriestooltip--same-event-series-with-breakdown--light:
-        hash: v1.k794b7964.6789c8ff57d974d5ca5d972f8c34a598eda20aaae36fe4c126a35d63bae682e5.XOC_sSq1rzYzWDr1OD8A6re6ebgFp251tmRjYNpHaaQ
+        hash: v1.k794b7964.b9596373fdd1604b76510220a1f84fe0bfab4e5fb4345d8dc38349d004adbf85.GPljI0_ciOeu_8GwLFZ7_3VQ_1M5SJWqnUkHZK6aITc
     insights-insightstable--aggregation--dark:
         hash: v1.k794b7964.531d5fdec5bc837da5dd1f334b850e6321fde25a7fb70834856ae88338214e28.RVObUcwlwFdjIrk0GTbySMzPeAWR7zUyPLsUtdIu57w
     insights-insightstable--aggregation--light:
@@ -3005,17 +3009,17 @@ snapshots:
     insights-trendspiechart--min-height-parent--light:
         hash: v1.k794b7964.cd52243e5d45d2eb6397a1efffcb6b6c9a5f98ef4a265fab0abc5974c69c0999.17OfM6Hht52excrKELBhQIdviX7ue6tytC6UMA-KrMk
     insights-trendsslopechart--default--dark:
-        hash: v1.k794b7964.16e3df64a87dc281cfed451ecc24f4339a33630c79e669b871de01199f7ff94a.H3KIvw2Ml6H8awHnTYxoDi6Fjl-IIr7dooFfW-waZoE
+        hash: v1.k794b7964.f843b256c76c813e822e3c899d5bb4302f8970671422576d82eab10dba5cec17.QicU0ACrmlNYm9zJKICNpTr7h41TZAYTe4xNsHoy2so
     insights-trendsslopechart--default--light:
-        hash: v1.k794b7964.909509ddc67bf8f11fa0adbe66d2b0498a8774f88ee86b23de67f902ef1d87b8.6ojVvepN-RDgcCFIYmv9k3mEZK4STH-lfc2-bluiZ2c
+        hash: v1.k794b7964.7365cc7bf59f8d9fee5b038b26cd577976e93beb136dac6db8a152c0bdb6d111.f57-e7SaZOA4YyvlWaAJAq2R8k1xTV9-s53EG3jNbss
     insights-trendsslopechart--incomplete-period--dark:
-        hash: v1.k794b7964.48b39da86494debe72863ebebb4dc0eb40f14d95fa3cfd73419e432e31ae3d3d.cfq-o6Z9SjHGQcIzHnqdDu9zftBoXST2WyKAZ80wOA4
+        hash: v1.k794b7964.7d8411f0e5332e792caac3a3bef24b6a6db6e800d55fbb285e5b2423d0cf801f.PihXh0BlAZFNMVS3Duetjy_ZI2uVX25coOf693qz2UI
     insights-trendsslopechart--incomplete-period--light:
-        hash: v1.k794b7964.7ec337274f5d4313f7ed0fbcc9b83d088c97f726da26142cec2ecaab2975f02c.DrF9wbFk4wR4xCHPrt1DAwYjQFSNxX5LaXyMzQwerPA
+        hash: v1.k794b7964.15677d4acb0cf6e1644cbf39fe04e09d2aebd9a67c3cf07908f8f3236e4400a9.4ULEVVXKd6iRsaOrZfY5K3tzbVLjnDOOm79GZXWzP-0
     insights-trendsslopechart--with-legend--dark:
-        hash: v1.k794b7964.056dd0e8337b4d7b9a1538c2fad85bb041d948491e7d57c4b54e101934761aa1.27wPyYu93YTRS_Qy9ka5CoSBccIWATkpwimC7uYNuRs
+        hash: v1.k794b7964.1afe6b88f466887272a79cc84d50caa10d1fa55201f40fc9f96fb0bd6999c046.5-DPfJgrbO1Va6Xg8PYG6dZEjeFSNeESXxkH7IPnvL4
     insights-trendsslopechart--with-legend--light:
-        hash: v1.k794b7964.3937154d2e4552549004489d9c6e51b4dfc1d0c8dc9fa807068f76afad58c07a.8rKiYquuAFHDf5OYem57vBg6axGT4ooMwJSX_U4-UvE
+        hash: v1.k794b7964.741230bf1c62eef2ad168576820c7b32c4d625c3930fed4a8290b64c89995acf.5S1wF2zrE9wuSnvvi_K2ke3N3ZDxGHbaXmhhKzO5NX4
     insights-variables--date-variable-input--dark:
         hash: v1.k794b7964.9f55263cf42996613af3d9a4e643fd80f6cc106a45365d2dd4e271894850e217.v6mqgP6NMvMvOWrF2XuxcO5OS03GKEoGV9wMH6hRZ4o
     insights-variables--date-variable-input--light:
@@ -4765,9 +4769,9 @@ snapshots:
     products-alerts-alert-modal--create-wizard--light:
         hash: v1.k794b7964.494bd726adc6e478744c5418538e1e5bc6e3afdffd7ffc6ee5db7f9447736ad8.XrOtsQ190MyCOe3g_QspkQn_2iNZXZmb0QaWh1xt-t8
     products-alerts-alert-modal--edit-alert--dark:
-        hash: v1.k794b7964.1b0b3ec51cc999c02f8442559b676a2e2f352998c0f3d4a9b10da7da8fc3aac1.ZktPS8oprYMZQ-rLsncCgMlyidqF97zUzqDfKjQGo1A
+        hash: v1.k794b7964.3cd55fcc87ecb1b851983a961e588bbae90b5c140752065d120914a1749e03e6.RM0Hv7J0tRa7mhOLS38ZbTcxsyCQ8Xtsrf6dePw9z3I
     products-alerts-alert-modal--edit-alert--light:
-        hash: v1.k794b7964.38643f06f9a727b550dfcde1c46769c13a24bcc43877362c3d6feab29fd2f581.L1ItMn6mhr4o_vWqlI3lpil3yPPBgM0BgUa-yB6TzUQ
+        hash: v1.k794b7964.3addb07978a52a6bb1c5e4173e8b97482f38ef111fd2555fb0096fede11fe652.tAbNUUogl_o9J4KfOOQrXwcmE_acMb9mAMo5mouwIfU
     products-alerts-alert-modal--missing-alert--dark:
         hash: v1.k794b7964.9180de7bde4303208cc92881f51bfc618108d5e7204acef1114b80858661662d.gbwUGmvs26EJFVhIM-HqBuAIPreZL8pNqn2ZMVi992I
     products-alerts-alert-modal--missing-alert--light:
@@ -4809,9 +4813,9 @@ snapshots:
     products-alerts-shared-components--editor-loading--light:
         hash: v1.k794b7964.5e3a2827ace05ced5a178649d4d511fde78fbd2efc102c1fd3d5cacc229b8395.GsnqMnxDeg6gkEjtWsWDcrdQRmw4OdCs2s4rfF0WdN4
     products-alerts-shared-components--evaluation-history--dark:
-        hash: v1.k794b7964.4c73cdf98a02e35050526eb3d8dbeb6290352aec664d5efeb427061b90ad3805.agcaltLoWhqx3J3mCJW_kDgM2eR3Z8Q1rLkTRISqmS4
+        hash: v1.k794b7964.c301187cffa9c24c3dfcf1d31d9d3c9653061a341d1324307d02e4681a058fa9.ug77pecvKyIvwawDbl4XyC3g30gbhoOVxKLLJaZPquw
     products-alerts-shared-components--evaluation-history--light:
-        hash: v1.k794b7964.c1926b36680c9eb9131bf374492a31d897583cc0219e0c12e31c57406ba42284.6e5ldiw6-7Xry45ZfkhsNoDiozPOldPRDzQ2Y3pFjYk
+        hash: v1.k794b7964.d96c40d0f9c6494027ed9783ce9829017ea951e37319a3a5f4dbe6545b9a8d75.EffdmabZDjxX3zaR-vyLx6V7s6PAGkqycx7jQub9x0s
     products-alerts-shared-components--notifications--dark:
         hash: v1.k794b7964.81ff4b2654d65e3866f9dd9e04dfcedb6d1dbbb45fcdf73acfd60153ba263480.Zq6Us8BfcBnrdUHjpISWQFYe5836RgaIlc6eoFwpshE
     products-alerts-shared-components--notifications--light:
@@ -4820,6 +4824,18 @@ snapshots:
         hash: v1.k794b7964.3c027b2e0731f9738cdfe21d14b6a893375c0fe0a0f11b587580adafc09340f9.GfzW8vynGlDg1ZO7Mp1sS9oDhRiKra5Vxhtopyi31Go
     products-alerts-shared-components--notifications-multiple-slack-workspaces--light:
         hash: v1.k794b7964.63ec31eddf76c6f6544838a9b765e091bbe84325070fff837ed94d2cc1e85ba8.rPHnjzF-XA_HZd7mJ9KKN8iLGsZVXVdne4uww2vsx4w
+    products-alerts-shared-components--preview--dark:
+        hash: v1.k794b7964.c9bdafae1ad47e45cba8bc136bc1f911fcd38d3f3adc0109c73c608fc7aff1a7.JQQcVBlkdE7zlG0B9V18hFYCe7DRINlSu1YhOXTSNFg
+    products-alerts-shared-components--preview--light:
+        hash: v1.k794b7964.b50bab9d45811f65807b4a8f70d7699e3a6622fe934fa972694fc2d96461041e.HFAHjicDLcs7EPMZlhlcmW4_mb6B-V9zulQ9sqcf6Js
+    products-alerts-shared-components--preview-log-scale--dark:
+        hash: v1.k794b7964.906c1930c0e5ceee290a929d4ba68eb4ff58ce08f6e89f89474ada2fff12505d.U1FElozFVhx4UwEdkRh8KkkZQl-n3074MGTZtdFD5Z4
+    products-alerts-shared-components--preview-log-scale--light:
+        hash: v1.k794b7964.1d56a7e6c72b61af4c361deccffcc8ce470332f24c7f9e3b02a6ac18a902262f.U0kGJ9j_ruYcrhE7eZTB75Jrurx8oKaQkPr5ZSQCBqU
+    products-alerts-shared-components--preview-relative--dark:
+        hash: v1.k794b7964.02aff297cb42e88497c414c91b2a0bb277eeb82eb1f74b66e89cd51fb97bc0a8.DrRaGseHJATwyVv8ZkYBLbJNV8RxucCYxM7RVe9rdBw
+    products-alerts-shared-components--preview-relative--light:
+        hash: v1.k794b7964.04078eed751e98c6e4c8c7ecfa6cadce5f55538c4597b94413aed2bfe7e1eb59.Ir9Gw-96fwl6KxKQ8WzkW6dxMZj6cc_L1T8bXeW87Yo
     products-alerts-shared-components--quiet-hours--dark:
         hash: v1.k794b7964.5882b745c748c44c9f3b1026e1c35953d8e2034b5f31588d2030a8502bd5afdd.k0NFXRurTVmlsO_6I1VF93n7KlCAP3ye3kztNwuaV0k
     products-alerts-shared-components--quiet-hours--light:
@@ -4941,13 +4957,13 @@ snapshots:
     products-dashboards-dashboard-widgets-widget-types-experiments-experiments-widget-settings--default--light:
         hash: v1.k794b7964.d5dbe93b525586357874c49627a55275abf01e67d68fb83ece720f205b73fe7e.v9g8wvzfgVkkkaGKaO_PvKGWh6DfkTlfMCC2eiY8rSw
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--default--dark:
-        hash: v1.k794b7964.1218b42154e64d863d2ce295a54b7a30162f1fee60ce187153cdb296bba7bf4c.xJPzgpEURMRZop-Rp5b84Lx2g1LZP1Yi28C5MLixQKQ
+        hash: v1.k794b7964.8030c814428bf39109c50aff4651de48b8abac48125f0fd4b33e5758d0630aee.-5otWfkf9AkiSzbZjiVXSgU66b1omRextmYvZdCq1ow
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--default--light:
-        hash: v1.k794b7964.09a79a317eddb8e0671abd52fa412ea4a0199aba5ac80c48c7368f68c9eec814.pGn0vgnaZ2L9zvP9vU6pS7b2Uz2S88moRRqduRJSEKw
+        hash: v1.k794b7964.74cb6b134a47f9ca08ea3e3dc6b03af584218928a249ee9bd1960d99bba3fa49.C8W2-v19-rlnqswSjA1ONm68Ipw0KbqyxUY7qsPEfY8
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--empty--dark:
-        hash: v1.k794b7964.edb58201c5ff97bc5e8279b8aefbc1fd4ffa2ba264cf21ca547a1f8d9eb454aa.DY3PHLl-lRRjakSe7MNk_falysr6kW43a4UjmTuzmCc
+        hash: v1.k794b7964.230ff6e82f0aa6aa2d2f529eae4373206a419a84d9a8475cf069182413ea7128.Yoq_m5XP4BD3Zb6V9BzLk6oomCn93-nGeD3w17-4VhQ
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--empty--light:
-        hash: v1.k794b7964.4f69ddab94cae07421d066cc1a4586ad004aaaa3e0cb4b98de40ce5cb0354e14.2Kuf5yTRWQ9hMtH-Zlb3pPZa_as-BsxYUwBBrb1KqkQ
+        hash: v1.k794b7964.92f72b1291e55fe5ee7650489b6741ccd509fe019834cfbe72371a37b8925f0b.1mcT5yTpk65rN7kH2uReC9RFjxswyaKUsUxgVBgn46A
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--loading--dark:
         hash: v1.k794b7964.0e488c170ef6d52da87a0a450ddaad59dd24e7bdd8050a0c53a2864de58f8c64.GFv5d3uFctY7JRfAaWfMOanvUysHRHtxagCKRVTaqmc
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--loading--light:
@@ -5276,6 +5292,18 @@ snapshots:
         hash: v1.k794b7964.d553cecf3e544087316e1687404c8e2b3a6c19f618a05e09880e60e656054f23.hNkLLb04XLyd-PQJa59WwPhgRAxMbW5fSDzCnowJKBs
     products-workflows-customerioimportmodal--step-4-track-not-configured--light:
         hash: v1.k794b7964.0954891b73cdc0b1bce1275fa11a5fa4af2055b83b518bce82f3fde886097659.mgEq2W8sZg7x-vt8z2EpwEHPBGRzPI1GWtn-9tu-46o
+    products-workflows-steps-delay--date-not-chosen-yet--dark:
+        hash: v1.k794b7964.ec9c913ba6edb54c2b521e3b1913e45fe914dcd4fc5b45febacd543038865cd0.khqeV0deGQR_Ows3heRrRyvzw8fUBJ6KUNQbhb1asas
+    products-workflows-steps-delay--date-not-chosen-yet--light:
+        hash: v1.k794b7964.dc158b1016438cce345c29d6286ded7e04c3425d8af7db8ceb8afedecb8fd2d3.kI3pKbOwmZIvyBcmr2W9FanENuzvek1DTD0L8x9LxgU
+    products-workflows-steps-delay--date-on-the-person--dark:
+        hash: v1.k794b7964.8833fd60d4b54c0751a7d18be9646611e7946c01182fda9ca2a90069a6462ac9.aZ7c7m-BBK3s1bidL57E4cLDR-CW36j527cyvA7Vgkw
+    products-workflows-steps-delay--date-on-the-person--light:
+        hash: v1.k794b7964.957751579f78f83fb2300b18ea372c50283e9b4caab2d2bd86b2246c5038204a.HH3ABZUVOmlM6GjJzheIbs3KYeZtbREPrlqkdFkt5G4
+    products-workflows-steps-delay--fixed-duration--dark:
+        hash: v1.k794b7964.9e7a12c3094416ddf703121095bc7eba5189420cab88d6967618bf43139069fe.UZSvEld_DwpzTPi6QpbRfxOtDYP7S_gR0F03DJcFMpM
+    products-workflows-steps-delay--fixed-duration--light:
+        hash: v1.k794b7964.f394f1e00c55c84136a291d5acb646dc12e0b27951a99e493137f7bad05a2082.zj4h9BHlkIR9RBHiB6nkO0QjDgPC1UKa08uSHemhjSQ
     queries-webvitals--web-vitals--dark:
         hash: v1.k794b7964.2ae778a0c5fdba3c69dfcbd3e9589c3c3d9cc2f0fef2eefd304c565be7e9a7c9.hH71byl33sIAdRCgaPk1lDOev0qooW1xhv0AL_yrIvg
     queries-webvitals--web-vitals--light:
@@ -5764,6 +5792,10 @@ snapshots:
         hash: v1.k794b7964.4b8d5226ee154debdf333ff93d65a90ca766bcb25951e1baf36affb8b84b548d.dWZSHssPc83RkHVE-JPJA562bJR7MUim2yfqhjfNE50
     scenes-app-customer-analytics-accounts--feature-gate-off--light:
         hash: v1.k794b7964.e8b91bf6a0dd1b5d31064f4cbb94e9791e999c210831c455a498d0c7cc7e6bbb.IkZPJrJz33sKS8zzKwoy8V3s0GvmKpe5EGYTCIljhLs
+    scenes-app-customer-analytics-accounts--row-expanded-conversations--dark:
+        hash: v1.k794b7964.c83d3e0351279053117a4376654ece30522ea04e0d17a21d084e58be220395e9.coxsJkBmbXdsAZSUNvss_RtW7LQ6MVRxvqbiW61JfQI
+    scenes-app-customer-analytics-accounts--row-expanded-conversations--light:
+        hash: v1.k794b7964.9ffbe7d6153dbbd3812945e1f0e70e48bf941371a6d8b30027d0b0eab61f98e4.86uwFxkcB9kgOSyT445fxXt_x_ckpJp3GRukqn62BGY
     scenes-app-customer-analytics-accounts--row-expanded-email-threads--dark:
         hash: v1.k794b7964.0b52a6a4b48bc77bd2f0cf6d4550c4ec9d5262aaf9ac1a1aee9e2e57f311bbf1.moW1nKPfmZWFyn0i-N8hewBU7i250wMB4P8xCmMt9w8
     scenes-app-customer-analytics-accounts--row-expanded-email-threads--light:
@@ -6311,7 +6343,7 @@ snapshots:
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--dark:
         hash: v1.k794b7964.980b559b32f54de08e32932b4d9e14e203c2ff084a7dd0fd16bce311dff6540e.RjlN-Zl7Betwf5MoCvu-4XAx75Dqu5OI8f_qbvOsQ20
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--light:
-        hash: v1.k794b7964.af14f7a5b3dfaf6798b66f81b80bb8ce6feb4e1052f198e93b2049956b2b0ab4.FvGIr17gWYEfiUdDTzI1vdffBD9QoChjzNbJukXbmZI
+        hash: v1.k794b7964.367868849fda12a0ca273c93bb6ad407a9b2cf0d76399547554cb9573b148a52.dBY6JqKOHSKACw47AmxmGDfiFgohjeuEVq_JspPeh8k
     scenes-app-experiments--experiment-with-multiple-metrics--dark:
         hash: v1.k794b7964.9a8e12167e506eda2587fc1ff4009fcd04818d71d5ebca5edae3886763cebf4f.pXfxrh4O5h1ylZCuDBDE0p_FcTT05xwy3XxaCdX1Tnw
     scenes-app-experiments--experiment-with-multiple-metrics--light:
@@ -6405,17 +6437,21 @@ snapshots:
     scenes-app-features--not-found-early-access--light:
         hash: v1.k794b7964.7c4c60522de8d6fd84b4334d53ed790c4094d4023de4d5defc07b613281bec68.zLhf-ChR2B4M8Gd-vTYGILy2agvAsBni1SFLC81icb0
     scenes-app-health-tables--data-modeling-default--dark:
-        hash: v1.k794b7964.f64ddfcb2e58e9afa4d47366865d045bd684870fd0a4a9f2f240158fed7edc72.wor9aqzrfyY7rIXvlhJKAflb1i49DNcWaZz3v3uDXYQ
+        hash: v1.k794b7964.52c292fdf2f68fd4caa39f6c1825ee7d8cdf3ac790ee0ad9e5ea3a1b7fcaddc6.c0rsHMyyO3K0Gr88BeHsb_PQO4J4XSRhvs16OLp1PDo
     scenes-app-health-tables--data-modeling-default--light:
-        hash: v1.k794b7964.83ef3c181f05acd771b5a37807c6731b3f14f1e15503daac4e7dbe7c2c453f87.EHZc1vUzyqxrGzNnC15UJ9SNWbF2L9CdTC_0p6Ih5Ek
+        hash: v1.k794b7964.c79588673a4bf83fa5ba1b700243a65cc5fe1941324815793c658dc3faeeec48.As3uxdvhbnBuebcrh5jK9p2xuyZFMAznD8qy-BH55QY
     scenes-app-health-tables--data-modeling-empty--dark:
         hash: v1.k794b7964.e0cec371110600c6ecf4cc56bfc1a17a100433c6a4455c24c11e3e3e82af5bc4.bLeZEkRSKv7JAomhMUpJXWgiUHOES27Uhf4hB_dRbW0
     scenes-app-health-tables--data-modeling-empty--light:
         hash: v1.k794b7964.d2973eef45332e598774e5c9fbc19ed42d1ad967167c74cb53b805a5d289acd1.1VDS8gMTBrWejKfoVf8yKy0f28-8PVQbfjd_FLfWIgk
+    scenes-app-health-tables--data-modeling-snoozed--dark:
+        hash: v1.k794b7964.1fc8887f7459b84762bfd5cc19009b69a47172c66a3e50e3dfcfa82d2596ac3f.-zVqTQdUAfVC662I_nI2-YQHmp1WG_Rw_1RpBZJswqE
+    scenes-app-health-tables--data-modeling-snoozed--light:
+        hash: v1.k794b7964.d2fb52a86e5c959e11f2f1098af9a70683374e0bca10933d7eb382bf1eb5a5e2.yqT26jkXdp50i99dBP3HWdInfupAJXBPPh-KEec9T7Y
     scenes-app-health-tables--data-modeling-with-dismissed--dark:
-        hash: v1.k794b7964.9340b5c4f1119b8f3f4c813b200b08d369f0086073e88141ee99ca3204bfb9ea.9vpX6V94nWh5mjMPYt7TeYIQPgDV-AqtoATMmE9ZFXI
+        hash: v1.k794b7964.8827b9f515e23093c19a920d3ea7e727f299975bdbfcd66742a8f21340da6a2d.CM9HW9M0QhOw88Oa03VOHD1AyoIkDVuxpCXhNw7A6FI
     scenes-app-health-tables--data-modeling-with-dismissed--light:
-        hash: v1.k794b7964.880d19043e667600d99528230667c48571423315edc0147586d6a1b5dd89d03b.JiVVNXvmveoZU3pNraon03-dyfIhLlO2G88EYO5z8oA
+        hash: v1.k794b7964.bcca9ef07584731a9ca0c76b0887fa3ddec98388ba0094d8c00a650a46359111.iJ0S4n8-kNmi3mDc090GMWhqMluphrtrAijz8aPuQ0w
     scenes-app-health-tables--detail-healthy--dark:
         hash: v1.k794b7964.cd1aaff53c8034b46d4507fa668a0c1b1ab38e6be8aa217f2fa4369ac56a229e.2nZbu_O8CJcsJlKldVsb3_hn_DQ3eS1MGwyDnVINTGY
     scenes-app-health-tables--detail-healthy--light:
@@ -6425,17 +6461,17 @@ snapshots:
     scenes-app-health-tables--detail-with-issues--light:
         hash: v1.k794b7964.9ca575a6d1b5820165829d960e8ca17ead7acf70ab045df5d980d7809f77b4ea.c2z60bJpQCLs7phwjcSXvjMww5XV_bGuq34s-L2ilEg
     scenes-app-health-tables--ingestion-warnings-default--dark:
-        hash: v1.k794b7964.3404023f585c174f1e4b89a66e98512e00f66d122bbc903fe625a7f9f583c154.8ZULOCBV4ZzOB2mHSQIftIwQwdUEl1vi6Yfyl7NUoa0
+        hash: v1.k794b7964.898964bdebab4373de52f8e8dcfd7485b33e5a78544f581d9c4d4f4afd9a40bf.yi-XcAQuQGuayAfTFX0lYtrceQOszz0a03IW9d8wxgo
     scenes-app-health-tables--ingestion-warnings-default--light:
-        hash: v1.k794b7964.492222da7576a848c236eb50803eb98e6c389661f38df9ef2a85885cdaf1b661.R9vAsUXYKfzGrGRomGtdnlM5HqZQDA4DfgIbCZMiwms
+        hash: v1.k794b7964.96bc85f78b2ed4da6a3b4a813e786eca079ffa126d006d0044f1c044c9573aff.a5zeaT0vwburbHn8RMY_f8fr46ISFDXPrExoo5eEfEw
     scenes-app-health-tables--ingestion-warnings-empty--dark:
         hash: v1.k794b7964.61f1a7133d8b4dc50d84975639cf468b8838f305c238d013371b0f2dac1b5a26.PsGLRRVGPwqPjt1KZbz-VY7lK5KXbcHjOQlIZn2lLI4
     scenes-app-health-tables--ingestion-warnings-empty--light:
         hash: v1.k794b7964.ddecc085c12a90a102d31d04b49385f3d754de5e758eaf6723e768c45d91e117.abXhn15J5KQNcRuCLmDqljtzkQjVyIqxzQE1QVA2zFI
     scenes-app-health-tables--pipeline-default--dark:
-        hash: v1.k794b7964.8135e69c41f1a91c315c85a14c9c2dee0bf8f1eec3bde0799ca74cba0db47cef.9xx2mf6L_pUXsWLLMIOaARx24TxrvyC_ZGgjvsk_-to
+        hash: v1.k794b7964.95f26d2efc84ead17242f6af0c8431078a1f557d9e91d04e72347e704c14c212.QM5MPy14AFFZu24DDgCMnjlp_ve64Qxoa6WkWZiIXrI
     scenes-app-health-tables--pipeline-default--light:
-        hash: v1.k794b7964.c4267cdc0ad3764afc39199fe329b7589a43e793b281ee6345e66da4eae6e117.qDas2Z01o94ugBSZXvOoAICpTGx59QVVKz-rQl01boY
+        hash: v1.k794b7964.a1e214d4b155dfc6e26b40e3af1a7d2218fc8095060096ec2ab1fbaccce24f1e.ION-3EyxVIpddyVwPdxbBR2sbJEI2nc8lsqd-2D4Wek
     scenes-app-health-tables--pipeline-empty--dark:
         hash: v1.k794b7964.f2527d03649132cee913b9da0f397f4c1d5edd34863d782be005049874d2f430.ntImg_aiZxhMpwJgv23GE2uDUEOjb6I-2pcQx6cJ4mQ
     scenes-app-health-tables--pipeline-empty--light:
@@ -6449,9 +6485,9 @@ snapshots:
     scenes-app-health-tables--sdk-outdated-empty--light:
         hash: v1.k794b7964.71eedb43b175f02dc50fdf0958682a8d27d244f86a60f34ff10d51147fc2878f.UbRwk4YbLiNtBWsLvWUUMJJNfAA1-JS0OxxZRcv-jsM
     scenes-app-health-tables--web-analytics-all-checks--dark:
-        hash: v1.k794b7964.a8d7b631caddf3035e8759ebe94288ac140895f70613f25d62f4aa2d01c26d2c.AzgkJuC2FOj00_H9ua7ns24-TXKkaKcRq47XuNB-jrc
+        hash: v1.k794b7964.a9b39a62bc1155bfb363fb6fe0b5cfb3f8333027d138a284b35d8655a82d6ad5.4b08uz8QGeBGJH-Zl6AHA0TVOYvBEAp4exf0bo1DGY4
     scenes-app-health-tables--web-analytics-all-checks--light:
-        hash: v1.k794b7964.3d5ec71feb4b2f8391122d005d2fa81a514e05868d51bc3f5126f4fc09f5dbdb.FQEfPmNfTmhQ-efzxAeviJSLbQhqmwtIEpB7ammtfyA
+        hash: v1.k794b7964.c54620210c7119377d9259097194d6e74db516c59b0aca19bf1725e7ea1108a0.mUD4P8hx6BKC4yYK3nkoLI5HbmGENLw3GZdUOvDiwFY
     scenes-app-health-tables--web-analytics-empty--dark:
         hash: v1.k794b7964.2834badf9e2f5eb60e24e0a8313eda1d0ebbe2e32e935f46fc7ca7f43b649f80.9UYuOYeCgZn7fesHSz9DnGYgFd_1Z_6BEKy2xrMtWXQ
     scenes-app-health-tables--web-analytics-empty--light:
@@ -6641,25 +6677,25 @@ snapshots:
     scenes-app-inbox-pullrequestdiffview--truncated--light:
         hash: v1.k794b7964.58a507666519d2ad2f2a5247605b2c903180639eae9e43580992de250bc8f258._lKwsnOWccjuN6S_pd8IgOfKLzqnIvVqmTh1uETW-TY
     scenes-app-inbox-scene--empty--dark:
-        hash: v1.k794b7964.f858226194a05f95be6add515297ea094114a47981c6fc46f83d223f343a77f0.tbBLBd5DJ7uLeRfZNIigvrF6ldFj2m243C4e_9Tb2W4
+        hash: v1.k794b7964.2572de9d05a91291ee5c54759632d9e451d42fbc1d76a631c168abd2dad70972.nrzYMXH-uB7esw-8ykrFpAiEoZHliLlEPRPWpZOzxHM
     scenes-app-inbox-scene--empty--light:
-        hash: v1.k794b7964.4a7e548249c74283c24da9a2085f1764f893e52457d26c651357b8f1c3053cd7.ccZxOShQTV1cwDR1QYyIeY99ZWOOxK-U-wIoISHRc30
+        hash: v1.k794b7964.2c92adb4c82dda0e5d316a0a3f8f06a6b426e9fa001edf2ff279340373a2a85c.Lz2dW5ir_CDN81bwkzkH6k71rcBHgob0I7bcwxwBiQg
     scenes-app-inbox-scene--empty-control--dark:
-        hash: v1.k794b7964.287760bbb696d8f90476a77fc0e054a0a521949d79c2a6c24a9ecd3a96b78514.LytaRdleivG8Ac7O1mKqUSob4bMzfczXrLVnuTx10vc
+        hash: v1.k794b7964.6bb999e7dd980b4bb9a6f5d90c07a7290b4fc2573a15f3352f0df7df4626f41a.sjmglF3RwFn90_WbmfnsPDkzheZgV3CIgAl1NWPko0Y
     scenes-app-inbox-scene--empty-control--light:
-        hash: v1.k794b7964.96786307b02ebea16bafb2280e59ca396c69134d05c732efb4f4b967cafe68e2.w6P9pCXHIVp1SGtYYekUzXdbtgFsxKA0uNXUa3BivZQ
+        hash: v1.k794b7964.bcc336cfa3b3bdc689ddc5a0243792886ed4bda2313e8dc808cb02e2419a49d1.8r6f3WN9J6DRWwaJNr5eYdQ05Q97smejgHKL4bbvMUY
     scenes-app-inbox-scene--empty-with-many-scouts--dark:
-        hash: v1.k794b7964.be8d5408e5f9eb7ec2294d987012b80a4aeeb2389a14c4456526a776012a8ad2.4AyDpXC7-gd1hIOG_iXX6EzNrBYC8bI8kDZWSsx6FTU
+        hash: v1.k794b7964.ad51c2deb25108d1798f1a457b545d3ac2b44a41db513d8fe82cd2643aade6cb.OdWP3HwXPw42shSujrp65nQZ-kGmszTxTTn7hzYUyg4
     scenes-app-inbox-scene--empty-with-many-scouts--light:
-        hash: v1.k794b7964.81e54a0e525e65c7da2f9b53ce7244dd9be3ebbd134904100a0c36c7c7c12805.4itPrcitfRSnQtatXUZq8y9qg2gAn_HPH3wV90pxXUg
+        hash: v1.k794b7964.b9a77600fe33803591c05e110e5c8373ea6f9f534088107e6244d4e2887a0248.uBGGTqK8QLmvzTOppyfWjubR-CyIYicZBeB4In3A2u0
     scenes-app-inbox-scene--inbox--dark:
         hash: v1.k794b7964.e1e4ab0d21ba58926ab2d57e366734264122b146701a84fe3f442012ec64fc19.6sbEcCnUZmsj3KMtQMzsKHuyPxgs2UIKKF6xN7gufSA
     scenes-app-inbox-scene--inbox--light:
         hash: v1.k794b7964.ac152ef65c5c6fe25d9b985a44f41279a017eff249d66920bcd77bbc17f78b64.B22XE-debF5iSr7REBQIZ9TrQN2y0pgYWX8tIS-_Vv4
     scenes-app-inbox-scene--installing-self-driving--dark:
-        hash: v1.k794b7964.df43e4442527c259636817481d05333152437f404c8db77ba2ac356dcdf26bf8.VZyPNYylWdYNotRNJfMVLi1UrMVlLp5sYTrPyVysLGc
+        hash: v1.k794b7964.0f5b7ce9c7a22d92f31420a483f74d03618a98a2ec1432efcb943e1af6a5d2b7.xoAgktzo4sCbmLekevXh9XG1Jt0LGBMauvn0A6vVbjM
     scenes-app-inbox-scene--installing-self-driving--light:
-        hash: v1.k794b7964.7a913919553fa3a43c955ecc6a692e359e7e4d1b24f2fe88917451059e5771fb.8o1rCkx5ytVZo4KLLi0Bko3taH9ON7PCBFmw5WLOZfc
+        hash: v1.k794b7964.44a79a0117f5a912252a4c7c7685fca78693fc92c9b5d06bba7e928913235663.DfHZQMzgqHbKBJAEZ3XBRpom-q0KbSRt_QYmOnJOCAQ
     scenes-app-inbox-scene--self-driving-onboarding--dark:
         hash: v1.k794b7964.7602d02fad26586f0a4773abe0fbe76ad39c625403c7648ec58ff711aa38d3a0.9ssGMF2bvYFiK299rvJqLc9mbtZk4SeJHRoWnZP3Ed8
     scenes-app-inbox-scene--self-driving-onboarding--light:
@@ -6669,9 +6705,9 @@ snapshots:
     scenes-app-inbox-scene--self-driving-onboarding-redesign--light:
         hash: v1.k794b7964.c2f7366b673e20e85513c454effae314d643958a3d2424e7902d572909f024fe.edek45zj8tVjVDjsqgddUJUnPKAHanQkzZwR5Ylr93Q
     scenes-app-inbox-scene--self-driving-paused--dark:
-        hash: v1.k794b7964.d558d73ed434d1f5ce6a864bc50d855e7916242c778e4719e6151432feb96319.ViMFd8U58Sjq4-bJWL57xU6EN55lwt-feu90J2gQbSU
+        hash: v1.k794b7964.ffc5557c01bbfb5497cbbc60ddec9df93367eef9507d600b9ac37f436eb92985.8pdD_uKVmeemQVwO3E6g526Fq7681IhrC2PA5AKCaiY
     scenes-app-inbox-scene--self-driving-paused--light:
-        hash: v1.k794b7964.c6cf53af6e534fe5746d6aa68367b638fe5a912f831e2275cffc2f4b5b4581dd.7G19eF0HbG7P9aV6LDqoLJMV_VRk0tWhp4-1LplyC4g
+        hash: v1.k794b7964.1f1c9fbabc723430900b6bd522016ccc1396391d797a87d6c71e44e910af209c.QOPeDKqrxxZE7HyPrTini_ZKF5_WNVMHvCDBfQP2Vwc
     scenes-app-inbox-scene--self-driving-verdict-pending--dark:
         hash: v1.k794b7964.570e5dddd645996b94ff94b2c563b32ced3793db3ab5ccf360d16126af3b9a0b.WC_VEZ1N_iX-o4r11w15QWfD8Nzo1gFerTznKiaIX84
     scenes-app-inbox-scene--self-driving-verdict-pending--light:

--- a/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
@@ -262,20 +262,16 @@ export const issueActionsLogic = kea<issueActionsLogicType>([
                 })
             },
             updateIssueSeverity: async ({ id, severity }) => {
-                await runMutation(
-                    'updateIssueSeverity',
-                    async () => {
-                        posthog.capture('error_tracking_issue_update_severity', {
-                            severity,
-                            issue_id: id,
-                            source: 'issue_actions',
-                        })
-                        await errorTrackingIssuesPartialUpdate(String(teamLogic.values.currentProjectId), id, {
-                            severity,
-                        })
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues([id], { severity })
-                )
+                await runMutation('updateIssueSeverity', async () => {
+                    posthog.capture('error_tracking_issue_update_severity', {
+                        severity,
+                        issue_id: id,
+                        source: 'issue_actions',
+                    })
+                    await errorTrackingIssuesPartialUpdate(String(teamLogic.values.currentProjectId), id, {
+                        severity,
+                    })
+                })
                 actions.finishIssueSeverityUpdate(id)
             },
             updateIssueName: async ({ id, name }) => {

--- a/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
@@ -220,70 +220,46 @@ export const issueActionsLogic = kea<issueActionsLogicType>([
                 })
             },
             resolveIssues: async ({ ids }) => {
-                await runMutation(
-                    'resolveIssues',
-                    async () => {
-                        posthog.capture('error_tracking_issue_bulk_resolve')
-                        await api.errorTracking.bulkMarkStatus(ids, 'resolved')
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues(ids, { status: 'resolved' })
-                )
+                await runMutation('resolveIssues', async () => {
+                    posthog.capture('error_tracking_issue_bulk_resolve')
+                    await api.errorTracking.bulkMarkStatus(ids, 'resolved')
+                })
 
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.ResolveFirstError)
             },
             suppressIssues: async ({ ids }) => {
-                await runMutation(
-                    'suppressIssues',
-                    async () => {
-                        posthog.capture('error_tracking_issue_bulk_suppress')
-                        await api.errorTracking.bulkMarkStatus(ids, 'suppressed')
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues(ids, { status: 'suppressed' })
-                )
+                await runMutation('suppressIssues', async () => {
+                    posthog.capture('error_tracking_issue_bulk_suppress')
+                    await api.errorTracking.bulkMarkStatus(ids, 'suppressed')
+                })
             },
             activateIssues: async ({ ids }) => {
-                await runMutation(
-                    'activateIssues',
-                    async () => {
-                        posthog.capture('error_tracking_issue_bulk_activate')
-                        await api.errorTracking.bulkMarkStatus(ids, 'active')
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues(ids, { status: 'active' })
-                )
+                await runMutation('activateIssues', async () => {
+                    posthog.capture('error_tracking_issue_bulk_activate')
+                    await api.errorTracking.bulkMarkStatus(ids, 'active')
+                })
             },
             assignIssues: async ({ ids, assignee }) => {
-                await runMutation(
-                    'assignIssues',
-                    async () => {
-                        posthog.capture('error_tracking_issue_bulk_assign')
-                        await api.errorTracking.bulkAssign(ids, assignee)
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues(ids, { assignee })
-                )
+                await runMutation('assignIssues', async () => {
+                    posthog.capture('error_tracking_issue_bulk_assign')
+                    await api.errorTracking.bulkAssign(ids, assignee)
+                })
             },
             updateIssueAssignee: async ({ id, assignee }) => {
-                await runMutation(
-                    'updateIssueAssignee',
-                    async () => {
-                        posthog.capture('error_tracking_issue_update_assignee')
-                        await api.errorTracking.assignIssue(id, assignee)
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues([id], { assignee })
-                )
+                await runMutation('updateIssueAssignee', async () => {
+                    posthog.capture('error_tracking_issue_update_assignee')
+                    await api.errorTracking.assignIssue(id, assignee)
+                })
             },
             updateIssueStatus: async ({ id, status }) => {
-                await runMutation(
-                    'updateIssueStatus',
-                    async () => {
-                        posthog.capture('error_tracking_issue_update_status', {
-                            status,
-                            issue_id: id,
-                            source: 'issue_actions',
-                        })
-                        await api.errorTracking.updateIssue(id, { status })
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues([id], { status })
-                )
+                await runMutation('updateIssueStatus', async () => {
+                    posthog.capture('error_tracking_issue_update_status', {
+                        status,
+                        issue_id: id,
+                        source: 'issue_actions',
+                    })
+                    await api.errorTracking.updateIssue(id, { status })
+                })
             },
             updateIssueSeverity: async ({ id, severity }) => {
                 await runMutation(
@@ -303,24 +279,16 @@ export const issueActionsLogic = kea<issueActionsLogicType>([
                 actions.finishIssueSeverityUpdate(id)
             },
             updateIssueName: async ({ id, name }) => {
-                await runMutation(
-                    'updateIssueName',
-                    async () => {
-                        posthog.capture('error_tracking_issue_update_name')
-                        await api.errorTracking.updateIssue(id, { name })
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues([id], { name })
-                )
+                await runMutation('updateIssueName', async () => {
+                    posthog.capture('error_tracking_issue_update_name')
+                    await api.errorTracking.updateIssue(id, { name })
+                })
             },
             updateIssueDescription: async ({ id, description }) => {
-                await runMutation(
-                    'updateIssueDescription',
-                    async () => {
-                        posthog.capture('error_tracking_issue_update_description')
-                        await api.errorTracking.updateIssue(id, { description })
-                    },
-                    async () => pendingUpdateActions()?.capturePendingUpdatesForIssues([id], { description })
-                )
+                await runMutation('updateIssueDescription', async () => {
+                    posthog.capture('error_tracking_issue_update_description')
+                    await api.errorTracking.updateIssue(id, { description })
+                })
             },
             createIssueCohort: async ({ id, name, description }) => {
                 await runMutation('createIssueCohort', async () => {

--- a/products/error_tracking/frontend/logics/issuesDataNodeLogic.test.tsx
+++ b/products/error_tracking/frontend/logics/issuesDataNodeLogic.test.tsx
@@ -24,12 +24,25 @@ const query: ErrorTrackingQuery = {
 }
 const issue = {
     id: 'issue-abc',
+    name: 'TypeError: undefined is not a function',
+    description: 'Something broke',
+    library: 'web',
     status: 'active',
     severity: 'low',
-} as ErrorTrackingIssue
+    assignee: null,
+    first_seen: '2026-05-01T10:00:00.000Z',
+    last_seen: '2026-05-26T08:00:00.000Z',
+    aggregations: {
+        occurrences: 12,
+        sessions: 4,
+        users: 3,
+        volume_buckets: [],
+    },
+} satisfies ErrorTrackingIssue
 
 describe('issuesDataNodeLogic', () => {
     let logic: ReturnType<typeof issuesDataNodeLogic.build>
+    let initialResults: ErrorTrackingIssue[]
 
     beforeEach(async () => {
         useMocks({
@@ -43,7 +56,8 @@ describe('issuesDataNodeLogic', () => {
         logic = issuesDataNodeLogic({ key: 'error-tracking-issues-test', query })
         logic.mount()
         await expectLogic(logic).toDispatchActions(['loadDataSuccess'])
-        logic.actions.setResponse({ results: [issue] })
+        initialResults = [issue]
+        logic.actions.setResponse({ results: initialResults })
         mockPerformQuery.mockClear()
     })
 
@@ -60,5 +74,6 @@ describe('issuesDataNodeLogic', () => {
             .toMatchValues({ results: [expect.objectContaining({ id: issue.id, severity: 'critical' })] })
 
         expect(mockPerformQuery.mock.calls[0][2]).toBe('force_blocking')
+        expect(initialResults).toEqual([issue])
     })
 })

--- a/products/error_tracking/frontend/logics/issuesDataNodeLogic.test.tsx
+++ b/products/error_tracking/frontend/logics/issuesDataNodeLogic.test.tsx
@@ -1,0 +1,64 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { performQuery } from '~/queries/query'
+import { ErrorTrackingIssue, ErrorTrackingQuery, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { errorTrackingIssuesPartialUpdate } from '../generated/api'
+import { issuesDataNodeLogic } from './issuesDataNodeLogic'
+
+jest.mock('~/queries/query')
+jest.mock('../generated/api', () => ({
+    errorTrackingIssuesPartialUpdate: jest.fn(),
+}))
+
+const mockPerformQuery = jest.mocked(performQuery)
+const mockErrorTrackingIssuesPartialUpdate = jest.mocked(errorTrackingIssuesPartialUpdate)
+
+const query: ErrorTrackingQuery = {
+    kind: NodeKind.ErrorTrackingQuery,
+    dateRange: { date_from: '-7d' },
+    orderBy: 'last_seen',
+    volumeResolution: 1,
+}
+const issue = {
+    id: 'issue-abc',
+    status: 'active',
+    severity: 'low',
+} as ErrorTrackingIssue
+
+describe('issuesDataNodeLogic', () => {
+    let logic: ReturnType<typeof issuesDataNodeLogic.build>
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/error_tracking/spike_events': { results: [] },
+            },
+        })
+        initKeaTests()
+        mockPerformQuery.mockResolvedValue({ results: [] })
+        mockErrorTrackingIssuesPartialUpdate.mockResolvedValue({} as never)
+        logic = issuesDataNodeLogic({ key: 'error-tracking-issues-test', query })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadDataSuccess'])
+        logic.actions.setResponse({ results: [issue] })
+        mockPerformQuery.mockClear()
+    })
+
+    afterEach(() => logic.unmount())
+
+    it('optimistically updates severity and reloads authoritative state after success', async () => {
+        mockPerformQuery.mockResolvedValue({ results: [{ ...issue, severity: 'critical' }] })
+
+        await expectLogic(logic, () => {
+            logic.actions.updateIssueSeverity(issue.id, 'critical')
+        })
+            .toDispatchActions(['setResponse', 'mutationSuccess', 'reloadData', 'loadData'])
+            .toFinishAllListeners()
+            .toMatchValues({ results: [expect.objectContaining({ id: issue.id, severity: 'critical' })] })
+
+        expect(mockPerformQuery.mock.calls[0][2]).toBe('force_blocking')
+    })
+})

--- a/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
+++ b/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
@@ -30,6 +30,18 @@ import { issueActionsLogic } from '../components/IssueActions/issueActionsLogic'
 import { mergeIssues } from '../utils'
 import { batchSpikeEventsLogic } from './batchSpikeEventsLogic'
 
+const ISSUE_STATE_MUTATION_NAMES = new Set([
+    'resolveIssues',
+    'suppressIssues',
+    'activateIssues',
+    'assignIssues',
+    'updateIssueAssignee',
+    'updateIssueStatus',
+    'updateIssueSeverity',
+    'updateIssueName',
+    'updateIssueDescription',
+])
+
 export interface IssuesDataNodeLogicProps {
     query: DataNodeLogicProps['query']
     key: DataNodeLogicProps['key']
@@ -89,6 +101,9 @@ export interface issuesDataNodeLogicActions {
         error: unknown
         mutationName: string
     } // issueActionsLogic
+    mutationSuccess: (mutationName: string) => {
+        mutationName: string
+    } // issueActionsLogic
     resolveIssues: (ids: string[]) => {
         ids: string[]
     } // issueActionsLogic
@@ -101,6 +116,13 @@ export interface issuesDataNodeLogicActions {
     ) => {
         assignee: ErrorTrackingIssueAssignee | null
         id: string
+    } // issueActionsLogic
+    updateIssueSeverity: (
+        id: string,
+        severity: null | import('~/queries/schema').ErrorTrackingQueryIssueSeverity
+    ) => {
+        id: string
+        severity: null | import('~/queries/schema').ErrorTrackingQueryIssueSeverity
     } // issueActionsLogic
     updateIssueStatus: (
         id: string,
@@ -268,6 +290,8 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
                     'assignIssues',
                     'updateIssueAssignee',
                     'updateIssueStatus',
+                    'updateIssueSeverity',
+                    'mutationSuccess',
                     'mutationFailure',
                     'clearNeedsReload',
                 ],
@@ -434,7 +458,24 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
             }
         },
 
-        // on mutation success a phantom pending update is injected into the query, so it reloads itself
+        updateIssueSeverity: ({ id, severity }) => {
+            const response = values.response
+            if (response) {
+                const results = ('results' in response ? response.results : []) as ErrorTrackingIssue[]
+                const recordIndex = results.findIndex((r) => r.id === id)
+                if (recordIndex > -1) {
+                    const issue = { ...results[recordIndex], severity }
+                    results.splice(recordIndex, 1, issue)
+                    actions.setResponse({ ...response, results })
+                }
+            }
+        },
+
+        mutationSuccess: ({ mutationName }) => {
+            if (ISSUE_STATE_MUTATION_NAMES.has(mutationName)) {
+                actions.reloadData()
+            }
+        },
         mutationFailure: () => actions.reloadData(),
     })),
 

--- a/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
+++ b/products/error_tracking/frontend/logics/issuesDataNodeLogic.tsx
@@ -434,12 +434,11 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
             const response = values.response
             if (response) {
                 const results = ('results' in response ? response.results : []) as ErrorTrackingIssue[]
-                const recordIndex = results.findIndex((r) => r.id === id)
-                if (recordIndex > -1) {
-                    const issue = { ...results[recordIndex], assignee }
-                    results.splice(recordIndex, 1, issue)
-                    // optimistically update local results
-                    actions.setResponse({ ...response, results: results })
+                if (results.some((issue) => issue.id === id)) {
+                    actions.setResponse({
+                        ...response,
+                        results: results.map((issue) => (issue.id === id ? { ...issue, assignee } : issue)),
+                    })
                 }
             }
         },
@@ -448,12 +447,11 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
             const response = values.response
             if (response) {
                 const results = ('results' in response ? response.results : []) as ErrorTrackingIssue[]
-                const recordIndex = results.findIndex((r) => r.id === id)
-                if (recordIndex > -1) {
-                    const issue = { ...results[recordIndex], status }
-                    results.splice(recordIndex, 1, issue)
-                    // optimistically update local results
-                    actions.setResponse({ ...response, results: results })
+                if (results.some((issue) => issue.id === id)) {
+                    actions.setResponse({
+                        ...response,
+                        results: results.map((issue) => (issue.id === id ? { ...issue, status } : issue)),
+                    })
                 }
             }
         },
@@ -462,11 +460,11 @@ export const issuesDataNodeLogic = kea<issuesDataNodeLogicType>([
             const response = values.response
             if (response) {
                 const results = ('results' in response ? response.results : []) as ErrorTrackingIssue[]
-                const recordIndex = results.findIndex((r) => r.id === id)
-                if (recordIndex > -1) {
-                    const issue = { ...results[recordIndex], severity }
-                    results.splice(recordIndex, 1, issue)
-                    actions.setResponse({ ...response, results })
+                if (results.some((issue) => issue.id === id)) {
+                    actions.setResponse({
+                        ...response,
+                        results: results.map((issue) => (issue.id === id ? { ...issue, severity } : issue)),
+                    })
                 }
             }
         },

--- a/products/error_tracking/frontend/logics/pendingFingerprintIssueStateUpdateLogic.ts
+++ b/products/error_tracking/frontend/logics/pendingFingerprintIssueStateUpdateLogic.ts
@@ -7,7 +7,7 @@ import { ErrorTrackingIssue, ErrorTrackingPendingFingerprintIssueStateUpdate } f
 
 import { errorTrackingIssueSceneLogic } from '../scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic'
 import { issuesDataNodeLogic } from './issuesDataNodeLogic'
-import { applyDelta, buildPendingUpdate, CurrentIssueState, IssueStateDelta } from './pendingUpdateHelpers'
+import { buildPendingUpdate, CurrentIssueState } from './pendingUpdateHelpers'
 
 // CH sync typically lands in seconds; 60s is generous.
 export const PENDING_UPDATE_TTL_MS = 60_000
@@ -31,13 +31,6 @@ export interface pendingFingerprintIssueStateUpdateLogicActions {
     ) => {
         primaryId: string
         sourceIds: string[]
-    }
-    capturePendingUpdatesForIssues: (
-        issueIds: string[],
-        delta: IssueStateDelta
-    ) => {
-        delta: IssueStateDelta
-        issueIds: string[]
     }
     clearAll: () => {
         value: true
@@ -65,7 +58,6 @@ export const pendingFingerprintIssueStateUpdateLogic = kea<pendingFingerprintIss
 
     actions({
         addPendingUpdates: (rows: ErrorTrackingPendingFingerprintIssueStateUpdate[]) => ({ rows }),
-        capturePendingUpdatesForIssues: (issueIds: string[], delta: IssueStateDelta) => ({ issueIds, delta }),
         captureMergePendingUpdates: (primaryId: string, sourceIds: string[]) => ({ primaryId, sourceIds }),
         clearAll: true,
     }),
@@ -120,17 +112,6 @@ export const pendingFingerprintIssueStateUpdateLogic = kea<pendingFingerprintIss
     }),
 
     listeners(({ actions }) => ({
-        capturePendingUpdatesForIssues: async ({ issueIds, delta }) => {
-            const uniqueIds = Array.from(new Set(issueIds)).filter(Boolean)
-            if (uniqueIds.length === 0) {
-                return
-            }
-            const fingerprintMap = await resolveFingerprintsForIssues(uniqueIds)
-            const rows = buildCaptureRows(uniqueIds, fingerprintMap, delta)
-            if (rows.length > 0) {
-                actions.addPendingUpdates(rows)
-            }
-        },
         captureMergePendingUpdates: async ({ primaryId, sourceIds }) => {
             const allIds = Array.from(new Set([primaryId, ...sourceIds])).filter(Boolean)
             const primaryState = allIds.length > 0 ? findCurrentIssueState(primaryId) : null
@@ -208,26 +189,6 @@ async function resolveFingerprintsForIssues(
     }
 
     return result
-}
-
-function buildCaptureRows(
-    issueIds: string[],
-    fingerprintMap: Record<string, string[]>,
-    delta: IssueStateDelta
-): ErrorTrackingPendingFingerprintIssueStateUpdate[] {
-    const version = Date.now()
-    const rows: ErrorTrackingPendingFingerprintIssueStateUpdate[] = []
-    for (const id of issueIds) {
-        const current = findCurrentIssueState(id)
-        if (!current) {
-            continue
-        }
-        const merged = applyDelta(current, delta)
-        for (const fp of fingerprintMap[id] ?? []) {
-            rows.push(buildPendingUpdate(fp, id, merged, version))
-        }
-    }
-    return rows
 }
 
 function buildMergeRows(

--- a/products/error_tracking/frontend/logics/pendingUpdateHelpers.ts
+++ b/products/error_tracking/frontend/logics/pendingUpdateHelpers.ts
@@ -5,14 +5,6 @@ import {
     ErrorTrackingPendingFingerprintIssueStateUpdate,
 } from '~/queries/schema/schema-general'
 
-export interface IssueStateDelta {
-    status?: ErrorTrackingIssueStatus
-    severity?: ErrorTrackingQueryIssueSeverity | null
-    name?: string | null
-    description?: string | null
-    assignee?: ErrorTrackingIssueAssignee | null
-}
-
 export interface CurrentIssueState {
     id: string
     name: string | null
@@ -21,17 +13,6 @@ export interface CurrentIssueState {
     severity: ErrorTrackingQueryIssueSeverity | null
     assignee: ErrorTrackingIssueAssignee | null
     first_seen: string
-}
-
-export function applyDelta(current: CurrentIssueState, delta: IssueStateDelta): CurrentIssueState {
-    return {
-        ...current,
-        status: delta.status ?? current.status,
-        severity: delta.severity !== undefined ? delta.severity : current.severity,
-        name: delta.name !== undefined ? delta.name : current.name,
-        description: delta.description !== undefined ? delta.description : current.description,
-        assignee: delta.assignee !== undefined ? delta.assignee : current.assignee,
-    }
 }
 
 export function buildPendingUpdate(


### PR DESCRIPTION
## Problem

Error tracking mutations fetch issue fingerprints and send temporary client rows after the request succeeds.

The parent PR makes recent Postgres state authoritative on the server. Keeping client rows would retain the 50-fingerprint limit and duplicate work.

Depends on #87915.

## Changes

- Status, assignment, name, and description mutations no longer resolve fingerprints or create temporary state rows.
- Existing list and detail reducers continue to show optimistic state while requests run.n- Successful state mutations force an authoritative reload after the optimistic update.
- Issue merges continue to create fingerprint-level rows because mappings can still lag in ClickHouse.
- Dead state-capture actions and helpers are removed.

## How did you test this code?

- Ran 28 focused error tracking frontend tests across issue actions, issue data, issue lists, and query construction.
- Ran the full frontend TypeScript check.
- Ran frontend Oxlint fixes and Oxfmt.
- Regenerated the two affected Kea logic types.
- Not run: `hogli ci:preflight` because it requires Git metadata unavailable in this Jujutsu workspace.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This removes an internal consistency workaround after the server-side replacement.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi removed the client state rows while preserving the merge mapping overlay and existing optimistic reducers.

Skills invoked: `/error-tracking`, `/stacking-prs`, `/writing-ui-components`, `/placing-product-frontend-code`, `/writing-kea-logics`, `/adopting-generated-api-types`, `/writing-tests`, `/writing-pr-descriptions`, and `/pr`.

The change contains no private customer material.