### PR TITLE
feat(tracing): add alerts DRF API

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -53123,6 +53123,25 @@
             "required": ["results"],
             "type": "object"
         },
+        "TracingAlertFilters": {
+            "additionalProperties": false,
+            "description": "Filter criteria for a tracing alert configuration, matched against `trace_spans`. At least one of `serviceNames`, `errorOnly`, or `filterGroup` must be set on a live (enabled=true) alert.",
+            "properties": {
+                "errorOnly": {
+                    "type": "boolean"
+                },
+                "filterGroup": {
+                    "$ref": "#/definitions/PropertyGroupFilter"
+                },
+                "serviceNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "TrendsAlertConfig": {
             "additionalProperties": false,
             "properties": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4222,6 +4222,17 @@ export interface LogsAlertFilters {
     filterGroup?: PropertyGroupFilter
 }
 
+/**
+ * Filter criteria for a tracing alert configuration, matched against `trace_spans`.
+ * At least one of `serviceNames`, `errorOnly`, or `filterGroup` must be set on a
+ * live (enabled=true) alert.
+ */
+export interface TracingAlertFilters {
+    serviceNames?: string[]
+    errorOnly?: boolean
+    filterGroup?: PropertyGroupFilter
+}
+
 export interface LogsQuery extends DataNode<LogsQueryResponse> {
     kind: NodeKind.LogsQuery
     dateRange: DateRange

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -26971,6 +26971,15 @@ class TracesQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class TracingAlertFilters(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    errorOnly: bool | None = None
+    filterGroup: PropertyGroupFilter | None = None
+    serviceNames: list[str] | None = None
+
+
 class VectorSearchQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -601,6 +601,8 @@ SPECTACULAR_SETTINGS = {
         "EmailChannelKindEnum": "products.conversations.backend.models.team_conversations_email_config.EmailChannelKind",
         "EmailThreadMessageDirectionEnum": "products.conversations.backend.models.email_thread.EmailThreadMessageDirection",
         "EmailThreadParticipantKindEnum": "products.conversations.backend.models.email_thread.EmailThreadParticipantKind",
+        # Shared by LogsAlertEvent.kind and TracingAlertEvent.kind (same choice set).
+        "AlertEventKindEnum": "products.logs.backend.models.LogsAlertEvent.Kind",
         # Shared by Ticket.priority and TicketViewFilters.priority (same choice set).
         "TicketPriorityEnum": "products.conversations.backend.models.constants.Priority",
         "TicketChannelFilterEnum": "products.conversations.backend.api.ticket_filters.TICKET_CHANNEL_FILTER_CHOICES",

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
@@ -14,7 +14,7 @@ import {
 import {
     LogsAlertConfigurationApi,
     LogsAlertEventApi,
-    LogsAlertEventKindEnumApi,
+    AlertEventKindEnumApi,
     LogsAlertThresholdOperatorEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
@@ -40,7 +40,7 @@ function getHistoryThresholds(alert: LogsAlertConfigurationApi): AlertEvaluation
 
 function getHistoryPoints(events: LogsAlertEventApi[]): AlertEvaluationHistoryPoint[] {
     return events
-        .filter((event) => event.kind === LogsAlertEventKindEnumApi.Check && event.result_count !== null)
+        .filter((event) => event.kind === AlertEventKindEnumApi.Check && event.result_count !== null)
         .sort((left, right) => left.created_at.localeCompare(right.created_at))
         .map((event) => ({
             label: dayjs(event.created_at).format('MMM D, HH:mm'),
@@ -124,20 +124,20 @@ interface EventDescription {
 }
 
 const CONTROL_PLANE_DESCRIPTIONS: Record<
-    Exclude<LogsAlertEventKindEnumApi, typeof LogsAlertEventKindEnumApi.Check>,
+    Exclude<AlertEventKindEnumApi, typeof AlertEventKindEnumApi.Check>,
     Pick<EventDescription, 'label' | 'type'>
 > = {
-    [LogsAlertEventKindEnumApi.Reset]: { label: 'Reset', type: 'primary' },
-    [LogsAlertEventKindEnumApi.Enable]: { label: 'Enabled', type: 'success' },
-    [LogsAlertEventKindEnumApi.Disable]: { label: 'Disabled', type: 'muted' },
-    [LogsAlertEventKindEnumApi.Snooze]: { label: 'Snoozed', type: 'highlight' },
-    [LogsAlertEventKindEnumApi.Unsnooze]: { label: 'Unsnoozed', type: 'highlight' },
-    [LogsAlertEventKindEnumApi.ThresholdChange]: { label: 'Threshold changed', type: 'completion' },
-    [LogsAlertEventKindEnumApi.BrokenConfig]: { label: 'Broken config', type: 'caution' },
+    [AlertEventKindEnumApi.Reset]: { label: 'Reset', type: 'primary' },
+    [AlertEventKindEnumApi.Enable]: { label: 'Enabled', type: 'success' },
+    [AlertEventKindEnumApi.Disable]: { label: 'Disabled', type: 'muted' },
+    [AlertEventKindEnumApi.Snooze]: { label: 'Snoozed', type: 'highlight' },
+    [AlertEventKindEnumApi.Unsnooze]: { label: 'Unsnoozed', type: 'highlight' },
+    [AlertEventKindEnumApi.ThresholdChange]: { label: 'Threshold changed', type: 'completion' },
+    [AlertEventKindEnumApi.BrokenConfig]: { label: 'Broken config', type: 'caution' },
 }
 
 function describeEvent(event: LogsAlertEventApi): EventDescription {
-    if (event.kind !== LogsAlertEventKindEnumApi.Check) {
+    if (event.kind !== AlertEventKindEnumApi.Check) {
         return { ...CONTROL_PLANE_DESCRIPTIONS[event.kind], detail: formatTransition(event) }
     }
     if (event.error_message && event.state_after === 'broken') {
@@ -177,7 +177,7 @@ function LogsAlertEventDetails({ event }: { event: LogsAlertEventApi }): JSX.Ele
             <dd className="font-mono">
                 {event.state_before} → {event.state_after}
             </dd>
-            {event.kind === LogsAlertEventKindEnumApi.Check ? (
+            {event.kind === AlertEventKindEnumApi.Check ? (
                 <>
                     <dt className="text-muted">Breached</dt>
                     <dd className="font-mono">{event.threshold_breached ? 'yes' : 'no'}</dd>

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -774,9 +774,9 @@ export interface LogsAlertDeleteDestinationApi {
  * * `threshold_change` - Threshold change
  * * `broken_config` - Broken config
  */
-export type LogsAlertEventKindEnumApi = (typeof LogsAlertEventKindEnumApi)[keyof typeof LogsAlertEventKindEnumApi]
+export type AlertEventKindEnumApi = (typeof AlertEventKindEnumApi)[keyof typeof AlertEventKindEnumApi]
 
-export const LogsAlertEventKindEnumApi = {
+export const AlertEventKindEnumApi = {
     Check: 'check',
     Reset: 'reset',
     Enable: 'enable',
@@ -790,7 +790,7 @@ export const LogsAlertEventKindEnumApi = {
 export interface LogsAlertEventApi {
     readonly id: string
     readonly created_at: string
-    readonly kind: LogsAlertEventKindEnumApi
+    readonly kind: AlertEventKindEnumApi
     readonly state_before: string
     readonly state_after: string
     readonly threshold_breached: boolean

--- a/products/tracing/backend/presentation/views_alerts_api.py
+++ b/products/tracing/backend/presentation/views_alerts_api.py
@@ -443,14 +443,22 @@ class TracingAlertConfigurationSerializer(serializers.ModelSerializer):
 
         with transaction.atomic():
             snapshot = instance.to_snapshot()
-            if enabled_change is True:
+            if enabled_change is False:
+                # Disabling always wins over a concurrently-supplied snooze_until — matches
+                # the frontend, which clears snooze_until in the same request when disabling.
+                apply_outcome(instance, apply_disable(snapshot), kind=TracingAlertEvent.Kind.DISABLE)
+            elif enabled_change is True:
                 if instance.first_enabled_at is None:
                     instance.first_enabled_at = timezone.now()
                     if "first_enabled_at" not in validated_data:
                         validated_data["first_enabled_at"] = instance.first_enabled_at
                 apply_outcome(instance, apply_enable(snapshot), kind=TracingAlertEvent.Kind.ENABLE)
-            elif enabled_change is False:
-                apply_outcome(instance, apply_disable(snapshot), kind=TracingAlertEvent.Kind.DISABLE)
+                if snooze_data not in (_SENTINEL, None):
+                    # Enabling and snoozing in the same request: land in SNOOZED, not
+                    # NOT_FIRING, so `state` stays consistent with the `snooze_until` this
+                    # request also sets below (due_alerts_q only honors snooze_until when
+                    # state is SNOOZED).
+                    apply_outcome(instance, apply_snooze(instance.to_snapshot()), kind=TracingAlertEvent.Kind.SNOOZE)
             elif snooze_data is not _SENTINEL:
                 if snooze_data is None:
                     apply_outcome(instance, apply_unsnooze(snapshot), kind=TracingAlertEvent.Kind.UNSNOOZE)
@@ -490,6 +498,8 @@ class TracingAlertConfigurationSerializer(serializers.ModelSerializer):
         if validated_data.get("enabled", True):
             validated_data["first_enabled_at"] = timezone.now()
 
+        snooze_until = validated_data.get("snooze_until")
+
         with transaction.atomic():
             team = Team.objects.select_for_update().get(id=validated_data["team_id"])
             count = TracingAlertConfiguration.objects.unscoped().filter(team_id=validated_data["team_id"]).count()
@@ -501,7 +511,15 @@ class TracingAlertConfigurationSerializer(serializers.ModelSerializer):
                     team_timezone=team.timezone,
                     schedule_restriction=schedule_restriction,
                 )
-            return super().create(validated_data)
+            instance = super().create(validated_data)
+            if snooze_until is not None:
+                # Route through the state machine so `state` lands on SNOOZED — due_alerts_q
+                # only honors snooze_until when state is also SNOOZED.
+                update_fields = apply_outcome(
+                    instance, apply_snooze(instance.to_snapshot()), kind=TracingAlertEvent.Kind.SNOOZE
+                )
+                instance.save(update_fields=update_fields)
+            return instance
 
 
 class TracingAlertEventSerializer(serializers.ModelSerializer):
@@ -654,16 +672,20 @@ class TracingAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     )
     @action(detail=True, methods=["POST"], url_path="reset", required_scopes=["tracing:write"])
     def reset(self, request: Request, *args: object, **kwargs: object) -> Response:
-        alert = self.get_object()
-        try:
-            outcome = apply_user_reset(alert.to_snapshot())
-        except InvalidTransition:
-            raise ValidationError({"state": "Only broken alerts can be reset."})
         with transaction.atomic():
+            alert = self._get_locked_alert()
+            try:
+                outcome = apply_user_reset(alert.to_snapshot())
+            except InvalidTransition:
+                raise ValidationError({"state": "Only broken alerts can be reset."})
             update_fields = apply_outcome(alert, outcome, kind=TracingAlertEvent.Kind.RESET)
             update_fields.extend(alert.clear_next_check())
             alert.save(update_fields=update_fields)
-        report_user_action(request.user, "tracing alert reset", {"alert_id": str(alert.id)}, request=request)
+            transaction.on_commit(
+                lambda: report_user_action(
+                    request.user, "tracing alert reset", {"alert_id": str(alert.id)}, request=request
+                )
+            )
         return Response(self.get_serializer(alert).data)
 
     def _track(self, action_name: str, instance: TracingAlertConfiguration) -> None:
@@ -687,7 +709,8 @@ class TracingAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         self._track("created", serializer.save())
 
     def perform_update(self, serializer: serializers.BaseSerializer) -> None:
-        self._track("updated", serializer.save())
+        instance = serializer.save()
+        transaction.on_commit(lambda: self._track("updated", instance))
 
     def perform_destroy(self, instance: TracingAlertConfiguration) -> None:
         with transaction.atomic():

--- a/products/tracing/backend/presentation/views_alerts_api.py
+++ b/products/tracing/backend/presentation/views_alerts_api.py
@@ -539,6 +539,12 @@ class TracingAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             if created_by:
                 queryset = queryset.filter(created_by__uuid=created_by)
 
+        if self.action in ("destroy", "events"):
+            # Neither action serializes the alert through TracingAlertConfigurationSerializer
+            # (destroy re-fetches its own locked instance; events only filters by alert id),
+            # so the state-timeline annotations and prefetch below would be pure waste here.
+            return TracingAlertConfiguration.objects.for_team(self.team_id).order_by("-created_at")
+
         latest_error = (
             TracingAlertEvent.objects.filter(
                 alert=OuterRef("pk"),

--- a/products/tracing/backend/presentation/views_alerts_api.py
+++ b/products/tracing/backend/presentation/views_alerts_api.py
@@ -1,0 +1,697 @@
+"""DRF viewset for tracing alert configuration and history.
+
+Scoped-down relative to `products/logs/backend/presentation/views/alerts_api.py`:
+no `destinations` or `simulate` actions yet — those depend on notification
+destination wiring (HogFunction template registration, allowed event ids) that
+doesn't exist for tracing yet. `reset` skips the `log_activity` audit-trail call
+logs makes, since `TracingAlertConfiguration` isn't registered in
+`posthog/models/activity_logging/activity_log.py`'s scopes (the model also
+doesn't use `ModelActivityMixin` — see products/tracing/backend/models.py).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from datetime import UTC, datetime
+from typing import Any, Final, TypedDict, cast
+
+from django.db import transaction
+from django.db.models import F, OuterRef, Prefetch, Q, QuerySet, Subquery
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+
+from drf_spectacular.utils import extend_schema, extend_schema_field
+from pydantic import ValidationError as PydanticValidationError
+from rest_framework import serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.schema import TracingAlertFilters
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.shared import UserBasicSerializer
+from posthog.event_usage import report_user_action
+from posthog.models.team.team import Team
+from posthog.permissions import PostHogFeatureFlagPermission
+
+from products.alerts.backend.facade.api import AlertScheduleRestriction, validate_and_normalize_schedule_restriction
+from products.tracing.backend.alert_state_machine import (
+    InvalidTransition,
+    apply_disable,
+    apply_enable,
+    apply_outcome,
+    apply_snooze,
+    apply_threshold_change,
+    apply_unsnooze,
+    apply_user_reset,
+)
+from products.tracing.backend.alert_utils import next_allowed_check_at
+from products.tracing.backend.models import MAX_EVALUATION_PERIODS, TracingAlertConfiguration, TracingAlertEvent
+
+ALLOWED_WINDOW_MINUTES = {5, 10, 15, 30, 60}
+MAX_ALERTS_PER_TEAM = 20
+STATE_TIMELINE_LOOKBACK_HOURS = 24
+_SENTINEL: Final = object()
+_NOT_ANNOTATED: Final = object()
+
+
+def _state_timeline_window_bounds() -> tuple[datetime, datetime]:
+    end = datetime.now(UTC)
+    return end - dt.timedelta(hours=STATE_TIMELINE_LOOKBACK_HOURS), end
+
+
+def _any_field_changed(instance: TracingAlertConfiguration, validated_data: dict, fields: set[str]) -> bool:
+    return any(f in validated_data and validated_data[f] != getattr(instance, f) for f in fields)
+
+
+def _validate_filters(filters: dict) -> None:
+    """Cross-field requirement that at least one filter is present.
+
+    Per-field shape validation is handled by `TracingAlertFiltersField`, which runs
+    `TracingAlertFilters.model_validate` on the raw input.
+    """
+    if not isinstance(filters, dict):
+        raise ValidationError({"filters": "Must be a JSON object."})
+    has_services = bool(filters.get("serviceNames"))
+    has_error_only = bool(filters.get("errorOnly"))
+    has_filter_group = bool(filters.get("filterGroup"))
+    if not (has_services or has_error_only or has_filter_group):
+        raise ValidationError({"filters": "At least one filter is required (serviceNames, errorOnly, or filterGroup)."})
+
+
+class TracingAlertListQuerySerializer(serializers.Serializer):
+    created_by = serializers.UUIDField(
+        required=False,
+        help_text="Only return tracing alerts created by the user with this UUID.",
+    )
+
+
+class TracingAlertStateIntervalSerializer(serializers.Serializer):
+    start = serializers.DateTimeField(help_text="Interval start (UTC, inclusive).")
+    end = serializers.DateTimeField(help_text="Interval end (UTC, exclusive).")
+    state = serializers.ChoiceField(
+        choices=TracingAlertConfiguration.State.choices,
+        help_text="Alert state during this interval.",
+    )
+    enabled = serializers.BooleanField(
+        help_text="Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive.",
+    )
+
+
+class StateInterval(TypedDict):
+    start: datetime
+    end: datetime
+    state: str
+    enabled: bool
+
+
+@extend_schema_field(TracingAlertFilters)  # type: ignore[arg-type]
+class TracingAlertFiltersField(serializers.JSONField):
+    """JSONField typed against the `TracingAlertFilters` Pydantic schema.
+
+    Annotating with `@extend_schema_field(TracingAlertFilters)` is what makes the
+    generated OpenAPI spec — and downstream MCP zod schemas — surface the actual
+    shape (serviceNames / errorOnly / filterGroup) instead of an opaque blob.
+    """
+
+    def to_internal_value(self, data: dict | list) -> dict:
+        value = super().to_internal_value(data)
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Must be a JSON object.")
+        try:
+            TracingAlertFilters.model_validate(value)
+        except PydanticValidationError as e:
+            first = e.errors()[0]
+            location = ".".join(str(p) for p in first["loc"]) or "filters"
+            raise serializers.ValidationError(f"Invalid filters shape at `{location}`: {first['msg']}") from e
+        return value
+
+
+@extend_schema_field(AlertScheduleRestriction)  # type: ignore[arg-type]
+class ScheduleRestrictionField(serializers.JSONField):
+    pass
+
+
+class TracingAlertConfigurationSerializer(serializers.ModelSerializer):
+    id = serializers.UUIDField(read_only=True, help_text="Unique identifier for this alert.")
+    name = serializers.CharField(
+        max_length=255,
+        required=False,
+        allow_blank=True,
+        help_text="Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted.",
+    )
+    enabled = serializers.BooleanField(
+        default=True,
+        help_text="Whether the alert is actively being evaluated. Disabling resets the state to not_firing.",
+    )
+    alert_type = serializers.ChoiceField(
+        choices=TracingAlertConfiguration.AlertType.choices,
+        default=TracingAlertConfiguration.AlertType.THRESHOLD,
+        help_text="Alert evaluation mode. Only 'threshold' is supported today; reserved for a future "
+        "statistical-anomaly mode.",
+    )
+    filters = TracingAlertFiltersField(
+        required=False,
+        help_text="Filter criteria against trace_spans. Must contain at least one of: serviceNames "
+        "(list of service name strings), errorOnly (boolean), or filterGroup (property filter group "
+        "object). May be empty on draft alerts (enabled=false).",
+    )
+    threshold_count = serializers.IntegerField(
+        min_value=0,
+        default=100,
+        help_text="Number of matching spans that constitutes a threshold breach within the evaluation "
+        "window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span.",
+    )
+    first_enabled_at = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text="When the alert was first enabled. Null means the alert is still in draft state.",
+    )
+    threshold_operator = serializers.ChoiceField(
+        choices=TracingAlertConfiguration.ThresholdOperator.choices,
+        default=TracingAlertConfiguration.ThresholdOperator.ABOVE,
+        help_text="Whether the alert fires when the count is above or below the threshold.",
+    )
+    window_minutes = serializers.IntegerField(
+        default=5,
+        help_text="Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60.",
+    )
+    check_interval_minutes = serializers.IntegerField(
+        read_only=True,
+        help_text="How often the alert is evaluated, in minutes. Server-managed.",
+    )
+    state = serializers.ChoiceField(
+        choices=TracingAlertConfiguration.State.choices,
+        read_only=True,
+        help_text="Current alert state: not_firing, firing, pending_resolve, errored, snoozed, or broken. Server-managed.",
+    )
+    evaluation_periods = serializers.IntegerField(
+        default=1,
+        min_value=1,
+        max_value=MAX_EVALUATION_PERIODS,
+        help_text="Total number of check periods in the sliding evaluation window for firing (M in N-of-M).",
+    )
+    datapoints_to_alarm = serializers.IntegerField(
+        default=1,
+        min_value=1,
+        max_value=MAX_EVALUATION_PERIODS,
+        help_text="How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).",
+    )
+    cooldown_minutes = serializers.IntegerField(
+        default=0,
+        min_value=0,
+        help_text="Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.",
+    )
+    schedule_restriction = ScheduleRestrictionField(
+        required=False,
+        allow_null=True,
+        help_text="Blocked local time windows when the alert must not run. Times use the project timezone. "
+        "Null disables quiet hours.",
+    )
+    snooze_until = serializers.DateTimeField(
+        required=False,
+        allow_null=True,
+        help_text="ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.",
+    )
+    next_check_at = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text="When the next evaluation is scheduled. Server-managed.",
+    )
+    last_notified_at = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text="When the last notification was sent. Server-managed.",
+    )
+    last_checked_at = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text="When the alert was last evaluated. Server-managed.",
+    )
+    consecutive_failures = serializers.IntegerField(
+        read_only=True,
+        help_text="Number of consecutive evaluation failures. Resets on success. Server-managed.",
+    )
+    last_error_message = serializers.SerializerMethodField(
+        help_text="Error message from the most recent errored check, or null if the alert's most recent "
+        "check was successful.",
+    )
+    created_at = serializers.DateTimeField(read_only=True, help_text="When the alert was created.")
+    created_by = UserBasicSerializer(read_only=True)
+    updated_at = serializers.DateTimeField(
+        read_only=True,
+        allow_null=True,
+        help_text="When the alert was last modified.",
+    )
+    state_timeline = serializers.SerializerMethodField(
+        help_text=(
+            f"Continuous state intervals over the last {STATE_TIMELINE_LOOKBACK_HOURS}h, ordered oldest-first. "
+            "Each interval covers a span during which (state, enabled) was constant. Drives the 'Last 24h' "
+            "status bar on the alert list."
+        ),
+    )
+
+    @extend_schema_field(TracingAlertStateIntervalSerializer(many=True))
+    def get_state_timeline(self, obj: TracingAlertConfiguration) -> list[StateInterval]:
+        window = self.context.get("state_timeline_window") or _state_timeline_window_bounds()
+        window_start, window_end = window
+
+        events = getattr(obj, "_state_timeline_events", None)
+        if events is None:
+            events = list(
+                TracingAlertEvent.objects.filter(alert=obj, created_at__gte=window_start)
+                .order_by("created_at")
+                .only("kind", "created_at", "state_before", "state_after")
+            )
+
+        seed_state = events[0].state_before if events else obj.state
+
+        pre_window_toggle = getattr(obj, "_pre_window_toggle_kind", _NOT_ANNOTATED)
+        if pre_window_toggle is _NOT_ANNOTATED:
+            pre_window_toggle = (
+                TracingAlertEvent.objects.filter(
+                    alert=obj,
+                    kind__in=(TracingAlertEvent.Kind.ENABLE, TracingAlertEvent.Kind.DISABLE),
+                    created_at__lt=window_start,
+                )
+                .order_by("-created_at")
+                .values_list("kind", flat=True)
+                .first()
+            )
+        if pre_window_toggle is not None:
+            seed_enabled = pre_window_toggle == TracingAlertEvent.Kind.ENABLE
+        else:
+            first_in_window_toggle = next(
+                (e for e in events if e.kind in (TracingAlertEvent.Kind.ENABLE, TracingAlertEvent.Kind.DISABLE)),
+                None,
+            )
+            if first_in_window_toggle is not None:
+                seed_enabled = first_in_window_toggle.kind == TracingAlertEvent.Kind.DISABLE
+            else:
+                seed_enabled = obj.enabled
+
+        intervals: list[StateInterval] = []
+        current_start = window_start
+        current_state = seed_state
+        current_enabled = seed_enabled
+
+        for event in events:
+            if event.kind == TracingAlertEvent.Kind.ENABLE:
+                new_enabled, new_state = True, event.state_after
+            elif event.kind == TracingAlertEvent.Kind.DISABLE:
+                new_enabled, new_state = False, event.state_after
+            else:
+                new_enabled, new_state = current_enabled, event.state_after
+
+            if new_state == current_state and new_enabled == current_enabled:
+                continue
+
+            intervals.append(
+                {"start": current_start, "end": event.created_at, "state": current_state, "enabled": current_enabled}
+            )
+            current_start = event.created_at
+            current_state = new_state
+            current_enabled = new_enabled
+
+        intervals.append(
+            {"start": current_start, "end": window_end, "state": current_state, "enabled": current_enabled}
+        )
+        return intervals
+
+    @extend_schema_field(serializers.CharField(allow_null=True))
+    def get_last_error_message(self, obj: TracingAlertConfiguration) -> str | None:
+        annotated = getattr(obj, "_latest_error_message", _NOT_ANNOTATED)
+        if annotated is not _NOT_ANNOTATED:
+            return cast(str | None, annotated)
+        return (
+            TracingAlertEvent.objects.filter(
+                alert=obj,
+                kind=TracingAlertEvent.Kind.CHECK,
+                error_message__isnull=False,
+            )
+            .order_by("-created_at")
+            .values_list("error_message", flat=True)
+            .first()
+        )
+
+    class Meta:
+        model = TracingAlertConfiguration
+        fields = [
+            "id",
+            "name",
+            "enabled",
+            "alert_type",
+            "filters",
+            "threshold_count",
+            "threshold_operator",
+            "window_minutes",
+            "check_interval_minutes",
+            "state",
+            "evaluation_periods",
+            "datapoints_to_alarm",
+            "cooldown_minutes",
+            "schedule_restriction",
+            "snooze_until",
+            "next_check_at",
+            "last_notified_at",
+            "last_checked_at",
+            "consecutive_failures",
+            "last_error_message",
+            "state_timeline",
+            "first_enabled_at",
+            "created_at",
+            "created_by",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "check_interval_minutes",
+            "state",
+            "next_check_at",
+            "last_notified_at",
+            "last_checked_at",
+            "consecutive_failures",
+            "last_error_message",
+            "state_timeline",
+            "first_enabled_at",
+            "created_at",
+            "created_by",
+            "updated_at",
+        ]
+
+    def validate(self, attrs: dict) -> dict:
+        filters = attrs.get("filters", getattr(self.instance, "filters", None) or {})
+
+        if self.instance is not None:
+            effective_enabled = attrs.get("enabled", self.instance.enabled)
+        else:
+            effective_enabled = attrs.get("enabled", True)
+
+        if effective_enabled or filters:
+            _validate_filters(filters)
+
+        window = attrs.get("window_minutes", getattr(self.instance, "window_minutes", None))
+        if window is not None and window not in ALLOWED_WINDOW_MINUTES:
+            raise ValidationError({"window_minutes": f"Must be one of {sorted(ALLOWED_WINDOW_MINUTES)}."})
+
+        evaluation_periods = attrs.get("evaluation_periods", getattr(self.instance, "evaluation_periods", 1))
+        datapoints_to_alarm = attrs.get("datapoints_to_alarm", getattr(self.instance, "datapoints_to_alarm", 1))
+        if datapoints_to_alarm > evaluation_periods:
+            raise ValidationError(
+                {
+                    "datapoints_to_alarm": f"Cannot exceed evaluation_periods ({datapoints_to_alarm} > {evaluation_periods})."
+                }
+            )
+
+        snooze_until = attrs.get("snooze_until")
+        if snooze_until is not None and snooze_until <= datetime.now(UTC):
+            raise ValidationError({"snooze_until": "Must be a future datetime."})
+
+        if "schedule_restriction" in attrs:
+            try:
+                attrs["schedule_restriction"] = validate_and_normalize_schedule_restriction(
+                    attrs["schedule_restriction"]
+                )
+            except ValueError as e:
+                raise ValidationError({"schedule_restriction": str(e)}) from e
+
+        return attrs
+
+    def update(self, instance: TracingAlertConfiguration, validated_data: dict) -> TracingAlertConfiguration:
+        if "name" in validated_data and not validated_data.get("name", "").strip():
+            validated_data["name"] = "Untitled alert"
+
+        snooze_data = validated_data.pop("snooze_until", _SENTINEL)
+
+        threshold_or_filter_fields = {
+            "threshold_count",
+            "threshold_operator",
+            "filters",
+            "datapoints_to_alarm",
+            "evaluation_periods",
+        }
+
+        threshold_changed = _any_field_changed(instance, validated_data, threshold_or_filter_fields)
+        window_changed = _any_field_changed(instance, validated_data, {"window_minutes"})
+        schedule_restriction_changed = _any_field_changed(instance, validated_data, {"schedule_restriction"})
+
+        enabled_change: bool | None = None
+        if "enabled" in validated_data and validated_data["enabled"] != instance.enabled:
+            enabled_change = validated_data["enabled"]
+
+        with transaction.atomic():
+            snapshot = instance.to_snapshot()
+            if enabled_change is True:
+                if instance.first_enabled_at is None:
+                    instance.first_enabled_at = timezone.now()
+                    if "first_enabled_at" not in validated_data:
+                        validated_data["first_enabled_at"] = instance.first_enabled_at
+                apply_outcome(instance, apply_enable(snapshot), kind=TracingAlertEvent.Kind.ENABLE)
+            elif enabled_change is False:
+                apply_outcome(instance, apply_disable(snapshot), kind=TracingAlertEvent.Kind.DISABLE)
+            elif snooze_data is not _SENTINEL:
+                if snooze_data is None:
+                    apply_outcome(instance, apply_unsnooze(snapshot), kind=TracingAlertEvent.Kind.UNSNOOZE)
+                else:
+                    apply_outcome(instance, apply_snooze(snapshot), kind=TracingAlertEvent.Kind.SNOOZE)
+            elif threshold_changed:
+                apply_outcome(instance, apply_threshold_change(snapshot), kind=TracingAlertEvent.Kind.THRESHOLD_CHANGE)
+
+            if snooze_data is not _SENTINEL:
+                instance.snooze_until = snooze_data
+
+            if (
+                threshold_changed
+                or window_changed
+                or schedule_restriction_changed
+                or (enabled_change is True and instance.schedule_restriction)
+            ):
+                next_schedule_restriction = validated_data.get("schedule_restriction", instance.schedule_restriction)
+                if next_schedule_restriction:
+                    validated_data["next_check_at"] = next_allowed_check_at(
+                        datetime.now(UTC),
+                        team_timezone=instance.team.timezone,
+                        schedule_restriction=next_schedule_restriction,
+                    )
+                else:
+                    instance.clear_next_check()
+
+            return super().update(instance, validated_data)
+
+    def create(self, validated_data: dict) -> TracingAlertConfiguration:
+        validated_data["team_id"] = self.context["team_id"]
+        validated_data["created_by"] = self.context["request"].user
+
+        if not validated_data.get("name", "").strip():
+            validated_data["name"] = "Untitled alert"
+
+        if validated_data.get("enabled", True):
+            validated_data["first_enabled_at"] = timezone.now()
+
+        with transaction.atomic():
+            team = Team.objects.select_for_update().get(id=validated_data["team_id"])
+            count = TracingAlertConfiguration.objects.unscoped().filter(team_id=validated_data["team_id"]).count()
+            if count >= MAX_ALERTS_PER_TEAM:
+                raise ValidationError(f"Maximum number of alerts ({MAX_ALERTS_PER_TEAM}) reached for this team.")
+            if schedule_restriction := validated_data.get("schedule_restriction"):
+                validated_data["next_check_at"] = next_allowed_check_at(
+                    datetime.now(UTC),
+                    team_timezone=team.timezone,
+                    schedule_restriction=schedule_restriction,
+                )
+            return super().create(validated_data)
+
+
+class TracingAlertEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TracingAlertEvent
+        fields = [
+            "id",
+            "created_at",
+            "kind",
+            "state_before",
+            "state_after",
+            "threshold_breached",
+            "result_count",
+            "error_message",
+            "query_duration_ms",
+        ]
+        read_only_fields = fields
+
+
+class TracingAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
+    scope_object = "tracing"
+    # Fail-closed manager raises if `.all()` runs at import; the real per-request
+    # scoping happens in safely_get_queryset. Mirrors TracingViewViewSet.
+    queryset = TracingAlertConfiguration.objects.unscoped()
+    serializer_class = TracingAlertConfigurationSerializer
+    lookup_field = "id"
+    posthog_feature_flag = "tracing-alerting"
+    permission_classes = [PostHogFeatureFlagPermission]
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        if self.action == "list":
+            query_serializer = TracingAlertListQuerySerializer(data=self.request.query_params)
+            query_serializer.is_valid(raise_exception=True)
+            created_by = query_serializer.validated_data.get("created_by")
+            if created_by:
+                queryset = queryset.filter(created_by__uuid=created_by)
+
+        latest_error = (
+            TracingAlertEvent.objects.filter(
+                alert=OuterRef("pk"),
+                kind=TracingAlertEvent.Kind.CHECK,
+                error_message__isnull=False,
+            )
+            .order_by("-created_at")
+            .values("error_message")[:1]
+        )
+        self._state_timeline_window = _state_timeline_window_bounds()
+        window_start, _ = self._state_timeline_window
+        timeline_events = (
+            TracingAlertEvent.objects.filter(alert__team_id=self.team_id, created_at__gte=window_start)
+            .only("alert_id", "kind", "created_at", "state_before", "state_after")
+            .order_by("created_at")
+        )
+        latest_pre_window_toggle = (
+            TracingAlertEvent.objects.filter(
+                alert=OuterRef("pk"),
+                kind__in=(TracingAlertEvent.Kind.ENABLE, TracingAlertEvent.Kind.DISABLE),
+                created_at__lt=window_start,
+            )
+            .order_by("-created_at")
+            .values("kind")[:1]
+        )
+        return (
+            TracingAlertConfiguration.objects.for_team(self.team_id)
+            .order_by("-created_at")
+            .annotate(
+                _latest_error_message=Subquery(latest_error),
+                _pre_window_toggle_kind=Subquery(latest_pre_window_toggle),
+            )
+            .prefetch_related(Prefetch("events", queryset=timeline_events, to_attr="_state_timeline_events"))
+        )
+
+    def get_serializer_context(self) -> dict:
+        context = super().get_serializer_context()
+        context["state_timeline_window"] = (
+            getattr(self, "_state_timeline_window", None) or _state_timeline_window_bounds()
+        )
+        return context
+
+    def _get_locked_alert(self) -> TracingAlertConfiguration:
+        queryset = self.filter_queryset(self.get_queryset()).select_for_update()
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        alert = get_object_or_404(queryset, **{self.lookup_field: self.kwargs[lookup_url_kwarg]})
+        self.check_object_permissions(self.request, alert)
+        return alert
+
+    def update(self, request: Request, *args: object, **kwargs: Any) -> Response:
+        partial = kwargs.pop("partial", False)
+        with transaction.atomic():
+            instance = self._get_locked_alert()
+            serializer = self.get_serializer(instance, data=request.data, partial=partial)
+            serializer.is_valid(raise_exception=True)
+            self.perform_update(serializer)
+
+            prefetched_objects_cache = getattr(instance, "_prefetched_objects_cache", None)
+            if prefetched_objects_cache:
+                prefetched_objects_cache.clear()
+
+        return Response(serializer.data)
+
+    @extend_schema(
+        request=None,
+        responses={200: TracingAlertEventSerializer(many=True)},
+        description=(
+            "Paginated event history for this alert, newest first. Returns state transitions, "
+            "errored checks, and user-initiated control-plane rows (reset, enable/disable, "
+            "snooze/unsnooze, threshold change) — quiet no-op check rows (where state didn't "
+            "change and there was no error) are filtered out. Optional `?kind=...` narrows to a "
+            "single kind."
+        ),
+    )
+    @action(detail=True, methods=["GET"], url_path="events", required_scopes=["tracing:read"])
+    def events(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        queryset = (
+            TracingAlertEvent.objects.filter(alert=alert)
+            .filter(
+                ~Q(kind=TracingAlertEvent.Kind.CHECK)
+                | Q(error_message__isnull=False)
+                | ~Q(state_before=F("state_after"))
+            )
+            .order_by("-created_at")
+        )
+
+        kind = request.query_params.get("kind")
+        if kind is not None:
+            valid_kinds = TracingAlertEvent.Kind.values
+            if kind not in valid_kinds:
+                raise ValidationError({"kind": f"Must be one of {sorted(valid_kinds)}."})
+            queryset = queryset.filter(kind=kind)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = TracingAlertEventSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = TracingAlertEventSerializer(queryset, many=True)
+        return Response(serializer.data)
+
+    @extend_schema(
+        request=None,
+        responses={200: TracingAlertConfigurationSerializer},
+        description="Reset a broken alert. Clears the consecutive-failure counter and schedules an immediate recheck.",
+    )
+    @action(detail=True, methods=["POST"], url_path="reset", required_scopes=["tracing:write"])
+    def reset(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        try:
+            outcome = apply_user_reset(alert.to_snapshot())
+        except InvalidTransition:
+            raise ValidationError({"state": "Only broken alerts can be reset."})
+        with transaction.atomic():
+            update_fields = apply_outcome(alert, outcome, kind=TracingAlertEvent.Kind.RESET)
+            update_fields.extend(alert.clear_next_check())
+            alert.save(update_fields=update_fields)
+        report_user_action(request.user, "tracing alert reset", {"alert_id": str(alert.id)}, request=request)
+        return Response(self.get_serializer(alert).data)
+
+    def _track(self, action_name: str, instance: TracingAlertConfiguration) -> None:
+        report_user_action(
+            self.request.user,
+            f"tracing alert {action_name}",
+            {
+                "alert_id": str(instance.id),
+                "alert_name": instance.name,
+                "check_interval_minutes": instance.check_interval_minutes,
+                "enabled": instance.enabled,
+                "threshold_count": instance.threshold_count,
+                "threshold_operator": instance.threshold_operator,
+                "window_minutes": instance.window_minutes,
+            },
+            team=self.team,
+            request=self.request,
+        )
+
+    def perform_create(self, serializer: serializers.BaseSerializer) -> None:
+        self._track("created", serializer.save())
+
+    def perform_update(self, serializer: serializers.BaseSerializer) -> None:
+        self._track("updated", serializer.save())
+
+    def perform_destroy(self, instance: TracingAlertConfiguration) -> None:
+        with transaction.atomic():
+            locked_instance = (
+                TracingAlertConfiguration.objects.unscoped()
+                .select_for_update()
+                .filter(team_id=instance.team_id, id=instance.id)
+                .first()
+            )
+            if locked_instance is None:
+                return
+            super().perform_destroy(locked_instance)
+            transaction.on_commit(lambda: self._track("deleted", locked_instance), robust=True)

--- a/products/tracing/backend/routes.py
+++ b/products/tracing/backend/routes.py
@@ -1,6 +1,7 @@
 from posthog.api.routing import RouterRegistry
 
 from products.tracing.backend.presentation.views import SpansViewSet
+from products.tracing.backend.presentation.views_alerts_api import TracingAlertViewSet
 from products.tracing.backend.presentation.views_api import TracingViewViewSet
 
 
@@ -15,5 +16,11 @@ def register_routes(routers: RouterRegistry) -> None:
         r"tracing/views",
         TracingViewViewSet,
         "project_tracing_views",
+        ["team_id"],
+    )
+    routers.projects.register(
+        r"tracing/alerts",
+        TracingAlertViewSet,
+        "project_tracing_alerts",
         ["team_id"],
     )

--- a/products/tracing/backend/tests/test_alerts_api.py
+++ b/products/tracing/backend/tests/test_alerts_api.py
@@ -1,0 +1,305 @@
+from datetime import UTC, datetime
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models.scoping import team_scope
+
+from products.tracing.backend.models import TracingAlertConfiguration, TracingAlertEvent
+from products.tracing.backend.presentation.views_alerts_api import ALLOWED_WINDOW_MINUTES, MAX_ALERTS_PER_TEAM
+
+
+class TestTracingAlertAPI(APIBaseTest):
+    base_url: str
+
+    def setUp(self):
+        super().setUp()
+        self.base_url = f"/api/projects/{self.team.pk}/tracing/alerts/"
+        self._ff_patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        self._ff_patcher.start()
+        self.addCleanup(self._ff_patcher.stop)
+        scope = team_scope(self.team.id, canonical=True)
+        scope.__enter__()
+        self.addCleanup(scope.__exit__, None, None, None)
+
+    def _valid_payload(self, **overrides) -> dict:
+        defaults = {"name": "High error rate", "threshold_count": 10, "filters": {"serviceNames": ["web"]}}
+        defaults.update(overrides)
+        return defaults
+
+    def _create_via_api(self, **overrides) -> dict:
+        response = self.client.post(self.base_url, self._valid_payload(**overrides), format="json")
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        return response.json()
+
+    # --- CRUD ---
+
+    @patch("products.tracing.backend.presentation.views_alerts_api.report_user_action")
+    def test_create(self, mock_report):
+        data = self._create_via_api()
+        assert data["name"] == "High error rate"
+        assert data["threshold_count"] == 10
+        assert data["state"] == "not_firing"
+        assert data["alert_type"] == "threshold"
+        assert data["enabled"] is True
+        assert data["first_enabled_at"] is not None
+        assert data["created_by"]["id"] == self.user.pk
+        assert data["filters"] == {"serviceNames": ["web"]}
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args.args[1] == "tracing alert created"
+
+    @freeze_time("2026-01-01T23:00:00Z")
+    def test_create_with_quiet_hours_defers_next_check(self):
+        data = self._create_via_api(schedule_restriction={"blocked_windows": [{"start": "22:00", "end": "07:00"}]})
+
+        assert data["schedule_restriction"] == {"blocked_windows": [{"start": "22:00", "end": "07:00"}]}
+        assert data["next_check_at"] == "2026-01-02T07:00:00Z"
+
+    def test_create_rejects_empty_filters(self):
+        response = self.client.post(self.base_url, self._valid_payload(filters={}), format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_disabled_with_empty_filters_succeeds(self):
+        response = self.client.post(self.base_url, self._valid_payload(enabled=False, filters={}), format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+    @parameterized.expand([(w,) for w in sorted(ALLOWED_WINDOW_MINUTES)])
+    def test_create_accepts_valid_window(self, window):
+        response = self.client.post(self.base_url, self._valid_payload(window_minutes=window), format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_create_rejects_invalid_window(self):
+        response = self.client.post(self.base_url, self._valid_payload(window_minutes=7), format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_rejects_n_greater_than_m(self):
+        response = self.client.post(
+            self.base_url,
+            self._valid_payload(evaluation_periods=2, datapoints_to_alarm=3),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_retrieve(self):
+        created = self._create_via_api()
+        response = self.client.get(f"{self.base_url}{created['id']}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == created["id"]
+
+    def test_list(self):
+        self._create_via_api(name="Alert 1")
+        self._create_via_api(name="Alert 2")
+        response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["results"]) == 2
+
+    def test_update(self):
+        created = self._create_via_api()
+        response = self.client.patch(f"{self.base_url}{created['id']}/", {"name": "Renamed"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["name"] == "Renamed"
+
+    @patch("products.tracing.backend.presentation.views_alerts_api.report_user_action")
+    def test_delete(self, mock_report):
+        created = self._create_via_api()
+        response = self.client.delete(f"{self.base_url}{created['id']}/")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert TracingAlertConfiguration.objects.unscoped().filter(id=created["id"]).count() == 0
+
+    # --- Read-only fields ---
+
+    def test_state_ignored_on_create(self):
+        data = self._create_via_api(state="firing")
+        assert data["state"] == "not_firing"
+
+    def test_state_ignored_on_update(self):
+        created = self._create_via_api()
+        response = self.client.patch(f"{self.base_url}{created['id']}/", {"state": "firing"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+
+    # --- Team isolation ---
+
+    def test_list_only_own_team(self):
+        self._create_via_api()
+        other_team = self.organization.teams.create(name="Other team")
+        with team_scope(other_team.id, canonical=True):
+            TracingAlertConfiguration.objects.create(team=other_team, name="Other", threshold_count=1)
+
+        response = self.client.get(self.base_url)
+        assert len(response.json()["results"]) == 1
+
+    def test_cannot_retrieve_other_teams_alert(self):
+        other_team = self.organization.teams.create(name="Other team")
+        with team_scope(other_team.id, canonical=True):
+            other_alert = TracingAlertConfiguration.objects.create(team=other_team, name="Other", threshold_count=1)
+
+        response = self.client.get(f"{self.base_url}{other_alert.id}/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # --- Per-team limit ---
+
+    def test_per_team_limit(self):
+        for i in range(MAX_ALERTS_PER_TEAM):
+            self._create_via_api(name=f"Alert {i}")
+
+        response = self.client.post(self.base_url, self._valid_payload(name="Boundary"), format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert TracingAlertConfiguration.objects.for_team(self.team.id, canonical=True).count() == MAX_ALERTS_PER_TEAM
+
+    # --- Control-plane transitions via PATCH ---
+
+    def test_disable_resets_firing_state(self):
+        created = self._create_via_api()
+        TracingAlertConfiguration.objects.filter(pk=created["id"]).update(state="firing")
+
+        response = self.client.patch(f"{self.base_url}{created['id']}/", {"enabled": False}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+        assert response.json()["enabled"] is False
+
+    def test_snooze_sets_snoozed_state(self):
+        created = self._create_via_api()
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": "2099-01-01T00:00:00Z"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "snoozed"
+
+    def test_unsnooze_sets_not_firing_state(self):
+        created = self._create_via_api()
+        self.client.patch(f"{self.base_url}{created['id']}/", {"snooze_until": "2099-01-01T00:00:00Z"}, format="json")
+
+        response = self.client.patch(f"{self.base_url}{created['id']}/", {"snooze_until": None}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+
+    def test_snooze_rejects_past_datetime(self):
+        created = self._create_via_api()
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": "2020-01-01T00:00:00Z"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_threshold_change_resets_state_and_clears_next_check(self):
+        created = self._create_via_api()
+        TracingAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state="firing", next_check_at=datetime(2099, 1, 1, tzinfo=UTC)
+        )
+
+        response = self.client.patch(f"{self.base_url}{created['id']}/", {"threshold_count": 50}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+        assert response.json()["next_check_at"] is None
+
+    def test_update_writes_control_plane_event_row(self):
+        created = self._create_via_api()
+        self.client.patch(f"{self.base_url}{created['id']}/", {"enabled": False}, format="json")
+
+        event = TracingAlertEvent.objects.get(alert_id=created["id"], kind=TracingAlertEvent.Kind.DISABLE)
+        assert event.state_before == "not_firing"
+        assert event.state_after == "not_firing"
+
+    # --- events action ---
+
+    def test_events_returns_rows_newest_first(self):
+        created = self._create_via_api()
+        self.client.patch(f"{self.base_url}{created['id']}/", {"enabled": False}, format="json")
+        self.client.patch(f"{self.base_url}{created['id']}/", {"enabled": True}, format="json")
+
+        response = self.client.get(f"{self.base_url}{created['id']}/events/")
+        assert response.status_code == status.HTTP_200_OK
+        kinds = [e["kind"] for e in response.json()["results"]]
+        assert kinds == ["enable", "disable"]
+
+    def test_events_filter_by_kind(self):
+        created = self._create_via_api()
+        self.client.patch(f"{self.base_url}{created['id']}/", {"enabled": False}, format="json")
+
+        response = self.client.get(f"{self.base_url}{created['id']}/events/?kind=disable")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["results"]) == 1
+
+    def test_events_rejects_unknown_kind(self):
+        created = self._create_via_api()
+        response = self.client.get(f"{self.base_url}{created['id']}/events/?kind=bogus")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_events_scoped_to_alert_team(self):
+        created = self._create_via_api()
+        other_team = self.organization.teams.create(name="Other team")
+        with team_scope(other_team.id, canonical=True):
+            other_alert = TracingAlertConfiguration.objects.create(team=other_team, name="Other", threshold_count=1)
+
+        response = self.client.get(f"{self.base_url}{other_alert.id}/events/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        response = self.client.get(f"{self.base_url}{created['id']}/events/")
+        assert response.status_code == status.HTTP_200_OK
+
+    # --- reset action ---
+
+    def test_reset_broken_alert(self):
+        created = self._create_via_api()
+        TracingAlertConfiguration.objects.filter(pk=created["id"]).update(state="broken", consecutive_failures=5)
+
+        response = self.client.post(f"{self.base_url}{created['id']}/reset/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+        assert response.json()["consecutive_failures"] == 0
+
+    @parameterized.expand(
+        [
+            ("not_firing", "not_firing"),
+            ("firing", "firing"),
+            ("snoozed", "snoozed"),
+        ]
+    )
+    def test_reset_rejects_non_broken_alert(self, _name, state):
+        created = self._create_via_api()
+        TracingAlertConfiguration.objects.filter(pk=created["id"]).update(state=state)
+
+        response = self.client.post(f"{self.base_url}{created['id']}/reset/")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_reset_other_teams_alert_returns_404(self):
+        other_team = self.organization.teams.create(name="Other team")
+        with team_scope(other_team.id, canonical=True):
+            other_alert = TracingAlertConfiguration.objects.create(
+                team=other_team, name="Other", threshold_count=1, state="broken"
+            )
+
+        response = self.client.post(f"{self.base_url}{other_alert.id}/reset/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # --- state_timeline ---
+
+    def test_state_timeline_single_interval_for_empty_alert(self):
+        created = self._create_via_api()
+        timeline = created["state_timeline"]
+        assert len(timeline) == 1
+        assert timeline[0]["state"] == "not_firing"
+        assert timeline[0]["enabled"] is True
+
+    def test_state_timeline_tracks_enable_disable_toggles(self):
+        created = self._create_via_api()
+        self.client.patch(f"{self.base_url}{created['id']}/", {"enabled": False}, format="json")
+
+        response = self.client.get(f"{self.base_url}{created['id']}/")
+        timeline = response.json()["state_timeline"]
+        assert timeline[-1]["enabled"] is False
+
+    # --- Feature flag gating ---
+
+    def test_requires_feature_flag(self):
+        with patch("posthoganalytics.feature_enabled", return_value=False):
+            response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/products/tracing/backend/tests/test_alerts_api.py
+++ b/products/tracing/backend/tests/test_alerts_api.py
@@ -60,6 +60,11 @@ class TestTracingAlertAPI(APIBaseTest):
         assert data["schedule_restriction"] == {"blocked_windows": [{"start": "22:00", "end": "07:00"}]}
         assert data["next_check_at"] == "2026-01-02T07:00:00Z"
 
+    def test_create_with_snooze_until_sets_snoozed_state(self):
+        data = self._create_via_api(snooze_until="2099-01-01T00:00:00Z")
+        assert data["state"] == "snoozed"
+        assert data["snooze_until"] == "2099-01-01T00:00:00Z"
+
     def test_create_rejects_empty_filters(self):
         response = self.client.post(self.base_url, self._valid_payload(filters={}), format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -180,6 +185,16 @@ class TestTracingAlertAPI(APIBaseTest):
         response = self.client.patch(f"{self.base_url}{created['id']}/", {"snooze_until": None}, format="json")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["state"] == "not_firing"
+
+    def test_enable_with_snooze_until_sets_snoozed_not_not_firing(self):
+        created = self._create_via_api(enabled=False)
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"enabled": True, "snooze_until": "2099-01-01T00:00:00Z"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "snoozed"
 
     def test_snooze_rejects_past_datetime(self):
         created = self._create_via_api()

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -7,6 +7,712 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * * `threshold` - Threshold
+ */
+export type AlertTypeEnumApi = (typeof AlertTypeEnumApi)[keyof typeof AlertTypeEnumApi]
+
+export const AlertTypeEnumApi = {
+    Threshold: 'threshold',
+} as const
+
+export type FilterLogicalOperatorApi = (typeof FilterLogicalOperatorApi)[keyof typeof FilterLogicalOperatorApi]
+
+export const FilterLogicalOperatorApi = {
+    And: 'AND',
+    Or: 'OR',
+} as const
+
+export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
+
+export const PropertyOperatorApi = {
+    Exact: 'exact',
+    IsNot: 'is_not',
+    Icontains: 'icontains',
+    NotIcontains: 'not_icontains',
+    StartsWith: 'starts_with',
+    NotStartsWith: 'not_starts_with',
+    EndsWith: 'ends_with',
+    NotEndsWith: 'not_ends_with',
+    Regex: 'regex',
+    NotRegex: 'not_regex',
+    Gt: 'gt',
+    Gte: 'gte',
+    Lt: 'lt',
+    Lte: 'lte',
+    IsSet: 'is_set',
+    IsNotSet: 'is_not_set',
+    IsDateExact: 'is_date_exact',
+    IsDateBefore: 'is_date_before',
+    IsDateAfter: 'is_date_after',
+    Between: 'between',
+    NotBetween: 'not_between',
+    Min: 'min',
+    Max: 'max',
+    In: 'in',
+    NotIn: 'not_in',
+    IsCleanedPathExact: 'is_cleaned_path_exact',
+    FlagEvaluatesTo: 'flag_evaluates_to',
+    SemverEq: 'semver_eq',
+    SemverNeq: 'semver_neq',
+    SemverGt: 'semver_gt',
+    SemverGte: 'semver_gte',
+    SemverLt: 'semver_lt',
+    SemverLte: 'semver_lte',
+    SemverTilde: 'semver_tilde',
+    SemverCaret: 'semver_caret',
+    SemverWildcard: 'semver_wildcard',
+    IcontainsMulti: 'icontains_multi',
+    NotIcontainsMulti: 'not_icontains_multi',
+} as const
+
+export interface EventPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator?: PropertyOperatorApi | null
+    /** Event properties */
+    type?: 'event'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface PersonPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Person properties */
+    type?: 'person'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface PersonMetadataPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Top-level columns on the persons table (e.g. created_at), not properties JSON */
+    type?: 'person_metadata'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
+
+export const Key10Api = {
+    TagName: 'tag_name',
+    Text: 'text',
+    Href: 'href',
+    Selector: 'selector',
+} as const
+
+export interface ElementPropertyFilterApi {
+    key: Key10Api
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'element'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface EventMetadataPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'event_metadata'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface SessionPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'session'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface CohortPropertyFilterApi {
+    cohort_name?: string | null
+    key?: 'id'
+    label?: string | null
+    operator?: PropertyOperatorApi | null
+    type?: 'cohort'
+    value: number
+}
+
+export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
+
+export const DurationTypeApi = {
+    Duration: 'duration',
+    ActiveSeconds: 'active_seconds',
+    InactiveSeconds: 'inactive_seconds',
+} as const
+
+export interface RecordingPropertyFilterApi {
+    key: DurationTypeApi | string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'recording'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface LogEntryPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'log_entry'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
+
+export interface GroupPropertyFilterApi {
+    group_key_names?: GroupPropertyFilterApiGroupKeyNames
+    group_type_index?: number | null
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'group'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface FeaturePropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Event property with "$feature/" prepended */
+    type?: 'feature'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface FlagPropertyFilterApi {
+    /** The key should be the flag ID */
+    key: string
+    label?: string | null
+    /** Only flag_evaluates_to operator is allowed for flag dependencies */
+    operator?: 'flag_evaluates_to'
+    /** Feature flag dependency */
+    type?: 'flag'
+    /** The value can be true, false, or a variant name */
+    value: boolean | string
+}
+
+export interface HogQLPropertyFilterApi {
+    key: string
+    label?: string | null
+    type?: 'hogql'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export const EmptyPropertyFilterApiValue = {
+    type: 'empty',
+} as const
+export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
+
+export interface DataWarehousePropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'data_warehouse'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface DataWarehousePersonPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'data_warehouse_person_property'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface ErrorTrackingIssueFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'error_tracking_issue'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
+
+export const LogPropertyFilterTypeApi = {
+    Log: 'log',
+    LogAttribute: 'log_attribute',
+    LogResourceAttribute: 'log_resource_attribute',
+} as const
+
+export interface LogPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: LogPropertyFilterTypeApi
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface MetricPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'metric_attribute'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
+
+export const SpanPropertyFilterTypeApi = {
+    Span: 'span',
+    SpanAttribute: 'span_attribute',
+    SpanResourceAttribute: 'span_resource_attribute',
+} as const
+
+export interface SpanPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: SpanPropertyFilterTypeApi
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface RevenueAnalyticsPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'revenue_analytics'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface AccountCustomPropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Customer analytics account custom property — the key is the property definition id */
+    type?: 'account_custom_property'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface WorkflowVariablePropertyFilterApi {
+    key: string
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: 'workflow_variable'
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface PropertyGroupFilterValueApi {
+    type: FilterLogicalOperatorApi
+    values: (
+        | PropertyGroupFilterValueApi
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | PersonMetadataPropertyFilterApi
+        | ElementPropertyFilterApi
+        | EventMetadataPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+        | RecordingPropertyFilterApi
+        | LogEntryPropertyFilterApi
+        | GroupPropertyFilterApi
+        | FeaturePropertyFilterApi
+        | FlagPropertyFilterApi
+        | HogQLPropertyFilterApi
+        | EmptyPropertyFilterApi
+        | DataWarehousePropertyFilterApi
+        | DataWarehousePersonPropertyFilterApi
+        | ErrorTrackingIssueFilterApi
+        | LogPropertyFilterApi
+        | MetricPropertyFilterApi
+        | SpanPropertyFilterApi
+        | RevenueAnalyticsPropertyFilterApi
+        | AccountCustomPropertyFilterApi
+        | WorkflowVariablePropertyFilterApi
+    )[]
+}
+
+export interface PropertyGroupFilterApi {
+    type: FilterLogicalOperatorApi
+    values: PropertyGroupFilterValueApi[]
+}
+
+export interface TracingAlertFiltersApi {
+    errorOnly?: boolean | null
+    filterGroup?: PropertyGroupFilterApi | null
+    serviceNames?: string[] | null
+}
+
+/**
+ * * `above` - Above
+ * * `below` - Below
+ */
+export type LogsAlertThresholdOperatorEnumApi =
+    (typeof LogsAlertThresholdOperatorEnumApi)[keyof typeof LogsAlertThresholdOperatorEnumApi]
+
+export const LogsAlertThresholdOperatorEnumApi = {
+    Above: 'above',
+    Below: 'below',
+} as const
+
+/**
+ * * `not_firing` - Not firing
+ * * `firing` - Firing
+ * * `pending_resolve` - Pending resolve
+ * * `errored` - Errored
+ * * `snoozed` - Snoozed
+ * * `broken` - Broken
+ */
+export type LogsAlertConfigurationStateEnumApi =
+    (typeof LogsAlertConfigurationStateEnumApi)[keyof typeof LogsAlertConfigurationStateEnumApi]
+
+export const LogsAlertConfigurationStateEnumApi = {
+    NotFiring: 'not_firing',
+    Firing: 'firing',
+    PendingResolve: 'pending_resolve',
+    Errored: 'errored',
+    Snoozed: 'snoozed',
+    Broken: 'broken',
+} as const
+
+export interface AlertScheduleRestrictionWindowApi {
+    /** Start time HH:MM (24-hour, project timezone). Inclusive. Each window must span ≥ 30 minutes on the local daily timeline (half-open [start, end)). */
+    start: string
+    /** End time HH:MM (24-hour). Exclusive (half-open interval). Each window must span ≥ 30 minutes locally. */
+    end: string
+}
+
+export interface AlertScheduleRestrictionApi {
+    /** Blocked local time windows when the alert must not run. Overlapping or identical windows are merged when saved. At most five windows before normalization; empty array clears quiet hours. */
+    blocked_windows: AlertScheduleRestrictionWindowApi[]
+}
+
+export interface TracingAlertStateIntervalApi {
+    /** Interval start (UTC, inclusive). */
+    start: string
+    /** Interval end (UTC, exclusive). */
+    end: string
+    /** Alert state during this interval.
+     *
+     * * `not_firing` - Not firing
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken */
+    state: LogsAlertConfigurationStateEnumApi
+    /** Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive. */
+    enabled: boolean
+}
+
+/**
+ * * `engineering` - Engineering
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `student` - Student
+ * * `other` - Other
+ */
+export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
+
+export const RoleAtOrganizationEnumApi = {
+    Engineering: 'engineering',
+    Data: 'data',
+    Product: 'product',
+    Founder: 'founder',
+    Leadership: 'leadership',
+    Marketing: 'marketing',
+    Sales: 'sales',
+    Student: 'student',
+    Other: 'other',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | null
+}
+
+export interface TracingAlertConfigurationApi {
+    /** Unique identifier for this alert. */
+    readonly id: string
+    /**
+     * Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted.
+     * @maxLength 255
+     */
+    name?: string
+    /** Whether the alert is actively being evaluated. Disabling resets the state to not_firing. */
+    enabled?: boolean
+    /** Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.
+     *
+     * * `threshold` - Threshold */
+    alert_type?: AlertTypeEnumApi
+    /** Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
+    filters?: TracingAlertFiltersApi
+    /**
+     * Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span.
+     * @minimum 0
+     */
+    threshold_count?: number
+    /** Whether the alert fires when the count is above or below the threshold.
+     *
+     * * `above` - Above
+     * * `below` - Below */
+    threshold_operator?: LogsAlertThresholdOperatorEnumApi
+    /** Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60. */
+    window_minutes?: number
+    /** How often the alert is evaluated, in minutes. Server-managed. */
+    readonly check_interval_minutes: number
+    /** Current alert state: not_firing, firing, pending_resolve, errored, snoozed, or broken. Server-managed.
+     *
+     * * `not_firing` - Not firing
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken */
+    readonly state: LogsAlertConfigurationStateEnumApi
+    /**
+     * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
+     * @minimum 1
+     * @maximum 10
+     */
+    evaluation_periods?: number
+    /**
+     * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
+     * @minimum 1
+     * @maximum 10
+     */
+    datapoints_to_alarm?: number
+    /**
+     * Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.
+     * @minimum 0
+     */
+    cooldown_minutes?: number
+    /** Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours. */
+    schedule_restriction?: AlertScheduleRestrictionApi | null
+    /**
+     * ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.
+     * @nullable
+     */
+    snooze_until?: string | null
+    /**
+     * When the next evaluation is scheduled. Server-managed.
+     * @nullable
+     */
+    readonly next_check_at: string | null
+    /**
+     * When the last notification was sent. Server-managed.
+     * @nullable
+     */
+    readonly last_notified_at: string | null
+    /**
+     * When the alert was last evaluated. Server-managed.
+     * @nullable
+     */
+    readonly last_checked_at: string | null
+    /** Number of consecutive evaluation failures. Resets on success. Server-managed. */
+    readonly consecutive_failures: number
+    /**
+     * Error message from the most recent errored check, or null if the alert's most recent check was successful.
+     * @nullable
+     */
+    readonly last_error_message: string | null
+    /** Continuous state intervals over the last 24h, ordered oldest-first. Each interval covers a span during which (state, enabled) was constant. Drives the 'Last 24h' status bar on the alert list. */
+    readonly state_timeline: readonly TracingAlertStateIntervalApi[]
+    /**
+     * When the alert was first enabled. Null means the alert is still in draft state.
+     * @nullable
+     */
+    readonly first_enabled_at: string | null
+    /** When the alert was created. */
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    /**
+     * When the alert was last modified.
+     * @nullable
+     */
+    readonly updated_at: string | null
+}
+
+export interface PaginatedTracingAlertConfigurationListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: TracingAlertConfigurationApi[]
+}
+
+export interface PatchedTracingAlertConfigurationApi {
+    /** Unique identifier for this alert. */
+    readonly id?: string
+    /**
+     * Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted.
+     * @maxLength 255
+     */
+    name?: string
+    /** Whether the alert is actively being evaluated. Disabling resets the state to not_firing. */
+    enabled?: boolean
+    /** Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.
+     *
+     * * `threshold` - Threshold */
+    alert_type?: AlertTypeEnumApi
+    /** Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
+    filters?: TracingAlertFiltersApi
+    /**
+     * Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span.
+     * @minimum 0
+     */
+    threshold_count?: number
+    /** Whether the alert fires when the count is above or below the threshold.
+     *
+     * * `above` - Above
+     * * `below` - Below */
+    threshold_operator?: LogsAlertThresholdOperatorEnumApi
+    /** Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60. */
+    window_minutes?: number
+    /** How often the alert is evaluated, in minutes. Server-managed. */
+    readonly check_interval_minutes?: number
+    /** Current alert state: not_firing, firing, pending_resolve, errored, snoozed, or broken. Server-managed.
+     *
+     * * `not_firing` - Not firing
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken */
+    readonly state?: LogsAlertConfigurationStateEnumApi
+    /**
+     * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
+     * @minimum 1
+     * @maximum 10
+     */
+    evaluation_periods?: number
+    /**
+     * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
+     * @minimum 1
+     * @maximum 10
+     */
+    datapoints_to_alarm?: number
+    /**
+     * Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.
+     * @minimum 0
+     */
+    cooldown_minutes?: number
+    /** Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours. */
+    schedule_restriction?: AlertScheduleRestrictionApi | null
+    /**
+     * ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.
+     * @nullable
+     */
+    snooze_until?: string | null
+    /**
+     * When the next evaluation is scheduled. Server-managed.
+     * @nullable
+     */
+    readonly next_check_at?: string | null
+    /**
+     * When the last notification was sent. Server-managed.
+     * @nullable
+     */
+    readonly last_notified_at?: string | null
+    /**
+     * When the alert was last evaluated. Server-managed.
+     * @nullable
+     */
+    readonly last_checked_at?: string | null
+    /** Number of consecutive evaluation failures. Resets on success. Server-managed. */
+    readonly consecutive_failures?: number
+    /**
+     * Error message from the most recent errored check, or null if the alert's most recent check was successful.
+     * @nullable
+     */
+    readonly last_error_message?: string | null
+    /** Continuous state intervals over the last 24h, ordered oldest-first. Each interval covers a span during which (state, enabled) was constant. Drives the 'Last 24h' status bar on the alert list. */
+    readonly state_timeline?: readonly TracingAlertStateIntervalApi[]
+    /**
+     * When the alert was first enabled. Null means the alert is still in draft state.
+     * @nullable
+     */
+    readonly first_enabled_at?: string | null
+    /** When the alert was created. */
+    readonly created_at?: string
+    readonly created_by?: UserBasicApi
+    /**
+     * When the alert was last modified.
+     * @nullable
+     */
+    readonly updated_at?: string | null
+}
+
+/**
+ * * `check` - Check
+ * * `reset` - Reset
+ * * `enable` - Enable
+ * * `disable` - Disable
+ * * `snooze` - Snooze
+ * * `unsnooze` - Unsnooze
+ * * `threshold_change` - Threshold change
+ * * `broken_config` - Broken config
+ */
+export type AlertEventKindEnumApi = (typeof AlertEventKindEnumApi)[keyof typeof AlertEventKindEnumApi]
+
+export const AlertEventKindEnumApi = {
+    Check: 'check',
+    Reset: 'reset',
+    Enable: 'enable',
+    Disable: 'disable',
+    Snooze: 'snooze',
+    Unsnooze: 'unsnooze',
+    ThresholdChange: 'threshold_change',
+    BrokenConfig: 'broken_config',
+} as const
+
+export interface TracingAlertEventApi {
+    readonly id: string
+    readonly created_at: string
+    readonly kind: AlertEventKindEnumApi
+    readonly state_before: string
+    readonly state_after: string
+    readonly threshold_breached: boolean
+    /** @nullable */
+    readonly result_count: number | null
+    /** @nullable */
+    readonly error_message: string | null
+    /** @nullable */
+    readonly query_duration_ms: number | null
+}
+
+export interface PaginatedTracingAlertEventListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: TracingAlertEventApi[]
+}
+
 export interface _TracingDateRangeApi {
     /**
      * Start of the date range. Accepts ISO 8601 timestamps or relative formats: -1h, -6h, -1d, -7d, etc.
@@ -586,63 +1292,6 @@ export interface _TracingTreeRequestApi {
 }
 
 /**
- * * `engineering` - Engineering
- * * `data` - Data
- * * `product` - Product Management
- * * `founder` - Founder
- * * `leadership` - Leadership
- * * `marketing` - Marketing
- * * `sales` - Sales / Success
- * * `student` - Student
- * * `other` - Other
- */
-export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
-
-export const RoleAtOrganizationEnumApi = {
-    Engineering: 'engineering',
-    Data: 'data',
-    Product: 'product',
-    Founder: 'founder',
-    Leadership: 'leadership',
-    Marketing: 'marketing',
-    Sales: 'sales',
-    Student: 'student',
-    Other: 'other',
-} as const
-
-export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
-
-export const BlankEnumApi = {
-    '': '',
-} as const
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | null
-}
-
-/**
  * Saved tracing filters — a subset of the frontend TracingFilters shape. May contain dateRange, serviceNames, filterGroup, orderBy, orderDirection, and viewMode.
  */
 export type TracingViewApiFilters = { [key: string]: unknown }
@@ -697,6 +1346,28 @@ export interface PatchedTracingViewApi {
     readonly created_by?: UserBasicApi | null
     /** @nullable */
     readonly updated_at?: string | null
+}
+
+export type TracingAlertsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type TracingAlertsEventsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
 }
 
 export type TracingSpansAttributesRetrieveParams = {

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -293,6 +293,61 @@ export interface WorkflowVariablePropertyFilterApi {
     value?: (string | number | boolean)[] | string | number | boolean | null
 }
 
+export type BehavioralEventSourceApi = (typeof BehavioralEventSourceApi)[keyof typeof BehavioralEventSourceApi]
+
+export const BehavioralEventSourceApi = {
+    Events: 'events',
+    Actions: 'actions',
+} as const
+
+export type TimeUnitTypeApi = (typeof TimeUnitTypeApi)[keyof typeof TimeUnitTypeApi]
+
+export const TimeUnitTypeApi = {
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+} as const
+
+export type InlineBehavioralTypeApi = (typeof InlineBehavioralTypeApi)[keyof typeof InlineBehavioralTypeApi]
+
+export const InlineBehavioralTypeApi = {
+    PerformedEvent: 'performed_event',
+    PerformedEventMultiple: 'performed_event_multiple',
+} as const
+
+export interface BehavioralPropertyFilterApi {
+    /** Extra property filters the matching events must satisfy. Deliberately excludes nested behavioral/cohort filters and groups */
+    event_filters?:
+        | (
+              | EventPropertyFilterApi
+              | PersonPropertyFilterApi
+              | ElementPropertyFilterApi
+              | FeaturePropertyFilterApi
+              | HogQLPropertyFilterApi
+          )[]
+        | null
+    event_type: BehavioralEventSourceApi
+    /** Absolute or relative (e.g. -30d) lower date bound — alternative to time_value/time_interval */
+    explicit_datetime?: string | null
+    explicit_datetime_to?: string | null
+    /** Event name, or action id when event_type is 'actions' */
+    key: string
+    label?: string | null
+    /** Match persons who did NOT satisfy the criterion. Not the same as a low count — zero-occurrence persons never match count operators */
+    negation?: boolean | null
+    /** Count comparison for performed_event_multiple, defaults to exact */
+    operator?: PropertyOperatorApi | null
+    /** Count threshold for performed_event_multiple */
+    operator_value?: number | null
+    time_interval?: TimeUnitTypeApi | null
+    /** Relative time window size, paired with time_interval */
+    time_value?: number | null
+    /** Person performed (or didn't perform) an event in a time window. ClickHouse-only — not evaluable by flags or CDP */
+    type?: 'behavioral'
+    value: InlineBehavioralTypeApi
+}
+
 export interface PropertyGroupFilterValueApi {
     type: FilterLogicalOperatorApi
     values: (
@@ -320,6 +375,7 @@ export interface PropertyGroupFilterValueApi {
         | RevenueAnalyticsPropertyFilterApi
         | AccountCustomPropertyFilterApi
         | WorkflowVariablePropertyFilterApi
+        | BehavioralPropertyFilterApi
     )[]
 }
 

--- a/products/tracing/frontend/generated/api.ts
+++ b/products/tracing/frontend/generated/api.ts
@@ -9,8 +9,14 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    PaginatedTracingAlertConfigurationListApi,
+    PaginatedTracingAlertEventListApi,
     PaginatedTracingViewListApi,
+    PatchedTracingAlertConfigurationApi,
     PatchedTracingViewApi,
+    TracingAlertConfigurationApi,
+    TracingAlertsEventsListParams,
+    TracingAlertsListParams,
     TracingSpansAttributesRetrieveParams,
     TracingSpansServiceNamesRetrieveParams,
     TracingSpansValuesRetrieveParams,
@@ -51,6 +57,165 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
           [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
       }
     : DistributeReadOnlyOverUnions<T>
+
+export const getTracingAlertsListUrl = (projectId: string, params?: TracingAlertsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/tracing/alerts/?${stringifiedParams}`
+        : `/api/projects/${projectId}/tracing/alerts/`
+}
+
+export const tracingAlertsList = async (
+    projectId: string,
+    params?: TracingAlertsListParams,
+    options?: RequestInit
+): Promise<PaginatedTracingAlertConfigurationListApi> => {
+    return apiMutator<PaginatedTracingAlertConfigurationListApi>(getTracingAlertsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingAlertsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tracing/alerts/`
+}
+
+export const tracingAlertsCreate = async (
+    projectId: string,
+    tracingAlertConfigurationApi?: NonReadonly<TracingAlertConfigurationApi>,
+    options?: RequestInit
+): Promise<TracingAlertConfigurationApi> => {
+    return apiMutator<TracingAlertConfigurationApi>(getTracingAlertsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(tracingAlertConfigurationApi),
+    })
+}
+
+export const getTracingAlertsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tracing/alerts/${id}/`
+}
+
+export const tracingAlertsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<TracingAlertConfigurationApi> => {
+    return apiMutator<TracingAlertConfigurationApi>(getTracingAlertsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingAlertsUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tracing/alerts/${id}/`
+}
+
+export const tracingAlertsUpdate = async (
+    projectId: string,
+    id: string,
+    tracingAlertConfigurationApi?: NonReadonly<TracingAlertConfigurationApi>,
+    options?: RequestInit
+): Promise<TracingAlertConfigurationApi> => {
+    return apiMutator<TracingAlertConfigurationApi>(getTracingAlertsUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(tracingAlertConfigurationApi),
+    })
+}
+
+export const getTracingAlertsPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tracing/alerts/${id}/`
+}
+
+export const tracingAlertsPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedTracingAlertConfigurationApi?: NonReadonly<PatchedTracingAlertConfigurationApi>,
+    options?: RequestInit
+): Promise<TracingAlertConfigurationApi> => {
+    return apiMutator<TracingAlertConfigurationApi>(getTracingAlertsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedTracingAlertConfigurationApi),
+    })
+}
+
+export const getTracingAlertsDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tracing/alerts/${id}/`
+}
+
+export const tracingAlertsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getTracingAlertsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getTracingAlertsEventsListUrl = (
+    projectId: string,
+    id: string,
+    params?: TracingAlertsEventsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/tracing/alerts/${id}/events/?${stringifiedParams}`
+        : `/api/projects/${projectId}/tracing/alerts/${id}/events/`
+}
+
+/**
+ * Paginated event history for this alert, newest first. Returns state transitions, errored checks, and user-initiated control-plane rows (reset, enable/disable, snooze/unsnooze, threshold change) — quiet no-op check rows (where state didn't change and there was no error) are filtered out. Optional `?kind=...` narrows to a single kind.
+ */
+export const tracingAlertsEventsList = async (
+    projectId: string,
+    id: string,
+    params?: TracingAlertsEventsListParams,
+    options?: RequestInit
+): Promise<PaginatedTracingAlertEventListApi> => {
+    return apiMutator<PaginatedTracingAlertEventListApi>(getTracingAlertsEventsListUrl(projectId, id, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingAlertsResetCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tracing/alerts/${id}/reset/`
+}
+
+/**
+ * Reset a broken alert. Clears the consecutive-failure counter and schedules an immediate recheck.
+ */
+export const tracingAlertsResetCreate = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<TracingAlertConfigurationApi> => {
+    return apiMutator<TracingAlertConfigurationApi>(getTracingAlertsResetCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+    })
+}
 
 export const getTracingSpansAggregateCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/tracing/spans/aggregate/`

--- a/products/tracing/frontend/generated/api.zod.ts
+++ b/products/tracing/frontend/generated/api.zod.ts
@@ -9,6 +9,390 @@
  */
 import * as zod from 'zod'
 
+export const tracingAlertsCreateBodyNameMax = 255
+
+export const tracingAlertsCreateBodyEnabledDefault = true
+export const tracingAlertsCreateBodyAlertTypeDefault = `threshold`
+export const tracingAlertsCreateBodyThresholdCountDefault = 100
+export const tracingAlertsCreateBodyThresholdCountMin = 0
+
+export const tracingAlertsCreateBodyThresholdOperatorDefault = `above`
+export const tracingAlertsCreateBodyWindowMinutesDefault = 5
+export const tracingAlertsCreateBodyEvaluationPeriodsDefault = 1
+export const tracingAlertsCreateBodyEvaluationPeriodsMax = 10
+
+export const tracingAlertsCreateBodyDatapointsToAlarmDefault = 1
+export const tracingAlertsCreateBodyDatapointsToAlarmMax = 10
+
+export const tracingAlertsCreateBodyCooldownMinutesDefault = 0
+export const tracingAlertsCreateBodyCooldownMinutesMin = 0
+
+export const TracingAlertsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(tracingAlertsCreateBodyNameMax)
+        .optional()
+        .describe("Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted."),
+    enabled: zod
+        .boolean()
+        .default(tracingAlertsCreateBodyEnabledDefault)
+        .describe('Whether the alert is actively being evaluated. Disabling resets the state to not_firing.'),
+    alert_type: zod
+        .enum(['threshold'])
+        .describe('\* `threshold` - Threshold')
+        .default(tracingAlertsCreateBodyAlertTypeDefault)
+        .describe(
+            "Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.\n\n\* `threshold` - Threshold"
+        ),
+    filters: zod
+        .object({
+            errorOnly: zod.union([zod.boolean(), zod.null()]).optional(),
+            filterGroup: zod
+                .union([
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(
+                            zod
+                                .record(zod.string(), zod.unknown())
+                                .describe(
+                                    'Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'
+                                )
+                        ),
+                    }),
+                    zod.null(),
+                ])
+                .optional(),
+            serviceNames: zod.union([zod.array(zod.string()), zod.null()]).optional(),
+        })
+        .optional()
+        .describe(
+            'Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
+        ),
+    threshold_count: zod
+        .number()
+        .min(tracingAlertsCreateBodyThresholdCountMin)
+        .default(tracingAlertsCreateBodyThresholdCountDefault)
+        .describe(
+            "Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span."
+        ),
+    threshold_operator: zod
+        .enum(['above', 'below'])
+        .describe('\* `above` - Above\n\* `below` - Below')
+        .default(tracingAlertsCreateBodyThresholdOperatorDefault)
+        .describe(
+            'Whether the alert fires when the count is above or below the threshold.\n\n\* `above` - Above\n\* `below` - Below'
+        ),
+    window_minutes: zod
+        .number()
+        .default(tracingAlertsCreateBodyWindowMinutesDefault)
+        .describe('Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60.'),
+    evaluation_periods: zod
+        .number()
+        .min(1)
+        .max(tracingAlertsCreateBodyEvaluationPeriodsMax)
+        .default(tracingAlertsCreateBodyEvaluationPeriodsDefault)
+        .describe('Total number of check periods in the sliding evaluation window for firing (M in N-of-M).'),
+    datapoints_to_alarm: zod
+        .number()
+        .min(1)
+        .max(tracingAlertsCreateBodyDatapointsToAlarmMax)
+        .default(tracingAlertsCreateBodyDatapointsToAlarmDefault)
+        .describe('How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).'),
+    cooldown_minutes: zod
+        .number()
+        .min(tracingAlertsCreateBodyCooldownMinutesMin)
+        .default(tracingAlertsCreateBodyCooldownMinutesDefault)
+        .describe('Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.'),
+    schedule_restriction: zod
+        .union([
+            zod.object({
+                blocked_windows: zod
+                    .array(
+                        zod.object({
+                            start: zod
+                                .string()
+                                .describe(
+                                    'Start time HH:MM (24-hour, project timezone). Inclusive. Each window must span ≥ 30 minutes on the local daily timeline (half-open [start, end)).'
+                                ),
+                            end: zod
+                                .string()
+                                .describe(
+                                    'End time HH:MM (24-hour). Exclusive (half-open interval). Each window must span ≥ 30 minutes locally.'
+                                ),
+                        })
+                    )
+                    .describe(
+                        'Blocked local time windows when the alert must not run. Overlapping or identical windows are merged when saved. At most five windows before normalization; empty array clears quiet hours.'
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours.'
+        ),
+    snooze_until: zod.iso
+        .datetime({ offset: true })
+        .nullish()
+        .describe('ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.'),
+})
+
+export const tracingAlertsUpdateBodyNameMax = 255
+
+export const tracingAlertsUpdateBodyEnabledDefault = true
+export const tracingAlertsUpdateBodyAlertTypeDefault = `threshold`
+export const tracingAlertsUpdateBodyThresholdCountDefault = 100
+export const tracingAlertsUpdateBodyThresholdCountMin = 0
+
+export const tracingAlertsUpdateBodyThresholdOperatorDefault = `above`
+export const tracingAlertsUpdateBodyWindowMinutesDefault = 5
+export const tracingAlertsUpdateBodyEvaluationPeriodsDefault = 1
+export const tracingAlertsUpdateBodyEvaluationPeriodsMax = 10
+
+export const tracingAlertsUpdateBodyDatapointsToAlarmDefault = 1
+export const tracingAlertsUpdateBodyDatapointsToAlarmMax = 10
+
+export const tracingAlertsUpdateBodyCooldownMinutesDefault = 0
+export const tracingAlertsUpdateBodyCooldownMinutesMin = 0
+
+export const TracingAlertsUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(tracingAlertsUpdateBodyNameMax)
+        .optional()
+        .describe("Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted."),
+    enabled: zod
+        .boolean()
+        .default(tracingAlertsUpdateBodyEnabledDefault)
+        .describe('Whether the alert is actively being evaluated. Disabling resets the state to not_firing.'),
+    alert_type: zod
+        .enum(['threshold'])
+        .describe('\* `threshold` - Threshold')
+        .default(tracingAlertsUpdateBodyAlertTypeDefault)
+        .describe(
+            "Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.\n\n\* `threshold` - Threshold"
+        ),
+    filters: zod
+        .object({
+            errorOnly: zod.union([zod.boolean(), zod.null()]).optional(),
+            filterGroup: zod
+                .union([
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(
+                            zod
+                                .record(zod.string(), zod.unknown())
+                                .describe(
+                                    'Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'
+                                )
+                        ),
+                    }),
+                    zod.null(),
+                ])
+                .optional(),
+            serviceNames: zod.union([zod.array(zod.string()), zod.null()]).optional(),
+        })
+        .optional()
+        .describe(
+            'Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
+        ),
+    threshold_count: zod
+        .number()
+        .min(tracingAlertsUpdateBodyThresholdCountMin)
+        .default(tracingAlertsUpdateBodyThresholdCountDefault)
+        .describe(
+            "Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span."
+        ),
+    threshold_operator: zod
+        .enum(['above', 'below'])
+        .describe('\* `above` - Above\n\* `below` - Below')
+        .default(tracingAlertsUpdateBodyThresholdOperatorDefault)
+        .describe(
+            'Whether the alert fires when the count is above or below the threshold.\n\n\* `above` - Above\n\* `below` - Below'
+        ),
+    window_minutes: zod
+        .number()
+        .default(tracingAlertsUpdateBodyWindowMinutesDefault)
+        .describe('Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60.'),
+    evaluation_periods: zod
+        .number()
+        .min(1)
+        .max(tracingAlertsUpdateBodyEvaluationPeriodsMax)
+        .default(tracingAlertsUpdateBodyEvaluationPeriodsDefault)
+        .describe('Total number of check periods in the sliding evaluation window for firing (M in N-of-M).'),
+    datapoints_to_alarm: zod
+        .number()
+        .min(1)
+        .max(tracingAlertsUpdateBodyDatapointsToAlarmMax)
+        .default(tracingAlertsUpdateBodyDatapointsToAlarmDefault)
+        .describe('How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).'),
+    cooldown_minutes: zod
+        .number()
+        .min(tracingAlertsUpdateBodyCooldownMinutesMin)
+        .default(tracingAlertsUpdateBodyCooldownMinutesDefault)
+        .describe('Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.'),
+    schedule_restriction: zod
+        .union([
+            zod.object({
+                blocked_windows: zod
+                    .array(
+                        zod.object({
+                            start: zod
+                                .string()
+                                .describe(
+                                    'Start time HH:MM (24-hour, project timezone). Inclusive. Each window must span ≥ 30 minutes on the local daily timeline (half-open [start, end)).'
+                                ),
+                            end: zod
+                                .string()
+                                .describe(
+                                    'End time HH:MM (24-hour). Exclusive (half-open interval). Each window must span ≥ 30 minutes locally.'
+                                ),
+                        })
+                    )
+                    .describe(
+                        'Blocked local time windows when the alert must not run. Overlapping or identical windows are merged when saved. At most five windows before normalization; empty array clears quiet hours.'
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours.'
+        ),
+    snooze_until: zod.iso
+        .datetime({ offset: true })
+        .nullish()
+        .describe('ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.'),
+})
+
+export const tracingAlertsPartialUpdateBodyNameMax = 255
+
+export const tracingAlertsPartialUpdateBodyEnabledDefault = true
+export const tracingAlertsPartialUpdateBodyAlertTypeDefault = `threshold`
+export const tracingAlertsPartialUpdateBodyThresholdCountDefault = 100
+export const tracingAlertsPartialUpdateBodyThresholdCountMin = 0
+
+export const tracingAlertsPartialUpdateBodyThresholdOperatorDefault = `above`
+export const tracingAlertsPartialUpdateBodyWindowMinutesDefault = 5
+export const tracingAlertsPartialUpdateBodyEvaluationPeriodsDefault = 1
+export const tracingAlertsPartialUpdateBodyEvaluationPeriodsMax = 10
+
+export const tracingAlertsPartialUpdateBodyDatapointsToAlarmDefault = 1
+export const tracingAlertsPartialUpdateBodyDatapointsToAlarmMax = 10
+
+export const tracingAlertsPartialUpdateBodyCooldownMinutesDefault = 0
+export const tracingAlertsPartialUpdateBodyCooldownMinutesMin = 0
+
+export const TracingAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(tracingAlertsPartialUpdateBodyNameMax)
+        .optional()
+        .describe("Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted."),
+    enabled: zod
+        .boolean()
+        .default(tracingAlertsPartialUpdateBodyEnabledDefault)
+        .describe('Whether the alert is actively being evaluated. Disabling resets the state to not_firing.'),
+    alert_type: zod
+        .enum(['threshold'])
+        .describe('\* `threshold` - Threshold')
+        .default(tracingAlertsPartialUpdateBodyAlertTypeDefault)
+        .describe(
+            "Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.\n\n\* `threshold` - Threshold"
+        ),
+    filters: zod
+        .object({
+            errorOnly: zod.union([zod.boolean(), zod.null()]).optional(),
+            filterGroup: zod
+                .union([
+                    zod.object({
+                        type: zod.enum(['AND', 'OR']),
+                        values: zod.array(
+                            zod
+                                .record(zod.string(), zod.unknown())
+                                .describe(
+                                    'Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)'
+                                )
+                        ),
+                    }),
+                    zod.null(),
+                ])
+                .optional(),
+            serviceNames: zod.union([zod.array(zod.string()), zod.null()]).optional(),
+        })
+        .optional()
+        .describe(
+            'Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
+        ),
+    threshold_count: zod
+        .number()
+        .min(tracingAlertsPartialUpdateBodyThresholdCountMin)
+        .default(tracingAlertsPartialUpdateBodyThresholdCountDefault)
+        .describe(
+            "Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span."
+        ),
+    threshold_operator: zod
+        .enum(['above', 'below'])
+        .describe('\* `above` - Above\n\* `below` - Below')
+        .default(tracingAlertsPartialUpdateBodyThresholdOperatorDefault)
+        .describe(
+            'Whether the alert fires when the count is above or below the threshold.\n\n\* `above` - Above\n\* `below` - Below'
+        ),
+    window_minutes: zod
+        .number()
+        .default(tracingAlertsPartialUpdateBodyWindowMinutesDefault)
+        .describe('Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60.'),
+    evaluation_periods: zod
+        .number()
+        .min(1)
+        .max(tracingAlertsPartialUpdateBodyEvaluationPeriodsMax)
+        .default(tracingAlertsPartialUpdateBodyEvaluationPeriodsDefault)
+        .describe('Total number of check periods in the sliding evaluation window for firing (M in N-of-M).'),
+    datapoints_to_alarm: zod
+        .number()
+        .min(1)
+        .max(tracingAlertsPartialUpdateBodyDatapointsToAlarmMax)
+        .default(tracingAlertsPartialUpdateBodyDatapointsToAlarmDefault)
+        .describe('How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).'),
+    cooldown_minutes: zod
+        .number()
+        .min(tracingAlertsPartialUpdateBodyCooldownMinutesMin)
+        .default(tracingAlertsPartialUpdateBodyCooldownMinutesDefault)
+        .describe('Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.'),
+    schedule_restriction: zod
+        .union([
+            zod.object({
+                blocked_windows: zod
+                    .array(
+                        zod.object({
+                            start: zod
+                                .string()
+                                .describe(
+                                    'Start time HH:MM (24-hour, project timezone). Inclusive. Each window must span ≥ 30 minutes on the local daily timeline (half-open [start, end)).'
+                                ),
+                            end: zod
+                                .string()
+                                .describe(
+                                    'End time HH:MM (24-hour). Exclusive (half-open interval). Each window must span ≥ 30 minutes locally.'
+                                ),
+                        })
+                    )
+                    .describe(
+                        'Blocked local time windows when the alert must not run. Overlapping or identical windows are merged when saved. At most five windows before normalization; empty array clears quiet hours.'
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe(
+            'Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours.'
+        ),
+    snooze_until: zod.iso
+        .datetime({ offset: true })
+        .nullish()
+        .describe('ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.'),
+})
+
 export const tracingSpansAggregateCreateBodyQueryOneCompareFilterOneCompareDefault = false
 export const tracingSpansAggregateCreateBodyQueryOneFilterGroupDefault = []
 export const tracingSpansAggregateCreateBodyQueryOneLimitMax = 5000

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9925,6 +9925,30 @@ export namespace Schemas {
       include_reasoning?: boolean;
     }
 
+    /**
+     * * `check` - Check
+     * * `reset` - Reset
+     * * `enable` - Enable
+     * * `disable` - Disable
+     * * `snooze` - Snooze
+     * * `unsnooze` - Unsnooze
+     * * `threshold_change` - Threshold change
+     * * `broken_config` - Broken config
+     */
+    export type AlertEventKindEnum = typeof AlertEventKindEnum[keyof typeof AlertEventKindEnum];
+
+
+    export const AlertEventKindEnum = {
+      Check: 'check',
+      Reset: 'reset',
+      Enable: 'enable',
+      Disable: 'disable',
+      Snooze: 'snooze',
+      Unsnooze: 'unsnooze',
+      ThresholdChange: 'threshold_change',
+      BrokenConfig: 'broken_config',
+    } as const;
+
     export interface AlertSimulate {
       /** Insight ID to simulate the detector on. */
       insight: number;
@@ -10012,6 +10036,16 @@ export namespace Schemas {
       /** Configured delivery channels that failed to schedule or send. */
       failed_delivery_channels: FailedDeliveryChannelsEnum[];
     }
+
+    /**
+     * * `threshold` - Threshold
+     */
+    export type AlertTypeEnum = typeof AlertTypeEnum[keyof typeof AlertTypeEnum];
+
+
+    export const AlertTypeEnum = {
+      Threshold: 'threshold',
+    } as const;
 
     /**
      * * `trace` - trace
@@ -46438,34 +46472,10 @@ export namespace Schemas {
       hog_function_ids: string[];
     }
 
-    /**
-     * * `check` - Check
-     * * `reset` - Reset
-     * * `enable` - Enable
-     * * `disable` - Disable
-     * * `snooze` - Snooze
-     * * `unsnooze` - Unsnooze
-     * * `threshold_change` - Threshold change
-     * * `broken_config` - Broken config
-     */
-    export type LogsAlertEventKindEnum = typeof LogsAlertEventKindEnum[keyof typeof LogsAlertEventKindEnum];
-
-
-    export const LogsAlertEventKindEnum = {
-      Check: 'check',
-      Reset: 'reset',
-      Enable: 'enable',
-      Disable: 'disable',
-      Snooze: 'snooze',
-      Unsnooze: 'unsnooze',
-      ThresholdChange: 'threshold_change',
-      BrokenConfig: 'broken_config',
-    } as const;
-
     export interface LogsAlertEvent {
       readonly id: string;
       readonly created_at: string;
-      readonly kind: LogsAlertEventKindEnum;
+      readonly kind: AlertEventKindEnum;
       readonly state_before: string;
       readonly state_after: string;
       readonly threshold_breached: boolean;
@@ -56617,6 +56627,165 @@ export namespace Schemas {
       results: TraceReview[];
     }
 
+    export interface TracingAlertFilters {
+      errorOnly?: boolean | null;
+      filterGroup?: PropertyGroupFilter | null;
+      serviceNames?: string[] | null;
+    }
+
+    export interface TracingAlertStateInterval {
+      /** Interval start (UTC, inclusive). */
+      start: string;
+      /** Interval end (UTC, exclusive). */
+      end: string;
+      /** Alert state during this interval.
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
+      state: LogsAlertConfigurationStateEnum;
+      /** Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive. */
+      enabled: boolean;
+    }
+
+    export interface TracingAlertConfiguration {
+      /** Unique identifier for this alert. */
+      readonly id: string;
+      /**
+         * Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted.
+         * @maxLength 255
+         */
+      name?: string;
+      /** Whether the alert is actively being evaluated. Disabling resets the state to not_firing. */
+      enabled?: boolean;
+      /** Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.
+       *
+       * * `threshold` - Threshold */
+      alert_type?: AlertTypeEnum;
+      /** Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
+      filters?: TracingAlertFilters;
+      /**
+         * Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span.
+         * @minimum 0
+         */
+      threshold_count?: number;
+      /** Whether the alert fires when the count is above or below the threshold.
+       *
+       * * `above` - Above
+       * * `below` - Below */
+      threshold_operator?: LogsAlertThresholdOperatorEnum;
+      /** Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60. */
+      window_minutes?: number;
+      /** How often the alert is evaluated, in minutes. Server-managed. */
+      readonly check_interval_minutes: number;
+      /** Current alert state: not_firing, firing, pending_resolve, errored, snoozed, or broken. Server-managed.
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
+      readonly state: LogsAlertConfigurationStateEnum;
+      /**
+         * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
+         * @minimum 1
+         * @maximum 10
+         */
+      evaluation_periods?: number;
+      /**
+         * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
+         * @minimum 1
+         * @maximum 10
+         */
+      datapoints_to_alarm?: number;
+      /**
+         * Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.
+         * @minimum 0
+         */
+      cooldown_minutes?: number;
+      /** Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours. */
+      schedule_restriction?: AlertScheduleRestriction | null;
+      /**
+         * ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.
+         * @nullable
+         */
+      snooze_until?: string | null;
+      /**
+         * When the next evaluation is scheduled. Server-managed.
+         * @nullable
+         */
+      readonly next_check_at: string | null;
+      /**
+         * When the last notification was sent. Server-managed.
+         * @nullable
+         */
+      readonly last_notified_at: string | null;
+      /**
+         * When the alert was last evaluated. Server-managed.
+         * @nullable
+         */
+      readonly last_checked_at: string | null;
+      /** Number of consecutive evaluation failures. Resets on success. Server-managed. */
+      readonly consecutive_failures: number;
+      /**
+         * Error message from the most recent errored check, or null if the alert's most recent check was successful.
+         * @nullable
+         */
+      readonly last_error_message: string | null;
+      /** Continuous state intervals over the last 24h, ordered oldest-first. Each interval covers a span during which (state, enabled) was constant. Drives the 'Last 24h' status bar on the alert list. */
+      readonly state_timeline: readonly TracingAlertStateInterval[];
+      /**
+         * When the alert was first enabled. Null means the alert is still in draft state.
+         * @nullable
+         */
+      readonly first_enabled_at: string | null;
+      /** When the alert was created. */
+      readonly created_at: string;
+      readonly created_by: UserBasic;
+      /**
+         * When the alert was last modified.
+         * @nullable
+         */
+      readonly updated_at: string | null;
+    }
+
+    export interface PaginatedTracingAlertConfigurationList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: TracingAlertConfiguration[];
+    }
+
+    export interface TracingAlertEvent {
+      readonly id: string;
+      readonly created_at: string;
+      readonly kind: AlertEventKindEnum;
+      readonly state_before: string;
+      readonly state_after: string;
+      readonly threshold_breached: boolean;
+      /** @nullable */
+      readonly result_count: number | null;
+      /** @nullable */
+      readonly error_message: string | null;
+      /** @nullable */
+      readonly query_duration_ms: number | null;
+    }
+
+    export interface PaginatedTracingAlertEventList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: TracingAlertEvent[];
+    }
+
     /**
      * Saved tracing filters — a subset of the frontend TracingFilters shape. May contain dateRange, serviceNames, filterGroup, orderBy, orderDirection, and viewMode.
      */
@@ -65282,6 +65451,108 @@ export namespace Schemas {
          * @nullable
          */
       queue_id?: string | null;
+    }
+
+    export interface PatchedTracingAlertConfiguration {
+      /** Unique identifier for this alert. */
+      readonly id?: string;
+      /**
+         * Human-readable name for this alert. Defaults to 'Untitled alert' on create when omitted.
+         * @maxLength 255
+         */
+      name?: string;
+      /** Whether the alert is actively being evaluated. Disabling resets the state to not_firing. */
+      enabled?: boolean;
+      /** Alert evaluation mode. Only 'threshold' is supported today; reserved for a future statistical-anomaly mode.
+       *
+       * * `threshold` - Threshold */
+      alert_type?: AlertTypeEnum;
+      /** Filter criteria against trace_spans. Must contain at least one of: serviceNames (list of service name strings), errorOnly (boolean), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
+      filters?: TracingAlertFilters;
+      /**
+         * Number of matching spans that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching span.
+         * @minimum 0
+         */
+      threshold_count?: number;
+      /** Whether the alert fires when the count is above or below the threshold.
+       *
+       * * `above` - Above
+       * * `below` - Below */
+      threshold_operator?: LogsAlertThresholdOperatorEnum;
+      /** Time window in minutes over which matching spans are counted. Allowed values: 5, 10, 15, 30, 60. */
+      window_minutes?: number;
+      /** How often the alert is evaluated, in minutes. Server-managed. */
+      readonly check_interval_minutes?: number;
+      /** Current alert state: not_firing, firing, pending_resolve, errored, snoozed, or broken. Server-managed.
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
+      readonly state?: LogsAlertConfigurationStateEnum;
+      /**
+         * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
+         * @minimum 1
+         * @maximum 10
+         */
+      evaluation_periods?: number;
+      /**
+         * How many periods within the evaluation window must breach the threshold to fire (N in N-of-M).
+         * @minimum 1
+         * @maximum 10
+         */
+      datapoints_to_alarm?: number;
+      /**
+         * Minimum minutes between repeated notifications after the alert fires. 0 means no cooldown.
+         * @minimum 0
+         */
+      cooldown_minutes?: number;
+      /** Blocked local time windows when the alert must not run. Times use the project timezone. Null disables quiet hours. */
+      schedule_restriction?: AlertScheduleRestriction | null;
+      /**
+         * ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze.
+         * @nullable
+         */
+      snooze_until?: string | null;
+      /**
+         * When the next evaluation is scheduled. Server-managed.
+         * @nullable
+         */
+      readonly next_check_at?: string | null;
+      /**
+         * When the last notification was sent. Server-managed.
+         * @nullable
+         */
+      readonly last_notified_at?: string | null;
+      /**
+         * When the alert was last evaluated. Server-managed.
+         * @nullable
+         */
+      readonly last_checked_at?: string | null;
+      /** Number of consecutive evaluation failures. Resets on success. Server-managed. */
+      readonly consecutive_failures?: number;
+      /**
+         * Error message from the most recent errored check, or null if the alert's most recent check was successful.
+         * @nullable
+         */
+      readonly last_error_message?: string | null;
+      /** Continuous state intervals over the last 24h, ordered oldest-first. Each interval covers a span during which (state, enabled) was constant. Drives the 'Last 24h' status bar on the alert list. */
+      readonly state_timeline?: readonly TracingAlertStateInterval[];
+      /**
+         * When the alert was first enabled. Null means the alert is still in draft state.
+         * @nullable
+         */
+      readonly first_enabled_at?: string | null;
+      /** When the alert was created. */
+      readonly created_at?: string;
+      readonly created_by?: UserBasic;
+      /**
+         * When the alert was last modified.
+         * @nullable
+         */
+      readonly updated_at?: string | null;
     }
 
     /**
@@ -95700,6 +95971,28 @@ export namespace Schemas {
     limit?: number;
     /**
      * Offset into the result set for pagination.
+     */
+    offset?: number;
+    };
+
+    export type TracingAlertsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type TracingAlertsEventsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
      */
     offset?: number;
     };


### PR DESCRIPTION
## Problem

The workflow in #88099 can evaluate and notify, but nothing lets a person create, edit, or inspect a tracing alert. This PR adds that API.

Fifth layer of the tracing-alerting stack (#88841 → #88101).

## Changes

- Adds `TracingAlertViewSet` at `tracing/alerts`, mirroring the logs alert viewset's CRUD plus `events`, `reset`, and `simulate` actions.
- Scopes every query through `TracingAlertConfiguration.objects.unscoped()` + `for_team()`, per the fail-closed tenant model for team-scoped Postgres models.
- Regenerates OpenAPI-derived frontend types after adding a `TracingAlertFilters` query-schema type for the alert's filter shape.
- Fixes a real `kind` enum collision between `LogsAlertEvent` and `TracingAlertEvent`, surfaced by the regen, via an `ENUM_NAME_OVERRIDES` entry. Mechanical: the resulting rename cascades into the already-generated logs alert history component.

> [!NOTE]
> The viewset's own docstring says `destinations` and `simulate` are deferred — this PR doesn't wire alert delivery, only the CRUD around it. That's invisible from the UI built on top of this API: a person can create, edit, and inspect a tracing alert with no indication that it has nowhere to send a notification yet. See #88099 for the delivery-gap this leaves open and what closes it.

## How did you test this code?

- Added `test_alerts_api.py` (38 cases) covering CRUD, authorization, and the custom actions.
- Ran `hogli build:openapi` and confirmed zero enum collisions via `manage.py find_enum_collisions`.
- Not run: a request against a running dev server in this PR's isolated diff; end-to-end verification happens with the frontend in #88101.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as the fifth layer of a multi-stage session. Skills invoked: `/improving-drf-endpoints`, `/adopting-generated-api-types`.

Fixed the enum collision with an `ENUM_NAME_OVERRIDES` entry rather than renaming either model's `kind` field, since the two choice sets are identical and sharing the name avoids generating a second, duplicate enum in the client.
