### PR TITLE
feat(tasks): add run status to the workflow task facade contract

### DIFF
--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -645,13 +645,17 @@ class CreatedTaskDTO:
 class WorkflowTaskDTO:
     """Outcome of a workflow's "Create AI task" action.
 
-    ``created`` is False when the request replayed an already-used idempotency key and the
-    ids belong to the previously created task. ``run_id`` is ``None`` only for a replayed
-    task whose run has since been deleted.
+    The stable shape the workflows product reads off the tasks facade: today for the
+    action's own response, and going forward for a per-workflow Tasks tab that lists
+    the runs a workflow has started. ``created`` is False when the request replayed an
+    already-used idempotency key and the ids belong to the previously created task.
+    ``run_id`` and ``run_status`` are ``None`` only for a replayed task whose run has
+    since been deleted. ``run_status`` mirrors ``TaskRun.Status``.
     """
 
     task_id: UUID
     run_id: UUID | None
+    run_status: str | None
     created: bool
 
 

--- a/products/tasks/backend/logic/services/workflow_tasks.py
+++ b/products/tasks/backend/logic/services/workflow_tasks.py
@@ -154,7 +154,12 @@ def create_workflow_task(
 
 def _task_dto(task: Task, *, created: bool) -> contracts.WorkflowTaskDTO:
     run = task.latest_run
-    return contracts.WorkflowTaskDTO(task_id=task.id, run_id=run.id if run is not None else None, created=created)
+    return contracts.WorkflowTaskDTO(
+        task_id=task.id,
+        run_id=run.id if run is not None else None,
+        run_status=run.status if run is not None else None,
+        created=created,
+    )
 
 
 def _find_replayed_task(

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -47,6 +47,7 @@ FACADE_MODULES = [
     "products.tasks.backend.facade.temporal",
     "products.tasks.backend.facade.max_tools",
     "products.tasks.backend.facade.webhooks",
+    "products.tasks.backend.facade.workflow_tasks",
 ]
 
 

--- a/products/tasks/backend/tests/test_workflow_tasks_api.py
+++ b/products/tasks/backend/tests/test_workflow_tasks_api.py
@@ -267,6 +267,7 @@ class TestWorkflowTasksAPI(APIBaseTest):
             team=self.team, hog_flow_id=self.hog_flow.id, owner_id=self.user.id, prompt="look into the alert"
         )
 
+        assert result.run_id is not None
         run = TaskRun.objects.get(id=result.run_id)
         assert result.run_status == run.status == TaskRun.Status.QUEUED
 
@@ -278,6 +279,7 @@ class TestWorkflowTasksAPI(APIBaseTest):
             prompt="look into the alert",
             origin_key="invocation-1",
         )
+        assert first.run_id is not None
         TaskRun.objects.filter(id=first.run_id).delete()
 
         replay = create_workflow_task(

--- a/products/tasks/backend/tests/test_workflow_tasks_api.py
+++ b/products/tasks/backend/tests/test_workflow_tasks_api.py
@@ -15,6 +15,7 @@ from posthog.jwt import PosthogJwtAudience, encode_jwt
 from posthog.models.integration import Integration
 from posthog.models.organization import OrganizationMembership
 
+from products.tasks.backend.logic.services.workflow_tasks import create_workflow_task
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.visibility import task_control_q, task_visibility_q
 from products.workflows.backend.api.workflow_tasks import WorkflowTaskCreateSerializer
@@ -260,6 +261,36 @@ class TestWorkflowTasksAPI(APIBaseTest):
         assert replay.json()["id"] == first.json()["id"]
         assert replay.json()["run_id"] == first.json()["run_id"]
         assert Task.objects.filter(hog_flow_id=self.hog_flow.id).count() == 1
+
+    def test_run_status_reflects_the_created_runs_status(self) -> None:
+        result = create_workflow_task(
+            team=self.team, hog_flow_id=self.hog_flow.id, owner_id=self.user.id, prompt="look into the alert"
+        )
+
+        run = TaskRun.objects.get(id=result.run_id)
+        assert result.run_status == run.status == TaskRun.Status.QUEUED
+
+    def test_run_status_is_none_for_a_replay_whose_run_was_since_deleted(self) -> None:
+        first = create_workflow_task(
+            team=self.team,
+            hog_flow_id=self.hog_flow.id,
+            owner_id=self.user.id,
+            prompt="look into the alert",
+            origin_key="invocation-1",
+        )
+        TaskRun.objects.filter(id=first.run_id).delete()
+
+        replay = create_workflow_task(
+            team=self.team,
+            hog_flow_id=self.hog_flow.id,
+            owner_id=self.user.id,
+            prompt="look into the alert",
+            origin_key="invocation-1",
+        )
+
+        assert replay.created is False
+        assert replay.run_id is None
+        assert replay.run_status is None
 
     @patch("products.tasks.backend.logic.services.workflow_tasks.get_active_installations")
     def test_a_replay_succeeds_even_after_connectors_and_the_limit_would_reject_it(


### PR DESCRIPTION
## Problem

The workflows product creates AI tasks through `products/tasks/backend/facade/workflow_tasks.py`, but the returned `WorkflowTaskDTO` only carries a task id, run id and created flag. A planned per-workflow Tasks tab needs to show whether a started run is queued, running, or finished, and the DTO had no documented promise to stay the one shape workflows reads instead of reaching into tasks internals.

## Changes

- `WorkflowTaskDTO` gains `run_status`, mirroring `TaskRun.Status`.
- `run_status` is `None` only when a replay's run has since been deleted, matching the existing `run_id` behavior.
- The docstring states the DTO is the stable shape for both the current create-task action and the planned Tasks tab.
- `workflow_tasks` joins the facade import/symbol-resolution check in `test_facade.py`.
- Mechanical: no other symbol in `products/tasks/backend/facade/` changed, and no callers outside the tasks product were touched.

## How did you test this code?

- Added `test_run_status_reflects_the_created_runs_status`: catches a mapper regression that drops or misreads the run's actual status.
- Added `test_run_status_is_none_for_a_replay_whose_run_was_since_deleted`: catches a regression where a replay of a task whose run was deleted would crash or return a stale status instead of `None` — this replay path previously had no direct test.
- Ran `products/tasks/backend/tests/test_workflow_tasks_api.py` and `test_facade.py::TestFacadeImports` locally against Postgres, Redis, ClickHouse and Kafka: 48 passed, 2 failed. Verified both failures are pre-existing and unrelated — they need a local Temporal server and fail identically on unmodified `master`.
- Ran `ruff check`/`ruff format --check` and `tach check --dependencies --interfaces` on the changed files: clean.
- Ran `mypy` on the two changed source files: clean. Not run: a full repo-wide `mypy` — skipped here given the scope of the change and time cost in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal facade contract, no documented public behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Built with Claude Code (Sonnet 5). Read `products/architecture.md` and the `writing-dataclasses` and `isolating-product-facade-contracts` skill docs to shape the DTO change (frozen `pydantic.dataclasses.dataclass`, `str | None` for a model status field, mapper stays the single place internal-to-external happens). No human directed this task's specifics beyond the original request.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*