### PR TITLE
feat(desktop): refine self-driving report actions

### DIFF
--- a/products/desktop/packages/ui/src/features/browser-tabs/tabAppViews.tsx
+++ b/products/desktop/packages/ui/src/features/browser-tabs/tabAppViews.tsx
@@ -37,7 +37,7 @@ export const TAB_APP_VIEW_META: Record<
     icon: <ClockCounterClockwiseIcon size={14} />,
   },
   home: { label: "Home", icon: <SquaresFourIcon size={14} /> },
-  inbox: { label: "Inbox", icon: <TrayIcon size={14} /> },
+  inbox: { label: "Self-driving", icon: <TrayIcon size={14} /> },
   agents: { label: "Agents", icon: <RobotIcon size={14} /> },
   loops: { label: "Loops", icon: <RepeatIcon size={14} /> },
   archived: { label: "Archived", icon: <ArchiveIcon size={14} /> },

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -343,7 +343,7 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
     <div className="flex h-full flex-col justify-between gap-3 p-3">
       <div className="flex flex-col gap-1 pt-1">
         <span className="font-medium text-[14px] text-gray-12">
-          Chat about this report
+          Chat with this report
         </span>
         <span className="text-[13px] text-gray-11">
           The agent joins with the full report and its evidence already in

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -221,7 +221,7 @@ function ReportChatConversation({
           </Button>
           <Button
             type="button"
-            variant="default"
+            variant="outline"
             className="h-9 flex-1 rounded-lg px-4 text-[13px]"
             loading={sendingPrompt === canvasPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
@@ -335,7 +335,7 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
       prompt:
         "Create a canvas that visualizes this report using its evidence and relevant live data.",
       Icon: ShapesIcon,
-      variant: "default" as const,
+      variant: "outline" as const,
     },
   ];
 

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -313,6 +313,24 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
     [isDiscussing, discussReport, fireAction],
   );
 
+  const starterPrompts = [
+    { label: "What caused this?", prompt: "What caused this?" },
+    { label: "Who is affected?", prompt: "Who is affected?" },
+    {
+      label: "Walk me through the fix",
+      prompt: "Walk me through the fix",
+    },
+    ...(!report.implementation_pr_url
+      ? [
+          {
+            label: "Visualize in a canvas",
+            prompt:
+              "Create a canvas that visualizes this report using its evidence and relevant live data.",
+          },
+        ]
+      : []),
+  ];
+
   return (
     <div className="flex h-full flex-col justify-between gap-3 p-3">
       <div className="flex flex-col gap-1 pt-1">
@@ -324,13 +342,9 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
           context. Highlight any part of the report to quote it here.
         </span>
         <div className="mt-1 flex flex-wrap gap-1.5">
-          {[
-            "What caused this?",
-            "Who is affected?",
-            "Walk me through the fix",
-          ].map((prompt) => (
+          {starterPrompts.map(({ label, prompt }) => (
             <Button
-              key={prompt}
+              key={label}
               type="button"
               variant="outline"
               size="sm"
@@ -340,7 +354,7 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
               disabled={isDiscussing || starterDraft.trim().length > 0}
               onClick={() => ask(prompt)}
             >
-              {prompt}
+              {label}
             </Button>
           ))}
         </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -342,9 +342,6 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
   return (
     <div className="flex h-full flex-col justify-between gap-3 p-3">
       <div className="flex flex-col gap-1 pt-1">
-        <span className="font-medium text-[14px] text-gray-12">
-          Chat with this report
-        </span>
         <span className="text-[13px] text-gray-11">
           The agent joins with the full report and its evidence already in
           context. Highlight any part of the report to quote it here.

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -2,7 +2,9 @@ import {
   ArrowsOutSimpleIcon,
   ChatCircleIcon,
   GitPullRequestIcon,
+  MagnifyingGlassIcon,
   ShapesIcon,
+  WrenchIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import {
@@ -150,11 +152,11 @@ function ReportChatConversation({
   );
   const [sendingPrompt, setSendingPrompt] = useState<string | null>(null);
   const workPrompt = report.implementation_pr_url
-    ? "Continue working on this report. Take the next concrete step toward resolving it."
-    : "Fix the issue in this report and monitor the result.";
+    ? "Continue working on this report and its existing pull request. Re-read the analysis and take the next concrete step toward resolving it."
+    : "Continue investigating this report. Analyze the evidence and take the next concrete step.";
   const workLabel = report.implementation_pr_url
-    ? "Continue the task"
-    : "Fix and monitor";
+    ? "Continue the fix"
+    : "Continue the analysis";
   const canvasPrompt =
     "Create a canvas that visualizes this report using its evidence and relevant live data.";
 
@@ -205,28 +207,28 @@ function ReportChatConversation({
     <EmbeddedSessionView
       task={task}
       threadActions={({ sendPrompt, isPromptPending }) => (
-        <div className="flex flex-wrap items-center gap-1.5 border-border border-t px-3 py-2">
+        <div className="flex items-center gap-2 border-border border-t px-3 py-3">
           <Button
             type="button"
-            variant="outline"
-            className="h-7 rounded-full px-3 text-[12px]"
+            variant="primary"
+            className="h-9 flex-1 rounded-lg px-4 text-[13px]"
             loading={sendingPrompt === workPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
             onClick={() => void sendSuggestedPrompt(workPrompt, sendPrompt)}
           >
-            <GitPullRequestIcon size={13} />
+            <GitPullRequestIcon size={15} />
             {workLabel}
           </Button>
           <Button
             type="button"
-            variant="outline"
-            className="h-7 rounded-full px-3 text-[12px]"
+            variant="default"
+            className="h-9 flex-1 rounded-lg px-4 text-[13px]"
             loading={sendingPrompt === canvasPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
             onClick={() => void sendSuggestedPrompt(canvasPrompt, sendPrompt)}
           >
-            <ShapesIcon size={13} />
-            Visualize on a canvas
+            <ShapesIcon size={15} />
+            Visualize in a Canvas
           </Button>
         </div>
       )}
@@ -314,21 +316,27 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
   );
 
   const starterPrompts = [
-    { label: "What caused this?", prompt: "What caused this?" },
-    { label: "Who is affected?", prompt: "Who is affected?" },
     {
-      label: "Walk me through the fix",
-      prompt: "Walk me through the fix",
+      label: "Fix this issue",
+      prompt:
+        "Fix the issue in this report. Investigate the root cause, implement the fix, and open a pull request.",
+      Icon: WrenchIcon,
+      variant: "primary" as const,
     },
-    ...(!report.implementation_pr_url
-      ? [
-          {
-            label: "Visualize in a canvas",
-            prompt:
-              "Create a canvas that visualizes this report using its evidence and relevant live data.",
-          },
-        ]
-      : []),
+    {
+      label: "Investigate further",
+      prompt:
+        "Continue investigating this report. Analyze the evidence and explain the most useful next step.",
+      Icon: MagnifyingGlassIcon,
+      variant: "outline" as const,
+    },
+    {
+      label: "Visualize in a Canvas",
+      prompt:
+        "Create a canvas that visualizes this report using its evidence and relevant live data.",
+      Icon: ShapesIcon,
+      variant: "default" as const,
+    },
   ];
 
   return (
@@ -341,19 +349,20 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
           The agent joins with the full report and its evidence already in
           context. Highlight any part of the report to quote it here.
         </span>
-        <div className="mt-1 flex flex-wrap gap-1.5">
-          {starterPrompts.map(({ label, prompt }) => (
+        <div className="mt-2 grid gap-2">
+          {starterPrompts.map(({ label, prompt, Icon, variant }) => (
             <Button
               key={label}
               type="button"
-              variant="outline"
-              size="sm"
+              variant={variant}
+              className="h-10 justify-start rounded-lg px-4 text-[13px]"
               // Once the composer holds a typed draft or a quoted passage, the
               // one-click chips step aside — firing a chip must not silently
               // discard what the user wrote or highlighted.
               disabled={isDiscussing || starterDraft.trim().length > 0}
               onClick={() => ask(prompt)}
             >
+              <Icon size={16} />
               {label}
             </Button>
           ))}


### PR DESCRIPTION
## Problem

Report chat suggestions do not clearly separate fixing, investigating, and visualizing.

**Why:** Report readers need obvious next actions that match the work they want to do.

## Changes

- New chats offer **Fix this issue**, **Investigate further**, and **Visualize in a Canvas** as large, prioritized actions.
- Existing chats offer one continuation action and one Canvas action.
- Canvas actions use an outline so every secondary action has a clear boundary.
- Existing PRs use **Continue the fix** so the current implementation work stays clear.
- The top tab labels this area **Self-driving**.

No screenshot: the authenticated report state was unavailable in the local environment.

## How did you test this code?

Ran the relevant report detail and browser tab tests.

Confirmed the desktop UI package typechecks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. The actions update an existing report interaction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change with the `posthog-desktop`, `writing-user-facing-copy`, and `writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*