### PR TITLE
fix(desktop): keep sidebar overlay below nav rail

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
@@ -90,6 +90,12 @@ import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/curre
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { NavRail } from "./NavRail";
 
+it("stays above floating sidebar layers", () => {
+  render(<NavRail />);
+
+  expect(screen.getByTestId("nav-rail")).toHaveClass("z-[60]");
+});
+
 /**
  * Seed where each destination was, as the ACTIVE TAB remembers it. Rail memory
  * lives on the tab rather than the window, so a pick in one tab can never

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
@@ -233,7 +233,8 @@ export function NavRail() {
     // state, so isolated providers never share it.
     <TooltipProvider delay={400}>
       <div
-        className="flex h-full shrink-0 flex-col items-center gap-1.5 bg-chrome py-2"
+        data-testid="nav-rail"
+        className="relative z-[60] flex h-full shrink-0 flex-col items-center gap-1.5 bg-chrome py-2"
         style={{ width: NAV_RAIL_WIDTH }}
       >
         {destinations.map((destination) => {

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -48,6 +48,7 @@ import { useIntegrations } from "@posthog/ui/features/integrations/useIntegratio
 import { useLoopDeepLink } from "@posthog/ui/features/loops/hooks/useLoopDeepLink";
 import { useScoutDeepLink } from "@posthog/ui/features/scouts/hooks/useScoutDeepLink";
 import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery";
+import { NAV_RAIL_WIDTH } from "@posthog/ui/features/sidebar/constants";
 import {
   beginSidebarPeek,
   cancelSidebarPeek,
@@ -442,6 +443,7 @@ function RootLayout() {
           {!sidebarOpen && (
             <Box
               aria-hidden
+              style={{ left: channelsLayout ? NAV_RAIL_WIDTH : 0 }}
               // The radix preset replaces Tailwind's palette, so plain
               // `bg-black/*` doesn't exist — use the radix black-alpha scale
               // (--black-a2 = 10%, --black-a5 = 30%).


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

When users collapse the left sidebar, its floating panel and dimming overlay can cover the navigation rail and obscure its icons.

**Why:** The navigation rail must remain visible and usable while the sidebar is collapsed or peeking.

## Changes

- The navigation rail now stays above the floating sidebar and dimming layers.
- The dimming overlay starts after the navigation rail in the channels layout.
- Screenshot not included because the cloud environment could not start the renderer target.

## How did you test this code?

- Added a regression test that requires the navigation rail to stay above floating sidebar layers.
- `pnpm exec vitest run src/features/canvas/components/NavRail.test.tsx`
- `pnpm typecheck`
- Live rendering was blocked because the environment lacked the native `node-pty` module required during desktop startup.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes are needed for this visual correction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this focused fix using the `/posthog-desktop` and `/writing-pr-descriptions` skills. The follow-up adds explicit stacking protection after moving only the scrim proved insufficient.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*