### PR TITLE
chore(replay-vision): say "billing period" in spend copy

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7609,7 +7609,7 @@ snapshots:
     scenes-app-replay-vision--observation-detail--light:
         hash: v1.k794b7964.6fa71e0981942176d54c6c3ae7a408f89a874ffe9f5bd9ebaa5eff0555109b74.Gl2gvSnNMXaaiSoqu5RJIQwa-fe5An65LGg_uh-7R-I
     scenes-app-replay-vision--scanner-calibration--dark:
-        hash: v1.k794b7964.466724aa8f93e012ae4eef9408b905ccca0503ad9c3fb83d166404e79e58cf24.iSSmrv7z3isqUmgqRo0TZxcshU-4yNWOF0vzlbCaUn4
+        hash: v1.k794b7964.552e7aeeaa303f346e08cc00e50e01e8ae73b11037189f30ee352c2539c079cc.netD6AKXfx9ScvYD3N4ZNR4wxXAKdtRUxavYrnrURTA
     scenes-app-replay-vision--scanner-calibration--light:
         hash: v1.k794b7964.052104891cea7a902b874826c922e3688d23053b0ebb2128b1c0dbca7ab2a32b.LofDLlNAhm2-XL4aPULNJ7Wwduy_ZItRnWWQdAvir1k
     scenes-app-replay-vision--scanner-configuration--dark:

--- a/products/replay_vision/backend/api/prompt_suggestions.py
+++ b/products/replay_vision/backend/api/prompt_suggestions.py
@@ -453,7 +453,7 @@ class ReplayScannerPromptSuggestionViewSet(
                         detail=(
                             f"This test would use {planned_credits:,} credits but this scanner has "
                             f"{scanner_budget.remaining or 0:,} left of its {scanner_budget.credit_limit or 0:,} credit "
-                            f"limit for this period. Lower the test session count or raise the scanner's limit."
+                            f"limit for this billing period. Lower the test session count or raise the scanner's limit."
                         ),
                         code="scanner_credit_limit_exceeded",
                     )

--- a/products/replay_vision/backend/api/trigger.py
+++ b/products/replay_vision/backend/api/trigger.py
@@ -94,7 +94,7 @@ def check_scanner_quota(scanner: ReplayScanner) -> None:
         raise QuotaLimitExceeded(
             detail=(
                 f"This scanner has {budget.remaining:,} of its {budget.credit_limit:,} credit limit left "
-                f"for this period, not enough for another observation. Raise the scanner's limit to keep "
+                f"for this billing period, not enough for another observation. Raise the scanner's limit to keep "
                 f"scanning."
             ),
             code="scanner_credit_limit_exceeded",

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -191,7 +191,7 @@ function QuotaBanner(): JSX.Element | null {
         <LemonBanner type="warning">
             {state.kind === 'exhausted'
                 ? `${
-                      onFreePlan ? 'Free credits used up' : 'Monthly spend limit reached'
+                      onFreePlan ? 'Free credits used up' : 'Spend limit reached'
                   }: ${formatCreditsRange(state.quota.credits_used, state.quota.credit_limit ?? 0)}. New observations are paused until ${state.resetsOn}.`
                 : onFreePlan
                   ? `You've used ${Math.round(state.quota.credits_used).toLocaleString('en-US')} of your ${Math.round(state.quota.credit_limit ?? 0).toLocaleString('en-US')} free credits this billing period. New observations will pause once they run out. Resets ${state.resetsOn}.`

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -194,8 +194,8 @@ function QuotaBanner(): JSX.Element | null {
                       onFreePlan ? 'Free credits used up' : 'Monthly spend limit reached'
                   }: ${formatCreditsRange(state.quota.credits_used, state.quota.credit_limit ?? 0)}. New observations are paused until ${state.resetsOn}.`
                 : onFreePlan
-                  ? `You've used ${Math.round(state.quota.credits_used).toLocaleString('en-US')} of your ${Math.round(state.quota.credit_limit ?? 0).toLocaleString('en-US')} free credits this month. New observations will pause once they run out. Resets ${state.resetsOn}.`
-                  : `You've used ${formatCreditsRange(state.quota.credits_used, state.quota.credit_limit ?? 0)} this month. New observations will pause once you hit the limit. Resets ${state.resetsOn}.`}
+                  ? `You've used ${Math.round(state.quota.credits_used).toLocaleString('en-US')} of your ${Math.round(state.quota.credit_limit ?? 0).toLocaleString('en-US')} free credits this billing period. New observations will pause once they run out. Resets ${state.resetsOn}.`
+                  : `You've used ${formatCreditsRange(state.quota.credits_used, state.quota.credit_limit ?? 0)} this billing period. New observations will pause once you hit the limit. Resets ${state.resetsOn}.`}
         </LemonBanner>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -156,7 +156,7 @@ export function ReplayScannersScene(): JSX.Element {
             sorter: true,
         },
         {
-            title: 'Spend this billing period',
+            title: 'Spend this period',
             key: 'credits_this_month',
             render: (_, scanner) => (
                 <div className="text-sm tabular-nums">

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -156,7 +156,7 @@ export function ReplayScannersScene(): JSX.Element {
             sorter: true,
         },
         {
-            title: 'Spend this period',
+            title: 'Spend this billing period',
             key: 'credits_this_month',
             render: (_, scanner) => (
                 <div className="text-sm tabular-nums">

--- a/products/replay_vision/frontend/replay_scanners/components/BackfillCostEstimate.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/BackfillCostEstimate.tsx
@@ -56,7 +56,7 @@ export function BackfillCostEstimate({ estimate, loading }: Props): JSX.Element 
     const breakdown = (
         <div className="text-xs space-y-0.5">
             <div>
-                Spent this period: <strong>{formatCreditCount(used)}</strong>
+                Spent this billing period: <strong>{formatCreditCount(used)}</strong>
             </div>
             <div>
                 Projected from scanners:{' '}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerCalibrationTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerCalibrationTab.tsx
@@ -218,7 +218,7 @@ function SuggestionEvaluationPanel({
                         {summary.errors > 0 && <LemonTag type="muted">{summary.errors} failed to run</LemonTag>}
                     </>
                 )}
-                <Tooltip title="Only results that ran successfully count against the monthly Replay Vision quota">
+                <Tooltip title="Only results that ran successfully count against the Replay vision quota">
                     <span className="text-muted text-xs">
                         {chargedCount} observation{chargedCount === 1 ? '' : 's'} charged to your quota
                     </span>
@@ -409,7 +409,7 @@ function ConfigRecommendationPanel({ scannerId }: { scannerId: string }): JSX.El
                                     (ratedCount === 0
                                         ? 'Rate at least one result first'
                                         : quota?.exhausted && quota.credit_limit !== null
-                                          ? `Monthly Replay vision budget of ${formatCreditCount(quota.credit_limit)} reached. Resets ${dayjs(quota.period_end).format('MMM D')}.`
+                                          ? `Replay vision budget of ${formatCreditCount(quota.credit_limit)} reached. Resets ${dayjs(quota.period_end).format('MMM D')}.`
                                           : quota && quota.remaining !== null && plannedTestCredits > quota.remaining
                                             ? `Only ${formatCreditCount(quota.remaining)} of budget left this billing period. Lower the number of results to test.`
                                             : undefined)

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerCalibrationTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerCalibrationTab.tsx
@@ -409,9 +409,9 @@ function ConfigRecommendationPanel({ scannerId }: { scannerId: string }): JSX.El
                                     (ratedCount === 0
                                         ? 'Rate at least one result first'
                                         : quota?.exhausted && quota.credit_limit !== null
-                                          ? `Monthly Replay Vision budget of ${formatCreditCount(quota.credit_limit)} reached. Resets ${dayjs(quota.period_end).format('MMM D')}.`
+                                          ? `Monthly Replay vision budget of ${formatCreditCount(quota.credit_limit)} reached. Resets ${dayjs(quota.period_end).format('MMM D')}.`
                                           : quota && quota.remaining !== null && plannedTestCredits > quota.remaining
-                                            ? `Only ${formatCreditCount(quota.remaining)} of budget left this period. Lower the number of results to test.`
+                                            ? `Only ${formatCreditCount(quota.remaining)} of budget left this billing period. Lower the number of results to test.`
                                             : undefined)
                                 }
                                 tooltip="Re-runs the scanner with the suggested prompt against your rated results, so you can see what would change. Each tested result is charged like a normal observation."
@@ -469,7 +469,7 @@ function ConfigRecommendationPanel({ scannerId }: { scannerId: string }): JSX.El
                             {Math.min(evaluationSessionCap, ratedCount) === 1 ? '' : 's'}, thumbs down first. Costs{' '}
                             {formatCreditCount(plannedTestCredits)}
                             {displayQuota && displayQuota.remaining !== null && displayQuota.credit_limit !== null
-                                ? `, ${formatCreditsRange(displayQuota.remaining, displayQuota.credit_limit)} left this period`
+                                ? `, ${formatCreditsRange(displayQuota.remaining, displayQuota.credit_limit)} left this billing period`
                                 : ''}
                             .
                         </span>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerCreditLimit.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerCreditLimit.tsx
@@ -86,8 +86,8 @@ export function ScannerCreditLimit({ scannerId }: ScannerCreditLimitProps): JSX.
                             )}
                             <div className="text-xs text-muted">
                                 When this scanner reaches its limit, it stops scanning until the next billing period. It
-                                stays enabled, but sessions it skipped this period aren't scanned later, even after you
-                                raise the limit.
+                                stays enabled, but sessions it skipped this billing period aren't scanned later, even
+                                after you raise the limit.
                             </div>
                         </>
                     )}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
@@ -94,7 +94,7 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
     const breakdown = (
         <div className="text-xs space-y-0.5">
             <div>
-                Spent this period: <strong>{formatCreditCount(used)}</strong>
+                Spent this billing period: <strong>{formatCreditCount(used)}</strong>
             </div>
             <div>
                 Projected from this scanner: <strong>~{formatCreditCount(projectedCredits ?? 0)}/month</strong>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
@@ -120,7 +120,7 @@ export function VisionMetrics(): JSX.Element {
                 </div>
                 <div className="flex-1 bg-bg-light border rounded p-4 flex flex-col">
                     <div className="flex items-baseline justify-between gap-3 mb-2">
-                        <div className="text-muted text-xs font-medium uppercase">Spend this period</div>
+                        <div className="text-muted text-xs font-medium uppercase">Spend this billing period</div>
                         {hasCap && (
                             <span className={`text-xs tabular-nums ${styles.text}`}>
                                 {periodEndPct}%{' '}
@@ -153,7 +153,7 @@ export function VisionMetrics(): JSX.Element {
                                         title={
                                             <div className="text-xs space-y-0.5">
                                                 <div>
-                                                    Spent this period:{' '}
+                                                    Spent this billing period:{' '}
                                                     <strong>{formatCreditCount(quota.credits_used)}</strong>
                                                 </div>
                                                 <div>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
@@ -211,11 +211,11 @@ export function VisionUsageTab(): JSX.Element {
             },
         },
         {
-            title: 'Spend this period',
+            title: 'Spend this billing period',
             key: 'credits_this_month',
             width: '30%',
             className: 'pl-6',
-            tooltip: 'How much of the total spend this period came from this scanner.',
+            tooltip: 'How much of the total spend this billing period came from this scanner.',
             render: (_, scanner) => {
                 const sharePct = totalCredits > 0 ? Math.round((scanner.credits_this_month / totalCredits) * 100) : 0
                 return (
@@ -243,7 +243,7 @@ export function VisionUsageTab(): JSX.Element {
                                     {hasCap
                                         ? formatCreditsRange(quota.credits_used, quota.credit_limit ?? 0)
                                         : formatCreditCount(quota.credits_used)}{' '}
-                                    this period
+                                    this billing period
                                     {projection.resetsOn ? `, resets ${projection.resetsOn}` : ''}
                                 </span>
                             </Tooltip>
@@ -282,7 +282,7 @@ export function VisionUsageTab(): JSX.Element {
                 rowKey={(scanner) => scanner.id}
                 emptyState={
                     <>
-                        No spend this period yet. Costs appear here once scanners produce observations.{' '}
+                        No spend this billing period yet. Costs appear here once scanners produce observations.{' '}
                         <VisionDocsLink page="quota-and-limits" dataAttr="vision-empty-docs-link-usage">
                             Learn how credits and limits work
                         </VisionDocsLink>
@@ -291,7 +291,8 @@ export function VisionUsageTab(): JSX.Element {
                 footer={
                     hiddenCount > 0 ? (
                         <div className="px-3 py-2 text-xs text-muted">
-                            {hiddenCount} scanner{hiddenCount === 1 ? '' : 's'} with no spend or estimate this period
+                            {hiddenCount} scanner{hiddenCount === 1 ? '' : 's'} with no spend or estimate this billing
+                            period
                         </div>
                     ) : undefined
                 }

--- a/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
@@ -211,7 +211,7 @@ export function VisionUsageTab(): JSX.Element {
             },
         },
         {
-            title: 'Spend this billing period',
+            title: 'Spend this period',
             key: 'credits_this_month',
             width: '30%',
             className: 'pl-6',

--- a/products/replay_vision/frontend/utils/quotaProjection.ts
+++ b/products/replay_vision/frontend/utils/quotaProjection.ts
@@ -153,7 +153,7 @@ export function quotaUx(quota: VisionQuotaApi | null): { disabledReason?: string
         }
     }
     return {
-        tooltip: `${formatCreditCount(state.quota.remaining ?? 0)} left this month (resets ${state.resetsOn})`,
+        tooltip: `${formatCreditCount(state.quota.remaining ?? 0)} left this billing period (resets ${state.resetsOn})`,
     }
 }
 

--- a/products/replay_vision/frontend/utils/quotaProjection.ts
+++ b/products/replay_vision/frontend/utils/quotaProjection.ts
@@ -149,7 +149,7 @@ export function quotaUx(quota: VisionQuotaApi | null): { disabledReason?: string
         return {
             disabledReason: isFreeAllocationOnly(quota)
                 ? `You've used all your free Replay vision credits. Resets ${state.resetsOn}.`
-                : `Monthly Replay vision spend limit reached. Resets ${state.resetsOn}.`,
+                : `Replay vision spend limit reached. Resets ${state.resetsOn}.`,
         }
     }
     return {


### PR DESCRIPTION
## Problem

Someone reading the Replay vision spend tile could not tell what period the number covered. The tile sits next to the Observations over time chart, which has its own date filter, so the spend figure looked like it followed the chart. It always follows the organization's billing period.

## Changes

- The spend tile, usage table, and scan-trigger tooltips now name the window: "this billing period".
- The scanner credit limit card no longer contradicts itself. It said "until the next billing period" and "skipped this period" two lines apart.
- The quota banner and calibration tab said "this month", wrong for any organization whose billing period is not a calendar month.
- Labels that said "Monthly limit" or "Monthly spend limit reached" drop the word. The reset date already carries the cadence, and `quota.credit_limit` is resolved from the billing period, not a calendar month.
- Two quota errors from the API now match. Their text is toasted verbatim, so a user could read "this billing period" in the banner and "this period" in the toast one click later.
- One tooltip read "Replay Vision" and now matches the sentence-case "Replay vision" used elsewhere.
- Copy only. No behavior, query, or layout change.

The backend already worked this way. `current_period_bounds()` resolves the organization's billing period and falls back to calendar months only when billing has not synced.

`credits_this_month` keeps its name. It is a generated API field, it backs `order_by=credits_this_month`, and it reaches MCP tool schemas. Per-month rate suffixes such as "1,200 credits/month" keep "month", because they state a rate rather than the current window.

## How did you test this code?

- `quotaProjection.test.ts` and `QuotaStatusLine.test.tsx` pass, 38 tests.
- No test asserted the old copy, so none changed. None added: a test asserting a label matches itself catches no regression.
- Visual review flagged 8 changed snapshots out of 1114, all of them the changed labels.
- Both spend column headers keep the shorter "Spend this period". The longer phrasing widened the scanners list column noticeably.
- The usage table column keeps the full phrasing in its tooltip, so the precision is one hover away.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code reviewed the original five-file change and swept the surfaces it left behind. Skills invoked: writing-user-facing-copy, writing-pr-descriptions, code-review, simplify.

Left for a follow-up: `QuotaStatusLine.tsx` says "Monthly spend limit exceeded" and has a test pinned to that string; "Replay Vision" survives in `bulkScanLogic.ts` and the product empty state; `quota.py` and `scanners.py` help_text say "this period" but regenerate TS types and MCP schemas.

---

*Created by [PostHog](https://posthog.com?ref=pr) from [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1787609247957529?thread_ts=1787609247.957529&cid=C03PB072FMJ)*
