### PR TITLE
fix(aio): stop sentiment tab exhausting query memory

### DIFF
--- a/products/ai_observability/frontend/sentimentQueries.test.ts
+++ b/products/ai_observability/frontend/sentimentQueries.test.ts
@@ -197,7 +197,7 @@ describe('sentimentQueries', () => {
         const [candidateQuery, , candidateOptions] = mockApi.queryHogQL.mock.calls[0]
         expect(candidateQuery).toContain("JSONExtractFloat(scores, 'positive')")
         expect(candidateQuery).toContain("JSONExtractFloat(scores, 'negative')")
-        expect(candidateQuery).toContain('toIntOrZero(message_count) > 0')
+        expect(candidateQuery).toContain('toIntOrZero(toString(properties.$ai_sentiment_message_count)) > 0')
         expect(candidateOptions?.queryParams?.filters).toEqual({
             dateRange: { date_from: '-7d', date_to: null },
         })
@@ -219,8 +219,18 @@ describe('sentimentQueries', () => {
     })
 
     it.each<[string, SentimentCategory[], string, string]>([
-        ['negative only', ['negative'], "label IN ['negative']", "ORDER BY JSONExtractFloat(scores, 'negative') DESC"],
-        ['positive only', ['positive'], "label IN ['positive']", "ORDER BY JSONExtractFloat(scores, 'positive') DESC"],
+        [
+            'negative only',
+            ['negative'],
+            "toString(properties.$ai_sentiment_label) IN ['negative']",
+            "ORDER BY JSONExtractFloat(scores, 'negative') DESC",
+        ],
+        [
+            'positive only',
+            ['positive'],
+            "toString(properties.$ai_sentiment_label) IN ['positive']",
+            "ORDER BY JSONExtractFloat(scores, 'positive') DESC",
+        ],
     ])('restricts the candidate query to the selected categories (%s)', async (_, categories, labelClause, order) => {
         mockApi.queryHogQL
             .mockResolvedValueOnce({ columns: candidateColumns, results: [] })

--- a/products/ai_observability/frontend/sentimentQueries.ts
+++ b/products/ai_observability/frontend/sentimentQueries.ts
@@ -17,6 +17,22 @@ function resolveActiveCategories(activeFilters: Set<SentimentCategory> | undefin
     return active.length > 0 ? active : [...SENTIMENT_CATEGORIES]
 }
 
+/** How far past a page the candidate scan reaches, to absorb rows the per-generation dedup drops */
+const CANDIDATE_SCAN_OVERFETCH = 3
+
+/** The scores payload before the candidate subquery aliases it, for use in that subquery's own clauses */
+const RAW_SCORES_EXPRESSION = 'toString(properties.$ai_sentiment_scores)'
+
+/**
+ * Ranks by the strongest score among the selected categories only, so a deselected category can't
+ * push a generation to the top of the page. Takes the scores expression because the inner and outer
+ * queries reach the same payload by different names.
+ */
+function buildRankingExpression(categories: SentimentCategory[], scoresExpression: string): string {
+    const categoryScores = categories.map((category) => `JSONExtractFloat(${scoresExpression}, '${category}')`)
+    return categoryScores.length > 1 ? `greatest(${categoryScores.join(', ')})` : categoryScores[0]
+}
+
 const SENTIMENT_QUERY_TAGS = {
     productKey: ProductKey.AI_OBSERVABILITY,
     scene: 'ai_observability_sentiment',
@@ -272,16 +288,24 @@ export async function fetchStoredGenerationSentiments(
     return results
 }
 
+/**
+ * Ranks candidates with a bounded top-N scan instead of aggregating the whole date range.
+ *
+ * Grouping by (trace_id, generation_id) held a hash table the size of its input, because there is
+ * one sentiment evaluation per generation and so the grouping deduplicated nothing. That exhausted
+ * query memory on wide date ranges. `LIMIT 1 BY` keeps the newest row per generation instead, so a
+ * re-evaluated generation still collapses to one row.
+ */
 async function fetchSentimentEvaluationCandidates(
     values: SentimentGenerationsQueryValues,
     offset: number,
     refresh?: RefreshType
 ): Promise<SentimentEvaluationCandidate[]> {
     const categories = resolveActiveCategories(values.activeFilters)
-    const categoryScores = categories.map((category) => `JSONExtractFloat(scores, '${category}')`)
-    // Rank by the strongest score among the selected categories only, so a deselected
-    // category can't push a generation to the top of the page
-    const rankingExpression = categoryScores.length > 1 ? `greatest(${categoryScores.join(', ')})` : categoryScores[0]
+    const safeOffset = Math.max(0, Math.trunc(offset))
+    // The scan has to reach past the page it fills, both to skip the offset and to leave room for
+    // rows the dedup drops.
+    const scanLimit = (safeOffset + GENERATIONS_PAGE_SIZE) * CANDIDATE_SCAN_OVERFETCH
     const evaluationClause = values.evaluationId
         ? `AND properties.$ai_evaluation_id = ${escapeHogQLString(values.evaluationId)}`
         : ''
@@ -296,27 +320,26 @@ async function fetchSentimentEvaluationCandidates(
                 SELECT
                     properties.$ai_trace_id AS trace_id,
                     ${hogql.raw(EVALUATION_TARGET_ID_SELECT)} AS generation_id,
-                    argMax(toString(uuid), timestamp) AS evaluation_id,
-                    argMax(toString(properties.$ai_sentiment_label), timestamp) AS label,
-                    argMax(toString(properties.$ai_sentiment_scores), timestamp) AS scores,
-                    argMax(toString(properties.$ai_sentiment_message_count), timestamp) AS message_count,
-                    max(timestamp) AS evaluation_timestamp
+                    toString(uuid) AS evaluation_id,
+                    toString(properties.$ai_sentiment_scores) AS scores,
+                    timestamp AS evaluation_timestamp
                 FROM events
                 WHERE event = '$ai_evaluation'
                   AND properties.$ai_evaluation_runtime = 'sentiment'
                   AND timestamp >= now() - INTERVAL 30 DAY
+                  AND toString(properties.$ai_sentiment_label) IN ${categories}
+                  AND toIntOrZero(toString(properties.$ai_sentiment_message_count)) > 0
+                  AND length(toString(properties.$ai_trace_id)) > 0
+                  AND length(${hogql.raw(EVALUATION_TARGET_ID_SELECT)}) > 0
                   ${hogql.raw(evaluationClause)}
                   AND {filters}
-                GROUP BY trace_id, generation_id
+                ORDER BY ${hogql.raw(buildRankingExpression(categories, RAW_SCORES_EXPRESSION))} DESC, timestamp DESC
+                LIMIT ${scanLimit}
             )
-            WHERE length(evaluation_id) > 0
-              AND length(trace_id) > 0
-              AND length(generation_id) > 0
-              AND label IN ${categories}
-              AND toIntOrZero(message_count) > 0
-            ORDER BY ${hogql.raw(rankingExpression)} DESC, evaluation_timestamp DESC, generation_id DESC
+            ORDER BY ${hogql.raw(buildRankingExpression(categories, 'scores'))} DESC, evaluation_timestamp DESC, generation_id DESC
+            LIMIT 1 BY trace_id, generation_id
             LIMIT ${GENERATIONS_PAGE_SIZE}
-            OFFSET ${Math.max(0, Math.trunc(offset))}
+            OFFSET ${safeOffset}
         `,
         { ...SENTIMENT_QUERY_TAGS, name: 'ai_observability_sentiment_evaluations' },
         {


### PR DESCRIPTION
## Problem

Anyone opening the Sentiment tab in AI observability over a wide date range waits about two minutes and then gets an error instead of results. Error tracking records it as a recurring out-of-memory failure, and the query that fails is the one that ranks candidates.

That query grouped by `(trace_id, generation_id)` and aggregated the whole date range before it could sort and take a page. The grouping deduplicates nothing, because there is one sentiment evaluation per generation. Measured on a sample day, the distinct group count matched the row count. So ClickHouse builds a hash table with one entry per input row, each entry holding the scores JSON through `argMax`, and exhausts the memory limit.

The filters made it worse. `label` and `message_count` sat in the outer query, applied to `argMax` results, so ClickHouse could not push them down. The aggregation processed every label before discarding all but the selected ones.

## Changes

- The tab now loads over date ranges that used to fail.
- The rows and their order do not change. The ranking users see is the same.
- The query ranks with a bounded top-N scan instead of aggregating the range, so memory scales with page size rather than with the range.
- `LIMIT 1 BY trace_id, generation_id` replaces the grouping, keeping the newest row per generation.
- The category and message-count filters move into the scan, where they cut rows before the sort.
- The scan deliberately over-fetches and keeps a dedup step. The one-evaluation-per-generation ratio comes from one project on one day, so a project that re-runs evaluations stays correct.
- Nothing looks different, so this PR has no screenshot. The tab renders the same rows from the same data.

## How did you test this code?

Both query shapes ran against production ClickHouse through the SQL editor, on PostHog's own project.

| Date range | Current query | This change |
| --- | --- | --- |
| 7 days | Works | Works, byte-identical rows |
| 30 days | Out of memory after about 2 minutes | Returns immediately |
| 90 days | Not attempted | Returns a full page |

Also covered: both ranking paths (one category, and both categories through `greatest()`), and offset pagination combined with the dedup clause, which returns a full page.

No new tests. The two properties that matter here, identical rows and bounded memory, need real ClickHouse and cannot be asserted in Jest. A test over the generated query text would detect edits to a string, not regressions in behavior. The existing cases in `sentimentQueries.test.ts` carry the query's observable contract and still pass; two of them asserted clause text this change removes and were updated to the new text.

Not run: the app. The dev stack was not started, so no part of this was seen in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus). Skills invoked: `/query-clickhouse-via-metabase`, `/writing-tests`, `/writing-pr-descriptions`.

Two earlier hypotheses were checked and dropped. The hydration query looked slow for want of a date bound, but `ai_events` is ordered by trace id, so that lookup is already cheap. The ranking itself looked structurally expensive, which pointed at replacing it with recency ordering. The cardinality measurement then showed the cost was the aggregation, not the sort, so the ranking stays as users know it.

A precomputed ranking would also fix this. It was not chosen because a materialized view and a backfill buy what removing the aggregation buys outright.

An earlier PR on this surface covered the error state rather than the cause, and was closed in favour of this one.

Investigation found two further defects on this surface, neither addressed here. The hydration query targets the dedicated AI events table unconditionally, and fails outright where a project's test-account filter references a cohort or a group property. The loader also starts one query per subscription on a page load, because it discards stale requests without debouncing them.

Nothing in this PR carries material from the agent session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
