### PR TITLE
fix(desktop): stop the auth retry loop with a refusal and backoff

### DIFF
--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1373,6 +1373,39 @@ describe("AuthService", () => {
       }
     });
 
+    it("raises a not-authenticated error on the rejection itself", async () => {
+      vi.useFakeTimers();
+      try {
+        oauthFlow.startFlow.mockResolvedValue(
+          mockTokenResponse({
+            accessToken: "current-access-token",
+            refreshToken: "current-refresh-token",
+          }),
+        );
+        stubAuthFetch();
+
+        await service.initialize();
+        await service.login("us");
+
+        oauthFlow.refreshToken.mockReset();
+        oauthFlow.refreshToken.mockResolvedValue({
+          success: false,
+          error: "Token revoked",
+          errorCode: "auth_error",
+        });
+
+        await vi.advanceTimersByTimeAsync(3_599_500);
+
+        // Raised by the rejection that tears the session down, so callers
+        // that stop on a dead session see it here, not one trigger later.
+        await expect(service.getValidAccessToken()).rejects.toBeInstanceOf(
+          NotAuthenticatedError,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not use the current access token when refresh token auth fails", async () => {
       vi.useFakeTimers();
       try {

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1200,8 +1200,7 @@ describe("AuthService", () => {
       await service.initialize();
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
 
-      // Storage still holds the dead token, so the refusal has to fail this
-      // attempt without a request.
+      // Storage still holds the dead token, so this must fail without a request.
       seedStoredSession();
       await expect(service.getValidAccessToken()).rejects.toThrow(
         NotAuthenticatedError,
@@ -1223,13 +1222,10 @@ describe("AuthService", () => {
         await service.initialize();
         expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
 
-        // A 429, or a 400 whose body will not parse, lands here. That is not
-        // evidence the token is dead, so the next trigger is paused.
         await expect(service.getValidAccessToken()).rejects.toThrow(/paused/i);
         expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
 
-        // Still held just under the cooldown, so the window is pinned to the
-        // constant rather than to any value below a minute.
+        // Held just under the cooldown, so the constant itself is pinned.
         vi.setSystemTime(new Date("2026-08-24T00:00:14.900Z"));
         await expect(service.getValidAccessToken()).rejects.toThrow(/paused/i);
         expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
@@ -1262,8 +1258,8 @@ describe("AuthService", () => {
       stubAuthFetch();
       await service.login("us");
 
-      // Same token value as the refused one, so only the generation bump can
-      // release it. Otherwise signing back in leaves the user locked out.
+      // Same token as the refused one, so only the generation bump can release
+      // it. Otherwise signing back in leaves the user locked out.
       seedStoredSession();
       oauthFlow.refreshToken.mockResolvedValue(
         mockTokenResponse({
@@ -1285,8 +1281,7 @@ describe("AuthService", () => {
       await service.initialize();
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
 
-      // A different stored token is a different credential, so the pause must
-      // not widen to it.
+      // A different token is a different credential; the pause must not widen.
       seedStoredSession({ refreshToken: "another-refresh-token" });
       await expect(service.getValidAccessToken()).rejects.toThrow();
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(2);
@@ -1309,8 +1304,7 @@ describe("AuthService", () => {
         const spent = oauthFlow.refreshToken.mock.calls.length;
         expect(spent).toBeGreaterThan(1);
 
-        // A 5xx token endpoint, or a captive portal whose reply will not parse,
-        // exhausts the budget here rather than in the unclassified arm.
+        // This exhausts the retry budget rather than failing on the first attempt.
         await expect(service.getValidAccessToken()).rejects.toThrow();
         expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(spent);
       } finally {

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1,6 +1,6 @@
 import type { RootLogger } from "@posthog/di/logger";
 import type { IPowerManager } from "@posthog/platform/power-manager";
-import { OAUTH_SCOPE_VERSION } from "@posthog/shared";
+import { NotAuthenticatedError, OAUTH_SCOPE_VERSION } from "@posthog/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthService } from "./auth";
 import type {
@@ -1187,6 +1187,86 @@ describe("AuthService", () => {
       });
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
       expect(sessionPort.getCurrent()).toBeNull();
+    });
+
+    it("never re-presents a refresh token the server rejected", async () => {
+      seedStoredSession();
+      oauthFlow.refreshToken.mockResolvedValue({
+        success: false,
+        error: "Token revoked",
+        errorCode: "auth_error",
+      });
+
+      await service.initialize();
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
+      // Storage still holds the dead token, so the refusal has to fail this
+      // attempt without a request.
+      seedStoredSession();
+      await expect(service.getValidAccessToken()).rejects.toThrow(
+        NotAuthenticatedError,
+      );
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it("pauses rather than retires a token after an unclassified failure", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+      try {
+        seedStoredSession();
+        oauthFlow.refreshToken.mockResolvedValue({
+          success: false,
+          error: "Something weird",
+          errorCode: "unknown_error",
+        });
+
+        await service.initialize();
+        expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
+        // A 429, or a 400 whose body will not parse, lands here. That is not
+        // evidence the token is dead, so the next trigger is paused.
+        await expect(service.getValidAccessToken()).rejects.toThrow(/paused/i);
+        expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
+        // And the pause lifts on its own, unlike a server rejection.
+        vi.setSystemTime(new Date("2026-08-24T00:01:01.000Z"));
+        await expect(service.getValidAccessToken()).rejects.toThrow();
+        expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("releases the refusal when a new grant bumps the session generation", async () => {
+      seedStoredSession();
+      oauthFlow.refreshToken.mockResolvedValue({
+        success: false,
+        error: "Token revoked",
+        errorCode: "auth_error",
+      });
+      await service.initialize();
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
+      oauthFlow.startFlow.mockResolvedValue(
+        mockTokenResponse({
+          accessToken: "fresh-access-token",
+          refreshToken: "stored-refresh-token",
+        }),
+      );
+      stubAuthFetch();
+      await service.login("us");
+
+      // Same token value as the refused one, so only the generation bump can
+      // release it. Otherwise signing back in leaves the user locked out.
+      seedStoredSession();
+      oauthFlow.refreshToken.mockResolvedValue(
+        mockTokenResponse({
+          accessToken: "rotated-access-token",
+          refreshToken: "rotated-refresh-token",
+        }),
+      );
+      await service.refreshAccessToken();
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(2);
     });
 
     it("keeps restoring after a non-retryable unknown_error", async () => {

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1228,8 +1228,14 @@ describe("AuthService", () => {
         await expect(service.getValidAccessToken()).rejects.toThrow(/paused/i);
         expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
 
+        // Still held just under the cooldown, so the window is pinned to the
+        // constant rather than to any value below a minute.
+        vi.setSystemTime(new Date("2026-08-24T00:00:14.900Z"));
+        await expect(service.getValidAccessToken()).rejects.toThrow(/paused/i);
+        expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
         // And the pause lifts on its own, unlike a server rejection.
-        vi.setSystemTime(new Date("2026-08-24T00:01:01.000Z"));
+        vi.setSystemTime(new Date("2026-08-24T00:00:15.100Z"));
         await expect(service.getValidAccessToken()).rejects.toThrow();
         expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(2);
       } finally {

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1269,6 +1269,49 @@ describe("AuthService", () => {
       expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(2);
     });
 
+    it("pauses only the token that failed", async () => {
+      seedStoredSession();
+      oauthFlow.refreshToken.mockResolvedValue({
+        success: false,
+        error: "Something weird",
+        errorCode: "unknown_error",
+      });
+      await service.initialize();
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(1);
+
+      // A different stored token is a different credential, so the pause must
+      // not widen to it.
+      seedStoredSession({ refreshToken: "another-refresh-token" });
+      await expect(service.getValidAccessToken()).rejects.toThrow();
+      expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(2);
+    });
+
+    it("pauses the token when retries are exhausted", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-24T00:00:00.000Z"));
+      try {
+        seedStoredSession();
+        oauthFlow.refreshToken.mockResolvedValue({
+          success: false,
+          error: "Boom",
+          errorCode: "server_error",
+        });
+
+        const restoring = service.initialize();
+        await vi.advanceTimersByTimeAsync(10_000);
+        await restoring;
+        const spent = oauthFlow.refreshToken.mock.calls.length;
+        expect(spent).toBeGreaterThan(1);
+
+        // A 5xx token endpoint, or a captive portal whose reply will not parse,
+        // exhausts the budget here rather than in the unclassified arm.
+        await expect(service.getValidAccessToken()).rejects.toThrow();
+        expect(oauthFlow.refreshToken).toHaveBeenCalledTimes(spent);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("keeps restoring after a non-retryable unknown_error", async () => {
       seedStoredSession();
       oauthFlow.refreshToken.mockResolvedValue({

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -42,6 +42,10 @@ import {
   type ValidAccessTokenOutput,
 } from "./schemas";
 
+// A refresh failure the classifier could not identify is not evidence the token
+// is dead: `unknown_error` absorbs 429s and any 400 whose body will not parse.
+// Pause that token instead of retiring it.
+const UNCLASSIFIED_REFRESH_COOLDOWN_MS = 60_000;
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
 const AUTH_FETCH_TIMEOUT_MS = 30_000;
 const AUTH_BOOTSTRAP_DEADLINE_MS = 20_000;
@@ -96,6 +100,14 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private refreshPromise: Promise<InMemorySession> | null = null;
   private impersonationExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   private sessionGeneration = 0;
+  // A refresh the server will not honour, keyed to the session generation so
+  // every teardown and new grant invalidates it. `until: null` means the server
+  // proved the token dead; a timestamp means the failure was unclassified.
+  private refusedRefresh: {
+    token: string;
+    generation: number;
+    until: number | null;
+  } | null = null;
   // Serializes session-state commits so overlapping selections can't
   // interleave across async encryption (see commitSessionState).
   private commitChain: Promise<void> = Promise.resolve();
@@ -707,6 +719,22 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       throw new Error("Offline");
     }
 
+    const refused = this.refusedRefresh;
+    if (
+      refused &&
+      refused.token === input.refreshToken &&
+      refused.generation === this.sessionGeneration
+    ) {
+      if (refused.until === null) {
+        throw new NotAuthenticatedError(
+          "Your session has expired. Sign in again to continue.",
+        );
+      }
+      if (Date.now() < refused.until) {
+        throw new Error("Token refresh paused after an unclassified failure");
+      }
+    }
+
     let lastError = "Token refresh failed";
 
     for (
@@ -731,6 +759,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       if (result.errorCode === "auth_error") {
         this.logger.warn("Refresh token rejected by server, forcing logout");
         this.sessionGeneration += 1;
+        this.refusedRefresh = {
+          token: input.refreshToken,
+          generation: this.sessionGeneration,
+          until: null,
+        };
         this.authSession.clearCurrent();
         this.session = null;
         this.setAnonymousState({
@@ -745,6 +778,16 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
         result.errorCode === "server_error";
 
       if (!isRetryable) {
+        // This arm keeps the session and the stored token, so nothing else
+        // stops the caller re-presenting the same token on the next trigger.
+        this.refusedRefresh = {
+          token: input.refreshToken,
+          generation: this.sessionGeneration,
+          until: Date.now() + UNCLASSIFIED_REFRESH_COOLDOWN_MS,
+        };
+        this.logger.warn("Refresh failed unclassified, pausing this token", {
+          errorCode: result.errorCode,
+        });
         throw new Error(lastError);
       }
 

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -781,7 +781,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
           generation: this.sessionGeneration,
           until: null,
         };
-        throw new Error(lastError);
+        // The session is already anonymous, so callers that stop on a dead
+        // session must see that class here rather than a trigger later.
+        throw new NotAuthenticatedError(lastError);
       }
 
       const isRetryable =

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -43,9 +43,9 @@ import {
 } from "./schemas";
 
 // A refresh failure that is not a rejection is no evidence the token is dead, so
-// pause it instead of retiring it. Must stay well inside TOKEN_EXPIRY_SKEW_MS:
-// refresh fires that far ahead of expiry, so a longer pause would guarantee the
-// retry lands after the access token has already died.
+// pause rather than retire. Sized inside TOKEN_EXPIRY_SKEW_MS so a fast failure
+// still retries on a live token. Retry exhaustion can already outrun the skew on
+// its own, so the sizing buys nothing there.
 const FAILED_REFRESH_COOLDOWN_MS = 15_000;
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
 const AUTH_FETCH_TIMEOUT_MS = 30_000;
@@ -101,9 +101,8 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private refreshPromise: Promise<InMemorySession> | null = null;
   private impersonationExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   private sessionGeneration = 0;
-  // A refresh the server will not honour, keyed to the session generation so
-  // every teardown and new grant invalidates it. `until: null` means the server
-  // proved the token dead; a timestamp means the failure was unclassified.
+  // A refresh already refused, keyed to the session generation so every teardown
+  // invalidates it. `until: null` is a proven-dead token, a timestamp is a pause.
   private refusedRefresh: {
     token: string;
     generation: number;
@@ -776,8 +775,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
           cloudRegion: input.cloudRegion,
           currentProjectId: input.selectedProjectId,
         });
-        // Last, so a throwing teardown cannot leave a refusal standing over a
-        // session the rest of the app still believes in.
+        // Last, so a throwing teardown leaves no refusal over a live-looking session.
         this.refusedRefresh = {
           token: input.refreshToken,
           generation: this.sessionGeneration,
@@ -791,8 +789,8 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
         result.errorCode === "server_error";
 
       if (!isRetryable) {
-        // This arm keeps the session and the stored token, so nothing else
-        // stops the caller re-presenting the same token on the next trigger.
+        // This arm keeps the session and the stored token, so only the pause
+        // stops the caller re-presenting it on the next trigger.
         this.pauseRefresh(input.refreshToken, result.errorCode);
         throw new Error(lastError);
       }
@@ -807,9 +805,8 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       await sleepWithBackoff(attempt, AuthService.REFRESH_BACKOFF);
     }
 
-    // Retries exhausted. A 5xx token endpoint, or a captive portal whose reply
-    // will not parse, arrives here rather than in the arm above, and without a
-    // pause each later trigger spends the whole retry budget again.
+    // A 5xx endpoint or a captive portal exhausts the budget here, not in the arm
+    // above; unpaused, each later trigger spends the whole budget again.
     this.pauseRefresh(input.refreshToken, "retries_exhausted");
 
     throw new Error(lastError);

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -42,10 +42,11 @@ import {
   type ValidAccessTokenOutput,
 } from "./schemas";
 
-// A refresh failure the classifier could not identify is not evidence the token
-// is dead: `unknown_error` absorbs 429s and any 400 whose body will not parse.
-// Pause that token instead of retiring it.
-const UNCLASSIFIED_REFRESH_COOLDOWN_MS = 60_000;
+// A refresh failure that is not a rejection is no evidence the token is dead, so
+// pause it instead of retiring it. Must stay well inside TOKEN_EXPIRY_SKEW_MS:
+// refresh fires that far ahead of expiry, so a longer pause would guarantee the
+// retry lands after the access token has already died.
+const FAILED_REFRESH_COOLDOWN_MS = 15_000;
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
 const AUTH_FETCH_TIMEOUT_MS = 30_000;
 const AUTH_BOOTSTRAP_DEADLINE_MS = 20_000;
@@ -511,6 +512,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     this.authSession.clearCurrent();
     this.clearImpersonationExpiryTimer();
     this.session = null;
+    this.refusedRefresh = null;
     this.setAnonymousState({ cloudRegion, currentProjectId });
     return this.getState();
   }
@@ -712,6 +714,15 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
 
     return storedSession;
   }
+  private pauseRefresh(token: string, errorCode: string | undefined): void {
+    this.refusedRefresh = {
+      token,
+      generation: this.sessionGeneration,
+      until: Date.now() + FAILED_REFRESH_COOLDOWN_MS,
+    };
+    this.logger.warn("Refresh failed, pausing this token", { errorCode });
+  }
+
   private async refreshSession(
     input: StoredSessionInput,
   ): Promise<InMemorySession> {
@@ -759,17 +770,19 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       if (result.errorCode === "auth_error") {
         this.logger.warn("Refresh token rejected by server, forcing logout");
         this.sessionGeneration += 1;
-        this.refusedRefresh = {
-          token: input.refreshToken,
-          generation: this.sessionGeneration,
-          until: null,
-        };
         this.authSession.clearCurrent();
         this.session = null;
         this.setAnonymousState({
           cloudRegion: input.cloudRegion,
           currentProjectId: input.selectedProjectId,
         });
+        // Last, so a throwing teardown cannot leave a refusal standing over a
+        // session the rest of the app still believes in.
+        this.refusedRefresh = {
+          token: input.refreshToken,
+          generation: this.sessionGeneration,
+          until: null,
+        };
         throw new Error(lastError);
       }
 
@@ -780,14 +793,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       if (!isRetryable) {
         // This arm keeps the session and the stored token, so nothing else
         // stops the caller re-presenting the same token on the next trigger.
-        this.refusedRefresh = {
-          token: input.refreshToken,
-          generation: this.sessionGeneration,
-          until: Date.now() + UNCLASSIFIED_REFRESH_COOLDOWN_MS,
-        };
-        this.logger.warn("Refresh failed unclassified, pausing this token", {
-          errorCode: result.errorCode,
-        });
+        this.pauseRefresh(input.refreshToken, result.errorCode);
         throw new Error(lastError);
       }
 
@@ -800,6 +806,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       });
       await sleepWithBackoff(attempt, AuthService.REFRESH_BACKOFF);
     }
+
+    // Retries exhausted. A 5xx token endpoint, or a captive portal whose reply
+    // will not parse, arrives here rather than in the arm above, and without a
+    // pause each later trigger spends the whole retry budget again.
+    this.pauseRefresh(input.refreshToken, "retries_exhausted");
 
     throw new Error(lastError);
   }
@@ -1407,6 +1418,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     this.sessionGeneration += 1;
     this.clearImpersonationExpiryTimer();
     this.session = null;
+    this.refusedRefresh = null;
     this.setAnonymousState({
       cloudRegion: session.cloudRegion,
       currentProjectId: session.currentProjectId,

--- a/products/desktop/packages/core/src/usage/usage-monitor.test.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.test.ts
@@ -73,13 +73,15 @@ let emitAuthState: (currentOrgId: string | null, status?: AuthStatus) => void =
 
 function makeAuthService(): AuthService {
   const listeners = new Set<(state: EmittedAuthState) => void>();
+  let currentStatus: AuthStatus = "authenticated";
   emitAuthState = (currentOrgId, status = "authenticated") => {
+    currentStatus = status;
     for (const listener of [...listeners]) {
       listener({ currentOrgId, status });
     }
   };
   return {
-    getState: () => ({ currentOrgId: "org-1", status: "authenticated" }),
+    getState: () => ({ currentOrgId: "org-1", status: currentStatus }),
     on: (_event: string, listener: (state: EmittedAuthState) => void) =>
       listeners.add(listener),
   } as unknown as AuthService;
@@ -311,16 +313,76 @@ describe("UsageMonitorService", () => {
     const fetchUsage = vi.fn().mockRejectedValue(new NotAuthenticatedError());
     const gateway = { fetchUsage } as unknown as GatewaySlice;
     service = makeService(gateway, makeActivityMonitor());
+    emitAuthState("org-1", "anonymous");
 
     await service.fetchOnce();
+    // No window expiry releases this one, and a signed-out session must not.
     vi.advanceTimersByTime(6 * 60 * 60_000);
     await service.fetchOnce();
     expect(fetchUsage).toHaveBeenCalledTimes(1);
 
-    // A re-login republishes "authenticated" without changing it, which is
-    // what the in-app re-auth prompt produces, so that has to release it.
     emitAuthState("org-1", "authenticated");
     await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets the window after a success", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const fetchUsage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("HTTP 500"))
+      .mockRejectedValueOnce(new Error("HTTP 500"))
+      .mockResolvedValueOnce(makeUsage({ burstPercent: 10 }))
+      .mockRejectedValue(new Error("HTTP 500"));
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+    vi.advanceTimersByTime(2_500);
+    await service.fetchOnce();
+    vi.advanceTimersByTime(5_000);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(3);
+
+    // The next failure starts from the base again, not from the escalated
+    // window two failures had reached.
+    await service.fetchOnce();
+    vi.advanceTimersByTime(2_500);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(5);
+  });
+
+  it("lets an org switch refetch through an open backoff window", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const fetchUsage = vi.fn().mockRejectedValue(new Error("HTTP 500"));
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    // Three failures put the window at 10s, wider than the coalesce delay the
+    // switch's refetch waits out, so the window is still open when it fires.
+    await service.fetchOnce();
+    vi.advanceTimersByTime(2_500);
+    await service.fetchOnce();
+    vi.advanceTimersByTime(5_000);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(3);
+
+    // The switch drops the snapshot, so its refetch must not be swallowed.
+    emitAuthState("org-2");
+    await vi.advanceTimersByTimeAsync(5_001);
+    expect(fetchUsage).toHaveBeenCalledTimes(4);
+  });
+
+  it("lets a forced refresh skip the timed window", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new Error("HTTP 500"));
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+
+    await service.refreshNow();
     expect(fetchUsage).toHaveBeenCalledTimes(2);
   });
 
@@ -328,6 +390,7 @@ describe("UsageMonitorService", () => {
     const fetchUsage = vi.fn().mockRejectedValue(new NotAuthenticatedError());
     const gateway = { fetchUsage } as unknown as GatewaySlice;
     service = makeService(gateway, makeActivityMonitor());
+    emitAuthState("org-1", "anonymous");
 
     await service.fetchOnce();
     // refreshNow is reachable from a settings-pane mount and the cloud-task

--- a/products/desktop/packages/core/src/usage/usage-monitor.test.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.test.ts
@@ -1,3 +1,4 @@
+import { NotAuthenticatedError } from "@posthog/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthService } from "../auth/auth";
 import type { UsageHost } from "./identifiers";
@@ -44,28 +45,43 @@ function makeThresholdStore(): ThresholdSlice {
   };
 }
 
+interface ScopedLog {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+}
+
+let lastScopedLog: ScopedLog;
+
 function makeLogger() {
   const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  lastScopedLog = log;
   return { ...log, scope: () => log };
 }
 
 type GatewaySlice = Pick<UsageHost, "fetchUsage">;
 
-let emitAuthState: (currentOrgId: string | null) => void = () => {};
+type AuthStatus = "anonymous" | "authenticated" | "restoring";
+interface EmittedAuthState {
+  currentOrgId: string | null;
+  status: AuthStatus;
+}
+
+let emitAuthState: (currentOrgId: string | null, status?: AuthStatus) => void =
+  () => {};
 
 function makeAuthService(): AuthService {
-  const listeners = new Set<(state: { currentOrgId: string | null }) => void>();
-  emitAuthState = (currentOrgId) => {
+  const listeners = new Set<(state: EmittedAuthState) => void>();
+  emitAuthState = (currentOrgId, status = "authenticated") => {
     for (const listener of [...listeners]) {
-      listener({ currentOrgId });
+      listener({ currentOrgId, status });
     }
   };
   return {
-    getState: () => ({ currentOrgId: "org-1" }),
-    on: (
-      _event: string,
-      listener: (state: { currentOrgId: string | null }) => void,
-    ) => listeners.add(listener),
+    getState: () => ({ currentOrgId: "org-1", status: "authenticated" }),
+    on: (_event: string, listener: (state: EmittedAuthState) => void) =>
+      listeners.add(listener),
   } as unknown as AuthService;
 }
 
@@ -130,6 +146,7 @@ describe("UsageMonitorService", () => {
   afterEach(() => {
     service?.stop();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("emits at 75% but not again on the next poll for the same anchor", async () => {
@@ -227,6 +244,109 @@ describe("UsageMonitorService", () => {
 
     await service.fetchOnce();
     expect(events[0]?.userIsActive).toBe(true);
+  });
+
+  it("backs off after a failure instead of refetching on the next trigger", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new Error("HTTP 401"));
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+
+    // The first window is the 5s base, jittered down to at most 5s.
+    vi.advanceTimersByTime(5_001);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps backing off when a mid-failure refresh emits a state change", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new Error("HTTP 401"));
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+    // The 401 retry refreshes the token from inside the failing fetch.
+    // Releasing the window on that emission pins it at its floor.
+    emitAuthState("org-1", "authenticated");
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("grows the backoff window and caps it at the backstop interval", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const fetchUsage = vi.fn().mockRejectedValue(new Error("HTTP 500"));
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    // Jitter pinned at its low end, so windows are 2.5s, 5s, 10s, ... 15m.
+    await service.fetchOnce();
+    vi.advanceTimersByTime(2_500);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(2);
+
+    // A flat, non-doubling backoff would release here.
+    vi.advanceTimersByTime(2_500);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(2_500);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(3);
+
+    for (let i = 0; i < 12; i++) {
+      vi.advanceTimersByTime(15 * 60_000);
+      await service.fetchOnce();
+    }
+    const capped = fetchUsage.mock.calls.length;
+    vi.advanceTimersByTime(15 * 60_000 - 1);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(capped);
+    vi.advanceTimersByTime(1);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(capped + 1);
+  });
+
+  it("stops polling entirely after a terminal auth failure", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new NotAuthenticatedError());
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+    vi.advanceTimersByTime(6 * 60 * 60_000);
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+
+    // A re-login republishes "authenticated" without changing it, which is
+    // what the in-app re-auth prompt produces, so that has to release it.
+    emitAuthState("org-1", "authenticated");
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a forced refresh bypass the terminal stop", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new NotAuthenticatedError());
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+    // refreshNow is reachable from a settings-pane mount and the cloud-task
+    // preflight, and a forced fetch with no session cannot succeed.
+    await service.refreshNow();
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when it enters the terminal stop", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new NotAuthenticatedError());
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+
+    await service.fetchOnce();
+
+    expect(lastScopedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("re-auth"),
+      { reason: "reauth_required" },
+    );
   });
 
   it("silently skips polls when the gateway throws", async () => {

--- a/products/desktop/packages/core/src/usage/usage-monitor.test.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.test.ts
@@ -326,6 +326,25 @@ describe("UsageMonitorService", () => {
     expect(fetchUsage).toHaveBeenCalledTimes(2);
   });
 
+  it("recovers polling when the user signs back into the same organization", async () => {
+    const fetchUsage = vi.fn().mockRejectedValue(new NotAuthenticatedError());
+    const gateway = { fetchUsage } as unknown as GatewaySlice;
+    service = makeService(gateway, makeActivityMonitor());
+    emitAuthState("org-1", "anonymous");
+
+    await service.fetchOnce();
+    expect(fetchUsage).toHaveBeenCalledTimes(1);
+
+    // A teardown publishes the anonymous org before any new sign-in, so
+    // returning to the same org is still a transition the listener acts on.
+    emitAuthState(null, "anonymous");
+    fetchUsage.mockResolvedValue(makeUsage());
+    emitAuthState("org-1", "authenticated");
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(fetchUsage).toHaveBeenCalledTimes(2);
+  });
+
   it("resets the window after a success", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
     const fetchUsage = vi

--- a/products/desktop/packages/core/src/usage/usage-monitor.test.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.test.ts
@@ -344,8 +344,7 @@ describe("UsageMonitorService", () => {
     await service.fetchOnce();
     expect(fetchUsage).toHaveBeenCalledTimes(3);
 
-    // The next failure starts from the base again, not from the escalated
-    // window two failures had reached.
+    // The next failure starts from the base, not the escalated window.
     await service.fetchOnce();
     vi.advanceTimersByTime(2_500);
     await service.fetchOnce();
@@ -393,8 +392,7 @@ describe("UsageMonitorService", () => {
     emitAuthState("org-1", "anonymous");
 
     await service.fetchOnce();
-    // refreshNow is reachable from a settings-pane mount and the cloud-task
-    // preflight, and a forced fetch with no session cannot succeed.
+    // A forced fetch with no session cannot succeed.
     await service.refreshNow();
     expect(fetchUsage).toHaveBeenCalledTimes(1);
   });

--- a/products/desktop/packages/core/src/usage/usage-monitor.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.ts
@@ -57,8 +57,8 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
       if (state.currentOrgId === orgId) return;
       orgId = state.currentOrgId;
       this.latestUsage = null;
-      // The snapshot was just dropped, so the refetch below has to be allowed
-      // through whatever window a previous failure left behind.
+      // The snapshot was just dropped, so let the refetch through any open
+      // window. This clears the terminal stop too, which the gate re-derives.
       this.resetBackoff();
       if (state.currentOrgId !== null) this.requestRefresh();
     });
@@ -117,9 +117,8 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     force?: boolean;
   } = {}): Promise<UsageOutput | null> {
     if (this.isFetching) return null;
-    // Re-derived, never trusted: the error that sets it can arrive after the
-    // last authenticated emission, and auth raises the same class for a refresh
-    // that was merely superseded.
+    // Re-derived, not trusted: the error can arrive after the last authenticated
+    // emission, and auth raises the same class for a merely superseded refresh.
     if (this.reauthRequired) {
       if (this.authService.getState().status !== "authenticated") return null;
       this.reauthRequired = false;

--- a/products/desktop/packages/core/src/usage/usage-monitor.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.ts
@@ -45,7 +45,7 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     @inject(ROOT_LOGGER)
     logger: RootLogger,
     @inject(AUTH_SERVICE)
-    authService: AuthService,
+    private readonly authService: AuthService,
   ) {
     super();
     this.log = logger.scope("usage-monitor");
@@ -54,13 +54,12 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     // never be served the previous account's spend.
     let orgId = authService.getState().currentOrgId;
     authService.on(AuthServiceEvent.StateChanged, (state) => {
-      // Level-triggered, so a re-login that republishes the same status still
-      // releases it. Only the terminal stop is cleared here: the timed window
-      // must survive the refresh that a failing fetch performs on its way out.
-      if (state.status === "authenticated") this.reauthRequired = false;
       if (state.currentOrgId === orgId) return;
       orgId = state.currentOrgId;
       this.latestUsage = null;
+      // The snapshot was just dropped, so the refetch below has to be allowed
+      // through whatever window a previous failure left behind.
+      this.resetBackoff();
       if (state.currentOrgId !== null) this.requestRefresh();
     });
   }
@@ -118,13 +117,15 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     force?: boolean;
   } = {}): Promise<UsageOutput | null> {
     if (this.isFetching) return null;
-    // force skips the timed window, never the terminal stop.
-    if (
-      this.reauthRequired ||
-      (!force && Date.now() < this.nextAllowedFetchAt)
-    ) {
-      return null;
+    // Re-derived, never trusted: the error that sets it can arrive after the
+    // last authenticated emission, and auth raises the same class for a refresh
+    // that was merely superseded.
+    if (this.reauthRequired) {
+      if (this.authService.getState().status !== "authenticated") return null;
+      this.reauthRequired = false;
     }
+    // force skips the timed window, never the terminal stop.
+    if (!force && Date.now() < this.nextAllowedFetchAt) return null;
     this.isFetching = true;
     this.lastFetchStartedAt = Date.now();
     if (this.coalesceTimeoutId) {

--- a/products/desktop/packages/core/src/usage/usage-monitor.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.ts
@@ -1,5 +1,5 @@
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
-import { TypedEventEmitter } from "@posthog/shared";
+import { isNotAuthenticatedError, TypedEventEmitter } from "@posthog/shared";
 import { inject, injectable, postConstruct, preDestroy } from "inversify";
 import type { AuthService } from "../auth/auth";
 import { AUTH_SERVICE } from "../auth/auth.module";
@@ -18,6 +18,9 @@ const COALESCE_INTERVAL_MS = 5_000;
 // Catches reset-window rollovers and out-of-band plan changes while the app
 // sits idle and no LlmActivity events fire.
 const BACKSTOP_INTERVAL_MS = 30 * 60_000;
+// Bounds a persistent failure to one request per window, not one per trigger.
+const FAILURE_BACKOFF_BASE_MS = COALESCE_INTERVAL_MS;
+const FAILURE_BACKOFF_MAX_MS = BACKSTOP_INTERVAL_MS;
 
 type BucketName = "burst" | "sustained";
 
@@ -27,6 +30,10 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
   private coalesceTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private lastFetchStartedAt = 0;
   private isFetching = false;
+  private consecutiveFailures = 0;
+  private nextAllowedFetchAt = 0;
+  // A dead session is fixed by a new sign-in, never by polling.
+  private reauthRequired = false;
   private thresholdsSeen: Record<string, string>;
   private latestUsage: UsageOutput | null = null;
 
@@ -47,6 +54,10 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     // never be served the previous account's spend.
     let orgId = authService.getState().currentOrgId;
     authService.on(AuthServiceEvent.StateChanged, (state) => {
+      // Level-triggered, so a re-login that republishes the same status still
+      // releases it. Only the terminal stop is cleared here: the timed window
+      // must survive the refresh that a failing fetch performs on its way out.
+      if (state.status === "authenticated") this.reauthRequired = false;
       if (state.currentOrgId === orgId) return;
       orgId = state.currentOrgId;
       this.latestUsage = null;
@@ -60,8 +71,9 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     return this.latestUsage;
   }
 
+  // Skips the failure backoff. The terminal stop still applies.
   async refreshNow(): Promise<UsageOutput | null> {
-    return this.fetchOnce();
+    return this.fetchOnce({ force: true });
   }
 
   // Coalesces N parallel agents finishing turns into at most two fetches
@@ -100,8 +112,19 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     }
   }
 
-  async fetchOnce(): Promise<UsageOutput | null> {
+  async fetchOnce({
+    force = false,
+  }: {
+    force?: boolean;
+  } = {}): Promise<UsageOutput | null> {
     if (this.isFetching) return null;
+    // force skips the timed window, never the terminal stop.
+    if (
+      this.reauthRequired ||
+      (!force && Date.now() < this.nextAllowedFetchAt)
+    ) {
+      return null;
+    }
     this.isFetching = true;
     this.lastFetchStartedAt = Date.now();
     if (this.coalesceTimeoutId) {
@@ -113,11 +136,14 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
       try {
         usage = await this.host.fetchUsage();
       } catch (err) {
+        this.recordFailure(err);
         this.log.debug("Usage fetch skipped", {
           error: err instanceof Error ? err.message : String(err),
+          consecutiveFailures: this.consecutiveFailures,
         });
       }
       if (usage) {
+        this.resetBackoff();
         const changed = !isSameUsage(this.latestUsage, usage);
         this.latestUsage = usage;
         if (changed) {
@@ -129,6 +155,29 @@ export class UsageMonitorService extends TypedEventEmitter<UsageMonitorEvents> {
     } finally {
       this.isFetching = false;
     }
+  }
+
+  private recordFailure(err: unknown): void {
+    if (isNotAuthenticatedError(err)) {
+      this.reauthRequired = true;
+      this.log.warn("Usage polling stopped, session needs re-auth", {
+        reason: "reauth_required",
+      });
+      return;
+    }
+    this.consecutiveFailures += 1;
+    const delay = Math.min(
+      FAILURE_BACKOFF_BASE_MS * 2 ** (this.consecutiveFailures - 1),
+      FAILURE_BACKOFF_MAX_MS,
+    );
+    // Jitter so N agents that failed together don't retry in lockstep.
+    this.nextAllowedFetchAt = Date.now() + delay * (0.5 + Math.random() / 2);
+  }
+
+  private resetBackoff(): void {
+    this.consecutiveFailures = 0;
+    this.nextAllowedFetchAt = 0;
+    this.reauthRequired = false;
   }
 
   private scheduleBackstop(): void {


### PR DESCRIPTION
## Problem

A PostHog Desktop client whose OAuth refresh token stops working keeps presenting it. Nothing records that a refresh already failed, so every trigger retries the same grant, and usage polling has no backoff when a fetch fails. The client issues failing requests until someone restarts it.

## Changes

Records a **refusal** in `AuthService`, keyed to `sessionGeneration` so every teardown and new grant invalidates it.

- **A rejection retires the token; any other failure pauses it for 15s.** Those other arms also catch rate limits and 400s whose body will not parse, and neither is evidence a credential is dead.
- All three failing exits of `refreshSession` record one, **including retry exhaustion**, which is where a 5xx endpoint or a captive portal lands.
- **The usage poller backs off** from the coalesce floor to the backstop ceiling, so a persistent failure costs one request per window instead of one per trigger.
- A dead session stops polling; `force` skips the timed window but never that stop.

Surfacing a sign-in prompt for the paused state is out of scope. The client recovers on its own once the endpoint does.

## How did you test this code?

Automated only, so the sign-out and sign-in cycle is unverified by hand.

`packages/core` vitest, `auth` and `usage-monitor`. The new cases catch regressions no existing test did:

- a refused token re-presented on the next trigger, a pause widening to a different token, or a refusal outliving the grant that should release it
- an unclassified failure retiring a live credential, a pause that never lifts, and the cooldown restored to a value that outruns the access token
- a signed-out session releasing the terminal stop, `force` skipping it, and a success or an org switch leaving an escalated window in place

Each was checked by mutating the line it covers and confirming the named test fails.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5), shaped over four `/branch-review` rounds plus `/code-comments`. Requires human review.
