### PR TITLE
fix(capture): report live queue bytes in producer queue bytes gauge

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -98,7 +98,7 @@ impl rdkafka::ClientContext for KafkaContext {
         gauge!("capture_kafka_callback_queue_depth",).set(stats.replyq as f64);
         gauge!("capture_kafka_producer_queue_depth",).set(stats.msg_cnt as f64);
         gauge!("capture_kafka_producer_queue_depth_limit",).set(stats.msg_max as f64);
-        gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_max as f64);
+        gauge!("capture_kafka_producer_queue_bytes",).set(stats.msg_size as f64);
         gauge!("capture_kafka_producer_queue_bytes_limit",).set(stats.msg_size_max as f64);
 
         for (topic, stats) in stats.topics {


### PR DESCRIPTION
## Problem

- The ingestion on-call never gets paged when the legacy capture producer's queue fills up by bytes, because the `capture-analytics producer queue bytes > 40%` alert cannot fire.
- `capture_kafka_producer_queue_bytes` is set from `stats.msg_max`, the static message-count limit, instead of `stats.msg_size`, the bytes currently queued ([rdkafka field docs](https://github.com/fede1024/rust-rdkafka/blob/v0.37.0/src/statistics.rs#L36-L43)).
- The alert divides that gauge by `capture_kafka_producer_queue_bytes_limit`, so it evaluates to a constant config ratio rather than a live signal.

## Changes

- The gauge now reports the live queue size in bytes, so the existing alert fires on real byte pressure. One-line fix in the legacy v0 sink at `rust/capture/src/sinks/kafka.rs`.
- The v1 sink already uses `msg_size` and is unchanged.
- No alert expression changes are needed; the alert in [PostHog/charts#14548](https://github.com/PostHog/charts/pull/14548) keeps its `bytes / bytes_limit > 0.40` form.

## How did you test this code?

- `cargo clippy -p capture --all-targets -- -D warnings` passes locally.
- No test added: the gauge is a pass-through from rdkafka stats with no logic to exercise.
- Not run: live verification. After deploy, `capture_kafka_producer_queue_bytes / capture_kafka_producer_queue_bytes_limit` should vary with traffic instead of holding a constant.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), session: https://claude.ai/code/session_01RptC2DGoyKEU83B7YpetRS. Skills invoked: `/writing-pr-descriptions`. The bug was flagged in review on the charts alert migration PR linked above; this PR is the code-side fix so that alert becomes meaningful.
