### PR TITLE
feat(alerts): add shared alert identity and destination ownership schema

### DIFF
--- a/products/alerts/backend/migrations/0004_shared_alert_identity_and_destination.py
+++ b/products/alerts/backend/migrations/0004_shared_alert_identity_and_destination.py
@@ -1,0 +1,82 @@
+# Hand-written: adds the shared alert identity and destination models from the
+# explicit-alert-ownership RFC. FKs into hot tables are constraint-free on create
+# and added back NOT VALID afterwards; the remaining constraints get real DB
+# constraints because their parents are small product tables.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("alerts", "0003_alter_alertconfiguration_calculation_interval"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AlertSharedIdentity",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=posthog.models.utils.uuid7, editable=False, primary_key=True, serialize=False),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("product", models.CharField(choices=[("insight", "Insight"), ("logs", "Logs"), ("billing", "Billing")], max_length=16)),
+                (
+                    "created_by",
+                    models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="posthog.user"),
+                ),
+                (
+                    "organization",
+                    models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, related_name="shared_alerts", to="posthog.organization"),
+                ),
+                (
+                    "execution_team",
+                    models.ForeignKey(blank=True, db_constraint=False, null=True, on_delete=django.db.models.deletion.CASCADE, related_name="shared_alerts", to="posthog.team"),
+                ),
+            ],
+            options={
+                "db_table": "alerts_sharedalert",
+            },
+        ),
+        migrations.CreateModel(
+            name="AlertDestination",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=posthog.models.utils.uuid7, editable=False, primary_key=True, serialize=False),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "type",
+                    models.CharField(choices=[("slack", "Slack"), ("discord", "Discord"), ("webhook", "Webhook"), ("teams", "Microsoft Teams")], max_length=16),
+                ),
+                ("name", models.CharField(blank=True, max_length=400)),
+                (
+                    "created_by",
+                    models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="posthog.user"),
+                ),
+                (
+                    "shared_alert",
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="destinations", to="alerts.alertsharedidentity"),
+                ),
+            ],
+            options={
+                "db_table": "alerts_alertdestination",
+            },
+        ),
+        migrations.AddField(
+            model_name="alertconfiguration",
+            name="shared_alert",
+            field=models.OneToOneField(
+                blank=True,
+                db_constraint=False,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="insight_configuration",
+                to="alerts.alertsharedidentity",
+            ),
+        ),
+    ]

--- a/products/alerts/backend/migrations/max_migration.txt
+++ b/products/alerts/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_alter_alertconfiguration_calculation_interval
+0004_shared_alert_identity_and_destination

--- a/products/alerts/backend/models/__init__.py
+++ b/products/alerts/backend/models/__init__.py
@@ -1,9 +1,13 @@
 from .alert import Alert, AlertCheck, AlertConfiguration, AlertSubscription, Threshold
+from .shared_alert import AlertDestination, AlertProduct, AlertSharedIdentity
 
 __all__ = [
     "Alert",
     "AlertCheck",
     "AlertConfiguration",
+    "AlertDestination",
+    "AlertProduct",
+    "AlertSharedIdentity",
     "AlertSubscription",
     "Threshold",
 ]

--- a/products/alerts/backend/models/alert.py
+++ b/products/alerts/backend/models/alert.py
@@ -114,6 +114,17 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     insight = models.ForeignKey("product_analytics.Insight", on_delete=models.CASCADE)
 
+    # Shared identity and destination-ownership root. Nullable until every alert
+    # row has been backfilled; DB constraints come after cleanup.
+    shared_alert = models.OneToOneField(
+        "alerts.AlertSharedIdentity",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="insight_configuration",
+        db_constraint=False,
+    )
+
     name = models.CharField(max_length=255, blank=True)
     subscribed_users = models.ManyToManyField(
         "posthog.User",

--- a/products/alerts/backend/models/shared_alert.py
+++ b/products/alerts/backend/models/shared_alert.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from django.db import models
+
+from posthog.models.utils import CreatedMetaFields, UUIDModel
+
+
+class AlertProduct(models.TextChoices):
+    INSIGHT = "insight", "Insight"
+    LOGS = "logs", "Logs"
+    BILLING = "billing", "Billing"
+
+
+class AlertSharedIdentity(UUIDModel, CreatedMetaFields):
+    """Shared identity for every alert, across products.
+
+    One row per user-visible alert. Product evaluation configuration stays in
+    one-to-one models (`AlertConfiguration`, `LogsAlertConfiguration`,
+    `BillingAlertConfiguration`); this row only establishes identity, tenant
+    scope, and the destination ownership root.
+
+    `organization` is the durable tenant boundary; `execution_team` says where
+    evaluation and delivery run. Insight and logs alerts always have an
+    execution team. Billing alerts are organization-owned and can have none —
+    e.g. while re-homing after team deletion.
+
+    Named `AlertSharedIdentity` because `alerts.Alert` is the deprecated
+    insight-alert model still occupying that name in this app (`posthog_alert`).
+    """
+
+    organization = models.ForeignKey(
+        "posthog.Organization",
+        on_delete=models.CASCADE,
+        related_name="shared_alerts",
+        # Organization deletion clears every team too, so cascade ordering is not
+        # a concern; the constraint-free FK keeps org teardown lock-free.
+        db_constraint=False,
+    )
+    execution_team = models.ForeignKey(
+        "posthog.Team",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="shared_alerts",
+        db_constraint=False,
+    )
+    product = models.CharField(max_length=16, choices=AlertProduct.choices)
+
+    class Meta:
+        db_table = "alerts_sharedalert"
+
+    def __str__(self) -> str:
+        return f"{self.product} alert {self.id}"
+
+
+class AlertDestination(UUIDModel, CreatedMetaFields):
+    """One logical destination a user configured for an alert.
+
+    A destination owns one executor (HogFunction) per alert event kind —
+    e.g. a Slack destination for a logs alert owns four HogFunctions, one per
+    event kind. The executors carry the secrets and executable inputs; this row
+    carries what is needed to identify, list, authorize, and delete the group.
+    """
+
+    class Type(models.TextChoices):
+        SLACK = "slack", "Slack"
+        DISCORD = "discord", "Discord"
+        WEBHOOK = "webhook", "Webhook"
+        TEAMS = "teams", "Microsoft Teams"
+
+    # Real FK constraint: `alerts_sharedalert` is not a hot table, so the database
+    # can enforce the alert → destination relationship the RFC asks for.
+    shared_alert = models.ForeignKey(
+        "alerts.AlertSharedIdentity",
+        on_delete=models.CASCADE,
+        related_name="destinations",
+    )
+    type = models.CharField(max_length=16, choices=Type.choices)
+    name = models.CharField(max_length=400, blank=True)
+
+    class Meta:
+        db_table = "alerts_alertdestination"
+
+    def __str__(self) -> str:
+        return f"{self.type} destination {self.id} (alert {self.shared_alert_id})"

--- a/products/billing_alerts/backend/migrations/0002_billingalertconfiguration_shared_alert.py
+++ b/products/billing_alerts/backend/migrations/0002_billingalertconfiguration_shared_alert.py
@@ -1,0 +1,28 @@
+# Hand-written: nullable OneToOne link to the shared alert identity from
+# the explicit-alert-ownership RFC. The DB constraint lands after backfill in
+# a later phase.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("billing_alerts", "0001_initial"),
+        ("alerts", "0004_shared_alert_identity_and_destination"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="billingalertconfiguration",
+            name="shared_alert",
+            field=models.OneToOneField(
+                blank=True,
+                db_constraint=False,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="billing_configuration",
+                to="alerts.alertsharedidentity",
+            ),
+        ),
+    ]

--- a/products/billing_alerts/backend/migrations/max_migration.txt
+++ b/products/billing_alerts/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0001_initial
+0002_billingalertconfiguration_shared_alert

--- a/products/billing_alerts/backend/models.py
+++ b/products/billing_alerts/backend/models.py
@@ -66,6 +66,17 @@ class BillingAlertConfiguration(UUIDModel):
         related_name="+",
     )
 
+    # Shared identity and destination-ownership root. Nullable until every alert
+    # row has been backfilled; DB constraints come after cleanup.
+    shared_alert = models.OneToOneField(
+        "alerts.AlertSharedIdentity",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="billing_configuration",
+        db_constraint=False,
+    )
+
     name = models.CharField(max_length=160)
     description = models.TextField(blank=True)
     enabled = models.BooleanField(default=True)

--- a/products/cdp/backend/migrations/0004_hogfunction_alert_ownership.py
+++ b/products/cdp/backend/migrations/0004_hogfunction_alert_ownership.py
@@ -1,0 +1,56 @@
+# Hand-written: alert-ownership columns and constraints on HogFunction from the
+# explicit-alert-ownership RFC. The owning side holds no DB constraint yet
+# (`db_constraint=False` on the shared-alert FKs); constraints land after
+# backfill in a later phase, so nothing here scans existing rows at write time.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cdp", "0003_hog_function_drafts"),
+        ("alerts", "0004_shared_alert_identity_and_destination"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="hogfunction",
+            name="alert_destination",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="executors",
+                to="alerts.alertdestination",
+            ),
+        ),
+        migrations.AddField(
+            model_name="hogfunction",
+            name="alert_event_kind",
+            field=models.CharField(blank=True, max_length=32, null=True),
+        ),
+        migrations.AddConstraint(
+            model_name="hogfunction",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(alert_destination__isnull=False),
+                fields=["alert_destination", "alert_event_kind"],
+                name="hogfunction_alert_destination_kind_uniq",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="hogfunction",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(alert_destination__isnull=True, alert_event_kind__isnull=True),
+                    models.Q(
+                        alert_destination__isnull=False,
+                        alert_event_kind__isnull=False,
+                        type="internal_destination",
+                    ),
+                    _connector="OR",
+                ),
+                name="hogfunction_alert_ownership_shape",
+            ),
+        ),
+    ]

--- a/products/cdp/backend/migrations/max_migration.txt
+++ b/products/cdp/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_hog_function_drafts
+0004_hogfunction_alert_ownership

--- a/products/cdp/backend/models/hog_functions/hog_function.py
+++ b/products/cdp/backend/models/hog_functions/hog_function.py
@@ -103,6 +103,27 @@ class HogFunction(FileSystemSyncMixin, UUIDTModel):
         indexes = [
             models.Index(fields=["type", "enabled", "team"]),
         ]
+        constraints = [
+            # One executor per event kind per alert destination.
+            models.UniqueConstraint(
+                fields=["alert_destination", "alert_event_kind"],
+                condition=models.Q(alert_destination__isnull=False),
+                name="hogfunction_alert_destination_kind_uniq",
+            ),
+            # Alert-owned executors always carry an event kind and stay internal;
+            # ordinary functions carry neither ownership field.
+            models.CheckConstraint(
+                condition=(
+                    models.Q(alert_destination__isnull=True, alert_event_kind__isnull=True)
+                    | models.Q(
+                        alert_destination__isnull=False,
+                        alert_event_kind__isnull=False,
+                        type="internal_destination",
+                    )
+                ),
+                name="hogfunction_alert_ownership_shape",
+            ),
+        ]
 
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     name = models.CharField(max_length=400, null=True, blank=True)
@@ -149,6 +170,18 @@ class HogFunction(FileSystemSyncMixin, UUIDTModel):
         null=True,
         blank=True,
     )
+
+    # Alert-owned executor: set when an alert destination owns this function.
+    # Ownership replaces the JSON `alert_id` filter as the source of truth;
+    # the filter keeps matching events until the runtime switches over.
+    alert_destination = models.ForeignKey(
+        "alerts.AlertDestination",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="executors",
+    )
+    alert_event_kind = models.CharField(max_length=32, null=True, blank=True)
 
     # db_default alongside default: the plugin-server test fixtures INSERT into this table with raw
     # SQL that doesn't list this column, and the test-schema builder skips migrations entirely.

--- a/products/logs/backend/migrations/0023_logsalertconfiguration_shared_alert.py
+++ b/products/logs/backend/migrations/0023_logsalertconfiguration_shared_alert.py
@@ -1,0 +1,28 @@
+# Hand-written: nullable OneToOne link to the shared alert identity from
+# the explicit-alert-ownership RFC. The DB constraint lands after backfill in
+# a later phase.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logs", "0022_backfill_logs_session_id_attribute_keys"),
+        ("alerts", "0004_shared_alert_identity_and_destination"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="logsalertconfiguration",
+            name="shared_alert",
+            field=models.OneToOneField(
+                blank=True,
+                db_constraint=False,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="logs_configuration",
+                to="alerts.alertsharedidentity",
+            ),
+        ),
+    ]

--- a/products/logs/backend/migrations/max_migration.txt
+++ b/products/logs/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0022_backfill_logs_session_id_attribute_keys
+0023_logsalertconfiguration_shared_alert

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -147,6 +147,18 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
         BELOW = "below", "Below"
 
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
+
+    # Shared identity and destination-ownership root. Nullable until every alert
+    # row has been backfilled; DB constraints come after cleanup.
+    shared_alert = models.OneToOneField(
+        "alerts.AlertSharedIdentity",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="logs_configuration",
+        db_constraint=False,
+    )
+
     name = models.CharField(max_length=255)
     enabled = models.BooleanField(default=True)
 


### PR DESCRIPTION
## Problem

Alert ownership of notification destinations currently lives in JSON filters on HogFunction rows, not in the database. There is no first-class `Alert` row shared across overlay products, so engineers adding a new alert type (or a HogFlow-owned destination) have to re-implement the same implicit convention in product code: read the `alert_id` property out of `filters\.properties`, group HogFunctions by template, and reconstruct ownership with OR'd JSON containment queries. That path is what sits behind every list/delete/count in `products/alerts/backend/destinations\.py`, the logs and billing destination APIs, and the CDP runtime's managed-alert routing.

This is Phase 1 of the explicit alert ownership RFC (PostHog/requests-for-comments-internal#1253). The schema is inert on its own - nothing here changes what alert users can see or do.

## Changes

- New `AlertSharedIdentity` model: one row per alert across products, carrying the durable tenant anchor (`organization_id`), the nullable routing target (`execution_team_id`) that lets billing alerts outlive team deletion, and a product discriminator. Insight/log/billing product configs link to it via a nullable one-to-one.
- New `AlertDestination` model: one row per user-visible destination a person configures for an alert. It owns one HogFunction executor per event kind through a cascading FK.
- `HogFunction` gains `alert_destination` (FK to `AlertDestination`, cascade) and `alert_event_kind`, a partial unique constraint pairing them, and a check constraint that rejects any function with only one of the two set or with a type other than `internal_destination`.
- Migrations for all four apps are additive only: nullable columns on existing tables, plain CREATE TABLE for the two new ones. FKs into hot tables (`posthog_team`, `posthog_organization`, `posthog_user`) are declared `db_constraint=False` so `CreateModel`/`AddField` take no lock on the parent; they get real DB constraints in the later cleanup phase.

Nothing reads these columns yet. Product alerting flows emit `alert_id` in the internal event payload today, so the DB and the runtime can resolve the same identifier during dual-write without an event-shape change.

## How did you test this code?

- `makemigrations --check --dry-run` passes with no changes detected for `alerts`, `cdp`, `logs`, `billing_alerts`.
- `manage.py migrate alerts/cdp/logs/billing_alerts` applies cleanly against the local dev-stack Postgres.
- Tests for the services that write into this schema land in the next PR in the stack; this one is migration-only.

## Notes

- The dual-read/write code in `products/alerts/backend/destinations\.py` is affected but not changed here; it still uses `filters__properties__contains` matching. The next layer teaches the writer to also stamp the typed columns.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools used: Claude Code in PostHog Desktop; read through `products/alerts/backend/`, `products/logs/backend/`, `products/billing_alerts/backend/`, and `products/cdp/backend/models/hog_functions/` before writing.
- Skills invoked: `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`.
- The schema shape (one shared root plus a product-typed one-to-one) follows the RFC: it avoids parallel nullable FK columns per product and avoids an untyped JSON union.
- FKs on hot tables use `db_constraint=False` during phase 1 so the migration takes zero locks on `posthog_team`/`posthog_organization`; the constraints land behind `AddForeignKeyNotValid`/`ValidateForeignKey` when the cleanup PR is planned.

Automatic notifications: skip changelog. Docs update: not applicable.<|close|>argument