### PR TITLE
chore(warehouse-sources): promote OpenRouter source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/source.py
@@ -63,7 +63,7 @@ class OpenRouterSource(ResumableSource[OpenRouterSourceConfig, OpenRouterResumeC
             name=SchemaExternalDataSourceType.OPEN_ROUTER,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="OpenRouter",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             caption="""Enter your OpenRouter API key to pull your OpenRouter usage and account data into the PostHog Data warehouse.
 
 Use a **management API key** (create one under [Settings -> Management Keys](https://openrouter.ai/settings/keys)) so the activity, API keys, credits, organization members, and workspaces tables can sync. A regular inference key can only read the models and providers catalogs.""",


### PR DESCRIPTION
## Problem

People connecting a data warehouse source saw OpenRouter labeled Alpha, a soft "new, lightly tested" tag. The connector has now earned a Beta label: it is used by 33 teams (threshold 30) with a 0.2% import error rate over the last 7 days (threshold under 5%).

## Changes

- The OpenRouter source now shows a Beta release label instead of Alpha in the new-source wizard.
- Mechanical: single-line change of `releaseStatus` from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` in the source config. No behavior, schema, or sync logic changes.

## How did you test this code?

No new tests. The change swaps one enum value in `get_source_config`; the release status is a display-only label. No test asserted the previous value.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change: the release label is not documented per-source.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Promotes the OpenRouter warehouse source from Alpha to Beta based on 7-day adoption and error-rate metrics. Invoked `/implementing-warehouse-sources` (to confirm where release status lives and the `ReleaseStatus` enum convention) and `/writing-pr-descriptions`. Verified no closely-coupled gating metadata exists for this source — no `unreleasedSource` flag or `featureFlag`, so nothing else changes with the stage. Searched open PRs (source name, "releaseStatus", and the maintainer's own open PRs) and found no human-authored duplicate.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
