### PR TITLE
chore(logs): remove the unshipped sparkline breakdown dropdown

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7077,17 +7077,17 @@ snapshots:
     scenes-app-llm-observability-evaluationreportconfig--quill--light:
         hash: v1.k794b7964.e6179df07dd55d64e0140d40ac812feb4662e28e5bded7ce2cf9e2575f245626.4iGTruUDV858d17xZIUMJCG2xFeWLagkzakPS2Yw4Ps
     scenes-app-logs-sparkline--volume-by-severity--dark:
-        hash: v1.k794b7964.ff9970e481267669b2b5c3e97de2daa5027224b3185da86e7841374a1c0ba80e.sStnKO155v5mRB-N445BcUDcc21g3jAW21Y5mDWfENw
+        hash: v1.k794b7964.0342a42ad3e96fb82282914a3c60aedb873de9f8dfc94c850b22b3f7f17d56a0.c_sYZ1aNex35E-5hGq0aHwwV1MQCROpZBvMfAznRPoY
     scenes-app-logs-sparkline--volume-by-severity--light:
-        hash: v1.k794b7964.8de90a8725adae02f3eb5ddff7b67a8b82635f4ee91a6fc8af918f847f3112aa.b71G5RHdgthOOmza6oa2KGdiK2bsMtGDdql7kyjlEUE
+        hash: v1.k794b7964.fdb549dcf3c59090354438aee587b98a298d3cdaf32d46bb01120664dfb820d8.J4QV-kc6iGHQyb0jyu2jxRYMN7IHzeesVVecacobQtM
     scenes-app-logs-sparkline--with-incomplete-buckets--dark:
-        hash: v1.k794b7964.d18b5bd8acb1c3cc0a815e002bd50d8382c4ed2bcc0d52975188d10565c094e8.lDTMLtBVAMn0BR_tMDOTiJkqQgTSmRMrBHUVjhcmWng
+        hash: v1.k794b7964.0df6634617e8ad5287e72205e998d50e832e06589d89e161ab5518ade03151e3.yU5OwWdnPPC2lYuWj2U_rrXRao56W8ez8oHJu0vC3_0
     scenes-app-logs-sparkline--with-incomplete-buckets--light:
-        hash: v1.k794b7964.ffcdf956d00fbd9c97d8843d86e1781202ba0da513e45594267dba56443ad824.IjOA2xr2ZUEtBos84aXnc_oogjc71FmgQf0lZGnyndw
+        hash: v1.k794b7964.18fa93a8be6e2423e42ab0f14a17509ff5c4edd6035fc78ba1f425244f781536.TL1gdFYq0wZuy2JyglNVWW9A9SAeo9VHrA-GcLcx8GY
     scenes-app-logs-sparkline--with-visible-row-range--dark:
-        hash: v1.k794b7964.6e7205adb133ed51c4e5c4822801101628929a2670208a3380051bd366ef1014.CjJZblD1hifo0CPfzGvsF5nuJbYoq3jTSZ1ZT9uXJPk
+        hash: v1.k794b7964.949d98f13ddb2a20738728392f4abdd995f17e081cde68329c3f5df69c144332.6kxBdqQfe5E7FOA6XCF6SSk2bcFgBxWWxVc-LQpCd-8
     scenes-app-logs-sparkline--with-visible-row-range--light:
-        hash: v1.k794b7964.b0f371959dd1ba3224600f73c6ce704356527d7e47eb2059391a4c6c340a098b.-AV9dQHySpjijS8TCrCM0nW459TOjWY356UVly4uCoo
+        hash: v1.k794b7964.fb69358c8aeb58426a04c00facab5399cd68aa9de3e988e6aa8d25f29e8d4c83._7BbQGMxvbU8KHxD2hLOFTF3DLr1ii76MQFwh6ir0Uw
     scenes-app-marketing-analytics-cell-actions--campaign-cell-action-globally-mapped--dark:
         hash: v1.k794b7964.52cf1cc9ecc8ac0c8dc3ff23da8f0e0f2605629c3df6ecbb5ed9608f570c4784.NtNmI3-76PkNhp-wrgqn8-92duqzx8Svtopeh0m9xw8
     scenes-app-marketing-analytics-cell-actions--campaign-cell-action-globally-mapped--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -376,7 +376,6 @@ export const FEATURE_FLAGS = {
     LOGS_SETTINGS_JSON: 'logs-settings-json', // owner: #team-logs
     LOGS_SETTINGS_PII_SCRUB: 'logs-settings-pii-scrub', // owner: #team-logs
     LOGS_SETTINGS_RETENTION_RULES: 'logs-settings-retention-rules', // owner: #team-logs
-    LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_TRANSFORMATIONS: 'logs-transformations', // owner: #team-logs
     MANAGED_MIGRATIONS_IAM_ROLE_AUTH: 'managed-migrations-iam-role-auth', // owner: #team-ingestion, gates IAM role auth for S3 batch imports
     MANAGED_MIGRATIONS_TRIAL_RUNS: 'managed-migrations-trial-runs', // owner: #team-ingestion, gates trial runs for managed migrations

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -120,9 +120,8 @@ function LogsViewerContent({
         clearSelection,
         togglePrettifyLog,
     } = useActions(logsViewerLogic)
-    const { orderBy, sparklineBreakdownBy, sparklineCollapsed, facetRailCollapsed, viewMode } =
-        useValues(logsViewerConfigLogic)
-    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed } = useActions(logsViewerConfigLogic)
+    const { orderBy, sparklineCollapsed, facetRailCollapsed, viewMode } = useValues(logsViewerConfigLogic)
+    const { setOrderBy, toggleSparklineCollapsed } = useActions(logsViewerConfigLogic)
     const {
         logsLoading,
         parsedLogs,
@@ -309,8 +308,6 @@ function LogsViewerContent({
                 sparklineLoading={sparklineLoading}
                 onDateRangeChange={setDateRange}
                 displayTimezone={timezone}
-                breakdownBy={sparklineBreakdownBy}
-                onBreakdownByChange={setSparklineBreakdownBy}
                 collapsed={sparklineCollapsed}
                 onToggleCollapse={toggleSparklineCollapsed}
                 incompleteBarIndices={sparklineIncompleteBarIndices}

--- a/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/LogsViewerSparkline.stories.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/LogsViewerSparkline.stories.tsx
@@ -1,7 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-
 import { OTHER_BREAKDOWN_LABEL } from 'products/logs/frontend/sparklineOtherBreakdown'
 
 import { LogsSparkline, LogsSparklineData } from './index'
@@ -38,14 +36,12 @@ const meta: Meta<typeof LogsSparkline> = {
         sparklineData: buildSparklineData(),
         sparklineLoading: false,
         displayTimezone: 'UTC',
-        breakdownBy: 'severity',
         collapsed: false,
     },
     parameters: {
         layout: 'padded',
         viewMode: 'story',
         mockDate: '2026-08-06',
-        featureFlags: [FEATURE_FLAGS.LOGS_SPARKLINE_SERVICE_BREAKDOWN],
         // Bars paint asynchronously (ResizeObserver, then rAF); chromium alone keeps the snapshot stable.
         testOptions: { snapshotBrowsers: ['chromium'] },
     },

--- a/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
@@ -1,19 +1,18 @@
 import { useCallback, useMemo } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
-import { LemonButton, LemonSelect, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 import { DefaultTooltip, HighlightedRange, TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { DateRangeZoomData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { getColorVar } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { shortTimeZone } from 'lib/utils/timezones'
 
-import { DateRange, LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
+import { DateRange } from '~/queries/schema/schema-general'
 
 import type { VisibleLogsTimeRange } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 
@@ -33,32 +32,22 @@ export interface LogsViewerSparklineProps {
     sparklineLoading: boolean
     onDateRangeChange: (dateRange: DateRange) => void
     displayTimezone: string // IANA timezone string (e.g. "UTC", "America/New_York", "Europe/London")
-    breakdownBy: LogsSparklineBreakdownBy
-    onBreakdownByChange: (breakdownBy: LogsSparklineBreakdownBy) => void
     collapsed?: boolean
     onToggleCollapse?: () => void
     incompleteBarIndices?: number[]
     visibleRowDateRange?: VisibleLogsTimeRange | null
 }
 
-const BREAKDOWN_OPTIONS: { value: LogsSparklineBreakdownBy; label: string }[] = [
-    { value: 'severity', label: 'Severity' },
-    { value: 'service', label: 'Service' },
-]
-
 export function LogsSparkline({
     sparklineData,
     sparklineLoading,
     onDateRangeChange,
     displayTimezone,
-    breakdownBy,
-    onBreakdownByChange,
     collapsed = false,
     onToggleCollapse,
     incompleteBarIndices,
     visibleRowDateRange,
 }: LogsViewerSparklineProps): JSX.Element | null {
-    const showServiceBreakdown = useFeatureFlag('LOGS_SPARKLINE_SERVICE_BREAKDOWN')
     const theme = useChartTheme()
 
     // Quill's automatic date axis has no seconds mode, and buckets target ~50 across the queried
@@ -115,7 +104,6 @@ export function LogsSparkline({
             xAxis: { tickFormatter: (value: string) => dayjs(value).tz(displayTimezone).format(tickFormat) },
             yAxis: { tickFormatter: humanFriendlyNumber },
             barCornerRadius: 2,
-            // A service breakdown reaches 13 rows, overflowing the tooltip, so it has to be scrollable.
             tooltip: { pinnable: true },
         }),
         [displayTimezone, tickFormat]
@@ -170,14 +158,6 @@ export function LogsSparkline({
                 >
                     <span className="text-xs text-muted">Volume over time</span>
                 </LemonButton>
-                {!collapsed && showServiceBreakdown && (
-                    <LemonSelect
-                        size="xsmall"
-                        value={breakdownBy}
-                        onChange={(value) => value && onBreakdownByChange(value)}
-                        options={BREAKDOWN_OPTIONS}
-                    />
-                )}
             </div>
             {!collapsed && (
                 // Quill chart roots are `flex-1`, so the sized box has to be a flex column.

--- a/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
@@ -77,7 +77,7 @@ export function LogsSparkline({
                 key: timeseries.name,
                 label: timeseries.name,
                 data: timeseries.values,
-                // The logic hands back vars.scss color names ('danger', 'data-color-1'); a canvas
+                // The logic hands back vars.scss color names ('danger', 'brand-blue'); a canvas
                 // fill needs a real color. `theme` is a dep so a light/dark flip re-resolves them.
                 color: getColorVar(timeseries.color || 'muted'),
                 // Buckets past the ingestion checkpoint are always a trailing run.
@@ -104,6 +104,8 @@ export function LogsSparkline({
             xAxis: { tickFormatter: (value: string) => dayjs(value).tz(displayTimezone).format(tickFormat) },
             yAxis: { tickFormatter: humanFriendlyNumber },
             barCornerRadius: 2,
+            // severity_text is free-form, so top-10 values plus the other row can overflow the
+            // tooltip; pinning makes it scrollable.
             tooltip: { pinnable: true },
         }),
         [displayTimezone, tickFormat]

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -1,6 +1,5 @@
 import { MakeLogicType, actions, afterMount, kea, key, path, props, reducers, selectors } from 'kea'
 
-import { LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
 import { FilterLogicalOperator } from '~/types'
 
 import {
@@ -26,8 +25,6 @@ export const DEFAULT_LOGS_VIEWER_CONFIG: LogsViewerConfig = {
         filterGroup: { type: FilterLogicalOperator.And, values: [] },
     },
 }
-
-export const DEFAULT_SPARKLINE_BREAKDOWN_BY: LogsSparklineBreakdownBy = 'severity'
 
 export const DEFAULT_ORDER_BY: LogsOrderBy = 'latest'
 
@@ -66,7 +63,6 @@ export interface logsViewerConfigLogicValues {
     filters: LogsViewerFilters
     groupBys: LogsViewerGroupBy[]
     orderBy: LogsOrderBy
-    sparklineBreakdownBy: LogsSparklineBreakdownBy
     sparklineCollapsed: boolean
     viewMode: LogsViewerViewMode
 }
@@ -138,9 +134,6 @@ export interface logsViewerConfigLogicActions {
         orderBy: LogsOrderBy
         source: 'header' | 'toolbar'
     }
-    setSparklineBreakdownBy: (sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
-        sparklineBreakdownBy: LogsSparklineBreakdownBy
-    }
     setViewMode: (viewMode: LogsViewerViewMode) => {
         viewMode: LogsViewerViewMode
     }
@@ -176,7 +169,6 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
             filter,
             value,
         }),
-        setSparklineBreakdownBy: (sparklineBreakdownBy: LogsSparklineBreakdownBy) => ({ sparklineBreakdownBy }),
         setOrderBy: (orderBy: LogsOrderBy, source: 'header' | 'toolbar' = 'toolbar') => ({ orderBy, source }),
         toggleSparklineCollapsed: true,
         setFacetRailCollapsed: (facetRailCollapsed: boolean) => ({ facetRailCollapsed }),
@@ -205,13 +197,6 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
                     ...state,
                     [filter]: value,
                 }),
-            },
-        ],
-        sparklineBreakdownBy: [
-            DEFAULT_SPARKLINE_BREAKDOWN_BY as LogsSparklineBreakdownBy,
-            { persist: true },
-            {
-                setSparklineBreakdownBy: (_, { sparklineBreakdownBy }) => sparklineBreakdownBy,
             },
         ],
         sparklineCollapsed: [

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -21,18 +21,11 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { dataColorVars } from 'lib/colors'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 
-import {
-    LogMessage,
-    LogsQuery,
-    LogsSparklineBreakdownBy,
-    ProductIntentContext,
-    ProductKey,
-} from '~/queries/schema/schema-general'
+import { LogMessage, LogsQuery, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
 import { JsonType, PropertyGroupFilter, UniversalFiltersGroup, UniversalFiltersGroupValue } from '~/types'
 
@@ -149,7 +142,6 @@ export function shouldSkipFilterGroupChange(
 export interface logsViewerDataLogicValues {
     customColumns: string[] | undefined // logsViewerConfigLogic
     orderBy: LogsOrderBy // logsViewerConfigLogic
-    sparklineBreakdownBy: LogsSparklineBreakdownBy // logsViewerConfigLogic
     filterGroup: UniversalFiltersGroup // logsViewerFiltersLogic
     filters: LogsViewerFilters // logsViewerFiltersLogic
     personId: string | undefined // logsViewerFiltersLogic
@@ -209,9 +201,6 @@ export interface logsViewerDataLogicActions {
     ) => {
         orderBy: LogsOrderBy
         source: 'header' | 'toolbar'
-    } // logsViewerConfigLogic
-    setSparklineBreakdownBy: (sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
-        sparklineBreakdownBy: LogsSparklineBreakdownBy
     } // logsViewerConfigLogic
     setDateRange: (dateRange: DateRange) => {
         dateRange: DateRange
@@ -445,10 +434,7 @@ export interface logsViewerDataLogicMeta {
             liveTailExpired: boolean
         ) => string | undefined
         parsedLogs: (logs: LogMessage[]) => ParsedLogMessage[]
-        sparklineData: (
-            sparkline: any[],
-            sparklineBreakdownBy: LogsSparklineBreakdownBy
-        ) => {
+        sparklineData: (sparkline: any[]) => {
             data: {
                 color: string | undefined
                 name: string
@@ -491,13 +477,13 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
             logsViewerFiltersLogic({ id }),
             ['setDateRange', 'setFilterGroup', 'setFilters', 'setSearchTerm'],
             logsViewerConfigLogic({ id }),
-            ['setSparklineBreakdownBy', 'setOrderBy', 'setColumns', 'addColumn', 'removeColumn'],
+            ['setOrderBy', 'setColumns', 'addColumn', 'removeColumn'],
         ],
         values: [
             logsViewerFiltersLogic({ id }),
             ['filters', 'utcDateRange', 'filterGroup', 'queryFilterGroup', 'personId'],
             logsViewerConfigLogic({ id }),
-            ['sparklineBreakdownBy', 'orderBy', 'customColumns'],
+            ['orderBy', 'customColumns'],
         ],
     })),
 
@@ -770,7 +756,6 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                             searchTerm: values.filters.searchTerm,
                             filterGroup: values.queryFilterGroup as PropertyGroupFilter,
                             ...unsetColumnQueryFields(),
-                            sparklineBreakdownBy: values.sparklineBreakdownBy,
                             personId: values.personId,
                         },
                         signal,
@@ -852,13 +837,11 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
             },
         ],
         sparklineData: [
-            (s) => [s.sparkline, s.sparklineBreakdownBy],
-            (sparkline: any[] | null, sparklineBreakdownBy: LogsSparklineBreakdownBy) => {
+            (s) => [s.sparkline],
+            (sparkline: any[] | null) => {
                 if (!sparkline) {
                     return { dates: [], data: [] }
                 }
-
-                const breakdownKey = sparklineBreakdownBy
 
                 let lastTime = ''
                 let i = -1
@@ -870,7 +853,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                             lastTime = currentItem.time
                             i++
                         }
-                        const key = currentItem[breakdownKey]
+                        const key = currentItem.severity
                         if (!key) {
                             return accumulator
                         }
@@ -903,20 +886,17 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                 const data = Object.entries(accumulated)
                     .filter(([name]) => name !== OTHER_BREAKDOWN_VALUE)
                     .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([name, values], index) => ({
+                    .map(([name, values]) => ({
                         name,
                         values: padToDatesLength(values as number[]),
-                        color:
-                            sparklineBreakdownBy === 'service'
-                                ? dataColorVars[index % dataColorVars.length]
-                                : {
-                                      fatal: 'danger-dark',
-                                      error: 'danger',
-                                      warn: 'warning',
-                                      info: 'brand-blue',
-                                      debug: 'muted',
-                                      trace: 'muted-alt',
-                                  }[name],
+                        color: {
+                            fatal: 'danger-dark',
+                            error: 'danger',
+                            warn: 'warning',
+                            info: 'brand-blue',
+                            debug: 'muted',
+                            trace: 'muted-alt',
+                        }[name],
                     }))
                 const otherValues = accumulated[OTHER_BREAKDOWN_VALUE]
                 if (otherValues) {
@@ -1025,9 +1005,6 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         setOrderBy: ({ orderBy, source }) => {
             posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy, source })
             actions.runQuery()
-        },
-        setSparklineBreakdownBy: () => {
-            actions.fetchSparkline()
         },
         // Structural column changes refetch only when the lowered wire value differs from what
         // the last query sent — resizing or reordering columns never re-runs the query.
@@ -1233,12 +1210,8 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                 }
             }
         },
-        // insert logs into the sparkline data (only works for severity breakdown)
+        // insert logs into the sparkline data
         addLogsToSparkline: (logs: LogMessage[]) => {
-            // Only update incrementally for severity breakdown - service would need service_name from logs
-            if (values.sparklineBreakdownBy !== 'severity') {
-                return
-            }
             // if the sparkline hasn't loaded do nothing.
             if (!values.sparkline || values.sparkline.length < 2) {
                 return

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -756,6 +756,9 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                             searchTerm: values.filters.searchTerm,
                             filterGroup: values.queryFilterGroup as PropertyGroupFilter,
                             ...unsetColumnQueryFields(),
+                            // The severity result key, colors, and live-tail merge all assume a
+                            // severity breakdown, so state it rather than lean on the server default.
+                            sparklineBreakdownBy: 'severity',
                             personId: values.personId,
                         },
                         signal,
@@ -1210,7 +1213,6 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                 }
             }
         },
-        // insert logs into the sparkline data
         addLogsToSparkline: (logs: LogMessage[]) => {
             // if the sparkline hasn't loaded do nothing.
             if (!values.sparkline || values.sparkline.length < 2) {


### PR DESCRIPTION
## Problem

The logs viewer sparkline carries a severity/service breakdown dropdown behind the `logs-sparkline-service-breakdown` flag. The flag never rolled out, and the facet rail now covers per-service filtering, so the dropdown and its state are dead code.

## Changes

- Nothing user-visible changes. The dropdown only rendered with the flag on, and the flag stayed off, so there are no screenshots.
- The viewer sparkline is now fixed to a severity breakdown.
- The request states `sparklineBreakdownBy: 'severity'`. The result key, the colors, and the live-tail merge all assume that breakdown.
- Removes the dropdown, its props, the persisted `sparklineBreakdownBy` config reducer, and the refetch listener.
- Removes the `LOGS_SPARKLINE_SERVICE_BREAKDOWN` flag constant. The component and its story were its only users.
- Keeps the backend `sparklineBreakdownBy` query field. The filter volume preview queries with `service` and the alert detail scene with `severity`.
- Mechanical: story args, regenerated kea type blocks, unused imports.

> [!NOTE]
> The `logs-sparkline-service-breakdown` flag should also be archived in the PostHog app. This PR only removes the client reference.

## How did you test this code?

- The `logsViewerDataLogic` jest suite passes locally, including the `sparklineData` selector cases.
- Kea typegen reports both edited logic types up to date.
- Not run: Storybook snapshots and Playwright. CI covers those.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc mentions the dropdown.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Fable 5) in an interactive session.
- Skills invoked: /writing-ui-components, /writing-kea-logics, /writing-pr-descriptions.
- The session started as an investigation into sparkline query performance; the removal was a separate, directed request. The backend query field stays because two other features send it.

