### PR TITLE
feat(logs): add measure-only log pattern masking logic

### DIFF
--- a/nodejs/src/logs/config.ts
+++ b/nodejs/src/logs/config.ts
@@ -14,6 +14,9 @@ import { isProdEnv } from '~/common/utils/env-utils'
 
 import { LogsProducerName, WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_LOGS_PRODUCER } from './outputs/producers'
 
+export const DEFAULT_PATTERN_MAX_INPUT_CHARS = 8192
+export const DEFAULT_PATTERN_MAX_OUTPUT_CHARS = 1024
+
 export type LogsIngestionOutputsConfig = {
     LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC: string
     LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER: LogsProducerName

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'node:crypto'
+import RE2 from 're2'
+
+import { JSON_ARRAY, MASK_RULES, PATTERN_VERSION, computeLogPattern, maskString } from './log-pattern-mask'
+
+const NO_CAP = 100_000
+
+describe('log-pattern-mask', () => {
+    describe('maskString', () => {
+        it.each([
+            ['timestamp iso Z', 'started at 2026-08-24T10:20:45.123Z ok', 'started at <TIMESTAMP> ok'],
+            ['timestamp space comma millis', 'at 2026-08-24 10:20:45,123 done', 'at <TIMESTAMP> done'],
+            ['timestamp offset', 'at 2026-08-24T10:20:45+02:00 done', 'at <TIMESTAMP> done'],
+            ['uuid', 'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 failed', 'request <UUID> failed'],
+            ['email', 'user alice@example.com rejected', 'user <EMAIL> rejected'],
+            ['hex0x', 'fault at 0xdeadBEEF handler', 'fault at <HEX> handler'],
+            ['hex long run', 'trace deadbeefdeadbeef00 end', 'trace <HEX> end'],
+            ['ipv4', 'connection from 10.0.0.1 refused', 'connection from <IP> refused'],
+            ['num', 'retry 5 of 7', 'retry <N> of <N>'],
+        ])('rule %s masks the token and leaves neighbouring text intact', (_name, input, expected) => {
+            expect(maskString(input).masked).toEqual(expected)
+        })
+
+        it.each([
+            ['timestamp is not shredded by num', '2026-08-24T10:20:45Z', '<TIMESTAMP>'],
+            ['ip octets are not eaten by num', 'peer 192.168.0.1:8080 up', 'peer <IP>:<N> up'],
+            ['email starting with digits is not mangled by num', '99bottles@example.com sent', '<EMAIL> sent'],
+        ])('ordering: %s', (_name, input, expected) => {
+            expect(maskString(input).masked).toEqual(expected)
+        })
+
+        it.each([
+            ['trailing boundary dropped', 'took 7141ms', 'took <N>ms'],
+            ['leading boundary kept', 'GET /v0/export', 'GET /v0/export'],
+            ['adjacent standalone numbers both mask', '5 7', '<N> <N>'],
+        ])('num boundary semantics: %s', (_name, input, expected) => {
+            expect(maskString(input).masked).toEqual(expected)
+        })
+
+        it('counts fires per rule', () => {
+            const { ruleFires } = maskString('a@example.com b@example.com from 10.0.0.1 in 12ms')
+            const byName = Object.fromEntries(MASK_RULES.map((rule, i) => [rule.name, ruleFires[i]]))
+            expect(byName).toEqual({ timestamp: 0, uuid: 0, email: 2, hex0x: 0, hex: 0, ipv4: 1, num: 1 })
+        })
+    })
+
+    describe('computeLogPattern', () => {
+        it('masks before truncating, so a UUID straddling the cut point still yields its placeholder', () => {
+            const body = 'abcdefghij 0f2d6faf-07e3-4cff-bf47-7efa1024aee2'
+            const result = computeLogPattern(body, NO_CAP, 20)
+            expect(result.pattern).toEqual('abcdefghij <UUID>')
+            expect(result.maskedLength).toEqual('abcdefghij <UUID>'.length)
+        })
+
+        it('reports the pre-truncation masked length and truncates the pattern', () => {
+            const result = computeLogPattern('x'.repeat(50), NO_CAP, 10)
+            expect(result.pattern).toEqual('x'.repeat(10))
+            expect(result.maskedLength).toEqual(50)
+        })
+
+        it('caps the input before masking and reports it', () => {
+            const result = computeLogPattern('abc 12345678', 6, NO_CAP)
+            expect(result.inputCapped).toEqual(true)
+            expect(result.pattern).toEqual('abc <N>')
+        })
+
+        it('caps the raw body before the JSON parse, so an oversized JSON body is treated as truncated prose', () => {
+            const body = JSON.stringify({ message: 'x'.repeat(100) })
+            const result = computeLogPattern(body, 20, NO_CAP)
+            expect(result.inputCapped).toEqual(true)
+            expect(result.bodyKind).toEqual('invalid_json')
+            expect(result.pattern).toEqual(body.slice(0, 20))
+        })
+
+        it.each([
+            ['null body', null, 'empty', ''],
+            // A record decoded from a schema with no `body` field yields undefined, not null.
+            ['missing body', undefined, 'empty', ''],
+            // `parseLogBodyForIngestion` calls '' invalid JSON; a body with no pattern in it must
+            // not land on the prose side of the structured-versus-prose split.
+            ['empty body', '', 'empty', ''],
+            [
+                'json object with message',
+                '{"message":"user 5 in","level":"info"}',
+                'json_object_or_array',
+                'user <N> in',
+            ],
+            ['json object with msg', '{"msg":"hi 9"}', 'json_object_or_array', 'hi <N>'],
+            ['json object with event', '{"event":"click 3"}', 'json_object_or_array', 'click <N>'],
+            ['json object without message key', '{"level":"info"}', 'json_object_or_array', '<JSON:level>'],
+            ['json array', '[1,2]', 'json_object_or_array', JSON_ARRAY],
+            ['json string', '"quoted 7"', 'json_string', 'quoted <N>'],
+            ['json number primitive', '42', 'primitive', '<N>'],
+            ['prose body', 'plain text 3', 'invalid_json', 'plain text <N>'],
+        ])('body kind %s', (_name, body, expectedKind, expectedPattern) => {
+            const result = computeLogPattern(body, NO_CAP, NO_CAP)
+            expect(result.bodyKind).toEqual(expectedKind)
+            expect(result.pattern).toEqual(expectedPattern)
+        })
+
+        describe('key-set identity for message-less JSON objects', () => {
+            const patternOf = (body: string): string => computeLogPattern(body, NO_CAP, NO_CAP).pattern
+
+            it('is independent of source key order', () => {
+                expect(patternOf('{"b":1,"a":2}')).toEqual('<JSON:a,b>')
+                expect(patternOf('{"a":2,"b":1}')).toEqual('<JSON:a,b>')
+            })
+
+            it('caps at 32 keys with a dropped-key suffix, deterministically across orderings', () => {
+                const keys = Array.from({ length: 40 }, (_, i) => `k${String(i).padStart(2, '0')}`)
+                const forward = JSON.stringify(Object.fromEntries(keys.map((k) => [k, 1])))
+                const reversed = JSON.stringify(Object.fromEntries([...keys].reverse().map((k) => [k, 1])))
+                const expected = `<JSON:${keys.slice(0, 32).join(',')},+8>`
+                expect(patternOf(forward)).toEqual(expected)
+                expect(patternOf(reversed)).toEqual(expected)
+                // The key-count metric sees the uncapped count.
+                expect(computeLogPattern(forward, NO_CAP, NO_CAP).jsonKeyCount).toEqual(40)
+            })
+
+            it('reports the key count only for key-set patterns', () => {
+                expect(computeLogPattern('{"a":1}', NO_CAP, NO_CAP).jsonKeyCount).toEqual(1)
+                expect(computeLogPattern('[1,2]', NO_CAP, NO_CAP).jsonKeyCount).toBeUndefined()
+                expect(computeLogPattern('{"message":"hi"}', NO_CAP, NO_CAP).jsonKeyCount).toBeUndefined()
+            })
+
+            it('renders an empty object as an empty key set', () => {
+                expect(patternOf('{}')).toEqual('<JSON:>')
+            })
+
+            it('takes only top-level keys from nested objects', () => {
+                expect(patternOf('{"outer":{"inner":1},"other":[1,2]}')).toEqual('<JSON:other,outer>')
+            })
+
+            it('never masks keys, so value-shaped keys stay verbatim', () => {
+                expect(patternOf('{"10.0.0.1":1,"7141":2,"user@example.com":3}')).toEqual(
+                    '<JSON:10.0.0.1,7141,user@example.com>'
+                )
+            })
+        })
+    })
+
+    describe('PATTERN_VERSION ratchet', () => {
+        // A stored pattern only compares to another from the same rule set, so PATTERN_VERSION has to
+        // move whenever the rules or their order do. Nothing reads the constant yet, so nothing else
+        // notices a rule change that forgot the bump. When this fails, bump PATTERN_VERSION and the
+        // digest below together, in the same commit.
+        it('moves whenever MASK_RULES changes', () => {
+            const digest = createHash('sha256')
+                .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
+                .digest('hex')
+                .slice(0, 16)
+            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 1, digest: 'd8b059c25a24983d' })
+        })
+    })
+
+    describe('RE2 ratchet', () => {
+        it.each(MASK_RULES.map((rule) => [rule.name, rule.pattern] as const))(
+            'rule %s compiles under RE2 and uses no lookaround, backreference, or capture group',
+            (_name, pattern) => {
+                expect(() => new RE2(pattern, 'g')).not.toThrow()
+                expect(pattern).not.toMatch(/\(\?=|\(\?!|\(\?</)
+                expect(pattern).not.toMatch(/\\[1-9]/)
+                expect(pattern.replace(/\\\(/g, '')).not.toMatch(/\((?!\?)/)
+            }
+        )
+    })
+
+    describe('node/ClickHouse agreement', () => {
+        // The rule set was validated in ClickHouse as a sequential replaceRegexpAll chain.
+        const sequentialChain = (input: string): string =>
+            MASK_RULES.reduce((acc, rule) => acc.replace(new RE2(rule.pattern, 'g'), rule.replacement), input)
+
+        const corpus = [
+            'events rate limited by distinct_id -- person processing disabled',
+            'geoIP computation error: The address 203.0.113.7 is not in the database.',
+            '2026-08-24T10:20:45.123Z error in worker 12: connect ECONNREFUSED 10.0.0.1:6379',
+            'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 for alice@example.com took 7141ms',
+            'checksum deadbeefdeadbeef00 at offset 0x7fff5fbff8c0',
+            'GET /v0/export?since=1724495000 -> 200 in 35ms',
+            'lag=1.5s status=500 retries=3',
+            'batch 5 7 11 done at 2026-08-24 10:20:45,001',
+            'no variable parts in this line at all',
+            'mixed a99@example.com then 192.168.0.1 then 99bottles@example.com',
+        ]
+
+        it.each(corpus.map((line) => [line] as const))('%s', (line) => {
+            expect(maskString(line).masked).toEqual(sequentialChain(line))
+        })
+    })
+})

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -74,10 +74,7 @@ describe('log-pattern-mask', () => {
 
         it.each([
             ['null body', null, 'empty', ''],
-            // A record decoded from a schema with no `body` field yields undefined, not null.
             ['missing body', undefined, 'empty', ''],
-            // `parseLogBodyForIngestion` calls '' invalid JSON; a body with no pattern in it must
-            // not land on the prose side of the structured-versus-prose split.
             ['empty body', '', 'empty', ''],
             [
                 'json object with message',
@@ -113,7 +110,6 @@ describe('log-pattern-mask', () => {
                 const expected = `<JSON:${keys.slice(0, 32).join(',')},+8>`
                 expect(patternOf(forward)).toEqual(expected)
                 expect(patternOf(reversed)).toEqual(expected)
-                // The key-count metric sees the uncapped count.
                 expect(computeLogPattern(forward, NO_CAP, NO_CAP).jsonKeyCount).toEqual(40)
             })
 
@@ -140,10 +136,6 @@ describe('log-pattern-mask', () => {
     })
 
     describe('PATTERN_VERSION ratchet', () => {
-        // A stored pattern only compares to another from the same rule set, so PATTERN_VERSION has to
-        // move whenever the rules or their order do. Nothing reads the constant yet, so nothing else
-        // notices a rule change that forgot the bump. When this fails, bump PATTERN_VERSION and the
-        // digest below together, in the same commit.
         it('moves whenever MASK_RULES changes', () => {
             const digest = createHash('sha256')
                 .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
@@ -166,7 +158,6 @@ describe('log-pattern-mask', () => {
     })
 
     describe('node/ClickHouse agreement', () => {
-        // The rule set was validated in ClickHouse as a sequential replaceRegexpAll chain.
         const sequentialChain = (input: string): string =>
             MASK_RULES.reduce((acc, rule) => acc.replace(new RE2(rule.pattern, 'g'), rule.replacement), input)
 

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -1,0 +1,182 @@
+/**
+ * Replace the variable parts of a log body with placeholders so the remaining shape is a stable
+ * pattern identity. One combined alternation regex, one pass; alternation order is rule priority.
+ * Rules must stay RE2-safe (bodies are attacker-controlled); a test ratchet enforces this.
+ */
+import { createTrackedRE2 } from '~/common/utils/tracked-re2'
+
+import { parseLogBodyForIngestion } from './log-body-parse'
+
+/** A rule change re-keys every pattern, so bump this in the same commit as any rule change. */
+export const PATTERN_VERSION = 1
+
+export type MaskRuleName = 'timestamp' | 'uuid' | 'email' | 'hex0x' | 'hex' | 'ipv4' | 'num'
+
+export type MaskRule = {
+    name: MaskRuleName
+    /** RE2-safe source with no capturing groups; the combined regex wraps it in one. */
+    pattern: string
+    replacement: string
+}
+
+/**
+ * Order is load-bearing: `timestamp` and `ipv4` before `num`, `email` before anything claiming
+ * part of an address. `num` drops the trailing `\b` on purpose so `7141ms` masks to `<N>ms`.
+ */
+export const MASK_RULES: readonly MaskRule[] = [
+    {
+        name: 'timestamp',
+        pattern: '\\b\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:[.,]\\d+)?(?:Z|[+-]\\d{2}:?\\d{2})?',
+        replacement: '<TIMESTAMP>',
+    },
+    {
+        name: 'uuid',
+        pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+        replacement: '<UUID>',
+    },
+    // Copied from `log-pii-scrub.ts` on purpose: sharing it would tie scrub edits to PATTERN_VERSION.
+    { name: 'email', pattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}', replacement: '<EMAIL>' },
+    { name: 'hex0x', pattern: '\\b0x[0-9a-fA-F]+\\b', replacement: '<HEX>' },
+    { name: 'hex', pattern: '\\b[0-9a-fA-F]{16,}\\b', replacement: '<HEX>' },
+    { name: 'ipv4', pattern: '\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b', replacement: '<IP>' },
+    { name: 'num', pattern: '\\b\\d+', replacement: '<N>' },
+]
+
+/** Bucket for JSON array bodies; key-set identity only applies to objects. */
+export const JSON_ARRAY = '<JSON_ARRAY>'
+
+/** Over the cap, the key-set pattern keeps the first keys after sorting and appends `,+N`. */
+const KEY_SET_MAX_KEYS = 32
+
+const MASK_COMBINED_RE = createTrackedRE2(
+    MASK_RULES.map((rule) => `(${rule.pattern})`).join('|'),
+    'g',
+    'log-pattern-mask:combined'
+)
+
+export type MaskResult = {
+    masked: string
+    /** Match counts aligned with `MASK_RULES` by index. */
+    ruleFires: number[]
+}
+
+export function maskString(input: string): MaskResult {
+    const ruleFires: number[] = new Array(MASK_RULES.length).fill(0)
+    const masked = input.replace(MASK_COMBINED_RE, (...args: unknown[]): string => {
+        for (let i = 0; i < MASK_RULES.length; i++) {
+            if (args[i + 1] !== undefined) {
+                ruleFires[i]++
+                return MASK_RULES[i].replacement
+            }
+        }
+        return args[0] as string
+    })
+    return { masked, ruleFires }
+}
+
+export type PatternBodyKind = 'empty' | 'invalid_json' | 'json_object_or_array' | 'json_string' | 'primitive'
+
+export type LogPatternResult = {
+    /** Masked, then truncated to `maxOutputChars`. */
+    pattern: string
+    bodyKind: PatternBodyKind
+    /** True when the body exceeded `maxInputChars` and was cut before masking. */
+    inputCapped: boolean
+    /** Masked length before truncation. */
+    maskedLength: number
+    /** Top-level key count when the pattern is a key-set identity; absent otherwise. */
+    jsonKeyCount?: number
+    ruleFires: number[]
+}
+
+const MESSAGE_KEYS = ['message', 'msg', 'event'] as const
+
+function extractJsonMessage(value: object): string | null {
+    if (Array.isArray(value)) {
+        return null
+    }
+    for (const key of MESSAGE_KEYS) {
+        const candidate = (value as Record<string, unknown>)[key]
+        if (typeof candidate === 'string') {
+            return candidate
+        }
+    }
+    return null
+}
+
+/**
+ * Sorted top-level key list as a deterministic identity for message-less JSON objects: sort so
+ * source key order does not matter, top-level only, keys verbatim. Keys are schema, not values,
+ * so the mask rules never run on this pattern.
+ */
+function jsonKeySetPattern(value: object): string {
+    const keys = Object.keys(value).sort()
+    const kept = keys.slice(0, KEY_SET_MAX_KEYS)
+    const overflow = keys.length - kept.length
+    return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
+}
+
+/**
+ * Cap the input, mask, then truncate the masked result. Mask before truncate so masking shortens
+ * the line first and more real content survives the cut.
+ */
+export function computeLogPattern(
+    body: string | null | undefined,
+    maxInputChars: number,
+    maxOutputChars: number
+): LogPatternResult {
+    // Nullish, not `=== null`: a record decoded from a schema with no `body` field yields undefined.
+    // `''` belongs here too — `parseLogBodyForIngestion` calls it invalid JSON, which would file a
+    // body carrying no pattern on the prose side of the structured-versus-prose split.
+    if (body === null || body === undefined || body === '') {
+        return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
+    }
+
+    // Cap before parsing so the ceiling guards the JSON.parse too; a capped JSON body parses as prose.
+    const inputCapped = body.length > maxInputChars
+    const cappedBody = inputCapped ? body.slice(0, maxInputChars) : body
+    const parsed = parseLogBodyForIngestion(cappedBody)
+    const bodyKind: PatternBodyKind = parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind
+
+    let maskInput: string
+    switch (parsed.kind) {
+        case 'empty':
+            maskInput = ''
+            break
+        case 'json_object_or_array': {
+            const message = extractJsonMessage(parsed.value)
+            if (message === null) {
+                const isArray = Array.isArray(parsed.value)
+                const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
+                return {
+                    pattern: pattern.length > maxOutputChars ? pattern.slice(0, maxOutputChars) : pattern,
+                    bodyKind,
+                    inputCapped,
+                    maskedLength: pattern.length,
+                    ...(isArray ? {} : { jsonKeyCount: Object.keys(parsed.value).length }),
+                    ruleFires: [],
+                }
+            }
+            maskInput = message
+            break
+        }
+        case 'json_string':
+            maskInput = parsed.value
+            break
+        case 'json_primitive':
+            maskInput = cappedBody
+            break
+        case 'invalid_json':
+            maskInput = parsed.raw
+            break
+    }
+
+    const { masked, ruleFires } = maskString(maskInput)
+    return {
+        pattern: masked.length > maxOutputChars ? masked.slice(0, maxOutputChars) : masked,
+        bodyKind,
+        inputCapped,
+        maskedLength: masked.length,
+        ruleFires,
+    }
+}

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -1,28 +1,17 @@
-/**
- * Replace the variable parts of a log body with placeholders so the remaining shape is a stable
- * pattern identity. One combined alternation regex, one pass; alternation order is rule priority.
- * Rules must stay RE2-safe (bodies are attacker-controlled); a test ratchet enforces this.
- */
 import { createTrackedRE2 } from '~/common/utils/tracked-re2'
 
 import { parseLogBodyForIngestion } from './log-body-parse'
 
-/** A rule change re-keys every pattern, so bump this in the same commit as any rule change. */
 export const PATTERN_VERSION = 1
 
 export type MaskRuleName = 'timestamp' | 'uuid' | 'email' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
 export type MaskRule = {
     name: MaskRuleName
-    /** RE2-safe source with no capturing groups; the combined regex wraps it in one. */
     pattern: string
     replacement: string
 }
 
-/**
- * Order is load-bearing: `timestamp` and `ipv4` before `num`, `email` before anything claiming
- * part of an address. `num` drops the trailing `\b` on purpose so `7141ms` masks to `<N>ms`.
- */
 export const MASK_RULES: readonly MaskRule[] = [
     {
         name: 'timestamp',
@@ -34,7 +23,6 @@ export const MASK_RULES: readonly MaskRule[] = [
         pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
         replacement: '<UUID>',
     },
-    // Copied from `log-pii-scrub.ts` on purpose: sharing it would tie scrub edits to PATTERN_VERSION.
     { name: 'email', pattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}', replacement: '<EMAIL>' },
     { name: 'hex0x', pattern: '\\b0x[0-9a-fA-F]+\\b', replacement: '<HEX>' },
     { name: 'hex', pattern: '\\b[0-9a-fA-F]{16,}\\b', replacement: '<HEX>' },
@@ -42,10 +30,8 @@ export const MASK_RULES: readonly MaskRule[] = [
     { name: 'num', pattern: '\\b\\d+', replacement: '<N>' },
 ]
 
-/** Bucket for JSON array bodies; key-set identity only applies to objects. */
 export const JSON_ARRAY = '<JSON_ARRAY>'
 
-/** Over the cap, the key-set pattern keeps the first keys after sorting and appends `,+N`. */
 const KEY_SET_MAX_KEYS = 32
 
 const MASK_COMBINED_RE = createTrackedRE2(
@@ -56,7 +42,6 @@ const MASK_COMBINED_RE = createTrackedRE2(
 
 export type MaskResult = {
     masked: string
-    /** Match counts aligned with `MASK_RULES` by index. */
     ruleFires: number[]
 }
 
@@ -77,14 +62,10 @@ export function maskString(input: string): MaskResult {
 export type PatternBodyKind = 'empty' | 'invalid_json' | 'json_object_or_array' | 'json_string' | 'primitive'
 
 export type LogPatternResult = {
-    /** Masked, then truncated to `maxOutputChars`. */
     pattern: string
     bodyKind: PatternBodyKind
-    /** True when the body exceeded `maxInputChars` and was cut before masking. */
     inputCapped: boolean
-    /** Masked length before truncation. */
     maskedLength: number
-    /** Top-level key count when the pattern is a key-set identity; absent otherwise. */
     jsonKeyCount?: number
     ruleFires: number[]
 }
@@ -104,11 +85,6 @@ function extractJsonMessage(value: object): string | null {
     return null
 }
 
-/**
- * Sorted top-level key list as a deterministic identity for message-less JSON objects: sort so
- * source key order does not matter, top-level only, keys verbatim. Keys are schema, not values,
- * so the mask rules never run on this pattern.
- */
 function jsonKeySetPattern(value: object): string {
     const keys = Object.keys(value).sort()
     const kept = keys.slice(0, KEY_SET_MAX_KEYS)
@@ -116,23 +92,15 @@ function jsonKeySetPattern(value: object): string {
     return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
 }
 
-/**
- * Cap the input, mask, then truncate the masked result. Mask before truncate so masking shortens
- * the line first and more real content survives the cut.
- */
 export function computeLogPattern(
     body: string | null | undefined,
     maxInputChars: number,
     maxOutputChars: number
 ): LogPatternResult {
-    // Nullish, not `=== null`: a record decoded from a schema with no `body` field yields undefined.
-    // `''` belongs here too — `parseLogBodyForIngestion` calls it invalid JSON, which would file a
-    // body carrying no pattern on the prose side of the structured-versus-prose split.
     if (body === null || body === undefined || body === '') {
         return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
     }
 
-    // Cap before parsing so the ceiling guards the JSON.parse too; a capped JSON body parses as prose.
     const inputCapped = body.length > maxInputChars
     const cappedBody = inputCapped ? body.slice(0, maxInputChars) : body
     const parsed = parseLogBodyForIngestion(cappedBody)

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -1,0 +1,87 @@
+import type { Counter } from 'prom-client'
+
+import { DEFAULT_PATTERN_MAX_INPUT_CHARS } from './config'
+import {
+    logsPatternBodyKindCounter,
+    logsPatternInputCappedCounter,
+    logsPatternRuleFiredCounter,
+    logsPatternStageErrorCounter,
+    makePatternMaskingStage,
+} from './log-pattern-stage'
+import type { LogRecord } from './log-record-avro'
+
+const makeRecord = (body: string | null): LogRecord => ({
+    uuid: null,
+    trace_id: null,
+    span_id: null,
+    trace_flags: null,
+    timestamp: null,
+    observed_timestamp: null,
+    body,
+    severity_text: null,
+    severity_number: null,
+    service_name: null,
+    resource_attributes: null,
+    instrumentation_scope: null,
+    event_name: null,
+    attributes: null,
+})
+
+describe('log-pattern-stage', () => {
+    beforeEach(() => {
+        logsPatternBodyKindCounter.reset()
+        logsPatternRuleFiredCounter.reset()
+        logsPatternInputCappedCounter.reset()
+        logsPatternStageErrorCounter.reset()
+    })
+
+    const counterValues = async (counter: Counter<string>): Promise<Record<string, number>> => {
+        const metric = await counter.get()
+        return Object.fromEntries(metric.values.map((v) => [Object.values(v.labels)[0] ?? '', v.value]))
+    }
+
+    it('tallies body kinds, rule fires, and input caps across a batch without touching the records', async () => {
+        const stage = makePatternMaskingStage(20, 1024)
+        const records = [
+            makeRecord(null),
+            makeRecord('plain 5'),
+            makeRecord('{"message":"hi"}'),
+            makeRecord('a long body over the input cap 123'),
+        ]
+        const bodiesBefore = records.map((r) => r.body)
+
+        await stage.run(records)
+
+        expect(records.map((r) => r.body)).toEqual(bodiesBefore)
+        expect(await counterValues(logsPatternBodyKindCounter)).toEqual({
+            empty: 1,
+            invalid_json: 2,
+            json_object_or_array: 1,
+        })
+        expect(await counterValues(logsPatternRuleFiredCounter)).toEqual({ num: 1 })
+        expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
+    })
+
+    it('falls back to the default caps when a configured cap is not a positive integer', async () => {
+        const stage = makePatternMaskingStage(Number.NaN, -1)
+        await stage.run([makeRecord('x'.repeat(DEFAULT_PATTERN_MAX_INPUT_CHARS + 1))])
+        expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
+    })
+
+    it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
+        const stage = makePatternMaskingStage(1024, 1024)
+        // A throwing getter stands in for any masking fault. Uncontained, this rejects
+        // `processLogMessageBuffer` and sends the whole message to the DLQ.
+        const record = makeRecord(null)
+        Object.defineProperty(record, 'body', {
+            get: () => {
+                throw new Error('boom')
+            },
+        })
+
+        // A throw escaping here fails the test, which is the regression being guarded.
+        await stage.run([record])
+
+        expect((await logsPatternStageErrorCounter.get()).values[0].value).toEqual(1)
+    })
+})

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -70,8 +70,6 @@ describe('log-pattern-stage', () => {
 
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
         const stage = makePatternMaskingStage(1024, 1024)
-        // A throwing getter stands in for any masking fault. Uncontained, this rejects
-        // `processLogMessageBuffer` and sends the whole message to the DLQ.
         const record = makeRecord(null)
         Object.defineProperty(record, 'body', {
             get: () => {
@@ -79,7 +77,6 @@ describe('log-pattern-stage', () => {
             },
         })
 
-        // A throw escaping here fails the test, which is the regression being guarded.
         await stage.run([record])
 
         expect((await logsPatternStageErrorCounter.get()).values[0].value).toEqual(1)

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -1,0 +1,119 @@
+import { performance } from 'node:perf_hooks'
+import { Counter, Histogram } from 'prom-client'
+
+import { DEFAULT_PATTERN_MAX_INPUT_CHARS, DEFAULT_PATTERN_MAX_OUTPUT_CHARS } from './config'
+import { MASK_RULES, computeLogPattern } from './log-pattern-mask'
+import type { LogRecord } from './log-record-avro'
+import type { PipelineStage } from './pipeline/log-processing-pipeline'
+
+/**
+ * Measure-only stage: computes a pattern per surviving record, records metrics, discards the
+ * pattern. It re-parses each body because earlier stages can mutate it after normalize.
+ * No `team_id` labels: per-team labels would blow up Prometheus cardinality.
+ */
+
+export const logsPatternBodyKindCounter = new Counter({
+    name: 'logs_ingestion_pattern_body_kind_total',
+    help: 'Log bodies seen by the pattern masking stage, split by parse outcome. The structured-versus-prose split.',
+    labelNames: ['kind'],
+})
+
+export const logsPatternMaskedLengthHistogram = new Histogram({
+    name: 'logs_ingestion_pattern_masked_length_chars',
+    help: 'Masked pattern length before output truncation. Picks the output truncation length from data.',
+    buckets: [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096],
+})
+
+export const logsPatternKeySetKeysHistogram = new Histogram({
+    name: 'logs_ingestion_pattern_keyset_keys',
+    help: 'Top-level key count of message-less JSON objects. Everything above the 32 bucket was capped; validates the key-set cap from data.',
+    buckets: [1, 2, 4, 8, 16, 24, 32, 48, 64, 128],
+})
+
+export const logsPatternMaskingDurationHistogram = new Histogram({
+    name: 'logs_ingestion_pattern_masking_duration_seconds',
+    help: 'Per-record pattern masking duration.',
+    buckets: [0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01],
+})
+
+export const logsPatternRuleFiredCounter = new Counter({
+    name: 'logs_ingestion_pattern_rule_fired_total',
+    help: 'Mask rule matches, by rule. Shows whether any rule is dead weight.',
+    labelNames: ['rule'],
+})
+
+export const logsPatternInputCappedCounter = new Counter({
+    name: 'logs_ingestion_pattern_input_capped_total',
+    help: 'Log bodies cut at the masking input ceiling. Sizes the long-line problem.',
+})
+
+export const logsPatternForcedDecodeCounter = new Counter({
+    name: 'logs_ingestion_pattern_forced_decode_total',
+    help: 'Batches the pattern masking gate pushed onto a costlier buffer path, by what the batch would have done without the stage.',
+    labelNames: ['from'],
+})
+
+export const logsPatternStageErrorCounter = new Counter({
+    name: 'logs_ingestion_pattern_stage_error_total',
+    help: 'Batches where the pattern masking stage threw. The records survive; only these metrics are lost.',
+})
+
+const positiveIntOr = (value: number, fallback: number): number =>
+    Number.isInteger(value) && value > 0 ? value : fallback
+
+export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: number): PipelineStage {
+    // A NaN cap would silently disable both limits and a negative one hits negative-slice semantics.
+    const inputCap = positiveIntOr(maxInputChars, DEFAULT_PATTERN_MAX_INPUT_CHARS)
+    const outputCap = positiveIntOr(maxOutputChars, DEFAULT_PATTERN_MAX_OUTPUT_CHARS)
+    return {
+        kind: 'mutate',
+        name: 'pattern_masking',
+        run: (records) => {
+            // Contained: this stage produces measurements, not records. Letting a throw out would
+            // reject the message and DLQ customer logs to protect a number, so lose the batch's
+            // metrics instead and count that it happened.
+            try {
+                measureBatch(records, inputCap, outputCap)
+            } catch {
+                logsPatternStageErrorCounter.inc()
+            }
+        },
+    }
+}
+
+function measureBatch(records: LogRecord[], inputCap: number, outputCap: number): void {
+    const kindCounts = new Map<string, number>()
+    const ruleFires: number[] = new Array(MASK_RULES.length).fill(0)
+    let inputCapped = 0
+
+    for (const record of records) {
+        const start = performance.now()
+        const result = computeLogPattern(record.body, inputCap, outputCap)
+        logsPatternMaskingDurationHistogram.observe((performance.now() - start) / 1000)
+
+        logsPatternMaskedLengthHistogram.observe(result.maskedLength)
+        if (result.jsonKeyCount !== undefined) {
+            logsPatternKeySetKeysHistogram.observe(result.jsonKeyCount)
+        }
+        kindCounts.set(result.bodyKind, (kindCounts.get(result.bodyKind) ?? 0) + 1)
+        for (let i = 0; i < result.ruleFires.length; i++) {
+            ruleFires[i] += result.ruleFires[i]
+        }
+        if (result.inputCapped) {
+            inputCapped++
+        }
+    }
+
+    // One increment per label per batch (not per record) to keep the hot path cheap.
+    for (const [kind, count] of kindCounts) {
+        logsPatternBodyKindCounter.inc({ kind }, count)
+    }
+    for (let i = 0; i < ruleFires.length; i++) {
+        if (ruleFires[i] > 0) {
+            logsPatternRuleFiredCounter.inc({ rule: MASK_RULES[i].name }, ruleFires[i])
+        }
+    }
+    if (inputCapped > 0) {
+        logsPatternInputCappedCounter.inc(inputCapped)
+    }
+}

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -6,12 +6,6 @@ import { MASK_RULES, computeLogPattern } from './log-pattern-mask'
 import type { LogRecord } from './log-record-avro'
 import type { PipelineStage } from './pipeline/log-processing-pipeline'
 
-/**
- * Measure-only stage: computes a pattern per surviving record, records metrics, discards the
- * pattern. It re-parses each body because earlier stages can mutate it after normalize.
- * No `team_id` labels: per-team labels would blow up Prometheus cardinality.
- */
-
 export const logsPatternBodyKindCounter = new Counter({
     name: 'logs_ingestion_pattern_body_kind_total',
     help: 'Log bodies seen by the pattern masking stage, split by parse outcome. The structured-versus-prose split.',
@@ -62,16 +56,12 @@ const positiveIntOr = (value: number, fallback: number): number =>
     Number.isInteger(value) && value > 0 ? value : fallback
 
 export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: number): PipelineStage {
-    // A NaN cap would silently disable both limits and a negative one hits negative-slice semantics.
     const inputCap = positiveIntOr(maxInputChars, DEFAULT_PATTERN_MAX_INPUT_CHARS)
     const outputCap = positiveIntOr(maxOutputChars, DEFAULT_PATTERN_MAX_OUTPUT_CHARS)
     return {
         kind: 'mutate',
         name: 'pattern_masking',
         run: (records) => {
-            // Contained: this stage produces measurements, not records. Letting a throw out would
-            // reject the message and DLQ customer logs to protect a number, so lose the batch's
-            // metrics instead and count that it happened.
             try {
                 measureBatch(records, inputCap, outputCap)
             } catch {
@@ -104,7 +94,6 @@ function measureBatch(records: LogRecord[], inputCap: number, outputCap: number)
         }
     }
 
-    // One increment per label per batch (not per record) to keep the hot path cheap.
     for (const [kind, count] of kindCounts) {
         logsPatternBodyKindCounter.inc({ kind }, count)
     }


### PR DESCRIPTION
## Problem

Log lines have no shape identity at ingestion, so nothing can detect a new error shape in a service's logs.

A stored pattern column is the fix, but a stored column is hard to reverse. Three unknowns need production numbers first: the CPU cost of masking, the JSON-versus-prose split, and the right truncation length. This PR adds the masking logic and the metrics that measure those numbers; #88233, stacked on top, wires it into the logs consumer. Nothing runs until that PR.

Replaces #87740, split for review shape: logic here, consumer wiring above. Its review comments apply to the same content.

## Changes

- No user-visible change. Nothing calls this code until #88233 lands.
- New module `log-pattern-mask.ts`: seven RE2 rules replace variable tokens with placeholders. `user 42 from 10.0.0.1` becomes `user <N> from <IP>`.
- JSON bodies use the string `message`/`msg`/`event` key when present. Without one, an object body becomes its sorted top-level key list (`<JSON:a,b,c>`, capped at 32 keys) and an array body becomes `<JSON_ARRAY>`, so those populations stay distinguishable.
- The rules run as one combined regex in a single pass, the same shape as `log-pii-scrub.ts`. RE2 keeps matching linear-time on attacker-controlled bodies.
- A new pipeline stage in `log-pattern-stage.ts` computes a pattern per surviving record, records metrics, and discards the pattern.
- Eight Prometheus metrics: body kind, masked length, masking duration, rule fires, input-cap hits, forced decodes, key-set key counts, and stage errors. No `team_id` labels.
- PostHog/grafana-dashboards#417 adds the dashboard over these metrics, one row per rollout question.
- The input cap cuts the raw body before the JSON parse, so a very large body cannot burn CPU in the parse.
- The stage never rejects a message: a masking fault increments an error counter and the batch continues.
- `config.ts` gains the two default cap constants the stage reads. Mechanical.

## How did you test this code?

New jest suites, one group per regression:

- Rule and ordering cases fail if `num` shreds timestamps or IP octets.
- The RE2 ratchet fails if a future rule needs native `RegExp` features (lookaround, backreference).
- The agreement corpus fails if the combined regex and a per-rule chain diverge.

The two suites ran standalone on this branch, without the wiring layer, and passed.

Not checked: ClickHouse `replaceRegexpAll` behavior. The agreement test runs both chains in Node.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The feature is internal, off by default, and stores nothing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/writing-pr-descriptions`.
- The content is #87740 rebased onto master (its `BufferProcessingMode` base merged there as #87787) and split into this logic layer and the wiring layer above.
- The tests use invented data only.

