### PR TITLE
fix(visual-review): clarify tolerate confirmation

### DIFF
--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -175,9 +175,9 @@ export function SnapshotDiffViewer({
                                     size="small"
                                     onClick={() => {
                                         LemonDialog.open({
-                                            title: 'Does this still render correctly?',
+                                            title: 'Does this snapshot really render correctly?',
                                             description:
-                                                'Only tolerate slight rendering noise above the diff threshold. Confirm there are no visible errors or missing elements. ' +
+                                                'Only tolerate slight rendering noise above the difference threshold. Confirm there are no visible errors or missing elements. ' +
                                                 'Otherwise, quarantine this snapshot.',
                                             primaryButton: {
                                                 children: 'Tolerate',

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -175,10 +175,10 @@ export function SnapshotDiffViewer({
                                     size="small"
                                     onClick={() => {
                                         LemonDialog.open({
-                                            title: 'Tolerate this difference?',
+                                            title: 'Does this still render correctly?',
                                             description:
-                                                'Marks this as rendering noise — future runs with the same hash pass automatically. ' +
-                                                'If this is a bug, fix it instead.',
+                                                'Only tolerate slight rendering noise above the diff threshold. Confirm there are no visible errors or missing elements. ' +
+                                                'Otherwise, quarantine this snapshot.',
                                             primaryButton: {
                                                 children: 'Tolerate',
                                                 onClick: onMarkTolerated,


### PR DESCRIPTION
## Problem

Reviewers could tolerate visual changes without being clearly asked to verify that the snapshot still rendered correctly.

## Why

Toleration is for slight rendering noise above the threshold. Snapshots with visible errors or missing elements should be quarantined instead.

## Changes

- Ask reviewers whether the snapshot still renders correctly.
- Explicitly require no visible errors or missing elements and direct other cases to quarantine.

## How did you test this code?

- `git diff --check`
- Frontend formatter and linter were not run because dependencies are unavailable in the shallow checkout.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex. No repository-provided or public skills were invoked. The change is limited to confirmation-dialog copy.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*