### PR TITLE
fix(annotations): keep project annotations when their parent is deleted

### DIFF
--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -145,7 +145,9 @@ class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.Mo
     """
 
     scope_object = "annotation"
-    queryset = Annotation.objects.select_related("dashboard_item").select_related("created_by")
+    queryset = (
+        Annotation.objects.select_related("dashboard_item").select_related("dashboard").select_related("created_by")
+    )
     serializer_class = AnnotationSerializer
     filter_backends = [filters.SearchFilter]
     pagination_class = AnnotationsLimitOffsetPagination

--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -17,10 +17,10 @@ from products.product_analytics.backend.facade.models import Insight
 
 class AnnotationSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
-    # Soft-deleted parents are accepted here: the frontend echoes both FKs back on every write, so a
-    # project-scoped annotation whose dashboard was deleted would otherwise be impossible to edit or
-    # delete. Annotations actually scoped to a deleted parent never reach validation — the scope-gated
-    # filter in AnnotationsViewSet.safely_get_queryset hides them first.
+    # Soft-deleted parents are accepted here because the frontend echoes both FKs back on every
+    # write, so a project-scoped annotation whose dashboard was deleted would otherwise be
+    # impossible to edit or delete. validate() still rejects a write whose own scope points at a
+    # soft-deleted parent.
     dashboard_id = serializers.IntegerField(
         required=False,
         allow_null=True,
@@ -111,14 +111,42 @@ class AnnotationSerializer(serializers.ModelSerializer):
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         team = self.context["get_team"]()
 
-        dashboard_id = attrs.get("dashboard_id")
-        if dashboard_id is not None:
-            if not Dashboard.objects_including_soft_deleted.filter(id=dashboard_id, team_id=team.id).exists():
-                raise serializers.ValidationError({"dashboard_id": "Dashboard not found."})
-
         scope = attrs.get("scope", None)
         if scope == Annotation.Scope.RECORDING.value:
             raise serializers.ValidationError("Recording scope is deprecated")
+
+        # Resolve the parents the annotation will have after this write. A key absent from `attrs`
+        # keeps the stored value, while a key present but null clears it, so membership is what
+        # distinguishes the two on a PATCH.
+        dashboard = None
+        if "dashboard_id" in attrs:
+            if attrs["dashboard_id"] is not None:
+                dashboard = Dashboard.objects_including_soft_deleted.filter(
+                    id=attrs["dashboard_id"], team_id=team.id
+                ).first()
+                if dashboard is None:
+                    raise serializers.ValidationError({"dashboard_id": "Dashboard not found."})
+        elif self.instance is not None:
+            dashboard = self.instance.dashboard
+
+        if "dashboard_item" in attrs:
+            insight = attrs["dashboard_item"]
+        else:
+            insight = getattr(self.instance, "dashboard_item", None)
+
+        # AnnotationsViewSet.safely_get_queryset hides an annotation whose own scope points at a
+        # soft-deleted parent, so accepting one here would strand a row that nothing can list, edit
+        # or delete. Project- and organization-scoped rows keep their pointers, which are only used
+        # to show where the annotation was created.
+        effective_scope = scope or getattr(self.instance, "scope", Annotation.Scope.INSIGHT.value)
+        if effective_scope == Annotation.Scope.INSIGHT.value and insight is not None and insight.deleted:
+            raise serializers.ValidationError(
+                {"dashboard_item": "This insight is deleted. Restore it, or pick a different scope."}
+            )
+        if effective_scope == Annotation.Scope.DASHBOARD.value and dashboard is not None and dashboard.deleted:
+            raise serializers.ValidationError(
+                {"dashboard_id": "This dashboard is deleted. Restore it, or pick a different scope."}
+            )
 
         return attrs
 
@@ -160,8 +188,8 @@ class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.Mo
             # We never want deleted items to be included in the queryset… except when we want to restore an annotation
             # That's because annotations are restored with a PATCH request setting `deleted` to `False`
             queryset = queryset.filter(deleted=False)
-        # Annotations attached to a soft-deleted insight or dashboard are hidden
-        # across all actions — including `partial_update`, so they cannot be
+        # Annotations scoped to a soft-deleted insight or dashboard are hidden
+        # across all actions, including `partial_update`, so they cannot be
         # individually edited or restored while their parent is soft-deleted.
         # They reappear automatically when the parent is restored. Mirrors how
         # alerts behave (see posthog/temporal/alerts/activities.py).

--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -156,9 +156,12 @@ class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.Mo
         # individually edited or restored while their parent is soft-deleted.
         # They reappear automatically when the parent is restored. Mirrors how
         # alerts behave (see posthog/temporal/alerts/activities.py).
+        # Gated on scope: every annotation records the insight and dashboard it was
+        # created from, so a project- or organization-scoped one would otherwise
+        # disappear project-wide once that parent is deleted.
         queryset = queryset.filter(
-            Q(dashboard_item__isnull=True) | Q(dashboard_item__deleted=False),
-            Q(dashboard__isnull=True) | Q(dashboard__deleted=False),
+            ~Q(scope=Annotation.Scope.INSIGHT) | Q(dashboard_item__isnull=True) | Q(dashboard_item__deleted=False),
+            ~Q(scope=Annotation.Scope.DASHBOARD) | Q(dashboard__isnull=True) | Q(dashboard__deleted=False),
         )
 
         scope = self.request.query_params.get("scope")

--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -21,9 +21,16 @@ class AnnotationSerializer(serializers.ModelSerializer):
     # project-scoped annotation whose dashboard was deleted would otherwise be impossible to edit or
     # delete. Annotations actually scoped to a deleted parent never reach validation — the scope-gated
     # filter in AnnotationsViewSet.safely_get_queryset hides them first.
-    dashboard_id = serializers.IntegerField(required=False, allow_null=True)
+    dashboard_id = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Optional dashboard ID to attach this annotation to. Must belong to the current project.",
+    )
     dashboard_item = TeamScopedPrimaryKeyRelatedField(
-        queryset=Insight.objects_including_soft_deleted.all(), required=False, allow_null=True
+        queryset=Insight.objects_including_soft_deleted.all(),
+        required=False,
+        allow_null=True,
+        help_text="Optional insight ID to attach this annotation to. Must belong to the current project.",
     )
 
     class Meta:
@@ -66,12 +73,6 @@ class AnnotationSerializer(serializers.ModelSerializer):
             },
             "creation_type": {
                 "help_text": "Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.",
-            },
-            "dashboard_id": {
-                "help_text": "Optional dashboard ID to attach this annotation to. Must belong to the current project.",
-            },
-            "dashboard_item": {
-                "help_text": "Optional insight ID to attach this annotation to. Must belong to the current project.",
             },
             "deleted": {
                 "help_text": "Soft-delete flag. Set to true to hide the annotation, or false to restore it.",
@@ -165,9 +166,8 @@ class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.Mo
         # Gated on scope: every annotation records the insight and dashboard it was
         # created from, so a project- or organization-scoped one would otherwise
         # disappear project-wide once that parent is deleted.
-        queryset = queryset.filter(
-            ~Q(scope=Annotation.Scope.INSIGHT) | Q(dashboard_item__isnull=True) | Q(dashboard_item__deleted=False),
-            ~Q(scope=Annotation.Scope.DASHBOARD) | Q(dashboard__isnull=True) | Q(dashboard__deleted=False),
+        queryset = queryset.exclude(scope=Annotation.Scope.INSIGHT, dashboard_item__deleted=True).exclude(
+            scope=Annotation.Scope.DASHBOARD, dashboard__deleted=True
         )
 
         scope = self.request.query_params.get("scope")

--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -17,8 +17,14 @@ from products.product_analytics.backend.facade.models import Insight
 
 class AnnotationSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
+    # Soft-deleted parents are accepted here: the frontend echoes both FKs back on every write, so a
+    # project-scoped annotation whose dashboard was deleted would otherwise be impossible to edit or
+    # delete. Annotations actually scoped to a deleted parent never reach validation — the scope-gated
+    # filter in AnnotationsViewSet.safely_get_queryset hides them first.
     dashboard_id = serializers.IntegerField(required=False, allow_null=True)
-    dashboard_item = TeamScopedPrimaryKeyRelatedField(queryset=Insight.objects.all(), required=False, allow_null=True)
+    dashboard_item = TeamScopedPrimaryKeyRelatedField(
+        queryset=Insight.objects_including_soft_deleted.all(), required=False, allow_null=True
+    )
 
     class Meta:
         model = Annotation
@@ -106,7 +112,7 @@ class AnnotationSerializer(serializers.ModelSerializer):
 
         dashboard_id = attrs.get("dashboard_id")
         if dashboard_id is not None:
-            if not Dashboard.objects.filter(id=dashboard_id, team_id=team.id).exists():
+            if not Dashboard.objects_including_soft_deleted.filter(id=dashboard_id, team_id=team.id).exists():
                 raise serializers.ValidationError({"dashboard_id": "Dashboard not found."})
 
         scope = attrs.get("scope", None)

--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -17,10 +17,11 @@ from products.product_analytics.backend.facade.models import Insight
 
 class AnnotationSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
-    # Soft-deleted parents are accepted here because the frontend echoes both FKs back on every
-    # write, so a project-scoped annotation whose dashboard was deleted would otherwise be
-    # impossible to edit or delete. validate() still rejects a write whose own scope points at a
-    # soft-deleted parent.
+    # Soft-deleted parents resolve here because the frontend echoes both FKs back on every write. A
+    # project-scoped annotation whose dashboard was deleted would otherwise be impossible to edit or
+    # delete. Only the pointer the annotation already stores may be echoed. Every other deleted
+    # parent answers as if it does not exist. validate() then rejects a write whose own scope points
+    # at a soft-deleted parent.
     dashboard_id = serializers.IntegerField(
         required=False,
         allow_null=True,
@@ -104,6 +105,13 @@ class AnnotationSerializer(serializers.ModelSerializer):
         # Normalise blank strings to None so the DB has a single canonical "no emoji" state.
         return value or None
 
+    def validate_dashboard_item(self, value: Insight | None) -> Insight | None:
+        # A deleted insight answers exactly as an unknown one does unless the annotation already
+        # points at it, so a guessed ID cannot report back its name.
+        if value is not None and value.deleted and value.pk != getattr(self.instance, "dashboard_item_id", None):
+            self.fields["dashboard_item"].fail("does_not_exist", pk_value=value.pk)
+        return value
+
     def update(self, instance: Annotation, validated_data: dict[str, Any]) -> Annotation:
         instance.team_id = self.context["team_id"]
         return super().update(instance, validated_data)
@@ -124,7 +132,11 @@ class AnnotationSerializer(serializers.ModelSerializer):
                 dashboard = Dashboard.objects_including_soft_deleted.filter(
                     id=attrs["dashboard_id"], team_id=team.id
                 ).first()
-                if dashboard is None:
+                # A deleted dashboard answers exactly as an unknown one does unless the annotation
+                # already points at it, so a guessed ID cannot report back its name.
+                if dashboard is None or (
+                    dashboard.deleted and dashboard.id != getattr(self.instance, "dashboard_id", None)
+                ):
                     raise serializers.ValidationError({"dashboard_id": "Dashboard not found."})
         elif self.instance is not None:
             dashboard = self.instance.dashboard

--- a/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
+++ b/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
@@ -383,9 +383,11 @@
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
+              OR "posthog_annotation"."dashboard_item_id" IS NULL
               OR NOT "posthog_dashboarditem"."deleted")
-         AND ("posthog_annotation"."dashboard_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
+              OR "posthog_annotation"."dashboard_id" IS NULL
               OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
@@ -484,9 +486,11 @@
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
+              OR "posthog_annotation"."dashboard_item_id" IS NULL
               OR NOT "posthog_dashboarditem"."deleted")
-         AND ("posthog_annotation"."dashboard_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
+              OR "posthog_annotation"."dashboard_id" IS NULL
               OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
@@ -1020,9 +1024,11 @@
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
+              OR "posthog_annotation"."dashboard_item_id" IS NULL
               OR NOT "posthog_dashboarditem"."deleted")
-         AND ("posthog_annotation"."dashboard_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
+              OR "posthog_annotation"."dashboard_id" IS NULL
               OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
@@ -1121,9 +1127,11 @@
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
+              OR "posthog_annotation"."dashboard_item_id" IS NULL
               OR NOT "posthog_dashboarditem"."deleted")
-         AND ("posthog_annotation"."dashboard_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
+              OR "posthog_annotation"."dashboard_id" IS NULL
               OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
@@ -1284,9 +1292,11 @@
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND ("posthog_annotation"."dashboard_item_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
+              OR "posthog_annotation"."dashboard_item_id" IS NULL
               OR NOT "posthog_dashboarditem"."deleted")
-         AND ("posthog_annotation"."dashboard_id" IS NULL
+         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
+              OR "posthog_annotation"."dashboard_id" IS NULL
               OR NOT "posthog_dashboard"."deleted")
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')

--- a/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
+++ b/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
@@ -441,6 +441,28 @@
          "posthog_dashboarditem"."updated_at",
          "posthog_dashboarditem"."deprecated_tags",
          "posthog_dashboarditem"."tags",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."last_refresh",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."variables",
+         "posthog_dashboard"."breakdown_colors",
+         "posthog_dashboard"."data_color_theme_id",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."quick_filter_ids",
+         "posthog_dashboard"."customization",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
          "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -1082,6 +1104,28 @@
          "posthog_dashboarditem"."updated_at",
          "posthog_dashboarditem"."deprecated_tags",
          "posthog_dashboarditem"."tags",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."last_refresh",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."variables",
+         "posthog_dashboard"."breakdown_colors",
+         "posthog_dashboard"."data_color_theme_id",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."quick_filter_ids",
+         "posthog_dashboard"."customization",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
          "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -1140,6 +1184,252 @@
   LIMIT 1000
   '''
 # ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.26
+  '''
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."credentials_reviewed_at",
+         "posthog_user"."requested_2fa_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."is_active",
+         "posthog_user"."role_at_organization",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."allow_impersonation",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."allow_sidebar_suggestions",
+         "posthog_user"."shortcut_position",
+         "posthog_user"."passkeys_enabled_for_2fa",
+         "posthog_user"."hide_mcp_hints",
+         "posthog_user"."ui_configuration",
+         "posthog_user"."onboarding_skipped_at",
+         "posthog_user"."onboarding_skipped_reason",
+         "posthog_user"."onboarding_skipped_organization_id",
+         "posthog_user"."onboarding_delegated_to_invite_id",
+         "posthog_user"."onboarding_delegated_to_organization_id",
+         "posthog_user"."onboarding_delegation_accepted_at",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_user"
+  WHERE ("posthog_user"."is_active"
+         AND "posthog_user"."id" = 99999)
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.27
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."is_ai_training_opted_in",
+         "posthog_organization"."is_ai_training_locked",
+         "posthog_organization"."is_ai_training_cta_shown",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."enforce_verified_domains",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_create_projects",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."members_can_see_org_members",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."has_active_subscription",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.28
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."ingested_production_event",
+         "posthog_team"."ingested_production_event_last_checked_at",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_recording_trigger_groups",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."event_retention_months",
+         "posthog_team"."conversations_enabled",
+         "posthog_team"."conversations_settings",
+         "posthog_team"."proactive_tasks_enabled",
+         "posthog_team"."survey_config",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."product_tours_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."logs_settings",
+         "posthog_team"."llm_gateway_enabled_at",
+         "posthog_team"."llm_gateway_revoked_at",
+         "posthog_team"."llm_gateway_overspend_allowance_usd",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."receive_org_level_activity_logs",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."web_analytics_pre_aggregated_tables_version",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."default_evaluation_environments_enabled",
+         "posthog_team"."require_evaluation_environment_tags",
+         "posthog_team"."default_evaluation_contexts_enabled",
+         "posthog_team"."require_evaluation_contexts",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency",
+         "posthog_team"."experiment_recalculation_time",
+         "posthog_team"."default_experiment_confidence_level",
+         "posthog_team"."default_experiment_stats_method",
+         "posthog_team"."business_model",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."is_ai_training_opted_in",
+         "posthog_organization"."is_ai_training_locked",
+         "posthog_organization"."is_ai_training_cta_shown",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."enforce_verified_domains",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_create_projects",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."members_can_see_org_members",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."has_active_subscription",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_team"
+  INNER JOIN "posthog_organization" ON ("posthog_team"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.29
+  '''
+  SELECT "posthog_project"."updated_at",
+         "posthog_project"."id",
+         "posthog_project"."organization_id",
+         "posthog_project"."name",
+         "posthog_project"."created_at",
+         "posthog_project"."product_description",
+         "posthog_project"."is_pending_deletion"
+  FROM "posthog_project"
+  WHERE "posthog_project"."id" = 99999
+  LIMIT 21
+  '''
+# ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.3
   '''
   SELECT "posthog_project"."updated_at",
@@ -1152,6 +1442,282 @@
   FROM "posthog_project"
   WHERE "posthog_project"."id" = 99999
   LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.30
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organizationmembership"."invited_by_id",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."is_ai_training_opted_in",
+         "posthog_organization"."is_ai_training_locked",
+         "posthog_organization"."is_ai_training_cta_shown",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."enforce_verified_domains",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_create_projects",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."members_can_see_org_members",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."has_active_subscription",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.31
+  '''
+  SELECT "ee_accesscontrol"."id",
+         "ee_accesscontrol"."team_id",
+         "ee_accesscontrol"."access_level",
+         "ee_accesscontrol"."resource",
+         "ee_accesscontrol"."resource_id",
+         "ee_accesscontrol"."organization_member_id",
+         "ee_accesscontrol"."role_id",
+         "ee_accesscontrol"."created_by_id",
+         "ee_accesscontrol"."created_at",
+         "ee_accesscontrol"."updated_at",
+         "posthog_team"."organization_id" AS "_team_organization_id"
+  FROM "ee_accesscontrol"
+  INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
+  LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_accesscontrol"."organization_member_id" = "posthog_organizationmembership"."id")
+  WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
+          AND "ee_accesscontrol"."role_id" IS NULL
+          AND "ee_accesscontrol"."team_id" = 99999)
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
+             AND "ee_accesscontrol"."role_id" IS NULL
+             AND "ee_accesscontrol"."team_id" = 99999))
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.32
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organizationmembership"."invited_by_id",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."is_ai_training_opted_in",
+         "posthog_organization"."is_ai_training_locked",
+         "posthog_organization"."is_ai_training_cta_shown",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."enforce_verified_domains",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_create_projects",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."members_can_see_org_members",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."has_active_subscription",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 99999
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.33
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
+  WHERE (NOT "posthog_annotation"."deleted"
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
+         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+               AND "posthog_annotation"."scope" = 'organization')
+              OR "posthog_annotation"."team_id" = 99999))
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.34
+  '''
+  SELECT "posthog_annotation"."id",
+         "posthog_annotation"."content",
+         "posthog_annotation"."created_at",
+         "posthog_annotation"."updated_at",
+         "posthog_annotation"."dashboard_item_id",
+         "posthog_annotation"."dashboard_id",
+         "posthog_annotation"."team_id",
+         "posthog_annotation"."organization_id",
+         "posthog_annotation"."created_by_id",
+         "posthog_annotation"."scope",
+         "posthog_annotation"."emoji",
+         "posthog_annotation"."creation_type",
+         "posthog_annotation"."date_marker",
+         "posthog_annotation"."deleted",
+         "posthog_annotation"."hidden_in_user_interface",
+         "posthog_annotation"."apply_all",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."query",
+         "posthog_dashboarditem"."query_metadata",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."last_refresh",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."variables",
+         "posthog_dashboard"."breakdown_colors",
+         "posthog_dashboard"."data_color_theme_id",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."quick_filter_ids",
+         "posthog_dashboard"."customization",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."credentials_reviewed_at",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."requested_2fa_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."is_active",
+         "posthog_user"."role_at_organization",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."allow_impersonation",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."allow_sidebar_suggestions",
+         "posthog_user"."shortcut_position",
+         "posthog_user"."passkeys_enabled_for_2fa",
+         "posthog_user"."hide_mcp_hints",
+         "posthog_user"."ui_configuration",
+         "posthog_user"."onboarding_skipped_at",
+         "posthog_user"."onboarding_skipped_reason",
+         "posthog_user"."onboarding_skipped_organization_id",
+         "posthog_user"."onboarding_delegated_to_invite_id",
+         "posthog_user"."onboarding_delegated_to_organization_id",
+         "posthog_user"."onboarding_delegation_accepted_at",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
+  WHERE (NOT "posthog_annotation"."deleted"
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
+         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+               AND "posthog_annotation"."scope" = 'organization')
+              OR "posthog_annotation"."team_id" = 99999))
+  ORDER BY "posthog_annotation"."date_marker" DESC
+  LIMIT 1000
   '''
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.4

--- a/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
+++ b/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
@@ -383,12 +383,12 @@
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
-              OR "posthog_annotation"."dashboard_item_id" IS NULL
-              OR NOT "posthog_dashboarditem"."deleted")
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
-              OR "posthog_annotation"."dashboard_id" IS NULL
-              OR NOT "posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -486,12 +486,12 @@
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
-              OR "posthog_annotation"."dashboard_item_id" IS NULL
-              OR NOT "posthog_dashboarditem"."deleted")
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
-              OR "posthog_annotation"."dashboard_id" IS NULL
-              OR NOT "posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -1024,12 +1024,12 @@
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
-              OR "posthog_annotation"."dashboard_item_id" IS NULL
-              OR NOT "posthog_dashboarditem"."deleted")
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
-              OR "posthog_annotation"."dashboard_id" IS NULL
-              OR NOT "posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -1127,12 +1127,12 @@
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
-              OR "posthog_annotation"."dashboard_item_id" IS NULL
-              OR NOT "posthog_dashboarditem"."deleted")
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
-              OR "posthog_annotation"."dashboard_id" IS NULL
-              OR NOT "posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))
@@ -1292,12 +1292,12 @@
   LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
   LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_annotation"."dashboard_id" = "posthog_dashboard"."id")
   WHERE (NOT "posthog_annotation"."deleted"
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard_item')
-              OR "posthog_annotation"."dashboard_item_id" IS NULL
-              OR NOT "posthog_dashboarditem"."deleted")
-         AND (NOT ("posthog_annotation"."scope" = 'dashboard')
-              OR "posthog_annotation"."dashboard_id" IS NULL
-              OR NOT "posthog_dashboard"."deleted")
+         AND NOT ("posthog_dashboarditem"."deleted"
+                  AND "posthog_dashboarditem"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard_item')
+         AND NOT ("posthog_dashboard"."deleted"
+                  AND "posthog_dashboard"."deleted" IS NOT NULL
+                  AND "posthog_annotation"."scope" = 'dashboard')
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 99999))

--- a/products/annotations/backend/api/test/test_annotation.py
+++ b/products/annotations/backend/api/test/test_annotation.py
@@ -744,6 +744,36 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
         assert response.json()["attr"] == "dashboard_item"
         assert response.json()["code"] == "does_not_exist"
 
+    @parameterized.expand(
+        [
+            ("insight", Annotation.Scope.INSIGHT, "dashboard_item"),
+            ("dashboard", Annotation.Scope.DASHBOARD, "dashboard_id"),
+        ]
+    )
+    def test_creating_an_annotation_scoped_to_a_soft_deleted_parent_returns_400(
+        self, parent_kind: str, scope: str, attr: str
+    ) -> None:
+        parent: Insight | Dashboard = (
+            Insight.objects.create(team=self.team, name="My Insight")
+            if parent_kind == "insight"
+            else Dashboard.objects.create(team=self.team, name="My Dashboard")
+        )
+        parent.deleted = True
+        parent.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/annotations/",
+            {
+                "content": "Rolled out the new checkout",
+                "scope": scope,
+                "date_marker": "2024-01-01T00:00:00.000000Z",
+                attr: parent.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == attr
+
     def test_creating_annotation_with_insight_from_same_team(self) -> None:
         insight = Insight.objects.create(team=self.team, name="My Insight")
 

--- a/products/annotations/backend/api/test/test_annotation.py
+++ b/products/annotations/backend/api/test/test_annotation.py
@@ -659,6 +659,38 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
         list_response = self.client.get(f"/api/projects/{self.team.id}/annotations/")
         assert annotation.id in {a["id"] for a in list_response.json()["results"]}
 
+    @parameterized.expand(
+        [
+            ("project_scope_deleted_dashboard", Annotation.Scope.PROJECT, "dashboard"),
+            ("project_scope_deleted_insight", Annotation.Scope.PROJECT, "insight"),
+            ("organization_scope_deleted_dashboard", Annotation.Scope.ORGANIZATION, "dashboard"),
+        ]
+    )
+    def test_project_wide_annotations_survive_a_soft_deleted_parent(
+        self, _name: str, scope: str, parent_kind: str
+    ) -> None:
+        insight = Insight.objects.create(team=self.team, name="My Insight")
+        dashboard = Dashboard.objects.create(team=self.team, name="My Dashboard")
+        annotation = Annotation.objects.create(
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="Rolled out the new checkout",
+            scope=scope,
+            dashboard_item=insight,
+            dashboard=dashboard,
+        )
+
+        parent = dashboard if parent_kind == "dashboard" else insight
+        parent.deleted = True
+        parent.save()
+
+        list_response = self.client.get(f"/api/projects/{self.team.id}/annotations/")
+        assert annotation.id in {a["id"] for a in list_response.json()["results"]}
+
+        retrieve_response = self.client.get(f"/api/projects/{self.team.id}/annotations/{annotation.id}/")
+        assert retrieve_response.status_code == status.HTTP_200_OK
+
     def test_creating_annotation_with_nonexistent_insight_returns_400(self) -> None:
         response = self.client.post(
             f"/api/projects/{self.team.id}/annotations/",

--- a/products/annotations/backend/api/test/test_annotation.py
+++ b/products/annotations/backend/api/test/test_annotation.py
@@ -65,6 +65,24 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
             response = self.client.get(f"/api/projects/{self.team.id}/annotations/").json()
             assert len(response["results"]) == 2
 
+        # Annotations that point at a dashboard must not add a query each: the serializer reads
+        # `dashboard_name` through the `dashboard` relation, so the queryset has to select it.
+        dashboard = Dashboard.objects.create(team=self.team, name="A dashboard")
+        for index in range(2):
+            Annotation.objects.create(
+                organization=self.organization,
+                team=self.team,
+                created_at="2020-01-04T12:00:00Z",
+                created_by=User.objects.create_and_join(self.organization, f"dash-{index}", ""),
+                content=now().isoformat(),
+                dashboard=dashboard,
+                scope=Annotation.Scope.PROJECT,
+            )
+
+        with self.assertNumQueries(FuzzyInt(9, 10)), snapshot_postgres_queries_context(self):
+            response = self.client.get(f"/api/projects/{self.team.id}/annotations/").json()
+            assert len(response["results"]) == 4
+
     def test_org_scoped_annotations_are_returned_between_projects(self) -> None:
         second_team = Team.objects.create(organization=self.organization, name="Second team")
         Annotation.objects.create(

--- a/products/annotations/backend/api/test/test_annotation.py
+++ b/products/annotations/backend/api/test/test_annotation.py
@@ -666,7 +666,7 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
             ("organization_scope_deleted_dashboard", Annotation.Scope.ORGANIZATION, "dashboard"),
         ]
     )
-    def test_project_wide_annotations_survive_a_soft_deleted_parent(
+    def test_project_and_org_scoped_annotations_survive_a_soft_deleted_parent(
         self, _name: str, scope: str, parent_kind: str
     ) -> None:
         insight = Insight.objects.create(team=self.team, name="My Insight")
@@ -690,6 +690,26 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
 
         retrieve_response = self.client.get(f"/api/projects/{self.team.id}/annotations/{annotation.id}/")
         assert retrieve_response.status_code == status.HTTP_200_OK
+
+        # The UI echoes both parent IDs back on every write, so editing and deleting have to tolerate
+        # the stale pointer to the now-deleted parent.
+        echoed_parents = {"dashboard_item": insight.id, "dashboard_id": dashboard.id}
+
+        edit_response = self.client.patch(
+            f"/api/projects/{self.team.id}/annotations/{annotation.id}/",
+            {"content": "Rolled back the new checkout", **echoed_parents},
+        )
+        assert edit_response.status_code == status.HTTP_200_OK
+        assert edit_response.json()["content"] == "Rolled back the new checkout"
+
+        delete_response = self.client.patch(
+            f"/api/projects/{self.team.id}/annotations/{annotation.id}/",
+            {"deleted": True, **echoed_parents},
+        )
+        assert delete_response.status_code == status.HTTP_200_OK
+
+        list_response = self.client.get(f"/api/projects/{self.team.id}/annotations/")
+        assert annotation.id not in {a["id"] for a in list_response.json()["results"]}
 
     def test_creating_annotation_with_nonexistent_insight_returns_400(self) -> None:
         response = self.client.post(

--- a/products/annotations/backend/api/test/test_annotation.py
+++ b/products/annotations/backend/api/test/test_annotation.py
@@ -744,22 +744,29 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
         assert response.json()["attr"] == "dashboard_item"
         assert response.json()["code"] == "does_not_exist"
 
-    @parameterized.expand(
-        [
-            ("insight", Annotation.Scope.INSIGHT, "dashboard_item"),
-            ("dashboard", Annotation.Scope.DASHBOARD, "dashboard_id"),
-        ]
-    )
-    def test_creating_an_annotation_scoped_to_a_soft_deleted_parent_returns_400(
-        self, parent_kind: str, scope: str, attr: str
-    ) -> None:
+    def _create_soft_deleted_parent(self, parent_kind: str) -> Insight | Dashboard:
+        name = f"Soft deleted {parent_kind}"
         parent: Insight | Dashboard = (
-            Insight.objects.create(team=self.team, name="My Insight")
+            Insight.objects.create(team=self.team, name=name)
             if parent_kind == "insight"
-            else Dashboard.objects.create(team=self.team, name="My Dashboard")
+            else Dashboard.objects.create(team=self.team, name=name)
         )
         parent.deleted = True
         parent.save()
+        return parent
+
+    @parameterized.expand(
+        [
+            ("insight_scope", "insight", Annotation.Scope.INSIGHT, "dashboard_item"),
+            ("dashboard_scope", "dashboard", Annotation.Scope.DASHBOARD, "dashboard_id"),
+            ("project_scope_insight_pointer", "insight", Annotation.Scope.PROJECT, "dashboard_item"),
+            ("project_scope_dashboard_pointer", "dashboard", Annotation.Scope.PROJECT, "dashboard_id"),
+        ]
+    )
+    def test_creating_an_annotation_pointing_at_a_soft_deleted_parent_returns_400(
+        self, _name: str, parent_kind: str, scope: str, attr: str
+    ) -> None:
+        parent = self._create_soft_deleted_parent(parent_kind)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/annotations/",
@@ -773,6 +780,34 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == attr
+        assert parent.name not in response.content.decode()
+
+    @parameterized.expand(
+        [
+            ("insight", "dashboard_item"),
+            ("dashboard", "dashboard_id"),
+        ]
+    )
+    def test_repointing_an_annotation_at_an_unrelated_soft_deleted_parent_returns_400(
+        self, parent_kind: str, attr: str
+    ) -> None:
+        parent = self._create_soft_deleted_parent(parent_kind)
+        annotation = Annotation.objects.create(
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="Rolled out the new checkout",
+            scope=Annotation.Scope.PROJECT,
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/annotations/{annotation.id}/",
+            {attr: parent.id},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == attr
+        assert parent.name not in response.content.decode()
 
     def test_creating_annotation_with_insight_from_same_team(self) -> None:
         insight = Insight.objects.create(team=self.team, name="My Insight")

--- a/products/annotations/frontend/generated/api.schemas.ts
+++ b/products/annotations/frontend/generated/api.schemas.ts
@@ -110,9 +110,15 @@ export interface AnnotationApi {
      * * `USR` - user
      * * `GIT` - GitHub */
     creation_type?: CreationTypeEnumApi
-    /** @nullable */
+    /**
+     * Optional insight ID to attach this annotation to. Must belong to the current project.
+     * @nullable
+     */
     dashboard_item?: number | null
-    /** @nullable */
+    /**
+     * Optional dashboard ID to attach this annotation to. Must belong to the current project.
+     * @nullable
+     */
     dashboard_id?: number | null
     /** @nullable */
     readonly dashboard_name: string | null
@@ -176,9 +182,15 @@ export interface PatchedAnnotationApi {
      * * `USR` - user
      * * `GIT` - GitHub */
     creation_type?: CreationTypeEnumApi
-    /** @nullable */
+    /**
+     * Optional insight ID to attach this annotation to. Must belong to the current project.
+     * @nullable
+     */
     dashboard_item?: number | null
-    /** @nullable */
+    /**
+     * Optional dashboard ID to attach this annotation to. Must belong to the current project.
+     * @nullable
+     */
     dashboard_id?: number | null
     /** @nullable */
     readonly dashboard_name?: string | null

--- a/products/annotations/frontend/generated/api.zod.ts
+++ b/products/annotations/frontend/generated/api.zod.ts
@@ -33,8 +33,14 @@ export const AnnotationsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot\/deployment notes.\n\n\* `USR` - user\n\* `GIT` - GitHub'
         ),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
+    dashboard_item: zod
+        .number()
+        .nullish()
+        .describe('Optional insight ID to attach this annotation to. Must belong to the current project.'),
+    dashboard_id: zod
+        .number()
+        .nullish()
+        .describe('Optional dashboard ID to attach this annotation to. Must belong to the current project.'),
     deleted: zod
         .boolean()
         .optional()
@@ -85,8 +91,14 @@ export const AnnotationsUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot\/deployment notes.\n\n\* `USR` - user\n\* `GIT` - GitHub'
         ),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
+    dashboard_item: zod
+        .number()
+        .nullish()
+        .describe('Optional insight ID to attach this annotation to. Must belong to the current project.'),
+    dashboard_id: zod
+        .number()
+        .nullish()
+        .describe('Optional dashboard ID to attach this annotation to. Must belong to the current project.'),
     deleted: zod
         .boolean()
         .optional()
@@ -137,8 +149,14 @@ export const AnnotationsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot\/deployment notes.\n\n\* `USR` - user\n\* `GIT` - GitHub'
         ),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
+    dashboard_item: zod
+        .number()
+        .nullish()
+        .describe('Optional insight ID to attach this annotation to. Must belong to the current project.'),
+    dashboard_id: zod
+        .number()
+        .nullish()
+        .describe('Optional dashboard ID to attach this annotation to. Must belong to the current project.'),
     deleted: zod
         .boolean()
         .optional()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -10032,9 +10032,15 @@ export namespace Schemas {
        * * `USR` - user
        * * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
-      /** @nullable */
+      /**
+         * Optional insight ID to attach this annotation to. Must belong to the current project.
+         * @nullable
+         */
       dashboard_item?: number | null;
-      /** @nullable */
+      /**
+         * Optional dashboard ID to attach this annotation to. Must belong to the current project.
+         * @nullable
+         */
       dashboard_id?: number | null;
       /** @nullable */
       readonly dashboard_name: string | null;
@@ -57543,9 +57549,15 @@ export namespace Schemas {
        * * `USR` - user
        * * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
-      /** @nullable */
+      /**
+         * Optional insight ID to attach this annotation to. Must belong to the current project.
+         * @nullable
+         */
       dashboard_item?: number | null;
-      /** @nullable */
+      /**
+         * Optional dashboard ID to attach this annotation to. Must belong to the current project.
+         * @nullable
+         */
       dashboard_id?: number | null;
       /** @nullable */
       readonly dashboard_name?: string | null;

--- a/services/mcp/src/generated/annotations/api.ts
+++ b/services/mcp/src/generated/annotations/api.ts
@@ -57,8 +57,14 @@ export const AnnotationsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot\/deployment notes.\n\n\* `USR` - user\n\* `GIT` - GitHub'
         ),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
+    dashboard_item: zod
+        .number()
+        .nullish()
+        .describe('Optional insight ID to attach this annotation to. Must belong to the current project.'),
+    dashboard_id: zod
+        .number()
+        .nullish()
+        .describe('Optional dashboard ID to attach this annotation to. Must belong to the current project.'),
     deleted: zod
         .boolean()
         .optional()
@@ -130,8 +136,14 @@ export const AnnotationsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot\/deployment notes.\n\n\* `USR` - user\n\* `GIT` - GitHub'
         ),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
+    dashboard_item: zod
+        .number()
+        .nullish()
+        .describe('Optional insight ID to attach this annotation to. Must belong to the current project.'),
+    dashboard_id: zod
+        .number()
+        .nullish()
+        .describe('Optional dashboard ID to attach this annotation to. Must belong to the current project.'),
     deleted: zod
         .boolean()
         .optional()


### PR DESCRIPTION
## Why

Deleting a dashboard could make project- and organization-scoped annotations disappear from unrelated charts. Annotations retain the insight and dashboard they were created from, while the API hid every annotation pointing to a soft-deleted parent without considering the annotation scope.

## What changed

- Keep project- and organization-scoped annotations visible when their recorded insight or dashboard is deleted.
- Continue hiding annotations whose own scope is tied to the deleted insight or dashboard.
- Allow existing project- and organization-scoped annotations to be edited or soft-deleted when the UI echoes stale parent IDs.
- Reject a write whose own scope points at a deleted parent, rather than creating a row nothing can reach.
- Accept a deleted parent ID only when the annotation already points at it. Every other deleted parent answers exactly as an unknown ID does, so a guessed ID cannot report back the name of a deleted insight or dashboard.
- Preload dashboard relations to avoid list-endpoint N+1 queries.
- Regenerate the affected API schemas and MCP types.

## Validation

Added regression coverage for deleted dashboards and insights, echoed parent IDs on writes, deleted-parent creates and repoints, and dashboard relation query counts. The annotations product test suite passes (59 tests, 35 snapshots). Repo-wide mypy is clean and `hogli build:openapi` reports no drift.

No frontend changes are required because the existing UI behavior is corrected by the API response.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BPULZFS84/p1787753444826889?thread_ts=1787753444.826889&cid=C0BPULZFS84)*
