### PR TITLE
fix(ci): make two shard-order-dependent tests self-contained

### DIFF
--- a/posthog/management/commands/test/test_persons_dedup.py
+++ b/posthog/management/commands/test/test_persons_dedup.py
@@ -1008,12 +1008,22 @@ class TestPersonsDedupLogVisibility:
 
         handler = _Collector()
         original_level = parent.level
+        original_disabled = module_logger.disabled
+        original_global_disable = logging.root.manager.disable
         parent.setLevel(logging.WARNING)
+        # Unrelated suites in the same worker reconfigure logging globally (dictConfig with
+        # disable_existing_loggers, logging.disable), which suppresses every record regardless
+        # of level. Clear both so the assertion isolates the one thing this test guards: the
+        # module's own level beating the parent clamp.
+        module_logger.disabled = False
+        logging.disable(logging.NOTSET)
         module_logger.addHandler(handler)
         try:
             persons_dedup_command.logger.info("persons_dedup.log_visibility_probe", team_id=1)
         finally:
             module_logger.removeHandler(handler)
+            module_logger.disabled = original_disabled
+            logging.disable(original_global_disable)
             parent.setLevel(original_level)
 
         assert captured, "INFO records are dropped, so a production run would leave no log"

--- a/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
@@ -452,7 +452,10 @@ def test_build_environment_variables_omits_otel_env_when_flag_disabled(_api, _jw
     assert not any(key.startswith("POSTHOG_AGENT_OTEL_") for key in env)
 
 
-def test_build_environment_variables_forwards_run_context_to_token_minting():
+@patch(f"{_PROVISION}.get_git_identity_env_vars", return_value={})
+@patch(f"{_PROVISION}.get_sandbox_jwt_public_key", return_value="pub")
+@patch(f"{_PROVISION}.get_sandbox_api_url", return_value="https://api.example")
+def test_build_environment_variables_forwards_run_context_to_token_minting(_api, _jwt, _git):
     """The fresh-provisioning path must forward team, origin, stage, and internal
     into token minting; a dropped kwarg silently degrades every fresh run to the
     Python gateway."""


### PR DESCRIPTION
## Problem

- Any PR that adds backend test files reshuffles the Django CI shards, and two tests fail when they lose the shard neighbors they silently depend on. PR #77490 hit both.
- `test_build_environment_variables_forwards_run_context_to_token_minting` fails with `ValueError: SANDBOX_JWT_PRIVATE_KEY setting is required` when run in isolation. It is the only test in its file that does not patch `get_sandbox_jwt_public_key`.
- `test_info_records_survive_the_posthog_logger_clamp` fails when an earlier suite in the worker disables loggers globally (dictConfig with `disable_existing_loggers`, `logging.disable`), which suppresses its probe record for a reason unrelated to what it guards.

## Changes

- The sandbox test gains the same three patches its siblings use (`get_sandbox_api_url`, `get_sandbox_jwt_public_key`, `get_git_identity_env_vars`), so it no longer needs the JWT setting.
- The dedup logging test clears `module_logger.disabled` and the global `logging.disable` threshold for its probe, restoring both afterward. The regression it guards still fails: removing the module's `setLevel(INFO)` still drops the record via the parent clamp.

## How did you test this code?

- Both tests now pass in full isolation (`pytest <the two tests> -q`), which was the failing condition. No new tests: this repairs existing ones.
- Not run: the full CI shard compositions; isolation passing is the property that makes any composition safe.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in a session driven by Tom Owers while stabilizing PR #77490, whose reshuffled shards exposed both tests.
- Skills invoked: `/debugging-ci-failures` conventions, `/fixing-flaky-tests` discipline (reproduced the sandbox failure in isolation locally; the logging failure reproduces only under CI's worker-global state, so its fix targets the two documented suppression vectors), `/writing-pr-descriptions`.
