### PR TITLE
feat(web-analytics): add llms.txt fetch endpoint for agent analytics

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -551,6 +551,22 @@ class HeatmapPreflightSustainedRateThrottle(_TeamBucketRateThrottle):
     rate = "300/hour"
 
 
+# The llms.txt fetch pulls a caller-supplied file of up to 1 MB from an arbitrary host, holding a web
+# worker for the whole transfer, so like the heatmap pre-flight its budget is about worker occupancy.
+# It is not covered by the project-global Burst/Sustained pair, which only ever throttles personal
+# API key traffic and lets the session-authenticated UI through untouched. A legitimate caller needs
+# one fetch per coverage analysis, so these rates clear a team's worth of concurrent viewers while
+# capping a scripted loop.
+class LlmsTxtFetchBurstRateThrottle(_TeamBucketRateThrottle):
+    scope = "llms_txt_fetch_burst"
+    rate = "20/minute"
+
+
+class LlmsTxtFetchSustainedRateThrottle(_TeamBucketRateThrottle):
+    scope = "llms_txt_fetch_sustained"
+    rate = "200/hour"
+
+
 # The batch session-context endpoint computes experiment context for up to 20 recordings per
 # call, in up to several per-day ClickHouse scan sets — heavier than most ClickHouse endpoints
 # — and its primary caller is the session-authenticated replay/experiment UI, which the

--- a/products/web_analytics/backend/api/api.py
+++ b/products/web_analytics/backend/api/api.py
@@ -1,15 +1,21 @@
+from typing import TypedDict
+
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import serializers, viewsets
+from rest_framework import exceptions, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.api.mixins import TypedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.user import User
 
+from products.web_analytics.backend.llms_txt import LlmsTxtFetchError, fetch_llms_txt
 from products.web_analytics.backend.recap import build_team_recap
 from products.web_analytics.backend.serializers import (
+    LlmsTxtFetchRequestSerializer,
+    LlmsTxtFetchResponseSerializer,
     WebAnalyticsRecapResponseSerializer,
     WeeklyDigestResponseSerializer,
 )
@@ -20,6 +26,10 @@ MAX_DAYS = 90
 DEFAULT_DAYS = 7
 
 
+class _LlmsTxtFetchRequestData(TypedDict):
+    url: str
+
+
 class _DigestQuerySerializer(serializers.Serializer):
     days = serializers.IntegerField(min_value=MIN_DAYS, max_value=MAX_DAYS, required=False, default=DEFAULT_DAYS)
     compare = serializers.BooleanField(required=False, default=True)
@@ -27,8 +37,27 @@ class _DigestQuerySerializer(serializers.Serializer):
 
 class WebAnalyticsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "web_analytics"
-    scope_object_read_actions = ["weekly_digest", "recap"]
+    scope_object_read_actions = ["weekly_digest", "recap", "llms_txt"]
     serializer_class = WeeklyDigestResponseSerializer
+
+    @validated_request(
+        request_serializer=LlmsTxtFetchRequestSerializer,
+        operation_id="web_analytics_fetch_llms_txt",
+        summary="Load an llms.txt file",
+        description="Loads an llms.txt file from a public URL for coverage analysis without saving it.",
+        responses={
+            200: OpenApiResponse(response=LlmsTxtFetchResponseSerializer),
+            400: OpenApiResponse(description="The URL is invalid, inaccessible, or does not return an llms.txt file."),
+        },
+        tags=["web_analytics"],
+    )
+    @action(detail=False, methods=["post"], url_path="llms_txt", pagination_class=None)
+    def llms_txt(self, request: TypedRequest[_LlmsTxtFetchRequestData], **kwargs: object) -> Response:
+        try:
+            fetched_file = fetch_llms_txt(request.validated_data["url"])
+        except LlmsTxtFetchError as error:
+            raise exceptions.ValidationError({"url": str(error)}) from error
+        return Response(LlmsTxtFetchResponseSerializer(instance=fetched_file).data)
 
     @extend_schema(
         operation_id="web_analytics_weekly_digest",

--- a/products/web_analytics/backend/api/api.py
+++ b/products/web_analytics/backend/api/api.py
@@ -1,15 +1,15 @@
-from typing import TypedDict
-
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import exceptions, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.throttling import BaseThrottle
 
-from posthog.api.mixins import TypedRequest, validated_request
+from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.user import User
+from posthog.rate_limit import LlmsTxtFetchBurstRateThrottle, LlmsTxtFetchSustainedRateThrottle
 
 from products.web_analytics.backend.llms_txt import LlmsTxtFetchError, fetch_llms_txt
 from products.web_analytics.backend.recap import build_team_recap
@@ -26,10 +26,6 @@ MAX_DAYS = 90
 DEFAULT_DAYS = 7
 
 
-class _LlmsTxtFetchRequestData(TypedDict):
-    url: str
-
-
 class _DigestQuerySerializer(serializers.Serializer):
     days = serializers.IntegerField(min_value=MIN_DAYS, max_value=MAX_DAYS, required=False, default=DEFAULT_DAYS)
     compare = serializers.BooleanField(required=False, default=True)
@@ -39,6 +35,12 @@ class WebAnalyticsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "web_analytics"
     scope_object_read_actions = ["weekly_digest", "recap", "llms_txt"]
     serializer_class = WeeklyDigestResponseSerializer
+
+    def get_throttles(self) -> list[BaseThrottle]:
+        if self.action == "llms_txt":
+            # One outbound fetch of a caller-supplied file per call, blocking a web worker while it runs.
+            return [LlmsTxtFetchBurstRateThrottle(), LlmsTxtFetchSustainedRateThrottle()]
+        return super().get_throttles()
 
     @validated_request(
         request_serializer=LlmsTxtFetchRequestSerializer,
@@ -51,8 +53,8 @@ class WebAnalyticsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         },
         tags=["web_analytics"],
     )
-    @action(detail=False, methods=["post"], url_path="llms_txt", pagination_class=None)
-    def llms_txt(self, request: TypedRequest[_LlmsTxtFetchRequestData], **kwargs: object) -> Response:
+    @action(detail=False, methods=["post"], url_path="llms_txt")
+    def llms_txt(self, request: ValidatedRequest, **kwargs: object) -> Response:
         try:
             fetched_file = fetch_llms_txt(request.validated_data["url"])
         except LlmsTxtFetchError as error:

--- a/products/web_analytics/backend/llms_txt.py
+++ b/products/web_analytics/backend/llms_txt.py
@@ -1,14 +1,20 @@
+import time
 import urllib.parse as urlparse
 
 import requests
+import structlog
 
 from posthog.dataclasses import frozen
 from posthog.security.pinned_requests import SSRFBlockedError, pinned_session
 from posthog.security.url_validation import strip_userinfo
 
+logger = structlog.get_logger(__name__)
+
 LLMS_TXT_MAX_BYTES = 1024 * 1024
 LLMS_TXT_MAX_REDIRECTS = 3
-LLMS_TXT_TIMEOUT = (3.05, 10.0)
+LLMS_TXT_CONNECT_TIMEOUT_SECONDS = 3.05
+LLMS_TXT_READ_TIMEOUT_SECONDS = 10.0
+LLMS_TXT_TOTAL_BUDGET_SECONDS = 20.0
 LLMS_TXT_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 
 
@@ -22,7 +28,7 @@ class FetchedLlmsTxt:
     url: str
 
 
-def _read_response_body(response: requests.Response) -> bytes:
+def _read_response_body(response: requests.Response, deadline: float) -> bytes:
     chunks: list[bytes] = []
     total_bytes = 0
     for chunk in response.iter_content(chunk_size=64 * 1024):
@@ -31,23 +37,33 @@ def _read_response_body(response: requests.Response) -> bytes:
         total_bytes += len(chunk)
         if total_bytes > LLMS_TXT_MAX_BYTES:
             raise LlmsTxtFetchError("The file is larger than 1 MB.")
+        if time.monotonic() > deadline:
+            raise LlmsTxtFetchError("The file took too long to load.")
         chunks.append(chunk)
     return b"".join(chunks)
 
 
 def fetch_llms_txt(url: str) -> FetchedLlmsTxt:
     current_url = strip_userinfo(urlparse.urldefrag(url.strip())[0])
+    # One budget for the whole chain: the read timeout bounds the gap between chunks, not the total
+    # transfer, so a host that trickles bytes would otherwise hold a web worker indefinitely.
+    deadline = time.monotonic() + LLMS_TXT_TOTAL_BUDGET_SECONDS
 
     for _redirect_count in range(LLMS_TXT_MAX_REDIRECTS + 1):
+        read_timeout = min(LLMS_TXT_READ_TIMEOUT_SECONDS, deadline - time.monotonic())
+        if read_timeout <= 0:
+            raise LlmsTxtFetchError("The file took too long to load.")
         try:
             with pinned_session(current_url) as session:
                 response = session.get(
                     current_url,
                     headers={
                         "Accept": "text/plain,text/markdown;q=0.9,*/*;q=0.1",
+                        # Undecoded, so the size cap counts what we actually read off the wire.
+                        "Accept-Encoding": "identity",
                         "User-Agent": "PostHog llms.txt fetcher",
                     },
-                    timeout=LLMS_TXT_TIMEOUT,
+                    timeout=(LLMS_TXT_CONNECT_TIMEOUT_SECONDS, read_timeout),
                     allow_redirects=False,
                     stream=True,
                 )
@@ -67,11 +83,7 @@ def fetch_llms_txt(url: str) -> FetchedLlmsTxt:
                     if media_type in {"text/html", "application/xhtml+xml"}:
                         raise LlmsTxtFetchError("The URL returned an HTML page instead of an llms.txt file.")
 
-                    content_length = response.headers.get("Content-Length", "")
-                    if content_length.isdigit() and int(content_length) > LLMS_TXT_MAX_BYTES:
-                        raise LlmsTxtFetchError("The file is larger than 1 MB.")
-
-                    body = _read_response_body(response)
+                    body = _read_response_body(response, deadline)
                     content = body.decode("utf-8-sig", errors="replace")
                     if not content.strip():
                         raise LlmsTxtFetchError("The file is empty.")
@@ -79,8 +91,12 @@ def fetch_llms_txt(url: str) -> FetchedLlmsTxt:
                 finally:
                     response.close()
         except SSRFBlockedError as error:
+            logger.info("llms_txt.url_blocked", reason=str(error))
             raise LlmsTxtFetchError("Enter a publicly accessible HTTP or HTTPS URL.") from error
         except requests.RequestException as error:
+            # Deliberately not logging the exception or the URL: both routinely echo the full target,
+            # and a customer-supplied URL can carry credentials or a signed token.
+            logger.info("llms_txt.request_failed")
             raise LlmsTxtFetchError("Could not reach the URL.") from error
 
     raise LlmsTxtFetchError("The URL redirected too many times.")

--- a/products/web_analytics/backend/llms_txt.py
+++ b/products/web_analytics/backend/llms_txt.py
@@ -15,7 +15,9 @@ LLMS_TXT_MAX_REDIRECTS = 3
 LLMS_TXT_CONNECT_TIMEOUT_SECONDS = 3.05
 LLMS_TXT_READ_TIMEOUT_SECONDS = 10.0
 LLMS_TXT_TOTAL_BUDGET_SECONDS = 20.0
+LLMS_TXT_READ_CHUNK_BYTES = 64 * 1024
 LLMS_TXT_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+LLMS_TXT_ACCEPTED_CONTENT_ENCODINGS = {"", "identity"}
 
 
 class LlmsTxtFetchError(Exception):
@@ -28,19 +30,27 @@ class FetchedLlmsTxt:
     url: str
 
 
+def _read_once(response: requests.Response, amt: int) -> bytes:
+    raw = response.raw
+    read1 = getattr(raw, "read1", None) or getattr(getattr(raw, "_fp", None), "read1", None)
+    if read1 is None:
+        raise LlmsTxtFetchError("Could not read the file.")
+    return bytes(read1(amt))
+
+
 def _read_response_body(response: requests.Response, deadline: float) -> bytes:
     chunks: list[bytes] = []
     total_bytes = 0
-    for chunk in response.iter_content(chunk_size=64 * 1024):
+    while True:
+        if time.monotonic() > deadline:
+            raise LlmsTxtFetchError("The file took too long to load.")
+        chunk = _read_once(response, LLMS_TXT_READ_CHUNK_BYTES)
         if not chunk:
-            continue
+            return b"".join(chunks)
         total_bytes += len(chunk)
         if total_bytes > LLMS_TXT_MAX_BYTES:
             raise LlmsTxtFetchError("The file is larger than 1 MB.")
-        if time.monotonic() > deadline:
-            raise LlmsTxtFetchError("The file took too long to load.")
         chunks.append(chunk)
-    return b"".join(chunks)
 
 
 def fetch_llms_txt(url: str) -> FetchedLlmsTxt:
@@ -82,6 +92,10 @@ def fetch_llms_txt(url: str) -> FetchedLlmsTxt:
                     media_type = content_type.split(";", 1)[0].strip().lower()
                     if media_type in {"text/html", "application/xhtml+xml"}:
                         raise LlmsTxtFetchError("The URL returned an HTML page instead of an llms.txt file.")
+
+                    content_encoding = response.headers.get("Content-Encoding", "").strip().lower()
+                    if content_encoding not in LLMS_TXT_ACCEPTED_CONTENT_ENCODINGS:
+                        raise LlmsTxtFetchError("The URL returned a compressed file. Serve llms.txt as plain text.")
 
                     body = _read_response_body(response, deadline)
                     content = body.decode("utf-8-sig", errors="replace")

--- a/products/web_analytics/backend/llms_txt.py
+++ b/products/web_analytics/backend/llms_txt.py
@@ -1,0 +1,86 @@
+import urllib.parse as urlparse
+
+import requests
+
+from posthog.dataclasses import frozen
+from posthog.security.pinned_requests import SSRFBlockedError, pinned_session
+from posthog.security.url_validation import strip_userinfo
+
+LLMS_TXT_MAX_BYTES = 1024 * 1024
+LLMS_TXT_MAX_REDIRECTS = 3
+LLMS_TXT_TIMEOUT = (3.05, 10.0)
+LLMS_TXT_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+class LlmsTxtFetchError(Exception):
+    pass
+
+
+@frozen
+class FetchedLlmsTxt:
+    content: str
+    url: str
+
+
+def _read_response_body(response: requests.Response) -> bytes:
+    chunks: list[bytes] = []
+    total_bytes = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total_bytes += len(chunk)
+        if total_bytes > LLMS_TXT_MAX_BYTES:
+            raise LlmsTxtFetchError("The file is larger than 1 MB.")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def fetch_llms_txt(url: str) -> FetchedLlmsTxt:
+    current_url = strip_userinfo(urlparse.urldefrag(url.strip())[0])
+
+    for _redirect_count in range(LLMS_TXT_MAX_REDIRECTS + 1):
+        try:
+            with pinned_session(current_url) as session:
+                response = session.get(
+                    current_url,
+                    headers={
+                        "Accept": "text/plain,text/markdown;q=0.9,*/*;q=0.1",
+                        "User-Agent": "PostHog llms.txt fetcher",
+                    },
+                    timeout=LLMS_TXT_TIMEOUT,
+                    allow_redirects=False,
+                    stream=True,
+                )
+                try:
+                    if response.status_code in LLMS_TXT_REDIRECT_STATUSES:
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise LlmsTxtFetchError("The URL redirected without a destination.")
+                        current_url = strip_userinfo(urlparse.urljoin(current_url, location))
+                        continue
+
+                    if response.status_code < 200 or response.status_code >= 300:
+                        raise LlmsTxtFetchError(f"The URL returned HTTP {response.status_code}.")
+
+                    content_type = response.headers.get("Content-Type", "")
+                    media_type = content_type.split(";", 1)[0].strip().lower()
+                    if media_type in {"text/html", "application/xhtml+xml"}:
+                        raise LlmsTxtFetchError("The URL returned an HTML page instead of an llms.txt file.")
+
+                    content_length = response.headers.get("Content-Length", "")
+                    if content_length.isdigit() and int(content_length) > LLMS_TXT_MAX_BYTES:
+                        raise LlmsTxtFetchError("The file is larger than 1 MB.")
+
+                    body = _read_response_body(response)
+                    content = body.decode("utf-8-sig", errors="replace")
+                    if not content.strip():
+                        raise LlmsTxtFetchError("The file is empty.")
+                    return FetchedLlmsTxt(content=content, url=current_url)
+                finally:
+                    response.close()
+        except SSRFBlockedError as error:
+            raise LlmsTxtFetchError("Enter a publicly accessible HTTP or HTTPS URL.") from error
+        except requests.RequestException as error:
+            raise LlmsTxtFetchError("Could not reach the URL.") from error
+
+    raise LlmsTxtFetchError("The URL redirected too many times.")

--- a/products/web_analytics/backend/serializers.py
+++ b/products/web_analytics/backend/serializers.py
@@ -1,6 +1,18 @@
 from rest_framework import serializers
 
 
+class LlmsTxtFetchRequestSerializer(serializers.Serializer):
+    url = serializers.URLField(
+        max_length=2048,
+        help_text="Public HTTP or HTTPS URL of the llms.txt file to load.",
+    )
+
+
+class LlmsTxtFetchResponseSerializer(serializers.Serializer):
+    content = serializers.CharField(help_text="UTF-8 contents of the fetched llms.txt file.")
+    url = serializers.URLField(help_text="Final public URL after redirects.")
+
+
 class WoWChangeSerializer(serializers.Serializer):
     percent = serializers.IntegerField(help_text="Absolute percentage change, rounded to nearest integer.")
     direction = serializers.ChoiceField(

--- a/products/web_analytics/backend/serializers.py
+++ b/products/web_analytics/backend/serializers.py
@@ -1,9 +1,12 @@
+from django.core.validators import URLValidator
+
 from rest_framework import serializers
 
 
 class LlmsTxtFetchRequestSerializer(serializers.Serializer):
     url = serializers.URLField(
         max_length=2048,
+        validators=[URLValidator(schemes=["http", "https"])],
         help_text="Public HTTP or HTTPS URL of the llms.txt file to load.",
     )
 

--- a/products/web_analytics/backend/test/test_api.py
+++ b/products/web_analytics/backend/test/test_api.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -11,6 +12,8 @@ from rest_framework import status
 
 from posthog.models import Organization, Team
 from posthog.models.utils import uuid7
+
+from products.web_analytics.backend.llms_txt import FetchedLlmsTxt
 
 QUERY_TIMESTAMP = "2025-01-29"
 
@@ -348,5 +351,50 @@ class TestWebAnalyticsRecapAPI(ClickhouseTestMixin, APIBaseTest):
 
         with freeze_time(QUERY_TIMESTAMP):
             response = self.client.get(self._url(), HTTP_AUTHORIZATION=f"Bearer {api_key}")
+
+        assert response.status_code == expected_status
+
+
+class TestWebAnalyticsLlmsTxtAPI(APIBaseTest):
+    ENDPOINT = "/api/projects/{team_id}/web_analytics/llms_txt/"
+
+    def _url(self):
+        return self.ENDPOINT.format(team_id=self.team.id)
+
+    @patch(
+        "products.web_analytics.backend.api.api.fetch_llms_txt",
+        return_value=FetchedLlmsTxt(content="# Example\n/docs", url="https://example.com/llms.txt"),
+    )
+    def test_loads_llms_txt_content(self, fetch_llms_txt_mock):
+        response = self.client.post(
+            self._url(),
+            data={"url": "https://example.com/llms.txt"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"content": "# Example\n/docs", "url": "https://example.com/llms.txt"}
+        fetch_llms_txt_mock.assert_called_once_with("https://example.com/llms.txt")
+
+    @parameterized.expand(
+        [
+            (["feature_flag:read"], status.HTTP_403_FORBIDDEN),
+            (["web_analytics:read"], status.HTTP_200_OK),
+        ]
+    )
+    def test_personal_api_key_requires_web_analytics_read_scope(self, scopes, expected_status):
+        api_key = self.create_personal_api_key_with_scopes(scopes)
+        self.client.logout()
+
+        with patch(
+            "products.web_analytics.backend.api.api.fetch_llms_txt",
+            return_value=FetchedLlmsTxt(content="# Example", url="https://example.com/llms.txt"),
+        ):
+            response = self.client.post(
+                self._url(),
+                data={"url": "https://example.com/llms.txt"},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {api_key}",
+            )
 
         assert response.status_code == expected_status

--- a/products/web_analytics/backend/test/test_api.py
+++ b/products/web_analytics/backend/test/test_api.py
@@ -3,8 +3,9 @@ from urllib.parse import urlparse
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from django.core.cache import cache
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -12,6 +13,7 @@ from rest_framework import status
 
 from posthog.models import Organization, Team
 from posthog.models.utils import uuid7
+from posthog.rate_limit import LlmsTxtFetchBurstRateThrottle
 
 from products.web_analytics.backend.llms_txt import FetchedLlmsTxt
 
@@ -358,14 +360,14 @@ class TestWebAnalyticsRecapAPI(ClickhouseTestMixin, APIBaseTest):
 class TestWebAnalyticsLlmsTxtAPI(APIBaseTest):
     ENDPOINT = "/api/projects/{team_id}/web_analytics/llms_txt/"
 
-    def _url(self):
+    def _url(self) -> str:
         return self.ENDPOINT.format(team_id=self.team.id)
 
     @patch(
         "products.web_analytics.backend.api.api.fetch_llms_txt",
         return_value=FetchedLlmsTxt(content="# Example\n/docs", url="https://example.com/llms.txt"),
     )
-    def test_loads_llms_txt_content(self, fetch_llms_txt_mock):
+    def test_loads_llms_txt_content(self, fetch_llms_txt_mock: Mock) -> None:
         response = self.client.post(
             self._url(),
             data={"url": "https://example.com/llms.txt"},
@@ -382,7 +384,7 @@ class TestWebAnalyticsLlmsTxtAPI(APIBaseTest):
             (["web_analytics:read"], status.HTTP_200_OK),
         ]
     )
-    def test_personal_api_key_requires_web_analytics_read_scope(self, scopes, expected_status):
+    def test_personal_api_key_requires_web_analytics_read_scope(self, scopes: list[str], expected_status: int) -> None:
         api_key = self.create_personal_api_key_with_scopes(scopes)
         self.client.logout()
 
@@ -398,3 +400,20 @@ class TestWebAnalyticsLlmsTxtAPI(APIBaseTest):
             )
 
         assert response.status_code == expected_status
+
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    @patch(
+        "products.web_analytics.backend.api.api.fetch_llms_txt",
+        return_value=FetchedLlmsTxt(content="# Example", url="https://example.com/llms.txt"),
+    )
+    def test_fetching_is_throttled_for_the_session_authenticated_ui(self, _fetch: Mock, _enabled: Mock) -> None:
+        # The project-global Burst/Sustained pair only throttles personal API key traffic, so without
+        # an override the browser could hold a web worker per call in an unbounded loop.
+        cache.clear()
+
+        with patch.object(LlmsTxtFetchBurstRateThrottle, "rate", "2/minute"):
+            assert self.client.post(self._url(), {"url": "https://example.com/llms.txt"}).status_code == 200
+            assert self.client.post(self._url(), {"url": "https://example.com/llms.txt"}).status_code == 200
+            throttled = self.client.post(self._url(), {"url": "https://example.com/llms.txt"})
+
+        assert throttled.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/products/web_analytics/backend/test/test_llms_txt.py
+++ b/products/web_analytics/backend/test/test_llms_txt.py
@@ -5,7 +5,14 @@ from unittest.mock import Mock, patch
 
 import requests
 
-from products.web_analytics.backend.llms_txt import LLMS_TXT_MAX_BYTES, LlmsTxtFetchError, fetch_llms_txt
+from posthog.security.pinned_requests import SSRFBlockedError
+
+from products.web_analytics.backend.llms_txt import (
+    LLMS_TXT_MAX_BYTES,
+    LLMS_TXT_MAX_REDIRECTS,
+    LlmsTxtFetchError,
+    fetch_llms_txt,
+)
 
 
 def _response(
@@ -59,3 +66,22 @@ def test_fetch_llms_txt_rejects_html_responses(pinned_session_mock: Mock) -> Non
 
     with pytest.raises(LlmsTxtFetchError, match="HTML page"):
         fetch_llms_txt("https://example.com/llms.txt")
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_reports_ssrf_blocked_targets_as_a_user_error(pinned_session_mock: Mock) -> None:
+    pinned_session_mock.side_effect = SSRFBlockedError("Private IP address not allowed")
+
+    with pytest.raises(LlmsTxtFetchError, match="publicly accessible"):
+        fetch_llms_txt("https://internal.example/llms.txt")
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_gives_up_once_the_redirect_limit_is_reached(pinned_session_mock: Mock) -> None:
+    redirect = _response(status_code=302, headers={"Location": "/next"})
+    pinned_session_mock.side_effect = [nullcontext(_session(redirect)) for _ in range(LLMS_TXT_MAX_REDIRECTS + 1)]
+
+    with pytest.raises(LlmsTxtFetchError, match="redirected too many times"):
+        fetch_llms_txt("https://example.com/llms.txt")
+
+    assert pinned_session_mock.call_count == LLMS_TXT_MAX_REDIRECTS + 1

--- a/products/web_analytics/backend/test/test_llms_txt.py
+++ b/products/web_analytics/backend/test/test_llms_txt.py
@@ -1,0 +1,61 @@
+from contextlib import nullcontext
+
+import pytest
+from unittest.mock import Mock, patch
+
+import requests
+
+from products.web_analytics.backend.llms_txt import LLMS_TXT_MAX_BYTES, LlmsTxtFetchError, fetch_llms_txt
+
+
+def _response(
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    chunks: list[bytes] | None = None,
+) -> Mock:
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.headers = headers or {"Content-Type": "text/plain; charset=utf-8"}
+    response.iter_content.return_value = chunks or [b"# Example\n- https://example.com/docs"]
+    return response
+
+
+def _session(response: Mock) -> Mock:
+    session = Mock(spec=requests.Session)
+    session.get.return_value = response
+    return session
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_revalidates_redirect_targets(pinned_session_mock: Mock) -> None:
+    redirect = _response(status_code=302, headers={"Location": "/llms-full.txt"})
+    success = _response(chunks=[b"# Example\n", b"- https://example.com/docs"])
+    pinned_session_mock.side_effect = [nullcontext(_session(redirect)), nullcontext(_session(success))]
+
+    fetched = fetch_llms_txt("https://example.com/llms.txt")
+
+    assert fetched.content == "# Example\n- https://example.com/docs"
+    assert fetched.url == "https://example.com/llms-full.txt"
+    assert [call.args[0] for call in pinned_session_mock.call_args_list] == [
+        "https://example.com/llms.txt",
+        "https://example.com/llms-full.txt",
+    ]
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_stops_streams_over_the_size_limit(pinned_session_mock: Mock) -> None:
+    response = _response(chunks=[b"x" * LLMS_TXT_MAX_BYTES, b"x"])
+    pinned_session_mock.return_value = nullcontext(_session(response))
+
+    with pytest.raises(LlmsTxtFetchError, match="larger than 1 MB"):
+        fetch_llms_txt("https://example.com/llms.txt")
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_rejects_html_responses(pinned_session_mock: Mock) -> None:
+    response = _response(headers={"Content-Type": "text/html"}, chunks=[b"<html>Not found</html>"])
+    pinned_session_mock.return_value = nullcontext(_session(response))
+
+    with pytest.raises(LlmsTxtFetchError, match="HTML page"):
+        fetch_llms_txt("https://example.com/llms.txt")

--- a/products/web_analytics/backend/test/test_llms_txt.py
+++ b/products/web_analytics/backend/test/test_llms_txt.py
@@ -1,4 +1,6 @@
+from collections.abc import Callable
 from contextlib import nullcontext
+from itertools import repeat
 
 import pytest
 from unittest.mock import Mock, patch
@@ -10,9 +12,21 @@ from posthog.security.pinned_requests import SSRFBlockedError
 from products.web_analytics.backend.llms_txt import (
     LLMS_TXT_MAX_BYTES,
     LLMS_TXT_MAX_REDIRECTS,
+    LLMS_TXT_TOTAL_BUDGET_SECONDS,
     LlmsTxtFetchError,
     fetch_llms_txt,
 )
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+    def __call__(self) -> float:
+        return self.now
 
 
 def _response(
@@ -20,11 +34,19 @@ def _response(
     status_code: int = 200,
     headers: dict[str, str] | None = None,
     chunks: list[bytes] | None = None,
+    on_read: Callable[[], None] | None = None,
 ) -> Mock:
     response = Mock(spec=requests.Response)
     response.status_code = status_code
     response.headers = headers or {"Content-Type": "text/plain; charset=utf-8"}
-    response.iter_content.return_value = chunks or [b"# Example\n- https://example.com/docs"]
+    reads = iter([*(chunks or [b"# Example\n- https://example.com/docs"]), b""])
+
+    def read1(_amt: int) -> bytes:
+        if on_read is not None:
+            on_read()
+        return next(reads, b"")
+
+    response.raw = Mock(read1=read1)
     return response
 
 
@@ -85,3 +107,28 @@ def test_fetch_llms_txt_gives_up_once_the_redirect_limit_is_reached(pinned_sessi
         fetch_llms_txt("https://example.com/llms.txt")
 
     assert pinned_session_mock.call_count == LLMS_TXT_MAX_REDIRECTS + 1
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_gives_up_on_a_host_that_trickles_bytes(pinned_session_mock: Mock) -> None:
+    clock = _Clock()
+    response = _response(chunks=list(repeat(b"x", 10_000)), on_read=lambda: clock.advance(1.0))
+    pinned_session_mock.return_value = nullcontext(_session(response))
+
+    with patch("products.web_analytics.backend.llms_txt.time.monotonic", clock):
+        with pytest.raises(LlmsTxtFetchError, match="took too long"):
+            fetch_llms_txt("https://example.com/llms.txt")
+
+    assert clock.now <= LLMS_TXT_TOTAL_BUDGET_SECONDS + 1.0
+
+
+@patch("products.web_analytics.backend.llms_txt.pinned_session")
+def test_fetch_llms_txt_rejects_a_body_the_host_compressed_anyway(pinned_session_mock: Mock) -> None:
+    response = _response(
+        headers={"Content-Type": "text/plain", "Content-Encoding": "gzip"},
+        chunks=[b"\x1f\x8b\x08\x00"],
+    )
+    pinned_session_mock.return_value = nullcontext(_session(response))
+
+    with pytest.raises(LlmsTxtFetchError, match="compressed"):
+        fetch_llms_txt("https://example.com/llms.txt")

--- a/products/web_analytics/frontend/generated/api.schemas.ts
+++ b/products/web_analytics/frontend/generated/api.schemas.ts
@@ -395,6 +395,21 @@ export interface HeatmapPrewarmRequestApi {
     block_consent_modals?: boolean
 }
 
+export interface LlmsTxtFetchRequestApi {
+    /**
+     * Public HTTP or HTTPS URL of the llms.txt file to load.
+     * @maxLength 2048
+     */
+    url: string
+}
+
+export interface LlmsTxtFetchResponseApi {
+    /** UTF-8 contents of the fetched llms.txt file. */
+    content: string
+    /** Final public URL after redirects. */
+    url: string
+}
+
 /**
  * * `Up` - Up
  * * `Down` - Down

--- a/products/web_analytics/frontend/generated/api.ts
+++ b/products/web_analytics/frontend/generated/api.ts
@@ -23,6 +23,8 @@ import type {
     HeatmapsEventsRetrieveParams,
     HeatmapsListParams,
     HeatmapsResponseApi,
+    LlmsTxtFetchRequestApi,
+    LlmsTxtFetchResponseApi,
     PaginatedWebAnalyticsFilterPresetListApi,
     PatchedSavedHeatmapRequestApi,
     PatchedWebAnalyticsFilterPresetApi,
@@ -354,6 +356,27 @@ export const savedPrewarmCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(heatmapPrewarmRequestApi),
+    })
+}
+
+export const getWebAnalyticsFetchLlmsTxtUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/web_analytics/llms_txt/`
+}
+
+/**
+ * Loads an llms.txt file from a public URL for coverage analysis without saving it.
+ * @summary Load an llms.txt file
+ */
+export const webAnalyticsFetchLlmsTxt = async (
+    projectId: string,
+    llmsTxtFetchRequestApi: LlmsTxtFetchRequestApi,
+    options?: RequestInit
+): Promise<LlmsTxtFetchResponseApi> => {
+    return apiMutator<LlmsTxtFetchResponseApi>(getWebAnalyticsFetchLlmsTxtUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(llmsTxtFetchRequestApi),
     })
 }
 

--- a/products/web_analytics/frontend/generated/api.zod.ts
+++ b/products/web_analytics/frontend/generated/api.zod.ts
@@ -199,6 +199,19 @@ export const SavedPrewarmCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Loads an llms.txt file from a public URL for coverage analysis without saving it.
+ * @summary Load an llms.txt file
+ */
+export const webAnalyticsFetchLlmsTxtBodyUrlMax = 2048
+
+export const WebAnalyticsFetchLlmsTxtBody = /* @__PURE__ */ zod.object({
+    url: zod
+        .url()
+        .max(webAnalyticsFetchLlmsTxtBodyUrlMax)
+        .describe('Public HTTP or HTTPS URL of the llms.txt file to load.'),
+})
+
+/**
  * Clears a pending celebration for the given track and stage once the client has shown it, so it isn't celebrated again. Idempotent.
  * @summary Acknowledge an achievement celebration
  */

--- a/products/web_analytics/mcp/tools.yaml
+++ b/products/web_analytics/mcp/tools.yaml
@@ -168,6 +168,9 @@ tools:
     web-analytics-achievements-update-preferences:
         operation: web_analytics_achievements_update_preferences
         enabled: false
+    web-analytics-fetch-llms-txt:
+        operation: web_analytics_fetch_llms_txt
+        enabled: false
     web-analytics-filter-presets-create:
         operation: web_analytics_filter_presets_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46033,6 +46033,21 @@ export namespace Schemas {
       provider?: string | null;
     }
 
+    export interface LlmsTxtFetchRequest {
+      /**
+         * Public HTTP or HTTPS URL of the llms.txt file to load.
+         * @maxLength 2048
+         */
+      url: string;
+    }
+
+    export interface LlmsTxtFetchResponse {
+      /** UTF-8 contents of the fetched llms.txt file. */
+      content: string;
+      /** Final public URL after redirects. */
+      url: string;
+    }
+
     export interface LogsAlertFilters {
       filterGroup?: PropertyGroupFilter | null;
       serviceNames?: string[] | null;


### PR DESCRIPTION
## Problem
Agent analytics readiness compares a site's `llms.txt` to the pages agents fetch, but there's no way to load one.

## Changes
Adds a `web_analytics/llms_txt` endpoint that loads a public `llms.txt` on demand and returns it without storing it. 

## How did you test this code?
Unit test + local tetsing 

## Automatic notifications
- [ ] Publish to changelog?

## Docs update
None

## 🤖 Agent context
