### PR TITLE
chore(devex): score test selection against product failures too

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -17,8 +17,9 @@
 #   additionally skips these on trunk-merge/** branches to save GITHUB_TOKEN budget;
 #   the shadow strips them entirely, so that gating has nothing to mirror), snapshot
 #   auto-commit (handle-snapshots), posthog-github-action telemetry (including the
-#   capture-test-selection job — select-tests still emits its telemetry outputs to
-#   stay apples-to-apples, they just have no consumer here),
+#   capture-test-selection and capture-test-selection-verdict jobs — select-tests
+#   still emits its telemetry outputs to stay apples-to-apples, they just have no
+#   consumer here),
 #   --store-durations write, test-selection verdict, Trunk flaky-test quarantine
 #   gate (canonical runs per-shard analytics-uploader steps that post to the
 #   external Trunk service; the upload is best-effort and a local "Fail on test

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3874,8 +3874,13 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.changes.result != 'skipped' }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        # Security invariant: this job runs PR-head-controlled scripts (the selector and the
+        # verdict). Never add secrets beyond github.token here; capture-test-selection-verdict
+        # below holds the DevEx token and reads only this job's output.
         permissions:
             contents: read
+        outputs:
+            telemetry: ${{ steps.telemetry.outputs.json }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -3887,10 +3892,12 @@ jobs:
               with:
                   version: '0.11.28'
 
+            # Both matrices: the verdict scores the Django shards and the product shards
+            # separately, telling them apart by artifact name.
             - name: Download JUnit artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
-                  pattern: junit-results-backend-*
+                  pattern: '{junit-results-backend,product-junit-results}-*'
                   path: /tmp/junit-results/
               continue-on-error: true
 
@@ -3926,6 +3933,12 @@ jobs:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   PR_SHA: ${{ github.event.pull_request.head.sha }}
                   PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+                  # What select-tests decided for this run. A verdict computed on a run where
+                  # selection was not trusted (mode=full, skip_reason=untrusted) is the shadow
+                  # measurement for widening the trust rule, so the reason has to travel with it.
+                  SELECTION_MODE: ${{ needs.select-tests.outputs.mode }}
+                  SELECTION_SKIP_REASON: ${{ needs.select-tests.outputs.skip_reason }}
+                  RUN_LEGACY_REASON: ${{ needs.select-tests.outputs.run_legacy_reason }}
               run: |
                   set -euo pipefail
                   mkdir -p /tmp/verdict
@@ -3957,6 +3970,71 @@ jobs:
                   name: test-selection-verdict-pr${{ github.event.pull_request.number }}
                   path: /tmp/verdict/
                   retention-days: 90
+
+            # Counts only, never the file lists: event properties stay small and the query side
+            # groups by reason and conclusion, not by test file.
+            - name: Summarize the verdict for telemetry
+              id: telemetry
+              env:
+                  RUN_ID: ${{ github.run_id }}
+                  RUN_ATTEMPT: ${{ github.run_attempt }}
+              run: |
+                  {
+                      echo 'json<<VERDICT_EOF'
+                      jq -c --arg run_id "$RUN_ID" --argjson run_attempt "$RUN_ATTEMPT" '{
+                          suite: "backend",
+                          run_id: $run_id,
+                          run_attempt: $run_attempt,
+                          pr_number: (.pr | tonumber? // null),
+                          sha,
+                          branch,
+                          selection_mode,
+                          selection_skip_reason,
+                          run_legacy_reason,
+                          selected_test_count,
+                          full_run_triggered,
+                          full_run_reasons_count: (.full_run_reasons | length),
+                          django_conclusion: .django.conclusion,
+                          django_failure_count: .django.failure_count,
+                          django_caught_count: (.django.caught | length),
+                          django_missed_count: (.django.missed | length),
+                          django_recall: .django.recall,
+                          products_conclusion: .products.conclusion,
+                          products_failure_count: .products.failure_count,
+                          products_caught_count: (.products.caught | length),
+                          products_missed_count: (.products.missed | length),
+                          products_recall: .products.recall,
+                          products_selected_product_count: (.products.selected_products | length),
+                          products_failed_product_count: (.products.failed_products | length),
+                          products_missed_product_count: (.products.missed_products | length),
+                          products_product_recall: .products.product_recall
+                      }' /tmp/verdict/verdict.json
+                      echo 'VERDICT_EOF'
+                  } >> "$GITHUB_OUTPUT"
+
+    capture-test-selection-verdict:
+        name: Capture test selection verdict
+        needs: [test-selection-verdict]
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        # Its own job so the DevEx token never reaches test-selection-verdict, which runs
+        # PR-head scripts. Same-repo PRs only: forks and Dependabot never have the secret.
+        # Every attempt, unlike capture-test-selection: a re-run that recovers a flake changes
+        # the verdict, and the query side keeps the latest attempt per run_id.
+        # continue-on-error so telemetry never reds CI.
+        if: |
+            !cancelled()
+            && needs.test-selection-verdict.result == 'success'
+            && github.actor != 'dependabot[bot]'
+            && github.event.pull_request.head.repo.full_name == 'PostHog/posthog'
+        steps:
+            - name: Capture test selection verdict to DevEx PostHog
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  event: 'posthog-ci-test-selection-verdict'
+                  properties: ${{ needs.test-selection-verdict.outputs.telemetry }}
 
     calculate-running-time:
         name: Calculate running time

--- a/tools/test_selection_verdict.py
+++ b/tools/test_selection_verdict.py
@@ -7,9 +7,12 @@
 # ///
 """Compare test selection against actual JUnit failures to produce a verdict.
 
-Evaluates whether the shadow test selector would have caught the tests
-that actually failed in CI. Outputs a JSON verdict suitable for batch
-collection across PRs.
+Evaluates whether the shadow test selector would have caught the tests that
+actually failed in CI, separately for the two matrices ci-backend runs: the
+Django shards (junit-results-backend-* artifacts) and the product shards
+(product-junit-results-* artifacts). The product side is scored twice: by test
+file, like Django, and by product, which is the grain the product matrix is
+built at. Outputs a JSON verdict suitable for batch collection across PRs.
 """
 
 from __future__ import annotations
@@ -21,6 +24,16 @@ import argparse
 from pathlib import Path
 
 from defusedxml import ElementTree
+
+DJANGO = "django"
+PRODUCTS = "products"
+
+# select-tests only runs on PRs, so these are empty on every other trigger.
+CONTEXT_ENV_VARS = {
+    "selection_mode": "SELECTION_MODE",
+    "selection_skip_reason": "SELECTION_SKIP_REASON",
+    "run_legacy_reason": "RUN_LEGACY_REASON",
+}
 
 
 def classname_to_filepath(classname: str) -> str:
@@ -44,8 +57,28 @@ def classname_to_filepath(classname: str) -> str:
     return "/".join(file_parts) + ".py"
 
 
-def parse_junit_failures(junit_dir: Path) -> tuple[list[str], int, int]:
-    """Parse all JUnit XML files and return (failed_test_files, total_tests_run, xml_files_seen)."""
+def junit_side(xml_file: Path, junit_dir: Path) -> str:
+    """Which matrix produced a JUnit file.
+
+    download-artifact unpacks each artifact into a directory named after it, so the
+    first path component under junit_dir is the artifact name. turbo-tests stages its
+    files as junit-product-<name>.xml, which also identifies a file on its own.
+    """
+    try:
+        artifact = xml_file.relative_to(junit_dir).parts[0]
+    except ValueError:
+        artifact = ""
+    if artifact.startswith("product-junit-results-") or xml_file.name.startswith("junit-product-"):
+        return PRODUCTS
+    return DJANGO
+
+
+def parse_junit_failures(junit_dir: Path, side: str | None = None) -> tuple[list[str], int, int]:
+    """Parse JUnit XML files and return (failed_test_files, total_tests_run, xml_files_seen).
+
+    With `side`, only files from that matrix count; the others are invisible to
+    all three results.
+    """
     failed_files: set[str] = set()
     total_tests = 0
     xml_files_seen = 0
@@ -54,6 +87,8 @@ def parse_junit_failures(junit_dir: Path) -> tuple[list[str], int, int]:
         return [], 0, 0
 
     for xml_file in sorted(junit_dir.rglob("*.xml")):
+        if side is not None and junit_side(xml_file, junit_dir) != side:
+            continue
         xml_files_seen += 1
         try:
             tree = ElementTree.parse(xml_file)
@@ -85,124 +120,167 @@ def parse_junit_failures(junit_dir: Path) -> tuple[list[str], int, int]:
     return sorted(failed_files), total_tests, xml_files_seen
 
 
-def compute_verdict(
-    selection_path: Path,
-    junit_dir: Path,
+def product_of(path: str) -> str | None:
+    parts = path.split("/")
+    if len(parts) >= 3 and parts[0] == "products":
+        return parts[1]
+    return None
+
+
+def score(failed: list[str], selected: set[str], full_run_triggered: bool) -> tuple[list[str], list[str], float | None]:
+    """Split failures into caught and missed. Returns (caught, missed, recall).
+
+    A selector that asked for a full run would have executed every failure, so
+    counting those as missed against the narrowed list would skew recall.
+    """
+    if not failed:
+        return [], [], None
+    if full_run_triggered:
+        return list(failed), [], 1.0
+    caught = sorted(f for f in failed if f in selected)
+    missed = sorted(f for f in failed if f not in selected)
+    return caught, missed, len(caught) / len(failed)
+
+
+def side_verdict(
+    failed_test_files: list[str],
+    total_tests_run: int,
+    xml_files_seen: int,
+    selected: set[str],
+    full_run_triggered: bool,
 ) -> dict[str, object]:
+    # No JUnit XMLs means we don't actually know what happened: the upstream
+    # artifact upload may have failed, the job may have run before tests
+    # finished, or this matrix was skipped. Emit "unknown" rather than the
+    # misleading "success" we'd otherwise infer from "0 failures observed".
+    if xml_files_seen == 0:
+        conclusion = "unknown"
+    elif not failed_test_files:
+        conclusion = "success"
+    else:
+        conclusion = "failure"
+
+    caught, missed, recall = score(failed_test_files, selected, full_run_triggered)
+    return {
+        "conclusion": conclusion,
+        "junit_xml_files_seen": xml_files_seen,
+        "total_tests_run": total_tests_run,
+        "failure_count": len(failed_test_files),
+        "failed_test_files": failed_test_files,
+        "caught": caught,
+        "missed": missed,
+        "recall": recall,
+    }
+
+
+def product_level(failed_files: list[str], selected: set[str], full_run_triggered: bool) -> dict[str, object]:
+    """Score the product side at the grain the product matrix is built at.
+
+    The question is whether a product matrix narrowed to the products the selector
+    touched would still have run the failing product's suite.
+    """
+    selected_products = sorted({p for p in (product_of(t) for t in selected) if p})
+    failed_products = sorted({p for p in (product_of(f) for f in failed_files) if p})
+    caught, missed, recall = score(failed_products, set(selected_products), full_run_triggered)
+    return {
+        "selected_products": selected_products,
+        "failed_products": failed_products,
+        "caught_products": caught,
+        "missed_products": missed,
+        "product_recall": recall,
+    }
+
+
+def compute_verdict(selection_path: Path, junit_dir: Path) -> dict[str, object]:
     """Build the verdict JSON comparing selection against actual failures."""
     with open(selection_path) as f:
         selection = json.load(f)
 
-    failed_test_files, total_tests_run, xml_files_seen = parse_junit_failures(junit_dir)
-
     combined = selection.get("combined", {})
     selected_tests: list[str] = combined.get("tests", [])
-    selected_set = set(selected_tests)
+    selected = set(selected_tests)
 
     ast_data = selection.get("ast", {})
     full_run_reasons: list[str] = ast_data.get("full_run_reasons", [])
     full_run_triggered = len(full_run_reasons) > 0
 
-    # No JUnit XMLs means we don't actually know what happened — the upstream
-    # artifact upload may have failed or the job may have run before tests
-    # finished. Emit "unknown" rather than the misleading "success" we'd
-    # otherwise infer from "0 failures observed".
-    if xml_files_seen == 0:
-        conclusion = "unknown"
-        recall: float | None = None
-        caught: list[str] = []
-        missed: list[str] = []
-    elif not failed_test_files:
-        conclusion = "success"
-        recall = None
-        caught = []
-        missed = []
-    elif full_run_triggered:
-        # Selector explicitly opted into running the whole suite, so every
-        # failure would have been executed. Recording these as "missed"
-        # against `combined.tests` would skew the recall metric.
-        conclusion = "failure"
-        caught = list(failed_test_files)
-        missed = []
-        recall = 1.0
-    else:
-        conclusion = "failure"
-        caught = sorted(f for f in failed_test_files if f in selected_set)
-        missed = sorted(f for f in failed_test_files if f not in selected_set)
-        recall = len(caught) / len(failed_test_files)
-
-    pr = os.environ.get("PR_NUMBER", "")
-    sha = os.environ.get("PR_SHA", "")
-    branch = os.environ.get("PR_BRANCH", "")
+    django = side_verdict(*parse_junit_failures(junit_dir, DJANGO), selected, full_run_triggered)
+    product_failures = parse_junit_failures(junit_dir, PRODUCTS)
+    products = side_verdict(*product_failures, selected, full_run_triggered)
+    products.update(product_level(product_failures[0], selected, full_run_triggered))
 
     return {
-        "pr": pr,
-        "sha": sha,
-        "branch": branch,
-        "backend_conclusion": conclusion,
-        "junit_xml_files_seen": xml_files_seen,
-        "total_tests_run": total_tests_run,
-        "failure_count": len(failed_test_files),
-        "failed_test_files": failed_test_files,
+        "pr": os.environ.get("PR_NUMBER", ""),
+        "sha": os.environ.get("PR_SHA", ""),
+        "branch": os.environ.get("PR_BRANCH", ""),
+        **{key: os.environ.get(var, "") for key, var in CONTEXT_ENV_VARS.items()},
         "selected_test_count": len(selected_tests),
-        "caught": caught,
-        "missed": missed,
-        "recall": recall,
         "full_run_triggered": full_run_triggered,
         "full_run_reasons": full_run_reasons,
+        DJANGO: django,
+        PRODUCTS: products,
     }
+
+
+def format_side(title: str, side: dict[str, object]) -> list[str]:
+    lines: list[str] = [f"### {title}", ""]
+    conclusion = side["conclusion"]
+    failure_count = side["failure_count"]
+    recall = side["recall"]
+
+    if conclusion == "unknown":
+        lines.append("Conclusion unknown. No JUnit XML artifacts were found for this matrix.")
+    elif conclusion == "success":
+        lines.append("Passed. No failures to evaluate recall against.")
+    else:
+        recall_str = f"{recall:.0%}" if isinstance(recall, float) else "n/a"
+        lines.append(f"**File recall: {recall_str}** ({failure_count} failed test files)")
+        product_recall = side.get("product_recall")
+        if isinstance(product_recall, float):
+            failed_products = side.get("failed_products", [])
+            assert isinstance(failed_products, list)
+            lines.append(f"**Product recall: {product_recall:.0%}** ({len(failed_products)} failed products)")
+        lines.append("")
+
+        for label, key in (("Caught", "caught"), ("Missed", "missed"), ("Missed products", "missed_products")):
+            items = side.get(key, [])
+            assert isinstance(items, list)
+            if items:
+                lines.append("")
+                lines.append(f"**{label}** ({len(items)}):")
+                lines.extend(f"- `{item}`" for item in items)
+
+    lines.append("")
+    return lines
 
 
 def format_summary(verdict: dict[str, object]) -> str:
     """Produce a concise markdown summary for GITHUB_STEP_SUMMARY."""
-    lines: list[str] = []
-    lines.append("## Test selection verdict")
+    lines: list[str] = ["## Test selection verdict", ""]
+
+    context = ", ".join(f"{key}={verdict[key]}" for key in CONTEXT_ENV_VARS if verdict.get(key))
+    lines.append(
+        f"{verdict['selected_test_count']} tests selected by the shadow selector" + (f" ({context})" if context else "")
+    )
+    if verdict.get("full_run_triggered"):
+        lines.append("")
+        lines.append("Full-run mode was active, so every failure counts as caught.")
     lines.append("")
 
-    conclusion = verdict["backend_conclusion"]
-    failure_count = verdict["failure_count"]
-    recall = verdict["recall"]
-    selected = verdict["selected_test_count"]
-    full_run_triggered = verdict.get("full_run_triggered", False)
-
-    if conclusion == "unknown":
-        lines.append("Backend conclusion unknown — no JUnit XML artifacts were found.")
-        lines.append("")
-        lines.append(f"{selected} tests would have been selected by the shadow selector.")
-    elif conclusion == "success":
-        lines.append(f"Backend passed. {selected} tests were selected by the shadow selector.")
-        lines.append("")
-        lines.append("No failures to evaluate recall against.")
-    else:
-        recall_str = f"{recall:.0%}" if recall is not None else "n/a"
-        lines.append(f"**Recall: {recall_str}** ({failure_count} failed test files, {selected} selected)")
-        if full_run_triggered:
-            lines.append("")
-            lines.append("Full-run mode was active, so every failure counts as caught.")
-        lines.append("")
-
-        caught = verdict.get("caught", [])
-        missed = verdict.get("missed", [])
-
-        if caught:
-            lines.append(f"**Caught** ({len(caught)}):")
-            for f in caught:
-                lines.append(f"- `{f}`")
-
-        if missed:
-            lines.append("")
-            lines.append(f"**Missed** ({len(missed)}):")
-            for f in missed:
-                lines.append(f"- `{f}`")
+    django = verdict[DJANGO]
+    products = verdict[PRODUCTS]
+    assert isinstance(django, dict)
+    assert isinstance(products, dict)
+    lines.extend(format_side("Django matrix", django))
+    lines.extend(format_side("Product matrix", products))
 
     full_run_reasons = verdict.get("full_run_reasons", [])
+    assert isinstance(full_run_reasons, list)
     if full_run_reasons:
+        lines.append("**Full-run triggered**, so the selector would have run everything anyway:")
+        lines.extend(f"- {reason}" for reason in full_run_reasons)
         lines.append("")
-        lines.append("**Full-run triggered** — selector would have run everything anyway:")
-        for reason in full_run_reasons:
-            lines.append(f"- {reason}")
 
-    lines.append("")
     return "\n".join(lines)
 
 

--- a/tools/test_selection_verdict.py
+++ b/tools/test_selection_verdict.py
@@ -21,6 +21,7 @@ import os
 import sys
 import json
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 
 from defusedxml import ElementTree
@@ -73,18 +74,32 @@ def junit_side(xml_file: Path, junit_dir: Path) -> str:
     return DJANGO
 
 
-def parse_junit_failures(junit_dir: Path, side: str | None = None) -> tuple[list[str], int, int]:
-    """Parse JUnit XML files and return (failed_test_files, total_tests_run, xml_files_seen).
+@dataclass(frozen=True, kw_only=True, slots=True)
+class JunitResults:
+    failed_test_files: list[str]
+    total_tests_run: int
+    xml_files_seen: int
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Score:
+    caught: list[str]
+    missed: list[str]
+    recall: float | None
+
+
+def parse_junit_failures(junit_dir: Path, side: str | None = None) -> JunitResults:
+    """Parse JUnit XML files under junit_dir.
 
     With `side`, only files from that matrix count; the others are invisible to
-    all three results.
+    every field of the result.
     """
     failed_files: set[str] = set()
     total_tests = 0
     xml_files_seen = 0
 
     if not junit_dir.exists():
-        return [], 0, 0
+        return JunitResults(failed_test_files=[], total_tests_run=0, xml_files_seen=0)
 
     for xml_file in sorted(junit_dir.rglob("*.xml")):
         if side is not None and junit_side(xml_file, junit_dir) != side:
@@ -117,7 +132,9 @@ def parse_junit_failures(junit_dir: Path, side: str | None = None) -> tuple[list
                     if classname:
                         failed_files.add(classname_to_filepath(classname))
 
-    return sorted(failed_files), total_tests, xml_files_seen
+    return JunitResults(
+        failed_test_files=sorted(failed_files), total_tests_run=total_tests, xml_files_seen=xml_files_seen
+    )
 
 
 def product_of(path: str) -> str | None:
@@ -127,49 +144,43 @@ def product_of(path: str) -> str | None:
     return None
 
 
-def score(failed: list[str], selected: set[str], full_run_triggered: bool) -> tuple[list[str], list[str], float | None]:
-    """Split failures into caught and missed. Returns (caught, missed, recall).
+def score(failed: list[str], selected: set[str], full_run_triggered: bool) -> Score:
+    """Split failures into caught and missed.
 
     A selector that asked for a full run would have executed every failure, so
     counting those as missed against the narrowed list would skew recall.
     """
     if not failed:
-        return [], [], None
+        return Score(caught=[], missed=[], recall=None)
     if full_run_triggered:
-        return list(failed), [], 1.0
+        return Score(caught=list(failed), missed=[], recall=1.0)
     caught = sorted(f for f in failed if f in selected)
     missed = sorted(f for f in failed if f not in selected)
-    return caught, missed, len(caught) / len(failed)
+    return Score(caught=caught, missed=missed, recall=len(caught) / len(failed))
 
 
-def side_verdict(
-    failed_test_files: list[str],
-    total_tests_run: int,
-    xml_files_seen: int,
-    selected: set[str],
-    full_run_triggered: bool,
-) -> dict[str, object]:
+def side_verdict(results: JunitResults, selected: set[str], full_run_triggered: bool) -> dict[str, object]:
     # No JUnit XMLs means we don't actually know what happened: the upstream
     # artifact upload may have failed, the job may have run before tests
     # finished, or this matrix was skipped. Emit "unknown" rather than the
     # misleading "success" we'd otherwise infer from "0 failures observed".
-    if xml_files_seen == 0:
+    if results.xml_files_seen == 0:
         conclusion = "unknown"
-    elif not failed_test_files:
+    elif not results.failed_test_files:
         conclusion = "success"
     else:
         conclusion = "failure"
 
-    caught, missed, recall = score(failed_test_files, selected, full_run_triggered)
+    scored = score(results.failed_test_files, selected, full_run_triggered)
     return {
         "conclusion": conclusion,
-        "junit_xml_files_seen": xml_files_seen,
-        "total_tests_run": total_tests_run,
-        "failure_count": len(failed_test_files),
-        "failed_test_files": failed_test_files,
-        "caught": caught,
-        "missed": missed,
-        "recall": recall,
+        "junit_xml_files_seen": results.xml_files_seen,
+        "total_tests_run": results.total_tests_run,
+        "failure_count": len(results.failed_test_files),
+        "failed_test_files": results.failed_test_files,
+        "caught": scored.caught,
+        "missed": scored.missed,
+        "recall": scored.recall,
     }
 
 
@@ -181,13 +192,13 @@ def product_level(failed_files: list[str], selected: set[str], full_run_triggere
     """
     selected_products = sorted({p for p in (product_of(t) for t in selected) if p})
     failed_products = sorted({p for p in (product_of(f) for f in failed_files) if p})
-    caught, missed, recall = score(failed_products, set(selected_products), full_run_triggered)
+    scored = score(failed_products, set(selected_products), full_run_triggered)
     return {
         "selected_products": selected_products,
         "failed_products": failed_products,
-        "caught_products": caught,
-        "missed_products": missed,
-        "product_recall": recall,
+        "caught_products": scored.caught,
+        "missed_products": scored.missed,
+        "product_recall": scored.recall,
     }
 
 
@@ -204,10 +215,10 @@ def compute_verdict(selection_path: Path, junit_dir: Path) -> dict[str, object]:
     full_run_reasons: list[str] = ast_data.get("full_run_reasons", [])
     full_run_triggered = len(full_run_reasons) > 0
 
-    django = side_verdict(*parse_junit_failures(junit_dir, DJANGO), selected, full_run_triggered)
-    product_failures = parse_junit_failures(junit_dir, PRODUCTS)
-    products = side_verdict(*product_failures, selected, full_run_triggered)
-    products.update(product_level(product_failures[0], selected, full_run_triggered))
+    django = side_verdict(parse_junit_failures(junit_dir, DJANGO), selected, full_run_triggered)
+    product_results = parse_junit_failures(junit_dir, PRODUCTS)
+    products = side_verdict(product_results, selected, full_run_triggered)
+    products.update(product_level(product_results.failed_test_files, selected, full_run_triggered))
 
     return {
         "pr": os.environ.get("PR_NUMBER", ""),

--- a/tools/test_test_selection_verdict.py
+++ b/tools/test_test_selection_verdict.py
@@ -119,29 +119,29 @@ class TestParseJunitFailures(unittest.TestCase):
     def test_returns_zero_when_dir_missing(self) -> None:
         verdict = _load_verdict_module()
         with tempfile.TemporaryDirectory() as root:
-            failures, total, seen = verdict.parse_junit_failures(Path(root) / "missing")
-            self.assertEqual(failures, [])
-            self.assertEqual(total, 0)
-            self.assertEqual(seen, 0)
+            results = verdict.parse_junit_failures(Path(root) / "missing")
+            self.assertEqual(results.failed_test_files, [])
+            self.assertEqual(results.total_tests_run, 0)
+            self.assertEqual(results.xml_files_seen, 0)
 
     def test_extracts_failures_with_classname_mapping(self) -> None:
         verdict = _load_verdict_module()
         with tempfile.TemporaryDirectory() as root:
             junit_dir = Path(root)
             _write_junit(junit_dir, "junit-core.xml", JUNIT_FAILURE)
-            failures, total, seen = verdict.parse_junit_failures(junit_dir)
-            self.assertEqual(failures, ["posthog/api/test/test_foo.py"])
-            self.assertEqual(total, 2)
-            self.assertEqual(seen, 1)
+            results = verdict.parse_junit_failures(junit_dir)
+            self.assertEqual(results.failed_test_files, ["posthog/api/test/test_foo.py"])
+            self.assertEqual(results.total_tests_run, 2)
+            self.assertEqual(results.xml_files_seen, 1)
 
     def test_finds_testcases_in_nested_testsuites(self) -> None:
         verdict = _load_verdict_module()
         with tempfile.TemporaryDirectory() as root:
             junit_dir = Path(root)
             _write_junit(junit_dir, "junit.xml", JUNIT_NESTED_FAILURE)
-            failures, total, _seen = verdict.parse_junit_failures(junit_dir)
-            self.assertEqual(failures, ["posthog/api/test/test_nested.py"])
-            self.assertEqual(total, 1)
+            results = verdict.parse_junit_failures(junit_dir)
+            self.assertEqual(results.failed_test_files, ["posthog/api/test/test_nested.py"])
+            self.assertEqual(results.total_tests_run, 1)
 
     def test_skips_malformed_xml(self) -> None:
         verdict = _load_verdict_module()
@@ -149,10 +149,10 @@ class TestParseJunitFailures(unittest.TestCase):
             junit_dir = Path(root)
             _write_junit(junit_dir, "good.xml", JUNIT_ALL_PASS)
             _write_junit(junit_dir, "bad.xml", "<not valid xml")
-            failures, total, seen = verdict.parse_junit_failures(junit_dir)
-            self.assertEqual(failures, [])
-            self.assertEqual(total, 1)
-            self.assertEqual(seen, 2)
+            results = verdict.parse_junit_failures(junit_dir)
+            self.assertEqual(results.failed_test_files, [])
+            self.assertEqual(results.total_tests_run, 1)
+            self.assertEqual(results.xml_files_seen, 2)
 
 
 class TestJunitSide(unittest.TestCase):
@@ -175,10 +175,10 @@ class TestJunitSide(unittest.TestCase):
             junit_dir = Path(root)
             _write_junit(junit_dir, DJANGO_XML, JUNIT_FAILURE)
             _write_junit(junit_dir, PRODUCT_XML, JUNIT_PRODUCT_FAILURE)
-            failures, total, seen = verdict.parse_junit_failures(junit_dir, side="products")
-            self.assertEqual(failures, ["products/error_tracking/backend/tests/test_issues.py"])
-            self.assertEqual(total, 1)
-            self.assertEqual(seen, 1)
+            results = verdict.parse_junit_failures(junit_dir, side="products")
+            self.assertEqual(results.failed_test_files, ["products/error_tracking/backend/tests/test_issues.py"])
+            self.assertEqual(results.total_tests_run, 1)
+            self.assertEqual(results.xml_files_seen, 1)
 
 
 class TestComputeVerdict(unittest.TestCase):

--- a/tools/test_test_selection_verdict.py
+++ b/tools/test_test_selection_verdict.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import json
 import tempfile
@@ -8,6 +9,7 @@ from pathlib import Path
 from types import ModuleType
 
 import unittest
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -25,7 +27,7 @@ def _load_verdict_module() -> ModuleType:
 
 
 def _write_junit(junit_dir: Path, name: str, content: str) -> None:
-    junit_dir.mkdir(parents=True, exist_ok=True)
+    (junit_dir / name).parent.mkdir(parents=True, exist_ok=True)
     (junit_dir / name).write_text(content)
 
 
@@ -68,6 +70,19 @@ JUNIT_ALL_PASS = """<?xml version="1.0" encoding="utf-8"?>
     </testsuite>
 </testsuites>
 """
+
+JUNIT_PRODUCT_FAILURE = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" tests="1" failures="1">
+        <testcase classname="products.error_tracking.backend.tests.test_issues.TestIssues" name="test_fail">
+            <failure message="assert False">Traceback...</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+"""
+
+DJANGO_XML = "junit-results-backend-core-1/junit-core.xml"
+PRODUCT_XML = "product-junit-results-0/junit-product-error_tracking.xml"
 
 
 class TestClassnameToFilepath(unittest.TestCase):
@@ -140,6 +155,32 @@ class TestParseJunitFailures(unittest.TestCase):
             self.assertEqual(seen, 2)
 
 
+class TestJunitSide(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("django_artifact", DJANGO_XML, "django"),
+            ("product_artifact", PRODUCT_XML, "products"),
+            ("product_file_without_artifact_dir", "junit-product-error_tracking.xml", "products"),
+            ("django_file_without_artifact_dir", "junit-core.xml", "django"),
+        ]
+    )
+    def test_side_from_artifact_layout(self, _name: str, relative: str, expected: str) -> None:
+        verdict = _load_verdict_module()
+        junit_dir = Path("/tmp/junit-results")
+        self.assertEqual(verdict.junit_side(junit_dir / relative, junit_dir), expected)
+
+    def test_side_filter_hides_other_matrix(self) -> None:
+        verdict = _load_verdict_module()
+        with tempfile.TemporaryDirectory() as root:
+            junit_dir = Path(root)
+            _write_junit(junit_dir, DJANGO_XML, JUNIT_FAILURE)
+            _write_junit(junit_dir, PRODUCT_XML, JUNIT_PRODUCT_FAILURE)
+            failures, total, seen = verdict.parse_junit_failures(junit_dir, side="products")
+            self.assertEqual(failures, ["products/error_tracking/backend/tests/test_issues.py"])
+            self.assertEqual(total, 1)
+            self.assertEqual(seen, 1)
+
+
 class TestComputeVerdict(unittest.TestCase):
     def _run(
         self,
@@ -147,6 +188,7 @@ class TestComputeVerdict(unittest.TestCase):
         combined_tests: list[str],
         full_run_reasons: list[str] | None = None,
         junit_files: list[tuple[str, str]] | None = None,
+        env: dict[str, str] | None = None,
     ) -> dict[str, object]:
         verdict = _load_verdict_module()
         with tempfile.TemporaryDirectory() as root:
@@ -158,58 +200,102 @@ class TestComputeVerdict(unittest.TestCase):
             for name, content in junit_files or []:
                 _write_junit(junit_dir, name, content)
 
-            return verdict.compute_verdict(selection_path, junit_dir)
+            with patch.dict(os.environ, env or {}, clear=False):
+                return verdict.compute_verdict(selection_path, junit_dir)
 
     def test_unknown_when_no_junit_xmls_found(self) -> None:
         result = self._run(combined_tests=["posthog/api/test/test_foo.py"])
-        self.assertEqual(result["backend_conclusion"], "unknown")
-        self.assertIsNone(result["recall"])
-        self.assertEqual(result["caught"], [])
-        self.assertEqual(result["missed"], [])
-        self.assertEqual(result["junit_xml_files_seen"], 0)
+        for side in ("django", "products"):
+            self.assertEqual(result[side]["conclusion"], "unknown")
+            self.assertIsNone(result[side]["recall"])
+            self.assertEqual(result[side]["caught"], [])
+            self.assertEqual(result[side]["missed"], [])
+            self.assertEqual(result[side]["junit_xml_files_seen"], 0)
 
     def test_success_when_all_pass(self) -> None:
         result = self._run(
             combined_tests=["posthog/api/test/test_bar.py"],
-            junit_files=[("junit.xml", JUNIT_ALL_PASS)],
+            junit_files=[(DJANGO_XML, JUNIT_ALL_PASS)],
         )
-        self.assertEqual(result["backend_conclusion"], "success")
-        self.assertIsNone(result["recall"])
-        self.assertEqual(result["failure_count"], 0)
+        self.assertEqual(result["django"]["conclusion"], "success")
+        self.assertIsNone(result["django"]["recall"])
+        self.assertEqual(result["django"]["failure_count"], 0)
+        self.assertEqual(result["products"]["conclusion"], "unknown")
 
-    def test_failure_caught_when_in_selection(self) -> None:
-        result = self._run(
-            combined_tests=["posthog/api/test/test_foo.py", "posthog/api/test/test_other.py"],
-            junit_files=[("junit.xml", JUNIT_FAILURE)],
-        )
-        self.assertEqual(result["backend_conclusion"], "failure")
-        self.assertEqual(result["recall"], 1.0)
-        self.assertEqual(result["caught"], ["posthog/api/test/test_foo.py"])
-        self.assertEqual(result["missed"], [])
-
-    def test_failure_missed_when_not_in_selection(self) -> None:
-        result = self._run(
-            combined_tests=["posthog/api/test/test_unrelated.py"],
-            junit_files=[("junit.xml", JUNIT_FAILURE)],
-        )
-        self.assertEqual(result["backend_conclusion"], "failure")
-        self.assertEqual(result["recall"], 0.0)
-        self.assertEqual(result["caught"], [])
-        self.assertEqual(result["missed"], ["posthog/api/test/test_foo.py"])
+    @parameterized.expand(
+        [
+            (
+                "caught",
+                ["posthog/api/test/test_foo.py", "posthog/api/test/test_other.py"],
+                1.0,
+                ["posthog/api/test/test_foo.py"],
+                [],
+            ),
+            ("missed", ["posthog/api/test/test_unrelated.py"], 0.0, [], ["posthog/api/test/test_foo.py"]),
+        ]
+    )
+    def test_django_failure_scored_against_selection(
+        self, _name: str, combined_tests: list[str], recall: float, caught: list[str], missed: list[str]
+    ) -> None:
+        result = self._run(combined_tests=combined_tests, junit_files=[(DJANGO_XML, JUNIT_FAILURE)])
+        self.assertEqual(result["django"]["conclusion"], "failure")
+        self.assertEqual(result["django"]["recall"], recall)
+        self.assertEqual(result["django"]["caught"], caught)
+        self.assertEqual(result["django"]["missed"], missed)
 
     def test_full_run_treats_failures_as_caught(self) -> None:
-        # Selection's combined.tests does NOT include the failing file, but
+        # Selection's combined.tests does NOT include the failing files, but
         # full_run_reasons indicates the selector opted into running everything.
         result = self._run(
             combined_tests=["posthog/api/test/test_unrelated.py"],
             full_run_reasons=["conftest.py matches full-run pattern"],
-            junit_files=[("junit.xml", JUNIT_FAILURE)],
+            junit_files=[(DJANGO_XML, JUNIT_FAILURE), (PRODUCT_XML, JUNIT_PRODUCT_FAILURE)],
         )
-        self.assertEqual(result["backend_conclusion"], "failure")
         self.assertTrue(result["full_run_triggered"])
-        self.assertEqual(result["recall"], 1.0)
-        self.assertEqual(result["caught"], ["posthog/api/test/test_foo.py"])
-        self.assertEqual(result["missed"], [])
+        self.assertEqual(result["django"]["recall"], 1.0)
+        self.assertEqual(result["django"]["missed"], [])
+        self.assertEqual(result["products"]["recall"], 1.0)
+        self.assertEqual(result["products"]["product_recall"], 1.0)
+        self.assertEqual(result["products"]["missed_products"], [])
+
+    @parameterized.expand(
+        [
+            ("file_selected", ["products/error_tracking/backend/tests/test_issues.py"], 1.0, 1.0, []),
+            ("other_file_same_product", ["products/error_tracking/backend/tests/test_other.py"], 0.0, 1.0, []),
+            ("other_product", ["products/tasks/backend/tests/test_other.py"], 0.0, 0.0, ["error_tracking"]),
+        ]
+    )
+    def test_product_failure_scored_by_file_and_by_product(
+        self, _name: str, combined_tests: list[str], recall: float, product_recall: float, missed_products: list[str]
+    ) -> None:
+        result = self._run(combined_tests=combined_tests, junit_files=[(PRODUCT_XML, JUNIT_PRODUCT_FAILURE)])
+        products = result["products"]
+        self.assertEqual(products["conclusion"], "failure")
+        self.assertEqual(products["recall"], recall)
+        self.assertEqual(products["product_recall"], product_recall)
+        self.assertEqual(products["failed_products"], ["error_tracking"])
+        self.assertEqual(products["missed_products"], missed_products)
+
+    def test_product_failure_does_not_count_against_django_side(self) -> None:
+        result = self._run(
+            combined_tests=["posthog/api/test/test_bar.py"],
+            junit_files=[(DJANGO_XML, JUNIT_ALL_PASS), (PRODUCT_XML, JUNIT_PRODUCT_FAILURE)],
+        )
+        self.assertEqual(result["django"]["conclusion"], "success")
+        self.assertEqual(result["products"]["conclusion"], "failure")
+
+    def test_records_selection_context_from_env(self) -> None:
+        result = self._run(
+            combined_tests=[],
+            env={
+                "SELECTION_MODE": "full",
+                "SELECTION_SKIP_REASON": "untrusted",
+                "RUN_LEGACY_REASON": "contract_cascade",
+            },
+        )
+        self.assertEqual(result["selection_mode"], "full")
+        self.assertEqual(result["selection_skip_reason"], "untrusted")
+        self.assertEqual(result["run_legacy_reason"], "contract_cascade")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

- Nobody can tell whether the backend test selector would catch a failure in the product matrix, so that matrix cannot be narrowed by file yet.
- The verdict job scored only the Django shards. The product JUnit was never read.
- Verdicts from runs where select-tests did not trust the selector carry no record of why, so recall cannot be sliced by trust reason.
- Verdicts exist only as 90-day artifacts, so measuring recall across PRs means downloading them by hand.

## Changes

- The verdict job now scores the product shards too, by test file and by product. Product recall answers whether a matrix narrowed to the selector's products would still run the failing suite.
- Each verdict records the select-tests mode, its skip reason, and turbo-discover's run_legacy reason.
- A new job sends the counts to the DevEx PostHog project as `posthog-ci-test-selection-verdict`. It is a separate job because test-selection-verdict runs PR-head scripts and must not see the token.
- The verdict JSON now has `django` and `products` blocks instead of flat backend fields. Nothing in the repo reads the old shape.
- Mechanical: the Depot shadow header lists the new job as stripped.

No matrix decision changes. Nothing is user-visible.

```mermaid
flowchart LR
    A[django_tests] --> V[test-selection-verdict]
    B[turbo-tests] -.->|needs only| V
    V --> R[(verdict artifact)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,B,V phBlue;
    class R phGray;
```

```mermaid
flowchart LR
    A[django_tests] -->|Django JUnit| V[test-selection-verdict]
    B[turbo-tests] -->|product JUnit| V
    S[select-tests] -->|mode, reasons| V
    V --> R[(verdict artifact)]
    V -->|counts| C[capture-test-selection-verdict]
    C --> P[DevEx PostHog]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,B,S,V,C phBlue;
    class P phRed;
    class R phGray;
```

## How did you test this code?

- New cases in `tools/test_test_selection_verdict.py`: a product failure no longer counts against the Django side, product-level recall differs from file-level recall when another file in the same product is selected, and the context env vars land in the verdict.
- The script and the jq telemetry expression ran locally against fixture JUnit for both matrices.
- Both PR runs so far ([first](https://github.com/PostHog/posthog/actions/runs/32745370628), [second](https://github.com/PostHog/posthog/actions/runs/32746790727)) produced a verdict and a capture, and both events are queryable in the DevEx project with every property set.
- Expected values for a draft that ran no tests: mode `skip`, reason `full_run_requested` (this PR edits `ci-backend.yml`), both matrices `unknown`. A ready PR or a merge-queue run is the first one that scores real failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) in the session linked from the commit. Skills invoked: /authoring-ci-workflows, /writing-tests, /writing-code-comments, /writing-pr-descriptions, /simplify.

The first plan also dropped the early skip in select-tests so the selector would run on untrusted PRs. The verdict job already regenerates the selection off the critical path when the artifact is missing, so select-tests is untouched. This PR is the measurement step; widening the trust rule and narrowing the product matrix wait for its numbers.
