### PR TITLE
fix(data-warehouse): show queryable table name on the sync-complete step

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SyncProgressStep.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncProgressStep.test.tsx
@@ -1,6 +1,45 @@
-import { getPreviewQueryUrl, getSourceAccessMethod } from './SyncProgressStep'
+import { ExternalDataSourceSchema, SimpleDataWarehouseTable } from '~/types'
+
+import { getPreviewQueryUrl, getQueryableTableName, getSourceAccessMethod } from './SyncProgressStep'
+
+const buildTable = (overrides: Partial<SimpleDataWarehouseTable>): SimpleDataWarehouseTable => ({
+    id: 't',
+    name: 'table',
+    columns: [],
+    row_count: 0,
+    ...overrides,
+})
+
+const buildSchema = (overrides: Partial<ExternalDataSourceSchema>): ExternalDataSourceSchema =>
+    ({ name: 'drivers', ...overrides }) as ExternalDataSourceSchema
 
 describe('SyncProgressStep', () => {
+    describe('getQueryableTableName', () => {
+        it('returns the prefixed table name when it differs from the label', () => {
+            expect(getQueryableTableName(buildSchema({ table: buildTable({ name: 'neon_drivers' }) }))).toEqual(
+                'neon_drivers'
+            )
+        })
+
+        it('prefers the hogql name over the raw table name', () => {
+            expect(
+                getQueryableTableName(
+                    buildSchema({ table: buildTable({ name: 'neon_drivers', hogql_name: 'drivers_v2' }) })
+                )
+            ).toEqual('drivers_v2')
+        })
+
+        it('returns undefined when the queryable name matches the label', () => {
+            expect(
+                getQueryableTableName(buildSchema({ label: 'drivers', table: buildTable({ name: 'drivers' }) }))
+            ).toBeUndefined()
+        })
+
+        it('returns undefined before the table has been created', () => {
+            expect(getQueryableTableName(buildSchema({ table: undefined }))).toBeUndefined()
+        })
+    })
+
     it('prefers the wizard access method before the source has loaded', () => {
         expect(getSourceAccessMethod('direct', undefined)).toEqual('direct')
     })

--- a/products/data_warehouse/frontend/shared/components/forms/SyncProgressStep.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncProgressStep.tsx
@@ -36,6 +36,17 @@ export function getPreviewQueryUrl(
     return buildTableQueryUrl(tableName, accessMethod === 'direct' ? (sourceId ?? undefined) : undefined)
 }
 
+// Synced tables are exposed under a prefixed name (e.g. schema "drivers" becomes "neon_drivers"),
+// but the row only shows the friendly schema label — so users try to query the label and hit
+// "Unknown table". Surface the real queryable name, but only when it differs from the label.
+export function getQueryableTableName(schema: ExternalDataSourceSchema): string | undefined {
+    const queryableName = schema.table?.hogql_name ?? schema.table?.name
+    if (!queryableName) {
+        return undefined
+    }
+    return queryableName === (schema.label ?? schema.name) ? undefined : queryableName
+}
+
 export const SyncProgressStep = (): JSX.Element => {
     const { sourceId, isWrapped, source: wizardSource, nextButtonText } = useValues(sourceWizardLogic)
     const { cancelWizard, closeWizard } = useActions(sourceWizardLogic)
@@ -98,17 +109,30 @@ export const SyncProgressStep = (): JSX.Element => {
             title: 'Table',
             key: 'table',
             render: function RenderTable(_, schema) {
-                if (!schema.table) {
-                    return schema.label ?? schema.name
-                }
-
-                return (
+                const displayName = schema.label ?? schema.name
+                const queryableName = getQueryableTableName(schema)
+                const title = schema.table ? (
                     <Link
                         to={getPreviewQueryUrl(schema.table.name, sourceAccessMethod, sourceId)}
                         onClick={() => cancelWizard()}
                     >
-                        {schema.label ?? schema.name}
+                        {displayName}
                     </Link>
+                ) : (
+                    displayName
+                )
+
+                if (!queryableName) {
+                    return title
+                }
+
+                return (
+                    <div className="flex flex-col">
+                        {title}
+                        <Tooltip title="Query this table by this name in the SQL editor">
+                            <code className="text-xs text-muted w-fit">{queryableName}</code>
+                        </Tooltip>
+                    </div>
                 )
             },
         },


### PR DESCRIPTION
## Problem

Someone finishing data-warehouse source setup lands on the "You're all set!" step, sees their tables listed by their friendly names (e.g. `drivers`), and goes to the SQL editor to query them. But synced tables are exposed under a prefixed name — `drivers` becomes `neon_drivers` — so `SELECT * FROM drivers` fails with "Unknown table". Replay Vision sessions of the new-source flow show users bouncing between the schema view and the SQL editor trying to work out the real name.

## Changes

- The sync-complete step now shows each table's actual queryable name as a monospace subtitle beneath the friendly label, so a person learns the name to type before they leave the wizard. A tooltip spells out that this is the name to use in the SQL editor.
- The name is only shown when it differs from the label, so it adds no noise for sources whose names already match.
- This mirrors the pattern already used on the source detail schemas tab, where the queryable name is shown the same way — the sync-complete step was the one place that omitted it.
- Extracted a small pure `getQueryableTableName` helper (mechanical) so the rule is unit-tested.

## How did you test this code?

- Added unit tests for `getQueryableTableName` covering: prefixed name differs from label, `hogql_name` preferred over raw name, hidden when it equals the label, and hidden before the table exists.
- Ran the `SyncProgressStep` Jest suite locally — all pass.
- Ran Oxlint + Oxfmt over the touched files. TypeScript check reports no errors in these files (the pre-existing errors in unrelated products come from an unbuilt `@posthog/quill` workspace).
- Not able to exercise the full wizard against a live sync in this environment; the change is an additive, read-only display of an existing field.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing workflow or API change beyond the on-screen hint.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (PostHog Desktop) while reviewing Replay Vision summaries of the data-warehouse new-source onboarding flow for low-risk friction fixes. The recurring "I don't know what my table is called" confusion pointed at the sync-complete step, which — unlike the source detail schemas tab — never showed the prefixed queryable name. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The committed test fixtures are invented, not derived from any session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
