### PR TITLE
fix(billing): align startup desktop limit cap

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -8305,9 +8305,9 @@ snapshots:
     scenes-other-billing-product--billing-product-post-hog-code-limit-editing--light:
         hash: v1.k794b7964.a3bbef49716d1ea6fa9b92b79005af056f34f2040c224961d804f85596acc784.JGw5-GTbeq_p8KyjdiTeoX1jkN190GqFI9xV9JzgdmE
     scenes-other-billing-product--billing-product-post-hog-code-limit-next-period-capped--dark:
-        hash: v1.k794b7964.9fde77b3e5aa2b9c585fd6b0ffcfd7310ee410804924ea2fdc7fa12e25dfa77d.CDr-pD-AT0ystYMo2yHqfqGU7fJKGdViAcVlhKE6JtI
+        hash: v1.k794b7964.f8583bd447708da6fa012fe9313d71600433bed0d03e5d41848cedecf5ab9d21.ZAHv0DJs7KHJ2Zdcp2-liP6z5Ubb22aqd1F91FZSXow
     scenes-other-billing-product--billing-product-post-hog-code-limit-next-period-capped--light:
-        hash: v1.k794b7964.bdca13fc394cc1a4dafa1046b520bca6d8ee0fd4592c7461d34269d349065a25.opatfCwjLk4ajx1oBTypxiFqZTLgLzC6Huv1Pe3feEA
+        hash: v1.k794b7964.c6c64e9653af75c621864353c2cdb6596fc3c016b0ffbecfac348ea78d567826.BbDTCv01DzFXPbewlxtb5wsW5YECFnZ2E4KgCgniHBU
     scenes-other-billing-product--billing-product-temporarily-free--dark:
         hash: v1.k794b7964.17457ea2e809235689317d9e0feb224c18f8d5a81c8adf04b314e4d0c7b6f7d4.l_BpJhV7_FHvsDrKy34afdUPZvjK2sjH2OizL4u6SnI
     scenes-other-billing-product--billing-product-temporarily-free--light:

--- a/frontend/src/scenes/billing/BillingProduct.stories.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.stories.tsx
@@ -51,6 +51,9 @@ const makePostHogCodeUsageBilling = ({
     const sourceProduct = billingJson.products.find(
         (product) => product.type === 'feature_flags'
     ) as BillingProductV2Type
+    const isAboveStartupCap = currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX
+    const currentAmountUsd = isAboveStartupCap ? currentLimitUsd : 25
+    const projectedAmountUsd = isAboveStartupCap ? currentLimitUsd + 150 : 75
     const product: BillingProductV2Type = {
         ...sourceProduct,
         name: 'PostHog Desktop (usage-based)',
@@ -61,12 +64,9 @@ const makePostHogCodeUsageBilling = ({
         docs_url: 'https://posthog.com/docs/posthog-desktop',
         subscribed: true,
         type: POSTHOG_CODE_USAGE_PRODUCT_KEY,
-        current_amount_usd:
-            currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '25.00',
-        projected_amount_usd:
-            currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '4100.00' : '75.00',
-        projected_amount_usd_with_limit:
-            currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '75.00',
+        current_amount_usd: currentAmountUsd.toFixed(2),
+        projected_amount_usd: projectedAmountUsd.toFixed(2),
+        projected_amount_usd_with_limit: isAboveStartupCap ? currentAmountUsd.toFixed(2) : '75.00',
         plans: sourceProduct.plans.map((plan) => ({
             ...plan,
             initial_billing_limit: 50,
@@ -180,7 +180,7 @@ export const BillingProductPostHogCodeLimitEditing: Story = {
 export const BillingProductPostHogCodeLimitNextPeriodCapped: Story = {
     render: () =>
         renderPostHogCodeUsageBillingProduct({
-            currentLimitUsd: 3750,
+            currentLimitUsd: 750,
             nextPeriodLimitUsd: POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX,
         }),
 }

--- a/frontend/src/scenes/billing/BillingProduct.stories.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.stories.tsx
@@ -8,7 +8,7 @@ import { makeBillingWithPlatformAddons } from '~/mocks/fixtures/_billing_platfor
 import preflightJson from '~/mocks/fixtures/_preflight.json'
 import { BillingProductV2Type, BillingType, StartupProgramLabel } from '~/types'
 
-import { POSTHOG_CODE_USAGE_PRODUCT_KEY, STARTUP_PROGRAM_BILLING_LIMIT_MAX } from './billingLimitConfig'
+import { POSTHOG_CODE_USAGE_PRODUCT_KEY, STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT } from './billingLimitConfig'
 import { BillingProduct } from './BillingProduct'
 
 const meta: Meta = {
@@ -34,6 +34,9 @@ export default meta
 
 type Story = StoryObj<{}>
 
+const POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX =
+    STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT[POSTHOG_CODE_USAGE_PRODUCT_KEY]
+
 const BillingProductStoryFrame = ({ children }: { children: JSX.Element }): JSX.Element => (
     <div className="w-[960px] max-w-full">{children}</div>
 )
@@ -58,9 +61,12 @@ const makePostHogCodeUsageBilling = ({
         docs_url: 'https://posthog.com/docs/posthog-desktop',
         subscribed: true,
         type: POSTHOG_CODE_USAGE_PRODUCT_KEY,
-        current_amount_usd: currentLimitUsd > STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '25.00',
-        projected_amount_usd: currentLimitUsd > STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '4100.00' : '75.00',
-        projected_amount_usd_with_limit: currentLimitUsd > STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '75.00',
+        current_amount_usd:
+            currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '25.00',
+        projected_amount_usd:
+            currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '4100.00' : '75.00',
+        projected_amount_usd_with_limit:
+            currentLimitUsd > POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '75.00',
         plans: sourceProduct.plans.map((plan) => ({
             ...plan,
             initial_billing_limit: 50,
@@ -175,7 +181,7 @@ export const BillingProductPostHogCodeLimitNextPeriodCapped: Story = {
     render: () =>
         renderPostHogCodeUsageBillingProduct({
             currentLimitUsd: 3750,
-            nextPeriodLimitUsd: 3000,
+            nextPeriodLimitUsd: POSTHOG_CODE_USAGE_STARTUP_PROGRAM_BILLING_LIMIT_MAX,
         }),
 }
 

--- a/frontend/src/scenes/billing/billingLimitConfig.test.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.test.ts
@@ -6,7 +6,7 @@ import {
     MAX_BILLING_LIMIT,
     POSTHOG_CODE_USAGE_PRODUCT_KEY,
     REPLAY_VISION_PRODUCT_KEY,
-    STARTUP_PROGRAM_BILLING_LIMIT_MAX,
+    STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT,
 } from './billingLimitConfig'
 
 describe('getBillingLimitConfig', () => {
@@ -23,14 +23,16 @@ describe('getBillingLimitConfig', () => {
         })
 
     it.each([
-        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 'Desktop'],
-        [REPLAY_VISION_PRODUCT_KEY, 'Replay vision'],
-    ])('caps %s for startup program customers and explains why', (productType, productName) => {
+        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 'Desktop', 500],
+        [REPLAY_VISION_PRODUCT_KEY, 'Replay vision', 3000],
+    ])('caps %s for startup program customers and explains why', (productType, productName, cap) => {
         const config = getConfig(productType, StartupProgramLabel.YC)
-        expect(config.max).toBe(STARTUP_PROGRAM_BILLING_LIMIT_MAX)
+        expect(config.max).toBe(cap)
         expect(config.removalDisabledReason).toBeTruthy()
         expect(config.help).toContain(`${productName} billing limits`)
+        expect(config.help).toContain(`$${cap.toLocaleString()}`)
         expect(config.maxExceededError).toContain(`${productName} billing limits`)
+        expect(config.maxExceededError).toContain(`$${cap.toLocaleString()}`)
     })
 
     it.each(['posthog_code_usage', 'replay_vision', 'product_analytics'])(
@@ -44,13 +46,15 @@ describe('getBillingLimitConfig', () => {
     )
 
     it.each([
-        [3750, 2000, true],
-        [3750, 5000, false],
-        [null, 2000, false],
+        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, 500, true],
+        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, 600, false],
+        [REPLAY_VISION_PRODUCT_KEY, 3750, 2000, true],
+        [REPLAY_VISION_PRODUCT_KEY, 3750, 5000, false],
+        [REPLAY_VISION_PRODUCT_KEY, null, 2000, false],
     ])(
-        'with current limit %p and next period limit %p, above-cap notice shown: %p',
-        (customLimitUsd, billingLimitNextPeriod, noticeShown) => {
-            const config = getConfig('replay_vision', StartupProgramLabel.YC, {
+        'for %s with current limit %p and next period limit %p, above-cap notice shown: %p',
+        (productType, customLimitUsd, billingLimitNextPeriod, noticeShown) => {
+            const config = getConfig(productType, StartupProgramLabel.YC, {
                 customLimitUsd,
                 billingLimitNextPeriod,
             })
@@ -61,4 +65,11 @@ describe('getBillingLimitConfig', () => {
             }
         }
     )
+
+    it('exports startup program caps by product', () => {
+        expect(STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT).toEqual({
+            [POSTHOG_CODE_USAGE_PRODUCT_KEY]: 500,
+            [REPLAY_VISION_PRODUCT_KEY]: 3000,
+        })
+    })
 })

--- a/frontend/src/scenes/billing/billingLimitConfig.test.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.test.ts
@@ -45,20 +45,21 @@ describe('getBillingLimitConfig', () => {
     )
 
     it.each([
-        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, 500, true],
-        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, 600, false],
-        [REPLAY_VISION_PRODUCT_KEY, 3750, 2000, true],
-        [REPLAY_VISION_PRODUCT_KEY, 3750, 5000, false],
-        [REPLAY_VISION_PRODUCT_KEY, null, 2000, false],
+        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, 500, 'The $500 limit starts next period.'],
+        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, null, 'future edits must be $500 or less.'],
+        [POSTHOG_CODE_USAGE_PRODUCT_KEY, 750, 600, 'future edits must be $500 or less.'],
+        [REPLAY_VISION_PRODUCT_KEY, 3750, 2000, 'The $2,000 limit starts next period.'],
+        [REPLAY_VISION_PRODUCT_KEY, 3750, 5000, 'future edits must be $3,000 or less.'],
+        [REPLAY_VISION_PRODUCT_KEY, null, 2000, null],
     ])(
-        'for %s with current limit %p and next period limit %p, above-cap notice shown: %p',
-        (productType, customLimitUsd, billingLimitNextPeriod, noticeShown) => {
+        'for %s with current limit %p and next period limit %p, above-cap notice includes %p',
+        (productType, customLimitUsd, billingLimitNextPeriod, expectedNotice) => {
             const config = getConfig(productType, StartupProgramLabel.YC, {
                 customLimitUsd,
                 billingLimitNextPeriod,
             })
-            if (noticeShown) {
-                expect(config.currentAboveMaxNotice).toContain('next period')
+            if (expectedNotice) {
+                expect(config.currentAboveMaxNotice).toContain(expectedNotice)
             } else {
                 expect(config.currentAboveMaxNotice).toBeNull()
             }

--- a/frontend/src/scenes/billing/billingLimitConfig.test.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.test.ts
@@ -6,7 +6,6 @@ import {
     MAX_BILLING_LIMIT,
     POSTHOG_CODE_USAGE_PRODUCT_KEY,
     REPLAY_VISION_PRODUCT_KEY,
-    STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT,
 } from './billingLimitConfig'
 
 describe('getBillingLimitConfig', () => {
@@ -65,11 +64,4 @@ describe('getBillingLimitConfig', () => {
             }
         }
     )
-
-    it('exports startup program caps by product', () => {
-        expect(STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT).toEqual({
-            [POSTHOG_CODE_USAGE_PRODUCT_KEY]: 500,
-            [REPLAY_VISION_PRODUCT_KEY]: 3000,
-        })
-    })
 })

--- a/frontend/src/scenes/billing/billingLimitConfig.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.ts
@@ -34,6 +34,23 @@ const DEFAULT_BILLING_LIMIT_CONFIG: BillingLimitConfig = {
 
 type BillingLimitConfigResolver = (context: BillingLimitConfigContext) => Partial<BillingLimitConfig> | null
 
+const currentAboveStartupCapNotice = (
+    productName: string,
+    cap: number,
+    customLimitUsd: number | null,
+    billingLimitNextPeriod: number | null
+): string | null => {
+    if (customLimitUsd === null || customLimitUsd <= cap) {
+        return null
+    }
+
+    if (billingLimitNextPeriod !== null && billingLimitNextPeriod <= cap) {
+        return `This period's ${productName} billing limit is above the startup program cap, so it stays at $${customLimitUsd.toLocaleString()}. The $${billingLimitNextPeriod.toLocaleString()} limit starts next period.`
+    }
+
+    return `This period's ${productName} billing limit is above the startup program cap, so future edits must be $${cap.toLocaleString()} or less.`
+}
+
 // Mirrors the caps the billing service enforces for startup-program customers, so the form
 // rejects out-of-range limits before the API does. The billing API product names are too
 // verbose for copy (e.g. "PostHog Desktop (usage-based)").
@@ -48,13 +65,12 @@ const startupProgramCapResolver = (productName: string, cap: number): BillingLim
             help: `While your organization is in the startup program, ${productName} billing limits can be set from $0 to $${cap.toLocaleString()} per month.`,
             removalDisabledReason: `While your organization is in the startup program, ${productName} billing limits can't be removed. Set the limit to $0 instead.`,
             maxExceededError: `While your organization is in the startup program, ${productName} billing limits can't exceed $${cap.toLocaleString()} per month.`,
-            currentAboveMaxNotice:
-                customLimitUsd !== null &&
-                customLimitUsd > cap &&
-                billingLimitNextPeriod !== null &&
-                billingLimitNextPeriod <= cap
-                    ? `Current usage is already above the startup program cap, so this period's limit stays at $${customLimitUsd.toLocaleString()}. The $${billingLimitNextPeriod.toLocaleString()} limit starts next period.`
-                    : null,
+            currentAboveMaxNotice: currentAboveStartupCapNotice(
+                productName,
+                cap,
+                customLimitUsd,
+                billingLimitNextPeriod
+            ),
         }
     }
 }

--- a/frontend/src/scenes/billing/billingLimitConfig.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.ts
@@ -4,10 +4,10 @@ export const MAX_BILLING_LIMIT: number = 50000
 
 export const POSTHOG_CODE_USAGE_PRODUCT_KEY = 'posthog_code_usage'
 export const REPLAY_VISION_PRODUCT_KEY = 'replay_vision'
-export const STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT: Record<string, number> = {
+export const STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT = {
     [POSTHOG_CODE_USAGE_PRODUCT_KEY]: 500,
     [REPLAY_VISION_PRODUCT_KEY]: 3000,
-}
+} as const satisfies Record<string, number>
 
 export type BillingLimitConfig = {
     max: number

--- a/frontend/src/scenes/billing/billingLimitConfig.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.ts
@@ -4,7 +4,10 @@ export const MAX_BILLING_LIMIT: number = 50000
 
 export const POSTHOG_CODE_USAGE_PRODUCT_KEY = 'posthog_code_usage'
 export const REPLAY_VISION_PRODUCT_KEY = 'replay_vision'
-export const STARTUP_PROGRAM_BILLING_LIMIT_MAX: number = 3000
+export const STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT: Record<string, number> = {
+    [POSTHOG_CODE_USAGE_PRODUCT_KEY]: 500,
+    [REPLAY_VISION_PRODUCT_KEY]: 3000,
+}
 
 export type BillingLimitConfig = {
     max: number
@@ -34,13 +37,12 @@ type BillingLimitConfigResolver = (context: BillingLimitConfigContext) => Partia
 // Mirrors the caps the billing service enforces for startup-program customers, so the form
 // rejects out-of-range limits before the API does. The billing API product names are too
 // verbose for copy (e.g. "PostHog Desktop (usage-based)").
-const startupProgramCapResolver = (productName: string): BillingLimitConfigResolver => {
+const startupProgramCapResolver = (productName: string, cap: number): BillingLimitConfigResolver => {
     return ({ billing, customLimitUsd, billingLimitNextPeriod }) => {
         if (!billing?.startup_program_label) {
             return null
         }
 
-        const cap = STARTUP_PROGRAM_BILLING_LIMIT_MAX
         return {
             max: cap,
             help: `While your organization is in the startup program, ${productName} billing limits can be set from $0 to $${cap.toLocaleString()} per month.`,
@@ -58,8 +60,14 @@ const startupProgramCapResolver = (productName: string): BillingLimitConfigResol
 }
 
 const BILLING_LIMIT_CONFIG_BY_PRODUCT: Record<string, BillingLimitConfigResolver> = {
-    [POSTHOG_CODE_USAGE_PRODUCT_KEY]: startupProgramCapResolver('Desktop'),
-    [REPLAY_VISION_PRODUCT_KEY]: startupProgramCapResolver('Replay vision'),
+    [POSTHOG_CODE_USAGE_PRODUCT_KEY]: startupProgramCapResolver(
+        'Desktop',
+        STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT[POSTHOG_CODE_USAGE_PRODUCT_KEY]
+    ),
+    [REPLAY_VISION_PRODUCT_KEY]: startupProgramCapResolver(
+        'Replay vision',
+        STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT[REPLAY_VISION_PRODUCT_KEY]
+    ),
 }
 
 export const getBillingLimitConfig = (context: BillingLimitConfigContext): BillingLimitConfig => {

--- a/products/replay_vision/frontend/utils/startupCap.ts
+++ b/products/replay_vision/frontend/utils/startupCap.ts
@@ -8,9 +8,9 @@ import type { BillingType } from '~/types'
 import type { VisionQuotaApi } from '../generated/api.schemas'
 import { CREDITS_PER_DOLLAR } from './credits'
 
-/** Billing enforces this same ceiling server-side, in dollars. */
 const STARTUP_PROGRAM_BILLING_LIMIT_MAX = STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT[REPLAY_VISION_PRODUCT_KEY]
 
+/** Billing enforces this same ceiling server-side, in dollars. */
 export const STARTUP_CAP_CREDITS: number = STARTUP_PROGRAM_BILLING_LIMIT_MAX * CREDITS_PER_DOLLAR
 
 export const STARTUP_CAP_EXPLANATION = `Startup credits are shared across all PostHog products, so the startup program caps Replay vision spend at $${STARTUP_PROGRAM_BILLING_LIMIT_MAX.toLocaleString()} per month.`

--- a/products/replay_vision/frontend/utils/startupCap.ts
+++ b/products/replay_vision/frontend/utils/startupCap.ts
@@ -1,4 +1,7 @@
-import { STARTUP_PROGRAM_BILLING_LIMIT_MAX } from 'scenes/billing/billingLimitConfig'
+import {
+    REPLAY_VISION_PRODUCT_KEY,
+    STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT,
+} from 'scenes/billing/billingLimitConfig'
 
 import type { BillingType } from '~/types'
 
@@ -6,6 +9,8 @@ import type { VisionQuotaApi } from '../generated/api.schemas'
 import { CREDITS_PER_DOLLAR } from './credits'
 
 /** Billing enforces this same ceiling server-side, in dollars. */
+const STARTUP_PROGRAM_BILLING_LIMIT_MAX = STARTUP_PROGRAM_BILLING_LIMIT_MAX_BY_PRODUCT[REPLAY_VISION_PRODUCT_KEY]
+
 export const STARTUP_CAP_CREDITS: number = STARTUP_PROGRAM_BILLING_LIMIT_MAX * CREDITS_PER_DOLLAR
 
 export const STARTUP_CAP_EXPLANATION = `Startup credits are shared across all PostHog products, so the startup program caps Replay vision spend at $${STARTUP_PROGRAM_BILLING_LIMIT_MAX.toLocaleString()} per month.`


### PR DESCRIPTION
## Problem

Startup-program customers editing a Desktop billing limit could see a $3,000 cap in the UI, while billing accepts $500.

Billing-side context: PostHog/billing#2185 lowered the Desktop cap to $500 and migrated old startup Desktop limits down to that cap. PostHog/billing#2194, PostHog/billing#2195, and PostHog/billing#2196 added the allowance flow, which can keep a higher current-period Desktop limit while scheduling $500 for the next period.

## Changes

- Desktop billing limit validation now uses a $500 startup-program cap.
- Replay vision keeps its existing $3,000 startup-program cap.
- The capped Desktop Storybook case now shows the next-period $500 transition state.
- Above-cap current-period limits now get explanatory copy even without a valid next-period limit.
- Billing limit tests now cover product-specific caps, validation copy, and above-cap notices.

No screenshot captured. This changes the billing limit amount shown in an existing form state.

## How did you test this code?

- Focused tests cover product-specific startup caps, above-cap notices, and the Replay vision utility.
- Frontend formatting and fixes pass.
- Full frontend TypeScript is still blocked by unrelated generated type/module errors in this checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Post-Deploy Monitoring & Validation

No special monitoring. This is a small frontend validation alignment; normal billing limit edit errors are enough to catch regressions.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This only aligns existing billing limit validation with the enforced caps.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex produced this patch in the local `posthog` checkout.

The review pass found one stale Storybook fixture and one missing validation-message assertion. Both were fixed before the final focused test run.
