### PR TITLE
fix(desktop): align model labels and guard open model pricing

### DIFF
--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
@@ -61,10 +61,6 @@ function piModelDisplayName(model: { id: string; name: string }): string {
   return formatGatewayModelName({
     id: model.id,
     owned_by: "",
-    context_window: 0,
-    supports_streaming: false,
-    supports_vision: false,
-    allowed: true,
   });
 }
 

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/models.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/models.ts
@@ -1,7 +1,7 @@
 import type { ThinkingLevelMap } from "@earendil-works/pi-ai";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
-import type { CloudRegion } from "@posthog/shared";
+import { type CloudRegion, formatGatewayModelName } from "@posthog/shared";
 import { buildPosthogProjectHeaderRecord } from "@posthog/shared/posthog-property-headers";
 import { getLlmGatewayUrl } from "./gateway";
 
@@ -81,7 +81,13 @@ function toModelConfig(
   region: CloudRegion,
 ): ProviderModelConfig {
   const family = detectFamily(model);
-  const name = model.display_name ?? model.id;
+  const displayName = model.display_name?.trim();
+  const name =
+    displayName && displayName !== model.id
+      ? displayName
+      : model.owned_by
+        ? formatGatewayModelName({ id: model.id, owned_by: model.owned_by })
+        : model.id;
   const contextWindow = model.context_window ?? 200000;
   const input: ("text" | "image")[] = model.supports_vision
     ? ["text", "image"]

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/provider.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/provider.test.ts
@@ -290,11 +290,13 @@ describe("model classification", () => {
         {
           id: "deepseek-ai/deepseek-v4-flash-0731",
           owned_by: "baseten",
+          display_name: "deepseek-ai/deepseek-v4-flash-0731",
           context_window: 1_048_000,
         },
       ],
       "us",
     );
+    expect(deepseek?.name).toBe("DeepSeek V4 Flash");
     expect(deepseek?.api).toBe("openai-completions");
     expect(deepseek?.reasoning).toBe(false);
     expect(deepseek?.baseUrl).toBe(

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -167,7 +167,9 @@ export function isBlockedModelId(modelId: string): boolean {
   return BLOCKED_GATEWAY_MODELS.has(modelId.toLowerCase());
 }
 
-export function isAnthropicModel(model: GatewayModel): boolean {
+type GatewayModelIdentity = Pick<GatewayModel, "id" | "owned_by">;
+
+export function isAnthropicModel(model: GatewayModelIdentity): boolean {
   if (model.owned_by) {
     return model.owned_by === "anthropic";
   }
@@ -178,7 +180,7 @@ export function isAnthropicModelId(modelId: string): boolean {
   return modelId.startsWith("claude-") || modelId.startsWith("anthropic/");
 }
 
-export function isOpenAIModel(model: GatewayModel): boolean {
+export function isOpenAIModel(model: GatewayModelIdentity): boolean {
   if (model.owned_by) {
     return model.owned_by === "openai";
   }
@@ -201,7 +203,7 @@ export function isGlm53FlashModelId(modelId: string): boolean {
   return modelId.toLowerCase() === "zai-org/glm-5.3-flash";
 }
 
-export function isCloudflareModel(model: GatewayModel): boolean {
+export function isCloudflareModel(model: GatewayModelIdentity): boolean {
   return isCloudflareModelId(model.id) || model.owned_by === "cloudflare";
 }
 
@@ -209,7 +211,7 @@ export function isModalModelId(modelId: string): boolean {
   return modelId === "moonshotai/kimi-k3";
 }
 
-export function isModalModel(model: GatewayModel): boolean {
+export function isModalModel(model: GatewayModelIdentity): boolean {
   return isModalModelId(model.id) || model.owned_by === "modal";
 }
 
@@ -217,7 +219,7 @@ export function isDeepseekModelId(modelId: string): boolean {
   return modelId.toLowerCase().includes("deepseek");
 }
 
-export function isBasetenModel(model: GatewayModel): boolean {
+export function isBasetenModel(model: GatewayModelIdentity): boolean {
   return isDeepseekModelId(model.id) || model.owned_by === "baseten";
 }
 
@@ -294,7 +296,7 @@ const MODEL_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   "deepseek-ai/deepseek-v4-flash-0731": "DeepSeek V4 Flash",
 };
 
-export function formatGatewayModelName(model: GatewayModel): string {
+export function formatGatewayModelName(model: GatewayModelIdentity): string {
   const displayName = MODEL_DISPLAY_NAMES[model.id];
   if (displayName) {
     return displayName;

--- a/services/llm-gateway/tests/test_cost_refresh.py
+++ b/services/llm-gateway/tests/test_cost_refresh.py
@@ -101,6 +101,8 @@ class TestApplyCostAliases:
             ("@cf/zai-org/glm-5.2", 1000, 100, 0.0014, 0.00044),
             ("zai-org/GLM-5.2-FP8", 1000, 100, 0.0014, 0.00044),
             ("zai-org/GLM-5.2", 1000, 100, 0.0014, 0.00044),
+            ("zai-org/GLM-5.3", 1000, 100, 0.0014, 0.00044),
+            ("deepseek-ai/DeepSeek-V4-Flash-0731", 1000, 100, 0.00013, 0.000026),
             ("moonshotai/kimi-k3", 1000, 100, 0.003, 0.0015),
         ],
     )


### PR DESCRIPTION
## Problem

Pi users see raw gateway model IDs where Claude Code users see readable model names.

Open-weight provider routes lacked direct pricing coverage for DeepSeek and GLM 5.3. A missing alias can emit a zero-cost generation and skip usage billing.

## Changes

- Pi uses the shared model formatter when the gateway repeats the raw model ID as its display name.
- Explicit gateway display names still take priority.
- Pricing tests now cover DeepSeek and GLM 5.3 through their OpenAI-compatible routes.
- The gateway parity audit found no contract change and refreshed the PostHog source revision.
- Screenshot not included because DeepSeek requires a live, flag-gated model catalog.

## How did you test this code?

- Harness and shared package unit suites cover the Pi label regression.
- Harness and shared package type checks cover the narrowed model identity contract.
- The gateway cost refresh test covers every current open-model route.
- The affected TypeScript files pass Biome, and the gateway test passes Ruff.
- The parity document passes markdownlint and Oxfmt.
- Manual app testing was not run because the DeepSeek catalog entry is flag-gated.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The gateway parity source revision is current. This change does not alter a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used repository tools and PostHog MCP analytics. Skills invoked: `/exploring-llm-costs`, `/querying-posthog-data`, `/auditing-llm-gateway-parity`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
