### PR TITLE
feat(alerts): dual-write shared alert ownership from logs and billing destination APIs

### DIFF
--- a/products/alerts/backend/facade/api.py
+++ b/products/alerts/backend/facade/api.py
@@ -26,7 +26,10 @@ from products.alerts.backend.destination_configs import (
 )
 from products.alerts.backend.destinations import (
     create_alert_destination_hog_functions,
+    delete_shared_alert_destinations,
+    get_or_create_shared_alert,
     soft_delete_alert_destinations,
+    soft_delete_alert_destinations_by_ids,
     soft_delete_alert_destinations_for_alerts,
     soft_delete_all_alert_destinations,
 )
@@ -212,12 +215,15 @@ __all__ = [
     "build_alert_destination_config",
     "create_alert_destination_hog_functions",
     "delete_insight_alerts",
+    "delete_shared_alert_destinations",
     "get_alert_team_id",
+    "get_or_create_shared_alert",
     "insight_alerts_prefetch",
     "insight_ids_with_alerts",
     "serialize_insight_alerts",
     "snooze_alert_from_slack",
     "soft_delete_alert_destinations",
+    "soft_delete_alert_destinations_by_ids",
     "soft_delete_alert_destinations_for_alerts",
     "soft_delete_all_alert_destinations",
     "send_alert_email",

--- a/products/billing_alerts/backend/facade/api.py
+++ b/products/billing_alerts/backend/facade/api.py
@@ -19,10 +19,12 @@ from products.alerts.backend.facade.api import (
     DestinationType,
     build_alert_destination_config,
     create_alert_destination_hog_functions,
+    get_or_create_shared_alert,
     soft_delete_alert_destinations,
     soft_delete_all_alert_destinations,
     validate_destination_data,
 )
+from products.alerts.backend.models.shared_alert import AlertProduct
 
 from ..alert_destinations import (
     BILLING_ALERT_EVENT_IDS,
@@ -209,6 +211,15 @@ def create_destination(alert: BillingAlertConfiguration, *, request: Any, data: 
         }
         if destination_data["type"].value in existing_types:
             raise DRFValidationError({"type": f"A {destination_data['type'].label} destination already exists."})
+
+        # Dual-write: stamp the explicit ownership columns alongside the legacy
+        # alert_id filter until the CDP runtime switches over.
+        shared_alert = get_or_create_shared_alert(
+            alert_id=locked_alert.id,
+            product=AlertProduct.BILLING.value,
+            organization_id=locked_alert.organization_id,
+            execution_team_id=locked_alert.execution_team_id,
+        )
         configs = [
             build_alert_destination_config(
                 team=locked_alert.team,
@@ -217,10 +228,13 @@ def create_destination(alert: BillingAlertConfiguration, *, request: Any, data: 
                 alert_name=locked_alert.name,
                 data=destination_data,
                 slack_context_elements=BILLING_ALERT_SLACK_CONTEXT_ELEMENTS,
+                alert_event_kind=kind,
             )
             for kind in EVENT_KINDS
         ]
-        hog_functions = create_alert_destination_hog_functions(configs, request=request)
+        hog_functions = create_alert_destination_hog_functions(
+            configs, request=request, shared_alert=shared_alert
+        )
         return [hog_function.id for hog_function in hog_functions]
 
 

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -28,7 +28,9 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.utils import relative_date_parse
 
+from products.alerts.backend.models.shared_alert import AlertProduct
 from products.alerts.backend.facade.api import (
+    get_or_create_shared_alert,
     DESTINATION_TEMPLATE_IDS,
     AlertDestinationData,
     AlertDestinationValidationError,
@@ -956,6 +958,15 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         with transaction.atomic():
             alert = self._get_locked_alert()
+            # Dual-write: stamp the same relationship on the explicit columns
+            # that multiplex with the `alert_id` filter while the runtime
+            # still matches on filters.
+            shared_alert = get_or_create_shared_alert(
+                alert_id=alert.id,
+                product=AlertProduct.LOGS.value,
+                organization_id=self.team.organization_id,
+                execution_team_id=alert.team_id,
+            )
             configs = [
                 build_alert_destination_config(
                     team=alert.team,
@@ -964,10 +975,13 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     alert_name=alert.name,
                     data=data,
                     slack_context_elements=LOGS_ALERT_SLACK_CONTEXT_ELEMENTS,
+                    alert_event_kind=kind,
                 )
                 for kind in EVENT_KINDS
             ]
-            hog_functions = create_alert_destination_hog_functions(configs, request=self.request)
+            hog_functions = create_alert_destination_hog_functions(
+                configs, request=self.request, shared_alert=shared_alert
+            )
 
         report_user_action(
             request.user,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1,7 +1,7 @@
 import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -865,6 +865,13 @@ class TestLogsAlertAPI(APIBaseTest):
                 "operator": "exact",
                 "type": "event",
             }
+            # Dual-write stamps the explicit ownership columns while the legacy
+            # filter keeps matching during the transition: one shared
+            # AlertDestination owns this executor, and the event kind is set
+            # from the SPECS key, not derived from the filter.
+            assert hf.alert_destination_id is not None
+            assert hf.alert_event_kind is not None
+            assert hf.alert_destination.shared_alert_id == UUID(created["id"])
 
         reset_calls = [c for c in mock_report.call_args_list if c.args[1] == "logs alert destination created"]
         assert len(reset_calls) == 1


### PR DESCRIPTION
## Why

Phase 3 of the explicit alert ownership RFC (PostHog/requests-for-comments-internal#1253). Stacked on #88110.

Alert users will not see any change. This wires the logs and billing
destination-creation paths through the dual-write harness from the previous
stacked PRs so new destinations produce the explicit ownership rows the
later runtime switch-over will need.

## Changes

- Logs `create\_destination` calls `get\_or\_create\_shared\_alert` before building configs and passes `shared\_alert` + the per-event-kind `alert\_event\_kind` through to `create\_alert\_destination\_hog\_functions`.
- Billing `create\_destination` mirrors the same wiring.
- Each new HogFunction ends up with both the legacy `alert\_id`/event-name filter intact and the typed `alert\_destination`/`alert\_event\_kind` columns set — satisfying Phase 3 dual-write.
- Facade now exports `get\_or\_create\_shared\_alert`, `delete\_shared\_alert\_destinations`, and `soft\_delete\_alert\_destinations\_by\_ids` so product code doesn't reach across product boundaries.
- Insight alert frontend continues to use the generic HogFunction create flow; the insight migration to the owned API happens in Phase 4 alongside the frontend switch.

Deletion paths stay on the legacy soft-delete-by-filters helper for now: during dual-write the filter still drives routing, and deleting the destination rows we just stamped via the new columns would orphan older executors that were created before dual-write. A later stacked PR migrates deletion to the typed path.

## How did you test this code?

- Extended `products/logs/backend/test/test\_alerts\_api\.py::TestAlertsApi::test\_create\_slack\_destination\_creates\_one\_hog\_function\_per\_event\_kind` to assert each created HogFunction gets its `alert\_destination\_id`, its `alert\_event\_kind`, and relationships back to a shared alert with the same UUID as the product row — the regression is silently dropping the ownership stamps the runtime will rely on in Phase 4. The existing test already pins the legacy filter payload so dual-write compatibility is covered too.
- Tests not run locally: dev-stack Django bootstrap in this sandbox deadlocks during compose migrations. CI will run them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code in PostHog Desktop.
- Skills invoked: `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`, `/improving-drf-endpoints` (for the endpoint wiring).
- Scope was deliberately kept to create-path wiring. Moving the matching delete path over requires also migrating the legacy function IDs the frontend still passes in — better for a follow-up stacked PR where the response payload shape can change with the API.

Automatic notifications: skip changelog. Docs update: none.