### PR TITLE
fix(new_relic): retry NerdGraph's generic resolver-failure error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/new_relic/new_relic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/new_relic/new_relic.py
@@ -196,7 +196,13 @@ def _execute_graphql(
     if errors:
         messages = "; ".join(str(error.get("message", error)) for error in errors)
         # NerdGraph reports server-side timeouts/deadlines inside `errors` on an HTTP 200.
-        if any(term in messages.lower() for term in ("timeout", "deadline", "too many requests")):
+        # "An error occurred resolving this field" is NerdGraph's generic resolver-failure
+        # message; it's known to fire intermittently on otherwise-valid queries and clear on
+        # retry (e.g. the New Relic Terraform provider retries the same message).
+        if any(
+            term in messages.lower()
+            for term in ("timeout", "deadline", "too many requests", "an error occurred resolving this field")
+        ):
             raise NewRelicRetryableError(f"New Relic GraphQL error (retryable): {messages}")
         raise NewRelicGraphQLError(f"New Relic GraphQL error: {messages}")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/new_relic/tests/test_new_relic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/new_relic/tests/test_new_relic.py
@@ -143,6 +143,7 @@ class TestExecuteGraphql:
             ("timeout", "NRQL query timeout after 120 seconds"),
             ("deadline", "Deadline exceeded"),
             ("throttled", "Too many requests"),
+            ("resolver_failure", "An error occurred resolving this field"),
         ]
     )
     def test_transient_graphql_errors_are_retryable(self, _name: str, message: str) -> None:


### PR DESCRIPTION
## Problem

A New Relic warehouse sync fails outright when NerdGraph returns "An error occurred resolving this field" - a generic resolver-failure message the [New Relic Terraform provider](https://github.com/newrelic/terraform-provider-newrelic/issues/2101) reports as intermittent and clearable on retry. Surfaced by an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a03477-2744-7193-8423-9dff057e09cf) raised from `_execute_graphql`.

The source already retries known-transient NerdGraph errors (timeout, deadline, rate limit) matched by message substring, but this one wasn't in that list, so it raised a non-retryable `NewRelicGraphQLError` and killed the sync instead of backing off and retrying.

## Changes

- The sync now retries when NerdGraph's error message contains "an error occurred resolving this field", using the same exponential-backoff retry already in place for other transient NerdGraph errors.

## How did you test this code?

Added a case to `test_transient_graphql_errors_are_retryable` asserting this message raises the retryable error rather than the terminal one. Ran the full `test_new_relic.py` suite (46 tests) locally - all pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal retry-classification change, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue lookup, sample exception event with full stack trace) to confirm the error originates in `new_relic.py`, then read the source and its tests before deciding this was a fixable retry-classification gap rather than a user/upstream credential issue. Searched the web to confirm the error message is a documented, intermittent NerdGraph quirk. Checked for duplicate open PRs (none found).