### PR TITLE
feat(workflows): link create-ai-task results in workflow run logs

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -2540,6 +2540,53 @@ describe('Hogflow Executor', () => {
             // No variables should be set since no result was produced
             expect(result.invocation.state.variables).toBeUndefined()
         })
+
+        it('links a create-ai-task result to the task in the stored action result log', async () => {
+            // Mirrors the shape template-posthog-create-task returns on success: { id, run_id }.
+            // A non-empty inputs_schema sidesteps an insertRow quirk where an empty array param
+            // reaches the jsonb column as an empty object, not an empty array.
+            await insertHogFunctionTemplate(hub.postgres, {
+                id: 'template-posthog-create-task',
+                name: 'Create AI task',
+                code: `return { 'id': 'task-1234', 'run_id': 'run-5678' }`,
+                inputs_schema: [{ key: 'prompt', type: 'string', required: false }],
+            })
+
+            const hogFlow = new FixtureHogFlowBuilder()
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        action_1: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-posthog-create-task',
+                                inputs: {},
+                            },
+                            output_variable: { key: 'task', result_path: null },
+                        } as any,
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'action_1', type: 'continue' },
+                        { from: 'action_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+            const result = await executeToCompletion(hogFlow)
+
+            expect(result.invocation.state.variables?.task).toEqual({ id: 'task-1234', run_id: 'run-5678' })
+            expect(result.logs.some((l) => l.message.includes('task = [Task:task-1234|run-5678]'))).toBe(true)
+        })
     })
 
     describe('billing metrics', () => {

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -889,9 +889,26 @@ export class HogFlowExecutorService {
         }
 
         const storedSummary = allStoredKeys
-            .map((key) => `${key} = ${JSON.stringify(result.invocation.state.variables![key])}`)
+            .map((key) => `${key} = ${this.describeStoredVariable(action, result.invocation.state.variables![key])}`)
             .join(', ')
         this.log(result, 'debug', `Stored action result in variable(s): ${storedSummary}`)
+    }
+
+    // The create-ai-task destination's result variable is what lets a workflow author jump from a
+    // run's logs to the task it kicked off. Everything else stays plain JSON.
+    private describeStoredVariable(action: HogFlowAction, value: unknown): string {
+        const isCreateAiTaskAction =
+            action.type === 'function' && action.config.template_id === 'template-posthog-create-task'
+        if (
+            isCreateAiTaskAction &&
+            value &&
+            typeof value === 'object' &&
+            typeof (value as Record<string, unknown>).id === 'string'
+        ) {
+            const runId = (value as Record<string, unknown>).run_id
+            return `[Task:${(value as Record<string, unknown>).id}|${typeof runId === 'string' ? runId : ''}]`
+        }
+        return JSON.stringify(value)
     }
 
     private logExecutionTriggerInfo(invocation: CyclotronJobInvocationHogFlow): MinimalLogEntry {

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -903,7 +903,8 @@ export class HogFlowExecutorService {
             isCreateAiTaskAction &&
             value &&
             typeof value === 'object' &&
-            typeof (value as Record<string, unknown>).id === 'string'
+            typeof (value as Record<string, unknown>).id === 'string' &&
+            (value as Record<string, unknown>).id !== ''
         ) {
             const runId = (value as Record<string, unknown>).run_id
             return `[Task:${(value as Record<string, unknown>).id}|${typeof runId === 'string' ? runId : ''}]`

--- a/products/workflows/frontend/Workflows/logs/log-utils.test.tsx
+++ b/products/workflows/frontend/Workflows/logs/log-utils.test.tsx
@@ -3,7 +3,18 @@ import { render } from '@testing-library/react'
 import { HogFlow } from '../hogflows/types'
 import { renderWorkflowLogMessage } from './log-utils'
 
-const workflow = { id: 'flow-1', actions: [] } as unknown as HogFlow
+const workflow: HogFlow = {
+    id: 'flow-1',
+    team_id: 1,
+    version: 1,
+    name: 'Test workflow',
+    status: 'draft',
+    exit_condition: 'exit_only_at_end',
+    actions: [],
+    edges: [],
+    created_at: '2026-08-24T00:00:00Z',
+    updated_at: '2026-08-24T00:00:00Z',
+}
 
 describe('renderWorkflowLogMessage', () => {
     it('links a [Task:id|run_id] token to the created task', () => {

--- a/products/workflows/frontend/Workflows/logs/log-utils.test.tsx
+++ b/products/workflows/frontend/Workflows/logs/log-utils.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react'
+
+import { HogFlow } from '../hogflows/types'
+import { renderWorkflowLogMessage } from './log-utils'
+
+const workflow = { id: 'flow-1', actions: [] } as unknown as HogFlow
+
+describe('renderWorkflowLogMessage', () => {
+    it('links a [Task:id|run_id] token to the created task', () => {
+        const { container } = render(
+            renderWorkflowLogMessage(
+                workflow,
+                'Stored action result in variable(s): task = [Task:8b70d61c-ca77-46fb-ba76-3330aaea3dad|80d1779f-6af1-4bfd-855b-556b3d7b2bc0]'
+            )
+        )
+
+        const link = container.querySelector('a')
+        expect(link?.getAttribute('href')).toContain('/code/task/8b70d61c-ca77-46fb-ba76-3330aaea3dad')
+        expect(link?.getAttribute('target')).toBe('_blank')
+        expect(link?.textContent).toContain('View task')
+    })
+})

--- a/products/workflows/frontend/Workflows/logs/log-utils.tsx
+++ b/products/workflows/frontend/Workflows/logs/log-utils.tsx
@@ -17,6 +17,7 @@ const PERSON_REGEX = /\[Person:([a-zA-Z0-9_-]+)\|(.*?)\]/
 const EVENT_REGEX = /\[Event:([a-zA-Z0-9_-]+)\|(.*?)\|(.*?)\]/
 const ACTOR_REGEX = /\[Actor:(.*?)\]/
 const EMAIL_REGEX = /\[Email:([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]*)\]/
+const TASK_REGEX = /\[Task:([a-zA-Z0-9-]+)\|([a-zA-Z0-9-]*)\]/
 
 export const renderWorkflowLogMessage = (workflow: HogFlow, message: string): JSX.Element => {
     // Modifies the rendered log message to auto-detect action or person parts and replace them with a link
@@ -81,6 +82,24 @@ export const renderWorkflowLogMessage = (workflow: HogFlow, message: string): JS
             const actionId = matchesEmailRegex[2]
             elements.push(
                 <EmailViewerChip key={part} workflowId={workflow.id} invocationId={invocationId} actionId={actionId} />
+            )
+            continue
+        }
+
+        const matchesTaskRegex = TASK_REGEX.exec(part)
+        if (matchesTaskRegex) {
+            const taskId = matchesTaskRegex[1]
+
+            elements.push(
+                <Link
+                    key={part}
+                    className="rounded p-1 -m-1 bg-border text-bg-primary"
+                    to={urls.codeTaskLink(taskId)}
+                    target="_blank"
+                    targetBlankIcon
+                >
+                    View task
+                </Link>
             )
             continue
         }


### PR DESCRIPTION
## Problem

A workflow author who kicks off an AI task from a "Create AI task" step has no way to jump from the run's logs to the task it started. The stored-variable log line shows the raw task ID as plain JSON text, so finding the task means copying the ID and searching for it elsewhere.

## Changes

- The "Stored action result in variable(s)" log line for a `create_ai_task` action now shows a clickable "View task" link instead of raw `{"id": ..., "run_id": ...}` JSON.
- The link opens the task in PostHog Desktop, reusing the existing `urls.codeTaskLink` deep link.
- Mechanical: the workflow log renderer gained one more bracket-token pattern (`[Task:id|run_id]`), following the same convention already used for `[Event:...]`, `[Action:...]`, and `[Person:...]` links.

Before:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/528637eaef33b3c7d4c07361e7ffca4d5ac6cb3c/2026/08/de24f5be-d694-4ce9-be21-3cbb759114e9.png)

After:

![after](https://raw.githubusercontent.com/PostHog/pr-assets/6e9c39e4be9bce3a386cdd5dd6bc77e6143db3ec/2026/08/7600b572-3b37-4d01-b1e5-8835ff19036a.png)

## How did you test this code?

- Added a case to `hogflow-executor.service.test.ts` covering a `create_ai_task`-shaped result — guards the `[Task:id|run_id]` token in the stored-variable log line, which no existing test checked.
- Added `log-utils.test.tsx` covering `renderWorkflowLogMessage` rendering that token as a link — the file had no prior test coverage.
- Ran both new tests locally, plus the full `hogflow-executor.service.test.ts` suite (one unrelated pre-existing failure in `email queue routing`, reproduced identically on unmodified master).
- Screenshots above were captured by rendering the real `LogsViewerTable` + `renderWorkflowLogMessage` production components in a temporary Storybook story (not committed), not mocked up separately.
- Not run: a manual click-through in the app UI.

## Docs update

None — no user-facing docs describe this log format.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Implemented with Claude Code. Investigated the workflow log rendering pipeline (`products/workflows/frontend/Workflows/logs/log-utils.tsx`) and the log-generation path (`hogflow-executor.service.ts`) to find the existing bracket-token convention, then extended it for tasks. No skills invoked beyond `/writing-tests` and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*