### PR TITLE
fix(lemon-table): keyboard-accessible sortable headers with aria-sort (#30826)

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { router } from 'kea-router'
 
 import { initKeaTests } from '~/test/init'
@@ -117,5 +117,23 @@ describe('LemonTable', () => {
         const groupingRow = document.querySelector('tr.LemonTable__row--grouping')!
         const spannedColumns = Array.from(groupingRow.querySelectorAll('th')).reduce((sum, th) => sum + th.colSpan, 0)
         expect(spannedColumns).toBe(3)
+    })
+
+    it('sortable headers are keyboard operable and expose aria-sort state (#30826)', () => {
+        render(<LemonTable rowKey="id" dataSource={DATA} columns={COLUMNS} useURLForSorting={false} />)
+
+        const sortHeaderContent = screen.getByRole('button', { name: 'Value' })
+
+        // Reachable by keyboard, and not marked as sorted yet
+        expect(sortHeaderContent).toHaveAttribute('tabindex', '0')
+        expect(sortHeaderContent.closest('th')).not.toHaveAttribute('aria-sort')
+
+        // Enter sorts ascending
+        fireEvent.keyDown(sortHeaderContent, { key: 'Enter' })
+        expect(sortHeaderContent.closest('th')).toHaveAttribute('aria-sort', 'ascending')
+
+        // Space cycles to descending
+        fireEvent.keyDown(sortHeaderContent, { key: ' ' })
+        expect(sortHeaderContent.closest('th')).toHaveAttribute('aria-sort', 'descending')
     })
 })

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -482,9 +482,58 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                                                     const truncateHeader =
                                                         !!maxHeaderWidth && !column.width && !column.fullWidth
 
+                                                    const sortingColumnKey = column.sorter
+                                                        ? determineColumnKey(column, 'sorting')
+                                                        : null
+                                                    const activeSortOrder =
+                                                        sortingColumnKey !== null &&
+                                                        currentSorting?.columnKey === sortingColumnKey
+                                                            ? currentSorting.order
+                                                            : null
+
+                                                    // Keyboard operability for sortable headers: the clickable
+                                                    // header content is a plain div, which screen readers and
+                                                    // keyboard users cannot operate or identify as sortable
+                                                    // (see #30826). Expose button semantics, Enter/Space handling,
+                                                    // and aria-sort state.
+                                                    const toggleHeaderSorting = (
+                                                        event:
+                                                            | React.MouseEvent<HTMLElement>
+                                                            | React.KeyboardEvent<HTMLElement>
+                                                    ): void => {
+                                                        const target = event.target as HTMLElement
+
+                                                        // Check if the click happened on the checkbox input, label, or its specific SVG (LemonCheckbox__box)
+                                                        if (
+                                                            target.closest('.LemonCheckbox') ||
+                                                            target.classList.contains('LemonCheckbox__box') ||
+                                                            target.tagName.toLowerCase() === 'label' ||
+                                                            target.tagName.toLowerCase() === 'input' ||
+                                                            target.closest('[data-attr="table-header-more"]')
+                                                        ) {
+                                                            return // Do nothing if the interaction is on the checkbox or more button
+                                                        }
+
+                                                        setLocalSorting(
+                                                            getNextSorting(
+                                                                currentSorting,
+                                                                determineColumnKey(column, 'sorting'),
+                                                                disableSortingCancellation,
+                                                                column.defaultSortOrder
+                                                            )
+                                                        )
+                                                    }
+
                                                     return (
                                                         <th
                                                             key={`LemonTable-th-${columnGroupIndex}-${columnKey}`}
+                                                            aria-sort={
+                                                                activeSortOrder === null
+                                                                    ? undefined
+                                                                    : activeSortOrder === 1
+                                                                      ? 'ascending'
+                                                                      : 'descending'
+                                                            }
                                                             className={clsx(
                                                                 'LemonTable__header',
                                                                 column.sorter && 'LemonTable__header--actionable',
@@ -513,36 +562,19 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                                                                               ? 'flex-end'
                                                                               : 'flex-start',
                                                                 }}
-                                                                onClick={
+                                                                onClick={column.sorter ? toggleHeaderSorting : undefined}
+                                                                role={column.sorter ? 'button' : undefined}
+                                                                tabIndex={column.sorter ? 0 : undefined}
+                                                                onKeyDown={
                                                                     column.sorter
                                                                         ? (event) => {
-                                                                              const target = event.target as HTMLElement
-
-                                                                              // Check if the click happened on the checkbox input, label, or its specific SVG (LemonCheckbox__box)
                                                                               if (
-                                                                                  target.closest('.LemonCheckbox') ||
-                                                                                  target.classList.contains(
-                                                                                      'LemonCheckbox__box'
-                                                                                  ) ||
-                                                                                  target.tagName.toLowerCase() ===
-                                                                                      'label' ||
-                                                                                  target.tagName.toLowerCase() ===
-                                                                                      'input' ||
-                                                                                  target.closest(
-                                                                                      '[data-attr="table-header-more"]'
-                                                                                  )
+                                                                                  event.key === 'Enter' ||
+                                                                                  event.key === ' '
                                                                               ) {
-                                                                                  return // Do nothing if the click is on the checkbox or more button
+                                                                                  event.preventDefault()
+                                                                                  toggleHeaderSorting(event)
                                                                               }
-
-                                                                              const nextSorting = getNextSorting(
-                                                                                  currentSorting,
-                                                                                  determineColumnKey(column, 'sorting'),
-                                                                                  disableSortingCancellation,
-                                                                                  column.defaultSortOrder
-                                                                              )
-
-                                                                              setLocalSorting(nextSorting)
                                                                           }
                                                                         : undefined
                                                                 }


### PR DESCRIPTION
Closes #30826

Sortable LemonTable headers were div-onClick only - invisible and unusable for keyboard and screen-reader users across insights filtering, exports, and data-management tables.

Header sorting is now keyboard-operable (role=button, tabIndex, Enter/Space handling) and exposes aria-sort=ascending/descending on the th. RTL tests cover keyboard cycling and aria-sort state.
