### PR TITLE
feat(data-warehouse): pace GitHub page fetches against the egress budget

### DIFF
--- a/posthog/egress/github/limiter.py
+++ b/posthog/egress/github/limiter.py
@@ -351,3 +351,20 @@ def consume_github_installation_sync(
     return get_outbound_rate_limiter().consume_sync(
         github_installation_key(installation_id, resource=resource), n, priority=priority, source=source
     )
+
+
+def github_installation_pace_seconds(
+    installation_id: str | int,
+    *,
+    priority: Priority = Priority.NORMAL,
+    resource: GitHubRateResource = GitHubRateResource.CORE,
+) -> float:
+    """Seconds to wait before the next call on this installation's budget for ``resource``.
+
+    For a caller that can wait rather than be shed, such as a bulk import walking pages. Zero means
+    the budget has room to spare. See ``OutboundRateLimiter.pace_seconds`` for what the wait means
+    and why it is not a wait for a reset.
+    """
+    return get_outbound_rate_limiter().pace_seconds(
+        github_installation_key(installation_id, resource=resource), priority=priority
+    )

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([e__person.properties___fish] AS value) AS prop_basic,
+                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,16 +44,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -121,17 +111,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -188,8 +168,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -198,16 +178,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -324,24 +294,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -373,24 +326,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -1,4 +1,5 @@
 import re
+import time
 import random
 import asyncio
 import dataclasses
@@ -12,9 +13,11 @@ import requests
 from asgiref.sync import async_to_sync
 from dateutil import parser as dateutil_parser
 from structlog.types import FilteringBoundLogger
+from temporalio import activity
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 from urllib3.util.retry import Retry
 
+from posthog.egress.github.limiter import github_installation_pace_seconds
 from posthog.egress.github.transport import (
     GitHubEgressBudgetExhausted,
     GitHubRateLimitError,
@@ -698,6 +701,7 @@ GITHUB_MAX_RETRY_AFTER_SECONDS = 300.0
 # us no reset to honor.
 _github_backoff_wait = wait_exponential_jitter(initial=1, max=30)
 
+
 # Disable the tracked session's default adapter retries on this path. That policy
 # retries 429/5xx and honors Retry-After *uncapped*, underneath _fetch_page — which
 # would defeat the 300s cap below and stack a second, untested retry layer. With
@@ -823,6 +827,36 @@ def _github_retry_wait(state: RetryCallState) -> float:
     return _github_backoff_wait(state)
 
 
+def _pace_before_request(installation_id: str, logger: FilteringBoundLogger) -> None:
+    """Wait out this installation's share of the shared egress budget before the next request.
+
+    A backfill spends one request per page and can run for hours, so at full speed it drains the
+    installation's budget and is then shed for the rest of the window. Each shed page costs a retry
+    attempt and a backoff that knows nothing about when the budget frees. Waiting first keeps the run
+    inside the budget instead of recovering from it, and leaves the headroom the budget reserves for
+    the interactive products that share this installation.
+
+    The wait is bounded by the worker drain signal rather than by sleep. The pipeline tests for
+    worker shutdown only between the chunks a source yields, so a plain sleep here would hold a
+    draining pod for the full wait and delay the hand-off by that much. Waiting on the shutdown event
+    returns as soon as the pod starts draining, so pacing costs the hand-off nothing.
+    """
+    # The same ceiling the Retry-After path honors, and safe here for the reason recorded on
+    # GITHUB_MAX_RETRY_AFTER_SECONDS: this runs in the source thread pool, while the activity's
+    # liveness heartbeat fires from the event loop.
+    pace = min(
+        github_installation_pace_seconds(installation_id, priority=Priority.BATCH), GITHUB_MAX_RETRY_AFTER_SECONDS
+    )
+    if pace <= 0:
+        return
+
+    logger.debug(f"Github: waiting {pace:.1f}s for egress budget before the next request")
+    if activity.in_activity():
+        activity.wait_for_worker_shutdown_sync(timeout=pace)
+    else:
+        time.sleep(pace)
+
+
 @retry(
     retry=retry_if_exception_type(
         (
@@ -857,6 +891,13 @@ def _fetch_page(
     # this function's @retry backs off on; transport failures are recorded and re-raised for the same
     # retry. We keep our own tracked session and the GitHub response→exception mapping below.
     installation_id = egress_identity.installation_id if egress_identity is not None else None
+    # Wait for budget before asking for it, so a long walk drips instead of draining its share and
+    # being shed. Only the App path has a budget to pace against; the PAT path has no installation
+    # and skips the gate too. On the rare page that is still shed, the retry backoff above applies
+    # as well, which is the conservative order: the budget really is spent at that point.
+    if installation_id is not None:
+        _pace_before_request(installation_id, logger)
+
     response = github_request(
         "GET",
         page_url,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -19,9 +19,12 @@ def _ok_response() -> mock.Mock:
     response.status_code = 200
     response.ok = True
     response.text = ""
-    # The egress recorder reads response.request.{method,url}; a spec'd mock doesn't expose the
-    # instance attribute, so set it explicitly (None falls back to defaults in the recorder).
+    # The egress recorder reads response.request.{method,url} and, for a known installation,
+    # response.headers; a spec'd mock doesn't expose either instance attribute, so set them
+    # explicitly (None falls back to defaults in the recorder, and no headers means no rate-limit
+    # sample rather than a parse over a Mock).
     response.request = None
+    response.headers = {}
     return response
 
 
@@ -198,6 +201,73 @@ def test_fetch_page_gates_on_egress_budget_when_installation_known():
         "source": "warehouse",
         "resource": GitHubRateResource.CORE,
     }
+
+
+@pytest.mark.parametrize(
+    "installation_id,pace,expected_wait",
+    [
+        # Budget with room to spare, which is every sync short enough never to spend its share.
+        # Waiting here would add latency to all of them and prevent nothing.
+        ("123", 0.0, None),
+        ("123", 12.5, 12.5),
+        # Spreading a nearly spent budget can imply most of a window. A source that holds a worker
+        # slot that long is worse than being shed and resuming, so the wait stops at the ceiling.
+        ("123", 9_999.0, github.GITHUB_MAX_RETRY_AFTER_SECONDS),
+        # PAT path: no installation, so no budget to pace against. Asking anyway would key the
+        # lookup on a missing installation and wait on a budget that is not this caller's.
+        (None, 12.5, None),
+    ],
+)
+def test_fetch_page_waits_for_egress_budget_before_asking_for_it(installation_id, pace, expected_wait):
+    # Waiting first is what keeps a long walk inside the budget rather than recovering from it. Every
+    # way of breaking this is silent: no wait means the run drains its share and is shed for the rest
+    # of the window, and waiting when there is headroom slows every small sync instead.
+    session = mock.Mock()
+    session.request.return_value = _ok_response()
+    identity = github.GithubEgressIdentity(installation_id=installation_id)
+
+    with (
+        mock.patch.object(github, "github_installation_pace_seconds", return_value=pace) as pace_for,
+        mock.patch.object(github, "activity") as temporal_activity,
+        mock.patch.object(github, "make_tracked_session", return_value=session),
+    ):
+        temporal_activity.in_activity.return_value = True
+        github._fetch_page("https://api.github.com/repos/o/r/issues", {}, mock.Mock(), identity)
+
+    expected_waits = [] if expected_wait is None else [mock.call(timeout=expected_wait)]
+    assert temporal_activity.wait_for_worker_shutdown_sync.call_args_list == expected_waits
+    assert pace_for.called is (installation_id is not None)
+    assert session.request.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "in_activity,expect_drain_wait,expect_sleep",
+    [
+        (True, True, False),
+        # Outside an activity there is no worker to drain, so a plain sleep is the whole behavior.
+        (False, False, True),
+    ],
+)
+def test_fetch_page_budget_wait_yields_to_a_draining_worker(in_activity, expect_drain_wait, expect_sleep):
+    # The pipeline tests for worker shutdown only between the chunks a source yields, so a wait that
+    # slept would hold a draining pod for its full duration and delay the hand-off by that much.
+    # Waiting on the shutdown event returns the moment the pod starts draining. Nothing about the
+    # sync looks wrong when this regresses; drains just get slower.
+    session = mock.Mock()
+    session.request.return_value = _ok_response()
+    identity = github.GithubEgressIdentity(installation_id="123")
+
+    with (
+        mock.patch.object(github, "github_installation_pace_seconds", return_value=30.0),
+        mock.patch.object(github, "activity") as temporal_activity,
+        mock.patch.object(github.time, "sleep") as sleep,
+        mock.patch.object(github, "make_tracked_session", return_value=session),
+    ):
+        temporal_activity.in_activity.return_value = in_activity
+        github._fetch_page("https://api.github.com/repos/o/r/issues", {}, mock.Mock(), identity)
+
+    assert temporal_activity.wait_for_worker_shutdown_sync.called is expect_drain_wait
+    assert sleep.called is expect_sleep
 
 
 def _error_response(status_code: int, message: str, headers: dict[str, str] | None = None) -> mock.Mock:


### PR DESCRIPTION
## Problem

A large GitHub backfill spends its installation's share of the shared egress budget, then gets shed for the rest of the window and crawls.

- A GitHub source costs one request per page, so a backfill of a busy repository runs for hours.
- Run flat out, it spends the installation's budget, after which every page is shed.
- Each shed page costs a retry attempt and a backoff that knows nothing about when the budget frees, so it often wakes into another denial.
- The budget is shared with the interactive PostHog products on the same GitHub App installation, so a backfill that empties it is felt outside the warehouse too.

```mermaid
flowchart LR
  A[next page] --> B{budget left?}
  B -->|yes| C[request]
  B -->|no| D[shed: burn an attempt,<br/>back off blind]
  D --> A
  class C phBlue
  class D phRed
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
```

```mermaid
flowchart LR
  A[next page] --> W{how long<br/>until budget?}
  W -->|zero| C[request]
  W -->|an interval| V[wait, waking early<br/>if the pod drains]
  V --> C
  class C phBlue
  class V phYellow
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
```

## Changes

- A long backfill now drips inside its budget instead of draining it and being shed, so it makes steady progress rather than stalling partway.
- A short sync is unchanged: the wait is zero while the window still has headroom, which is every sync too small to spend its share.
- Interactive products sharing the installation keep the headroom the budget reserves for them, because the backfill stops before taking it.
- The wait stops at the ceiling the Retry-After path already honors. A source holding a worker slot for most of a window is worse than being shed and resuming.
- Only the GitHub App path paces. The PAT path has no installation, so there is no budget to pace against, and it skips the gate for the same reason.
- Draining a pod is no slower. The wait blocks on the worker shutdown signal rather than sleeping, so it returns the moment the pod starts draining and the pipeline's hand-off runs on its usual schedule.
- Mechanical: `github_installation_pace_seconds` wraps limiter key construction the way the existing GitHub gate helpers do, and the test response mock gains the `headers` attribute `spec=Response` does not expose.

Waiting on the shutdown event rather than sleeping is the part worth a second look. The pipeline tests for worker shutdown only between the chunks a source yields, so a plain sleep here would hold a draining pod for the full wait and delay every hand-off by that much. This is why pacing does not trade drain latency for budget behavior.

## How did you test this code?

Automated only. This sandbox has no dev stack, so no sync was paced against a real budget.

Tests added to the existing `test_github_fetch_page.py`, next to the egress-gate test that covers the denial path:

- How long the wait is, parameterized over headroom, a capped wait, and the PAT path. No wait means the run drains its share and is shed; waiting when there is headroom slows every small sync instead. Neither raises.
- The wait yields to a draining worker, and falls back to a plain sleep outside an activity. Nothing about a sync looks wrong when this regresses; drains just get slower.

Repo-wide `mypy --cache-fine-grained` passes. The 22 errors in `test_github_webhook_template.py` in this sandbox are missing-Postgres and reproduce identically on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The pacing contract is documented on the primitive, in the base PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog support session, directed by the assignee while working out why a large warehouse GitHub backfill ran for hours.

Stacked on the limiter primitive so the domain-generic budget change and the GitHub behavior change can be judged separately.

Two designs were checked and dropped before this one. Threading a shutdown monitor through `SourceInputs` turned out to be unnecessary once `temporalio.activity` proved reachable from the source's thread pool, which `async_iterate` guarantees by running the generator inside a copied context. Raising on drain from inside the source was dropped in favor of waking early and letting the pipeline's existing hand-off decide, which keeps one bail policy rather than two and leaves the partial-buffer flush discipline untouched.

Worth knowing at review time: pacing removes the wasted third of the budget's *use*, but a backfill of a large repository is still bounded by its request count, so this makes such a run clean rather than fast. Reducing that count is a separate change.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

No customer data reached this PR. The behavior is described from the source's own code, and the tests use invented installation ids and `api.github.com` paths.
