### PR TITLE
chore(rust): own the embedding worker

### DIFF
--- a/rust/owners.yaml
+++ b/rust/owners.yaml
@@ -7,9 +7,7 @@ rules:
       owners: team-web-analytics
     - match: ['/common/symbol_data/', '/cymbal-proto/', '/cymbal/']
       owners: team-error-tracking
-    # No team has claimed this crate: it started in error tracking, signals did the
-    # recent work, and several other products call it. Route reviews to the engineer
-    # who wrote nearly all of it, until a team takes it on.
+    # No team owns this crate yet, so reviews route to an individual until a team takes it on.
     - match: '/embedding-worker/'
       owners: '@oliverb123'
     - match: ['/feature-flags/', '/flags-consumer/', '/flags_read_store_migrations/']

--- a/rust/owners.yaml
+++ b/rust/owners.yaml
@@ -7,7 +7,6 @@ rules:
       owners: team-web-analytics
     - match: ['/common/symbol_data/', '/cymbal-proto/', '/cymbal/']
       owners: team-error-tracking
-    # No team owns this crate yet, so reviews route to an individual until a team takes it on.
     - match: '/embedding-worker/'
       owners: '@oliverb123'
     - match: ['/feature-flags/', '/flags-consumer/', '/flags_read_store_migrations/']

--- a/rust/owners.yaml
+++ b/rust/owners.yaml
@@ -7,6 +7,11 @@ rules:
       owners: team-web-analytics
     - match: ['/common/symbol_data/', '/cymbal-proto/', '/cymbal/']
       owners: team-error-tracking
+    # No team has claimed this crate: it started in error tracking, signals did the
+    # recent work, and several other products call it. Route reviews to the engineer
+    # who wrote nearly all of it, until a team takes it on.
+    - match: '/embedding-worker/'
+      owners: '@oliverb123'
     - match: ['/feature-flags/', '/flags-consumer/', '/flags_read_store_migrations/']
       owners: team-feature-flags
     - match: '/hogql/'


### PR DESCRIPTION
## Problem

A pull request that touches the embedding worker goes out with nobody asked to review it, so it waits until someone notices.

`hogli owners:who rust/embedding-worker/src/main.rs` answers `(unowned)`. No rule in `rust/owners.yaml` matches the crate, and `.github/CODEOWNERS` covers only `rust/persons_migrations/**`.

The crate drifted rather than moved. It started in error tracking, signals did most of the later work, and nine products call it today, so no team treats it as theirs.

## Changes

- A pull request touching `rust/embedding-worker/` now requests `@oliverb123`, who wrote 17 of the crate's 23 commits.
- All 19 tracked files in the crate resolve to him, and no file outside it changes owner.
- The owner is a person rather than a team, so `owners:who` reports no Slack channel for the crate. A team can go second in the list once one claims it.

Nothing user-facing changes. The diff is five lines of repository metadata.

## How did you test this code?

- `hogli owners:lint` passes, with the same five warnings master already reports.
- `hogli owners:lint --live rust/owners.yaml` passes. That is the identity check CI runs against GitHub, and it confirms the handle resolves to a real account.
- `hogli owners:resolve` over all 19 tracked files in the crate returns `@oliverb123` for every one.

> [!NOTE]
> `hogli owners:fmt` crashes with an `AssertionError` about a `nodejs/` snapshot file. It fails the same way on a clean master checkout, so it predates this change and is unrelated. Flagging it because team-devex owns that tooling and reviews this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app. A PostHog engineer asked who should review a change to the embedding worker, learned the crate had no owner, and asked for one to be recorded.

Skills invoked: `/establishing-code-ownership`, `/writing-pr-descriptions`.

The handle came from GitHub's commit author API for a commit in this crate, not from matching a display name.

An individual owner is unusual in this file, where almost every rule names a team. Error tracking and signals are both defensible, and neither has claimed the crate, so this records the person who maintains it instead of guessing a team. The comment says that, so a later reader knows the rule is a placeholder rather than a decision.

Split out of [#76973](https://github.com/PostHog/posthog/pull/76973), which changes the same crate. Ownership edits route to team-devex, and folding this in would have widened that PR's reviewer set for no functional gain.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
