### PR TITLE
fix(desktop): preserve project during auth recovery

### DIFF
--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -1285,6 +1285,58 @@ describe("AuthService", () => {
   });
 
   describe("transient org fetch failures", () => {
+    it("does not replace the stored project with another org's first project during partial recovery", async () => {
+      seedStoredSession({ selectedProjectId: 84 });
+      oauthFlow.refreshToken.mockResolvedValue(
+        mockTokenResponse({ scopedOrgs: ["org-1", "org-2"] }),
+      );
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | Request) => {
+          const url = typeof input === "string" ? input : input.url;
+
+          if (url.includes("/api/users/@me/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                uuid: "user-1",
+                organization: { id: "org-1" },
+              }),
+            } as unknown as Response;
+          }
+
+          if (url.includes("/api/organizations/org-1/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                name: "Org 1",
+                teams: [{ id: 42, name: "Project 42" }],
+              }),
+            } as unknown as Response;
+          }
+
+          if (url.includes("/api/organizations/org-2/")) {
+            return {
+              ok: false,
+              status: 503,
+              json: vi.fn().mockResolvedValue({}),
+            } as unknown as Response;
+          }
+
+          return {
+            ok: true,
+            json: vi.fn().mockResolvedValue({ allowed: true, reason: null }),
+          } as unknown as Response;
+        }) as unknown as typeof fetch,
+      );
+
+      await service.initialize();
+
+      expect(service.getState().currentProjectId).toBeNull();
+      expect(sessionPort.getCurrent()?.selectedProjectId).toBe(84);
+    });
+
     it("retries the org fetch on a transient network failure and keeps the selected project", async () => {
       seedStoredSession({ selectedProjectId: 84 });
       oauthFlow.refreshToken.mockResolvedValue(mockTokenResponse());

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -815,13 +815,21 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     const lastPrefs = accountKey
       ? this.authPreference.get(accountKey, options.cloudRegion)
       : null;
+    const preferredProjectId =
+      options.selectedProjectId ?? lastPrefs?.lastSelectedProjectId ?? null;
     const selection = this.reconcileInitialSelection({
       orgProjectsMap,
       currentOrgId,
-      preferredProjectId:
-        options.selectedProjectId ?? lastPrefs?.lastSelectedProjectId ?? null,
+      preferredProjectId,
       lastSelectedOrgId: lastPrefs?.lastSelectedOrgId ?? null,
     });
+    if (
+      orgProjectsIncomplete &&
+      preferredProjectId !== null &&
+      !flattenProjectIds(orgProjectsMap).includes(preferredProjectId)
+    ) {
+      selection.currentProjectId = null;
+    }
 
     const refreshToken =
       tokenResponse.refresh_token ?? options.fallbackRefreshToken ?? null;


### PR DESCRIPTION
## Problem

Desktop users can land in another project after a temporary authentication recovery failure, making their existing tasks appear missing.

**Why:** Authentication recovery must preserve the user's working context when only part of the project list is temporarily unavailable.

## Changes

- Desktop now waits for project recovery instead of selecting another organization's first project.
- The stored project remains available for the recovery pass to restore.

## How did you test this code?

- Added a regression test for partial multi-organization recovery with the active organization unavailable.
- Ran the Desktop core test suite, typecheck, lint, and core boundary lint.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This fixes internal recovery behavior without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and verified this fix using the `posthog-desktop` and `writing-pr-descriptions` skills. The regression test uses invented project and organization data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
