### PR TITLE
fix(error-tracking): keep selection when linking an existing issue

### DIFF
--- a/products/error_tracking/frontend/components/ExternalReferences.tsx
+++ b/products/error_tracking/frontend/components/ExternalReferences.tsx
@@ -381,27 +381,25 @@ function linkExistingIssueForm(integration: ErrorTrackingIntegration, onSubmit: 
     LemonDialog.openForm({
         title: `Link existing ${label} issue`,
         shouldAwaitSubmit: true,
-        initialValues: { externalContext: null as ErrorTrackingExternalIssueResultApiExternalContext | null },
+        initialValues: { externalIssue: null as ErrorTrackingExternalIssueResultApi | null },
         content: (
-            <LemonField name="externalContext" label="Issue">
+            <LemonField name="externalIssue" label="Issue">
                 <ExistingIssueSelect integrationId={integration.id} kind={integration.kind} />
             </LemonField>
         ),
         errors: {
-            externalContext: (externalContext) => (!externalContext ? 'You must select an issue' : undefined),
+            externalIssue: (externalIssue) => (!externalIssue ? 'You must select an issue' : undefined),
         },
-        onSubmit: ({ externalContext }) => {
-            if (externalContext) {
-                onSubmit(integration.id, externalContext)
+        onSubmit: ({ externalIssue }) => {
+            if (externalIssue) {
+                onSubmit(integration.id, externalIssue.external_context)
             }
         },
     })
 }
 
-// Searchable picker of existing provider issues. Designed to sit inside a LemonField, so it takes the
-// field's value/onChange and emits the selected issue's external_context (the payload the backend stores).
 // Searchable picker of existing provider issues. Search state lives in externalIssueSearchLogic;
-// this component only bridges the LemonField value/onChange to the selected issue's external_context.
+// this component only bridges the LemonField value/onChange to the selected issue.
 function ExistingIssueSelect({
     integrationId,
     kind,
@@ -410,8 +408,8 @@ function ExistingIssueSelect({
 }: {
     integrationId: number
     kind: ErrorTrackingIntegrationKind
-    value?: ErrorTrackingExternalIssueResultApiExternalContext | null
-    onChange?: (value: ErrorTrackingExternalIssueResultApiExternalContext | null) => void
+    value?: ErrorTrackingExternalIssueResultApi | null
+    onChange?: (value: ErrorTrackingExternalIssueResultApi | null) => void
 }): JSX.Element {
     const requiresRepository = kind === 'github'
     const logic = externalIssueSearchLogic({ integrationId, requiresRepository })
@@ -419,11 +417,16 @@ function ExistingIssueSelect({
     const { setRepository, inputChanged, issueSelected } = useActions(logic)
 
     const optionKey = (result: ErrorTrackingExternalIssueResultApi): string => result.url || `${result.id}`
+    const selectedKey = value ? optionKey(value) : null
     const options = results.map((result) => ({
         key: optionKey(result),
         label: result.title,
     }))
-    const selectedResult = value ? results.find((result) => result.external_context === value) : undefined
+    // A results refresh must not visually drop a valid selection, so the selected
+    // issue stays in the options even when the fresh results no longer include it.
+    if (value && selectedKey && !options.some((option) => option.key === selectedKey)) {
+        options.push({ key: selectedKey, label: value.title })
+    }
 
     return (
         <div className="flex flex-col gap-y-2">
@@ -449,7 +452,7 @@ function ExistingIssueSelect({
                 // would hide valid matches whose titles don't contain the raw query text.
                 disableFiltering
                 options={options}
-                value={selectedResult ? [optionKey(selectedResult)] : []}
+                value={selectedKey ? [selectedKey] : []}
                 onInputChange={(query) => {
                     inputChanged(query)
                     // Typing a new query invalidates the current pick - submitting while results
@@ -460,11 +463,13 @@ function ExistingIssueSelect({
                 }}
                 onChange={(selection) => {
                     const key = selection[0] ?? null
-                    const selected = results.find((result) => optionKey(result) === key)
+                    const selected =
+                        results.find((result) => optionKey(result) === key) ??
+                        (key !== null && key === selectedKey ? value : null)
                     if (selected) {
                         issueSelected()
                     }
-                    onChange?.(selected ? selected.external_context : null)
+                    onChange?.(selected ?? null)
                 }}
             />
         </div>

--- a/products/error_tracking/frontend/components/externalIssueSearchLogic.test.ts
+++ b/products/error_tracking/frontend/components/externalIssueSearchLogic.test.ts
@@ -47,4 +47,20 @@ describe('externalIssueSearchLogic', () => {
         }).toDispatchActions(['searchIssuesSuccess'])
         expect(mockSearchIssues).toHaveBeenCalledTimes(1)
     })
+
+    it('typing right after a selection does not suppress the next genuine clear', async () => {
+        // Typing within the debounce cancels the selection-clear search before it can
+        // consume the suppression, so the flag must be reset by the nonblank search.
+        await expectLogic(logic, () => {
+            logic.actions.inputChanged('')
+            logic.actions.issueSelected()
+            logic.actions.inputChanged('crash')
+        }).toDispatchActions(['searchIssuesSuccess'])
+        expect(mockSearchIssues).toHaveBeenCalledTimes(1)
+
+        await expectLogic(logic, () => {
+            logic.actions.inputChanged('')
+        }).toDispatchActions(['searchIssuesSuccess'])
+        expect(mockSearchIssues).toHaveBeenCalledTimes(2)
+    })
 })

--- a/products/error_tracking/frontend/components/externalIssueSearchLogic.test.ts
+++ b/products/error_tracking/frontend/components/externalIssueSearchLogic.test.ts
@@ -1,0 +1,50 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { errorTrackingExternalReferencesSearchIssuesRetrieve } from '../generated/api'
+import { externalIssueSearchLogic } from './externalIssueSearchLogic'
+
+jest.mock('../generated/api', () => ({
+    errorTrackingExternalReferencesSearchIssuesRetrieve: jest.fn(),
+}))
+
+const mockSearchIssues = jest.mocked(errorTrackingExternalReferencesSearchIssuesRetrieve)
+
+const RECENT_ISSUES = [
+    { id: 'ISS-1', title: 'First issue', url: 'https://example.com/ISS-1', external_context: { id: 'ISS-1' } },
+    { id: 'ISS-2', title: 'Second issue', url: 'https://example.com/ISS-2', external_context: { id: 'ISS-2' } },
+]
+
+describe('externalIssueSearchLogic', () => {
+    let logic: ReturnType<typeof externalIssueSearchLogic.build>
+
+    beforeEach(async () => {
+        initKeaTests()
+        mockSearchIssues.mockResolvedValue({ issues: RECENT_ISSUES })
+        logic = externalIssueSearchLogic({ integrationId: 1, requiresRepository: false })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['searchIssuesSuccess'])
+        mockSearchIssues.mockClear()
+    })
+
+    afterEach(() => logic.unmount())
+
+    it('only a genuine input clear refetches, not the clear caused by selecting an issue', async () => {
+        // LemonInputSelect clears its input BEFORE it reports the selection, so the
+        // blank inputChanged lands before issueSelected. It must not trigger a search
+        // that replaces the results the selection was made from.
+        await expectLogic(logic, () => {
+            logic.actions.inputChanged('')
+            logic.actions.issueSelected()
+        }).toDispatchActions(['searchIssuesSuccess'])
+        expect(mockSearchIssues).not.toHaveBeenCalled()
+        expect(logic.values.results).toEqual(RECENT_ISSUES)
+
+        // The suppression is consumed: the user clearing the search afterwards refetches.
+        await expectLogic(logic, () => {
+            logic.actions.inputChanged('')
+        }).toDispatchActions(['searchIssuesSuccess'])
+        expect(mockSearchIssues).toHaveBeenCalledTimes(1)
+    })
+})

--- a/products/error_tracking/frontend/components/externalIssueSearchLogic.ts
+++ b/products/error_tracking/frontend/components/externalIssueSearchLogic.ts
@@ -73,6 +73,12 @@ export const externalIssueSearchLogic: LogicWrapper<externalIssueSearchLogicType
             {
                 searchIssues: async (query, breakpoint) => {
                     const search = query.trim()
+                    if (search) {
+                        // A nonblank search cancels any pending selection-clear search at the
+                        // breakpoint below, so its suppression must not survive to swallow a
+                        // later genuine clear.
+                        cache.suppressNextBlankSearch = false
+                    }
                     if (props.requiresRepository && !values.repository) {
                         return values.results
                     }
@@ -115,7 +121,11 @@ export const externalIssueSearchLogic: LogicWrapper<externalIssueSearchLogicType
         },
     }),
     listeners(({ actions, cache }) => ({
-        setRepository: () => actions.searchIssues(''),
+        setRepository: () => {
+            // A repository change clears the results, so the reload must not be suppressed.
+            cache.suppressNextBlankSearch = false
+            actions.searchIssues('')
+        },
         issueSelected: () => {
             cache.suppressNextBlankSearch = true
         },

--- a/products/error_tracking/frontend/components/externalIssueSearchLogic.ts
+++ b/products/error_tracking/frontend/components/externalIssueSearchLogic.ts
@@ -67,7 +67,7 @@ export const externalIssueSearchLogic: LogicWrapper<externalIssueSearchLogicType
         inputChanged: (query: string) => ({ query }),
         issueSelected: true,
     }),
-    loaders(({ props, values }) => ({
+    loaders(({ props, values, cache }) => ({
         results: [
             [] as ErrorTrackingExternalIssueResultApi[],
             {
@@ -79,6 +79,14 @@ export const externalIssueSearchLogic: LogicWrapper<externalIssueSearchLogicType
                     // The breakpoint debounces typing and cancels superseded searches, so a slow
                     // response can never overwrite the results of a newer query.
                     await breakpoint(300)
+                    // Selecting an option makes LemonInputSelect clear its input, which is
+                    // indistinguishable from the user clearing the search. The clear can land
+                    // before issueSelected (option click) or after it (input blur), so the flag
+                    // is only reliable here, after the debounce, not at dispatch time.
+                    if (!search && cache.suppressNextBlankSearch) {
+                        cache.suppressNextBlankSearch = false
+                        return values.results
+                    }
                     const response = await errorTrackingExternalReferencesSearchIssuesRetrieve(
                         String(teamLogic.values.currentTeamId),
                         {
@@ -111,16 +119,7 @@ export const externalIssueSearchLogic: LogicWrapper<externalIssueSearchLogicType
         issueSelected: () => {
             cache.suppressNextBlankSearch = true
         },
-        inputChanged: ({ query }) => {
-            // Selecting an option makes LemonInputSelect clear its input, which is
-            // indistinguishable from the user clearing a search - except that it directly
-            // follows issueSelected. Only a genuine clear reloads the recent issues.
-            if (!query.trim() && cache.suppressNextBlankSearch) {
-                cache.suppressNextBlankSearch = false
-                return
-            }
-            actions.searchIssues(query)
-        },
+        inputChanged: ({ query }) => actions.searchIssues(query),
     })),
     afterMount(({ actions }) => {
         actions.searchIssues('')


### PR DESCRIPTION
## Problem

- Picking an issue in the "Link existing issue" dialog (shipped in #79955) triggers a new search and visually clears the pick.
- LemonInputSelect clears its input before it reports the selection, so the blank input change dispatched a search before the suppression flag was set.
- The refreshed results are fresh objects, and the picker matched the selection by object reference, so the selected issue vanished from the field.

## Changes

- Picking an issue no longer refetches: the suppression check moved behind the search debounce, where the flag is reliably set regardless of whether the input clear lands before or after the selection event.
- A genuine clear still reloads recent issues: a newer non-blank search or a repository change resets the suppression instead of letting it leak.
- The picker matches the selection by the issue's stable key (URL/id) instead of object reference, and keeps the selected option visible when a results refresh no longer includes it.
- Mechanical: the link form now stores the full selected result and extracts `external_context` on submit; the submitted payload is unchanged.

No static UI change — the fix is selection/search behavior, so no screenshot.

## How did you test this code?

- New kea logic tests in `externalIssueSearchLogic.test.ts`:
  - the input clear caused by selecting an issue does not refetch (fails on the pre-fix logic, verified by stashing the fix);
  - typing right after a selection does not suppress the next genuine clear.
- `typescript:check` and `typegen:check` pass.
- Not run: manual browser verification of the dialog.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a user bug report against #79955; diagnosis traced the event order in `LemonInputSelect._addItem` (input clear before `onChange`).
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions, plus a structured Codex review pass, which caught the suppression-flag leak fixed in the second commit.
