### PR TITLE
fix(tasks): claim slack relay before posting so retries never repost

### DIFF
--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -653,7 +653,6 @@ def execute_posthog_code_agent_relay_workflow(
             id=workflow_id,
             id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             task_queue=settings.TASKS_TASK_QUEUE,
-            retry_policy=RetryPolicy(maximum_attempts=3),
         )
     )
     return relay_id

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -442,6 +442,26 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
     if handler.footer_enabled():
         handler.run_footer = load_run_footer(task_run.id)
     mention_prefix = f"<@{target}> " if target else ""
+
+    def _record_sent_relay(state: dict[str, Any]) -> None:
+        sent_relay_ids = state.get("slack_sent_relay_ids") or []
+        if input.relay_id in sent_relay_ids:
+            raise _RelayAlreadyRecorded
+
+        sent_relay_ids.append(input.relay_id)
+        # Keep a rolling window to bound state size while preserving idempotency for recent relays.
+        state["slack_sent_relay_ids"] = sent_relay_ids[-30:]
+
+    # Claim the relay before the first Slack call. The Slack posts below swallow their own
+    # errors, so this write is the only step that can fail after a message is already in the
+    # thread, and a retry would then post it again. Claiming first means a failed write retries
+    # before anything is sent, and a retry after the claim skips instead of duplicating.
+    try:
+        TaskRun.mutate_state_atomic(input.run_id, _record_sent_relay)
+    except _RelayAlreadyRecorded:
+        logger.info("slack_relay_duplicate_skipped", run_id=input.run_id, relay_id=input.relay_id)
+        return
+
     if input.delete_progress:
         handler.delete_progress()
 
@@ -467,17 +487,3 @@ def relay_slack_message(input: RelaySlackMessageInput) -> None:
 
     if input.reaction_emoji is not None:
         handler.update_reaction(input.reaction_emoji)
-
-    def _record_sent_relay(state: dict[str, Any]) -> None:
-        sent_relay_ids = state.get("slack_sent_relay_ids") or []
-        if input.relay_id in sent_relay_ids:
-            raise _RelayAlreadyRecorded
-
-        sent_relay_ids.append(input.relay_id)
-        # Keep a rolling window to bound state size while preserving idempotency for recent relays.
-        state["slack_sent_relay_ids"] = sent_relay_ids[-30:]
-
-    try:
-        TaskRun.mutate_state_atomic(input.run_id, _record_sent_relay)
-    except _RelayAlreadyRecorded:
-        logger.info("slack_relay_duplicate_skipped", run_id=input.run_id, relay_id=input.relay_id)

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -4,6 +4,7 @@ from typing import ClassVar
 import unittest
 from unittest.mock import patch
 
+from django.db import DatabaseError
 from django.test import TestCase, override_settings
 
 from parameterized import parameterized
@@ -119,6 +120,20 @@ class TestRelaySlackMessage(TestCase):
             mock_update.assert_called_once_with(reaction_emoji)
         self.task_run.refresh_from_db()
         assert relay_id in self.task_run.state.get("slack_sent_relay_ids", [])
+
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.post_thread_message")
+    @patch("products.slack_app.backend.slack_thread.SlackThreadHandler.delete_progress")
+    def test_relay_does_not_post_when_claim_write_fails(self, mock_delete_progress, mock_post):
+        with (
+            patch.object(TaskRun, "mutate_state_atomic", side_effect=DatabaseError("read-only")),
+            self.assertRaises(DatabaseError),
+        ):
+            relay_slack_message(
+                RelaySlackMessageInput(run_id=str(self.task_run.id), relay_id="relay-claim-fails", text="Done.")
+            )
+
+        mock_delete_progress.assert_not_called()
+        mock_post.assert_not_called()
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- A person who asks @PostHog in Slack can get the bot's final answer posted many times in the same thread.
- `relay_slack_message` posts to Slack first and records the relay id in the run state last.
- The Slack posts swallow their own errors, so that state write is the only step that can fail after a message is already in the thread.
- When the write fails, Temporal retries the activity, the dedup check finds no record, and the answer posts again.
- Retries stack: three activity attempts inside three workflow attempts, so one transient database failure becomes nine identical posts.

## Changes

- The relay records its id before the first Slack call. A failed write now retries before anything is sent, and a retry after the record exists skips.
- `execute_posthog_code_agent_relay_workflow` no longer sets a workflow-level retry policy. The activity retry policy stays.
- Trade-off: a worker crash between the claim and the post loses that one reply instead of duplicating it. The answer is still on the task page.
- Nothing changes on the happy path.

## How did you test this code?

- Added `test_relay_does_not_post_when_claim_write_fails`: a failing state write must not reach Slack. It fails on the old ordering and passes now.
- Ran `products/tasks/backend/temporal/slack_relay/tests/test_activities.py` locally.
- Not run: repo-wide mypy. The diff removes one kwarg and moves a nested function.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Root cause came from the Temporal worker logs for one affected run: nine activity attempts across three workflow run ids, each failing on the state write after the post.
- Making the state write non-fatal was rejected: it leaves the relay unrecorded, so a later retry would still repost.
