### PR TITLE
fix(dags): stop a dag import from silencing every existing logger

### DIFF
--- a/posthog/dags/__init__.py
+++ b/posthog/dags/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 import django
+from django.apps import apps
 
 # setup PostHog Django Project
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
@@ -9,4 +10,5 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 # This prevents hanging during database connection in app.ready()
 os.environ["SERVER_GATEWAY_INTERFACE"] = "ASGI"
 
-django.setup()
+if not apps.ready:
+    django.setup()

--- a/posthog/dags/tests/test_loggers.py
+++ b/posthog/dags/tests/test_loggers.py
@@ -68,6 +68,15 @@ def test_engine_event_records_are_dropped_but_messages_pass():
     assert log.filter(_record(dagster_event=None))
 
 
+def test_importing_the_package_does_not_silence_existing_loggers():
+    probe = logging.getLogger("posthog.dags.tests.import_probe")
+    probe.disabled = False
+
+    importlib.reload(importlib.import_module("posthog.dags"))
+
+    assert probe.disabled is False
+
+
 def test_locations_export_single_shared_logger_instance():
     assert loggers == {"console": structlog_console_logger}
 


### PR DESCRIPTION
## Problem

A backend test shard fails whenever it collects any test that imports a dag, and the failure lands on an unrelated module. This blocks PRs that changed neither file. [Example run](https://github.com/PostHog/posthog/actions/runs/32779777193/job/97604814865).

- `posthog/dags/__init__.py` calls `django.setup()` when the package is imported.
- Under pytest Django is already configured, so the second call re-runs `configure_logging`.
- `posthog/settings/logs.py` sets `disable_existing_loggers`, so every logger built before that import is left disabled.
- `posthog/dags/common/loggers.py` already documents this hazard and re-enables its own logger to work around it.

## Changes

- Skip the setup when the app registry is ready. A real Dagster process still runs it, because nothing configured Django there.
- Nothing user-visible changes. A Dagster process behaves as before.

## How did you test this code?

The failing shard reduces to two files. `posthog/management/commands/test/test_persons_dedup.py` asserts its command's INFO logs survive, and `posthog/session/test/test_backfill.py` imports a dag. Either file alone passes.

- Before: `pytest posthog/management/commands/test/test_persons_dedup.py posthog/session/test/test_backfill.py` fails on `test_info_records_survive_the_posthog_logger_clamp`.
- After: the same command passes, 118 tests.
- The new test in `test_loggers.py` catches a removal of the guard: it reloads the package and asserts a logger created first stays enabled. It fails on master.

Not run: the rest of the backend suite, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code found this while fixing CI on an unrelated PR, [#83720](https://github.com/PostHog/posthog/pull/83720). That PR's shard collected a dag importer for the first time, which surfaced the latent disable.

The culprit came from bisecting the shard's 176 collected files down to two, then tracing the `disabled` flag through each import in the surviving file.

The alternative was to set `disable_existing_loggers` to false in `posthog/settings/logs.py`. That changes logging for every process, including production, so this PR guards the duplicate setup instead.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
