### PR TITLE
feat(data-warehouse): add the Redshift destination writer

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_destination.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_destination.py
@@ -24,6 +24,7 @@ from products.warehouse_sources.backend.facade.models import ExternalDataDestina
 # a user cannot select one until its writer ships.
 DESTINATION_INTEGRATION_KINDS: dict[str, tuple[str, ...]] = {
     str(ExternalDataDestination.Type.POSTGRES): (str(Integration.IntegrationKind.POSTGRESQL),),
+    str(ExternalDataDestination.Type.REDSHIFT): (str(Integration.IntegrationKind.AWS_REDSHIFT),),
 }
 
 # Types a user may create. The PostHog warehouse row is created by the sync itself the first

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/destinations_load/builtin_writers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/destinations_load/builtin_writers.py
@@ -1,6 +1,6 @@
 """Registering the writers that ship with warehouse sources.
 
-Only Postgres ships here. The other destination types have writers built on batch exports'
+Postgres and Redshift ship here. The other destination types have writers built on batch exports'
 clients, parked on `tom/dwh-destination-writers-parked`, and each one lands in its own change
 once it has been run against that warehouse. Registering a type whose writer has never
 executed is how a customer discovers it does not work.
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.destinations.regis
 # claiming a type with no writer would lease the group and then fail every batch in it.
 SUPPORTED_DESTINATION_TYPES: list[str] = [
     str(ExternalDataDestination.Type.POSTGRES),
+    str(ExternalDataDestination.Type.REDSHIFT),
 ]
 
 
@@ -38,8 +39,12 @@ def register_builtin_destination_writers() -> None:
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.destinations_load.writers.postgres import (  # noqa: PLC0415
         PostgresDestinationWriter,
     )
+    from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.destinations_load.writers.redshift import (  # noqa: PLC0415
+        RedshiftDestinationWriter,
+    )
 
     register_destination_writer(ExternalDataDestination.Type.POSTGRES, PostgresDestinationWriter)
+    register_destination_writer(ExternalDataDestination.Type.REDSHIFT, RedshiftDestinationWriter)
 
 
 def builtin_destination_types() -> list[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/destinations_load/writers/redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/destinations_load/writers/redshift.py
@@ -1,0 +1,182 @@
+"""Delivering a run's batches to Redshift.
+
+Redshift speaks the Postgres wire protocol, so this builds on the Postgres writer and on batch
+exports' `RedshiftClient`, which is itself a `PostgreSQLClient`. A Redshift destination is
+backed by an `aws-redshift` integration, which is a `PostgreSQLServerIntegration` and so
+carries the cluster's host, user and password.
+
+Three things genuinely differ and are overridden here:
+
+- No `COPY ... FROM STDIN`. Rows are inserted through a client cursor instead.
+- No unbounded `TEXT`. Columns are `VARCHAR(MAX)`, and nested values go in `SUPER`.
+- No unique indexes, so no `ON CONFLICT`. Upserts go through `RedshiftClient.amerge_tables`,
+  which merges on the key alone once its version-aware delete is turned off.
+
+`RedshiftClient.acopy_from_s3_bucket` would be the fast path, since a run's batches are
+already parquet in S3. It is not usable as-is: it needs a MANIFEST file and an IAM role or AWS
+credentials that let the customer's cluster read the bucket the parquet sits in, which is a
+PostHog bucket. Batch exports solve that by staging into a customer-owned bucket first.
+Wiring that up here is follow-up work.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, ClassVar, cast
+
+import pyarrow as pa
+from psycopg import sql
+
+from posthog.models.integration import Integration, RedshiftIntegration
+
+from products.batch_exports.backend.temporal.destinations.postgres_batch_export import Fields, PostgreSQLClient
+from products.batch_exports.backend.temporal.destinations.redshift_batch_export import RedshiftClient
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.destinations_load.writers.postgres import (
+    PostgresDestinationWriter,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.destinations_load.writers.sql_types import (
+    is_nested_type,
+)
+
+# Redshift's widest string type, which holds 65535 bytes. Nothing here asks the cluster to
+# truncate, so a longer value fails the statement instead of being cut short: batch exports
+# reports the same overflow as `StringLimitExceededError` and never retries it.
+VARCHAR_MAX = "VARCHAR(MAX)"
+
+_REDSHIFT_BY_ARROW = {
+    pa.bool_(): "BOOLEAN",
+    pa.int8(): "SMALLINT",
+    pa.int16(): "SMALLINT",
+    pa.int32(): "INTEGER",
+    pa.int64(): "BIGINT",
+    pa.uint8(): "SMALLINT",
+    pa.uint16(): "INTEGER",
+    pa.uint32(): "BIGINT",
+    pa.uint64(): "NUMERIC(20, 0)",
+    pa.float16(): "REAL",
+    pa.float32(): "REAL",
+    pa.float64(): "DOUBLE PRECISION",
+    pa.string(): VARCHAR_MAX,
+    pa.large_string(): VARCHAR_MAX,
+    pa.binary(): VARCHAR_MAX,
+    pa.large_binary(): VARCHAR_MAX,
+    pa.date32(): "DATE",
+    pa.date64(): "DATE",
+}
+
+
+def redshift_type_for(arrow_type: pa.DataType) -> str:
+    mapped = _REDSHIFT_BY_ARROW.get(arrow_type)
+    if mapped is not None:
+        return mapped
+    if pa.types.is_timestamp(arrow_type):
+        return "TIMESTAMPTZ" if arrow_type.tz else "TIMESTAMP"
+    if pa.types.is_time(arrow_type):
+        return "TIME"
+    if pa.types.is_decimal(arrow_type):
+        return f"NUMERIC({arrow_type.precision}, {arrow_type.scale})"
+    if is_nested_type(arrow_type):
+        # SUPER holds semi-structured values without flattening them, so a struct that grows a
+        # field keeps loading instead of needing a schema change.
+        return "SUPER"
+    return VARCHAR_MAX
+
+
+class RedshiftDestinationWriter(PostgresDestinationWriter):
+    holds_sync_lock: ClassVar[bool] = False
+    runs_post_load: ClassVar[bool] = False
+
+    integration_kind: ClassVar[str] = RedshiftIntegration.integration_kind
+
+    def _client_from_integration(self, integration: Integration) -> PostgreSQLClient:
+        return RedshiftClient.from_inputs(RedshiftIntegration(integration), database=self._database)
+
+    def _column_type(self, arrow_type: pa.DataType) -> str:
+        return redshift_type_for(arrow_type)
+
+    async def _load_batch(
+        self, client: PostgreSQLClient, table: str, batch: pa.RecordBatch, column_names: list[str]
+    ) -> None:
+        """Insert rather than COPY FROM STDIN, which Redshift does not support."""
+        statement = sql.SQL("INSERT INTO {}.{} ({}) VALUES ({})").format(
+            sql.Identifier(self._schema),
+            sql.Identifier(table),
+            sql.SQL(", ").join(sql.Identifier(c) for c in column_names),
+            sql.SQL(", ").join(sql.Placeholder() for _ in column_names),
+        )
+        payload = [[_encode(record.get(name)) for name in column_names] for record in batch.to_pylist()]
+
+        async with self._write_cursor(client) as cursor:
+            await cursor.executemany(statement, payload)
+
+    @asynccontextmanager
+    async def _merge_stage(
+        self, client: PostgreSQLClient, target: str, stage: str, schema: pa.Schema
+    ) -> AsyncIterator[str]:
+        """Stage a batch in a copy of the destination table.
+
+        `amerge_tables` inserts an unmatched row positionally, so the stage has to carry the
+        destination's own columns in the destination's own order. Copying the destination's
+        definition is the only way to hold that for a table this writer grows column by
+        column. Columns the batch does not carry stay NULL, which is what the row would have
+        held anyway.
+        """
+        async with self._write_cursor(client) as cursor:
+            # A previous attempt at this batch may have died before dropping the stage, and
+            # its rows are not this batch's.
+            await cursor.execute(
+                sql.SQL("DROP TABLE IF EXISTS {}.{}").format(sql.Identifier(self._schema), sql.Identifier(stage))
+            )
+            await cursor.execute(
+                sql.SQL("CREATE TABLE {}.{} (LIKE {}.{})").format(
+                    sql.Identifier(self._schema),
+                    sql.Identifier(stage),
+                    sql.Identifier(self._schema),
+                    sql.Identifier(target),
+                )
+            )
+
+        async with client.managed_table(self._schema, stage, [], create=False, delete=True) as name:
+            yield name
+
+    async def _upsert_from_stage(
+        self,
+        client: PostgreSQLClient,
+        target: str,
+        stage: str,
+        column_names: list[str],
+        primary_keys: list[str],
+    ) -> None:
+        """Merge the stage into the destination on the primary keys.
+
+        `skip_delete` turns off the pass `amerge_tables` runs for the person model, which
+        drops stage rows older than the row they would replace and so needs a column that only
+        ever increases. A synced source table has none, and without that pass what is left is
+        a plain upsert on the merge key. Going through `amerge_tables` still brings the
+        `SERIALIZABLE` lock, the schema-mismatch diagnostic and the string-limit mapping.
+        """
+        # The stage was created from the destination, so both share this order. Only the name
+        # in each field is read, which is why the types are left empty.
+        final_table_fields: Fields = [(name, "") for name in await client.aget_table_columns(self._schema, target)]
+        merge_key: Fields = [(key, "") for key in primary_keys]
+
+        await cast(RedshiftClient, client).amerge_tables(
+            final_table_name=target,
+            stage_table_name=stage,
+            schema=self._schema,
+            merge_key=merge_key,
+            # Only read to build the delete that `skip_delete` suppresses.
+            update_key=[],
+            final_table_fields=final_table_fields,
+            remove_duplicates=False,
+            skip_delete=True,
+        )
+
+
+def _encode(value: Any) -> Any:
+    """Send nested values as JSON text, which Redshift parses into SUPER."""
+    if isinstance(value, dict | list):
+        return json.dumps(value)
+    return value


### PR DESCRIPTION
## Problem

A warehouse source can sync a table to Postgres (#86986) and to nowhere else. Redshift is the most requested of the remaining destinations, and it is the cheapest to add: it speaks the Postgres wire protocol, so it builds on the writer that already ships.

## Changes

Adds `RedshiftDestinationWriter`, which subclasses the Postgres writer and swaps three things Redshift does differently.

**Taken from batch exports:** `RedshiftClient`, which is itself a `PostgreSQLClient`, so the connection, retrying connect and SSL handling come with it. Credentials come from an `aws-redshift` integration, which is a PostgreSQL-server integration and carries the cluster's host, user and password.

Merges go through `amerge_tables(skip_delete=True, remove_duplicates=False)`. That is a plain upsert on the merge key with no version-column requirement, and it brings the serializable `LOCK TABLE` guard, the schema-mismatch diagnostic and the over-length-value error mapping.

**Kept local, with the reason in the file:**

- `VARCHAR(MAX)` and `SUPER` column types. Redshift has no unbounded `TEXT`, and `SUPER` holds a nested value without flattening it.
- No unique indexes, which Redshift does not have.
- Rows insert through a client cursor rather than `COPY ... FROM STDIN`, which Redshift does not support.

`RedshiftClient.acopy_from_s3_bucket` would be faster, since a run's batches are already parquet in S3. It needs a MANIFEST and credentials letting the customer's cluster read the bucket, and the bucket is PostHog's. Batch exports solves that by staging into a customer-owned bucket first. That is separate work.

## How did you test this code?

Not against a Redshift cluster. Covered here: the writer registers, resolves by type, and conforms to the writer protocol.

Worth knowing for whoever verifies it: because the writer is Postgres-wire, a good deal of it could be exercised against a local Postgres 15, which supports `MERGE`. The type mapping and `SUPER` handling could not.

> [!WARNING]
> **This writer has never run against Redshift.** No statement in it has been executed. This environment has no cluster, so the coverage below is registration and protocol conformance only.
>
> Do not merge until someone has run a real sync to a real Redshift. The track record on this feature is that the code is wrong until it runs: the end-to-end tests found six defects in the delivery path, and the audit that produced this writer found a merge that inlined one placeholder per row at 50,000 rows a batch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The destinations doc under `products/warehouse_sources/backend/temporal/data_imports/pipelines/README.md` covers the mechanism, and it does not name individual destinations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The writer was first hand-rolled against the vendor SDK. An audit against batch exports rebuilt it on the shared client, which is what this PR contains. The audit's findings for this destination are listed above, including the ones not addressed.

This branch and its five siblings each add one writer on top of #86986. They all touch `builtin_writers.py` and the destination-kinds map, so whichever lands second conflicts there. The conflict is two lines and resolving it is the prompt to check the registry still matches what ships.
