### PR TITLE
fix(data-imports): stop missing App Store Connect vendor number retrying

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/app_store_connect.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/app_store_connect.py
@@ -104,6 +104,14 @@ APP_STORE_CONNECT_ANALYTICS_INACTIVE_ERROR = (
     "new request, which only an Admin key can create. Give the key the Admin role, then reconnect."
 )
 
+# A sales or subscription report sync started without a vendor number. `/v1/salesReports` can't be
+# read without one, so every retry fails identically until the user adds it in the source settings.
+# `AppStoreConnectSource.get_non_retryable_errors` matches on this text to fail fast.
+APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR = (
+    "Syncing App Store Connect sales reports needs your vendor number. "
+    "Add it in the source settings, then run the sync again."
+)
+
 
 @frozen
 class _AppleApiError:
@@ -783,10 +791,7 @@ def _get_sales_report(
     db_incremental_field_last_value: Any,
 ) -> Iterator[list[dict[str, Any]]]:
     if not vendor_number:
-        raise ValueError(
-            "Syncing App Store Connect sales reports needs your vendor number. "
-            "Add it in the source settings, then run the sync again."
-        )
+        raise ValueError(APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR)
 
     today = datetime.now(UTC).date()
     end = today - timedelta(days=SALES_REPORT_END_OFFSET_DAYS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
@@ -12,6 +12,7 @@ from posthog.schema import (
 from products.warehouse_sources.backend.temporal.data_imports.sources.app_store_connect.app_store_connect import (
     APP_STORE_CONNECT_ANALYTICS_CREATE_FORBIDDEN_ERROR,
     APP_STORE_CONNECT_ANALYTICS_INACTIVE_ERROR,
+    APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR,
     APP_STORE_CONNECT_READ_FORBIDDEN_ERROR,
     AppStoreConnectResumeConfig,
     app_store_connect_source,
@@ -155,6 +156,9 @@ The analytics tables need a key with the Admin role. Apple lets only an Admin ke
             APP_STORE_CONNECT_READ_FORBIDDEN_ERROR: APP_STORE_CONNECT_READ_FORBIDDEN_ERROR,
             # Any 403 that didn't come through the custom raises still fails fast with the read message.
             "403 Client Error: Forbidden for url: https://api.appstoreconnect.apple.com": APP_STORE_CONNECT_READ_FORBIDDEN_ERROR,
+            # A report sync selected without a vendor number can never read `/v1/salesReports`, so fail
+            # fast instead of retrying the activity's whole budget until the user adds the number.
+            APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR: APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR,
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -14,6 +14,7 @@ from posthog.schema import (
 from products.warehouse_sources.backend.temporal.data_imports.sources.app_store_connect.app_store_connect import (
     APP_STORE_CONNECT_ANALYTICS_CREATE_FORBIDDEN_ERROR,
     APP_STORE_CONNECT_ANALYTICS_INACTIVE_ERROR,
+    APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR,
     APP_STORE_CONNECT_READ_FORBIDDEN_ERROR,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.app_store_connect.settings import (
@@ -191,6 +192,13 @@ class TestAppStoreConnectSource:
         assert valid is False
         assert error is not None and "vendor number" in error
         mocked.assert_not_called()
+
+    def test_missing_vendor_number_is_non_retryable(self) -> None:
+        # A report sync raises this ValueError when no vendor number is set. It can never succeed on
+        # retry, so the source must classify it non-retryable rather than burn the activity's budget.
+        friendly = _resolve_friendly_error(APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR)
+
+        assert friendly is not None
 
     def test_auth_and_permission_failures_are_non_retryable(self) -> None:
         errors = cast(dict[str, Any], AppStoreConnectSource().get_non_retryable_errors())


### PR DESCRIPTION
## Problem

A team syncing App Store Connect sales or subscription reports without a vendor number saw the sync retry for hours and never finish, while the same error hit error tracking on every attempt.

- The report endpoints read `/v1/salesReports`, which Apple cannot serve without a vendor number.
- When the number is missing, shared pipeline code raises a `ValueError` before any request.
- The source did not list this message as non-retryable, so the import activity retried its whole budget.
- Each retry logged the exception, so one misconfigured source produced repeated noise in error tracking. See [issue 01a03481](https://us.posthog.com/project/2/error_tracking/01a03481-b753-76d1-98c5-b60443b742ba).

## Changes

- A report sync missing its vendor number now fails fast with the message telling the user to add the number in source settings, instead of retrying and re-reporting.
- `AppStoreConnectSource.get_non_retryable_errors` maps the raised message to itself, so the finalization layer surfaces the same actionable wording (mechanical).
- The message moves to `APP_STORE_CONNECT_MISSING_VENDOR_NUMBER_ERROR`, shared by the raise site and the matcher so they cannot drift (mechanical).

This stays user/config, not a PostHog bug: the number can only be added in source settings, and no retry recovers it. The change is scoped to this one message and does not touch retry policy.

## How did you test this code?

- Added `test_missing_vendor_number_is_non_retryable`: the raised constant resolves to a non-null friendly message through the source mapping. Catches a regression where dropping the entry would send the sync back to retrying and re-reporting; no existing test covered the vendor-number classification (401/403 only).
- Ran the source and raise-site suites locally; the raise-site test still matches on the `vendor number` substring after the constant refactor.
- Not run: the Temporal-backed import activity end to end, which needs the full dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking webhook. Traced the stack from the import activity's error handler (`_handle_import_error` in `import_data_sync.py`) to the raise site in `app_store_connect.py`, confirmed the message fell through to the retry-and-report branch, and matched the existing per-source non-retryable pattern (same shape as the Adobe Commerce fix in flight).

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Ruled out duplicates: bot PR #86126 handles Apple's misleading 400 body for empty subscription days (a valid vendor number), a different root cause. No human-authored open PR covers this.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
