### PR TITLE
fix(data-warehouse): anchor repartition rewrite deadline to activity start

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -103,8 +103,17 @@ _TRANSIENT_ERROR_SNIPPETS = (
 REWRITE_DEADLINE_MARGIN = dt.timedelta(minutes=5)
 
 
-def _rewrite_deadline() -> float | None:
+def _rewrite_deadline(activity_started: float) -> float | None:
     """Monotonic time by which the rewrite must stop to leave room to record its own failure.
+
+    `activity_started` is the `time.monotonic()` reading taken when the activity began. The deadline
+    is anchored to it, not to now: the budget is measured from `start_to_close_timeout`, which Temporal
+    counts from the same start, so the pre-rewrite work (job fetch, flag evaluation, the pre-extraction
+    Delta-log measurement, temp validation) has to be charged against it too. Anchoring to now instead
+    hands the rewrite a deadline later than the activity's own timeout by however long that pre-work
+    took, so on the heavily-fragmented tables this path exists to rescue — where reading the log alone
+    runs into minutes — Temporal kills the rewrite mid-stream before it can record an outcome, and the
+    hard-killed attempt counts toward the give-up cap.
 
     None when there is no budget to derive one from: outside an activity context (direct calls from
     tests), when the activity declares no `start_to_close_timeout`, or when that timeout is shorter
@@ -120,7 +129,7 @@ def _rewrite_deadline() -> float | None:
     budget = (info.start_to_close_timeout - REWRITE_DEADLINE_MARGIN).total_seconds()
     if budget <= 0:
         return None
-    return time.monotonic() + budget
+    return activity_started + budget
 
 
 def _is_transient_infra_error(error: Exception) -> bool:
@@ -242,6 +251,10 @@ def maybe_repartition_table_activity(inputs: RepartitionActivityInputs) -> None:
 
 
 def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: FilteringBoundLogger) -> None:
+    # Anchor the rewrite deadline to when the activity began, so the pre-rewrite work below (job fetch,
+    # flag evaluation, pre-extraction Delta-log measurement) is charged against the activity's timeout
+    # rather than handed to the rewrite on top of it. See `_rewrite_deadline`.
+    activity_started = time.monotonic()
     try:
         schema = retry_on_db_connection_drop(
             lambda: ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
@@ -412,7 +425,7 @@ def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: Filterin
                 target=target,
                 logger=logger,
                 claim_token=claim_token,
-                deadline=_rewrite_deadline(),
+                deadline=_rewrite_deadline(activity_started),
             )
     except RepartitionBudgetExceededError as e:
         # The rewrite didn't fit in one activity's budget. Checkpoint/resume lets a large table

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -192,11 +192,23 @@ class TestRewriteDeadline:
             else MagicMock(return_value=info)
         )
 
+        with patch(f"{MODULE}.activity.info", info_fn):
+            assert _rewrite_deadline(1000.0) == expected
+
+    def test_deadline_is_anchored_to_the_activity_start_not_now(self) -> None:
+        # The deadline must be measured from when the activity began, because Temporal counts the
+        # start_to_close_timeout from the same point. Time already spent before the rewrite starts
+        # (log measurement on a fragmented table can run into minutes) has to shrink the rewrite's
+        # window, not be handed to it on top of the full budget — otherwise the rewrite outlives the
+        # timeout and Temporal kills it before it records an outcome.
+        info = MagicMock()
+        info.start_to_close_timeout = dt.timedelta(hours=6)
         with (
-            patch(f"{MODULE}.activity.info", info_fn),
-            patch(f"{MODULE}.time", MagicMock(monotonic=MagicMock(return_value=1000.0))),
+            patch(f"{MODULE}.activity.info", MagicMock(return_value=info)),
+            # A later wall reading must not move the deadline: it depends only on the passed anchor.
+            patch(f"{MODULE}.time", MagicMock(monotonic=MagicMock(return_value=9_999_999.0))),
         ):
-            assert _rewrite_deadline() == expected
+            assert _rewrite_deadline(1000.0) == 22300.0
 
 
 class TestBudgetExhaustion:


### PR DESCRIPTION
## Problem

A data-warehouse table whose in-place repartition is repeatedly hard-killed mid-rewrite gets abandoned: after three killed attempts the controller gives up (`RepartitionAttemptsExhausted`), leaving the table un-repartitioned and syncing on the layout that OOMs it, until the daily cooldown re-detects it.

The rewrite has a deadline meant to stop it *before* Temporal's `start_to_close_timeout` fires, so it can record its own outcome instead of being killed. But `_rewrite_deadline` measured the budget from the moment the rewrite starts, not from when the activity started:

- Temporal counts `start_to_close_timeout` from activity start.
- The pre-rewrite work — job fetch, flag evaluation, the pre-extraction Delta-log measurement, temp validation — runs before that point.
- On a heavily fragmented or large table, reading the log alone runs into minutes.
- So the rewrite got a deadline later than the activity's own timeout, and Temporal killed it mid-stream before it recorded an outcome.

A hard-killed attempt records no outcome, so it counts toward the give-up cap. Three of them and the table is abandoned.

## Changes

- The rewrite now stops in time to record its outcome on tables with slow pre-rewrite work, instead of being killed and counted as a failed attempt.
- `_rewrite_deadline` takes a monotonic reading captured at activity entry and anchors the deadline to it, so pre-rewrite time is charged against the timeout and the full margin stays reserved for recording the outcome.
- The deadline can only move earlier, never later, so the change is strictly more conservative: a rewrite that would have overrun now gives up cleanly and resumes from its checkpoint next run.

## How did you test this code?

Added `test_deadline_is_anchored_to_the_activity_start_not_now`: it patches a later `time.monotonic()` and asserts the deadline depends only on the passed anchor. This catches the regression — an implementation that reads the clock at call time would move the deadline past the timeout. Existing `_rewrite_deadline` cases were updated to the new signature.

Ran locally: `TestRewriteDeadline` (5 passed) and the full `test_repartition_table.py` (33 passed). Not run: the database-backed and Temporal-worker suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Internal pipeline behavior only — no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged reported `warehouse_repartition_failed` failure modes and traced the terminal `RepartitionAttemptsExhausted` mode to the deadline reference-point defect. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`. Ruled out duplicate work: the open human-authored PR #73080 reworks the same files but targets the perpetual-repartition-loop (a higher-level circuit breaker) and does not touch the deadline, give-up, or budget-exceeded paths.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
