### PR TITLE
fix(data-quality): say which sync the checks tested

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -76,6 +76,7 @@ export function QueryInfo({ tabId, view }: QueryInfoProps): JSX.Element {
                                 subjectType="view"
                                 subjectId={targetView.id}
                                 columns={targetView.columns ?? []}
+                                dataLastSyncedAt={targetView.is_materialized ? targetView.last_run_at : undefined}
                             />
                         )}
                     </>

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -18,11 +18,11 @@ import { DataModelingNode, DataWarehouseSavedQuery } from '~/types'
 
 import { LineageGraph } from 'products/data_modeling/frontend/lineage/LineageGraph'
 import { NODE_TYPE_TAG_SETTINGS } from 'products/data_modeling/frontend/lineage/nodeStyles'
-import { DataQualityChecksPanel } from 'products/data_quality/frontend/DataQualityChecksPanel'
 import { syncIntervalToShorthand } from 'products/data_warehouse/frontend/utils'
 
 import { sqlEditorLogic } from '../sqlEditorLogic'
 import { infoTabLogic } from './infoTabLogic'
+import { ViewDataQualityChecks } from './ViewDataQualityChecks'
 
 interface QueryInfoProps {
     tabId: string
@@ -71,14 +71,7 @@ export function QueryInfo({ tabId, view }: QueryInfoProps): JSX.Element {
                 {targetView ? (
                     <>
                         <MaterializationStatusPanel viewId={targetView.id} />
-                        {featureFlags[FEATURE_FLAGS.DATA_QUALITY_CHECKS] && (
-                            <DataQualityChecksPanel
-                                subjectType="view"
-                                subjectId={targetView.id}
-                                columns={targetView.columns ?? []}
-                                dataLastSyncedAt={targetView.is_materialized ? targetView.last_run_at : undefined}
-                            />
-                        )}
+                        {featureFlags[FEATURE_FLAGS.DATA_QUALITY_CHECKS] && <ViewDataQualityChecks view={targetView} />}
                     </>
                 ) : (
                     <div>

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/ViewDataQualityChecks.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/ViewDataQualityChecks.tsx
@@ -1,0 +1,27 @@
+import { useValues } from 'kea'
+
+import { materializationJobsLogic } from 'scenes/data-warehouse/saved_queries/materializationJobsLogic'
+
+import { DataWarehouseSavedQuery } from '~/types'
+
+import { DataQualityChecksPanel } from 'products/data_quality/frontend/DataQualityChecksPanel'
+
+interface ViewDataQualityChecksProps {
+    view: DataWarehouseSavedQuery
+}
+
+export function ViewDataQualityChecks({ view }: ViewDataQualityChecksProps): JSX.Element {
+    // Read the sync time from the run history rather than the view's `last_run_at`, which advances
+    // on failed, cancelled and quality-blocked runs too. Those leave the previous version serving,
+    // so they must not be named as the sync the checks tested.
+    const { lastSuccessfulSyncAt } = useValues(materializationJobsLogic({ viewId: view.id }))
+
+    return (
+        <DataQualityChecksPanel
+            subjectType="view"
+            subjectId={view.id}
+            columns={view.columns ?? []}
+            dataLastSyncedAt={view.is_materialized ? lastSuccessfulSyncAt : undefined}
+        />
+    )
+}

--- a/frontend/src/scenes/data-warehouse/saved_queries/materializationJobUtils.test.ts
+++ b/frontend/src/scenes/data-warehouse/saved_queries/materializationJobUtils.test.ts
@@ -1,6 +1,6 @@
 import { DataModelingJob } from '~/types'
 
-import { computeJobDuration, jobLogsWindow } from './materializationJobUtils'
+import { computeJobDuration, jobLogsWindow, latestSuccessfulSyncAt } from './materializationJobUtils'
 
 const START = '2024-01-10T10:00:00Z'
 const START_PLUS_90S = '2024-01-10T10:01:30Z'
@@ -73,5 +73,22 @@ describe('materializationJobUtils', () => {
         ],
     ])('jobLogsWindow: %s', (_name, overrides, expectedFrom, expectedTo) => {
         expect(jobLogsWindow(makeJob(overrides), 'UTC')).toEqual({ dateFrom: expectedFrom, dateTo: expectedTo })
+    })
+
+    const LATER = '2024-01-10T12:00:00Z'
+
+    test.each<[string, Partial<DataModelingJob>[], string | null]>([
+        ['no jobs yet', [], null],
+        ['the only completed run', [{}], START_PLUS_90S],
+        ['a later failed run does not become the sync', [{ status: 'Failed', last_run_at: LATER }, {}], START_PLUS_90S],
+        [
+            'a later quality-blocked run is recorded as failed, so it does not either',
+            [{ status: 'Failed', last_run_at: LATER, error: '2 data quality checks failed.' }, {}],
+            START_PLUS_90S,
+        ],
+        ['a run still in flight does not either', [{ status: 'Running', last_run_at: LATER }, {}], START_PLUS_90S],
+        ['nothing has completed yet', [{ status: 'Failed' }, { status: 'Cancelled' }, { status: 'Skipped' }], null],
+    ])('latestSuccessfulSyncAt: %s', (_name, jobs, expected) => {
+        expect(latestSuccessfulSyncAt(jobs.map(makeJob))).toEqual(expected)
     })
 })

--- a/frontend/src/scenes/data-warehouse/saved_queries/materializationJobUtils.ts
+++ b/frontend/src/scenes/data-warehouse/saved_queries/materializationJobUtils.ts
@@ -46,6 +46,13 @@ export function computeJobDuration(job: DataModelingJob): string {
     return humanFriendlyDuration(durationSeconds)
 }
 
+/** When the data the view currently serves was synced. A run that failed, was cancelled, was
+ * skipped, or was blocked by failing data quality checks leaves the previous version in place.
+ * Only a completed run answers this. The newest run does not. */
+export function latestSuccessfulSyncAt(jobs: DataModelingJob[] | undefined): string | null {
+    return latestOf(...(jobs ?? []).filter((job) => job.status === 'Completed').map((job) => job.last_run_at))
+}
+
 /** Time window for the run's log search. An open `dateTo` (still running, or no usable end
  * timestamp) lets the LogsViewer default to "now" instead of silently cutting off logs. */
 export function jobLogsWindow(job: DataModelingJob, timezone: string): { dateFrom?: string; dateTo?: string } {

--- a/frontend/src/scenes/data-warehouse/saved_queries/materializationJobsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/saved_queries/materializationJobsLogic.ts
@@ -32,6 +32,7 @@ import { warehouseSavedQueriesResumeCreate } from 'products/data_warehouse/front
 import type { CountedPaginatedResponse } from '../../../lib/api'
 import { EMPTY_INCREMENTAL_DRAFT, IncrementalConfigDraft } from '../editor/IncrementalConfigFields'
 import { DEFAULT_MATERIALIZE_SYNC_FREQUENCY, dataWarehouseViewsLogic } from './dataWarehouseViewsLogic'
+import { latestSuccessfulSyncAt } from './materializationJobUtils'
 
 const REFRESH_INTERVAL = 10000
 const DEFAULT_JOBS_PAGE_SIZE = 10
@@ -52,6 +53,7 @@ export interface materializationJobsLogicValues {
     incrementalDraft: IncrementalConfigDraft
     incrementalDraftTouched: boolean
     initialSyncFrequency: DataModelingSyncInterval
+    lastSuccessfulSyncAt: string | null
     resumingMaterialization: boolean
     savedQuery: DataWarehouseSavedQuery | null
     savedQueryLoading: boolean
@@ -175,6 +177,7 @@ export interface materializationJobsLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
         hasMoreJobsToLoad: (dataModelingJobs: PaginatedResponse<DataModelingJob> | null) => boolean
+        lastSuccessfulSyncAt: (dataModelingJobs: PaginatedResponse<DataModelingJob> | null) => string | null
     }
 }
 
@@ -329,6 +332,11 @@ export const materializationJobsLogic = kea<materializationJobsLogicType>([
         hasMoreJobsToLoad: [
             (s) => [s.dataModelingJobs],
             (dataModelingJobs: PaginatedResponse<DataModelingJob> | null) => !!dataModelingJobs?.next,
+        ],
+        lastSuccessfulSyncAt: [
+            (s) => [s.dataModelingJobs],
+            (dataModelingJobs: PaginatedResponse<DataModelingJob> | null) =>
+                latestSuccessfulSyncAt(dataModelingJobs?.results),
         ],
     }),
     afterMount(({ actions, props }) => {

--- a/products/data_quality/frontend/ChecksTable.tsx
+++ b/products/data_quality/frontend/ChecksTable.tsx
@@ -109,6 +109,7 @@ export function ChecksTable({ columns, ...props }: ChecksTableProps): JSX.Elemen
                 },
                 {
                     title: 'Last run',
+                    tooltip: 'When the check last ran, not when the data was last synced.',
                     key: 'last_run_at',
                     render: (_, check) => (check.last_run_at ? <TZLabel time={check.last_run_at} /> : '-'),
                 },

--- a/products/data_quality/frontend/DataQualityChecksPanel.tsx
+++ b/products/data_quality/frontend/DataQualityChecksPanel.tsx
@@ -2,6 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 
 import { LemonBanner, LemonButton, LemonSwitch, LemonTag, Spinner } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 
 import { DatabaseSchemaField } from '~/queries/schema/schema-general'
@@ -19,11 +20,13 @@ interface DataQualityChecksPanelProps extends DataQualityChecksLogicProps {
     columns: DatabaseSchemaField[]
     /** Materialized views only: the gate is a project-wide setting and only bites on materialization. */
     showGateToggle?: boolean
+    dataLastSyncedAt?: string | null
 }
 
 export function DataQualityChecksPanel({
     columns,
     showGateToggle,
+    dataLastSyncedAt,
     ...logicProps
 }: DataQualityChecksPanelProps): JSX.Element | null {
     const logic = dataQualityChecksLogic(logicProps)
@@ -97,6 +100,13 @@ export function DataQualityChecksPanel({
                         </LemonButton>
                     </div>
                 </div>
+
+                {dataLastSyncedAt && (
+                    <p className="mb-0 text-secondary text-sm">
+                        Checks test the data from the last sync (synced <TZLabel time={dataLastSyncedAt} />
+                        ). After you change this view, sync it to test the new query.
+                    </p>
+                )}
 
                 {isSuiteRunning && (
                     <LemonBanner type="info" icon={<Spinner />}>


### PR DESCRIPTION
## Problem

Someone who edits a view, re-runs its checks and sees them pass reads that as a pass on the new query. It is not. The checks ran against the data from the last sync, which still holds the old query's rows.

The panel showed only when each check ran, so nothing on the page distinguished the two.

## Changes

- The checks panel now names the sync its results came from, and says to sync the view again to test a new query.
- The sync it names is the last run that completed. A run that failed, was cancelled, was skipped, or was blocked by failing checks leaves the previous version serving, so naming it would misreport what the checks read.
- The "Last run" column tooltip says it reports when the check ran, not when the data landed.
- The view's `last_run_at` looks like the right source and is not. It reports the newest run whatever its status, so a quality-blocked run would be named as the sync its own checks tested. The timestamp comes from the run history instead, through a new `lastSuccessfulSyncAt` selector on `materializationJobsLogic`.
- Mechanical: `dataLastSyncedAt` is a new optional prop, so call sites that omit it render as before. The SQL editor's call site moves into `ViewDataQualityChecks` so it can read that selector.

Only materialized views pass a timestamp. A view with no materialization shows nothing new. The note hides when no completed run is in the loaded history.

## How did you test this code?

Six `test.each` cases in `materializationJobUtils.test.ts` cover `latestSuccessfulSyncAt`. They catch the misattribution directly: a later failed, quality-blocked, skipped or running job must not move the timestamp off the earlier completed one.

No screenshot. The rendered string is the one this PR already shipped in its first revision, and only the timestamp behind it changed.

Not run: the whole-repo frontend typecheck. It reports pre-existing errors from the unbuilt `@posthog/quill` and `@posthog/hogvm` workspaces in this sandbox. No error falls in the files this PR touches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote the commits and this description. Skills invoked: `/writing-user-facing-copy` for the two strings, `/writing-tests` to gate the new cases, `/writing-pr-descriptions` for this body.

An automated reviewer flagged the sync attribution as a P1 after the first revision. That is the second and fourth bullets above; the thread carries the reasoning for taking the last completed run rather than the suite run's own materialization job.

This is the base layer of a two-PR stack. #88079 builds the model detail page's Tests tab on top of it and needs the `dataLastSyncedAt` prop this adds.

Nothing here draws on material from the agent session that is not already in this repository.
