### PR TITLE
chore(ci): extend expired test quarantine entries

### DIFF
--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -18,7 +18,7 @@
             "owner": "@team-product-analytics",
             "issue": "https://github.com/PostHog/posthog/pull/82398",
             "added": "2026-08-13",
-            "expires": "2026-08-20",
+            "expires": "2026-09-07",
             "mode": "run"
         },
         {

--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -8,7 +8,7 @@
             "owner": "@team-product-analytics",
             "issue": "https://github.com/PostHog/posthog/pull/82398",
             "added": "2026-08-13",
-            "expires": "2026-08-20",
+            "expires": "2026-09-07",
             "mode": "run"
         },
         {
@@ -37,7 +37,7 @@
             "reason": "Ingested screenshot does not reach a phaiblob:// pointer before the poll window ends, so the assertion sees the raw value; fails on master and gates every PR",
             "owner": "@team-ai-observability",
             "added": "2026-08-10",
-            "expires": "2026-08-17",
+            "expires": "2026-09-07",
             "mode": "run"
         }
     ]


### PR DESCRIPTION
## Problem

- Every open PR fails the required Python code quality check since 2026-08-25 00:00 UTC, including the merge queue's trunk-merge branches.
- `test_repo_quarantine_file_is_valid` errors once a `.test_quarantine.json` entry is more than 7 days past expiry. The multimodal-trace entry expired 2026-08-17 and crossed that line at midnight UTC.
- Two more entries (dashboards insight-deletion, insight side panel view-source) expired 2026-08-20 and start erroring 2026-08-28.
- All three quarantined specs still fail on master per their entry reasons, so removing the entries would put those failures back into every PR.

Failing example: https://github.com/PostHog/posthog/actions/runs/32794867939

## Changes

- Extends the `expires` date on all three entries to 2026-09-07. The specs stay quarantined; nothing user-visible changes.
- The validator caps `expires` at 30 days after `added`, so these entries cannot extend much past this date. The owning teams must fix or remove the specs by then.

## How did you test this code?

- Ran the quarantine validator (`hogli_commands.quarantine.core.check`) against the edited file for 2026-08-25: no violations, no warnings.
- Not run: the quarantined Playwright specs themselves; their failures are pre-existing on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** human-directed (agent-authored)

Written by Claude Code while unblocking CI for two perf PRs that failed on this check. Skills invoked: debugging-ci-failures, writing-pr-descriptions. The change is three date bumps in `.test_quarantine.json`; the owning teams (@team-ai-observability, @team-product-analytics) still have the underlying fixes to make before the new expiry.
