### PR TITLE
feat(experiments): show metric actions only on hover

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -783,7 +783,7 @@ export function MetricRowGroup({
                 >
                     {/* Metric column: real header spanning every variant row, stays interactive while loading */}
                     <td
-                        className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
+                        className={`group/metric-cell w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
                             !isLastMetric ? 'border-b' : ''
                         } ${bg}`}
                         rowSpan={skeletonVariantKeys.length}
@@ -861,7 +861,7 @@ export function MetricRowGroup({
                 >
                     {/* Metric column - always visible */}
                     <td
-                        className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
+                        className={`group/metric-cell w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
                             !isLastMetric ? 'border-b' : ''
                         } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                         // eslint-disable-next-line react/forbid-dom-props
@@ -977,7 +977,7 @@ export function MetricRowGroup({
             >
                 {/* Metric column - with rowspan */}
                 <td
-                    className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${!isLastMetric ? 'border-b' : ''} ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                    className={`group/metric-cell w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${!isLastMetric ? 'border-b' : ''} ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                     rowSpan={variantResults.length + 1}
                     // eslint-disable-next-line react/forbid-dom-props
                     style={totalRowsHeightStyle}

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
@@ -264,7 +265,14 @@ export const MetricHeader = ({
                         </div>
                     </div>
                     {!readOnly && (
-                        <div className="flex flex-shrink-0 gap-1">
+                        <div
+                            className={clsx(
+                                'flex flex-shrink-0 gap-1 transition-opacity',
+                                menuVisible
+                                    ? 'opacity-100'
+                                    : 'opacity-0 group-hover/metric-cell:opacity-100 focus-within:opacity-100'
+                            )}
+                        >
                             <LemonButton
                                 type="tertiary"
                                 size="xsmall"

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -270,7 +270,7 @@ export const MetricHeader = ({
                                 'flex flex-shrink-0 gap-1 transition-opacity',
                                 menuVisible
                                     ? 'opacity-100'
-                                    : 'opacity-0 group-hover/metric-cell:opacity-100 focus-within:opacity-100'
+                                    : 'opacity-0 group-hover/metric-cell:opacity-100 focus-within:opacity-100 pointer-coarse:opacity-100'
                             )}
                         >
                             <LemonButton


### PR DESCRIPTION
## Problem

The edit and more-actions buttons sit on every metric row in the experiment metrics table at all times, cluttering an otherwise minimal view.

## Changes

- The pencil and ellipsis buttons on a metric are now hidden until the pointer hovers over the metric cell.
- They stay visible while the actions menu is open and when a button holds keyboard focus.
- Mechanical: the metric cell in `MetricRowGroup` gets a named Tailwind group class; `MetricHeader` toggles opacity off it.

## How did you test this code?

Not run: visual verification in the app, since this branch lives in a light worktree without a runnable frontend. The change is limited to CSS classes on existing elements.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code in a worktree on request. Skills invoked: /wt, /writing-pr-descriptions.
