### PR TITLE
fix(desktop): remove the MCP reachability probe

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -284,10 +284,6 @@ describe("AgentService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // The Codex MCP reachability probe hits the network; default it to "reachable"
-    // so unrelated session tests stay deterministic and offline-safe.
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ body: null }));
-
     deps = createMockDependencies();
     service = new AgentService(
       deps.processTracking as never,
@@ -686,25 +682,7 @@ describe("AgentService", () => {
       );
     });
 
-    it("passes identical MCP servers to both adapters when all servers are reachable", async () => {
-      await service.startSession({
-        ...baseSessionParams,
-        taskRunId: "run-claude",
-        adapter: "claude",
-      });
-
-      await service.startSession({
-        ...baseSessionParams,
-        taskRunId: "run-codex",
-        adapter: "codex",
-      });
-
-      const claudeMcp = mockNewSession.mock.calls[0][0].mcpServers;
-      const codexMcp = mockNewSession.mock.calls[1][0].mcpServers;
-      expect(codexMcp).toEqual(claudeMcp);
-    });
-
-    it("drops unreachable MCP servers for codex but keeps them for claude", async () => {
+    it("passes the same MCP servers to codex as to claude without probing them first", async () => {
       vi.stubGlobal(
         "fetch",
         vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
@@ -721,10 +699,10 @@ describe("AgentService", () => {
         adapter: "codex",
       });
 
-      // Claude connects to MCP lazily, so an unreachable server is harmless.
-      expect(mockNewSession.mock.calls[0][0].mcpServers).toHaveLength(1);
-      // codex-acp dies on an unreachable server, so it must be pruned.
-      expect(mockNewSession.mock.calls[1][0].mcpServers).toHaveLength(0);
+      const claudeMcp = mockNewSession.mock.calls[0][0].mcpServers;
+      const codexMcp = mockNewSession.mock.calls[1][0].mcpServers;
+      expect(claudeMcp).toHaveLength(1);
+      expect(codexMcp).toEqual(claudeMcp);
     });
 
     it("passes reasoning effort to local Codex startup options", async () => {

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -71,7 +71,6 @@ import {
   type CloudRegion,
   type ExecutionMode,
   isAuthError,
-  type McpServerConnection,
   resolveCloudInitialPermissionMode,
   serializeError,
   TypedEventEmitter,
@@ -1036,16 +1035,6 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
         })),
       );
 
-      // codex-acp connects to every MCP server eagerly during session creation
-      // and treats an unreachable one as fatal, which kills the session
-      // ("ACP connection closed") and makes the host silently fall back to a
-      // Claude/Opus session. Claude connects lazily and is unaffected, so only
-      // the Codex server list is pruned to the reachable ones.
-      const sessionMcpServers =
-        adapter === "codex"
-          ? await this.filterReachableMcpServers(mcpServers, taskRunId)
-          : mcpServers;
-
       let externalPlugins: Awaited<ReturnType<typeof discoverExternalPlugins>> =
         [];
       try {
@@ -1097,7 +1086,7 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
           const loadResponse = await connection.loadSession({
             sessionId: importedSessionId,
             cwd: repoPath,
-            mcpServers: sessionMcpServers,
+            mcpServers,
             _meta: {
               ...(logUrl && {
                 persistence: { taskId, runId: taskRunId, logUrl },
@@ -1185,7 +1174,7 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
         const resumeResponse = await connection.resumeSession({
           sessionId: existingSessionId,
           cwd: repoPath,
-          mcpServers: sessionMcpServers,
+          mcpServers,
           _meta: {
             ...(logUrl && {
               persistence: { taskId, runId: taskRunId, logUrl },
@@ -1223,7 +1212,7 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
         }
         const newSessionResponse = await connection.newSession({
           cwd: repoPath,
-          mcpServers: sessionMcpServers,
+          mcpServers,
           _meta: {
             taskRunId,
             environment: "local",
@@ -1385,78 +1374,6 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
     const history = formatConversationForResume(conversation);
     if (!history) return undefined;
     return `You are resuming a previous conversation after the native session could not be restored. Here is the conversation history from the previous session:\n\n${history}\n\nContinue from where you left off when responding to the user's next message.`;
-  }
-
-  private async filterReachableMcpServers<T extends McpServerConnection>(
-    servers: T[],
-    taskRunId: string,
-  ): Promise<T[]> {
-    const probed = await Promise.all(
-      servers.map(async (server) => ({
-        server,
-        reachable: await this.isMcpServerReachable(server),
-      })),
-    );
-    const reachable: T[] = [];
-    for (const { server, reachable: ok } of probed) {
-      if (ok) {
-        reachable.push(server);
-      } else {
-        this.log.warn(
-          "Dropping unreachable MCP server from Codex session; codex-acp treats an unreachable server as a fatal startup error",
-          { taskRunId, server: server.name, url: server.url },
-        );
-      }
-    }
-    return reachable;
-  }
-
-  private async isMcpServerReachable(
-    server: Pick<McpServerConnection, "url" | "headers">,
-  ): Promise<boolean> {
-    const PROBE_TIMEOUT_MS = 2_000;
-    try {
-      const headers: Record<string, string> = {
-        "content-type": "application/json",
-        accept: "application/json, text/event-stream",
-      };
-      for (const header of server.headers) {
-        headers[header.name] = header.value;
-      }
-      const response = await fetch(server.url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 0,
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            capabilities: {},
-            clientInfo: { name: "posthog-code", version: "1.0.0" },
-          },
-        }),
-        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-      });
-      // Release the body without draining it. A cancel rejection (e.g. an
-      // already-disturbed stream) is a cleanup detail, not a reachability
-      // signal, so it must not flip the result to unreachable.
-      try {
-        await response.body?.cancel();
-      } catch {
-        // ignore body cleanup failures
-      }
-      // Any HTTP response means the endpoint is reachable. codex-acp only treats
-      // transport failures (connection refused, DNS, timeout) as fatal; HTTP or
-      // JSON-RPC error responses are handled gracefully.
-      return true;
-    } catch (err) {
-      this.log.debug("MCP server reachability probe failed", {
-        url: server.url,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return false;
-    }
   }
 
   async prompt(


### PR DESCRIPTION
## Problem

Local Codex sessions often start without the PostHog MCP. Claude sessions and cloud Codex runs are fine.

Before starting a Codex thread, the app pings every MCP server with a 2 second timeout and drops any that miss it. `mcp.posthog.com` regularly takes a bit longer than that to answer `initialize`, so the PostHog server gets dropped.

The ping was there for the old `codex-acp` bridge, which died on an unreachable server. The native codex app-server just reports the failure and keeps going. (e.g. this was a hack fix that we no longer need)

## Changes

- Remove the ping. Codex gets the same MCP server list Claude does.

## How did you test this code?

- Updated the unit test: Codex receives the same server list as Claude even when the ping would have failed.
- Ran codex 0.144 directly with a refused server, a slow server (5 s) and a hung server. The thread survives all three.
