### PR TITLE
feat(replay-vision): mark scouts beta and sharpen the digest template

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -158,7 +158,14 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                         ? [
                               {
                                   key: ReplayScannerTab.Scouts,
-                                  label: 'Scouts',
+                                  label: (
+                                      <>
+                                          Scouts{' '}
+                                          <LemonTag type="completion" size="small" className="ml-1">
+                                              Beta
+                                          </LemonTag>
+                                      </>
+                                  ),
                                   content: <ScannerScoutsTab scannerId={scannerId} />,
                               },
                           ]

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerScoutRow.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerScoutRow.tsx
@@ -7,6 +7,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { cn } from 'lib/utils/css-classes'
+import { capitalizeFirstLetter } from 'lib/utils/strings'
 import { teamLogic } from 'scenes/teamLogic'
 
 import type { SignalScoutConfigApi } from 'products/signals/frontend/generated/api.schemas'
@@ -74,21 +75,25 @@ export function ScannerScoutRow({
     return (
         <div className={cn('flex flex-col rounded border bg-surface-primary', !config.enabled && 'opacity-65')}>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-2.5">
-                <LemonButton
-                    size="small"
-                    icon={<IconChevronRight className={cn('transition-transform', expanded && 'rotate-90')} />}
+                <button
+                    type="button"
+                    className="-mx-1 flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded px-1 py-1 text-left transition-colors hover:bg-surface-secondary"
                     onClick={() => toggleScoutExpanded(config.skill_name)}
                     aria-label={`${expanded ? 'Hide' : 'Show'} reports from ${prettifyScoutSkillName(config.skill_name)}`}
                     aria-expanded={expanded}
                     data-attr="vision-scout-row-expand"
-                />
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-sm font-medium">{prettifyScoutSkillName(config.skill_name)}</span>
-                    <span className="text-[11px] text-muted">
-                        {scoutCadenceLabel(config)}
-                        {nextRunText && ` · next run ${nextRunText}`}
+                >
+                    <IconChevronRight
+                        className={cn('shrink-0 text-base transition-transform', expanded && 'rotate-90')}
+                    />
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <span className="text-sm font-medium">{prettifyScoutSkillName(config.skill_name)}</span>
+                        <span className="text-[11px] text-muted">
+                            {capitalizeFirstLetter(scoutCadenceLabel(config))}
+                            {nextRunText && ` · next run ${nextRunText}`}
+                        </span>
                     </span>
-                </div>
+                </button>
                 <div className="flex shrink-0 items-center gap-1">
                     <Tooltip title="Scout settings">
                         <LemonButton
@@ -195,8 +200,11 @@ export function ScannerScoutRow({
                             {
                                 title: '',
                                 key: 'touchedAt',
+                                // Baseline, not centre: `TZLabel` carries a dotted bottom border, so
+                                // centring the two boxes puts its text half a pixel off, and which way
+                                // that rounds shifts with the width of the digits.
                                 render: (_, report) => (
-                                    <span className="text-muted">
+                                    <span className="inline-flex items-baseline gap-1 text-muted">
                                         Filed <TZLabel time={report.filed_at} />
                                     </span>
                                 ),

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerScoutSlackDestination.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerScoutSlackDestination.tsx
@@ -21,8 +21,13 @@ export function ScannerScoutSlackDestination({
     // `output_destinations` also holds the webhook destination this scout provisioned, and replacing
     // the object would drop that pointer while the destination kept delivering.
     const destination = destinations?.slack
+    // Threading is always on rather than a setting: it only takes effect when a report is too long
+    // for one Slack section, and the alternative there is a clipped digest. A short one still posts
+    // as a single message however many headings it has.
     const withSlack = (slack: SignalScoutOutputDestinationsApi['slack'] | undefined): void =>
-        onChange(slack ? { ...destinations, slack } : { ...destinations, slack: null })
+        onChange(
+            slack ? { ...destinations, slack: { ...slack, thread_reports: true } } : { ...destinations, slack: null }
+        )
     const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
     const header = <span className="text-xs text-default">Slack</span>
 

--- a/products/replay_vision/frontend/replay_scanners/scannerScout.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScout.ts
@@ -96,7 +96,7 @@ interface ScoutFocus {
  * scanner id is the sole baked-in context; the scanner's name, type, and prompt are read live via
  * `vision-scanners-get`, so editing the scanner never requires touching the scout. */
 const DEFAULT_QUIET_VERDICT =
-    'When nothing clears the bar, still file the report, with the verdict `Nothing notable` and a short coverage line ("42 observations across 30 sessions, distributions steady").'
+    'When nothing clears the bar, still file the report: open with the verdict `Nothing notable`, then a short coverage line naming what you read and what it showed ("42 observations across 30 sessions, distributions steady").'
 
 const DEFAULT_REPORT_SHAPE = `- Open with the takeaway in one line, then at most three bullets ordered by impact.
 - Each bullet: what changed, with only the numbers needed to judge it; why it matters; the evidence-backed cause or best next investigation; and the specific next action.`
@@ -251,15 +251,17 @@ Lead the summary with whatever the window is actually about, and lean on:
 - A friction theme, complaint, or failure mode recurring across several distinct sessions.
 - A verdict rate, score distribution, or tag mix stepping away from the scanner's prior weeks.
 - A single session severe enough that the team should watch the recording today.`,
-                quiet: 'A window where nothing changed still has content: what users did, which themes dominated, and how the distribution sat against prior weeks. Say plainly that nothing stood out, then summarize the window anyway. `Nothing notable` on its own is not a digest.',
+                quiet: 'A window where nothing changed still has content: what users did, which themes dominated, and how the distribution sat against prior weeks.',
                 skip: `- Anything the scanner's own per-session signals already pushed to the inbox.
 - Observations whose own signals contradict the claim (a session marked \`friction: none\` is never evidence of an error).`,
                 quietVerdict:
                     'A digest has no bar to clear, so it never files a bare verdict. Say in the opening line that nothing stood out, then summarize the window as below.',
-                shape: `- Open with a two or three sentence read on the window: what users were doing, and what stood out.
-- Then a short section per theme, each a heading and two to four bullets. Order them by how much of the window they cover, and say roughly how many sessions each rests on.
+                shape: `- Open with one scope line naming the scanner and what you read: \`Summary for [<scanner name>](/project/<project_id>/replay-vision/${scannerId}) — 27 recordings since Aug 21, 2026 at 9:00 AM\`, in the project timezone. The link is how a reader reaches the scanner this came from, and the count and start time are how they judge what it covers.
+- Then \`**TL;DR:**\` and two or three sentences: what users were doing, and what stood out. A reader who stops here should still have the answer.
+- Then a short section per theme, each a heading and two to four bullets, ordered by how much of the window they cover. Bullets, never paragraphs: a digest is read at a glance, and prose hides the one line that mattered.
+- Every theme opens with how many sessions it rests on. A theme you cannot count is a theme you cannot weigh, and a reader has no way to tell the dominant pattern from the anecdote.
 - A theme resting on one or two observations is worth a sentence, not a section: say how thin it is rather than inflating it or dropping it.
-- Close with "What to look at": the few things worth someone's time, each naming the action.`,
+- Close with the detail behind the scope line (how the outcomes split, anything you could not cover), then "What to look at", listing only things a person would actually do, each naming the action and what it would settle. Nothing worth doing means no section: never pad it with "no action needed", and never file "keep monitoring", which is what the next run is for.`,
                 priority: 'Priority P3 by default; P2 when a severe problem is spreading.',
             }),
         },
@@ -276,7 +278,7 @@ Lead the summary with whatever the window is actually about, and lean on:
 - \`vision-scanners-observations-stats\` (scanner_id \`${scannerId}\`) for the distribution the scanner reports for itself.
 - \`vision-scanners-get\` — read \`scanner_version\` and \`updated_at\` before calling any shift a finding: a config edit near the onset explains it.`,
                 notable: lens.notable,
-                quiet: 'Holding steady is the expected outcome. When nothing has moved, refresh your `pattern:` baseline entries and file the digest with verdict `Nothing notable`, saying what you compared.',
+                quiet: 'Holding steady is the expected outcome. When nothing has moved, refresh your `pattern:` baseline entries and say what you compared.',
                 skip: `- Low-volume windows (under roughly 30 sessions in the week) — rates wobble there; write a \`pattern:\` note instead.
 - A shift explained by a scanner config edit, a sampling change, or the scanner being disabled.
 ${lens.skip}`,
@@ -302,7 +304,7 @@ ${lens.skip}`,
 - A failure, error, or friction theme appearing in this scanner's observations with no counterpart in your catalog, across at least two or three distinct sessions.
 - A single new occurrence severe enough to act on regardless of spread: a blocked purchase, lost work, a dead end with no way out.
 - A known problem reappearing after you recorded it as resolved — a regression is new again.`,
-                quiet: 'Most runs find nothing new, and that is the point: this scout is quiet by design. Refresh the catalog, then file the digest with verdict `Nothing notable`, saying what window you diffed.',
+                quiet: 'Most runs find nothing new, and that is the point: this scout is quiet by design. Refresh the catalog, and say what window you diffed.',
                 skip: `- Anything already in your catalog, even when its wording differs. Summaries are freeform prose, so match on what happened, not on how it was phrased.
 - A one-off single session below the severity bar. Note it in the catalog as seen; if it recurs next week, it is a pattern, not a novelty.
 - Something "new" that a scanner prompt or config edit near the onset explains: the scanner changed what it reports, the product did not change. Cite the edit and stop.
@@ -328,7 +330,7 @@ ${lens.skip}`,
                 notable: `<WHAT IS WORTH REPORTING>
 
 Be specific about the bar, so a quiet window stays quiet: how many distinct sessions it takes, how far from this scanner's own prior weeks, and how severe a single case has to be to count on its own.`,
-                quiet: 'A window that clears none of those bars is a normal outcome, and still files its digest: verdict `Nothing notable`, plus what you checked.',
+                quiet: 'A window that clears none of those bars is a normal outcome for this scout.',
                 skip: `- <WHAT THIS SCOUT SHOULD LEAVE ALONE>. Anything another scout or the scanner's own signals already reported belongs here, and so does anything resting on too little evidence to stand up.`,
                 priority: 'Priority P3 by default; P2 when something is severe or spreading.',
             }),


### PR DESCRIPTION
## Problem

The Scouts tab is behind a flag and reads as finished. Nothing tells a person it is new, while every other product ships a tag for that.

In the roster underneath it, the cadence reads "daily at 09:00" in the middle of a column that capitalizes everything else, a report's filed time sits a pixel off the text beside it, and only the arrow expands a row, so the obvious click does nothing.

The digest itself was rebuilt last week to summarize its window rather than report an exception, and a colleague's guide for digests across Replay Vision and AI observability arrived after that: lead with a TL;DR, organize with headers, prefer bullets to paragraphs, and open with what was analyzed and a link to where the report is configured. Our digest had none of those four.

## Changes

- The Scouts tab carries a Beta tag, matching the one AI observability uses on its self-driving tab down to the type, size and casing.
- A scout's cadence reads "Daily at 09:00".
- "Filed 7 days ago" sits on one line. `TZLabel` carries a dotted bottom border, so centring the two boxes put its text half a pixel off, and which way that rounded shifted with the width of the digits.
- Clicking anywhere along a scout's name expands its reports, with a hover highlight, rather than the arrow alone. The chevron and the name are one button now, so it takes keyboard focus; the settings, delete and enable controls sit outside it and still do their own thing.
- A digest opens with a scope line linking the scanner and naming what it read ("27 recordings since Aug 21 at 9:00 AM"), then a TL;DR, then a section per theme stating how many sessions it rests on, and closes with only what someone would act on. Themes went uncounted before, coverage was stated twice, and the closing section padded itself with "no action needed".
- A long report threads in Slack instead of being clipped at Slack's section limit. Threading is on for every scout rather than a setting: it only engages when a report outgrows one section, and it splits at the report's own headings.

Reviewing the four templates together turned up the quiet-window rule stated twice in each, once under notability and once at filing, in wording that did not match: one asked for a coverage line, the other for "what you compared". A model reading both follows one of them. `quiet` now says what a quiet window means for that scout, `quietVerdict` says what to file.

## How did you test this code?

The UI changes were driven in a local instance and checked by the author.

The template changes are prose in a prompt, and only a real run exercises them. The last one was run against a scanner over a 24-hour window and read next to the legacy digest for the same window, which is where the uncounted themes, the duplicated coverage and the padded closing section came from.

Not tested: no scout has run against this revision, and the Slack threading path has not been exercised from a Vision scout, only read.

No new tests. A test asserting a template contains a sentence breaks on any rewording and proves nothing about what a model does with it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @TueHaulund. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. The Beta tag copies AI observability rather than the Journeys insight tab, which was the first precedent I reached for: same situation, a flag-gated tab inside a product scene, and it is the surface scout reports already feed. And Slack threading is unconditional rather than a checkbox, because the setting only decides whether a too-long report gets clipped, which is not a preference worth asking a user for.

The scope line also reverses a call from earlier the same day: counts had just been moved out of the opening so it read as an answer rather than arithmetic. The guide wants them up front, so the scope line carries the headline count and the close keeps the breakdown.

**Public artifact:** nothing here came from a customer conversation, ticket, or log.
