### PR TITLE
fix(dashboards): handle cleared activity event filter

### DIFF
--- a/products/dashboards/frontend/widgets/activity/ActivityEventsWidgetTileFilters.test.tsx
+++ b/products/dashboards/frontend/widgets/activity/ActivityEventsWidgetTileFilters.test.tsx
@@ -8,7 +8,11 @@ import { WIDGET_TILE_REFRESH_DEBOUNCE_MS } from '../constants'
 import { ActivityEventsWidgetTileFilters } from './ActivityEventsWidgetTileFilters'
 
 jest.mock('products/actions/frontend/components/EventName', () => ({
-    EventName: (): JSX.Element => <div>Event name filter</div>,
+    EventName: ({ onChange }: { onChange: (value: string | null) => void }): JSX.Element => (
+        <button type="button" onClick={() => onChange('')}>
+            Clear event filter
+        </button>
+    ),
 }))
 
 jest.mock('~/queries/nodes/EventsNode/EventPropertyFilters', () => ({
@@ -89,6 +93,31 @@ describe('ActivityEventsWidgetTileFilters', () => {
             dateRange: { date_from: '-7d' },
             eventName: '$pageview',
             properties: [],
+        })
+    })
+
+    it('persists a cleared event filter as null', async () => {
+        const onUpdateConfig = jest.fn().mockResolvedValue(undefined)
+
+        render(
+            <ActivityEventsWidgetTileFilters
+                tileId={1}
+                config={{ limit: 10, dateRange: { date_from: '-7d' }, eventName: '$pageview' }}
+                onUpdateConfig={onUpdateConfig}
+            />
+        )
+
+        fireEvent.click(screen.getByText('Clear event filter'))
+
+        await act(async () => {
+            await Promise.resolve()
+        })
+
+        expect(onUpdateConfig).toHaveBeenCalledWith({
+            limit: 10,
+            dateRange: { date_from: '-7d' },
+            eventName: null,
+            properties: undefined,
         })
     })
 })

--- a/products/dashboards/frontend/widgets/activity/ActivityEventsWidgetTileFilters.tsx
+++ b/products/dashboards/frontend/widgets/activity/ActivityEventsWidgetTileFilters.tsx
@@ -97,7 +97,7 @@ export function ActivityEventsWidgetTileFilters({
                 disabled={!canUpdate}
                 placeholder="All events"
                 onChange={(value) => {
-                    void applyEventName(value)
+                    void applyEventName(value === '' ? null : value)
                 }}
             />
             {canUpdate && (


### PR DESCRIPTION
## Problem

- Dashboard users see the activity widget fail when they clear the event filter.
- The clear control sends an empty value, which the widget schema rejects instead of treating as no filter.

## Changes

- The activity widget converts an empty event value to `null` before persisting it.
- The widget test covers clearing an event filter without a validation error.
- No visual change occurs; the existing clear control now completes successfully.

## How did you test this code?

- The focused Jest test covers the regression where clearing the event filter must persist `eventName: null`.
- Frontend formatting and diff checks passed.
- The full TypeScript check remains blocked by unrelated existing errors outside this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update is needed for this behavior-only fix.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted)
- **Agent and tools:** PostHog Desktop agent with PostHog MCP, Git, Jest, and frontend formatting tools.
- **Skills invoked:** `/inbox-exploration`, `/writing-tests`, `/writing-pr-descriptions`.
- **Decision:** The fix stays in the activity widget boundary to avoid changing shared `TaxonomicPopover` behavior for other consumers.
- **Public artifact check:** The PR contains only repository code and an invented regression test case. No customer data or private operational details are included.
