### PR TITLE
fix(experiments): small interaction polish in experiment view

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -77,7 +77,7 @@ export function DistributionModal(): JSX.Element {
                         onClick={handleSave}
                         type="primary"
                         loading={experimentLoading}
-                        disabled={!areVariantRolloutsValid}
+                        disabledReason={!areVariantRolloutsValid ? 'Percentage splits must sum to 100' : undefined}
                     >
                         Save
                     </LemonButton>

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -60,7 +60,14 @@ export function SettingsTab(): JSX.Element {
                         {isBayesian ? 'Bayesian' : 'Frequentist'} / {confidenceDisplay}
                         {!isBayesian && sequentialEnabled && ' · Sequential testing'}
                     </span>
-                    <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openStatsEngineModal} />
+                    <LemonButton
+                        type="secondary"
+                        size="xsmall"
+                        icon={<IconPencil />}
+                        onClick={openStatsEngineModal}
+                        tooltip="Edit statistics settings"
+                        aria-label="Edit statistics settings"
+                    />
                 </div>
                 <StatsMethodModal />
             </div>
@@ -71,7 +78,14 @@ export function SettingsTab(): JSX.Element {
                         {cupedEnabled ? 'Enabled' : 'Disabled'}
                     </LemonTag>
                     {cupedEnabled && <span>{cupedLookbackDays}-day lookback</span>}
-                    <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openCupedModal} />
+                    <LemonButton
+                        type="secondary"
+                        size="xsmall"
+                        icon={<IconPencil />}
+                        onClick={openCupedModal}
+                        tooltip="Edit CUPED settings"
+                        aria-label="Edit CUPED settings"
+                    />
                 </div>
                 <p className="text-muted text-xs mt-1">
                     Use pre-experiment data to detect significant effects faster. Currently supported for mean and

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -31,10 +31,10 @@ import { Experiment, FilterLogicalOperator, RecordingUniversalFilters } from '~/
 import {
     ExperimentVariantResult,
     formatChanceToWinForGoal,
+    formatIntervalPercent,
     formatMetricValue,
     formatPValue,
     getIntervalLabel,
-    getVariantInterval,
     isBayesianResult,
     isFrequentistResult,
 } from '../shared/utils'
@@ -174,11 +174,7 @@ export function ResultDetails({
                 if (item.key === baselineKey) {
                     return '—'
                 }
-                const interval = getVariantInterval(item)
-                if (!interval) {
-                    return '—'
-                }
-                return `[${(interval[0] * 100).toFixed(2)}%, ${(interval[1] * 100).toFixed(2)}%]`
+                return formatIntervalPercent(item)
             },
         },
         {

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesTooltip.tsx
@@ -11,7 +11,8 @@ import { teamLogic } from 'scenes/teamLogic'
 const DATE_FORMAT = 'MMM D, YYYY'
 const DATETIME_FORMAT = 'MMM D, YYYY h:mm A'
 
-const formatPercent = (value: number | null): string => (value === null ? '—' : `${(value * 100).toFixed(2)}%`)
+const formatPercent = (value: number | null): string =>
+    value === null || !Number.isFinite(value) ? '—' : `${(value * 100).toFixed(2)}%`
 
 export interface VariantTimeseriesTooltipProps {
     date: string


### PR DESCRIPTION
## Problem

Four small rough edges in the experiment view:

- The Save button in the distribution modal disables with no explanation when variant splits don't sum to 100.
- The pencil buttons on the Settings tab (statistics, CUPED) have no tooltip or accessible label.
- The details table formats confidence intervals inline instead of using the shared `formatIntervalPercent` helper.
- The timeseries tooltip renders "NaN%" or "Infinity%" if a bound is not a finite number.

## Changes

- The distribution modal's Save button now shows "Percentage splits must sum to 100" on hover when disabled, matching the editor's inline error copy.
- The Settings tab pencil buttons now have "Edit statistics settings" / "Edit CUPED settings" tooltips and aria-labels.
- The details table uses `formatIntervalPercent`. Mechanical, output is identical.
- The timeseries tooltip shows "—" for non-finite values, matching `formatMetricValue`.

## How did you test this code?

No logic changes beyond the non-finite guard. No tests reference the touched props or strings. Not run: frontend typecheck and jest (light worktree without node_modules); no screenshots for the same reason. The tooltip and disabled-reason changes use standard LemonButton props.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. These fixes come from the same experiment-view polish audit as #88216. Skills invoked: /wt, /writing-user-facing-copy, /writing-pr-descriptions (loaded earlier this session).
