### PR TITLE
fix(data-imports): treat a read-only writer as a transient DB error

### DIFF
--- a/posthog/temporal/common/test_db_errors.py
+++ b/posthog/temporal/common/test_db_errors.py
@@ -47,30 +47,19 @@ def test_is_transient_db_error_by_message(error: BaseException, expected: bool) 
     [
         (OperationalError, "57P03", True),  # cannot_connect_now (server starting up/shutting down)
         (OperationalError, "3D000", False),  # invalid_catalog_name — persistent misconfiguration
-        (OperationalError, "08P01", False),  # protocol_violation — shared with genuine protocol bugs, so message-only
-        # read_only_sql_transaction: a primary briefly refusing writes/locks mid-failover. psycopg
-        # classes this under its own InternalError rather than OperationalError.
+        (OperationalError, "08P01", False),  # protocol_violation — shared with genuine protocol bugs
+        # read_only_sql_transaction: Django wraps psycopg's ReadOnlySqlTransaction as InternalError,
+        # not OperationalError/InterfaceError — a primary/replica failover briefly rejects writes
+        # with this exact SQLSTATE until promotion completes. Exercises the class-independent path.
         (InternalError, "25006", True),
         (InternalError, "42601", False),  # syntax_error — a real bug, must keep reaching error tracking
+        # in_failed_sql_transaction shares class 25 with the code above but means a prior statement
+        # in the same transaction already failed — a real defect, not a self-healing infra blip.
+        # Guards against widening the match to the whole class-25 prefix instead of the exact code.
+        (InternalError, "25P02", False),
     ],
 )
 def test_is_transient_db_error_by_sqlstate(error_cls: type[Exception], sqlstate: str, expected: bool) -> None:
     error = error_cls("some driver-specific message")
     error.__cause__ = _WithSqlstate(sqlstate)
     assert is_transient_db_error(error) is expected
-
-
-def test_is_transient_db_error_for_read_only_transaction_failover() -> None:
-    # psycopg raises this under InternalError, not OperationalError — a primary/replica failover
-    # briefly rejects writes with this exact SQLSTATE until promotion completes.
-    error = InternalError("cannot execute INSERT in a read-only transaction")
-    error.__cause__ = _WithSqlstate("25006")
-    assert is_transient_db_error(error) is True
-
-
-def test_is_transient_db_error_rejects_other_internal_errors() -> None:
-    # Class 25 (invalid transaction state) has other codes that are real bugs, not infra hiccups —
-    # only the exact read-only-transaction code should be treated as transient.
-    error = InternalError("current transaction is aborted")
-    error.__cause__ = _WithSqlstate("25P02")
-    assert is_transient_db_error(error) is False


### PR DESCRIPTION
## Problem

A brief writer read-only window (an Aurora failover or maintenance promotion) makes every write against PostHog's own database fail at once. In the warehouse-sources data-imports pipeline this hit schema-sync activities, and `is_transient_db_error` failed to recognize it, so each occurrence minted a fresh error tracking issue instead of being treated like the pipeline's other self-healing DB conditions.

Related error tracking issue: read-only writer failures surfaced as `InternalError: cannot execute UPDATE in a read-only transaction` from `ExternalDataSchema.save()` during schema discovery.

## Changes

- `is_transient_db_error` now matches Postgres SQLSTATE `25006` (`read_only_sql_transaction`) independently of the exception's Python class.
- Django wraps psycopg's `ReadOnlySqlTransaction` as `InternalError`, not `OperationalError`/`InterfaceError`, so the existing class-restricted check missed it. The SQLSTATE check now runs for any `django.db.Error`, before the class-restricted message check.
- The match is an exact code, not the whole class-25 prefix: sibling code `25P02` (`in_failed_sql_transaction`) means a prior statement in the same transaction already failed, which is a real defect, not a self-healing infra blip, so it still reaches error tracking.

## How did you test this code?

- Extended `test_is_transient_db_error_by_sqlstate` in `posthog/temporal/common/test_db_errors.py` with two cases: `InternalError` wrapping SQLSTATE `25006` returns transient, and `25P02` on the same exception class does not — guarding against widening the match to the whole class-25 prefix.
- `pytest posthog/temporal/common/test_db_errors.py` — 16 passed.
- `ruff check` / `ruff format` and `mypy` clean on both changed files.
- Not run: a live Aurora failover, or the broader Temporal worker suite (no dev stack in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal pipeline error-handling behavior with no documented workflow.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code from an error-tracking issue triage task.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- An open PR from this same bot, [#86039](https://github.com/PostHog/posthog/pull/86039), addresses the same underlying read-only-writer condition more broadly (a global `before_send` hook, an admin-save retry message, and Temporal connection-eviction retries). It does not touch `db_errors.py`. This PR is a narrower, non-conflicting fix at the specific classification point the warehouse-sources pipeline already relies on; worth reconciling the two at review time.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*