### PR TITLE
feat(desktop): experiment with report chat default state

### DIFF
--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -75,6 +75,10 @@ export const CHANNEL_REPORTS_FLAG = "posthog-desktop-channel-reports";
  */
 export const REPORTS_INBOX_FLAG = "posthog-desktop-reports-inbox";
 
+/** Experiment: open the report chat panel when a report detail loads. */
+export const REPORT_CHAT_DEFAULT_OPEN_FLAG =
+  "posthog-desktop-report-chat-default-open";
+
 /**
  * One-report-at-a-time keyboard triage inside the reports inbox. On by
  * default in dev builds for iteration (see useTriageFocusEnabled); off in

--- a/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagVariant.test.tsx
+++ b/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagVariant.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFeatureFlagVariant } from "./useFeatureFlagVariant";
+
+const { flags } = vi.hoisted(() => ({
+  flags: {
+    getVariant: vi.fn<(key: string) => string | undefined>(),
+    onFlagsLoaded: vi.fn<(handler: () => void) => () => void>(),
+  },
+}));
+
+vi.mock("@posthog/di/react", () => ({ useService: () => flags }));
+
+describe("useFeatureFlagVariant", () => {
+  beforeEach(() => {
+    flags.getVariant.mockReset();
+    flags.onFlagsLoaded.mockReset();
+    flags.onFlagsLoaded.mockReturnValue(() => undefined);
+  });
+
+  it("updates when feature flags load", () => {
+    let onFlagsLoaded: (() => void) | undefined;
+    flags.getVariant
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue("test");
+    flags.onFlagsLoaded.mockImplementation((handler) => {
+      onFlagsLoaded = handler;
+      return () => undefined;
+    });
+
+    const { result } = renderHook(() => useFeatureFlagVariant("report-chat"));
+    expect(result.current).toBeUndefined();
+
+    act(() => onFlagsLoaded?.());
+
+    expect(result.current).toBe("test");
+    expect(flags.getVariant).toHaveBeenCalledWith("report-chat");
+  });
+});

--- a/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagVariant.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagVariant.ts
@@ -1,0 +1,16 @@
+import { useService } from "@posthog/di/react";
+import { useEffect, useState } from "react";
+import { FEATURE_FLAGS, type FeatureFlags } from "./identifiers";
+
+export function useFeatureFlagVariant(flagKey: string): string | undefined {
+  const flags = useService<FeatureFlags>(FEATURE_FLAGS);
+  const [variant, setVariant] = useState(() => flags.getVariant(flagKey));
+
+  useEffect(() => {
+    const read = () => setVariant(flags.getVariant(flagKey));
+    read();
+    return flags.onFlagsLoaded(read);
+  }, [flags, flagKey]);
+
+  return variant;
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -1,5 +1,7 @@
 import { FileTextIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { REPORT_CHAT_DEFAULT_OPEN_FLAG } from "@posthog/shared";
 import type { SignalReport } from "@posthog/shared/types";
+import { useFeatureFlagVariant } from "@posthog/ui/features/feature-flags/useFeatureFlagVariant";
 import {
   AskAboutSelection,
   quoteSelection,
@@ -71,11 +73,15 @@ function ReportDetailContent({
   const chatOpen = useReportChatPanelStore((s) => s.open);
   const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
   const setPendingQuote = useReportChatPanelStore((s) => s.setPendingQuote);
+  const defaultOpenVariant = useFeatureFlagVariant(
+    REPORT_CHAT_DEFAULT_OPEN_FLAG,
+  );
   const contentRef = useRef<HTMLDivElement>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: each report should start in its assigned default state rather than inherit the previous report's panel state.
   useEffect(() => {
-    setChatOpen(true);
-  }, [setChatOpen]);
+    setChatOpen(defaultOpenVariant === "test");
+  }, [defaultOpenVariant, report.id, setChatOpen]);
 
   const handleAsk = useCallback(
     (text: string) => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -80,7 +80,7 @@ function ReportDetailContent({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: each report should start in its assigned default state rather than inherit the previous report's panel state.
   useEffect(() => {
-    setChatOpen(defaultOpenVariant === "test");
+    setChatOpen(defaultOpenVariant !== "control");
   }, [defaultOpenVariant, report.id, setChatOpen]);
 
   const handleAsk = useCallback(


### PR DESCRIPTION
## Problem

Report chat always opens by default without evidence that this improves report engagement.

**Why:** Report readers should get the most useful default without losing control of the panel.

## Changes

- A PostHog experiment assigns report chat to start open or closed.
- Missing or inactive assignments preserve the current open-by-default behavior.
- Each report resets to its assigned default instead of inheriting the previous report state.
- The experiment remains draft until this change deploys.

No screenshot: the authenticated report state was unavailable in the local environment.

## How did you test this code?

Added coverage for loading multivariate flag assignments and ran the relevant report detail tests.

Confirmed the desktop UI package typechecks with rebuilt shared package types.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. The experiment changes an existing report interaction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change with the `posthog-desktop`, `instrument-feature-flags`, `creating-experiments`, `configuring-experiment-rollout`, `configuring-experiment-analytics`, and `writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*