### PR TITLE
fix(session-replay): reject invalid configuration text

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/README.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/README.md
@@ -191,6 +191,8 @@ XMP is an opt-out for that image when it has one of these values:
 
 **3.22** The lane uses separate cache entries for robots.txt, tdmrep.json, and each URL crawl result. A robots.txt or tdmrep.json success, absence, or valid refusal has a 24-hour TTL. An unreachable result without a cached version has a 1-hour TTL. A terminal URL result has a minimum TTL of 30 days. If the response's explicit freshness lifetime is longer, the entry uses that longer TTL.
 
+**3.23** A retained configuration body must be valid UTF-8. If the 500KiB robots.txt prefix ends inside a UTF-8 code point, the lane discards that incomplete code point. Any other invalid UTF-8 makes the configuration file unreachable.
+
 ### 4. Web Bot Auth
 
 **4.1** Our User Agent starts with `PostHogImageFetcherBot` and contains a link to https://posthog.com/docs/ai-research/image-fetcher-bot. An example value is `PostHogImageFetcherBot/1.0 (+https://posthog.com/docs/ai-research/image-fetcher-bot)`

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
@@ -338,6 +338,14 @@ describe('HttpConfigurationFetcher', () => {
         })
     })
 
+    it('treats invalid UTF-8 configuration text as unreachable', async () => {
+        fetchStreamedMock.mockResolvedValue(
+            response(200, [], { bytes: Buffer.from([0x75, 0x73, 0x65, 0x72, 0xff]), overLimit: false })
+        )
+
+        await expect(httpFetcher().fetch(ORIGIN, 'robots')).resolves.toMatchObject({ outcome: 'unreachable' })
+    })
+
     it('treats an oversized or invalid TDMRep document as unreachable', async () => {
         fetchStreamedMock
             .mockResolvedValueOnce(response(200, [], { bytes: Buffer.from('[]'), overLimit: true }))

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.test.ts
@@ -329,7 +329,13 @@ describe('HttpConfigurationFetcher', () => {
 
     it('uses the retained prefix when robots.txt exceeds its byte limit', async () => {
         fetchStreamedMock.mockResolvedValue(
-            response(200, [], { bytes: Buffer.from('User-agent: *\nDisallow: /private'), overLimit: true })
+            response(200, [], {
+                bytes: Buffer.concat([
+                    Buffer.from('User-agent: *\nDisallow: /private'),
+                    Buffer.from([0xf0, 0x9f, 0x98]),
+                ]),
+                overLimit: true,
+            })
         )
 
         await expect(httpFetcher().fetch(ORIGIN, 'robots')).resolves.toMatchObject({

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/configuration-policy.ts
@@ -163,7 +163,12 @@ export class HttpConfigurationFetcher {
         if (body.overLimit && file === 'tdmrep') {
             return complete({ kind: 'done', result: { outcome: 'unreachable', cache } })
         }
-        const text = body.bytes.toString('utf8')
+        let text: string
+        try {
+            text = new TextDecoder('utf-8', { fatal: true }).decode(body.bytes, { stream: body.overLimit })
+        } catch {
+            return complete({ kind: 'done', result: { outcome: 'unreachable', cache } })
+        }
         if (file === 'tdmrep' && !isValidTdmrepDocument(text)) {
             return complete({ kind: 'done', result: { outcome: 'unreachable', cache } })
         }


### PR DESCRIPTION
## Problem

Image-fetch consumers can restart when a successful configuration response contains invalid UTF-8. Replacement characters can expand the bounded body beyond crawl-history storage limits.

## Changes

- Invalid UTF-8 configuration responses now use the existing unreachable path, so existing cache and retry rules apply.
- A truncated robots.txt prefix still drops only an incomplete trailing UTF-8 code point.
- Requirement 3.23 now defines the configuration-text behavior.
- Merge order: independent of the Grafana dashboard PR.

## How did you test this code?

- Ran the focused configuration-policy Jest suite after building the replay-anonymizer workspace package.
- Ran Prettier and ESLint on the changed TypeScript files.
- Ran hogli ci:preflight --fix against the final commit.
- The new test catches an invalid UTF-8 HTTP 200 response before crawl-history persistence. No existing test covered this failure.
- No production mutation was performed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the image-fetch requirements with the invalid UTF-8 and truncated-prefix behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change with browser inspection and repository tooling. Skills used: monitoring-ingestion-pipeline, ingestion-pipeline-doctor-nodejs, writing-tests, writing-pr-descriptions, running-ci-preflight, browser control, and ASD-STE100.

Operational evidence identified the failure class only. The committed test bytes and example.com data are invented.