### PR TITLE
feat(cdp): charge watcher cost for failed invocations

### DIFF
--- a/nodejs/src/cdp/cdp-e2e.test.ts
+++ b/nodejs/src/cdp/cdp-e2e.test.ts
@@ -72,6 +72,7 @@ describe('CDP Consumer loop', () => {
 
             hub.CDP_FETCH_RETRIES = 2
             hub.CDP_FETCH_BACKOFF_BASE_MS = 100 // fast backoff
+            hub.CDP_WATCHER_COST_ERROR = 1
             hub.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA = true
 
             // Include integration parsing as part of the e2e check
@@ -528,6 +529,28 @@ describe('CDP Consumer loop', () => {
             // signature window.
             expect(sigv4AmzDates[0]).not.toEqual(sigv4AmzDates[1])
             expect(sigv4Authorizations[0]).not.toEqual(sigv4Authorizations[1])
+        })
+
+        it('charges the hog watcher when a destination exhausts its retries', async () => {
+            // The unit tests build an errored result by hand. This case proves the executor sets
+            // `error` once retries run out, that the worker forwards the result to the watcher, and
+            // that the charge reaches Redis.
+            mockFetch.mockImplementation(() => {
+                return Promise.resolve({
+                    status: 500,
+                    headers: {},
+                    json: () => Promise.resolve({ error: 'Server error' }),
+                    text: () => Promise.resolve(JSON.stringify({ error: 'Server error' })),
+                    dump: () => Promise.resolve(),
+                })
+            })
+
+            await eventsConsumer.processBatch([globals])
+
+            await waitForExpect(async () => {
+                const state = await cyclotronWorker.hogWatcher.getPersistedState(fnFetchNoFilters.id)
+                expect(hub.CDP_WATCHER_BUCKET_SIZE - state.tokens).toBeGreaterThanOrEqual(hub.CDP_WATCHER_COST_ERROR)
+            }, 10000)
         })
 
         it('should handle fetch failures with retries', async () => {

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -124,6 +124,7 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_WATCHER_ASYNC_COST_TIMING_LOWER_MS'
         | 'CDP_WATCHER_ASYNC_COST_TIMING_UPPER_MS'
         | 'CDP_WATCHER_ASYNC_COST_TIMING'
+        | 'CDP_WATCHER_COST_ERROR'
         | 'CDP_WATCHER_SEND_EVENTS'
         | 'CDP_WATCHER_BUCKET_SIZE'
         | 'CDP_WATCHER_REFILL_RATE'
@@ -364,6 +365,7 @@ export function createCdpCoreServices(
         asyncCostTimingLowerMs: config.CDP_WATCHER_ASYNC_COST_TIMING_LOWER_MS,
         asyncCostTimingUpperMs: config.CDP_WATCHER_ASYNC_COST_TIMING_UPPER_MS,
         asyncCostTiming: config.CDP_WATCHER_ASYNC_COST_TIMING,
+        costError: config.CDP_WATCHER_COST_ERROR,
         sendEvents: config.CDP_WATCHER_SEND_EVENTS,
         bucketSize: config.CDP_WATCHER_BUCKET_SIZE,
         refillRate: config.CDP_WATCHER_REFILL_RATE,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -201,8 +201,9 @@ export type CdpConfig = ClickhouseConfig & {
 export function getDefaultCdpConfig(): CdpConfig {
     return {
         ...getDefaultClickhouseConfig(),
-        // Off by default: enabling fleet-wide auto-disable is a rollout decision, made per
-        // environment in charts. Only bites above CDP_WATCHER_REFILL_RATE errors/sec.
+        // Off by default because enabling shedding across every destination is a rollout
+        // decision, taken per environment in charts. A non-zero cost only drains the bucket on
+        // net once a function exceeds CDP_WATCHER_REFILL_RATE failures per second.
         CDP_WATCHER_COST_ERROR: 0,
         CDP_WATCHER_HOG_COST_TIMING: 100,
         CDP_WATCHER_HOG_COST_TIMING_LOWER_MS: 50,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -201,7 +201,9 @@ export type CdpConfig = ClickhouseConfig & {
 export function getDefaultCdpConfig(): CdpConfig {
     return {
         ...getDefaultClickhouseConfig(),
-        CDP_WATCHER_COST_ERROR: 100,
+        // Off by default: enabling fleet-wide auto-disable is a rollout decision, made per
+        // environment in charts. Only bites above CDP_WATCHER_REFILL_RATE errors/sec.
+        CDP_WATCHER_COST_ERROR: 0,
         CDP_WATCHER_HOG_COST_TIMING: 100,
         CDP_WATCHER_HOG_COST_TIMING_LOWER_MS: 50,
         CDP_WATCHER_HOG_COST_TIMING_UPPER_MS: 550,

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.test.ts
@@ -21,6 +21,7 @@ const DEFAULT_WATCHER_CONFIG: HogWatcherConfig = {
     asyncCostTimingLowerMs: 100,
     asyncCostTimingUpperMs: 5000,
     asyncCostTiming: 20,
+    costError: 0,
     sendEvents: true,
     bucketSize: 10000,
     refillRate: 10,
@@ -188,6 +189,45 @@ describe('HogWatcher', () => {
                 expect(result.state).toEqual(expectedScore.state)
             }
         )
+
+        describe('error cost', () => {
+            const rebuildWith = (costError: number) => {
+                watcherConfig.costError = costError
+                watcher = new HogWatcherService(hub.teamManager, watcherConfig, redis)
+            }
+
+            const erroredResult = () => createResult({ error: 'Webhook failed with status 429' })
+
+            it.each([
+                ['charges nothing while disabled', 0, [erroredResult, erroredResult, erroredResult], 0],
+                ['charges once per errored result', 100, [erroredResult], 100],
+                ['accumulates across errored results', 100, [erroredResult, erroredResult, erroredResult], 300],
+                ['charges nothing for a successful result', 100, [() => createResult({})], 0],
+            ])('%s', async (_name, costError, makeResults, expectedCost) => {
+                rebuildWith(costError as number)
+
+                await watcher.observeResults((makeResults as (() => any)[]).map((make) => make()))
+
+                const state = await watcher.getPersistedState(hogFunctionId)
+                expect(hub.CDP_WATCHER_BUCKET_SIZE - state.tokens).toEqual(expectedCost)
+            })
+
+            it('sheds a function failing fast in volume, and leaves it healthy when disabled', async () => {
+                // The Discord incident shape: a destination erroring thousands of times an hour
+                // returns too quickly to accrue timing cost, so it stayed healthy indefinitely.
+                const failFast = () => Array.from({ length: 100 }, erroredResult)
+
+                rebuildWith(0)
+                await watcher.observeResults(failFast())
+                expect((await watcher.getPersistedState(hogFunctionId)).state).toEqual(HogWatcherState.healthy)
+
+                await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
+
+                rebuildWith(100)
+                await watcher.observeResults(failFast())
+                expect((await watcher.getPersistedState(hogFunctionId)).state).not.toEqual(HogWatcherState.healthy)
+            })
+        })
 
         it('should calculate costs per individual timing not based on total duration', async () => {
             // Create a result with multiple timings that would have different costs

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -22,6 +22,7 @@ export interface HogWatcherConfig {
     asyncCostTimingLowerMs: number
     asyncCostTimingUpperMs: number
     asyncCostTiming: number
+    costError: number
     sendEvents: boolean
     bucketSize: number
     refillRate: number
@@ -432,6 +433,13 @@ export class HogWatcherService {
                 functionId: result.invocation.functionId,
                 cost: 0,
                 hogFunction: result.invocation.hogFunction,
+            }
+
+            // A function that fails fast accrues almost no timing cost, so without this a
+            // destination erroring thousands of times a second stays healthy forever and keeps
+            // hammering the third party. Charged once per terminal failure, not per retry.
+            if (result.error) {
+                functionCost.cost += this.config.costError
             }
 
             if (result.finished) {

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.ts
@@ -435,9 +435,9 @@ export class HogWatcherService {
                 hogFunction: result.invocation.hogFunction,
             }
 
-            // A function that fails fast accrues almost no timing cost, so without this a
-            // destination erroring thousands of times a second stays healthy forever and keeps
-            // hammering the third party. Charged once per terminal failure, not per retry.
+            // The timing costs below only charge for slow execution, so a function that fails
+            // quickly accrues nothing and never leaves the healthy state, however often it fails.
+            // Charged once per terminal failure, so a retried invocation pays when it gives up.
             if (result.error) {
                 functionCost.cost += this.config.costError
             }

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.service.unit.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.service.unit.test.ts
@@ -18,6 +18,7 @@ const WATCHER_CONFIG: HogWatcherConfig = {
     asyncCostTimingLowerMs: 100,
     asyncCostTimingUpperMs: 5000,
     asyncCostTiming: 20,
+    costError: 0,
     sendEvents: false,
     bucketSize: 10000,
     refillRate: 10,

--- a/nodejs/src/cdp/services/monitoring/hog-watcher.valkey.integration.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-watcher.valkey.integration.test.ts
@@ -20,6 +20,7 @@ const WATCHER_CONFIG: HogWatcherConfig = {
     asyncCostTimingLowerMs: 100,
     asyncCostTimingUpperMs: 5000,
     asyncCostTiming: 20,
+    costError: 0,
     sendEvents: false,
     bucketSize: 10000,
     refillRate: 10,


### PR DESCRIPTION
## Problem

A destination that fails fast is never degraded or disabled, so it keeps sending requests to a third-party API that is already rejecting them. When that API rate-limits by IP, deliveries fail for every customer using the same provider, not only the one whose destination is broken.

- The hog watcher charges the token bucket only for execution timings (`hog-watcher.service.ts`, `observeResults`).
- A fast failure produces a short timing, and cost scales from the timing's duration, so it rounds to zero.
- A function can therefore fail on every single invocation, indefinitely, and stay `healthy`.
- `CDP_WATCHER_COST_ERROR` has existed for this and is read nowhere.

## Changes

- Nothing changes on merge. The setting defaults to `0`, so the watcher behaves exactly as it does today until an environment opts in.
- The watcher charges `CDP_WATCHER_COST_ERROR` once per terminal failure, alongside the existing timing costs.
- `CDP_WATCHER_COST_ERROR` reaches the watcher for the first time, through `CdpCoreServicesConfig`.
- The default drops from `100` to `0`.

Defaulting to `0` rather than shipping a value is the part worth reviewing. Enabling this turns on automatic degrade-and-disable for every destination in an environment at once, which is a rollout decision rather than a code change. Enabling it is a charts value, tunable per environment without a deploy.

The cost is self-calibrating against the existing refill. A non-zero cost only drains the bucket on net once a function exceeds `CDP_WATCHER_REFILL_RATE` failures per second, so a destination failing a few times a day never approaches a transition, while one failing continuously reaches `degraded` in minutes.

> [!NOTE]
> This sheds a broken destination. It does not make the retries themselves better behaved. Honoring `Retry-After` and backing retries off both need `queueScheduledAt` to survive the queue, which the Kafka job queue drops today. Those are separate follow-ups.

## How did you test this code?

Automated, run by the agent against real Redis and Postgres in a sandbox:

- Added 5 cases to the existing `observeResults` describe in `hog-watcher.service.test.ts`.
- The parameterized cases catch a removed charge or a miswired config key: each would silently restore "fails fast, never shed", and no existing case covers an errored result at all.
- The last case encodes the failure shape directly. The same volume of fast failures leaves the function `healthy` at cost `0`, and moves it out of `healthy` above `0`.

Not done, and worth a reviewer knowing:

- No end-to-end run against a live worker consuming from Kafka with a real failing destination. The sandbox cannot pull the container images that stack needs.
- `hog-watcher.valkey.integration.test.ts` has one failing case in the sandbox, `reproduces CROSSSLOT`. It needs a Valkey cluster rather than standalone Redis, and it fails identically on `master` in the same sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code) wrote this. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The change started from a question about why a destination failing on every invocation was never disabled automatically. Reading `observeResults` showed the cost model only charges for timings, and `CDP_WATCHER_COST_ERROR` was already declared, defaulted, and unused, which suggested the intent existed and the wiring was missing.

The first version kept the existing default of `100`. That was wrong: at a bucket of 10000 it disables a function after 100 failures regardless of rate, which would shed destinations that fail in short bursts and recover. Defaulting to `0` and letting the value calibrate against `CDP_WATCHER_REFILL_RATE` keeps the decision with whoever rolls it out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjAwGCorRz6qs3YiLMqRKL)_