### PR TITLE
fix(kafka): report producer liveness after the broker ping

### DIFF
--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -148,7 +148,12 @@ fn build_client_config(config: &KafkaConfig) -> ClientConfig {
 
 /// Ping the Kafka brokers by fetching metadata, so a broker that's unreachable
 /// at startup surfaces as an error here rather than silently later.
-fn ping_brokers<C, P>(producer: &P) -> Result<(), KafkaError>
+///
+/// Reports the liveness component healthy on success. The stats callback is the
+/// only other heartbeat and first fires one `statistics.interval.ms` in, so a
+/// readiness probe before then would fail on a producer that just proved it can
+/// reach the cluster.
+fn ping_brokers<C, P>(producer: &P, liveness: &impl SyncLivenessReporter) -> Result<(), KafkaError>
 where
     C: ProducerContext,
     P: Producer<C>,
@@ -162,6 +167,7 @@ where
                 "Successfully connected to Kafka brokers. Found {} topics.",
                 metadata.topics().len()
             );
+            liveness.report_healthy();
             Ok(())
         }
         Err(error) => {
@@ -181,9 +187,9 @@ where
     let client_config = build_client_config(config);
     debug!("rdkafka configuration: {:?}", client_config);
     let api: FutureProducer<KafkaContext> =
-        client_config.create_with_context(KafkaContext::new(liveness))?;
+        client_config.create_with_context(KafkaContext::new(liveness.clone()))?;
 
-    ping_brokers(&api)?;
+    ping_brokers(&api, &liveness)?;
 
     Ok(api)
 }
@@ -255,9 +261,9 @@ where
     L: SyncLivenessReporter + Clone + 'static,
     F: Fn(&DeliveryResult, K) + Send + Sync + 'static,
 {
-    let producer = create_threaded_kafka_producer_no_ping(config, liveness, on_delivery)?;
+    let producer = create_threaded_kafka_producer_no_ping(config, liveness.clone(), on_delivery)?;
 
-    ping_brokers(&producer)?;
+    ping_brokers(&producer, &liveness)?;
 
     Ok(producer)
 }


### PR DESCRIPTION
## Problem

Every service that builds a Kafka producer through `common-kafka` starts unready for ten seconds and logs a health check failure while it waits, even though the producer connected to the cluster before the process began serving.

- The producer's health component reports healthy from librdkafka's stats callback, and `statistics.interval.ms` is 10000.
- A readiness probe that lands before the first callback sees the component in `Starting` and fails.
- The registry logs `health check failed: {"kafka_producer": Starting}` at WARN on each of those probes.
- `create_kafka_producer` already fetches broker metadata at startup and returns an error when that fails, so a producer that reaches this point can reach the cluster.

Seen on the usage ingestion gateway in dev, whose readiness probe starts at 3s with a 5s period.

## Changes

- A pod with a reachable Kafka cluster now passes its first readiness probe instead of its third. `ping_brokers` reports the liveness component healthy when the metadata fetch succeeds.
- Both pinging constructors get it: `create_kafka_producer` and `create_threaded_kafka_producer`. They clone the reporter into the client context and keep the original for the ping.
- `create_threaded_kafka_producer_no_ping` is unchanged. It proves nothing about the cluster, so it has nothing to report.
- The stalled-component behavior is unchanged. The component still needs a stats callback every 30 seconds to stay healthy, so a producer whose poll loop dies still goes unhealthy.

## Testing

No test added. The reachable-broker path needs a live cluster, and the change is one call on an existing success path.

- `cargo check -p common-kafka` and `cargo clippy -p common-kafka --all-targets -- -D warnings` pass.
- Not run: any test with a broker, and no service redeployed to watch a real probe sequence.

## 🤖 Agent context

**Autonomy:** Agent-authored (human-directed)

- Claude Code (Opus 5) traced the dev warning from the usage ingestion gateway to the stats-callback heartbeat, then fixed it in the shared crate rather than by raising the app's probe delay, because every producer caller has the same gap.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
