### PR TITLE
fix(tasks): clear merged reports from pull requests

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1280,6 +1280,25 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
 
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_merge_does_not_attest_a_run_that_only_read_the_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        research_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"ai_stage": "research"},
+            output={"pr_url": "https://github.com/posthog/posthog/pull/42"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        research_run.refresh_from_db()
+        assert research_run.output is not None
+        self.assertIsNone(research_run.output.get("pr_merged"))
+
     @parameterized.expand(
         [
             ("trailing_slash", "https://github.com/posthog/posthog/pull/42/"),

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1184,6 +1184,60 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
 
+    @parameterized.expand(
+        [
+            ("merged", True, SignalReport.Status.RESOLVED),
+            ("closed", False, SignalReport.Status.SUPPRESSED),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_event_transitions_report_when_pr_is_bound_to_another_task(
+        self, _name, merged, expected_status, _mock_capture, mock_get_secret
+    ):
+        mock_get_secret.return_value = self.webhook_secret
+        pr_url = "https://github.com/posthog/posthog/pull/42"
+        self.task_run.state = {}
+        self.task_run.save(update_fields=["state"])
+        review_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review task",
+            description="Review the implementation",
+            origin_product=Task.OriginProduct.REVIEW_HOG,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=review_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"verified_pr_urls": [pr_url]},
+            output={"pr_url": pr_url},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=merged)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, expected_status)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_event_does_not_transition_report_for_older_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/99"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.READY)
+
 
 class TestExternalPRWebhook(TestCase):
     """PRs with no matching TaskRun are emitted as external PR events."""
@@ -1505,6 +1559,68 @@ class TestFindTaskRun(TestCase):
         )
         result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
+
+    @parameterized.expand([("branch", False), ("signed_head_branch", True)])
+    def test_branch_fallback_prefers_active_run_over_newer_terminal_run(self, _name, signed_head_branch):
+        branch_fields = (
+            {
+                "branch": "master",
+                "output": {"head_branches": [{"repository": "posthog/posthog", "branch": "feature/shared-branch"}]},
+            }
+            if signed_head_branch
+            else {"branch": "feature/shared-branch"}
+        )
+        implementation_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            **branch_fields,
+        )
+        review_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review task",
+            description="Review the implementation",
+            origin_product=Task.OriginProduct.REVIEW_HOG,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=review_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            **branch_fields,
+        )
+
+        result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
+
+        self.assertEqual(result, implementation_run)
+
+    @parameterized.expand([("branch", False), ("signed_head_branch", True)])
+    def test_branch_fallback_prefers_newest_run_with_same_status_rank(self, _name, signed_head_branch):
+        branch_fields = (
+            {
+                "branch": "master",
+                "output": {"head_branches": [{"repository": "posthog/posthog", "branch": "feature/shared-branch"}]},
+            }
+            if signed_head_branch
+            else {"branch": "feature/shared-branch"}
+        )
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            **branch_fields,
+        )
+        newest_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.QUEUED,
+            **branch_fields,
+        )
+
+        result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
+
+        self.assertEqual(result, newest_run)
 
     def test_finds_by_signed_commit_head_branch(self):
         task_run = TaskRun.objects.create(

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1111,11 +1111,11 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
             task_id=str(self.task.id),
         )
 
-    def _post_pr_webhook(self, action: str, merged: bool):
+    def _post_pr_webhook(self, action: str, merged: bool, pr_url: str = "https://github.com/posthog/posthog/pull/42"):
         payload = {
             "action": action,
             "pull_request": {
-                "html_url": "https://github.com/posthog/posthog/pull/42",
+                "html_url": pr_url,
                 "merged": merged,
             },
         }
@@ -1169,6 +1169,10 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, expected_status)
+        if merged:
+            self.task_run.refresh_from_db()
+            assert self.task_run.output is not None
+            self.assertIs(self.task_run.output.get("pr_merged"), True)
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
@@ -1220,6 +1224,10 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, expected_status)
+        if merged:
+            self.task_run.refresh_from_db()
+            assert self.task_run.output is not None
+            self.assertIs(self.task_run.output.get("pr_merged"), True)
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
@@ -1237,6 +1245,63 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_implementation_pr_takes_priority_over_newer_discussion_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        discussion_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Discuss report",
+            description="Discuss the signal report",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=discussion_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/99"},
+        )
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(self.report.id),
+            product="signals",
+            type="discussion",
+            task_id=str(discussion_task.id),
+        )
+
+        response = self._post_pr_webhook(
+            action="closed", merged=False, pr_url="https://github.com/posthog/posthog/pull/99"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @parameterized.expand(
+        [
+            ("trailing_slash", "https://github.com/posthog/posthog/pull/42/"),
+            ("www_host", "https://www.github.com/posthog/posthog/pull/42"),
+            ("www_host_trailing_slash", "https://www.github.com/posthog/posthog/pull/42/"),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_url_variants_match_the_webhook_pr(self, _name, stored_pr_url, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self.task_run.output = {"pr_url": stored_pr_url}
+        self.task_run.save(update_fields=["output"])
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.task_run.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.RESOLVED)
+        assert self.task_run.output is not None
+        self.assertIs(self.task_run.output.get("pr_merged"), True)
 
 
 class TestExternalPRWebhook(TestCase):
@@ -1561,7 +1626,7 @@ class TestFindTaskRun(TestCase):
         self.assertEqual(result, task_run)
 
     @parameterized.expand([("branch", False), ("signed_head_branch", True)])
-    def test_branch_fallback_prefers_active_run_over_newer_terminal_run(self, _name, signed_head_branch):
+    def test_branch_fallback_prefers_newest_run_even_when_it_is_terminal(self, _name, signed_head_branch):
         branch_fields = (
             {
                 "branch": "master",
@@ -1570,7 +1635,7 @@ class TestFindTaskRun(TestCase):
             if signed_head_branch
             else {"branch": "feature/shared-branch"}
         )
-        implementation_run = TaskRun.objects.create(
+        TaskRun.objects.create(
             task=self.task,
             team=self.team,
             status=TaskRun.Status.IN_PROGRESS,
@@ -1584,7 +1649,7 @@ class TestFindTaskRun(TestCase):
             origin_product=Task.OriginProduct.REVIEW_HOG,
             repository="posthog/posthog",
         )
-        TaskRun.objects.create(
+        newest_run = TaskRun.objects.create(
             task=review_task,
             team=self.team,
             status=TaskRun.Status.COMPLETED,
@@ -1593,7 +1658,7 @@ class TestFindTaskRun(TestCase):
 
         result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
 
-        self.assertEqual(result, implementation_run)
+        self.assertEqual(result, newest_run)
 
     @parameterized.expand([("branch", False), ("signed_head_branch", True)])
     def test_branch_fallback_prefers_newest_run_with_same_status_rank(self, _name, signed_head_branch):

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1282,6 +1282,26 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_merge_attests_the_run_the_badge_reads(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self.task_run.status = TaskRun.Status.IN_PROGRESS
+        self.task_run.save(update_fields=["status"])
+        newest_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/42"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        newest_run.refresh_from_db()
+        assert newest_run.output is not None
+        self.assertIs(newest_run.output.get("pr_merged"), True)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
     def test_merge_does_not_attest_a_run_that_only_read_the_pr(self, _mock_capture, mock_get_secret):
         mock_get_secret.return_value = self.webhook_secret
         research_run = TaskRun.objects.create(

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -7,7 +7,7 @@ from contextlib import ExitStack, contextmanager
 from django.conf import settings
 from django.db import OperationalError, connections, router, transaction
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import Case, IntegerField, Q, Value, When
+from django.db.models import Case, IntegerField, OuterRef, Q, Value, When
 from django.http import HttpResponse
 
 import structlog
@@ -22,10 +22,15 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 
+from products.signals.backend.implementation_pr import pr_bearing_task_run_filter
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
 from products.tasks.backend.constants import PR_LOOP_ENABLED_STATE_KEY
-from products.tasks.backend.facade.api import post_pr_created_thread_update, signal_workflow_completion
+from products.tasks.backend.facade.api import (
+    latest_task_run_pr_url_subquery,
+    post_pr_created_thread_update,
+    signal_workflow_completion,
+)
 from products.tasks.backend.facade.cancellation import cancel_task_run
 from products.tasks.backend.metrics import (
     GitHubWebhookAnalyticsEvent,
@@ -113,6 +118,14 @@ def find_task_run(
                 branch=branch,
                 state__wizard_head_branch__isnull=True,
             )
+            .annotate(
+                terminal_rank=Case(
+                    When(status__in=_TERMINAL_RUN_STATUSES, then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("terminal_rank", "-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -129,6 +142,14 @@ def find_task_run(
                 output__head_branches__contains=[head_branch],
                 state__wizard_head_branch__isnull=True,
             )
+            .annotate(
+                terminal_rank=Case(
+                    When(status__in=_TERMINAL_RUN_STATUSES, then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("terminal_rank", "-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -286,27 +307,22 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         event_uuid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{pr_url}:{analytics_event}"))
         _capture_pr_event(payload, task_run, analytics_event, event_uuid)
 
-    if task_run and action == "closed" and merged:
+    if action == "closed" and merged:
         # Only trust the merge for the run that actually claims this PR URL. The pr_url backstop
         # above already covers branch-matched internal PRs, so requiring equality here keeps a
         # same-branch webhook for a different PR from marking this run's PR as merged.
-        if pr_url in claimed_pr_urls:
+        if task_run and pr_url in claimed_pr_urls:
             _record_run_pr_merged(task_run)
-        # Ungated on the pr_url match above: unlike the run-bookkeeping calls, this keys off
-        # task_id (reports_for_task_filter), not output.pr_url, so the same-branch trust rule
-        # doesn't apply — a merged PR resolves its report.
-        _transition_signal_reports_for_task(
-            task_run.task_id, pr_url, SignalReport.Status.RESOLVED, "github_pr_webhook_signal_report_resolved"
+        _transition_signal_reports_for_pr(
+            pr_url, SignalReport.Status.RESOLVED, "github_pr_webhook_signal_report_resolved"
         )
 
-    if task_run and action == "closed" and not merged:
+    if action == "closed" and not merged:
         # Same trust rule as the merge branch: only the run that claims this PR URL.
-        if pr_url in claimed_pr_urls:
+        if task_run and pr_url in claimed_pr_urls:
             _cancel_wizard_run_on_close(task_run)
-        # Ungated for the same reason as the merge branch's resolve call: a closed-unmerged PR
-        # archives (suppresses) its report so it leaves the inbox instead of lingering.
-        _transition_signal_reports_for_task(
-            task_run.task_id, pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
+        _transition_signal_reports_for_pr(
+            pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
         )
 
     return HttpResponse(status=200)
@@ -909,18 +925,21 @@ def _resolve_external_team(payload: dict) -> Team | None:
     return Team.objects.filter(pk=team_ids[0]).first()
 
 
-def _transition_signal_reports_for_task(
-    task_id: uuid.UUID, pr_url: str, target_status: SignalReport.Status, success_log_event: str
-) -> None:
-    """Transition signal reports linked to a task's PR to ``target_status``.
+def _transition_signal_reports_for_pr(pr_url: str, target_status: SignalReport.Status, success_log_event: str) -> None:
+    """Transition signal reports whose surfaced implementation PR matches ``pr_url``.
 
     Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
     (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
     Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
     5xx responses and we've already acknowledged the PR event.
     """
+    implementation_pr_url = latest_task_run_pr_url_subquery(
+        SignalReport.associated_task_runs_filter(OuterRef(OuterRef("id"))),
+        pr_bearing_task_run_filter(),
+    )
     reports = (
-        SignalReport.objects.filter(SignalReport.reports_for_task_filter(task_id))
+        SignalReport.objects.annotate(implementation_pr_url=implementation_pr_url)
+        .filter(implementation_pr_url=pr_url)
         .exclude(
             status__in=[
                 SignalReport.Status.RESOLVED,
@@ -946,6 +965,5 @@ def _transition_signal_reports_for_task(
         logger.info(
             success_log_event,
             report_id=str(report.id),
-            task_id=str(task_id),
             pr_url=pr_url,
         )

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -7,7 +7,7 @@ from contextlib import ExitStack, contextmanager
 from django.conf import settings
 from django.db import OperationalError, connections, router, transaction
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.db.models import Case, IntegerField, OuterRef, Q, Value, When
+from django.db.models import Case, IntegerField, Q, Value, When
 from django.http import HttpResponse
 
 import structlog
@@ -15,6 +15,7 @@ import posthoganalytics
 from social_django.models import UserSocialAuth
 
 from posthog.event_usage import groups
+from posthog.models.github_integration_base import GitHubIntegrationBase
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.integration import Integration
 from posthog.models.organization import OrganizationMembership
@@ -22,15 +23,11 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 
-from products.signals.backend.implementation_pr import pr_bearing_task_run_filter
+from products.signals.backend.implementation_pr import fetch_implementation_pr_state_for_reports
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
 from products.tasks.backend.constants import PR_LOOP_ENABLED_STATE_KEY
-from products.tasks.backend.facade.api import (
-    latest_task_run_pr_url_subquery,
-    post_pr_created_thread_update,
-    signal_workflow_completion,
-)
+from products.tasks.backend.facade.api import post_pr_created_thread_update, signal_workflow_completion
 from products.tasks.backend.facade.cancellation import cancel_task_run
 from products.tasks.backend.metrics import (
     GitHubWebhookAnalyticsEvent,
@@ -118,14 +115,7 @@ def find_task_run(
                 branch=branch,
                 state__wizard_head_branch__isnull=True,
             )
-            .annotate(
-                terminal_rank=Case(
-                    When(status__in=_TERMINAL_RUN_STATUSES, then=Value(1)),
-                    default=Value(0),
-                    output_field=IntegerField(),
-                )
-            )
-            .order_by("terminal_rank", "-created_at", "-id")
+            .order_by("-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -142,14 +132,7 @@ def find_task_run(
                 output__head_branches__contains=[head_branch],
                 state__wizard_head_branch__isnull=True,
             )
-            .annotate(
-                terminal_rank=Case(
-                    When(status__in=_TERMINAL_RUN_STATUSES, then=Value(1)),
-                    default=Value(0),
-                    output_field=IntegerField(),
-                )
-            )
-            .order_by("terminal_rank", "-created_at", "-id")
+            .order_by("-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -257,9 +240,8 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
 
     branch = pull_request.get("head", {}).get("ref")
     repository_full_name = (payload.get("repository") or {}).get("full_name")
-    task_run = find_task_run(
-        pr_url=pr_url, branch=branch, repository=repository_full_name, team_ids=_task_run_scope_team_ids(payload)
-    )
+    scoped_team_ids = _task_run_scope_team_ids(payload)
+    task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name, team_ids=scoped_team_ids)
     claimed_pr_urls = (
         read_pr_urls(task_run.output if isinstance(task_run.output, dict) else {}) if task_run is not None else []
     )
@@ -314,7 +296,11 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         if task_run and pr_url in claimed_pr_urls:
             _record_run_pr_merged(task_run)
         _transition_signal_reports_for_pr(
-            pr_url, SignalReport.Status.RESOLVED, "github_pr_webhook_signal_report_resolved"
+            pr_url,
+            SignalReport.Status.RESOLVED,
+            "github_pr_webhook_signal_report_resolved",
+            scoped_team_ids or ([task_run.team_id] if task_run else None),
+            record_merge=True,
         )
 
     if action == "closed" and not merged:
@@ -322,7 +308,10 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         if task_run and pr_url in claimed_pr_urls:
             _cancel_wizard_run_on_close(task_run)
         _transition_signal_reports_for_pr(
-            pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
+            pr_url,
+            SignalReport.Status.SUPPRESSED,
+            "github_pr_webhook_signal_report_archived",
+            scoped_team_ids or ([task_run.team_id] if task_run else None),
         )
 
     return HttpResponse(status=200)
@@ -925,21 +914,39 @@ def _resolve_external_team(payload: dict) -> Team | None:
     return Team.objects.filter(pk=team_ids[0]).first()
 
 
-def _transition_signal_reports_for_pr(pr_url: str, target_status: SignalReport.Status, success_log_event: str) -> None:
-    """Transition signal reports whose surfaced implementation PR matches ``pr_url``.
+def _pull_request_identity(pr_url: str) -> tuple[str, int] | None:
+    parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+    if parsed is None:
+        return None
+    return parsed.repository.lower(), parsed.number
 
-    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
-    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
-    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
-    5xx responses and we've already acknowledged the PR event.
+
+def _pr_url_lookup_values(pr_url: str) -> list[str]:
+    """The ``output.pr_url`` strings that can stand for ``pr_url``.
+
+    ``output.pr_url`` is caller-supplied: the agent server PATCHes it onto the run, so it can hold
+    a valid but noncanonical form of the URL GitHub sends as ``html_url``. The variants are
+    enumerated rather than matched with a prefix or a normalizing scan so the lookup stays on the
+    partial index ``task_run_output_pr_url_idx``. A prefix match cannot use that index, and this
+    lookup runs on every closed-PR delivery, including the many for PRs no run ever opened.
     """
-    implementation_pr_url = latest_task_run_pr_url_subquery(
-        SignalReport.associated_task_runs_filter(OuterRef(OuterRef("id"))),
-        pr_bearing_task_run_filter(),
-    )
-    reports = (
-        SignalReport.objects.annotate(implementation_pr_url=implementation_pr_url)
-        .filter(implementation_pr_url=pr_url)
+    parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+    if parsed is None:
+        return [pr_url]
+    values = {pr_url}
+    for host in ("github.com", "www.github.com"):
+        for repository in (parsed.repository, parsed.repository.lower()):
+            base = f"https://{host}/{repository}/pull/{parsed.number}"
+            values.update((base, f"{base}/"))
+    return sorted(values)
+
+
+def _signal_reports_for_pr_runs(pr_url: str, runs: list[TaskRun]) -> list[SignalReport]:
+    if not runs:
+        return []
+
+    reports = list(
+        SignalReport.objects.filter(SignalReport.reports_for_task_ids_filter({run.task_id for run in runs}))
         .exclude(
             status__in=[
                 SignalReport.Status.RESOLVED,
@@ -949,6 +956,49 @@ def _transition_signal_reports_for_pr(pr_url: str, target_status: SignalReport.S
         )
         .distinct()
     )
+    pr_identity = _pull_request_identity(pr_url)
+    surfaced_prs = fetch_implementation_pr_state_for_reports([str(report.id) for report in reports])
+    return [
+        report
+        for report in reports
+        if (surfaced_pr := surfaced_prs.get(str(report.id))) and _pull_request_identity(surfaced_pr.url) == pr_identity
+    ]
+
+
+def _transition_signal_reports_for_pr(
+    pr_url: str,
+    target_status: SignalReport.Status,
+    success_log_event: str,
+    team_ids: list[int] | None,
+    *,
+    record_merge: bool = False,
+) -> None:
+    """Transition signal reports whose surfaced implementation PR matches ``pr_url``.
+
+    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
+    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
+    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
+    5xx responses and we've already acknowledged the PR event.
+    """
+    run_candidates = TaskRun.objects.filter(output__pr_url__in=_pr_url_lookup_values(pr_url))
+    if team_ids:
+        run_candidates = run_candidates.filter(team_id__in=team_ids)
+    reports = _signal_reports_for_pr_runs(pr_url, list(run_candidates))
+
+    if record_merge and reports:
+        report_task_runs = SignalReport.associated_task_runs_for_reports(
+            report_ids=[str(report.id) for report in reports]
+        )
+        associated_task_ids = {run.task_id for runs in report_task_runs.values() for run in runs}
+        surfaced_runs = (
+            TaskRun.objects.filter(task_id__in=associated_task_ids, output__pr_url__isnull=False)
+            .exclude(output__pr_url="")
+            .order_by("task_id", "-created_at", "-id")
+            .distinct("task_id")
+        )
+        for run in surfaced_runs:
+            if _pull_request_identity((run.output or {}).get("pr_url", "")) == _pull_request_identity(pr_url):
+                _record_run_pr_merged(run)
 
     for report in reports:
         try:

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -23,7 +23,10 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 
-from products.signals.backend.implementation_pr import fetch_implementation_pr_state_for_reports
+from products.signals.backend.implementation_pr import (
+    fetch_implementation_pr_state_for_reports,
+    pr_bearing_task_run_filter,
+)
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
 from products.tasks.backend.constants import PR_LOOP_ENABLED_STATE_KEY
@@ -986,19 +989,30 @@ def _transition_signal_reports_for_pr(
     reports = _signal_reports_for_pr_runs(pr_url, list(run_candidates))
 
     if record_merge and reports:
+        # The inbox badge reads pr_merged off the run the report's surfaced PR came from, so the
+        # attestation has to land there and not only on the run the webhook bound to.
+        # Research, repo-selection and scout runs are excluded because a PR URL on one of them is a
+        # PR the agent read while checking for in-flight work, not one it opened.
+        # Non-terminal first, for the same reason the pr_url leg of find_task_run orders that way:
+        # a resumed run shares its predecessor's PR, and only the live run can act on the merge.
         report_task_runs = SignalReport.associated_task_runs_for_reports(
             report_ids=[str(report.id) for report in reports]
         )
         associated_task_ids = {run.task_id for runs in report_task_runs.values() for run in runs}
         surfaced_runs = (
-            TaskRun.objects.filter(task_id__in=associated_task_ids, output__pr_url__isnull=False)
-            .exclude(output__pr_url="")
-            .order_by("task_id", "-created_at", "-id")
+            run_candidates.filter(pr_bearing_task_run_filter(), task_id__in=associated_task_ids)
+            .annotate(
+                terminal_rank=Case(
+                    When(status__in=_TERMINAL_RUN_STATUSES, then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("task_id", "terminal_rank", "-created_at", "-id")
             .distinct("task_id")
         )
         for run in surfaced_runs:
-            if _pull_request_identity((run.output or {}).get("pr_url", "")) == _pull_request_identity(pr_url):
-                _record_run_pr_merged(run)
+            _record_run_pr_merged(run)
 
     for report in reports:
         try:

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -993,22 +993,16 @@ def _transition_signal_reports_for_pr(
         # attestation has to land there and not only on the run the webhook bound to.
         # Research, repo-selection and scout runs are excluded because a PR URL on one of them is a
         # PR the agent read while checking for in-flight work, not one it opened.
-        # Non-terminal first, for the same reason the pr_url leg of find_task_run orders that way:
-        # a resumed run shares its predecessor's PR, and only the live run can act on the merge.
+        # Newest run per task, matching get_latest_pr_url_by_task and get_merged_pr_task_ids
+        # run-for-run. Those two decide which run the badge reads, so any other ordering here can
+        # attest one run while the badge reads another, which is the bug this block exists to fix.
         report_task_runs = SignalReport.associated_task_runs_for_reports(
             report_ids=[str(report.id) for report in reports]
         )
         associated_task_ids = {run.task_id for runs in report_task_runs.values() for run in runs}
         surfaced_runs = (
             run_candidates.filter(pr_bearing_task_run_filter(), task_id__in=associated_task_ids)
-            .annotate(
-                terminal_rank=Case(
-                    When(status__in=_TERMINAL_RUN_STATUSES, then=Value(1)),
-                    default=Value(0),
-                    output_field=IntegerField(),
-                )
-            )
-            .order_by("task_id", "terminal_rank", "-created_at", "-id")
+            .order_by("task_id", "-created_at", "-id")
             .distinct("task_id")
         )
         for run in surfaced_runs:


### PR DESCRIPTION
## Problem

A self-driving report whose implementation PR has already merged stays in the Inbox Pull requests tab, with an Open badge, until someone dismisses it by hand.

**Why:** One code path flips the report's status, and it keys off the task run the webhook attributed the PR to. Several runs share a head branch, so the webhook often binds to the code-review run instead of the implementation run, and the report never transitions.

Closes #88140

## Changes

- A report leaves the Pull requests tab when its surfaced PR closes, whichever run the webhook attributed the PR to. A merged PR resolves the report, an unmerged PR suppresses it.
- The card's Open badge clears on merge, because the merge flag now lands on the run the report surfaces.
- The lookup keys on the PR the inbox surfaces, so a report holding both an implementation PR and a newer discussion PR still follows the implementation one.
- The lookup matches a fixed list of URL forms (`www.`, trailing slash, repository casing) and stays on the `task_run_output_pr_url_idx` index. A prefix match cannot use that index and would read every PR-bearing run on every closed-PR delivery.
- The branch fallback in `find_task_run` gains an `-id` tie-breaker. Mechanical: the model already orders by `-created_at`, so only runs created in the same instant change.

> [!NOTE]
> This clears reports from the tab on the next `closed` webhook. Reports whose PR merged before this ships get no further webhook, so the backlog needs the reconciler #88140 lists as a follow-up.

**Before**

```mermaid
flowchart LR
    Hook[GitHub closed webhook] --> Run[Attributed task run]
    Run --> Report[Reports linked to that task]
    Report --> Stale[Wrong attribution leaves report ready]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Hook phRed;
    class Run,Report phBlue;
    class Stale phYellow;
```

**After**

```mermaid
flowchart LR
    Hook[GitHub closed webhook] --> Runs[Runs with the same PR identity]
    Runs --> Surface[Canonical surfaced PR]
    Surface --> Outcome[Resolve or suppress report]
    Surface --> Merge[Record merge on surfaced run]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Hook phRed;
    class Runs,Surface phBlue;
    class Outcome,Merge phYellow;
```

No screenshot: nothing renders differently. The card leaves the tab because its status changes.

## How did you test this code?

New cases in `products/tasks/backend/tests/test_webhooks.py`, each naming a regression:

- A closed webhook attributed to a different run still transitions the report. This is the bug.
- A report with an implementation PR and a newer discussion PR ignores the discussion PR's close.
- A run storing a `www.` or trailing-slash URL form still matches the webhook PR.
- The branch fallback picks the newest run, including a terminal one.

The whole file runs against Postgres locally.

Verified the index claim with `EXPLAIN` on a local Postgres:

<details>
<summary>Plans for both lookup forms</summary>

```text
-- fixed URL list (this PR)
Bitmap Index Scan on task_run_output_pr_url_idx
  Index Cond: ((output -> 'pr_url') = ANY (...))

-- prefix match
Bitmap Index Scan on task_run_output_pr_url_idx
  Recheck Cond: ((output -> 'pr_url') IS NOT NULL)
  Filter: (upper((output -> 'pr_url')::text) ~~ '"HTTPS://GITHUB.COM/...%')
```

The prefix form reads every run that carries a PR URL, then filters in memory.

</details>

Not checked: behavior against production data.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This changes internal webhook bookkeeping only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

@BaconMan1168 authored the original patch and the first round of tests. Two review commits sit on top: one merges master, one applies the automated review feedback and replaces the prefix URL match with the indexed fixed list.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
