### PR TITLE
fix(experiments): align code tab styling with the rest of the scene

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6333,13 +6333,17 @@ snapshots:
     scenes-app-events-mcp-tool-calls--mcp-tool-calls--light:
         hash: v1.k794b7964.a70db27155e0ba6979890a1d3b328a91d7f2cae9e89d37cb7346fa2d79aaec6d.ybMAg6DfJ6iwBrtLWjqVo9qC-a412ihqd6H6KiAYkgc
     scenes-app-experiments--draft-experiment--dark:
-        hash: v1.k794b7964.862ae6da1335a0cec5825234d2a6baf1d5e4eb5c1dec6650924d62d0e117e56b.9_kP5gSMifRjF9JZKyTMqKI2rD78F8UYSBa8ENH_GXU
+        hash: v1.k794b7964.c54bc70ed3ef1f9da5493475a002cd1eb1effa331f8ccbb54dda180bbecb7507.Okif3ufUoD3KpD1568ZzpvAxTcJkFR7s6KZHUQmpc6Q
     scenes-app-experiments--draft-experiment--light:
-        hash: v1.k794b7964.7355787f803ecf45b38311ba4494e1744c4e4cba40629fdb625adf5187dbe1a2.jJTifUL_cmDr_Evsxg-lPWmRkjh2zZuQJTXkBmHgu_8
+        hash: v1.k794b7964.c25f2146cdcd2142f7b2c1bcd45890b6a0a7d9b03e82bccb1ef891b64cf2f493.2D2m-q3OCoqqC_zQqtJPYL4me6M9Ajd-esVxbM8bur4
     scenes-app-experiments--experiment-asymmetric-intervals--dark:
         hash: v1.k794b7964.bf7de0d95fd6957a66852dd17ca6a9337bd52d161640743753affa3ac6447274.srHzGS4gYQ64kYkVNSiLB3SSboJUj6wdl9jmfuxovKU
     scenes-app-experiments--experiment-asymmetric-intervals--light:
         hash: v1.k794b7964.b2f88c3e5cf6d621251402158277210de513f053465f9bd7457dd474d47c58ce.mlXqwZI6iFPTGP29XubXnVvM-KG6i50XjGVau81jpJg
+    scenes-app-experiments--experiment-code-tab--dark:
+        hash: v1.k794b7964.a6d2aea20a3beea31a02b496003e06c9ead29a5739b67fe373f3a6691483667e.9NjTP48PGseyxT2-jbYawzRWiiSE7acbF_ES5TbLi4w
+    scenes-app-experiments--experiment-code-tab--light:
+        hash: v1.k794b7964.e7058a4c235c2202d5a63a7c5e32ab4eae2c69a422def4f9b494f7e18a61681a.30IpMGKStgL22CU4wcSp_p3KotOGPoTX5L146C-9tLg
     scenes-app-experiments--experiment-exposures-expanded--dark:
         hash: v1.k794b7964.0a4465a38b5d6bdb99882c5e15112c7c84ee7dd51658e3ef6691c8e67152c6de.Gn0quaLD1veID5PR0yx-hItLfNo6CbGjz6DxSRyrIAU
     scenes-app-experiments--experiment-exposures-expanded--light:

--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -158,13 +158,13 @@ export function GolangSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
         <>
             <CodeSnippet language={Language.Go} wrap compact>
                 {`experimentFlagValue, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
-    Key:        "${flagKey}",
+    Key:        ${JSON.stringify(flagKey)},
     DistinctId: "distinct-id",
 })
 if err != nil {
     // Handle error (e.g. capture error and fallback to default behaviour)
 }
-if experimentFlagValue == "${variant}" {
+if experimentFlagValue == ${JSON.stringify(variant)} {
     // Do something differently for this user
 } else {
     // It's a good idea to let control variant always be the default behaviour,

--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -1,18 +1,15 @@
-import { Link } from '@posthog/lemon-ui'
+import { LemonBanner, Link } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 
 function ServerSideWarning(): JSX.Element {
     return (
-        <div className="warning">
-            <p>
-                <b>Warning:</b> Server side experiment metrics require you to manually send the feature flag
-                information.{' '}
-                <Link to="https://posthog.com/docs/experiments/adding-experiment-code" target="_blank">
-                    See this tutorial for more information.
-                </Link>
-            </p>
-        </div>
+        <LemonBanner type="warning" className="mt-2">
+            Server-side experiment metrics require you to manually send the feature flag information.{' '}
+            <Link to="https://posthog.com/docs/experiments/adding-experiment-code" target="_blank">
+                See this tutorial for more information.
+            </Link>
+        </LemonBanner>
     )
 }
 
@@ -24,7 +21,7 @@ interface SnippetProps {
 export function AndroidSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.Kotlin} wrap>
+            <CodeSnippet language={Language.Kotlin} wrap compact>
                 {`if (PostHog.getFeatureFlag("${flagKey}") == "${variant}") {
     // do something
 } else {
@@ -39,7 +36,7 @@ export function AndroidSnippet({ flagKey, variant }: SnippetProps): JSX.Element 
 export function IOSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.Swift} wrap>
+            <CodeSnippet language={Language.Swift} wrap compact>
                 {`if (PostHogSDK.shared.getFeatureFlag("${flagKey}") as? String == "${variant}") {
     // do something
 } else {
@@ -54,10 +51,10 @@ export function IOSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
 export function NodeJSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.JavaScript} wrap>
+            <CodeSnippet language={Language.JavaScript} wrap compact>
                 {`const experimentFlagValue = await client.getFeatureFlag('${flagKey}', 'user distinct id')
 
-if (experimentFlagValue === '${variant}' ) {
+if (experimentFlagValue === '${variant}') {
     // Do something differently for this user
 } else {
     // It's a good idea to let control variant always be the default behaviour,
@@ -72,7 +69,7 @@ if (experimentFlagValue === '${variant}' ) {
 export function JSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <div>
-            <CodeSnippet language={Language.JavaScript} wrap>
+            <CodeSnippet language={Language.JavaScript} wrap compact>
                 {`if (posthog.getFeatureFlag('${flagKey}') === '${variant}') {
     // Do something differently for this user
 } else {
@@ -80,10 +77,8 @@ export function JSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     // so if something goes wrong with flag evaluation, you don't break your app.
 }`}
             </CodeSnippet>
-            <div className="mt-4 mb-1">
-                <b>Test that it works</b>
-            </div>
-            <CodeSnippet language={Language.JavaScript} wrap>
+            <h3 className="text-sm font-medium mt-4 mb-1">Test that it works</h3>
+            <CodeSnippet language={Language.JavaScript} wrap compact>
                 {`posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'} })`}
             </CodeSnippet>
         </div>
@@ -93,7 +88,7 @@ export function JSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
 export function ReactSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.JavaScript} wrap>
+            <CodeSnippet language={Language.JavaScript} wrap compact>
                 {`// You can either use the useFeatureFlagVariantKey hook,
 // or you can use the feature flags component - https://posthog.com/docs/libraries/react#feature-flags-react-component
 
@@ -130,7 +125,7 @@ posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'} 
 export function RNSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.JavaScript} wrap>
+            <CodeSnippet language={Language.JavaScript} wrap compact>
                 {`if (posthog.getFeatureFlag('${flagKey}') === '${variant}') {
     // Do something differently for this user
 } else {
@@ -145,7 +140,7 @@ export function RNSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
 export function PHPSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.PHP} wrap>
+            <CodeSnippet language={Language.PHP} wrap compact>
                 {`if (PostHog::getFeatureFlag('${flagKey}', 'user distinct id') == '${variant}') {
     // Do something differently for this user
 } else {
@@ -161,15 +156,15 @@ export function PHPSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
 export function GolangSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.Go} wrap>
+            <CodeSnippet language={Language.Go} wrap compact>
                 {`experimentFlagValue, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
-    Key:        '${flagKey}',
+    Key:        "${flagKey}",
     DistinctId: "distinct-id",
 })
 if err != nil {
     // Handle error (e.g. capture error and fallback to default behaviour)
 }
-if experimentFlagValue == '${variant}' {
+if experimentFlagValue == "${variant}" {
     // Do something differently for this user
 } else {
     // It's a good idea to let control variant always be the default behaviour,
@@ -188,14 +183,13 @@ export function FlutterSnippet({ flagKey, variant }: SnippetProps): JSX.Element 
 
     return (
         <>
-            <CodeSnippet language={Language.Dart} wrap>
+            <CodeSnippet language={Language.Dart} wrap compact>
                 {`if (${clientSuffix}${flagFunction}('${flagKey}')${variantSuffix}) {
   // Do something differently for this user
 } else {
   // It's a good idea to let control variant always be the default behaviour,
   // so if something goes wrong with flag evaluation, you don't break your app.
-}
-            `}
+}`}
             </CodeSnippet>
         </>
     )
@@ -204,17 +198,15 @@ export function FlutterSnippet({ flagKey, variant }: SnippetProps): JSX.Element 
 export function RubySnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.Ruby} wrap>
+            <CodeSnippet language={Language.Ruby} wrap compact>
                 {`experimentFlagValue = posthog.get_feature_flag('${flagKey}', 'user distinct id')
-
 
 if experimentFlagValue == '${variant}'
     # Do something differently for this user
 else
     # It's a good idea to let control variant always be the default behaviour,
     # so if something goes wrong with flag evaluation, you don't break your app.
-end
-`}
+end`}
             </CodeSnippet>
             <ServerSideWarning />
         </>
@@ -224,15 +216,15 @@ end
 export function PythonSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.Python} wrap>
-                {`experiment_flag_value = posthog.get_feature_flag("${flagKey}", "user_distinct_id"):
+            <CodeSnippet language={Language.Python} wrap compact>
+                {`experiment_flag_value = posthog.get_feature_flag("${flagKey}", "user_distinct_id")
 
 if experiment_flag_value == '${variant}':
     # Do something differently for this user
 else:
     # It's a good idea to let control variant always be the default behaviour,
     # so if something goes wrong with flag evaluation, you don't break your app.
-`}
+    pass`}
             </CodeSnippet>
             <ServerSideWarning />
         </>
@@ -242,15 +234,14 @@ else:
 export function JavaSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
     return (
         <>
-            <CodeSnippet language={Language.Java} wrap>
+            <CodeSnippet language={Language.Java} wrap compact>
                 {`Object flagValue = postHog.getFeatureFlag("user distinct id", "${flagKey}");
 if ("${variant}".equals(flagValue)) {
     // Do something differently for this user
 } else {
     // It's a good idea to let control variant always be the default behaviour,
     // so if something goes wrong with flag evaluation, you don't break your app.
-}
-`}
+}`}
             </CodeSnippet>
             <ServerSideWarning />
         </>
@@ -263,7 +254,7 @@ export interface PromptSnippetProps {
 
 export function PromptExperimentPythonSnippet({ flagKey }: PromptSnippetProps): JSX.Element {
     return (
-        <CodeSnippet language={Language.Python} wrap>
+        <CodeSnippet language={Language.Python} wrap compact>
             {`import json
 import os
 
@@ -318,7 +309,7 @@ print(response.choices[0].message.content)
 
 export function PromptExperimentJSSnippet({ flagKey }: PromptSnippetProps): JSX.Element {
     return (
-        <CodeSnippet language={Language.TypeScript} wrap>
+        <CodeSnippet language={Language.TypeScript} wrap compact>
             {`import { PostHog } from 'posthog-node'
 import { OpenAI } from '@posthog/ai/openai'
 import { Prompts } from '@posthog/ai/prompts'
@@ -372,7 +363,7 @@ console.log(response.choices[0].message.content)
 
 export function PromptExperimentAgentPromptSnippet({ flagKey }: PromptSnippetProps): JSX.Element {
     return (
-        <CodeSnippet language={Language.Text} wrap>
+        <CodeSnippet language={Language.Text} wrap compact>
             {`Wire up a PostHog prompt experiment in this project.
 
 Context

--- a/frontend/src/scenes/experiments/ExperimentImplementationDetails.tsx
+++ b/frontend/src/scenes/experiments/ExperimentImplementationDetails.tsx
@@ -159,7 +159,7 @@ export function CodeLanguageSelect({
                         value,
                         label: value,
                         labelInMenu: (
-                            <div className="flex items-center deprecated-space-x-2">
+                            <div className="flex items-center gap-2">
                                 <Icon />
                                 <span>{value}</span>
                             </div>
@@ -172,7 +172,7 @@ export function CodeLanguageSelect({
                         value,
                         label: value,
                         labelInMenu: (
-                            <div className="flex items-center deprecated-space-x-2">
+                            <div className="flex items-center gap-2">
                                 <Icon />
                                 <span>{value}</span>
                             </div>
@@ -195,58 +195,54 @@ function PromptExperimentImplementation({
 }): JSX.Element {
     const [activeTab, setActiveTab] = useState<PromptImplementationTab>('agent')
     return (
-        <div className="mb-4">
-            <div className="border rounded bg-surface-primary">
-                <div className="p-6 deprecated-space-y-4">
-                    <div className="text-secondary text-sm">
-                        Prompt experiment for <b>{promptMetadata.name}</b>{' '}
-                        <span className="text-muted">({promptMetadata.templates.join(', ')})</span>
-                    </div>
-                    <div>
-                        <div className="mb-1">
-                            <b>Wire up the experiment in your code</b>
-                        </div>
-                        <p className="text-secondary text-xs">
-                            Each variant carries a <code>{`{prompt_name, prompt_version}`}</code> payload on the feature
-                            flag, so the SDK reads the right version via <code>flags.get_flag_payload(...)</code>. The
-                            PostHog AI wrapper auto-emits <code>$ai_generation</code> tagged with{' '}
-                            <code>$ai_prompt_name</code>, which is how the experiment metric attributes results.
-                        </p>
-                        <LemonTabs
-                            activeKey={activeTab}
-                            onChange={(key) => setActiveTab(key as PromptImplementationTab)}
-                            tabs={[
-                                {
-                                    key: 'agent',
-                                    label: 'Agent prompt',
-                                    content: (
-                                        <>
-                                            <p className="text-secondary text-xs mb-2">
-                                                Copy this and paste it into your AI coding assistant (Cursor, Claude
-                                                Code, ChatGPT, …) to wire up the experiment in your project's framework
-                                                and style. Language-agnostic; the agent figures out the SDK.
-                                            </p>
-                                            <PromptExperimentAgentPromptSnippet flagKey={flagKey} />
-                                        </>
-                                    ),
-                                },
-                                {
-                                    key: 'python',
-                                    label: 'Python',
-                                    content: <PromptExperimentPythonSnippet flagKey={flagKey} />,
-                                },
-                                {
-                                    key: 'javascript',
-                                    label: 'JavaScript',
-                                    content: <PromptExperimentJSSnippet flagKey={flagKey} />,
-                                },
-                            ]}
-                        />
-                        <Link subtle to="https://posthog.com/docs/prompt-management" target="_blank">
-                            See the docs for prompt management.
-                        </Link>
-                    </div>
+        <div className="space-y-4">
+            <div>
+                <h2 className="font-semibold text-lg mb-0">Implementation</h2>
+                <div className="text-secondary text-sm">
+                    Prompt experiment for <b>{promptMetadata.name}</b>{' '}
+                    <span className="text-muted">({promptMetadata.templates.join(', ')})</span>
                 </div>
+            </div>
+            <div>
+                <p className="text-secondary text-xs">
+                    Each variant carries a <code>{`{prompt_name, prompt_version}`}</code> payload on the feature flag,
+                    so the SDK reads the right version via <code>flags.get_flag_payload(...)</code>. The PostHog AI
+                    wrapper auto-emits <code>$ai_generation</code> tagged with <code>$ai_prompt_name</code>, which is
+                    how the experiment metric attributes results.
+                </p>
+                <LemonTabs
+                    activeKey={activeTab}
+                    onChange={(key) => setActiveTab(key as PromptImplementationTab)}
+                    tabs={[
+                        {
+                            key: 'agent',
+                            label: 'Agent prompt',
+                            content: (
+                                <>
+                                    <p className="text-secondary text-xs mb-2">
+                                        Copy this and paste it into your AI coding assistant (Cursor, Claude Code,
+                                        ChatGPT, …) to wire up the experiment in your project's framework and style.
+                                        Language-agnostic; the agent figures out the SDK.
+                                    </p>
+                                    <PromptExperimentAgentPromptSnippet flagKey={flagKey} />
+                                </>
+                            ),
+                        },
+                        {
+                            key: 'python',
+                            label: 'Python',
+                            content: <PromptExperimentPythonSnippet flagKey={flagKey} />,
+                        },
+                        {
+                            key: 'javascript',
+                            label: 'JavaScript',
+                            content: <PromptExperimentJSSnippet flagKey={flagKey} />,
+                        },
+                    ]}
+                />
+                <Link subtle to="https://posthog.com/docs/prompt-management" target="_blank">
+                    See the docs for prompt management.
+                </Link>
             </div>
         </div>
     )
@@ -267,46 +263,33 @@ function GenericExperimentImplementation({ experiment }: ExperimentImplementatio
     }
 
     return (
-        <div className="mb-4">
-            <div className="border rounded bg-surface-primary">
-                <div className="p-6 deprecated-space-y-4">
-                    <div className="flex justify-between">
-                        <div className="flex items-center">
-                            <span className="mr-2">Variant group</span>
-                            <LemonSelect
-                                size="small"
-                                className="min-w-[5rem]"
-                                onSelect={setCurrentVariant}
-                                value={currentVariant}
-                                options={getExperimentVariants(experiment).map((variant: MultivariateFlagVariant) => ({
-                                    value: variant.key,
-                                    label: variant.key,
-                                }))}
-                            />
-                        </div>
-                        <div>
-                            <CodeLanguageSelect
-                                selectOption={selectOption}
-                                selectedOptionValue={selectedOption.value}
-                            />
-                        </div>
+        <div className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+                <h2 className="font-semibold text-lg mb-0">Implementation</h2>
+                <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2">
+                        <span className="text-secondary text-sm">Variant group</span>
+                        <LemonSelect
+                            size="small"
+                            className="min-w-[5rem]"
+                            onSelect={setCurrentVariant}
+                            value={currentVariant}
+                            options={getExperimentVariants(experiment).map((variant: MultivariateFlagVariant) => ({
+                                value: variant.key,
+                                label: variant.key,
+                            }))}
+                        />
                     </div>
-                    <div>
-                        <div className="mb-1">
-                            <b>Implement your experiment in code</b>
-                        </div>
-                        <div className="mb-1">
-                            <selectedOption.Snippet
-                                variant={currentVariant}
-                                flagKey={experiment?.feature_flag?.key ?? ''}
-                            />
-                        </div>
-
-                        <Link subtle to={selectedOption.documentationLink} target="_blank">
-                            See the docs for more implementation information.
-                        </Link>
-                    </div>
+                    <CodeLanguageSelect selectOption={selectOption} selectedOptionValue={selectedOption.value} />
                 </div>
+            </div>
+            <div>
+                <div className="mb-2">
+                    <selectedOption.Snippet variant={currentVariant} flagKey={experiment?.feature_flag?.key ?? ''} />
+                </div>
+                <Link subtle to={selectedOption.documentationLink} target="_blank">
+                    See the docs for more implementation information.
+                </Link>
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentHeader.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentHeader.tsx
@@ -10,13 +10,13 @@ export function ExperimentHeader(): JSX.Element {
     return (
         <>
             {!isExperimentLaunched && (
-                <>
+                <div className="border rounded bg-surface-primary p-4">
                     {experiment.type === 'web' ? (
                         <WebExperimentImplementationDetails experiment={experiment} />
                     ) : (
                         <ExperimentImplementationDetails experiment={experiment} />
                     )}
-                </>
+                </div>
             )}
         </>
     )

--- a/frontend/src/scenes/experiments/WebExperimentImplementationDetails.tsx
+++ b/frontend/src/scenes/experiments/WebExperimentImplementationDetails.tsx
@@ -29,27 +29,17 @@ export function WebExperimentImplementationDetails({ experiment }: WebExperiment
     }
 
     return (
-        <>
-            <div>
-                <div className="border p-6 rounded bg-surface-primary deprecated-space-y-2">
-                    <div className="font-semibold leading-tight text-base text-current">
-                        Define variant changes directly on your website
-                    </div>
-                    <div className="text-sm text-secondary">
-                        Use our toolbar to select elements and apply transformations for each variant.
-                    </div>
-                    <div>
-                        <LemonButton
-                            size="small"
-                            type="secondary"
-                            onClick={onSelectElement}
-                            sideIcon={<IconOpenInApp />}
-                        >
-                            Launch toolbar on your website
-                        </LemonButton>
-                    </div>
-                </div>
+        <div className="space-y-2">
+            <h2 className="font-semibold text-lg mb-0">Implementation</h2>
+            <div className="text-sm text-secondary">
+                Define variant changes directly on your website. Use our toolbar to select elements and apply
+                transformations for each variant.
             </div>
-        </>
+            <div>
+                <LemonButton size="small" type="secondary" onClick={onSelectElement} sideIcon={<IconOpenInApp />}>
+                    Launch toolbar on your website
+                </LemonButton>
+            </div>
+        </div>
     )
 }

--- a/frontend/src/scenes/experiments/stories/ExperimentCodeTab.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentCodeTab.stories.tsx
@@ -1,0 +1,43 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { makeDelay } from 'lib/utils/async'
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+import EXPERIMENT_WITH_FUNNEL_METRIC from '~/mocks/fixtures/api/experiments/experiment_with_funnel_metric.json'
+
+// A launched experiment on the Code tab, showing the implementation snippet with its
+// variant and language selectors.
+const meta: Meta = {
+    component: App,
+    title: 'Scenes-App/Experiments',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2025-06-01',
+        pageUrl: urls.experiment(EXPERIMENT_WITH_FUNNEL_METRIC.id) + '?tab=code',
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                [`/api/projects/:team_id/experiments/${EXPERIMENT_WITH_FUNNEL_METRIC.id}/`]:
+                    EXPERIMENT_WITH_FUNNEL_METRIC,
+                '/api/projects/:team_id/experiment_holdouts': [],
+                '/api/projects/:team_id/experiment_saved_metrics/': [],
+                [`/api/projects/:team_id/feature_flags/${EXPERIMENT_WITH_FUNNEL_METRIC.feature_flag.id}/`]: {},
+                [`/api/projects/:team_id/feature_flags/${EXPERIMENT_WITH_FUNNEL_METRIC.feature_flag.id}/status/`]: {},
+                '/api/environments/:team_id/default_release_conditions/': [],
+                '/api/environments/:team_id/experiments_config/': {},
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': [200, { results: [] }],
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const ExperimentCodeTab: Story = { play: makeDelay(700) }


### PR DESCRIPTION
## Problem

The Code tab looks inconsistent with the rest of the experiment view. Its content sits in a heavy padded card with a bold body-text line as the heading, while sibling tabs (Settings, Variants) render plain sections with proper headings. The server-side warning under Python, Node.js, PHP, Go, Ruby, and Java snippets references a `warning` CSS class that doesn't exist anywhere, so it renders as unstyled paragraph text.

## Changes

| | Before | After |
|---|---|---|
| JavaScript | ![before](https://raw.githubusercontent.com/PostHog/pr-assets/c1fca218a93f3cb378ad80a229ef58fb5f06f5ab/2026/08/5da630d1-8247-45b6-a277-393c9724355a.png) | ![after](https://raw.githubusercontent.com/PostHog/pr-assets/3c1a0d271583b40ee485320fd43bd1101fff5fb6/2026/08/53b6e619-5ae5-4f62-83b0-e5aeea1ccbc7.png) |
| Python | ![before](https://raw.githubusercontent.com/PostHog/pr-assets/728b06325530e6ef75fbd23bf796405869bd85af/2026/08/c49e80b4-a985-4399-8a50-10ded2f24213.png) | ![after](https://raw.githubusercontent.com/PostHog/pr-assets/662b3199072166afc49a5a5c2cf1ff751abc9897/2026/08/0b37dae4-0179-43bf-bcdb-4239bc4f8ff9.png) |

- The tab now shows an "Implementation" heading matching the other tabs, with the variant and language selectors right-aligned on the same row.
- Snippets use the compact `CodeSnippet` variant, so code renders at 13px instead of 14px.
- The server-side warning renders as a `LemonBanner` instead of plain text.
- The web and prompt experiment variants of the tab get the same heading treatment.
- The pre-launch view (implementation details above the tabs on a draft experiment) keeps a bordered card. The card styling moved to `ExperimentHeader`, so the shared components no longer assume a context.
- Snippet content fixes: the Python snippet had a stray trailing colon and a comment-only `else:` block, and the Go snippet used single-quoted strings. Both were invalid in their language.
- Mechanical: `deprecated-space-*` utilities replaced with `gap-*` / `space-y-*`, and a redundant `mb-4` removed that doubled the scene's own `gap-y-4`.

## How did you test this code?

- Added a Storybook story (`ExperimentCodeTab`) that renders a launched experiment on the Code tab, so this surface now has visual regression coverage.
- The screenshots above come from that story and the existing `DraftExperiment` story, rendered headlessly from this branch.
- Typecheck and lint pass. Not run: jest (no jest tests cover these components), dark mode was not checked visually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in a git worktree. Skills invoked: /wt, /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions. The visual direction came from surveying sibling tabs (Settings, Variants) and the feature flags instructions UI; the snippet syntax fixes were found while sweeping the snippet file. All fixture data in the story and screenshots is repo-local mock data.
