### PR TITLE
fix(replay): enable focus replay so focus-driven overlays render (#22275)

### DIFF
--- a/common/replay-shared/src/index.test.ts
+++ b/common/replay-shared/src/index.test.ts
@@ -9,6 +9,7 @@ import {
     chunkMutationSnapshot,
     PLACEHOLDER_SVG_DATA_IMAGE_URL,
 } from './index'
+import { COMMON_REPLAYER_CONFIG } from './rrweb-plugins'
 
 describe('@posthog/replay-shared', () => {
     describe('parseJsonSnapshots', () => {
@@ -112,6 +113,16 @@ describe('@posthog/replay-shared', () => {
     describe('PLACEHOLDER_SVG_DATA_IMAGE_URL', () => {
         it('is a data URL string', () => {
             expect(PLACEHOLDER_SVG_DATA_IMAGE_URL).toContain('data:image/svg+xml;base64,')
+        })
+    })
+
+    describe('COMMON_REPLAYER_CONFIG', () => {
+        it('replays focus interactions so :focus driven overlays render (#22275)', () => {
+            expect(COMMON_REPLAYER_CONFIG.triggerFocus).toBe(true)
+        })
+
+        it('keeps the replay iframe scriptless', () => {
+            expect(COMMON_REPLAYER_CONFIG.UNSAFE_replayCanvas).toBe(false)
         })
     })
 })

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -67,8 +67,12 @@ const defaultStyleRules = `.ph-no-capture { background-image: ${PLACEHOLDER_SVG_
 const shopifyShorthandCSSFix =
     '@media (prefers-reduced-motion: no-preference) { .scroll-trigger:not(.scroll-trigger--offscreen).animate--slide-in { animation: var(--animation-slide-in) } }'
 
+// Focus changes recorded as MouseInteraction(Focus) are replayed for real (rrweb's
+// default), so :focus/:focus-within/:focus-visible driven UI — dropdowns, backdrops,
+// autocomplete panels — renders as it did live instead of staying hidden (#22275).
+// preventScroll avoids jumpiness; focusing stays inside the sandboxed replay iframe.
 export const COMMON_REPLAYER_CONFIG: Partial<playerConfig> = {
-    triggerFocus: false,
+    triggerFocus: true,
     insertStyleRules: [defaultStyleRules, shopifyShorthandCSSFix],
     // Keep the replay iframe scriptless. UNSAFE_replayCanvas makes rrweb add `allow-scripts`
     // to the sandbox, which combined with the required `allow-same-origin` lets untrusted


### PR DESCRIPTION
Closes #22275

Recorded sessions lost dropdown menus, backdrops, and other focus-driven overlays: COMMON_REPLAYER_CONFIG set triggerFocus:false, suppressing rrweb focus replay, so CSS :focus/:focus-within UI (e.g. Tailwind peer-focus-*) never rendered during playback despite correct DOM.

Focus replay is re-enabled at rrweb defaults (preventScroll applies); regression tests added. Reviewer note: playback now moves focus into the sandboxed iframe per stock rrweb-player behavior, which can pull keyboard context from player hotkeys until clicking outside - flagged in case maintainers prefer scoping.
