### PR TITLE
feat(replay-vision): enable/disable scanners from the usage tab and config

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7609,17 +7609,17 @@ snapshots:
     scenes-app-replay-vision--scanner-calibration--light:
         hash: v1.k794b7964.052104891cea7a902b874826c922e3688d23053b0ebb2128b1c0dbca7ab2a32b.LofDLlNAhm2-XL4aPULNJ7Wwduy_ZItRnWWQdAvir1k
     scenes-app-replay-vision--scanner-configuration--dark:
-        hash: v1.k794b7964.c77594e83f7c7ef19638baf76277c9f744ef7ee375a9793f8a0373cfa52f1b18.rR2jerhahs-q8Bhq1djYA2ZENUnMiqWbNHtmxZRdaS0
+        hash: v1.k794b7964.6ccd7edeaa1ca21973cdd4db3c9270adfba38841de505035a3450b485ee0accd.0_nUNj0v4Xv_lV4FsJIMxePHpu3lv4jgfcNh0VMxvsI
     scenes-app-replay-vision--scanner-configuration--light:
-        hash: v1.k794b7964.76d581830af6ecf2f4003f3a6182e6dd06fbc9ce50bc5044122ab1c9b4669780._u4rb_FDHVcZVh_c6lORoMDoHa-2WDIk8tunpgJfrEs
+        hash: v1.k794b7964.7b4aac492018e4b4b7e267ea6b9eb3afdca3bdb380cffe217c3a35ca115633f7.aNrewc17QuCb7XiC_K2d6_2o3LbvWZ_V7K1mogzASbg
     scenes-app-replay-vision--scanner-configuration-lite-standard-pro--dark:
-        hash: v1.k794b7964.2a5060c282a0ce36215998686f26a9c80d05f324158bb77c393d7a1ad7ef65c7.79svu7jvDHY7FOQ9_lrYdXg7BsSV-rKG2fTgbLIBqrQ
+        hash: v1.k794b7964.9178a54f8ed46d377a064544b3a715566d9f5d26a86d47873c0b05e56cbaeeb7._hSa4Mpof7PAwqz8pymlqsZSitkrhp77OVc92KVb0W8
     scenes-app-replay-vision--scanner-configuration-lite-standard-pro--light:
-        hash: v1.k794b7964.129d9ae29c83fe6c83f4cadd240d7d00678d39772968239768aa256978086b1f.QEJDd_0bqhq2u2aXq9PkS0zdh0A4YeqD2v9nCXQMlWU
+        hash: v1.k794b7964.2b25fe709d4ed8209b695ceb99502831f7a824a1265255064b94c45be897d47f.-QU4HBV07wI8N4xj_twCWqRkecqxjVzepmnIbs8lsP0
     scenes-app-replay-vision--scanner-configuration-tier-names--dark:
-        hash: v1.k794b7964.a25af64ee96340a7626331ef731f91a3236ebe8a546872a7317930547ea83b69.zG_jCMVVgFfPtTq4r5uZlBMc4taGEDGAUe_QBNe6Neo
+        hash: v1.k794b7964.1cbb6ff2103365a2c2c0b4a250c25f518667ccdd3ec579bac44f0edb841d3fc7.z5RZjRLvjPqlt7Koy61ANS_3C67zOHP7Mc7FvKGucP0
     scenes-app-replay-vision--scanner-configuration-tier-names--light:
-        hash: v1.k794b7964.991ecbf284af2423ad7f8f83f26053197e0003eefaedadad4869a1bb243d1822.309ACp4CkQCk6_Bq7Qmef93hciFy3lpOcipREBvpvE0
+        hash: v1.k794b7964.1b3757504deeeb68d21ffdab3f8ca532a0aed50f0c898876b550d7de862cb238.TssiDaxgE6EHc1ssQ8lIwO8gatmYG8g9MrhHleNZ6Xs
     scenes-app-replay-vision--scanner-digests--dark:
         hash: v1.k794b7964.cfb6e46fefd93430d17c650dfceeb62bc813855dd034c2a815db8559686dbeab.4iB6ZrgxCuEO7AoLgZCuqcAMX6eqMa42Fn3j6N6n5Xg
     scenes-app-replay-vision--scanner-digests--light:
@@ -7681,9 +7681,9 @@ snapshots:
     scenes-app-replay-vision--summarizer-overview--light:
         hash: v1.k794b7964.c4c10f01522dae58cfa74b31763cc511792be4e089715c3a2dc368069709903a.oNfnCNLDZrnVpzs6I9cQGdG22Hrp5C3PQ3LukYHNIE0
     scenes-app-replay-vision--usage-tab--dark:
-        hash: v1.k794b7964.7597963aa31229871d070717ba14ab862d3a449c34cda3a6daf955bb9ed3303e.C-QVr_MQvoR9HIQ4FucF431T-QkWUVYpf9KK7bSO4L0
+        hash: v1.k794b7964.ad98efcf3b03420b327b36588d5c1c47c509446d50ab452de9c5859b5a530ea4.6Pn4bDGW95UO7bPpfjNrW0ToWQCQZXaLBy5qCAbOUOA
     scenes-app-replay-vision--usage-tab--light:
-        hash: v1.k794b7964.905ddad41ffd554979e273efe3fa22a592b2ed65cf1d96ce18fdf557817e6aae.c30xFjJse9ILNiHi07sdYEbyINvpBVlVwXT6Y2m-R1k
+        hash: v1.k794b7964.ffd83813d408db75ccb39b74e28deae6710255f4d6807c2ea488c24236b16306.nkvTTvPdr-SB88WsAuWl0QvFP7yzMwqLjSsvW-0JjYg
     scenes-app-saved-insights--empty-state--dark:
         hash: v1.k794b7964.43545664c9133c8afd354be6a6ed8f808c35b381101325d9605114632fcdc0c9.l8w9uEOEmrH6Xl1kNd9ueRtg_51cJUSjWLdjWDM0Fko
     scenes-app-saved-insights--empty-state--light:

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -446,6 +446,23 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
 
     return (
         <div className="flex flex-col gap-4">
+            <div className="rounded border p-4 bg-bg-light flex flex-col gap-2">
+                <LemonSwitch
+                    checked={scanner.enabled}
+                    onChange={() => toggleEnabled()}
+                    loading={togglingEnabled}
+                    disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
+                    label="Enable scanner"
+                    bordered
+                    fullWidth
+                    data-attr="vision-scanner-toggle-enabled"
+                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                    data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
+                />
+                <span className="text-muted text-xs">
+                    {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
+                </span>
+            </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 <LemonCard className="p-4" hoverEffect={false}>
                     <CardHeader icon={<IconInfo />} title="Overview" />
@@ -466,22 +483,6 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                         </LabeledRow>
                         <LabeledRow label="Model">
                             <OptionTags options={getModelOptions(namingVariant)} selected={scanner.model} />
-                        </LabeledRow>
-                        <LabeledRow label="Status">
-                            <div className="flex items-center gap-2">
-                                <LemonSwitch
-                                    checked={scanner.enabled}
-                                    onChange={() => toggleEnabled()}
-                                    loading={togglingEnabled}
-                                    disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
-                                    data-attr="vision-scanner-toggle-enabled"
-                                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                                    data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
-                                />
-                                <span className="text-muted text-xs">
-                                    {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
-                                </span>
-                            </div>
                         </LabeledRow>
                     </div>
                 </LemonCard>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -446,22 +446,24 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
 
     return (
         <div className="flex flex-col gap-4">
-            <div className="rounded border p-4 bg-bg-light flex flex-col gap-2">
-                <LemonSwitch
-                    checked={scanner.enabled}
-                    onChange={() => toggleEnabled()}
-                    loading={togglingEnabled}
-                    disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
-                    label="Enable scanner"
-                    bordered
-                    fullWidth
-                    data-attr="vision-scanner-toggle-enabled"
-                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                    data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
-                />
-                <span className="text-muted text-xs">
-                    {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
-                </span>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <div className="rounded border p-4 bg-bg-light flex flex-col gap-2">
+                    <LemonSwitch
+                        checked={scanner.enabled}
+                        onChange={() => toggleEnabled()}
+                        loading={togglingEnabled}
+                        disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
+                        label="Enable scanner"
+                        bordered
+                        fullWidth
+                        data-attr="vision-scanner-toggle-enabled"
+                        data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                        data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
+                    />
+                    <span className="text-muted text-xs">
+                        {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
+                    </span>
+                </div>
             </div>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 <LemonCard className="p-4" hoverEffect={false}>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -447,49 +447,49 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
     return (
         <div className="flex flex-col gap-4">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div className="rounded border p-4 bg-bg-light flex flex-col gap-2">
-                    <LemonSwitch
-                        checked={scanner.enabled}
-                        onChange={() => toggleEnabled()}
-                        loading={togglingEnabled}
-                        disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
-                        label="Enable scanner"
-                        bordered
-                        fullWidth
-                        data-attr="vision-scanner-toggle-enabled"
-                        data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                        data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
-                    />
-                    <span className="text-muted text-xs">
-                        {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
-                    </span>
-                </div>
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <LemonCard className="p-4" hoverEffect={false}>
-                    <CardHeader icon={<IconInfo />} title="Overview" />
-                    <div className="flex flex-col gap-3">
-                        <LabeledRow label="Type">
-                            <div className="flex flex-wrap gap-1">
-                                {SCANNER_TYPES.map((scannerType) => (
-                                    <ScannerTypeBadge
-                                        key={scannerType}
-                                        scannerType={scannerType}
-                                        variant={scanner.scanner_type === scannerType ? 'default' : 'deemphasized'}
-                                    />
-                                ))}
-                            </div>
-                        </LabeledRow>
-                        <LabeledRow label="Description">
-                            <Multiline value={scanner.description} />
-                        </LabeledRow>
-                        <LabeledRow label="Model">
-                            <OptionTags options={getModelOptions(namingVariant)} selected={scanner.model} />
-                        </LabeledRow>
+                <div className="flex flex-col gap-4">
+                    <div className="rounded border p-4 bg-bg-light flex flex-col gap-2">
+                        <LemonSwitch
+                            checked={scanner.enabled}
+                            onChange={() => toggleEnabled()}
+                            loading={togglingEnabled}
+                            disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
+                            label="Enable scanner"
+                            bordered
+                            fullWidth
+                            data-attr="vision-scanner-toggle-enabled"
+                            data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                            data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
+                        />
+                        <span className="text-muted text-xs">
+                            {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
+                        </span>
                     </div>
-                </LemonCard>
+                    <LemonCard className="p-4" hoverEffect={false}>
+                        <CardHeader icon={<IconInfo />} title="Overview" />
+                        <div className="flex flex-col gap-3">
+                            <LabeledRow label="Type">
+                                <div className="flex flex-wrap gap-1">
+                                    {SCANNER_TYPES.map((scannerType) => (
+                                        <ScannerTypeBadge
+                                            key={scannerType}
+                                            scannerType={scannerType}
+                                            variant={scanner.scanner_type === scannerType ? 'default' : 'deemphasized'}
+                                        />
+                                    ))}
+                                </div>
+                            </LabeledRow>
+                            <LabeledRow label="Description">
+                                <Multiline value={scanner.description} />
+                            </LabeledRow>
+                            <LabeledRow label="Model">
+                                <OptionTags options={getModelOptions(namingVariant)} selected={scanner.model} />
+                            </LabeledRow>
+                        </div>
+                    </LemonCard>
+                </div>
 
-                <LemonCard className="p-4" hoverEffect={false}>
+                <LemonCard className="p-4 h-full" hoverEffect={false}>
                     <CardHeader icon={<IconPencil />} title="Behavior" />
                     <div className="flex flex-col gap-3">
                         <BehaviorCardContent scanner={scanner} />

--- a/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonSegmentedButton, LemonTable, LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSwitch, LemonTable, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
@@ -15,6 +15,7 @@ import { BaseMathType, ChartDisplayType, InsightLogicProps, PropertyFilterType, 
 import { VisionDocsLink } from '../../components/DocsLink'
 import { CreditPriceNote } from '../../components/PricingLink'
 import { visionQuotaLogic } from '../../logics/visionQuotaLogic'
+import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
 import { creditsToUsd, formatCreditCount, formatCreditsMaybeUsd, formatCreditsRange } from '../../utils/credits'
 import { exhaustionForecast, hasCreditLimit, projectQuota } from '../../utils/quotaProjection'
 import { STARTUP_CAP_EXPLANATION } from '../../utils/startupCap'
@@ -56,8 +57,8 @@ const SPEND_CHART_CREDITS_FORMULA = SPEND_CHART_MODEL_PRICES.map(
 ).join(' + ')
 
 export function VisionUsageTab(): JSX.Element {
-    const { usageScanners, usageScannersLoading, spendChartInterval } = useValues(visionUsageLogic)
-    const { setSpendChartInterval } = useActions(visionUsageLogic)
+    const { usageScanners, usageScannersLoading, spendChartInterval, togglingScannerIds } = useValues(visionUsageLogic)
+    const { setSpendChartInterval, toggleScannerEnabled } = useActions(visionUsageLogic)
     const {
         displayQuota: quota,
         quotaLoading,
@@ -134,12 +135,25 @@ export function VisionUsageTab(): JSX.Element {
             key: 'name',
             width: '25%',
             render: (_, scanner) => (
-                <div className="flex items-center gap-2">
-                    <Link to={urls.replayVision(scanner.id)} className="font-semibold text-primary">
-                        {scanner.name || '(untitled)'}
-                    </Link>
-                    {!scanner.enabled && <LemonTag type="muted">Disabled</LemonTag>}
-                </div>
+                <Link to={urls.replayVision(scanner.id)} className="font-semibold text-primary">
+                    {scanner.name || '(untitled)'}
+                </Link>
+            ),
+        },
+        {
+            title: 'Enabled',
+            key: 'enabled',
+            tooltip: 'Enabled scanners run automatically on a schedule. Disabled scanners run on-demand only.',
+            render: (_, scanner) => (
+                <LemonSwitch
+                    checked={scanner.enabled}
+                    onChange={() => toggleScannerEnabled(scanner)}
+                    loading={togglingScannerIds.includes(scanner.id)}
+                    disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
+                    data-attr="vision-usage-scanner-toggle-enabled"
+                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                    data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
+                />
             ),
         },
         {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -1862,6 +1862,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     await visionScannersPartialUpdate(String(teamId), props.id, { enabled: next })
                     actions.toggleEnabledSuccess(next)
                     refreshVisionQuota()
+                    lemonToast.success(`Scanner ${next ? 'enabled' : 'disabled'}`)
                 } catch (error: any) {
                     actions.setScannerValue('enabled', !next)
                     const verb = next ? 'enable' : 'disable'

--- a/products/replay_vision/frontend/replay_scanners/visionUsageLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionUsageLogic.test.ts
@@ -1,0 +1,99 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { ReplayScanner } from './types'
+import { visionUsageLogic } from './visionUsageLogic'
+
+jest.mock('lib/lemon-ui/LemonToast', () => ({
+    lemonToast: { success: jest.fn(), error: jest.fn() },
+}))
+
+function makeScanner(overrides: Partial<ReplayScanner> = {}): ReplayScanner {
+    const base = {
+        id: 'a',
+        name: 'Confused checkout',
+        description: '',
+        tags: [],
+        enabled: true,
+        sampling_rate: 0.1,
+        query: null,
+        provider: 'google',
+        model: 'gemini-3.7-flash',
+        emits_signals: false,
+        scanner_version: 1,
+        last_swept_at: '2026-05-12T00:00:00Z',
+        created_at: '2026-05-12T00:00:00Z',
+        updated_at: '2026-05-12T00:00:00Z',
+        created_by: null,
+        scanner_type: 'monitor',
+        scanner_config: { prompt: 'Did the user struggle?' },
+    }
+    return { ...base, ...overrides } as ReplayScanner
+}
+
+describe('visionUsageLogic', () => {
+    let logic: ReturnType<typeof visionUsageLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/vision/scanners/': { results: [makeScanner()], count: 1 },
+            },
+            patch: {
+                '/api/projects/:team/vision/scanners/:id/': () => [200, {}],
+            },
+        })
+        initKeaTests()
+        jest.clearAllMocks()
+        logic = visionUsageLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('toggleScannerEnabled', () => {
+        it('optimistically flips the row and marks it in-flight, then clears in-flight on success', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleScannerEnabled(makeScanner({ enabled: true }))
+            }).toMatchValues({
+                usageScanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: false })]),
+                togglingScannerIds: ['a'],
+            })
+
+            await expectLogic(logic)
+                .toFinishAllListeners()
+                .toMatchValues({
+                    usageScanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: false })]),
+                    togglingScannerIds: [],
+                })
+            expect(lemonToast.success).toHaveBeenCalledWith('Scanner disabled')
+        })
+
+        it('rolls the row back and clears in-flight when the request fails', async () => {
+            useMocks({
+                patch: {
+                    '/api/projects/:team/vision/scanners/:id/': () => [400, { detail: 'nope' }],
+                },
+            })
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleScannerEnabled(makeScanner({ enabled: true }))
+            })
+                .toFinishAllListeners()
+                .toMatchValues({
+                    usageScanners: expect.arrayContaining([expect.objectContaining({ id: 'a', enabled: true })]),
+                    togglingScannerIds: [],
+                })
+            expect(lemonToast.error).toHaveBeenCalledWith('Failed to disable scanner: nope')
+        })
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/visionUsageLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionUsageLogic.ts
@@ -1,11 +1,12 @@
-import { MakeLogicType, actions, afterMount, kea, path, reducers } from 'kea'
-import { loaders } from 'kea-loaders'
+import { MakeLogicType, actions, afterMount, kea, listeners, path, reducers } from 'kea'
 
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { IntervalType } from '~/types'
 
-import { visionScannersList } from '../generated/api'
+import { visionScannersList, visionScannersPartialUpdate } from '../generated/api'
+import { refreshVisionQuota } from '../logics/visionQuotaLogic'
 import type { ReplayScanner } from './types'
 
 export type SpendChartInterval = Extract<IntervalType, 'day' | 'week' | 'month'>
@@ -14,51 +15,104 @@ interface visionUsageLogicValues {
     usageScanners: ReplayScanner[]
     usageScannersLoading: boolean
     spendChartInterval: SpendChartInterval
+    togglingScannerIds: string[]
 }
 
 interface visionUsageLogicActions {
-    loadUsageScanners: () => void
+    loadUsageScanners: () => { value: true }
     loadUsageScannersSuccess: (usageScanners: ReplayScanner[]) => { usageScanners: ReplayScanner[] }
-    loadUsageScannersFailure: (error: string) => { error: string }
     setSpendChartInterval: (interval: SpendChartInterval) => { interval: SpendChartInterval }
+    toggleScannerEnabled: (scanner: ReplayScanner) => { scanner: ReplayScanner }
+    setScannerEnabled: (id: string, enabled: boolean) => { id: string; enabled: boolean }
+    finishTogglingScanner: (id: string) => { id: string }
 }
 
 export type visionUsageLogicType = MakeLogicType<visionUsageLogicValues, visionUsageLogicActions>
 
 // Loads the whole team's scanners ordered by spend for the Usage tab and the overview's
 // usage bridge. Separate from replayScannersLogic so the list tab's filters and
-// pagination never leak into usage math.
+// pagination never leak into usage math. Loaded manually rather than via kea-loaders so a
+// per-row enable toggle can update the list optimistically without a refetch.
 export const visionUsageLogic = kea<visionUsageLogicType>([
     path(['products', 'replay_vision', 'frontend', 'replay_scanners', 'visionUsageLogic']),
     actions({
+        loadUsageScanners: true,
+        loadUsageScannersSuccess: (usageScanners: ReplayScanner[]) => ({ usageScanners }),
         setSpendChartInterval: (interval: SpendChartInterval) => ({ interval }),
+        toggleScannerEnabled: (scanner: ReplayScanner) => ({ scanner }),
+        setScannerEnabled: (id: string, enabled: boolean) => ({ id, enabled }),
+        finishTogglingScanner: (id: string) => ({ id }),
     }),
     reducers({
+        usageScanners: [
+            [] as ReplayScanner[],
+            {
+                loadUsageScannersSuccess: (_, { usageScanners }) => usageScanners,
+                setScannerEnabled: (state, { id, enabled }) =>
+                    state.map((scanner) => (scanner.id === id ? { ...scanner, enabled } : scanner)),
+            },
+        ],
+        usageScannersLoading: [
+            false,
+            {
+                loadUsageScanners: () => true,
+                loadUsageScannersSuccess: () => false,
+            },
+        ],
         spendChartInterval: [
             'day' as SpendChartInterval,
             {
                 setSpendChartInterval: (_, { interval }) => interval,
             },
         ],
-    }),
-    loaders({
-        usageScanners: [
-            [] as ReplayScanner[],
+        togglingScannerIds: [
+            [] as string[],
             {
-                loadUsageScanners: async (): Promise<ReplayScanner[]> => {
-                    const teamId = teamLogic.values.currentTeamId
-                    if (!teamId) {
-                        return []
-                    }
-                    const response = await visionScannersList(String(teamId), {
-                        order_by: '-credits_this_month',
-                        limit: 100,
-                    })
-                    return (response.results ?? []) as unknown as ReplayScanner[]
-                },
+                toggleScannerEnabled: (state, { scanner }) =>
+                    state.includes(scanner.id) ? state : [...state, scanner.id],
+                finishTogglingScanner: (state, { id }) => state.filter((toggling) => toggling !== id),
             },
         ],
     }),
+    listeners(({ actions, values }) => ({
+        loadUsageScanners: async () => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                actions.loadUsageScannersSuccess([])
+                return
+            }
+            try {
+                const response = await visionScannersList(String(teamId), {
+                    order_by: '-credits_this_month',
+                    limit: 100,
+                })
+                actions.loadUsageScannersSuccess((response.results ?? []) as unknown as ReplayScanner[])
+            } catch {
+                // Keep whatever list is already shown; the table's own empty/loaded state stays consistent.
+                actions.loadUsageScannersSuccess(values.usageScanners)
+            }
+        },
+        toggleScannerEnabled: async ({ scanner }) => {
+            const teamId = teamLogic.values.currentTeamId
+            const next = !scanner.enabled
+            if (!teamId) {
+                actions.finishTogglingScanner(scanner.id)
+                return
+            }
+            actions.setScannerEnabled(scanner.id, next)
+            try {
+                await visionScannersPartialUpdate(String(teamId), scanner.id, { enabled: next })
+                refreshVisionQuota()
+                lemonToast.success(`Scanner ${next ? 'enabled' : 'disabled'}`)
+            } catch (error: any) {
+                actions.setScannerEnabled(scanner.id, scanner.enabled)
+                const verb = next ? 'enable' : 'disable'
+                lemonToast.error(`Failed to ${verb} scanner${error.detail ? `: ${error.detail}` : ''}`)
+            } finally {
+                actions.finishTogglingScanner(scanner.id)
+            }
+        },
+    })),
     afterMount(({ actions }) => {
         actions.loadUsageScanners()
     }),


### PR DESCRIPTION
## Problem

Enabling or disabling a Replay Vision scanner from the Usage tab meant opening each scanner's Configuration page one at a time. The Usage tab lists every scanner by spend but had no way to act on them.

On the Configuration page itself, the enable toggle sat as one row inside the Overview card, below Type, Description, and Model, so the most consequential control on the page was the least prominent.

## Changes

- The Usage tab gains an "Enabled" column with a per-scanner toggle. Flipping it updates the row immediately, shows a spinner on that row while the request runs, and shows a success or failure toast.
- A failed toggle rolls the row back to its previous state, so the switch never shows a state the backend rejected.
- The Configuration tab moves the enable toggle into its own card in the left column, stacked above the Overview card, styled like the feature flag enable/disable card. The Behavior card fills the right column to match their combined height.
- The Configuration-tab toggle now also toasts on success. It previously toasted only on failure.

Mechanical: `visionUsageLogic` now loads its scanner list through a manual action and reducer instead of kea-loaders, so a toggle can update one row optimistically without refetching the whole list.

### Usage tab

![replay-vision-usage-tab-enable-toggle](https://raw.githubusercontent.com/PostHog/pr-assets/66cc4f892231a4e3b931852fa13499aa681149b4/2026/08/b12d9dff-59dc-4ac5-b824-ec56dc99bc1b.png)

### Configuration tab

![replay-vision-config-enable-card-stacked](https://raw.githubusercontent.com/PostHog/pr-assets/ccd7306394132de9110000805eadc58df123a8fd/2026/08/e9d16d38-5d3e-45de-86a3-af71087ed723.png)

## How did you test this code?

- Added `visionUsageLogic.test.ts` with two cases. One catches a regression where a failed toggle leaves the row showing the wrong enabled state: it asserts the optimistic flip, then the rollback and error toast. The other asserts the success path clears the in-flight marker and toasts. No existing test covered this logic.
- Rendered both stories (`UsageTab`, `ScannerConfiguration`) in Storybook to confirm the column and the card render as shown above.
- Ran the frontend typecheck: no errors in the changed files. One pre-existing error in `ComposerModePicker.tsx` came in from master and is unrelated.
- Not run: no other suites were run locally; CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs describe this surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8) in Claude Code, directed by @ksvat.

Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-pr-descriptions`.

The reused `toggleEnabled` action already existed on the single-scanner `replayScannerLogic`, but it mutates that logic's own scanner state, which the Usage tab's list does not read. The toggle was added to `visionUsageLogic` instead so the list stays the single source of truth for the table. That required converting `usageScanners` off kea-loaders to a manual load, since a loader value cannot also take an optimistic reducer case.
