### PR TITLE
chore(workflows): remove the email priority dequeue flag

### DIFF
--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -91,10 +91,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_SES_RATE_LIMIT_REFILL_PER_SECOND: number
     CDP_SES_RATE_LIMIT_CAPACITY: number
     CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: number
-    // When enabled, the email queue dequeues by priority class before the
-    // per-team fair ordering, so transactional-class sends aren't stuck behind
-    // a broadcast backlog. Requires idx_cyclotron_jobs_email_priority_fair_dequeue.
-    CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED: boolean
 
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
@@ -263,7 +259,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_SES_RATE_LIMIT_REFILL_PER_SECOND: 100,
         CDP_SES_RATE_LIMIT_CAPACITY: 50,
         CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: 250,
-        CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED: false,
 
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1745,7 +1745,7 @@ describe('Cyclotron V2', () => {
             const createFairWorker = (overrides?: Record<string, unknown>): CyclotronV2Worker =>
                 createWorker(EMAIL_QUEUE, overrides)
 
-            it('dequeues the fast class before an earlier-enqueued bulk backlog when priority dequeue is enabled', async () => {
+            it('dequeues the fast class before an earlier-enqueued bulk backlog', async () => {
                 // A bulk broadcast (priority 1) is already queued when two fast-class
                 // sends (priority 0) arrive, one from the same team. Without priority
                 // ordering, the same-team fast job waits behind the whole backlog.
@@ -1757,7 +1757,7 @@ describe('Cyclotron V2', () => {
                     { teamId: teamB, queueName: EMAIL_QUEUE, priority: 0 },
                 ])
 
-                const worker = createFairWorker({ batchMaxSize: 2, priorityDequeue: true })
+                const worker = createFairWorker({ batchMaxSize: 2 })
                 const jobs = await dequeueOneBatch(worker)
 
                 expect(jobs.map((j) => j.priority)).toEqual([0, 0])
@@ -1775,7 +1775,7 @@ describe('Cyclotron V2', () => {
 
                 const drained: Array<[number, number]> = []
                 for (let i = 0; i < 5; i++) {
-                    const worker = createFairWorker({ batchMaxSize: 1, priorityDequeue: true })
+                    const worker = createFairWorker({ batchMaxSize: 1 })
                     const batch = await dequeueOneBatch(worker)
                     expect(batch).toHaveLength(1)
                     drained.push([batch[0].priority, batch[0].teamId])
@@ -1789,23 +1789,6 @@ describe('Cyclotron V2', () => {
                     [1, teamA],
                     [1, teamB],
                 ])
-            })
-
-            it('ignores priority when priority dequeue is disabled', async () => {
-                const teamA = 100
-                const teamB = 200
-                await manager.bulkCreateJobs([
-                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE, priority: 1 })),
-                    { teamId: teamA, queueName: EMAIL_QUEUE, priority: 0 },
-                    { teamId: teamB, queueName: EMAIL_QUEUE, priority: 0 },
-                ])
-
-                const worker = createFairWorker({ batchMaxSize: 2 })
-                const jobs = await dequeueOneBatch(worker)
-
-                // Legacy ordering is dequeue_seq only: the first fair round is team A's
-                // first bulk job and team B's fast job, so priorities stay mixed.
-                expect(jobs.map((j) => j.priority).sort((a, b) => a - b)).toEqual([0, 1])
             })
 
             it('picks small-tenant jobs into the same batch as big-tenant jobs', async () => {

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -204,9 +204,6 @@ export type CyclotronV2WorkerConfig = {
     pollDelayMs?: number
     heartbeatTimeoutMs?: number
     includeEmptyBatches?: boolean
-    // Orders the email queue's fair dequeue by priority class before dequeue_seq.
-    // Only meaningful on the email queue; other queues already order by priority.
-    priorityDequeue?: boolean
 }
 
 export type CyclotronV2JanitorConfig = {

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -213,7 +213,6 @@ export class CyclotronV2Worker {
     private readonly heartbeatTimeoutMs: number
     protected readonly includeEmptyBatches: boolean
     protected readonly fairDequeue: boolean
-    private readonly priorityDequeue: boolean
 
     constructor(private config: CyclotronV2WorkerConfig) {
         this.pool = new Pool({
@@ -230,7 +229,6 @@ export class CyclotronV2Worker {
         // CyclotronV2Manager), so deriving this from the queue name keeps the
         // worker's ORDER BY in lockstep with where the sort key actually exists.
         this.fairDequeue = config.queueName === 'email'
-        this.priorityDequeue = config.priorityDequeue ?? false
     }
 
     async connect(processBatch: (jobs: CyclotronV2DequeuedJob[]) => Promise<void>): Promise<void> {
@@ -342,29 +340,24 @@ export class CyclotronV2Worker {
     }
 
     /**
-     * Fair dequeue: orders by the precomputed `dequeue_seq` so jobs interleave
-     * across tenants instead of being strict FIFO. The sort key is assigned at
-     * insert time (see `CyclotronV2Manager.bulkCreateJobs` and the helper
+     * Fair dequeue: priority class leads the sort so transactional-class sends
+     * aren't stuck behind a broadcast backlog, then the precomputed
+     * `dequeue_seq` interleaves jobs across tenants within a class instead of
+     * being strict FIFO. The sort key is assigned at insert time (see
+     * `CyclotronV2Manager.bulkCreateJobs` and the helper
      * `cyclotron_email_team_seq`); this method just reads them back in order.
      *
-     * Hits the partial index `idx_cyclotron_jobs_email_fair_dequeue` (only
-     * indexes email-queue rows with status='available'). NULLS FIRST drains
-     * any pre-migration legacy rows ahead of new fair-ordered ones.
+     * Hits the partial index `idx_cyclotron_jobs_email_priority_fair_dequeue`
+     * (only indexes email-queue rows with status='available'). NULLS FIRST
+     * drains any pre-migration legacy rows ahead of new fair-ordered ones.
      *
-     * Email-specific by intent — but mechanically just "ORDER BY a different
-     * column", so the SQL shape mirrors `dequeueJobs` exactly. Kept as a
+     * Email-specific by intent — but mechanically just "ORDER BY different
+     * columns", so the SQL shape mirrors `dequeueJobs` exactly. Kept as a
      * separate method so non-fair callers can read `dequeueJobs` end-to-end
      * without following a conditional or an indirection.
      */
     protected async fairDequeueJobs(limit: number = this.batchMaxSize): Promise<RawJobRow[]> {
         const lockId = uuidv7()
-        // With priorityDequeue, priority class leads the sort so transactional-class
-        // sends aren't stuck behind a broadcast backlog; the per-team interleave
-        // still orders jobs within each class. Served by
-        // idx_cyclotron_jobs_email_priority_fair_dequeue.
-        const orderBy = this.priorityDequeue
-            ? 'priority ASC, dequeue_seq ASC NULLS FIRST'
-            : 'dequeue_seq ASC NULLS FIRST'
         const result = await this.pool.query<RawJobRow>(
             `WITH available AS (
                 SELECT id
@@ -372,7 +365,7 @@ export class CyclotronV2Worker {
                 WHERE status = 'available'
                   AND queue_name = $1
                   AND scheduled <= NOW()
-                ORDER BY ${orderBy}
+                ORDER BY priority ASC, dequeue_seq ASC NULLS FIRST
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
             )
@@ -403,9 +396,10 @@ export class CyclotronV2Worker {
             [this.config.queueName, limit, lockId]
         )
         // Within-batch order is undefined (UPDATE...RETURNING doesn't preserve
-        // the CTE's ORDER BY), but the fairness guarantee is *across* batches:
-        // the CTE picks the rows with the lowest dequeue_seq values, so a
-        // small-tenant job never gets stuck behind a large-tenant backlog.
+        // the CTE's ORDER BY), but the guarantee is *across* batches: the CTE
+        // picks the rows with the lowest priority, then the lowest dequeue_seq,
+        // so a transactional send never waits behind a marketing backlog and a
+        // small-tenant job never gets stuck behind a large-tenant one.
         return result.rows
     }
 

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -47,7 +47,6 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             | 'CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE'
             | 'CDP_CYCLOTRON_INSERT_PARALLEL_BATCHES'
             | 'CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS'
-            | 'CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED'
         >
     ) {
         this.sanitizer = createInvocationSanitizer(config)
@@ -93,7 +92,6 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             batchMaxSize: this.consumerBatchSize,
             pollDelayMs: this.config.CDP_CYCLOTRON_BATCH_DELAY_MS,
             includeEmptyBatches: true,
-            priorityDequeue: this.config.CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED,
         })
 
         await this.worker.connect(async (jobs) => {


### PR DESCRIPTION
## Problem

Nothing changes for a person: transactional email already overtakes a team's own broadcast in every environment. The flag that made that happen (`CDP_EMAIL_PRIORITY_DEQUEUE_ENABLED`, shipped in #86241) is on everywhere, so the flag-off path is dead code that anyone touching the email worker's dequeue still has to read and reason about.

## Changes

- The email worker's fair dequeue orders by priority class unconditionally. This matches the current production config, so no send ordering changes.
- Mechanical: drops the config key, its `Pick` entry on the postgres-v2 job queue, and the `priorityDequeue` option on `CyclotronV2WorkerConfig`.
- Drops the test that asserted the flag-off ordering, because that ordering no longer exists.
- Fixes the `fairDequeueJobs` docstring, which still named an index dropped back in migration `20260622000002`.

> [!NOTE]
> Two follow-ups, in this order. First remove the variable from the chart (PostHog/charts#14630) — that must land **after** this deploys, or pods on the old image read the missing variable as `false` and fall back to per-team ordering. Then drop the superseded `idx_cyclotron_jobs_email_fair_dequeue_v2` index, which #86241 left for a follow-up. The index drop is held back on purpose: while it stays, this PR is revertible with no migration.

## How did you test this code?

- The two kept ordering tests now exercise the unconditional path and still catch the regressions they were written for: a fast-class send stuck behind a bulk backlog, and a lost per-team interleave within one class.
- Ran the cyclotron-v2, email-priority, and job-queue suites against a local postgres with the cyclotron migrations applied.
- Not run: the messaging suites that need `test_posthog` and `test_persons`, because this sandbox only has the cyclotron database. No manual verification against a deployed worker.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread, after the flag reached full rollout. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The index drop and the chart edit were both considered for this diff and left out. The chart edit cannot ship before this deploys, and keeping the index means a revert of this PR needs no migration.
