### PR TITLE
feat(alerts): dual-write alert identity and destinations for logs and billing

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -400,6 +400,8 @@ signal_exclusions: dict[ActivityScope, list[str]] = {
         "last_checked_at",
         "consecutive_failures",
         "state",
+        # Internal ownership pointer — not user-meaningful activity.
+        "alert",
     ],
     "Loop": [
         "last_run_at",

--- a/products/alerts/backend/destination_configs.py
+++ b/products/alerts/backend/destination_configs.py
@@ -174,6 +174,20 @@ def validate_destination_data(
         raise AlertDestinationValidationError(f"{destination_type.label} destinations require {formatted_fields}.")
 
 
+def destination_display_name(data: AlertDestinationData) -> str:
+    """User-visible name for one logical destination, shared by HogFunction names
+    and `AlertDestination.name`."""
+    destination_type = data["type"]
+    if destination_type == DestinationType.SLACK:
+        channel_display = data.get("slack_channel_name") or "channel"
+        return f"Slack #{channel_display}"
+    if destination_type == DestinationType.WEBHOOK:
+        return f"Webhook {data['webhook_url']}"
+    if destination_type == DestinationType.DISCORD:
+        return "Discord"
+    return "Microsoft Teams"
+
+
 def build_alert_destination_config(
     *,
     team: Any,
@@ -185,10 +199,9 @@ def build_alert_destination_config(
 ) -> AlertDestinationConfig:
     destination_type = data["type"]
     product_name = spec.product_label.capitalize()
+    destination_name = destination_display_name(data)
 
     if destination_type == DestinationType.SLACK:
-        channel_display = data.get("slack_channel_name") or "channel"
-        destination_name = f"Slack #{channel_display}"
         inputs = {
             "blocks": {"value": slack_blocks(spec, slack_context_elements)},
             "text": {"value": spec.header},
@@ -196,20 +209,17 @@ def build_alert_destination_config(
             "channel": {"value": data["slack_channel_id"]},
         }
     elif destination_type == DestinationType.WEBHOOK:
-        destination_name = f"Webhook {data['webhook_url']}"
         inputs = {
             "body": {"value": spec.webhook_body},
             "url": {"value": data["webhook_url"]},
             "headers": {"value": WEBHOOK_HEADERS},
         }
     elif destination_type == DestinationType.DISCORD:
-        destination_name = "Discord"
         inputs = {
             "content": {"value": teams_text(spec)},
             "webhookUrl": {"value": data["webhook_url"]},
         }
     else:
-        destination_name = "Microsoft Teams"
         inputs = {
             "webhookUrl": {"value": data["webhook_url"]},
             "text": {"value": teams_text(spec)},

--- a/products/alerts/backend/destinations.py
+++ b/products/alerts/backend/destinations.py
@@ -23,6 +23,7 @@ from posthog.kafka_client.client import ProduceResult
 from posthog.plugins.plugin_server_api import reload_hog_functions_on_workers
 
 from products.alerts.backend.destination_configs import DESTINATION_TEMPLATE_IDS, AlertDestinationConfig
+from products.alerts.backend.models.alert_identity import AlertDestination, AlertIdentity, AlertProduct
 from products.cdp.backend.api.hog_function import HogFunctionSerializer
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
@@ -79,6 +80,29 @@ def _active_alert_destinations_qs(
     )
 
 
+def get_or_create_alert_identity(
+    *,
+    product: AlertProduct,
+    organization_id: UUID,
+    execution_team_id: int | None,
+    alert_id: UUID,
+) -> AlertIdentity:
+    """Return the shared identity for one product alert, creating it on first use.
+
+    Reuses the product alert's own UUID so API identifiers and internal-event
+    `alert_id` properties stay stable across the migration.
+    """
+    alert_identity, _ = AlertIdentity.objects.get_or_create(
+        id=alert_id,
+        defaults={
+            "product": product,
+            "organization_id": organization_id,
+            "execution_team_id": execution_team_id,
+        },
+    )
+    return alert_identity
+
+
 def create_alert_destination_hog_functions(configs: list[AlertDestinationConfig], *, request: Any) -> list[HogFunction]:
     created: list[HogFunction] = []
     hog_function_ids_by_team: dict[int, list[UUID]] = {}
@@ -87,6 +111,53 @@ def create_alert_destination_hog_functions(configs: list[AlertDestinationConfig]
             team = config.team
             serializer = HogFunctionSerializer(
                 data=config.payload,
+                context={
+                    "request": request,
+                    "get_team": lambda team=team: team,
+                    "is_create": True,
+                    "allow_managed_alert_destination": True,
+                },
+            )
+            serializer.is_valid(raise_exception=True)
+            hog_function = serializer.save(team=team)
+            created.append(hog_function)
+            hog_function_ids_by_team.setdefault(team.id, []).append(hog_function.id)
+        for team_id, hog_function_ids in hog_function_ids_by_team.items():
+            _reload_hog_functions_after_commit(team_id=team_id, hog_function_ids=hog_function_ids)
+    return created
+
+
+def create_owned_alert_destination(
+    configs: list[tuple[AlertDestinationConfig, str]],
+    *,
+    request: Any,
+    alert_identity: AlertIdentity,
+    destination_type: str,
+    destination_name: str,
+) -> list[HogFunction]:
+    """Create one logical AlertDestination plus its executors, stamping ownership.
+
+    `configs` pairs each `AlertDestinationConfig` with its event kind (e.g.
+    "firing"), so the executors are linked to the AlertDestination and typed by
+    kind instead of relying solely on JSON filters. Used during Phase 3 dual-write.
+    """
+    destination = AlertDestination.objects.create(
+        alert=alert_identity,
+        type=destination_type,
+        name=destination_name,
+    )
+    created: list[HogFunction] = []
+    hog_function_ids_by_team: dict[int, list[UUID]] = {}
+    with transaction.atomic():
+        for config, event_kind in configs:
+            team = config.team
+            payload = {
+                **config.payload,
+                "alert_destination": str(destination.id),
+                "alert_event_kind": event_kind,
+            }
+            serializer = HogFunctionSerializer(
+                data=payload,
                 context={
                     "request": request,
                     "get_team": lambda team=team: team,

--- a/products/alerts/backend/facade/api.py
+++ b/products/alerts/backend/facade/api.py
@@ -22,14 +22,18 @@ from products.alerts.backend.destination_configs import (
     AlertDestinationValidationError,
     DestinationType,
     build_alert_destination_config,
+    destination_display_name,
     validate_destination_data,
 )
 from products.alerts.backend.destinations import (
     create_alert_destination_hog_functions,
+    create_owned_alert_destination,
+    get_or_create_alert_identity,
     soft_delete_alert_destinations,
     soft_delete_alert_destinations_for_alerts,
     soft_delete_all_alert_destinations,
 )
+from products.alerts.backend.models.alert_identity import AlertProduct
 from products.alerts.backend.email_notifications import send_alert_email
 from products.alerts.backend.insight_alert_state_machine import apply_snooze
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration
@@ -205,13 +209,17 @@ __all__ = [
     "DESTINATION_TEMPLATE_IDS",
     "AlertDestinationData",
     "AlertDestinationValidationError",
+    "AlertProduct",
     "AlertScheduleRestriction",
     "DestinationType",
     "SLACK_SNOOZE_MAX_DAYS",
     "SlackSnoozeOutcome",
     "build_alert_destination_config",
     "create_alert_destination_hog_functions",
+    "create_owned_alert_destination",
     "delete_insight_alerts",
+    "destination_display_name",
+    "get_or_create_alert_identity",
     "get_alert_team_id",
     "insight_alerts_prefetch",
     "insight_ids_with_alerts",

--- a/products/alerts/backend/test/test_destinations.py
+++ b/products/alerts/backend/test/test_destinations.py
@@ -7,11 +7,14 @@ from rest_framework.exceptions import ValidationError
 from products.alerts.backend.destinations import (
     AlertDelivery,
     alert_internal_event_delivered,
+    create_owned_alert_destination,
+    get_or_create_alert_identity,
     list_active_alert_destinations,
     serialize_deliveries,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
 )
+from products.alerts.backend.models.alert_identity import AlertDestination, AlertIdentity, AlertProduct
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
 ALLOWED_EVENT_IDS = ("$logs_alert_firing", "$logs_alert_resolved")
@@ -280,6 +283,119 @@ class TestListActiveAlertDestinations(APIBaseTest):
         )
 
         assert [d.name for d in destinations] == ["Webhook discord.com"]
+
+
+def _destination_payload(event_kind: str, alert_id: str) -> dict:
+    return {
+        "type": "internal_destination",
+        "enabled": True,
+        "name": f"Logs — Test ({event_kind}) → Slack #general",
+        "description": "Sends notifications",
+        "template_id": "template-slack",
+        "filters": {
+            "events": [{"id": f"$logs_alert_{event_kind}", "type": "events"}],
+            "properties": [{"key": "alert_id", "value": alert_id}],
+        },
+        "inputs": {
+            "blocks": {"value": []},
+            "text": {"value": "Alert"},
+            "slack_workspace": {"value": 1},
+            "channel": {"value": "C123"},
+        },
+        "hog": "return event",
+        "inputs_schema": [],
+    }
+
+
+class TestGetOrCreateAlertIdentity(APIBaseTest):
+    def test_creates_identity_reusing_alert_id(self) -> None:
+        from uuid import uuid4
+
+        alert_id = uuid4()
+        identity = get_or_create_alert_identity(
+            product=AlertProduct.LOGS,
+            organization_id=self.organization.id,
+            execution_team_id=self.team.id,
+            alert_id=alert_id,
+        )
+
+        assert identity.id == alert_id
+        assert identity.product == AlertProduct.LOGS
+        assert identity.organization_id == self.organization.id
+        assert identity.execution_team_id == self.team.id
+
+    def test_returns_existing_identity_for_same_alert_id(self) -> None:
+        from uuid import uuid4
+
+        alert_id = uuid4()
+        first = get_or_create_alert_identity(
+            product=AlertProduct.LOGS,
+            organization_id=self.organization.id,
+            execution_team_id=self.team.id,
+            alert_id=alert_id,
+        )
+        second = get_or_create_alert_identity(
+            product=AlertProduct.LOGS,
+            organization_id=self.organization.id,
+            execution_team_id=self.team.id,
+            alert_id=alert_id,
+        )
+
+        assert first.id == second.id
+        assert AlertIdentity.objects.count() == 1
+
+
+class TestCreateOwnedAlertDestination(APIBaseTest):
+    def _make_configs(self, alert_identity: AlertIdentity) -> list[tuple]:
+        from products.alerts.backend.destination_configs import AlertDestinationConfig
+
+        return [
+            (
+                AlertDestinationConfig(
+                    team=self.team,
+                    payload=_destination_payload(event_kind, str(alert_identity.id)),
+                ),
+                event_kind,
+            )
+            for event_kind in ("firing", "resolved")
+        ]
+
+    def test_creates_destination_and_ownership_stamped_executors(self) -> None:
+        from unittest.mock import MagicMock
+        from uuid import uuid4
+
+        from posthog.cdp.templates.fixtures import template_slack
+        from posthog.cdp.templates.hog_function_template import sync_template_to_db
+
+        sync_template_to_db(template_slack)
+
+        identity = get_or_create_alert_identity(
+            product=AlertProduct.LOGS,
+            organization_id=self.organization.id,
+            execution_team_id=self.team.id,
+            alert_id=uuid4(),
+        )
+        configs = self._make_configs(identity)
+
+        hog_functions = create_owned_alert_destination(
+            configs,
+            request=MagicMock(user=None),
+            alert_identity=identity,
+            destination_type="slack",
+            destination_name="Slack #general",
+        )
+
+        assert len(hog_functions) == 2
+        destinations = AlertDestination.objects.filter(alert=identity)
+        assert destinations.count() == 1
+        destination = destinations.get()
+        assert destination.type == "slack"
+        assert destination.name == "Slack #general"
+        kinds = {hf.alert_event_kind for hf in hog_functions}
+        assert kinds == {"firing", "resolved"}
+        for hf in hog_functions:
+            assert hf.alert_destination_id == destination.id
+            assert hf.type == "internal_destination"
 
 
 class TestSerializeDeliveries(APIBaseTest):

--- a/products/billing_alerts/backend/facade/api.py
+++ b/products/billing_alerts/backend/facade/api.py
@@ -16,9 +16,12 @@ from posthog.models.team.team import Team
 
 from products.alerts.backend.facade.api import (
     AlertDestinationData,
+    AlertProduct,
     DestinationType,
     build_alert_destination_config,
-    create_alert_destination_hog_functions,
+    create_owned_alert_destination,
+    destination_display_name,
+    get_or_create_alert_identity,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
     validate_destination_data,
@@ -210,17 +213,35 @@ def create_destination(alert: BillingAlertConfiguration, *, request: Any, data: 
         if destination_data["type"].value in existing_types:
             raise DRFValidationError({"type": f"A {destination_data['type'].label} destination already exists."})
         configs = [
-            build_alert_destination_config(
-                team=locked_alert.team,
-                spec=EVENT_KIND_CONFIG[kind],
-                alert_id=str(locked_alert.id),
-                alert_name=locked_alert.name,
-                data=destination_data,
-                slack_context_elements=BILLING_ALERT_SLACK_CONTEXT_ELEMENTS,
+            (
+                build_alert_destination_config(
+                    team=locked_alert.team,
+                    spec=EVENT_KIND_CONFIG[kind],
+                    alert_id=str(locked_alert.id),
+                    alert_name=locked_alert.name,
+                    data=destination_data,
+                    slack_context_elements=BILLING_ALERT_SLACK_CONTEXT_ELEMENTS,
+                ),
+                kind,
             )
             for kind in EVENT_KINDS
         ]
-        hog_functions = create_alert_destination_hog_functions(configs, request=request)
+        alert_identity = get_or_create_alert_identity(
+            product=AlertProduct.BILLING,
+            organization_id=locked_alert.organization_id,
+            execution_team_id=locked_alert.execution_team_id,
+            alert_id=locked_alert.id,
+        )
+        hog_functions = create_owned_alert_destination(
+            configs,
+            request=request,
+            alert_identity=alert_identity,
+            destination_type=destination_data["type"].value,
+            destination_name=destination_display_name(destination_data),
+        )
+        if locked_alert.alert_id is None:
+            locked_alert.alert_id = alert_identity.id
+            locked_alert.save(update_fields=["alert"])
         return [hog_function.id for hog_function in hog_functions]
 
 

--- a/products/billing_alerts/backend/test/test_alert_destinations.py
+++ b/products/billing_alerts/backend/test/test_alert_destinations.py
@@ -7,6 +7,7 @@ from rest_framework import status
 
 from posthog.models.organization import OrganizationMembership
 
+from products.alerts.backend.models.alert_identity import AlertDestination, AlertIdentity, AlertProduct
 from products.billing_alerts.backend.alert_destinations import BILLING_ALERT_EVENT_IDS, EVENT_KIND_CONFIG
 from products.billing_alerts.backend.models import BillingAlertConfiguration
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
@@ -114,6 +115,38 @@ class TestBillingAlertDestinations(APIBaseTest):
         assert alert_response.json()["destinations"] == [
             {"type": "webhook", "hog_function_ids": sorted(hog_function_ids)}
         ]
+
+    def test_create_destination_dual_writes_alert_identity_and_destination(self) -> None:
+        self._sync_webhook_template()
+        alert = self._alert()
+
+        response = self.client.post(
+            f"{self.url}{alert.id}/destinations/",
+            {"type": "webhook", "webhook_url": "https://example.com/billing-alert"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        hog_function_ids = response.json()["hog_function_ids"]
+
+        identity = AlertIdentity.objects.get(id=alert.id)
+        assert identity.product == AlertProduct.BILLING
+        assert identity.organization_id == self.organization.id
+        assert identity.execution_team_id == alert.execution_team_id
+
+        destination = AlertDestination.objects.get(alert=identity)
+        assert destination.type == "webhook"
+        assert destination.name == "Webhook https://example.com/billing-alert"
+
+        hog_functions = HogFunction.objects.filter(id__in=hog_function_ids)
+        expected_kinds = set(EVENT_KIND_CONFIG)
+        assert {hf.alert_event_kind for hf in hog_functions} == expected_kinds
+        for hf in hog_functions:
+            assert hf.alert_destination_id == destination.id
+            assert hf.type == "internal_destination"
+
+        alert.refresh_from_db()
+        assert alert.alert_id == identity.id
 
     def test_configuration_and_destination_changes_commit_atomically(self) -> None:
         self._sync_webhook_template()

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -53,6 +53,7 @@ from posthog.models import Team
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.plugins.plugin_server_api import create_hog_invocation_test, rerun_hog_invocations
 
+from products.alerts.backend.models.alert_identity import AlertDestination
 from products.cdp.backend.api.hog_function_template import HogFunctionTemplateSerializer
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import (
@@ -356,6 +357,12 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         required=False, help_text="Event filters that control which events trigger this function."
     )
     _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
+    # Alert ownership fields: only honored when the serializer runs in the alert-managed
+    # context (see `allow_managed_alert_destination`). Ignored on generic create/update.
+    alert_destination = serializers.PrimaryKeyRelatedField(
+        queryset=AlertDestination.objects.all(), required=False, allow_null=True, write_only=True
+    )
+    alert_event_kind = serializers.CharField(required=False, allow_null=True, max_length=32, write_only=True)
 
     class Meta:
         model = HogFunction
@@ -389,6 +396,8 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
             "draft",
             "draft_updated_at",
             "base_updated_at",
+            "alert_destination",
+            "alert_event_kind",
         ]
         read_only_fields = [
             "id",
@@ -573,6 +582,9 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         )
 
         if not self.context.get("allow_managed_alert_destination"):
+            # Generic create/update must not be able to attach alert ownership.
+            attrs.pop("alert_destination", None)
+            attrs.pop("alert_event_kind", None)
             current_filters = self.instance.filters if isinstance(self.instance, HogFunction) else {}
             proposed_filters = attrs.get("filters", current_filters)
             current_is_managed = any(

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -32,10 +32,13 @@ from products.alerts.backend.facade.api import (
     DESTINATION_TEMPLATE_IDS,
     AlertDestinationData,
     AlertDestinationValidationError,
+    AlertProduct,
     AlertScheduleRestriction,
     DestinationType,
     build_alert_destination_config,
-    create_alert_destination_hog_functions,
+    create_owned_alert_destination,
+    destination_display_name,
+    get_or_create_alert_identity,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
     validate_and_normalize_schedule_restriction,
@@ -957,17 +960,35 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         with transaction.atomic():
             alert = self._get_locked_alert()
             configs = [
-                build_alert_destination_config(
-                    team=alert.team,
-                    spec=EVENT_KIND_CONFIG[kind],
-                    alert_id=str(alert.id),
-                    alert_name=alert.name,
-                    data=data,
-                    slack_context_elements=LOGS_ALERT_SLACK_CONTEXT_ELEMENTS,
+                (
+                    build_alert_destination_config(
+                        team=alert.team,
+                        spec=EVENT_KIND_CONFIG[kind],
+                        alert_id=str(alert.id),
+                        alert_name=alert.name,
+                        data=data,
+                        slack_context_elements=LOGS_ALERT_SLACK_CONTEXT_ELEMENTS,
+                    ),
+                    kind,
                 )
                 for kind in EVENT_KINDS
             ]
-            hog_functions = create_alert_destination_hog_functions(configs, request=self.request)
+            alert_identity = get_or_create_alert_identity(
+                product=AlertProduct.LOGS,
+                organization_id=alert.team.organization_id,
+                execution_team_id=alert.team_id,
+                alert_id=alert.id,
+            )
+            hog_functions = create_owned_alert_destination(
+                configs,
+                request=self.request,
+                alert_identity=alert_identity,
+                destination_type=data["type"].value,
+                destination_name=destination_display_name(data),
+            )
+            if alert.alert_id is None:
+                alert.alert_id = alert_identity.id
+                alert.save(update_fields=["alert"])
 
         report_user_action(
             request.user,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -20,6 +20,7 @@ from posthog.models.user import User
 
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
+from products.alerts.backend.models.alert_identity import AlertDestination, AlertIdentity, AlertProduct
 from products.logs.backend.alert_check_query import AlertCheckQuery, BucketedCount
 from products.logs.backend.alert_utils import compute_shard_offset_seconds
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
@@ -868,6 +869,43 @@ class TestLogsAlertAPI(APIBaseTest):
 
         reset_calls = [c for c in mock_report.call_args_list if c.args[1] == "logs alert destination created"]
         assert len(reset_calls) == 1
+
+    @patch("products.logs.backend.presentation.views.alerts_api.report_user_action")
+    def test_create_slack_destination_dual_writes_alert_identity_and_destination(self, mock_report):
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        response = self.client.post(
+            self._destinations_url(created["id"]),
+            {
+                "type": "slack",
+                "slack_workspace_id": 42,
+                "slack_channel_id": "C123",
+                "slack_channel_name": "alerts",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        hog_function_ids = response.json()["hog_function_ids"]
+
+        identity = AlertIdentity.objects.get(id=created["id"])
+        assert identity.product == AlertProduct.LOGS
+        assert identity.organization_id == self.organization.id
+        assert identity.execution_team_id == self.team.id
+
+        destination = AlertDestination.objects.get(alert=identity)
+        assert destination.type == "slack"
+        assert destination.name == "Slack #alerts"
+
+        hog_functions = HogFunction.objects.filter(id__in=hog_function_ids)
+        expected_kinds = {"firing", "resolved", "broken", "errored"}
+        assert {hf.alert_event_kind for hf in hog_functions} == expected_kinds
+        for hf in hog_functions:
+            assert hf.alert_destination_id == destination.id
+            assert hf.type == "internal_destination"
+
+        # The product configuration points back to the shared identity.
+        alert = LogsAlertConfiguration.objects.get(id=created["id"])
+        assert alert.alert_id == identity.id
 
     @patch("products.alerts.backend.destinations.reload_hog_functions_on_workers")
     @patch("products.cdp.backend.models.hog_functions.hog_function.reload_hog_functions_on_workers")


### PR DESCRIPTION
## Problem

Stacked on [#88036](https://github.com/PostHog/posthog/pull/88036), this PR starts writing explicit alert ownership from the Logs and Billing destination APIs. Today, every alert-owned HogFunction carries the ownership link only in its JSON `filters.properties` — mutable, unenforced. This is Phase 3a (dual-write) of the [RFC's migration plan](https://github.com/PostHog/requests-for-comments-internal/pull/1253); read paths still use the legacy filters, so existing alerts and destinations continue working unchanged.

## Changes

- **`get_or_create_alert_identity`** (in `products/alerts/backend/destinations.py`) returns the `AlertIdentity` for a product alert, creating one on first use and **reusing the product alert's UUID** so API identifiers and internal-event `alert_id` properties stay stable.
- **`create_owned_alert_destination`** creates one logical `AlertDestination` row plus its HogFunction executors, stamping each with `alert_destination` and `alert_event_kind` through a single save.
- **Logs and Billing destination APIs** now call the owned helper — new destinations get explicit identity + destination + stamped executors alongside the existing filter-based behavior.
- **`HogFunctionSerializer`** accepts two new write-only fields (`alert_destination`, `alert_event_kind`), which are popped unless the serializer context has `allow_managed_alert_destination`, so generic create/update cannot attach ownership.
- **`posthog/models/activity_logging/activity_log.py`** adds `alert` to `LogsAlertConfiguration`'s field exclusions to avoid `AlertIdentity` being captured into the activity log details JSON.
- **`destination_display_name`** extracted from `build_alert_destination_config` so both the HogFunction name and the new `AlertDestination.name` use the one canonical display name.

Existing filter-based ownership is left untouched. Nothing reads the new columns yet — that's Phase 4.

## How did you test this code?

- Added `products/alerts/backend/test/test_destinations.py::TestGetOrCreateAlertIdentity` (reuse-the-UUID happy path, get-vs-create idempotency) and `TestCreateOwnedAlertDestination` (asserts AlertDestination creation and stamped HogFunction event kinds).
- Added `logs/.../test_alerts_api.py::test_create_slack_destination_dual_writes_alert_identity_and_destination` — full request cycle asserting identity + destination + stamped HogFunctions + config.alert back-link.
- Added `billing_alerts/.../test_alert_destinations.py::test_create_destination_dual_writes_alert_identity_and_destination` — same coverage for billing.
- `products/logs/backend/test/test_alerts_api.py::TestLogsAlertAPI` (149 passed), `products/billing_alerts/backend/test/test_alert_destinations.py` (11 passed), `products/alerts/backend/test/test_destinations.py` (22 passed).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Skip — internal write-path change only; no user-visible behavior yet.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Agent: Claude (moonshotai/kimi-k3). Tool: PostHog Desktop agent.
- Built on PR #88036's schema after reading products/alerts, products/logs, products/billing_alerts, and products/cdp backend code to identify the smallest dual-write seam (`create_alert_destination_hog_functions`).
- Key design choice: keep one HogFunction save (not create-then-update) so the worker-reload signal fires once per function.
- No customer data or internal material included.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
