### PR TITLE
fix(mongodb): give an actionable error for an unparseable connection string

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -36,6 +36,16 @@ _MONGO_UNREACHABLE_MESSAGE = (
     "IP addresses are allowlisted in your database's network access settings."
 )
 
+# `_parse_connection_string` raises a ValueError when the string isn't a usable MongoDB URI: a
+# wrong or missing scheme, or a host/port that urlparse rejects. The raw reason gives the user
+# little to act on, so point at the expected scheme and format instead.
+_MONGO_INVALID_CONNECTION_STRING_MESSAGE = (
+    # nosemgrep: trailofbits.generic.mongodb-insecure-transport.mongodb-insecure-transport
+    "PostHog couldn't read your MongoDB connection string. It must start with mongodb:// or "
+    "mongodb+srv:// and follow the standard format, for example "
+    "mongodb+srv://user:password@cluster.mongodb.net/database. Check the connection string and try again."
+)
+
 _MONGO_UNESCAPED_CREDENTIALS_MESSAGE = (
     "Your MongoDB connection string is invalid: the username and password must be percent-encoded "
     "per RFC 3986. Escape any reserved characters (e.g. : / ? # [ ] @ %) in your credentials — for "
@@ -227,8 +237,8 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
 
         try:
             connection_params = _parse_connection_string(config.connection_string, config.database_name)
-        except:
-            return False, "Invalid connection string"
+        except Exception:
+            return False, _MONGO_INVALID_CONNECTION_STRING_MESSAGE
 
         if not connection_params.get("database"):
             return False, DATABASE_NAME_REQUIRED_ERROR

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.so
     _MONGO_AUTHENTICATION_FAILED_MESSAGE,
     _MONGO_CONNECT_FAILED_MESSAGE,
     _MONGO_HOST_UNRESOLVED_MESSAGE,
+    _MONGO_INVALID_CONNECTION_STRING_MESSAGE,
     _MONGO_NO_COLLECTIONS_MESSAGE,
     _MONGO_NOT_AUTHORIZED_MESSAGE,
     _MONGO_UNESCAPED_CREDENTIALS_MESSAGE,
@@ -45,6 +46,21 @@ class TestParseConnectionStringDatabaseOverride:
 
 
 class TestMongoValidateCredentialsDatabaseName:
+    @pytest.mark.parametrize(
+        "connection_string",
+        [
+            "https://cluster.example.com/db",  # wrong scheme, rejected by our own check
+            "mongodb://host:not-a-port/db",  # urlparse rejects the non-numeric port
+        ],
+    )
+    def test_unparseable_connection_string_returns_actionable_error(self, connection_string):
+        config = MongoDBSourceConfig.from_dict({"connection_string": connection_string})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_INVALID_CONNECTION_STRING_MESSAGE
+
     def test_missing_database_everywhere_returns_actionable_error(self):
         config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_NO_DB})
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -50,7 +50,7 @@ class TestMongoValidateCredentialsDatabaseName:
         "connection_string",
         [
             "https://cluster.example.com/db",  # wrong scheme, rejected by our own check
-            "mongodb://host:not-a-port/db",  # urlparse rejects the non-numeric port
+            "mongodb+srv://host:not-a-port/db",  # urlparse rejects the non-numeric port
         ],
     )
     def test_unparseable_connection_string_returns_actionable_error(self, connection_string):


### PR DESCRIPTION
## Problem

A user setting up a MongoDB source saw only "Invalid connection string" when the connection string could not be parsed. The message did not say what was wrong or how to fix it, so users had no next step.

The validator caught every parse failure with a bare `except` and returned that terse text, even though the parser already raised a specific reason (a wrong or missing scheme, or a host or port that `urlparse` rejects).

## Changes

- A failed connection string now returns a message naming the required scheme (`mongodb://` or `mongodb+srv://`) and the expected format, so the user knows what to correct.
- The handler is narrowed from a bare `except` to `except Exception`, so it no longer swallows control-flow exceptions.
- Mechanical: the new message is a module-level constant next to the other MongoDB error messages.

## How did you test this code?

- Added two cases to `TestMongoValidateCredentialsDatabaseName` for a wrong scheme and a non-numeric port. They guard that an unparseable connection string returns the actionable message rather than the terse one, which no existing case covered.
- Ran that test class locally: passing. Did not run the database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of failed data-warehouse source-creation errors and found this MongoDB case: a bare `except` discarding an actionable parse error. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions. The single-message approach was chosen over surfacing the raw parser text, which can include unfriendly `urlparse` internals.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
