### PR TITLE
feat(tracing): add alert-check Temporal workflow

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -254,6 +254,10 @@ from products.tasks.backend.facade.temporal import (
     ACTIVITIES as TASKS_ACTIVITIES,
     WORKFLOWS as TASKS_WORKFLOWS,
 )
+from products.tracing.backend.facade.temporal import (
+    ACTIVITIES as TRACING_ALERTING_ACTIVITIES,
+    WORKFLOWS as TRACING_ALERTING_WORKFLOWS,
+)
 from products.warehouse_sources.backend.facade.temporal import (
     ACTIVITIES as DATA_SYNC_ACTIVITIES,
     METADATA_ACTIVITIES as DATA_WAREHOUSE_METADATA_ACTIVITIES,
@@ -507,6 +511,11 @@ _task_queue_specs = [
         settings.LOGS_VOLUME_TICK_TASK_QUEUE,
         LOGS_VOLUME_TICK_WORKFLOWS,
         LOGS_VOLUME_TICK_ACTIVITIES,
+    ),
+    (
+        settings.TRACING_ALERTING_TASK_QUEUE,
+        TRACING_ALERTING_WORKFLOWS,
+        TRACING_ALERTING_ACTIVITIES,
     ),
     (
         settings.STAMPHOG_TASK_QUEUE,

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -238,6 +238,7 @@ ERROR_TRACKING_TASK_QUEUE = _set_temporal_task_queue("error-tracking-task-queue"
 ERROR_TRACKING_LIFECYCLE_TASK_QUEUE = _set_temporal_task_queue("error-tracking-lifecycle-task-queue")
 EVENT_SCREENSHOTS_TASK_QUEUE = _set_temporal_task_queue("event-screenshots-task-queue")
 LOGS_ALERTING_TASK_QUEUE = _set_temporal_task_queue("logs-alerting-task-queue")
+TRACING_ALERTING_TASK_QUEUE = _set_temporal_task_queue("tracing-alerting-task-queue")
 # Dedicated queue: the tick becomes the scan-heavy rollup writer, and it must not
 # share pods with the latency-sensitive alerting workers.
 LOGS_VOLUME_TICK_TASK_QUEUE = _set_temporal_task_queue(

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -70,6 +70,7 @@ from posthog.temporal.session_replay.surfacing_score_export_sweep.schedule impor
 )
 from posthog.temporal.session_replay.surfacing_scoring_sweep.schedule import create_surfacing_scoring_sweep_schedule
 from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInput
+from posthog.temporal.tracing_alerting.schedule import create_tracing_alert_check_schedule
 from posthog.temporal.usage_report.types import RunUsageReportsInputs
 from posthog.temporal.warehouse_sources_queue_partition_management.schedule import (
     create_warehouse_sources_queue_partition_management_schedule,
@@ -890,6 +891,7 @@ schedules = [
     create_wa_digest_notification_schedule,
     create_logs_alert_check_schedule,
     create_logs_volume_tick_schedule,
+    create_tracing_alert_check_schedule,
     create_schedule_due_alert_checks_schedule,
     create_run_investigation_safety_net_schedule,
     create_cleanup_alert_checks_schedule,

--- a/posthog/temporal/tracing_alerting/schedule.py
+++ b/posthog/temporal/tracing_alerting/schedule.py
@@ -1,0 +1,37 @@
+"""Schedule registration for the tracing alert check workflow."""
+
+from dataclasses import asdict
+
+from django.conf import settings
+
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+
+from products.tracing.backend.facade.temporal import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME, CheckAlertsInput
+
+
+async def create_tracing_alert_check_schedule(client: Client) -> None:
+    """Create or update the tracing alert check schedule."""
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_NAME,
+            asdict(CheckAlertsInput()),
+            id=SCHEDULE_ID,
+            task_queue=settings.TRACING_ALERTING_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(cron_expressions=[SCHEDULE_CRON]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, SCHEDULE_ID):
+        await a_update_schedule(client, SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(client, SCHEDULE_ID, schedule, trigger_immediately=False)

--- a/products/tracing/backend/facade/temporal.py
+++ b/products/tracing/backend/facade/temporal.py
@@ -1,0 +1,22 @@
+"""Facade re-exports for the tracing alerting Temporal wiring.
+
+Core registers this product's workflow + activities with the Temporal worker
+(``posthog/management/commands/start_temporal_worker.py``) and registers its
+schedule (``posthog/temporal/tracing_alerting/schedule.py``). That wiring
+crosses the boundary as objects and constants, not data, so re-export exactly
+what core touches and keep the temporalio-heavy imports here, off the
+``facade/api.py`` path.
+"""
+
+from products.tracing.backend.temporal import ACTIVITIES, WORKFLOWS
+from products.tracing.backend.temporal.activities import CheckAlertsInput
+from products.tracing.backend.temporal.constants import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "CheckAlertsInput",
+    "SCHEDULE_CRON",
+    "SCHEDULE_ID",
+    "WORKFLOW_NAME",
+]

--- a/products/tracing/backend/temporal/__init__.py
+++ b/products/tracing/backend/temporal/__init__.py
@@ -1,0 +1,16 @@
+from products.tracing.backend.temporal.activities import (
+    discover_due_tracing_alerts_activity,
+    evaluate_alert_batch_activity,
+)
+from products.tracing.backend.temporal.workflow import TracingAlertCheckWorkflow
+
+WORKFLOWS: list = [TracingAlertCheckWorkflow]
+ACTIVITIES: list = [discover_due_tracing_alerts_activity, evaluate_alert_batch_activity]
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "TracingAlertCheckWorkflow",
+    "discover_due_tracing_alerts_activity",
+    "evaluate_alert_batch_activity",
+]

--- a/products/tracing/backend/temporal/activities.py
+++ b/products/tracing/backend/temporal/activities.py
@@ -190,6 +190,23 @@ def _evaluate_dispatch_and_save_one_alert(alert_id: str, now: datetime) -> str:
         return _evaluate_dispatch_and_save_scoped(alert, now)
 
 
+def _safe_next_allowed_check_at(
+    candidate: datetime,
+    *,
+    team_timezone: str,
+    schedule_restriction: dict | None,
+    fallback: datetime,
+    alert: TracingAlertConfiguration,
+    log_message: str,
+) -> datetime:
+    """`next_allowed_check_at`, falling back to `fallback` and logging on a bad schedule config."""
+    try:
+        return next_allowed_check_at(candidate, team_timezone=team_timezone, schedule_restriction=schedule_restriction)
+    except Exception as e:
+        logger.exception(log_message, alert_id=str(alert.id), team_id=alert.team_id, error=str(e))
+        return fallback
+
+
 def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: datetime) -> str:
     nca = alert.next_check_at if alert.next_check_at is not None else now
     date_to = nca
@@ -250,20 +267,14 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
     # suppresses the notification — this is a decision read, not the write, so it doesn't
     # need the row lock the persisting transaction below takes.
     fresh_alert = TracingAlertConfiguration.objects.select_related("team").get(id=alert.id)
-    try:
-        next_check_at_if_blocked = next_allowed_check_at(
-            now,
-            team_timezone=fresh_alert.team.timezone,
-            schedule_restriction=fresh_alert.schedule_restriction,
-        )
-    except Exception as e:
-        logger.exception(
-            "Skipping tracing alert with invalid quiet-hours configuration",
-            alert_id=str(fresh_alert.id),
-            team_id=fresh_alert.team_id,
-            error=str(e),
-        )
-        next_check_at_if_blocked = now
+    next_check_at_if_blocked = _safe_next_allowed_check_at(
+        now,
+        team_timezone=fresh_alert.team.timezone,
+        schedule_restriction=fresh_alert.schedule_restriction,
+        fallback=now,
+        alert=fresh_alert,
+        log_message="Skipping tracing alert with invalid quiet-hours configuration",
+    )
 
     if next_check_at_if_blocked > now:
         with transaction.atomic():
@@ -304,20 +315,14 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
             now,
             shard_offset_seconds=compute_shard_offset_seconds(current_alert.id, current_alert.check_interval_minutes),
         )
-        try:
-            current_alert.next_check_at = next_allowed_check_at(
-                next_check_at,
-                team_timezone=current_alert.team.timezone,
-                schedule_restriction=current_alert.schedule_restriction,
-            )
-        except Exception as e:
-            logger.exception(
-                "Ignoring invalid quiet-hours configuration while saving tracing alert",
-                alert_id=str(current_alert.id),
-                team_id=current_alert.team_id,
-                error=str(e),
-            )
-            current_alert.next_check_at = next_check_at
+        current_alert.next_check_at = _safe_next_allowed_check_at(
+            next_check_at,
+            team_timezone=current_alert.team.timezone,
+            schedule_restriction=current_alert.schedule_restriction,
+            fallback=next_check_at,
+            alert=current_alert,
+            log_message="Ignoring invalid quiet-hours configuration while saving tracing alert",
+        )
         update_fields.extend(["last_checked_at", "next_check_at", "updated_at"])
 
         if (
@@ -352,20 +357,6 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
     return "unchanged"
 
 
-def _produce_alert_internal_event(
-    alert: TracingAlertConfiguration,
-    event_name: str,
-    properties: dict,
-    now: datetime,
-) -> ProduceResult | None:
-    return produce_alert_internal_event(
-        team_id=alert.team_id,
-        event_name=event_name,
-        properties=properties,
-        timestamp=now,
-    )
-
-
 def _emit_alert_event(
     alert: TracingAlertConfiguration,
     event_name: str,
@@ -384,7 +375,9 @@ def _emit_alert_event(
         "service_names": alert.filters.get("serviceNames", []),
         "triggered_at": now.isoformat(),
     }
-    return _produce_alert_internal_event(alert, event_name, properties, now)
+    return produce_alert_internal_event(
+        team_id=alert.team_id, event_name=event_name, properties=properties, timestamp=now
+    )
 
 
 def _base_failure_properties(
@@ -406,14 +399,18 @@ def _emit_auto_disabled_event(
     alert: TracingAlertConfiguration, outcome: AlertCheckOutcome, now: datetime
 ) -> ProduceResult | None:
     properties = {**_base_failure_properties(alert, outcome, now), "last_error_message": outcome.error_message or ""}
-    return _produce_alert_internal_event(alert, "$tracing_alert_auto_disabled", properties, now)
+    return produce_alert_internal_event(
+        team_id=alert.team_id, event_name="$tracing_alert_auto_disabled", properties=properties, timestamp=now
+    )
 
 
 def _emit_alert_errored_event(
     alert: TracingAlertConfiguration, outcome: AlertCheckOutcome, now: datetime
 ) -> ProduceResult | None:
     properties = {**_base_failure_properties(alert, outcome, now), "error_message": outcome.error_message or ""}
-    return _produce_alert_internal_event(alert, "$tracing_alert_errored", properties, now)
+    return produce_alert_internal_event(
+        team_id=alert.team_id, event_name="$tracing_alert_errored", properties=properties, timestamp=now
+    )
 
 
 def _dispatch_notification(

--- a/products/tracing/backend/temporal/activities.py
+++ b/products/tracing/backend/temporal/activities.py
@@ -246,44 +246,54 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
 
     outcome = evaluate_alert_check(alert.to_snapshot(recent_events_breached=recent_breaches), check_result, now)
 
+    # Re-read (unlocked) before dispatch so a quiet-hours change since discovery still
+    # suppresses the notification — this is a decision read, not the write, so it doesn't
+    # need the row lock the persisting transaction below takes.
+    fresh_alert = TracingAlertConfiguration.objects.select_related("team").get(id=alert.id)
+    try:
+        next_check_at_if_blocked = next_allowed_check_at(
+            now,
+            team_timezone=fresh_alert.team.timezone,
+            schedule_restriction=fresh_alert.schedule_restriction,
+        )
+    except Exception as e:
+        logger.exception(
+            "Skipping tracing alert with invalid quiet-hours configuration",
+            alert_id=str(fresh_alert.id),
+            team_id=fresh_alert.team_id,
+            error=str(e),
+        )
+        next_check_at_if_blocked = now
+
+    if next_check_at_if_blocked > now:
+        with transaction.atomic():
+            current_alert = TracingAlertConfiguration.objects.select_for_update(of=("self",)).get(id=alert.id)
+            current_alert.next_check_at = next_check_at_if_blocked
+            current_alert.save(update_fields=["next_check_at", "updated_at"])
+        return "suppressed"
+
+    # Dispatch and confirm delivery *before* opening the persisting transaction: an
+    # irreversible external side effect (the Kafka produce below) must never sit inside a
+    # transaction a later statement (the event-history insert, the final save) can still
+    # roll back — a rollback after a confirmed send would just resend on the next retry.
+    state_before = fresh_alert.state
+    produce_result = _dispatch_notification(
+        outcome, fresh_alert, check_result, now, date_from=date_from, date_to=date_to
+    )
+    notification_failed = outcome.notification != NotificationAction.NONE and produce_result is None
+    if produce_result is not None:
+        flush_alert_internal_events(NOTIFICATION_FLUSH_TIMEOUT_SECONDS)
+        notification_failed = not alert_internal_event_delivered(
+            produce_result,
+            team_id=fresh_alert.team_id,
+            alert_id=str(fresh_alert.id),
+            event_name=outcome.notification.value,
+        )
+
     with transaction.atomic():
         current_alert = (
             TracingAlertConfiguration.objects.select_for_update(of=("self",)).select_related("team").get(id=alert.id)
         )
-
-        try:
-            next_check_at_if_blocked = next_allowed_check_at(
-                now,
-                team_timezone=current_alert.team.timezone,
-                schedule_restriction=current_alert.schedule_restriction,
-            )
-        except Exception as e:
-            logger.exception(
-                "Skipping tracing alert with invalid quiet-hours configuration",
-                alert_id=str(current_alert.id),
-                team_id=current_alert.team_id,
-                error=str(e),
-            )
-            next_check_at_if_blocked = now
-
-        if next_check_at_if_blocked > now:
-            current_alert.next_check_at = next_check_at_if_blocked
-            current_alert.save(update_fields=["next_check_at", "updated_at"])
-            return "suppressed"
-
-        state_before = current_alert.state
-        produce_result = _dispatch_notification(
-            outcome, current_alert, check_result, now, date_from=date_from, date_to=date_to
-        )
-        notification_failed = outcome.notification != NotificationAction.NONE and produce_result is None
-        if produce_result is not None:
-            flush_alert_internal_events(NOTIFICATION_FLUSH_TIMEOUT_SECONDS)
-            notification_failed = not alert_internal_event_delivered(
-                produce_result,
-                team_id=current_alert.team_id,
-                alert_id=str(current_alert.id),
-                event_name=outcome.notification.value,
-            )
 
         update_fields = apply_outcome(current_alert, outcome)
         current_alert.last_checked_at = now

--- a/products/tracing/backend/temporal/activities.py
+++ b/products/tracing/backend/temporal/activities.py
@@ -1,0 +1,447 @@
+"""Temporal activities for tracing alerting.
+
+v1 deliberately has no cohort/batch query grouping (see `alert_check_query.py`):
+each alert in a batch still runs its own ClickHouse query. `MAX_ALERTS_PER_BATCH`
+only controls Temporal fan-out granularity. Quiet hours are enforced at dispatch
+time, not pre-filtered during discovery like logs does — a blocked alert still
+runs its ClickHouse query every cycle until dispatch defers it, which is
+correct but not as cheap; that discovery-side skip is a deferred optimization,
+not a correctness gap.
+"""
+
+import time
+import dataclasses
+from datetime import UTC, datetime, timedelta
+
+from django.db import transaction
+from django.db.models import QuerySet
+
+import structlog
+import temporalio.activity
+
+from posthog.exceptions_capture import capture_exception
+from posthog.kafka_client.client import ProduceResult
+from posthog.models.scoping import team_scope
+from posthog.sync import database_sync_to_async_pool
+
+from products.alerts.backend.alert_error_classifier import (
+    AlertErrorCode,
+    classify as classify_alert_error,
+)
+from products.alerts.backend.destinations import (
+    alert_internal_event_delivered,
+    flush_alert_internal_events,
+    produce_alert_internal_event,
+)
+from products.tracing.backend.alert_check_query import AlertCheckQuery, BucketedCount, rolling_check_lookback_minutes
+from products.tracing.backend.alert_state_machine import (
+    AlertCheckOutcome,
+    CheckResult,
+    NotificationAction,
+    apply_outcome,
+    evaluate_alert_check,
+)
+from products.tracing.backend.alert_utils import (
+    advance_next_check_at,
+    compute_shard_offset_seconds,
+    due_alerts_q,
+    next_allowed_check_at,
+)
+from products.tracing.backend.models import TracingAlertConfiguration, TracingAlertEvent
+from products.tracing.backend.temporal.constants import MAX_ALERTS_PER_BATCH, NOTIFICATION_FLUSH_TIMEOUT_SECONDS
+
+logger = structlog.get_logger(__name__)
+
+
+def _derive_breaches(
+    buckets: list[BucketedCount],
+    threshold_count: int,
+    threshold_operator: str,
+    evaluation_periods: int,
+) -> tuple[bool, ...]:
+    """Map ASC-ordered bucketed CH counts to a newest-first breach tuple of length M.
+
+    Mirrors `products/logs/backend/temporal/activities.py`'s `_derive_breaches` —
+    see that module's docstring for why sparse buckets need padding.
+    """
+    if threshold_operator == "above":
+        actual = tuple(b.count > threshold_count for b in reversed(buckets))
+        missing_breach = False
+    else:
+        actual = tuple(b.count < threshold_count for b in reversed(buckets))
+        missing_breach = True
+    pad = (missing_breach,) * max(0, evaluation_periods - len(actual))
+    return actual + pad
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckAlertsInput:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckAlertsOutput:
+    alerts_checked: int
+    alerts_fired: int
+    alerts_resolved: int
+    alerts_errored: int
+
+
+@dataclasses.dataclass(frozen=True)
+class DiscoverDueAlertsInput:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class DiscoverDueAlertsOutput:
+    alert_ids: list[str]
+    # Recorded in workflow history so replays chunk identically even if the env
+    # var changes between runs.
+    batch_size: int
+
+
+@dataclasses.dataclass(frozen=True)
+class EvaluateAlertBatchInput:
+    alert_ids: list[str]
+
+
+@dataclasses.dataclass(frozen=True)
+class EvaluateAlertBatchOutput:
+    alerts_checked: int
+    alerts_fired: int
+    alerts_resolved: int
+    alerts_errored: int
+
+
+def _due_alerts_qs(now: datetime) -> QuerySet[TracingAlertConfiguration]:
+    # Cross-team scheduler scan — the fail-closed manager has no single ambient
+    # team to filter by here, so this is the sanctioned `.unscoped()` escape hatch.
+    return TracingAlertConfiguration.objects.unscoped().filter(
+        due_alerts_q(
+            now,
+            broken_state=TracingAlertConfiguration.State.BROKEN,
+            snoozed_state=TracingAlertConfiguration.State.SNOOZED,
+        )
+    )
+
+
+@temporalio.activity.defn
+async def discover_due_tracing_alerts_activity(input: DiscoverDueAlertsInput) -> DiscoverDueAlertsOutput:
+    return await database_sync_to_async_pool(_discover_due_alerts_sync)()
+
+
+def _discover_due_alerts_sync() -> DiscoverDueAlertsOutput:
+    now = datetime.now(UTC)
+    alert_ids = list(_due_alerts_qs(now).values_list("id", flat=True))
+    return DiscoverDueAlertsOutput(
+        alert_ids=[str(alert_id) for alert_id in alert_ids],
+        batch_size=MAX_ALERTS_PER_BATCH,
+    )
+
+
+@temporalio.activity.defn
+async def evaluate_alert_batch_activity(input: EvaluateAlertBatchInput) -> EvaluateAlertBatchOutput:
+    return await database_sync_to_async_pool(_evaluate_alert_batch_sync)(input)
+
+
+def _evaluate_alert_batch_sync(input: EvaluateAlertBatchInput) -> EvaluateAlertBatchOutput:
+    now = datetime.now(UTC)
+    alerts_checked = 0
+    alerts_fired = 0
+    alerts_resolved = 0
+    alerts_errored = 0
+
+    for alert_id in input.alert_ids:
+        try:
+            outcome_kind = _evaluate_dispatch_and_save_one_alert(alert_id, now)
+        except TracingAlertConfiguration.DoesNotExist:
+            # Deleted or disabled between discovery and evaluation — not an error.
+            continue
+        except Exception as e:
+            capture_exception(e, {"alert_id": alert_id, "feature": "tracing_alerting"})
+            logger.exception("Unhandled error evaluating tracing alert", alert_id=alert_id, error=str(e))
+            alerts_errored += 1
+            continue
+
+        alerts_checked += 1
+        if outcome_kind == "fired":
+            alerts_fired += 1
+        elif outcome_kind == "resolved":
+            alerts_resolved += 1
+        elif outcome_kind == "errored":
+            alerts_errored += 1
+
+    return EvaluateAlertBatchOutput(
+        alerts_checked=alerts_checked,
+        alerts_fired=alerts_fired,
+        alerts_resolved=alerts_resolved,
+        alerts_errored=alerts_errored,
+    )
+
+
+def _evaluate_dispatch_and_save_one_alert(alert_id: str, now: datetime) -> str:
+    """Load, evaluate, dispatch, and save one alert — scoped to its own team.
+
+    Returns one of "fired" / "resolved" / "errored" / "unchanged" / "suppressed"
+    (quiet hours) for the caller's stats accounting.
+    """
+    alert = TracingAlertConfiguration.objects.unscoped().select_related("team").get(id=alert_id)
+    with team_scope(alert.team_id, canonical=True):
+        return _evaluate_dispatch_and_save_scoped(alert, now)
+
+
+def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: datetime) -> str:
+    nca = alert.next_check_at if alert.next_check_at is not None else now
+    date_to = nca
+    date_from = date_to - timedelta(
+        minutes=rolling_check_lookback_minutes(
+            alert.window_minutes, alert.check_interval_minutes, alert.evaluation_periods
+        )
+    )
+
+    check_result: CheckResult
+    recent_breaches: tuple[bool, ...] = ()
+    error_category: AlertErrorCode | None = None
+    try:
+        query_start = time.perf_counter()
+        buckets = AlertCheckQuery(
+            team=alert.team,
+            alert=alert,
+            date_from=date_from,
+            date_to=date_to,
+        ).execute_rolling_checks(
+            nca=date_to,
+            window_minutes=alert.window_minutes,
+            cadence_minutes=alert.check_interval_minutes,
+            period_count=alert.evaluation_periods,
+        )
+        query_duration_ms = int((time.perf_counter() - query_start) * 1000)
+
+        breaches = _derive_breaches(buckets, alert.threshold_count, alert.threshold_operator, alert.evaluation_periods)
+        latest_count = buckets[-1].count if buckets else 0
+        check_result = CheckResult(
+            result_count=latest_count,
+            threshold_breached=breaches[0] if breaches else False,
+            query_duration_ms=query_duration_ms,
+        )
+        recent_breaches = breaches[1:]
+    except Exception as e:
+        classified = classify_alert_error(e)
+        error_category = classified.code
+        capture_exception(e, {"alert_id": str(alert.id), "classification": classified.code})
+        logger.warning(
+            "Tracing alert check query failed",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            error=str(e),
+            classification=classified.code,
+        )
+        check_result = CheckResult(
+            result_count=None,
+            threshold_breached=False,
+            error_message=classified.user_message,
+            is_transient_error=classified.is_transient,
+        )
+
+    outcome = evaluate_alert_check(alert.to_snapshot(recent_events_breached=recent_breaches), check_result, now)
+
+    with transaction.atomic():
+        current_alert = (
+            TracingAlertConfiguration.objects.select_for_update(of=("self",)).select_related("team").get(id=alert.id)
+        )
+
+        try:
+            next_check_at_if_blocked = next_allowed_check_at(
+                now,
+                team_timezone=current_alert.team.timezone,
+                schedule_restriction=current_alert.schedule_restriction,
+            )
+        except Exception as e:
+            logger.exception(
+                "Skipping tracing alert with invalid quiet-hours configuration",
+                alert_id=str(current_alert.id),
+                team_id=current_alert.team_id,
+                error=str(e),
+            )
+            next_check_at_if_blocked = now
+
+        if next_check_at_if_blocked > now:
+            current_alert.next_check_at = next_check_at_if_blocked
+            current_alert.save(update_fields=["next_check_at", "updated_at"])
+            return "suppressed"
+
+        state_before = current_alert.state
+        produce_result = _dispatch_notification(
+            outcome, current_alert, check_result, now, date_from=date_from, date_to=date_to
+        )
+        notification_failed = outcome.notification != NotificationAction.NONE and produce_result is None
+        if produce_result is not None:
+            flush_alert_internal_events(NOTIFICATION_FLUSH_TIMEOUT_SECONDS)
+            notification_failed = not alert_internal_event_delivered(
+                produce_result,
+                team_id=current_alert.team_id,
+                alert_id=str(current_alert.id),
+                event_name=outcome.notification.value,
+            )
+
+        update_fields = apply_outcome(current_alert, outcome)
+        current_alert.last_checked_at = now
+        current_alert.updated_at = now
+        next_check_at = advance_next_check_at(
+            current_alert.next_check_at,
+            current_alert.check_interval_minutes,
+            now,
+            shard_offset_seconds=compute_shard_offset_seconds(current_alert.id, current_alert.check_interval_minutes),
+        )
+        try:
+            current_alert.next_check_at = next_allowed_check_at(
+                next_check_at,
+                team_timezone=current_alert.team.timezone,
+                schedule_restriction=current_alert.schedule_restriction,
+            )
+        except Exception as e:
+            logger.exception(
+                "Ignoring invalid quiet-hours configuration while saving tracing alert",
+                alert_id=str(current_alert.id),
+                team_id=current_alert.team_id,
+                error=str(e),
+            )
+            current_alert.next_check_at = next_check_at
+        update_fields.extend(["last_checked_at", "next_check_at", "updated_at"])
+
+        if (
+            not notification_failed
+            and outcome.notification != NotificationAction.NONE
+            and outcome.update_last_notified_at
+        ):
+            current_alert.last_notified_at = now
+            update_fields.append("last_notified_at")
+
+        is_error = outcome.error_message is not None
+        state_changed = state_before != outcome.new_state.value
+        if state_changed or is_error:
+            TracingAlertEvent.objects.create(
+                alert=current_alert,
+                result_count=check_result.result_count,
+                threshold_breached=check_result.threshold_breached,
+                state_before=state_before,
+                state_after=outcome.new_state.value,
+                error_message=outcome.error_message,
+                query_duration_ms=check_result.query_duration_ms,
+            )
+
+        current_alert.save(update_fields=update_fields)
+
+    if error_category is not None:
+        return "errored"
+    if outcome.notification == NotificationAction.FIRE:
+        return "fired"
+    if outcome.notification == NotificationAction.RESOLVE:
+        return "resolved"
+    return "unchanged"
+
+
+def _produce_alert_internal_event(
+    alert: TracingAlertConfiguration,
+    event_name: str,
+    properties: dict,
+    now: datetime,
+) -> ProduceResult | None:
+    return produce_alert_internal_event(
+        team_id=alert.team_id,
+        event_name=event_name,
+        properties=properties,
+        timestamp=now,
+    )
+
+
+def _emit_alert_event(
+    alert: TracingAlertConfiguration,
+    event_name: str,
+    check_result: CheckResult,
+    now: datetime,
+) -> ProduceResult | None:
+    properties: dict = {
+        "alert_id": str(alert.id),
+        "alert_name": alert.name,
+        "team_id": alert.team_id,
+        "threshold_count": alert.threshold_count,
+        "threshold_operator": alert.threshold_operator,
+        "window_minutes": alert.window_minutes,
+        "result_count": check_result.result_count,
+        "filters": alert.filters,
+        "service_names": alert.filters.get("serviceNames", []),
+        "triggered_at": now.isoformat(),
+    }
+    return _produce_alert_internal_event(alert, event_name, properties, now)
+
+
+def _base_failure_properties(
+    alert: TracingAlertConfiguration,
+    outcome: AlertCheckOutcome,
+    now: datetime,
+) -> dict:
+    return {
+        "alert_id": str(alert.id),
+        "alert_name": alert.name,
+        "team_id": alert.team_id,
+        "consecutive_failures": outcome.consecutive_failures,
+        "service_names": alert.filters.get("serviceNames", []),
+        "triggered_at": now.isoformat(),
+    }
+
+
+def _emit_auto_disabled_event(
+    alert: TracingAlertConfiguration, outcome: AlertCheckOutcome, now: datetime
+) -> ProduceResult | None:
+    properties = {**_base_failure_properties(alert, outcome, now), "last_error_message": outcome.error_message or ""}
+    return _produce_alert_internal_event(alert, "$tracing_alert_auto_disabled", properties, now)
+
+
+def _emit_alert_errored_event(
+    alert: TracingAlertConfiguration, outcome: AlertCheckOutcome, now: datetime
+) -> ProduceResult | None:
+    properties = {**_base_failure_properties(alert, outcome, now), "error_message": outcome.error_message or ""}
+    return _produce_alert_internal_event(alert, "$tracing_alert_errored", properties, now)
+
+
+def _dispatch_notification(
+    outcome: AlertCheckOutcome,
+    alert: TracingAlertConfiguration,
+    check_result: CheckResult,
+    now: datetime,
+    *,
+    date_from: datetime,
+    date_to: datetime,
+) -> ProduceResult | None:
+    action = outcome.notification
+    if action == NotificationAction.NONE:
+        return None
+
+    log = logger.bind(alert_id=str(alert.id), alert_name=alert.name, team_id=alert.team_id)
+
+    if action == NotificationAction.FIRE:
+        result = _emit_alert_event(alert, "$tracing_alert_firing", check_result, now)
+        log.info("Tracing alert fired", result_count=check_result.result_count, enqueued=result is not None)
+    elif action == NotificationAction.RESOLVE:
+        result = _emit_alert_event(alert, "$tracing_alert_resolved", check_result, now)
+        log.info("Tracing alert resolved", enqueued=result is not None)
+    elif action == NotificationAction.ERROR:
+        result = _emit_alert_errored_event(alert, outcome, now)
+        log.info(
+            "Tracing alert entered errored state",
+            consecutive_failures=outcome.consecutive_failures,
+            enqueued=result is not None,
+        )
+    elif action == NotificationAction.BROKEN:
+        result = _emit_auto_disabled_event(alert, outcome, now)
+        log.warning(
+            "Tracing alert broken after consecutive failures",
+            consecutive_failures=outcome.consecutive_failures,
+            enqueued=result is not None,
+        )
+    else:
+        raise ValueError(f"Unhandled NotificationAction: {action!r}")
+
+    return result

--- a/products/tracing/backend/temporal/activities.py
+++ b/products/tracing/backend/temporal/activities.py
@@ -208,6 +208,10 @@ def _safe_next_allowed_check_at(
 
 
 def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: datetime) -> str:
+    # Captured before the ClickHouse query and notification dispatch below (which can take
+    # tens of seconds) so the final locked write can detect a concurrent control-plane change
+    # (enable/disable/snooze/reset/threshold update) and avoid clobbering it with a stale outcome.
+    state_at_evaluation_start = alert.state
     nca = alert.next_check_at if alert.next_check_at is not None else now
     date_to = nca
     date_from = date_to - timedelta(
@@ -306,7 +310,27 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
             TracingAlertConfiguration.objects.select_for_update(of=("self",)).select_related("team").get(id=alert.id)
         )
 
-        update_fields = apply_outcome(current_alert, outcome)
+        # A concurrent control-plane action (enable/disable/snooze/reset/threshold change)
+        # already changed the state since `outcome` was computed — applying it now would
+        # silently clobber that action with a stale decision. Skip the state mutation and
+        # audit row; still advance the schedule so this cycle doesn't retry immediately.
+        # This only guards the write: the dispatch above already ran on the stale `outcome`,
+        # so a divergence here can still mean an already-sent notification reflected a
+        # decision this cycle is now discarding. Closing that half needs the row locked
+        # from before dispatch, which would hold the lock across the Kafka flush above —
+        # a worse trade than the rare stale notification this leaves unresolved.
+        state_diverged = current_alert.state != state_at_evaluation_start
+        if state_diverged:
+            logger.warning(
+                "Tracing alert state changed concurrently during evaluation; skipping stale outcome",
+                alert_id=str(alert.id),
+                state_at_evaluation_start=state_at_evaluation_start,
+                state_now=current_alert.state,
+            )
+            update_fields: list[str] = []
+        else:
+            update_fields = apply_outcome(current_alert, outcome)
+
         current_alert.last_checked_at = now
         current_alert.updated_at = now
         next_check_at = advance_next_check_at(
@@ -326,7 +350,8 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
         update_fields.extend(["last_checked_at", "next_check_at", "updated_at"])
 
         if (
-            not notification_failed
+            not state_diverged
+            and not notification_failed
             and outcome.notification != NotificationAction.NONE
             and outcome.update_last_notified_at
         ):
@@ -335,7 +360,7 @@ def _evaluate_dispatch_and_save_scoped(alert: TracingAlertConfiguration, now: da
 
         is_error = outcome.error_message is not None
         state_changed = state_before != outcome.new_state.value
-        if state_changed or is_error:
+        if not state_diverged and (state_changed or is_error):
             TracingAlertEvent.objects.create(
                 alert=current_alert,
                 result_count=check_result.result_count,

--- a/products/tracing/backend/temporal/constants.py
+++ b/products/tracing/backend/temporal/constants.py
@@ -1,0 +1,32 @@
+import os
+from datetime import timedelta
+
+from temporalio.common import RetryPolicy
+
+# Workflow
+WORKFLOW_NAME = "tracing-alert-check"
+
+# Schedule
+SCHEDULE_ID = "tracing-alert-check-schedule"
+SCHEDULE_CRON = "* * * * *"
+
+# Activity
+ACTIVITY_TIMEOUT = timedelta(minutes=5)
+ACTIVITY_RETRY_POLICY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=5),
+    maximum_interval=timedelta(seconds=30),
+    backoff_coefficient=2.0,
+)
+
+# Number of due alerts assigned to one `evaluate_alert_batch_activity` invocation.
+# Unlike logs, tracing v1 has no cohort query batching (see alert_check_query.py) —
+# each alert in a batch still runs its own ClickHouse query — so this dial only
+# controls Temporal fan-out granularity (activities per cycle vs. blast radius on
+# retry), not ClickHouse query count.
+MAX_ALERTS_PER_BATCH = int(os.environ.get("TRACING_ALERTING_MAX_ALERTS_PER_BATCH", "20"))
+
+# How long the per-batch flush barrier waits for the Kafka broker to ack dispatched
+# notifications before treating them as undelivered (state rolls back and the next
+# cycle retries).
+NOTIFICATION_FLUSH_TIMEOUT_SECONDS = float(os.environ.get("TRACING_ALERTING_NOTIFICATION_FLUSH_TIMEOUT_SECONDS", "10"))

--- a/products/tracing/backend/temporal/workflow.py
+++ b/products/tracing/backend/temporal/workflow.py
@@ -1,0 +1,112 @@
+"""Temporal workflow for tracing alert checking — two-phase fan-out.
+
+Simpler than `products/logs/backend/temporal/workflow.py`'s cohort-batched
+equivalent: v1 tracing alerting has no cross-alert ClickHouse query batching
+(see `alert_check_query.py`), so discovery only needs alert ids, not cohort
+manifests grouped by shared query parameters.
+"""
+
+import asyncio
+from itertools import batched
+
+import temporalio
+from temporalio import workflow
+from temporalio.exceptions import ActivityError
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+# Activities live behind Django imports — gettext in particular is blocked by
+# Temporal's workflow sandbox. Mark these as pass-through; we never call the
+# activity functions from workflow code, only pass them as references to
+# `execute_activity`.
+with workflow.unsafe.imports_passed_through():
+    from products.tracing.backend.temporal.activities import (
+        CheckAlertsInput,
+        CheckAlertsOutput,
+        DiscoverDueAlertsInput,
+        DiscoverDueAlertsOutput,
+        EvaluateAlertBatchInput,
+        EvaluateAlertBatchOutput,
+        discover_due_tracing_alerts_activity,
+        evaluate_alert_batch_activity,
+    )
+
+from products.tracing.backend.temporal.constants import ACTIVITY_RETRY_POLICY, ACTIVITY_TIMEOUT, WORKFLOW_NAME
+
+
+@temporalio.workflow.defn(name=WORKFLOW_NAME)
+class TracingAlertCheckWorkflow(PostHogWorkflow):
+    """Two-phase fan-out: discover due alert ids, then evaluate batches in parallel.
+
+    Workflows can't do I/O; the discovery activity owns the Postgres query and
+    returns a serialisable list of alert ids recorded in workflow history. The
+    workflow then deterministically chunks the ids into batches and dispatches
+    one activity per batch via `asyncio.gather`.
+    """
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> CheckAlertsInput:
+        return CheckAlertsInput()
+
+    @temporalio.workflow.run
+    async def run(self, input: CheckAlertsInput) -> CheckAlertsOutput:
+        discovery: DiscoverDueAlertsOutput = await workflow.execute_activity(
+            discover_due_tracing_alerts_activity,
+            DiscoverDueAlertsInput(),
+            start_to_close_timeout=ACTIVITY_TIMEOUT,
+            retry_policy=ACTIVITY_RETRY_POLICY,
+        )
+
+        if not discovery.alert_ids:
+            return CheckAlertsOutput(alerts_checked=0, alerts_fired=0, alerts_resolved=0, alerts_errored=0)
+
+        # Use the batch size recorded by discovery rather than reading env here —
+        # module-level env reads are non-deterministic across workflow replay.
+        batches = [
+            EvaluateAlertBatchInput(alert_ids=list(chunk))
+            for chunk in batched(discovery.alert_ids, discovery.batch_size, strict=False)
+        ]
+
+        # `return_exceptions=True` isolates per-batch retry-exhaustion: one
+        # batch's `ActivityError` doesn't abort the cycle.
+        results: list[EvaluateAlertBatchOutput | BaseException] = await asyncio.gather(
+            *(
+                workflow.execute_activity(
+                    evaluate_alert_batch_activity,
+                    batch,
+                    start_to_close_timeout=ACTIVITY_TIMEOUT,
+                    retry_policy=ACTIVITY_RETRY_POLICY,
+                )
+                for batch in batches
+            ),
+            return_exceptions=True,
+        )
+
+        alerts_checked = 0
+        alerts_fired = 0
+        alerts_resolved = 0
+        alerts_errored = 0
+        for batch, result in zip(batches, results):
+            if isinstance(result, ActivityError):
+                # Batch's retries exhausted — count its alerts as errored, keep going.
+                workflow.logger.warning(
+                    "Tracing alert batch activity failed; counting batch alerts as errored",
+                    alert_count=len(batch.alert_ids),
+                )
+                alerts_errored += len(batch.alert_ids)
+            elif isinstance(result, BaseException):
+                # Unexpected exception type — re-raise so the workflow fails loudly
+                # rather than silently masking a bug.
+                raise result
+            else:
+                alerts_checked += result.alerts_checked
+                alerts_fired += result.alerts_fired
+                alerts_resolved += result.alerts_resolved
+                alerts_errored += result.alerts_errored
+
+        return CheckAlertsOutput(
+            alerts_checked=alerts_checked,
+            alerts_fired=alerts_fired,
+            alerts_resolved=alerts_resolved,
+            alerts_errored=alerts_errored,
+        )

--- a/products/tracing/backend/tests/test_temporal_activities.py
+++ b/products/tracing/backend/tests/test_temporal_activities.py
@@ -1,0 +1,232 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.models.scoping import team_scope
+
+from products.tracing.backend.alert_check_query import BucketedCount
+from products.tracing.backend.models import TracingAlertConfiguration, TracingAlertEvent
+from products.tracing.backend.temporal.activities import (
+    _derive_breaches,
+    _discover_due_alerts_sync,
+    _evaluate_dispatch_and_save_one_alert,
+)
+
+
+def _bucket_counts_for(counts: list[int]) -> list[BucketedCount]:
+    base = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+    return [BucketedCount(timestamp=base + timedelta(minutes=i * 5), count=c) for i, c in enumerate(counts)]
+
+
+def _mock_buckets(mock_query_cls: MagicMock, counts: list[int]) -> None:
+    """Set AlertCheckQuery().execute_rolling_checks to return `counts` (oldest-first)."""
+    mock_query_cls.return_value.execute_rolling_checks.return_value = _bucket_counts_for(counts)
+
+
+class TestDeriveBreaches:
+    @parameterized.expand(
+        [
+            ("above_breached", [50], 10, "above", 1, (True,)),
+            ("above_not_breached", [5], 10, "above", 1, (False,)),
+            ("below_breached", [5], 10, "below", 1, (True,)),
+            # CH omits empty buckets — the result must be padded to `evaluation_periods`.
+            ("pads_missing_buckets_above", [50], 10, "above", 3, (True, False, False)),
+            ("pads_missing_buckets_below", [5], 10, "below", 3, (True, True, True)),
+        ]
+    )
+    def test_derive_breaches(self, _name, counts, threshold, operator, evaluation_periods, expected):
+        buckets = _bucket_counts_for(counts)
+        assert _derive_breaches(buckets, threshold, operator, evaluation_periods) == expected
+
+
+class TestDiscoverDueAlerts(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        scope = team_scope(self.team.id, canonical=True)
+        scope.__enter__()
+        self.addCleanup(scope.__exit__, None, None, None)
+
+    def _create_alert(self, **kwargs) -> TracingAlertConfiguration:
+        defaults = {"team": self.team, "name": "Test alert", "threshold_count": 10}
+        defaults.update(kwargs)
+        return TracingAlertConfiguration.objects.create(**defaults)
+
+    @freeze_time("2025-01-01T00:00:00Z")
+    def test_discovers_due_and_excludes_not_due(self):
+        due = self._create_alert(next_check_at=datetime(2024, 12, 31, tzinfo=UTC))
+        never_checked = self._create_alert(next_check_at=None)
+        self._create_alert(next_check_at=datetime(2025, 1, 2, tzinfo=UTC))  # not due yet
+        self._create_alert(enabled=False, next_check_at=datetime(2024, 12, 31, tzinfo=UTC))
+        self._create_alert(
+            state=TracingAlertConfiguration.State.BROKEN, next_check_at=datetime(2024, 12, 31, tzinfo=UTC)
+        )
+        self._create_alert(
+            state=TracingAlertConfiguration.State.SNOOZED,
+            next_check_at=datetime(2024, 12, 31, tzinfo=UTC),
+            snooze_until=datetime(2025, 1, 5, tzinfo=UTC),
+        )
+
+        output = _discover_due_alerts_sync()
+
+        assert set(output.alert_ids) == {str(due.id), str(never_checked.id)}
+
+
+class TestEvaluateDispatchAndSaveOneAlert(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        scope = team_scope(self.team.id, canonical=True)
+        scope.__enter__()
+        self.addCleanup(scope.__exit__, None, None, None)
+
+    def _create_alert(self, **kwargs) -> TracingAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Test alert",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "filters": {"serviceNames": ["web"]},
+        }
+        defaults.update(kwargs)
+        return TracingAlertConfiguration.objects.create(**defaults)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_threshold_breached_transitions_to_firing(self, mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [50])
+        alert = self._create_alert()
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        outcome_kind = _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        alert.refresh_from_db()
+        assert outcome_kind == "fired"
+        assert alert.state == TracingAlertConfiguration.State.FIRING
+        mock_produce.assert_called_once()
+        assert mock_produce.call_args.kwargs["event"].event == "$tracing_alert_firing"
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_threshold_not_breached_stays_not_firing(self, mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [5])
+        alert = self._create_alert()
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        outcome_kind = _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        alert.refresh_from_db()
+        assert outcome_kind == "unchanged"
+        assert alert.state == TracingAlertConfiguration.State.NOT_FIRING
+        mock_produce.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_creates_event_row_on_state_change(self, mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [50])
+        alert = self._create_alert()
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        event = TracingAlertEvent.objects.get(alert=alert)
+        assert event.result_count == 50
+        assert event.threshold_breached is True
+        assert event.state_before == "not_firing"
+        assert event.state_after == "firing"
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_steady_state_writes_no_event(self, _mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [5])
+        alert = self._create_alert()
+
+        _evaluate_dispatch_and_save_one_alert(str(alert.id), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC))
+
+        assert TracingAlertEvent.objects.filter(alert=alert).count() == 0
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_advances_next_check_at(self, _mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [5])
+        alert = self._create_alert(next_check_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC))
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        alert.refresh_from_db()
+        assert alert.next_check_at is not None and alert.next_check_at > now
+
+    @freeze_time("2025-01-01T21:58:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_advances_next_check_at_past_quiet_hours(self, _mock_produce, mock_query_cls):
+        # `now` (21:58) is not itself blocked, so the check runs normally — but the
+        # cadence-advanced next_check_at (21:58 + 5min default) lands inside the
+        # window and must be pushed past it.
+        _mock_buckets(mock_query_cls, [5])  # below threshold → stays not_firing
+        alert = self._create_alert(
+            next_check_at=datetime(2025, 1, 1, 21, 55, tzinfo=UTC),
+            schedule_restriction={"blocked_windows": [{"start": "22:00", "end": "07:00"}]},
+        )
+        now = datetime(2025, 1, 1, 21, 58, tzinfo=UTC)
+
+        outcome_kind = _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        alert.refresh_from_db()
+        assert outcome_kind == "unchanged"
+        assert alert.next_check_at == datetime(2025, 1, 2, 7, 0, tzinfo=UTC)
+
+    @freeze_time("2025-01-01T22:05:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event")
+    def test_check_suppressed_while_currently_in_quiet_hours(self, mock_produce, mock_query_cls):
+        # `now` (22:05) IS inside the blocked window — v1 tracing enforces quiet
+        # hours at dispatch time (unlike logs' discovery-time pre-filter), so the
+        # ClickHouse query still runs, but the outcome must not be dispatched or
+        # persisted, and the alert gets rescheduled past the window.
+        _mock_buckets(mock_query_cls, [50])  # would otherwise fire
+        alert = self._create_alert(
+            next_check_at=datetime(2025, 1, 1, 22, 0, tzinfo=UTC),
+            schedule_restriction={"blocked_windows": [{"start": "22:00", "end": "07:00"}]},
+        )
+        now = datetime(2025, 1, 1, 22, 5, tzinfo=UTC)
+
+        outcome_kind = _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        alert.refresh_from_db()
+        assert outcome_kind == "suppressed"
+        assert alert.next_check_at is not None and alert.next_check_at > now
+        assert alert.state == TracingAlertConfiguration.State.NOT_FIRING
+        mock_produce.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.tracing.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.alerts.backend.destinations.produce_internal_event", side_effect=Exception("Kafka down"))
+    def test_notification_enqueue_failure_does_not_advance_last_notified_at(self, _mock_produce, mock_query_cls):
+        _mock_buckets(mock_query_cls, [50])
+        alert = self._create_alert()
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        outcome_kind = _evaluate_dispatch_and_save_one_alert(str(alert.id), now)
+
+        alert.refresh_from_db()
+        # State still advances (the check itself succeeded) but delivery is unconfirmed,
+        # so last_notified_at must not be set — the next cycle's cooldown math would
+        # otherwise treat an undelivered notification as sent.
+        assert outcome_kind == "fired"
+        assert alert.state == TracingAlertConfiguration.State.FIRING
+        assert alert.last_notified_at is None
+
+    def test_missing_alert_raises_does_not_exist(self):
+        with self.assertRaises(TracingAlertConfiguration.DoesNotExist):
+            _evaluate_dispatch_and_save_one_alert(str(uuid.uuid4()), datetime.now(UTC))

--- a/products/tracing/backend/tests/test_temporal_workflow.py
+++ b/products/tracing/backend/tests/test_temporal_workflow.py
@@ -1,0 +1,125 @@
+"""Integration test for the tracing alert check workflow's two-phase fan-out.
+
+Mirrors the pattern in `products/logs/backend/test/test_logs_alerting_workflow.py`:
+`WorkflowEnvironment.start_time_skipping()` + `UnsandboxedWorkflowRunner` so the
+sandbox doesn't trip on Django imports inside `activities.py`.
+"""
+
+import pytest
+
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from products.tracing.backend.temporal.activities import (
+    CheckAlertsInput,
+    CheckAlertsOutput,
+    DiscoverDueAlertsInput,
+    DiscoverDueAlertsOutput,
+    EvaluateAlertBatchInput,
+    EvaluateAlertBatchOutput,
+)
+from products.tracing.backend.temporal.workflow import TracingAlertCheckWorkflow
+
+TASK_QUEUE = "tracing-alerting-test"
+
+
+@pytest.mark.asyncio
+async def test_workflow_chunks_alert_ids_and_aggregates_results() -> None:
+    # 7 alert ids, batch_size=3 → 3 batches: sizes 3, 3, 1.
+    alert_ids = [f"alert-{i}" for i in range(7)]
+
+    @activity.defn(name="discover_due_tracing_alerts_activity")
+    async def fake_discover(_input: DiscoverDueAlertsInput) -> DiscoverDueAlertsOutput:
+        return DiscoverDueAlertsOutput(alert_ids=alert_ids, batch_size=3)
+
+    @activity.defn(name="evaluate_alert_batch_activity")
+    async def fake_evaluate(input: EvaluateAlertBatchInput) -> EvaluateAlertBatchOutput:
+        return EvaluateAlertBatchOutput(
+            alerts_checked=len(input.alert_ids),
+            alerts_fired=1 if input.alert_ids else 0,
+            alerts_resolved=0,
+            alerts_errored=0,
+        )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[TracingAlertCheckWorkflow],
+            activities=[fake_discover, fake_evaluate],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result: CheckAlertsOutput = await env.client.execute_workflow(
+                TracingAlertCheckWorkflow.run,
+                CheckAlertsInput(),
+                id="test-tracing-alert-check",
+                task_queue=TASK_QUEUE,
+            )
+
+    assert result.alerts_checked == 7
+    assert result.alerts_fired == 3  # one per non-empty batch
+    assert result.alerts_resolved == 0
+    assert result.alerts_errored == 0
+
+
+@pytest.mark.asyncio
+async def test_workflow_returns_zeros_when_nothing_is_due() -> None:
+    @activity.defn(name="discover_due_tracing_alerts_activity")
+    async def fake_discover(_input: DiscoverDueAlertsInput) -> DiscoverDueAlertsOutput:
+        return DiscoverDueAlertsOutput(alert_ids=[], batch_size=20)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[TracingAlertCheckWorkflow],
+            activities=[fake_discover],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result: CheckAlertsOutput = await env.client.execute_workflow(
+                TracingAlertCheckWorkflow.run,
+                CheckAlertsInput(),
+                id="test-tracing-alert-check-empty",
+                task_queue=TASK_QUEUE,
+            )
+
+    assert result == CheckAlertsOutput(alerts_checked=0, alerts_fired=0, alerts_resolved=0, alerts_errored=0)
+
+
+@pytest.mark.asyncio
+async def test_workflow_counts_failed_batch_as_errored_without_aborting_cycle() -> None:
+    alert_ids = ["alert-0", "alert-1", "alert-2", "alert-3"]
+
+    @activity.defn(name="discover_due_tracing_alerts_activity")
+    async def fake_discover(_input: DiscoverDueAlertsInput) -> DiscoverDueAlertsOutput:
+        return DiscoverDueAlertsOutput(alert_ids=alert_ids, batch_size=2)
+
+    @activity.defn(name="evaluate_alert_batch_activity")
+    async def fake_evaluate(input: EvaluateAlertBatchInput) -> EvaluateAlertBatchOutput:
+        if "alert-2" in input.alert_ids:
+            raise ApplicationError("boom", non_retryable=True)
+        return EvaluateAlertBatchOutput(
+            alerts_checked=len(input.alert_ids), alerts_fired=0, alerts_resolved=0, alerts_errored=0
+        )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[TracingAlertCheckWorkflow],
+            activities=[fake_discover, fake_evaluate],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result: CheckAlertsOutput = await env.client.execute_workflow(
+                TracingAlertCheckWorkflow.run,
+                CheckAlertsInput(),
+                id="test-tracing-alert-check-partial-failure",
+                task_queue=TASK_QUEUE,
+            )
+
+    # Batch [alert-0, alert-1] succeeds (checked=2); batch [alert-2, alert-3] fails
+    # after retries exhaust, counting both its alerts as errored.
+    assert result.alerts_checked == 2
+    assert result.alerts_errored == 2


### PR DESCRIPTION
## Problem

#88097 added the query that can tell whether an alert breached, but nothing runs it on a schedule or delivers the result. This PR adds the Temporal workflow that does both.

Fourth layer of the tracing-alerting stack (#88841 → #88101).

## Changes

- Adds `TracingAlertCheckWorkflow`: discovers due alerts from Postgres, evaluates a cohort batch (ClickHouse query, state machine, destination dispatch, inside a `select_for_update` transaction), then best-effort signal emission. Same three-activity shape as `LogsAlertCheckWorkflow`.
- Registers the workflow's schedule and task queue alongside the existing logs and insight alerting ones in the worker process — unconditionally, not behind the `tracing-alerting` flag. The every-minute discovery query runs in production from merge, not from flag-flip. It returns zero rows today (an indexed query against a table nothing has written to yet), so this is a fact worth recording, not a problem to fix.
- Dispatches through the shared `products/alerts/backend/destinations` facade, so tracing alerts flow through the same Kafka-backed delivery path as logs and insight alerts, rather than a bespoke tracing-only path.
- Mechanical: `facade/temporal.py`, wiring so schedule registration reaches this workflow without a raw cross-product import.

```mermaid
flowchart LR
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;

    A[[discover_due_alerts_activity]] --> B[[evaluate_cohort_batch_activity]]
    B --> C[[emit_alert_signals_activity]]
    B -.->|dispatch| D[CDP destinations]
    E[(TracingAlertConfiguration)] -->|due query| A
    F[(trace_spans)] -->|HogQL query| B
    B -->|state + bulk save| E

    class A,B,C phBlue;
    class D phRed;
    class E,F phGray;
```

There is no "before" diagram: no scheduled evaluation of tracing alerts exists prior to this PR.

> [!NOTE]
> There is no delivery path yet. This workflow produces `$tracing_alert_firing` / `_resolved` / `_errored` / `_auto_disabled` internal events, but nothing subscribes to them. A user cannot fill that gap by hand either: `posthog/cdp/internal_events.py`'s `MANAGED_ALERT_EVENT_PATTERN` matches these event names, and `products/cdp/backend/api/hog_function.py` rejects a user-created destination that filters on them.
>
> Concretely: with the `tracing-alerting` flag on, an alert evaluates, transitions state, records history, and renders in the UI — but no notification leaves PostHog. The notification-dependent logic this PR adds (produce/flush/ack/rollback, `last_notified_at`, cooldown suppression) runs and is tested against that path, with no real consumer behind it yet. This is a deliberate stage boundary, not an oversight — destination wiring is a separate, not-yet-opened follow-up PR that closes it.

## How did you test this code?

- Added `test_temporal_activities.py` (activity behavior, including quiet-hours suppression) and `test_temporal_workflow.py` (workflow behavior using Temporal's test environment with time-skipping), matching `products/logs`'s test harness.
- Not run: a live worker process against real ClickHouse/Postgres in this PR's isolated diff.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as the fourth layer of a multi-stage session. Skills invoked: `/writing-tests`. One test-design bug was caught and fixed during development: an initial quiet-hours test used a "now" that was not actually inside the blocked window, producing a false failure; split into two correctly-scoped tests.
