### PR TITLE
fix(desktop): leave scout runs out of the task list

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -228,6 +228,12 @@ describe("PostHogAPIClient", () => {
     ["pinned", { pinned: true }, "pinned", "true"],
     ["commented-by", { commentedBy: 17 }, "commented_by", "17"],
     ["mentions", { mentions: 19 }, "mentions", "19"],
+    [
+      "exclude-origin-product",
+      { excludeOriginProduct: "signals_scout" },
+      "exclude_origin_product",
+      "signals_scout",
+    ],
   ])("sends the %s task-list filter", async (_name, options, param, value) => {
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ results: [], count: 0 }), {

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -210,6 +210,11 @@ export interface TaskListOptions {
   repository?: string;
   createdBy?: number;
   originProduct?: string;
+  /**
+   * Drop tasks with this origin from the results. The server rejects an unknown value rather
+   * than matching nothing, so a typo can't quietly return the very tasks the caller excluded.
+   */
+  excludeOriginProduct?: string;
   internal?: boolean;
   channel?: string;
   /** Case-insensitive substring match over task title, description, and number. */
@@ -2585,6 +2590,10 @@ export class PostHogAPIClient {
 
     if (options?.originProduct) {
       params.origin_product = options.originProduct;
+    }
+
+    if (options?.excludeOriginProduct) {
+      params.exclude_origin_product = options.excludeOriginProduct;
     }
 
     if (options?.internal) {

--- a/products/desktop/packages/ui/src/features/tasks/taskKeys.ts
+++ b/products/desktop/packages/ui/src/features/tasks/taskKeys.ts
@@ -2,6 +2,7 @@ export interface TaskListFilters {
   repository?: string;
   createdBy?: number;
   originProduct?: string;
+  excludeOriginProduct?: string;
   internal?: boolean;
 }
 

--- a/products/desktop/packages/ui/src/features/tasks/useTasks.test.tsx
+++ b/products/desktop/packages/ui/src/features/tasks/useTasks.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetTasks = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockClient = vi.hoisted(() => ({
+  getTasks: mockGetTasks,
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => mockClient,
+}));
+
+import { useTasks } from "./useTasks";
+
+describe("useTasks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ id: 7 });
+    mockGetTasks.mockResolvedValue([]);
+  });
+
+  function renderTasks(filters?: Parameters<typeof useTasks>[0]) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return renderHook(() => useTasks(filters), { wrapper });
+  }
+
+  // Scout runs are created under the viewer's own id, so dropping this filter
+  // refills the list they read as "my sessions" with unattended automation —
+  // and in show-all-users mode, with every scout run on the team.
+  it.each([
+    ["own tasks", undefined],
+    ["all users' tasks", { showAllUsers: true }],
+  ])("excludes scout runs when listing %s", async (_name, filters) => {
+    renderTasks(filters);
+
+    await waitFor(() => expect(mockGetTasks).toHaveBeenCalled());
+    expect(mockGetTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeOriginProduct: "signals_scout" }),
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/tasks/useTasks.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTasks.ts
@@ -19,6 +19,14 @@ const TASK_SUMMARY_POLL_INTERVAL_MS = 30_000;
 // heaviest poll in the app (~2.2MB per response every 30s).
 const SLACK_TASK_POLL_INTERVAL_MS = 5 * 60_000;
 
+// A scout runs unattended in the cloud as the user who owns it, so its runs are
+// created_by that user and arrive in this list beside the sessions they started
+// themselves — enough of them, on a schedule, to bury those sessions. This list
+// is what the app offers as "your sessions", so it leaves scout runs out. They
+// stay reachable by id, which is what a deep link, a search hit, and the scouts
+// view all use; excluded here means unlisted, not unreachable.
+const EXCLUDED_ORIGIN_PRODUCT = "signals_scout";
+
 export function useTasks(
   filters?: {
     repository?: string;
@@ -32,11 +40,17 @@ export function useTasks(
   const internal = filters?.showInternal ? true : undefined;
 
   return useAuthenticatedQuery(
-    taskKeys.list({ repository: filters?.repository, createdBy, internal }),
+    taskKeys.list({
+      repository: filters?.repository,
+      createdBy,
+      excludeOriginProduct: EXCLUDED_ORIGIN_PRODUCT,
+      internal,
+    }),
     (client) =>
       client.getTasks({
         repository: filters?.repository,
         createdBy,
+        excludeOriginProduct: EXCLUDED_ORIGIN_PRODUCT,
         internal,
       }) as unknown as Promise<Task[]>,
     {


### PR DESCRIPTION
## Problem

Anyone running scouts sees their desktop session list fill with runs they never started.

- A scout runs unattended as the user who owns it, so every run is `created_by` that user and arrives in that user's task list.
- Scouts run on a schedule, so the runs accumulate and bury the sessions the person actually opened.
- The web task list already splits them out, behind its "My scouts" filter ([#86258](https://github.com/PostHog/posthog/pull/86258)). Desktop could not do the same: `TaskListOptions` had no `exclude_origin_product`, so the param that filter relies on was unreachable from the app.
- Nothing in desktop filtered on origin, so this was a gap rather than a deliberate choice. Scout runs are a first-class origin there, with their own icon and label.

## Changes

- The desktop task list no longer lists scout runs. This covers the sidebar, the menu behind it, the command menu, and the badges that count those rows, because all of them read one hook.
- Scout runs stay reachable by id. A deep link, a search hit, and the scouts view all resolve a scout run as before. Excluded here means unlisted, not unreachable.
- `useTasks` sends `exclude_origin_product=signals_scout`. The server drops the rows, so the app does not filter a page it already paid to fetch.
- The exclusion sits in the hook rather than at each call site, which keeps one query key for every list consumer. A per-surface filter would have split the app's heaviest poll in two.

> [!NOTE]
> Three callers read this list as an existence check rather than a list: `useLiveTaskIds`, `useCommandCenterActiveCount`, and `useCloudPrUrls`. A task only becomes eligible for a command-center cell if it has a local workspace ([eligibility.ts](https://github.com/PostHog/posthog/blob/master/products/desktop/packages/core/src/command-center/eligibility.ts#L9-L18)), and a cloud scout run never has one, so none of them can be asked about a scout id. This is the part of the change worth a second look.

Mechanical: `excludeOriginProduct` added to `TaskListOptions` and to the query-key filter type.

No screenshot. The change removes rows from a live list, and this sandbox has no desktop session with scout runs to photograph.

## How did you test this code?

- `useTasks.test.tsx` is new. It guards that the list request carries the exclusion. No existing test covered that: the api-client suite tested the transport, not whether any caller asked for it. Removing the filter from `useTasks` was confirmed to make both cases fail.
- One row was added to the existing task-list param matrix in `posthog-client.test.ts`, covering `exclude_origin_product`. It catches the mapping being dropped from `getTasksPage`.
- Ran locally: the `@posthog/ui` tasks, sidebar, command-center and archive suites, the `@posthog/api-client` suite, `pnpm typecheck` across all 27 desktop packages, and `hogli ci:preflight --fix`.
- Not done: the Electron app was never launched, so the change was not observed in a running list. Reviewers with scouts on their team are the fastest check here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested in a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787613849220769?thread_ts=1787613849.220769&cid=C09G8Q32R6F) after scout runs showed up in an activity feed, which raised the question of whether desktop filtered them at all. Left unassigned: the requester's GitHub handle was not established in that thread, and guessing one risks tagging an unrelated account. The reviewer who picks this up should set the assignee.

Written with Claude Code. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The first draft added a `useSidebarTasks` wrapper and applied it at the two sidebar call sites. That was reverted once it became clear it gave the sidebar its own query key, doubling the full task-list poll that `useTasks` documents as the app's largest memory and CPU drain. Verifying that command-center cells require a local workspace is what made the single-hook version safe.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787613849220769?thread_ts=1787613849.220769&cid=C09G8Q32R6F)*
