### PR TITLE
fix(notebooks): fail a kernel run whose callback never arrives

### DIFF
--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -80,7 +80,7 @@ from products.notebooks.backend.sql_v2_references import (
     resolve_python_node_inputs,
     resolve_sql_node_run,
 )
-from products.notebooks.backend.sql_v2_runs import finish_node_run
+from products.notebooks.backend.sql_v2_runs import expire_stale_kernel_run, finish_node_run
 from products.notebooks.backend.sql_v2_serializers import (
     NotebookKernelConfigResponseSerializer,
     NotebookKernelStatusResponseSerializer,
@@ -1336,6 +1336,10 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         # caller lost access mid-query. Advancing the row leaks nothing — the gate below still
         # decides whether any of it is returned.
         rows = sync_direct_run(run)
+        # The kernel lane's equivalent, and here for the same reason: the sandbox delivers its
+        # envelope once with no retry, so a lost delivery leaves a run nothing else can move.
+        # The two are mutually exclusive — each is a no-op for the other's node types.
+        expire_stale_kernel_run(run)
         self._require_run_connection_access(run, user)
 
         # Interrupted runs keep their envelope too: the walkthrough (Journey 9) promises the

--- a/products/notebooks/backend/sql_v2.py
+++ b/products/notebooks/backend/sql_v2.py
@@ -195,9 +195,16 @@ def build_data_plane_url() -> str:
     return f"{_backend_base_url()}/internal/notebooks/data_plane/query/"
 
 
-def mint_data_plane_token(notebook_short_id: str, team_id: int, user_id: int | None) -> str:
+def mint_data_plane_token(notebook_short_id: str, team_id: int, user_id: int | None, run_id: str | None = None) -> str:
+    """Sign a data-plane token for the sandbox.
+
+    `run_id` names the run the fetch belongs to, so a data-plane query counts as observable
+    progress on it (see `touch_run_progress`). It rides the signed token rather than the
+    request body because the sandbox must not be able to name a different run than the one
+    the backend dispatched to it.
+    """
     return signing.dumps(
-        {"notebook_short_id": notebook_short_id, "team_id": team_id, "user_id": user_id},
+        {"notebook_short_id": notebook_short_id, "team_id": team_id, "user_id": user_id, "run_id": run_id},
         salt=_DATA_PLANE_TOKEN_SALT,
     )
 
@@ -207,16 +214,21 @@ class DataPlaneClaims:
     notebook_short_id: str
     team_id: int
     user_id: int | None
+    # Absent on a token minted before the run-progress claim existed, so it stays optional:
+    # such a token still fetches data, it just cannot advance its run's watchdog clock.
+    run_id: str | None = None
 
 
 def verify_data_plane_token(token: str) -> DataPlaneClaims:
     """Return the claims from a valid token, else raise signing.BadSignature."""
     data = signing.loads(token, salt=_DATA_PLANE_TOKEN_SALT, max_age=_DATA_PLANE_TOKEN_MAX_AGE_SECONDS)
     user_id = data.get("user_id")
+    run_id = data.get("run_id")
     return DataPlaneClaims(
         notebook_short_id=str(data["notebook_short_id"]),
         team_id=int(data["team_id"]),
         user_id=int(user_id) if user_id is not None else None,
+        run_id=str(run_id) if run_id else None,
     )
 
 
@@ -414,7 +426,7 @@ def dispatch_sql_v2_run(
         "callback_url": build_callback_url(str(run.id)),
         "callback_token": mint_callback_token(str(run.id), notebook.team_id),
         "data_plane_url": build_data_plane_url(),
-        "data_plane_token": mint_data_plane_token(notebook.short_id, notebook.team_id, user_id),
+        "data_plane_token": mint_data_plane_token(notebook.short_id, notebook.team_id, user_id, str(run.id)),
         "page_limit": DISPLAY_PAGE_LIMIT,
         "cache_limit": RESULT_CACHE_ROWS,
     }
@@ -455,7 +467,7 @@ def fetch_sql_v2_page(notebook: Notebook, user: User | None, run: NotebookNodeRu
     if run.node_type == NotebookNodeRun.NodeType.HOGQL:
         payload["code"] = run.code
         payload["data_plane_url"] = build_data_plane_url()
-        payload["data_plane_token"] = mint_data_plane_token(notebook.short_id, notebook.team_id, user_id)
+        payload["data_plane_token"] = mint_data_plane_token(notebook.short_id, notebook.team_id, user_id, str(run.id))
     else:
         payload["result_id"] = str(run.result_id)
     try:

--- a/products/notebooks/backend/sql_v2_data_plane.py
+++ b/products/notebooks/backend/sql_v2_data_plane.py
@@ -45,6 +45,7 @@ from products.notebooks.backend.sql_v2 import (
     verify_data_plane_token,
 )
 from products.notebooks.backend.sql_v2_direct import apply_page_bounds
+from products.notebooks.backend.sql_v2_runs import touch_run_progress
 from products.notebooks.backend.sql_v2_serializers import NotebookSQLV2DataPlaneRequestSerializer
 
 logger = structlog.get_logger(__name__)
@@ -138,6 +139,13 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
 
     if not Notebook.objects.filter(team_id=claims.team_id, short_id=claims.notebook_short_id).exists():
         return JsonResponse({"error": "Notebook not found"}, status=404)
+
+    # This request is the kernel's only observable sign of life during a run, so it resets the
+    # run's watchdog clock. A python cell materializes one input per upstream node, one after
+    # another, and without this the watchdog would count that whole sequence against a single
+    # budget and fail a cell that is working correctly.
+    if claims.run_id:
+        touch_run_progress(claims.team_id, claims.run_id)
     team = Team.objects.get(id=claims.team_id)
     user = User.objects.filter(id=claims.user_id).first() if claims.user_id else None
 

--- a/products/notebooks/backend/sql_v2_direct.py
+++ b/products/notebooks/backend/sql_v2_direct.py
@@ -273,8 +273,8 @@ def sync_direct_run(run: NotebookNodeRun) -> list[list[Any]] | None:
     except QueryNotFoundError:
         age_seconds = (timezone.now() - run.created_at).total_seconds()
         if run.status == NotebookNodeRun.Status.RUNNING and age_seconds > DIRECT_RUN_RESULT_GRACE_SECONDS:
-            # The watchdog the kernel lane never had: with no status left to complete
-            # this run, waiting longer cannot help.
+            # With no status left to complete this run, waiting longer cannot help.
+            # `expire_stale_kernel_run` is the kernel lane's counterpart.
             finish_node_run(
                 run,
                 NotebookNodeRun.Status.FAILED,

--- a/products/notebooks/backend/sql_v2_runs.py
+++ b/products/notebooks/backend/sql_v2_runs.py
@@ -1,10 +1,11 @@
 """Claim a NotebookNodeRun's RUNNING -> terminal transition and report it exactly once.
 
 Every lane that finishes a run funnels through `finish_node_run`: the direct (hogql)
-lane's pollers and grace-expiry watchdog, dispatch failures (the run view and the
-Temporal mark-failed activity), and the interrupt endpoints. The sandbox callback is
-the one deliberate exception — it upserts losing deliveries too, so a late real result
-can overwrite an interrupt placeholder — and keeps its own block in sql_v2_callback.py.
+lane's pollers and grace-expiry watchdog, the kernel lane's watchdog below, dispatch
+failures (the run view and the Temporal mark-failed activity), and the interrupt
+endpoints. The sandbox callback is the one deliberate exception — it upserts losing
+deliveries too, so a late real result can overwrite an interrupt placeholder — and keeps
+its own block in sql_v2_callback.py.
 """
 
 from typing import Any
@@ -12,7 +13,15 @@ from typing import Any
 from django.utils import timezone
 
 from products.notebooks.backend.models import NotebookNodeRun
-from products.notebooks.backend.sql_v2_metrics import outcome_for_status, record_node_run_terminal
+from products.notebooks.backend.sql_v2_metrics import OUTCOME_TIMED_OUT, outcome_for_status, record_node_run_terminal
+
+# How long a RUNNING kernel run may go without a callback before a watchdog fails it.
+# The kernel lane's analogue of DIRECT_RUN_RESULT_GRACE_SECONDS, and necessarily wider: a
+# python node materializes its HogQL inputs before it executes any code, and that
+# materialization is its own Temporal job with a 10 minute deadline, on top of the kernel's
+# 5 minute execute cap. Sized above their sum so the watchdog can never kill a cell that is
+# legitimately still working.
+KERNEL_RUN_RESULT_GRACE_SECONDS = 20 * 60
 
 
 def finish_node_run(
@@ -47,3 +56,35 @@ def finish_node_run(
     if updated:
         record_node_run_terminal(run, outcome or outcome_for_status(status))
     return bool(updated)
+
+
+def expire_stale_kernel_run(run: NotebookNodeRun) -> bool:
+    """Fail a kernel (python/duckdb) run whose callback never arrived; return whether it did.
+
+    The sandbox POSTs its envelope exactly once, with no retry, so a lost delivery leaves
+    the row RUNNING with nothing left to complete it. The dispatch workflow's mark-failed
+    activity does not cover this: it fires when dispatch never landed, not when a run landed
+    and then went quiet. This is the watchdog the kernel lane never had, mirroring
+    `sync_direct_run`'s grace expiry for the lane that already has one.
+
+    Anchored on `updated_at`, which dispatch writes when it records the kernel that took the
+    run, so the budget measures time since the kernel held the work rather than time since
+    the row was created. Nothing else touches the row mid-run, so the anchor holds.
+
+    Safe to call from any reader: it is a no-op for a hogql run, for a run that already
+    reached a terminal state, and for one still inside its budget.
+    """
+    if run.node_type == NotebookNodeRun.NodeType.HOGQL:
+        return False
+    if run.status != NotebookNodeRun.Status.RUNNING:
+        return False
+    if (timezone.now() - run.updated_at).total_seconds() <= KERNEL_RUN_RESULT_GRACE_SECONDS:
+        return False
+    return finish_node_run(
+        run,
+        NotebookNodeRun.Status.FAILED,
+        error="The kernel never reported a result. Re-run the cell.",
+        # A lost callback is a timeout, not a user error — the status alone would file it
+        # under the same bucket as a failed query.
+        outcome=OUTCOME_TIMED_OUT,
+    )

--- a/products/notebooks/backend/sql_v2_runs.py
+++ b/products/notebooks/backend/sql_v2_runs.py
@@ -10,17 +10,27 @@ its own block in sql_v2_callback.py.
 
 from typing import Any
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
+
+import structlog
 
 from products.notebooks.backend.models import NotebookNodeRun
 from products.notebooks.backend.sql_v2_metrics import OUTCOME_TIMED_OUT, outcome_for_status, record_node_run_terminal
 
-# How long a RUNNING kernel run may go without a callback before a watchdog fails it.
-# The kernel lane's analogue of DIRECT_RUN_RESULT_GRACE_SECONDS, and necessarily wider: a
-# python node materializes its HogQL inputs before it executes any code, and that
-# materialization is its own Temporal job with a 10 minute deadline, on top of the kernel's
-# 5 minute execute cap. Sized above their sum so the watchdog can never kill a cell that is
-# legitimately still working.
+logger = structlog.get_logger(__name__)
+
+# How long a RUNNING kernel run may go **without observable progress** before a watchdog
+# fails it. The kernel lane's analogue of DIRECT_RUN_RESULT_GRACE_SECONDS, and necessarily
+# wider, because one cell can spend a long time in the kernel before it reports anything.
+#
+# This is a gap budget, not a total-runtime budget, and the distinction is load-bearing. A
+# python node materializes one input per referenced upstream node, one after another, each
+# with its own 11 minute data-plane deadline, and only then executes for up to 5 minutes. No
+# fixed total-runtime budget can hold: two inputs already outrun 20 minutes while the cell is
+# working correctly. `touch_run_progress` re-anchors the clock on every input the kernel
+# fetches, so what must fit here is the longest gap between two signs of life — one input's
+# wait plus the execute cap — rather than their sum over N inputs.
 KERNEL_RUN_RESULT_GRACE_SECONDS = 20 * 60
 
 
@@ -58,6 +68,28 @@ def finish_node_run(
     return bool(updated)
 
 
+def touch_run_progress(team_id: int, run_id: str) -> None:
+    """Record that the kernel is still working on `run_id`, resetting its watchdog clock.
+
+    Called from the data plane, which is the kernel's only way back to PostHog during a run:
+    every uncached HogQL input it materializes lands there. Without this the watchdog would
+    measure total runtime from dispatch, and a cell with several inputs would outrun the
+    budget while working correctly.
+
+    Guarded on RUNNING so a late fetch cannot revive the clock of a run a callback or the
+    watchdog already finished. Best effort: the run's progress matters less than the query
+    the sandbox is waiting on, so a failure here must never fail the fetch.
+    """
+    try:
+        NotebookNodeRun.objects.for_team(team_id).filter(id=run_id, status=NotebookNodeRun.Status.RUNNING).update(
+            updated_at=timezone.now()
+        )
+    except (DjangoValidationError, ValueError):
+        # The id comes out of a signed token, so a malformed one means the minting side has a
+        # bug. Swallow it here rather than failing the sandbox's fetch over it.
+        logger.warning("notebook_run_progress_touch_invalid_run_id", run_id=run_id, team_id=team_id)
+
+
 def expire_stale_kernel_run(run: NotebookNodeRun) -> bool:
     """Fail a kernel (python/duckdb) run whose callback never arrived; return whether it did.
 
@@ -68,8 +100,13 @@ def expire_stale_kernel_run(run: NotebookNodeRun) -> bool:
     `sync_direct_run`'s grace expiry for the lane that already has one.
 
     Anchored on `updated_at`, which dispatch writes when it records the kernel that took the
-    run, so the budget measures time since the kernel held the work rather than time since
-    the row was created. Nothing else touches the row mid-run, so the anchor holds.
+    run and `touch_run_progress` re-writes on every data-plane fetch, so the budget measures
+    the gap since the kernel was last seen working rather than the run's total time.
+
+    One gap stays uncovered: a run queued in the kernel behind another cell makes no fetches
+    of its own, so its clock runs while it waits. That needs several runs dispatched to one
+    kernel at once, which the editor never does (a chain waits for each cell), so it takes an
+    API caller running cells in parallel.
 
     Safe to call from any reader: it is a no-op for a hogql run, for a run that already
     reached a terminal state, and for one still inside its budget.

--- a/products/notebooks/backend/temporal/__init__.py
+++ b/products/notebooks/backend/temporal/__init__.py
@@ -6,6 +6,7 @@ from products.notebooks.backend.temporal.frame_materialize import (
 from products.notebooks.backend.temporal.sql_v2 import (
     NotebookSQLV2RunWorkflow,
     dispatch_sql_v2_run_activity,
+    expire_sql_v2_run_activity,
     mark_sql_v2_run_failed_activity,
 )
 
@@ -16,6 +17,7 @@ WORKFLOWS = [
 
 ACTIVITIES = [
     dispatch_sql_v2_run_activity,
+    expire_sql_v2_run_activity,
     mark_sql_v2_run_failed_activity,
     materialize_frame_activity,
     mark_frame_materialize_failed_activity,

--- a/products/notebooks/backend/temporal/sql_v2.py
+++ b/products/notebooks/backend/temporal/sql_v2.py
@@ -4,6 +4,10 @@ The run endpoint kicks this off fire-and-forget so the sandbox I/O (kernel-serve
 bootstrap on first run, the /run POST) runs on a Temporal worker with retries —
 never on a web worker. Instance lifecycle is owned by the Kernel info panel
 (kernel/start); dispatch lazily ensures the SQLV2 server on the running kernel.
+
+After dispatch lands, the workflow stays open as the run's watchdog: the sandbox delivers
+its envelope in one un-retried POST, so a lost delivery would otherwise leave the run row
+RUNNING with nothing able to move it.
 """
 
 from dataclasses import dataclass, field
@@ -18,7 +22,17 @@ from posthog.temporal.common.base import PostHogWorkflow
 from products.notebooks.backend.kernel_runtime import get_kernel_runtime
 from products.notebooks.backend.models import Notebook, NotebookNodeRun
 from products.notebooks.backend.sql_v2 import SQLV2KernelNotRunning, dispatch_sql_v2_run
-from products.notebooks.backend.sql_v2_runs import finish_node_run
+from products.notebooks.backend.sql_v2_runs import (
+    KERNEL_RUN_RESULT_GRACE_SECONDS,
+    expire_stale_kernel_run,
+    finish_node_run,
+)
+
+# Margin on top of the run budget before the workflow applies the watchdog. The budget is
+# measured from `updated_at` in the database and the sleep is measured by Temporal, so a
+# sleep of exactly the budget can land a moment early and find the run still inside it,
+# which would leave the row stuck with nobody left to check it again.
+_EXPIRY_MARGIN_SECONDS = 60
 
 
 @dataclass
@@ -81,6 +95,16 @@ def mark_sql_v2_run_failed_activity(input: SQLV2RunInput) -> None:
         finish_node_run(run, NotebookNodeRun.Status.FAILED, error="Run failed to dispatch to the kernel.")
 
 
+@activity.defn(name="notebook-sandbox-cmd-expire")
+def expire_sql_v2_run_activity(input: SQLV2RunInput) -> None:
+    # The watchdog for a run the kernel accepted but never reported on. Guarded inside
+    # expire_stale_kernel_run on both status and elapsed time, so a run whose callback
+    # landed keeps its real outcome and this call does nothing.
+    run = NotebookNodeRun.objects.for_team(input.team_id).filter(id=input.run_id).first()
+    if run is not None:
+        expire_stale_kernel_run(run)
+
+
 @workflow.defn(name="notebook-sandbox-cmd-run")
 class NotebookSQLV2RunWorkflow(PostHogWorkflow):
     inputs_cls = SQLV2RunInput
@@ -106,3 +130,17 @@ class NotebookSQLV2RunWorkflow(PostHogWorkflow):
                 retry_policy=common.RetryPolicy(maximum_attempts=3),
             )
             raise
+
+        # Dispatch landed, so the kernel owns the run. Its envelope POST is a single attempt
+        # with no retry, and losing it would strand the row RUNNING forever: the poll's
+        # watchdog only fires for a run somebody is still watching, and an abandoned tab or a
+        # finished agent means nobody is. Waiting here is a Temporal timer rather than a
+        # worker slot, and this workflow already exists one-per-kernel-run, so the cost is a
+        # longer-lived execution rather than a new one.
+        await workflow.sleep(timedelta(seconds=KERNEL_RUN_RESULT_GRACE_SECONDS + _EXPIRY_MARGIN_SECONDS))
+        await workflow.execute_activity(
+            expire_sql_v2_run_activity,
+            input,
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=common.RetryPolicy(maximum_attempts=3),
+        )

--- a/products/notebooks/backend/temporal/sql_v2.py
+++ b/products/notebooks/backend/temporal/sql_v2.py
@@ -138,9 +138,14 @@ class NotebookSQLV2RunWorkflow(PostHogWorkflow):
         # worker slot, and this workflow already exists one-per-kernel-run, so the cost is a
         # longer-lived execution rather than a new one.
         await workflow.sleep(timedelta(seconds=KERNEL_RUN_RESULT_GRACE_SECONDS + _EXPIRY_MARGIN_SECONDS))
+        # The watchdog is the run's last resort. A brief database outage while it fires must
+        # not burn a three-attempt budget and leave the row RUNNING with nothing left to move
+        # it. The activity is idempotent (guarded on status and elapsed time), so retry until
+        # it lands, bounded by schedule_to_close rather than a fixed attempt count.
         await workflow.execute_activity(
             expire_sql_v2_run_activity,
             input,
             start_to_close_timeout=timedelta(seconds=30),
-            retry_policy=common.RetryPolicy(maximum_attempts=3),
+            schedule_to_close_timeout=timedelta(hours=1),
+            retry_policy=common.RetryPolicy(maximum_attempts=0),
         )

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -1748,6 +1748,57 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
         self.assertEqual(types[0][0], "answer")
         self.assertIn("Int", types[0][1])
 
+    @parameterized.expand(
+        [
+            # The reviewer's case on #88304: a python cell materializes one input per upstream
+            # node, in sequence, each with its own 11 minute data-plane deadline. Measured from
+            # dispatch, a two-input cell outruns the 20 minute budget while working correctly,
+            # and the watchdog fails it. A fetch is the kernel's only sign of life mid-run, so
+            # it has to move the clock.
+            ("running_run_stays_alive", NotebookNodeRun.Status.RUNNING, False, NotebookNodeRun.Status.RUNNING),
+            # And the guard on the other side: a fetch arriving after the run already finished
+            # must not revive its clock, or a late straggler would resurrect a settled row.
+            ("finished_run_is_not_revived", NotebookNodeRun.Status.DONE, False, NotebookNodeRun.Status.DONE),
+        ]
+    )
+    def test_a_data_plane_fetch_resets_the_run_watchdog_clock(
+        self, _name, initial_status, expect_expired, expected_status
+    ):
+        with freeze_time("2026-07-01T00:00:00Z"), team_scope(self.team.id):
+            run = NotebookNodeRun.objects.create(
+                team=self.team,
+                notebook=self.notebook,
+                node_id="n1",
+                node_type=NotebookNodeRun.NodeType.PYTHON,
+                status=initial_status,
+            )
+        token = mint_data_plane_token(self.notebook.short_id, self.team.id, self.user.id, str(run.id))
+        self.assertEqual(self._post({"query": "select 1"}, token=token).status_code, 202)
+
+        from products.notebooks.backend.sql_v2_runs import expire_stale_kernel_run
+
+        run.refresh_from_db()
+        self.assertEqual(expire_stale_kernel_run(run), expect_expired)
+        self.assertEqual(run.status, expected_status)
+
+    def test_a_fetch_without_a_run_claim_touches_no_run(self):
+        # Tokens minted before the run claim existed stay valid across the deploy that adds
+        # it. They fetch data as before; they just cannot advance any run's clock.
+        with freeze_time("2026-07-01T00:00:00Z"), team_scope(self.team.id):
+            run = NotebookNodeRun.objects.create(
+                team=self.team,
+                notebook=self.notebook,
+                node_id="n1",
+                node_type=NotebookNodeRun.NodeType.PYTHON,
+                status=NotebookNodeRun.Status.RUNNING,
+            )
+        self.assertEqual(self._post({"query": "select 1"}, token=self._token()).status_code, 202)
+
+        from products.notebooks.backend.sql_v2_runs import expire_stale_kernel_run
+
+        run.refresh_from_db()
+        self.assertTrue(expire_stale_kernel_run(run))
+
     def test_outer_limit_and_offset_cap_the_page(self):
         response = self._run_to_completion({"query": "select number from numbers(10)", "limit": 3, "offset": 2})
         self.assertEqual(response.status_code, 200, response.content)

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -1275,10 +1275,16 @@ class TestSQLV2RunResult(APIBaseTest):
     def _url(self, run_id: str) -> str:
         return f"/api/projects/{self.team.id}/notebooks/{self.notebook.short_id}/sql_v2/runs/{run_id}/"
 
-    def _create_run(self, status, envelope=None, error="") -> NotebookNodeRun:
+    def _create_run(self, status, envelope=None, error="", node_type=NotebookNodeRun.NodeType.HOGQL) -> NotebookNodeRun:
         with team_scope(self.team.id):
             return NotebookNodeRun.objects.create(
-                team=self.team, notebook=self.notebook, node_id="n1", status=status, envelope=envelope, error=error
+                team=self.team,
+                notebook=self.notebook,
+                node_id="n1",
+                status=status,
+                envelope=envelope,
+                error=error,
+                node_type=node_type,
             )
 
     @parameterized.expand(
@@ -1330,18 +1336,26 @@ class TestSQLV2RunResult(APIBaseTest):
         _restrict_query_access(self)
         self.assertEqual(self.client.get(self._url(str(run.id))).status_code, 403)
 
+    @parameterized.expand(
+        [
+            # hogql: no query status left, so the run can never complete.
+            ("direct", NotebookNodeRun.NodeType.HOGQL, "expired"),
+            # python: the sandbox delivers its envelope once with no retry, so a lost
+            # delivery leaves nothing able to move the row.
+            ("kernel", NotebookNodeRun.NodeType.PYTHON, "never reported"),
+        ]
+    )
     @patch("products.notebooks.backend.presentation.views.notebook.is_sql_v2_enabled", return_value=True)
-    def test_running_direct_run_expires_to_failed_after_grace(self, _mock_enabled):
-        # A RUNNING hogql run with no query status left can never complete — this poll is
-        # its watchdog. Within the grace window it keeps waiting (covers pre-deploy
-        # kernel-executed hogql runs whose callback is still due).
+    def test_running_run_expires_to_failed_after_grace(self, _name, node_type, expected_error, _mock_enabled):
+        # This poll is the watchdog for both lanes. Within the grace window it keeps waiting,
+        # which for hogql also covers pre-deploy kernel-executed runs whose callback is due.
         with freeze_time("2026-07-01T00:00:00Z"):
-            expired = self._create_run(NotebookNodeRun.Status.RUNNING)
+            expired = self._create_run(NotebookNodeRun.Status.RUNNING, node_type=node_type)
         body = self.client.get(self._url(str(expired.id))).json()
         self.assertEqual(body["status"], NotebookNodeRun.Status.FAILED)
-        self.assertIn("expired", body["error"])
+        self.assertIn(expected_error, body["error"])
 
-        young = self._create_run(NotebookNodeRun.Status.RUNNING)
+        young = self._create_run(NotebookNodeRun.Status.RUNNING, node_type=node_type)
         body = self.client.get(self._url(str(young.id))).json()
         self.assertEqual(body["status"], NotebookNodeRun.Status.RUNNING)
 


### PR DESCRIPTION
## Problem

A notebook Python or DuckDB cell can hang for good. The browser reports "Timed out waiting for result" after 5.5 minutes, and the Stop button then does nothing.

- The sandbox delivers a run's envelope in one POST with no retry.
- A lost delivery leaves the run row `RUNNING`, and nothing else moves it.
- The dispatch workflow's mark-failed activity only covers dispatch that never landed.
- `sync_direct_run`'s grace expiry returns early for python and duckdb runs.
- An agent polling `notebooks-run-cell-result` polls that run forever, and `notebooks-get` reports the cell as `running` for good.

## Changes

A stuck cell now fails within 20 minutes with "The kernel never reported a result. Re-run the cell.", so a person can re-run it instead of reloading the page.

**Before** — one path closes a kernel run, and losing it strands the row:

```mermaid
flowchart LR
    W{{Dispatch workflow}} -->|POST /run| K[Sandbox kernel]
    W --> E([Workflow ends])
    K -->|envelope POST, no retry| C[Callback endpoint]
    C --> T([Run terminal])
    K -.->|delivery lost| S([Run stays RUNNING])
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class W phBlue;
    class K,C phRed;
    class T,E phYellow;
    class S phGray;
```

**After** — two more paths reach the same terminal state:

```mermaid
flowchart LR
    W{{Dispatch workflow}} -->|POST /run| K[Sandbox kernel]
    K -->|envelope POST, no retry| C[Callback endpoint]
    C --> T([Run terminal])
    W -->|sleep 20 min| X[expire_stale_kernel_run]
    P[Run-result poll] --> X
    X --> T
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class W,X phBlue;
    class K,C,P phRed;
    class T phYellow;
```

- `expire_stale_kernel_run` in `sql_v2_runs.py` is the kernel lane's counterpart to `sync_direct_run`'s watchdog.
- The run-result poll calls it, so the row is right the moment anyone looks. The poll already holds the row, so the check costs nothing until it fires.
- The dispatch workflow calls it after sleeping the budget, which covers a run nobody polls.
- The budget is anchored on `updated_at`. Dispatch writes that field when it records the kernel that took the run, so the clock restarts on a dispatch retry.
- 20 minutes clears the materialize deadline plus the kernel's 300 second execute cap, so the watchdog cannot kill a cell that is still working.
- A periodic sweeper was the alternative. `NotebookNodeRun` indexes only `(team, notebook, node_id)`, so a status sweep would scan the product's fastest-growing table on every tick, and a cheap version needs a partial index on a hot table.
- The Temporal timer needs no migration and starts no new workflow executions. The dispatch workflow already runs one per kernel run, and it never serves the SQL lane.
- Mechanical: a stale comment in `sql_v2_direct.py` that claimed the kernel lane had no watchdog.

> [!NOTE]
> The browser still gives up at 5.5 minutes. This PR guarantees the run row reaches a terminal state. Aligning the frontend budget with the backend one is a separate change.

Nothing in the UI looks different. The failure message and the enabled Stop button are existing states that a stuck run never reached.

## How did you test this code?

The existing direct-lane watchdog test is parameterized over both lanes. The kernel case catches a python run left `RUNNING` past its budget, which no test covered, because the direct lane's expiry returns early for that node type. The young-run case catches a watchdog that fires early and kills a working cell.

- Ran: `hogli test products/notebooks/backend/test/`, repo-wide `uv run mypy --cache-fine-grained .`, `hogli ci:preflight --fix`, and `tach check --dependencies --interfaces`.
- Not covered: the workflow wiring itself. The sleep needs a Temporal test environment, and the six lines it guards call the same function the poll test exercises.
- Not run: no manual run against a live sandbox, and no attempt to reproduce a dropped callback in a real deployment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing API, setting, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This came out of a code-verified risk review of the Markdown Notebooks V2 rollout, which ranked a stuck kernel run as the highest-value correctness gap. Agent: Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`, and the `artifact-design` skill for the review document that preceded this change.

The review originally proposed a periodic sweeper alongside the poll check. A strain check on that proposal found the missing index and the resulting sequential scan, so the sweeper was dropped in favour of the Temporal timer, which covers the same case for no migration and no extra workflow executions. The reasoning is in Changes, where a reviewer will see it.

One deploy note: the workflow change appends commands after the existing history rather than altering recorded ones, so workflows in flight during the deploy replay safely.

Nothing in this PR carries material from the agent session that is not already public. The change came from reading this repository, and the test data is the existing suite's own fixtures.
