### PR TITLE
fix(experiments): don't treat completed experiment results as stale

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -14,6 +14,7 @@ import { Label } from 'lib/ui/Label/Label'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 
 import { experimentLogic } from '../experimentLogic'
+import { hasEnded } from '../experimentStatus'
 
 /**
  * Hook to check if experiment data is stale and trigger refresh if needed.
@@ -65,14 +66,21 @@ function useStaleDataCheck({
     }, [lastRefresh, enabled, intervalSeconds, onRefresh])
 }
 
-export const ExperimentLastRefreshText = ({ lastRefresh }: { lastRefresh: string | null }): JSX.Element => {
-    const colorClass = lastRefresh
-        ? dayjs().diff(dayjs(lastRefresh), 'hours') > 12
-            ? 'text-danger'
-            : dayjs().diff(dayjs(lastRefresh), 'hours') > 6
-              ? 'text-warning'
-              : ''
-        : ''
+export const ExperimentLastRefreshText = ({
+    lastRefresh,
+    showStaleness = true,
+}: {
+    lastRefresh: string | null
+    showStaleness?: boolean
+}): JSX.Element => {
+    const colorClass =
+        showStaleness && lastRefresh
+            ? dayjs().diff(dayjs(lastRefresh), 'hours') > 12
+                ? 'text-danger'
+                : dayjs().diff(dayjs(lastRefresh), 'hours') > 6
+                  ? 'text-warning'
+                  : ''
+            : ''
 
     return <span className={colorClass}>{lastRefresh ? <TZLabel time={lastRefresh} /> : 'a while ago'}</span>
 }
@@ -100,13 +108,16 @@ export const ExperimentReloadAction = ({
     onClick: () => void
     progress?: { completed: number; total: number }
 }): JSX.Element => {
-    const { autoRefresh } = useValues(experimentLogic)
+    const { autoRefresh, experiment } = useValues(experimentLogic)
     const { setAutoRefresh, setPageVisibility, stopAutoRefreshInterval } = useActions(experimentLogic)
+
+    // Completed experiments have final results: no staleness warning, no auto refresh
+    const ended = hasEnded(experiment)
 
     // Check if data is stale on mount or when page becomes visible
     useStaleDataCheck({
         lastRefresh,
-        enabled: autoRefresh.enabled,
+        enabled: autoRefresh.enabled && !ended,
         intervalSeconds: autoRefresh.interval,
         onRefresh: onClick,
     })
@@ -147,55 +158,63 @@ export const ExperimentReloadAction = ({
                     icon={isRefreshing ? <Spinner textColored /> : <IconRefresh />}
                     data-attr="refresh-experiment"
                     disabledReason={isRefreshing ? 'Loading...' : null}
-                    sideAction={{
-                        'data-attr': 'refresh-experiment-dropdown',
-                        dropdown: {
-                            closeOnClickInside: false,
-                            placement: 'bottom-end',
-                            overlay: (
-                                <LemonMenuOverlay
-                                    items={[
-                                        {
-                                            label: () => (
-                                                <LemonSwitch
-                                                    onChange={(checked) =>
-                                                        setAutoRefresh(checked, autoRefresh.interval)
-                                                    }
-                                                    label="Auto refresh while on page"
-                                                    checked={autoRefresh.enabled}
-                                                    fullWidth
-                                                    className="mt-1 mb-2"
-                                                />
-                                            ),
-                                        },
-                                        ...(autoRefresh.enabled
-                                            ? [
+                    sideAction={
+                        ended
+                            ? undefined
+                            : {
+                                  'data-attr': 'refresh-experiment-dropdown',
+                                  dropdown: {
+                                      closeOnClickInside: false,
+                                      placement: 'bottom-end',
+                                      overlay: (
+                                          <LemonMenuOverlay
+                                              items={[
                                                   {
-                                                      title: 'Refresh interval',
-                                                      items: [
-                                                          {
-                                                              label: () => (
-                                                                  <LemonRadio
-                                                                      value={autoRefresh.interval}
-                                                                      options={options}
-                                                                      onChange={(value: number) => {
-                                                                          setAutoRefresh(true, value)
-                                                                      }}
-                                                                      className="mx-2 mb-1"
-                                                                  />
-                                                              ),
-                                                          },
-                                                      ],
+                                                      label: () => (
+                                                          <LemonSwitch
+                                                              onChange={(checked) =>
+                                                                  setAutoRefresh(checked, autoRefresh.interval)
+                                                              }
+                                                              label="Auto refresh while on page"
+                                                              checked={autoRefresh.enabled}
+                                                              fullWidth
+                                                              className="mt-1 mb-2"
+                                                          />
+                                                      ),
                                                   },
-                                              ]
-                                            : []),
-                                    ]}
-                                />
-                            ),
-                        },
-                    }}
+                                                  ...(autoRefresh.enabled
+                                                      ? [
+                                                            {
+                                                                title: 'Refresh interval',
+                                                                items: [
+                                                                    {
+                                                                        label: () => (
+                                                                            <LemonRadio
+                                                                                value={autoRefresh.interval}
+                                                                                options={options}
+                                                                                onChange={(value: number) => {
+                                                                                    setAutoRefresh(true, value)
+                                                                                }}
+                                                                                className="mx-2 mb-1"
+                                                                            />
+                                                                        ),
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ]
+                                                      : []),
+                                              ]}
+                                          />
+                                      ),
+                                  },
+                              }
+                    }
                 >
-                    {isRefreshing ? loadingText : <ExperimentLastRefreshText lastRefresh={lastRefresh} />}
+                    {isRefreshing ? (
+                        loadingText
+                    ) : (
+                        <ExperimentLastRefreshText lastRefresh={lastRefresh} showStaleness={!ended} />
+                    )}
                 </LemonButton>
                 <LemonBadge
                     size="small"
@@ -204,7 +223,7 @@ export const ExperimentReloadAction = ({
                             <IconRefresh className="mr-0" /> {humanFriendlyDuration(autoRefresh.interval)}
                         </>
                     }
-                    visible={autoRefresh.enabled}
+                    visible={autoRefresh.enabled && !ended}
                     position="top-right"
                     status="muted"
                 />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -3927,6 +3927,11 @@ export const experimentLogic = kea<experimentLogicType>([
             if (values.autoRefresh.enabled && !hasEnded(values.experiment)) {
                 cache.disposables.add(() => {
                     const intervalId = window.setInterval(() => {
+                        // The experiment may have ended while the interval was running
+                        if (hasEnded(values.experiment)) {
+                            cache.disposables.dispose('autoRefreshInterval')
+                            return
+                        }
                         // Track auto-refresh trigger
                         actions.reportExperimentMetricsRefreshed(values.experiment, true, {
                             triggered_by: 'auto-refresh',

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -3923,7 +3923,8 @@ export const experimentLogic = kea<experimentLogicType>([
             // Clear any existing interval first
             cache.disposables.dispose('autoRefreshInterval')
 
-            if (values.autoRefresh.enabled) {
+            // Completed experiments have final results — never poll them
+            if (values.autoRefresh.enabled && !hasEnded(values.experiment)) {
                 cache.disposables.add(() => {
                     const intervalId = window.setInterval(() => {
                         // Track auto-refresh trigger


### PR DESCRIPTION
## Problem

A completed experiment shows its "Last refreshed" timestamp in red, as if the results were stale and needed a refresh. Completed experiments are intentionally not auto refreshed, so their results are final and the warning is wrong.

## Changes

- The timestamp on a completed experiment keeps the normal text color instead of turning orange after 6 hours and red after 12.
- The auto refresh dropdown and interval badge are hidden for completed experiments.
- The stale-data check on page load and the auto refresh interval no longer fire for completed experiments, so viewing one does not silently re-run its metric queries.

The manual refresh button stays. Refreshing is still useful after editing a metric or when a query failed, so hiding the whole control would create a dead end.

| Before | After |
| --- | --- |
| ![exp-refresh-before](https://raw.githubusercontent.com/PostHog/pr-assets/cf35880ddc9d308b6d53e7bd30ccee8f5a942cf9/2026/08/c4b6cdb8-5066-4d44-b29b-950dccd77d62.png) | ![exp-refresh-after](https://raw.githubusercontent.com/PostHog/pr-assets/3c73f53090ce7e678cf9cd16e31f3cdda6ed0702/2026/08/0b29ead7-7e25-42d1-9637-2822951e9687.png) |

## How did you test this code?

Verified in the local app on a completed experiment, with the results response forced to a 7 day old last_refresh: the timestamp renders neutral and the dropdown is gone, and with the change reverted it renders red with the dropdown (screenshots above). Frontend typecheck passes.

Not tested: no jest tests added, since the auto refresh behavior has no existing coverage and the change is a color and visibility gate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-pr-descriptions. The discussed alternative was hiding the refresh control entirely for completed experiments and moving it elsewhere; keeping it with the staleness treatment removed was chosen instead.
