### PR TITLE
fix(support): stop the support modal reopening from a stale URL hash

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.test.ts
+++ b/frontend/src/lib/components/Support/supportLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
@@ -71,6 +72,74 @@ describe('supportLogic', () => {
 
             expect(sidePanelStateLogic.values.sidePanelOpen).toBe(false)
             expect(openSupportModal).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('support panel URL hash lifecycle', () => {
+        let logic: ReturnType<typeof supportLogic.build>
+
+        beforeEach(() => {
+            localStorage.clear()
+            window.history.replaceState(null, '', '/')
+            initKeaTests()
+            sidePanelStateLogic.mount()
+            logic = supportLogic.build()
+            logic.mount()
+            openSupportModal.mockClear()
+        })
+
+        afterEach(() => {
+            logic?.unmount()
+        })
+
+        it('does not write the panel hash when the form opens as a modal', async () => {
+            router.actions.push('/login', { next: '/home' })
+
+            await expectLogic(logic, () => {
+                logic.actions.openSupportForm({ kind: 'support', target: 'modal' })
+            }).toFinishAllListeners()
+
+            expect(router.values.hashParams['panel']).toBeUndefined()
+        })
+
+        it('clears a support deep-link hash on close when no side panel owns it', async () => {
+            router.actions.push('/login', { next: '/home' }, { panel: 'support:support:false' })
+
+            await expectLogic(logic, () => {
+                logic.actions.openSupportForm({ kind: 'support', target: 'modal' })
+            }).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.closeSupportForm()
+            }).toFinishAllListeners()
+
+            expect(router.values.hashParams['panel']).toBeUndefined()
+            expect(router.values.location.pathname).toBe('/login')
+            expect(router.values.searchParams).toEqual({ next: '/home' })
+        })
+
+        it('clears the legacy supportModal hash on close when no side panel owns it', async () => {
+            router.actions.push('/login', {}, { supportModal: 'support' })
+
+            await expectLogic(logic, () => {
+                logic.actions.openSupportForm({ kind: 'support', target: 'modal' })
+                logic.actions.closeSupportForm()
+            }).toFinishAllListeners()
+
+            expect(router.values.hashParams['supportModal']).toBeUndefined()
+            expect(router.values.hashParams['panel']).toBeUndefined()
+        })
+
+        it('leaves the panel hash alone on close when the side panel is available', async () => {
+            sidePanelStateLogic.actions.setSidePanelAvailable(true)
+            router.actions.push('/project/1/home', {}, { panel: 'support:support:false' })
+
+            await expectLogic(logic, () => {
+                logic.actions.openSupportForm({ kind: 'support', target: 'sidePanel' })
+                logic.actions.closeSupportForm()
+            }).toFinishAllListeners()
+
+            expect(String(router.values.hashParams['panel'])).toContain('support')
         })
     })
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -1,6 +1,7 @@
 import { MakeLogicType, actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import type { DeepPartial, DeepPartialMap, FieldName, ValidationErrorType } from 'kea-forms'
+import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { EMAIL_SUPPORT_BUTTON, lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -487,6 +488,10 @@ export const supportLogic = kea<supportLogicType>([
     }),
     listeners(({ actions, props, values }) => ({
         updateUrlParams: async () => {
+            if (!values.sidePanelAvailable) {
+                return
+            }
+
             // Only include non-text fields in the URL parameters
             // This prevents focus loss when typing in text fields
             const panelOptions = [values.sendSupportRequest.kind ?? '', values.isEmailFormOpen ?? 'false'].join(':')
@@ -646,6 +651,22 @@ export const supportLogic = kea<supportLogicType>([
         },
 
         closeSupportForm: () => {
+            if (!values.sidePanelAvailable) {
+                const hashParams = { ...router.values.hashParams }
+                let changed = false
+                if (String(hashParams['panel'] ?? '').split(':')[0] === SidePanelTab.Support) {
+                    delete hashParams['panel']
+                    changed = true
+                }
+                if ('supportModal' in hashParams) {
+                    delete hashParams['supportModal']
+                    changed = true
+                }
+                if (changed) {
+                    router.actions.replace(router.values.location.pathname, router.values.searchParams, hashParams)
+                }
+            }
+
             // Form is only reset by explicit Cancel button or successful submission
             props.onClose?.()
         },


### PR DESCRIPTION
## Problem

- A logged-out user who reaches the login screen through a support deep link gets the support form popping open again on every navigation, even after closing it.
- posthog.com docs link "contact support" to `us.posthog.com/home#supportModal`. Logged out, that redirects to `/login` and the browser keeps the fragment.
- `supportRouterLogic` re-runs on every route change and reopens the form whenever the hash names the support panel.
- On pages without a side panel the form opens as a modal, but closing the modal never removed the hash, so the loop only ended when a navigation happened to drop the fragment.
- Opening the form also wrote the `#panel=support...` hash even in modal mode, planting the same trap on pages reached without a deep link.

## Changes

- Closing the support modal now clears a leftover support `#panel` or legacy `#supportModal` hash, so the form stays closed across navigations.
- Opening the form as a modal no longer writes the `#panel` hash into the URL.
- Side panel behavior is unchanged: there the hash is the panel's state, and `closeSidePanel` still owns it.
- Nothing looks different. The modal itself is untouched; it just stops reopening.

## How did you test this code?

- Four new cases in `supportLogic.test.ts`, each guarding a distinct regression: modal open writing the hash, close leaving the deep-link hash (the reported loop), close leaving the legacy `#supportModal` hash, and close wrongly stripping the hash while the side panel owns it.
- No existing test covered the hash lifecycle, so the cases could not extend an existing one.
- Manually verified on a local stack, logged out: `/login#supportModal` and `/login#panel=support:support:false` open the modal once, closing it removes the hash, and a reload no longer reopens it. On master the modal reopens.
- Manually verified logged in: a `#panel=support:support:false` deep link still opens the side panel with the hash present, and closing the panel clears it, unchanged.
- Not manually run: the "Report an issue" button on the login page - it renders only on cloud (`preflight?.cloud`), so the no-hash-on-open path is covered by the unit test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5) from a support investigation into a session recording showing the loop on the login screen during a password reset. Manual testing was performed by the assignee against the PR branch.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The description contains no customer material; the reproduction is derivable from the linked code paths alone.
- Related: #82414 rewrites `supportRouterLogic` surface selection and touches `supportLogic.ts`; the two changes are independent but will conflict textually.
