### PR TITLE
fix(data-management): refetch empty event definition pages instead of caching forever (#25913)

### DIFF
--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -372,5 +372,26 @@ describe('eventDefinitionsTableLogic', () => {
                 })
             expect(api.get).toHaveBeenCalledTimes(4)
         })
+
+        it('refetches instead of serving a stale cached empty list so newly arriving events show up (#25913)', async () => {
+            const emptyPage = { count: 0, next: null, previous: null, results: [] }
+            const populatedPage = { count: 1, next: null, previous: null, results: [mockEventDefinitions[0]] }
+            ;(api.get as jest.Mock).mockResolvedValueOnce(emptyPage)
+
+            await expectLogic(logic, () => {
+                logic.actions.loadEventDefinitions()
+            }).toDispatchActions(['loadEventDefinitions', 'loadEventDefinitionsSuccess'])
+            expect(logic.values.eventDefinitions.results).toEqual([])
+
+            // Same URL requested again after events have arrived: must hit the API
+            // instead of returning the cached empty page.
+            ;(api.get as jest.Mock).mockResolvedValueOnce(populatedPage)
+            await expectLogic(logic, () => {
+                logic.actions.loadEventDefinitions()
+            }).toDispatchActions(['loadEventDefinitions', 'loadEventDefinitionsSuccess'])
+
+            expect(api.get).toHaveBeenCalledTimes(2)
+            expect(logic.values.eventDefinitions.results).toHaveLength(1)
+        })
     })
 })

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -408,7 +408,13 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     }
 
                     if (url && url in (cache.apiCache ?? {})) {
-                        return cache.apiCache[url]
+                        const cached = cache.apiCache[url]
+                        // Never serve an empty page from cache: definitions stream in continuously,
+                        // so an empty snapshot goes stale immediately and left the data-management
+                        // events tab blank even after events had arrived (see #25913).
+                        if ((cached.results || []).length > 0) {
+                            return cached
+                        }
                     }
 
                     await breakpoint(200)


### PR DESCRIPTION
Closes #25913

loadEventDefinitions served any cached response forever, so if the first fetch landed before events existed the page stayed blank for the whole session - reported on both self-hosted and Cloud.

The cache now only serves pages that contain results; empty pages always refetch. Regression test covers empty -> repopulated -> second network hit. Deeper ingestion-side sync causes remain possible but were not verifiable without running services.
