### PR TITLE
feat(workflows): bill workflow task llm and compute cost

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4737,8 +4737,11 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_posthog_code_credits_only_counts_posthog_code_events(self, mock_region: MagicMock) -> None:
-        """The posthog_code query only counts generations tagged ai_product='posthog_code'."""
-        from posthog.tasks.usage_report import get_teams_with_posthog_code_credits_used_in_period
+        """posthog_code counts only its own generations; workflow origins split out to the workflow counter."""
+        from posthog.tasks.usage_report import (
+            get_teams_with_posthog_code_credits_used_in_period,
+            get_teams_with_workflow_ai_credits_used_in_period,
+        )
 
         mock_region.return_value = "US"
         self._setup_teams()
@@ -4796,12 +4799,34 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
             },
         )
 
+        # Workflow-created task run: excluded here, billed under the workflow counter at 20% markup.
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_workflow",
+            timestamp=period.start + relativedelta(hours=4),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_workflow",
+                "$ai_total_cost_usd": 5.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_code",
+                "task_origin_product": "workflow",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
         flush_persons_and_events()
 
         posthog_code_result = get_teams_with_posthog_code_credits_used_in_period(period.start, period.end)
 
-        # posthog_code bills at cost (no markup): 2.0 USD * 100 * 1.0 = 200 — only the
+        # posthog_code bills at cost (no markup): 2.0 USD * 100 * 1.0 = 200. Only the first event counts.
         self.assertEqual(posthog_code_result, [(self.org_1_team_1.id, 200)])
+
+        workflow_result = get_teams_with_workflow_ai_credits_used_in_period(period.start, period.end)
+
+        # workflow AI credits bill at 20% markup: 5.0 USD * 100 * 1.2 = 600
+        self.assertEqual(workflow_result, [(self.org_1_team_1.id, 600)])
 
     @parameterized.expand(
         [
@@ -4860,6 +4885,54 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         self.assertFalse(has_non_zero_usage(UsageReportCounters(**zero)))
         self.assertTrue(has_non_zero_usage(UsageReportCounters(**{**zero, "posthog_code_credits_used_in_period": 5})))
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_workflow_ai_credits_requires_posthog_code_ai_product(self, mock_region: MagicMock) -> None:
+        from posthog.tasks.usage_report import (
+            get_teams_with_ai_credits_used_in_period,
+            get_teams_with_workflow_ai_credits_used_in_period,
+        )
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        # A Max generation carrying a workflow task origin must bill once, under Max only.
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_max_workflow",
+            timestamp=period.start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_max_workflow",
+                "$ai_total_cost_usd": 1.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_ai",
+                "task_origin_product": "workflow",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        self.assertEqual(get_teams_with_workflow_ai_credits_used_in_period(period.start, period.end), [])
+        self.assertEqual(
+            get_teams_with_ai_credits_used_in_period(period.start, period.end), [(self.org_1_team_1.id, 120)]
+        )
+
+    def test_has_non_zero_usage_counts_workflow_ai_credits(self) -> None:
+        import dataclasses
+
+        from posthog.tasks.usage_report import UsageReportCounters, has_non_zero_usage
+
+        zero = {field.name: 0 for field in dataclasses.fields(UsageReportCounters)}
+
+        self.assertTrue(has_non_zero_usage(UsageReportCounters(**{**zero, "workflow_ai_credits_used_in_period": 5})))
 
 
 class TestTaskSandboxUsageReport(APIBaseTest):

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4825,8 +4825,8 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         workflow_result = get_teams_with_workflow_ai_credits_used_in_period(period.start, period.end)
 
-        # workflow AI credits bill at 20% markup: 5.0 USD * 100 * 1.2 = 600
-        self.assertEqual(workflow_result, [(self.org_1_team_1.id, 600)])
+        # workflow token credits pass through at cost (no markup): 5.0 USD * 100 * 1.0 = 500
+        self.assertEqual(workflow_result, [(self.org_1_team_1.id, 500)])
 
     @parameterized.expand(
         [
@@ -5002,6 +5002,10 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
             "sandbox_compute_credits_used_in_period",
             "sandbox_compute_cpu_millicore_seconds_in_period",
             "sandbox_compute_memory_mib_seconds_in_period",
+            "workflow_ai_token_credits_used_in_period",
+            "workflow_compute_credits_used_in_period",
+            "workflow_compute_cpu_millicore_seconds_in_period",
+            "workflow_compute_memory_mib_seconds_in_period",
         }
 
         assert all(UsageReportCounters.__annotations__[metric] is int for metric in component_metrics)
@@ -5012,6 +5016,11 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
         from posthog.tasks.usage_report import combine_posthog_code_credits
 
         assert combine_posthog_code_credits(123, 45) == 168
+
+    def test_workflow_credits_reconcile_with_components(self) -> None:
+        from posthog.tasks.usage_report import combine_workflow_ai_credits
+
+        assert combine_workflow_ai_credits(123, 45) == 168
 
     @patch("posthog.tasks.usage_report.capture_exception")
     @patch("posthog.tasks.usage_report.get_billable_sandbox_compute_usage_by_team")
@@ -5026,6 +5035,25 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
         mock_compute.side_effect = error
 
         result = get_teams_with_billable_sandbox_compute_usage_in_period(
+            datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC)
+        )
+
+        assert result == SandboxComputeUsageByTeam([], [], [])
+        mock_capture.assert_called_once_with(error)
+
+    @patch("posthog.tasks.usage_report.capture_exception")
+    @patch("posthog.tasks.usage_report.get_billable_workflow_sandbox_compute_usage_by_team")
+    def test_invalid_workflow_compute_configuration_is_observed_without_breaking_report(
+        self, mock_compute: MagicMock, mock_capture: MagicMock
+    ) -> None:
+        from posthog.tasks.usage_report import get_teams_with_workflow_compute_usage_in_period
+
+        from products.tasks.backend.facade.billing import ComputeRateCardConfigurationError, SandboxComputeUsageByTeam
+
+        error = ComputeRateCardConfigurationError("invalid")
+        mock_compute.side_effect = error
+
+        result = get_teams_with_workflow_compute_usage_in_period(
             datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC)
         )
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -70,6 +70,7 @@ from products.tasks.backend.facade.billing import (
     SandboxComputeUsageByTeam,
     SandboxUsageByTeam,
     get_billable_sandbox_compute_usage_by_team,
+    get_billable_workflow_sandbox_compute_usage_by_team,
     get_task_sandbox_usage_by_team,
 )
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataJob, ExternalDataSchema
@@ -332,9 +333,14 @@ class UsageReportCounters:
     workflow_push_sent_in_period: int
     workflow_sms_sent_in_period: int
     workflow_billable_invocations_in_period: int
-    # LLM credits of workflow-created agent tasks ($ai_generation with ai_product='posthog_code'
-    # and task_origin_product='workflow'), billed at 20% markup under the workflows product
+    # Combined LLM token + sandbox compute cost of workflow-created agent tasks, billed
+    # under the workflows product. Tokens pass through at WORKFLOW_AI_COST_MARKUP_PERCENT
+    # (0% to start); compute is billed at cost. See combine_workflow_ai_credits.
     workflow_ai_credits_used_in_period: int
+    workflow_ai_token_credits_used_in_period: int
+    workflow_compute_credits_used_in_period: int
+    workflow_compute_cpu_millicore_seconds_in_period: int
+    workflow_compute_memory_mib_seconds_in_period: int
 
     # Logs
     logs_bytes_in_period: int
@@ -1664,9 +1670,11 @@ def get_teams_with_ai_event_count_in_period(
 AI_COST_MARKUP_PERCENT = 0.2
 # PostHog Desktop bills model costs as pure pass-through: no markup
 POSTHOG_CODE_COST_MARKUP_PERCENT = 0.0
-# Workflow-created agent tasks bill under the workflows product at PostHog AI's markup.
-# Kept as a separate constant so the two levers can move independently.
-WORKFLOW_AI_COST_MARKUP_PERCENT = 0.2
+# Workflow-created agent tasks bill under the workflows product. Tokens pass through at
+# cost to start (0%), while sandbox compute (below) is billed to cover its cost; the plan
+# is to raise this once compute cost is covered. Kept independent of AI_COST_MARKUP_PERCENT
+# and POSTHOG_CODE_COST_MARKUP_PERCENT so it can move on its own schedule.
+WORKFLOW_AI_COST_MARKUP_PERCENT = 0.0
 # Tools excluded from AI billing (traces with only these tools are not billed)
 AI_BILLING_EXCLUDED_TOOLS = ["summarize_sessions", "search"]
 AI_BILLING_INSTANCE_GROUP_TYPE = "instance"
@@ -2024,11 +2032,13 @@ def get_teams_with_workflow_ai_credits_used_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    """Workflows billing credits: LLM spend of agent tasks created by the workflows product.
+    """Workflow token spend: LLM cost of agent tasks created by the workflows product.
 
     Same gateway product as PostHog Desktop (ai_product='posthog_code'), split out by
-    task_origin_product='workflow' and billed at 20% markup under workflows. The posthog_code
-    counter excludes these origins, so each generation bills exactly once.
+    task_origin_product='workflow' so the posthog_code counter excludes these origins and
+    each generation bills exactly once. Billed at WORKFLOW_AI_COST_MARKUP_PERCENT (pass-
+    through at 0% to start). This is the token-only portion; combine_workflow_ai_credits
+    adds workflow compute cost to produce the total workflow_ai_credits_used_in_period.
     """
     return _get_teams_with_ai_credits_for_products(
         begin,
@@ -2070,6 +2080,26 @@ def get_teams_with_billable_sandbox_compute_usage_in_period(
 
 
 def combine_posthog_code_credits(token_credits: int, compute_credits: int) -> int:
+    return token_credits + compute_credits
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_workflow_compute_usage_in_period(begin: datetime, end: datetime) -> SandboxComputeUsageByTeam:
+    """Sandbox compute cost of workflow-created tasks, billed under the workflows product.
+
+    Same rate-card-error fallback as the posthog_code compute counter: a misconfiguration
+    degrades to empty usage rather than aborting the report.
+    """
+    try:
+        return get_billable_workflow_sandbox_compute_usage_by_team(begin, end)
+    except ComputeRateCardConfigurationError as err:
+        logger.exception("workflow_compute.usage_report_failed")
+        capture_exception(err)
+        return SandboxComputeUsageByTeam([], [], [])
+
+
+def combine_workflow_ai_credits(token_credits: int, compute_credits: int) -> int:
     return token_credits + compute_credits
 
 
@@ -2875,6 +2905,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
     )
     task_sandbox_usage = get_teams_with_task_sandbox_usage_in_period(period_start, period_end)
     sandbox_compute_usage = get_teams_with_billable_sandbox_compute_usage_in_period(period_start, period_end)
+    workflow_compute_usage = get_teams_with_workflow_compute_usage_in_period(period_start, period_end)
     token_credits = get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
 
     return {
@@ -3141,6 +3172,9 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_workflow_ai_credits_used_in_period": get_teams_with_workflow_ai_credits_used_in_period(
             period_start, period_end
         ),
+        "teams_with_workflow_compute_credits_used_in_period": workflow_compute_usage.credits,
+        "teams_with_workflow_compute_cpu_millicore_seconds_in_period": workflow_compute_usage.cpu_millicore_seconds,
+        "teams_with_workflow_compute_memory_mib_seconds_in_period": workflow_compute_usage.memory_mib_seconds,
         "teams_with_logs_bytes_in_period": get_teams_with_logs_bytes_in_period(period_start, period_end),
         "teams_with_logs_retention_14d_bytes_in_period": logs_retention_by_tier["14d"],
         "teams_with_logs_retention_30d_bytes_in_period": logs_retention_by_tier["30d"],
@@ -3372,7 +3406,22 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         workflow_billable_invocations_in_period=all_data["teams_with_workflow_billable_invocations_in_period"].get(
             team.id, 0
         ),
-        workflow_ai_credits_used_in_period=all_data["teams_with_workflow_ai_credits_used_in_period"].get(team.id, 0),
+        workflow_ai_credits_used_in_period=combine_workflow_ai_credits(
+            all_data["teams_with_workflow_ai_credits_used_in_period"].get(team.id, 0),
+            all_data["teams_with_workflow_compute_credits_used_in_period"].get(team.id, 0),
+        ),
+        workflow_ai_token_credits_used_in_period=all_data["teams_with_workflow_ai_credits_used_in_period"].get(
+            team.id, 0
+        ),
+        workflow_compute_credits_used_in_period=all_data["teams_with_workflow_compute_credits_used_in_period"].get(
+            team.id, 0
+        ),
+        workflow_compute_cpu_millicore_seconds_in_period=all_data[
+            "teams_with_workflow_compute_cpu_millicore_seconds_in_period"
+        ].get(team.id, 0),
+        workflow_compute_memory_mib_seconds_in_period=all_data[
+            "teams_with_workflow_compute_memory_mib_seconds_in_period"
+        ].get(team.id, 0),
         logs_bytes_in_period=all_data["teams_with_logs_bytes_in_period"].get(team.id, 0),
         logs_records_in_period=all_data["teams_with_logs_records_in_period"].get(team.id, 0),
         logs_mb_in_period=int(all_data["teams_with_logs_bytes_in_period"].get(team.id, 0) // 1_000_000),

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -162,6 +162,7 @@ USAGE_REPORT_PARENT_TASK_KWARGS = {
 
 
 @dataclasses.dataclass
+# nosemgrep: prefer-frozen-dataclasses -- pre-existing; OrgReport subclasses it, out of scope here
 class UsageReportCounters:
     event_count_in_period: int
     enhanced_persons_event_count_in_period: int

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -162,8 +162,7 @@ USAGE_REPORT_PARENT_TASK_KWARGS = {
 
 
 @dataclasses.dataclass
-# nosemgrep: prefer-frozen-dataclasses -- pre-existing; OrgReport subclasses it, out of scope here
-class UsageReportCounters:
+class UsageReportCounters:  # nosemgrep: prefer-frozen-dataclasses -- pre-existing; OrgReport subclasses it
     event_count_in_period: int
     enhanced_persons_event_count_in_period: int
     event_count_with_groups_in_period: int
@@ -2615,6 +2614,7 @@ def get_teams_with_logs_retention_bytes_in_period(
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+# nosemgrep: tuple-return-prefer-dataclass -- pre-existing; only flagged as new because earlier edits in this file shifted its line number
 def get_teams_with_logs_records_in_period(
     begin: datetime,
     end: datetime,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -332,6 +332,9 @@ class UsageReportCounters:
     workflow_push_sent_in_period: int
     workflow_sms_sent_in_period: int
     workflow_billable_invocations_in_period: int
+    # LLM credits of workflow-created agent tasks ($ai_generation with ai_product='posthog_code'
+    # and task_origin_product='workflow'), billed at 20% markup under the workflows product
+    workflow_ai_credits_used_in_period: int
 
     # Logs
     logs_bytes_in_period: int
@@ -1661,6 +1664,9 @@ def get_teams_with_ai_event_count_in_period(
 AI_COST_MARKUP_PERCENT = 0.2
 # PostHog Desktop bills model costs as pure pass-through: no markup
 POSTHOG_CODE_COST_MARKUP_PERCENT = 0.0
+# Workflow-created agent tasks bill under the workflows product at PostHog AI's markup.
+# Kept as a separate constant so the two levers can move independently.
+WORKFLOW_AI_COST_MARKUP_PERCENT = 0.2
 # Tools excluded from AI billing (traces with only these tools are not billed)
 AI_BILLING_EXCLUDED_TOOLS = ["summarize_sessions", "search"]
 AI_BILLING_INSTANCE_GROUP_TYPE = "instance"
@@ -1690,6 +1696,13 @@ POSTHOG_AI_PRODUCTS = [
 UNBILLED_TASK_ORIGIN_PRODUCTS = ("task_analysis",)
 POSTHOG_CODE_AI_PRODUCTS = ["posthog_code"]
 
+# Mirrors Task.OriginProduct.WORKFLOW as a string literal, like UNBILLED_TASK_ORIGIN_PRODUCTS
+# does for task_analysis: tasks-product models do not cross the facade boundary.
+WORKFLOW_TASK_ORIGIN_PRODUCTS = ("workflow",)
+# Origins carved out of the posthog_code counter: PostHog-funded origins are never billed;
+# workflow origins bill under the workflow counter instead, so each generation bills exactly once.
+POSTHOG_CODE_EXCLUDED_TASK_ORIGIN_PRODUCTS = (*UNBILLED_TASK_ORIGIN_PRODUCTS, *WORKFLOW_TASK_ORIGIN_PRODUCTS)
+
 
 def get_ai_billing_instance_group_type_index(team_id: int) -> int | None:
     """Resolve the $group_N index that holds the customer cloud URL for the internal AI events team."""
@@ -1716,6 +1729,8 @@ def _get_teams_with_ai_credits_for_products(
     usage_report_tag: str,
     product_tag: Product = Product.MAX_AI,
     markup_percent: float = AI_COST_MARKUP_PERCENT,
+    required_task_origin_products: tuple[str, ...] | None = None,
+    excluded_task_origin_products: tuple[str, ...] = UNBILLED_TASK_ORIGIN_PRODUCTS,
 ) -> list[tuple[int, int]]:
     """
     Shared implementation for AI billing credit aggregation, whitelisting on the
@@ -1744,6 +1759,11 @@ def _get_teams_with_ai_credits_for_products(
 
     Events are stored in team 1 (EU) or team 2 (US), with the actual team (on which we group by) in properties.
     We filter by the configured `instance` group column, which contains the region URL.
+
+    Task-origin filters: `excluded_task_origin_products` drops origins that must not bill on this
+    counter (PostHog-funded origins, or origins billed on another product's counter).
+    `required_task_origin_products`, when set, keeps only those origins. Events without the
+    property yield '', so they pass the exclusion and fail any required filter.
     """
     region = get_instance_region()
 
@@ -1787,6 +1807,11 @@ def _get_teams_with_ai_credits_for_products(
     )
     task_origin_expr, _ = get_property_string_expr(
         "events", "task_origin_product", "'task_origin_product'", "properties", use_new_events_schema=use_new
+    )
+
+    # ClickHouse rejects `IN ()`, so the required-origin filter is injected only when set.
+    required_task_origin_filter = (
+        f"AND {task_origin_expr} IN %(required_task_origins)s" if required_task_origin_products else ""
     )
 
     with tags_context(
@@ -1868,9 +1893,11 @@ def _get_teams_with_ai_credits_for_products(
                         AND timestamp < %(end)s
                         AND event = '$ai_generation'
                         AND {ai_product_expr} IN %(ai_products)s
-                        -- PostHog-funded task origins (e.g. task_analysis runs) are never billed
-                        -- to the customer. Events without the property yield '' and pass.
-                        AND {task_origin_expr} NOT IN %(unbilled_task_origins)s
+                        -- Origin filters are param-driven per counter: excluded origins never bill
+                        -- here (PostHog-funded, or billed on another product's counter); a required
+                        -- filter keeps only that counter's origins. See the docstring.
+                        AND {task_origin_expr} NOT IN %(excluded_task_origins)s
+                        {required_task_origin_filter}
                 )
                 WHERE
                     ai_billable = 1
@@ -1904,7 +1931,8 @@ def _get_teams_with_ai_credits_for_products(
                 "markup_multiplier": 1 + markup_percent,
                 "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
                 "ai_products": tuple(ai_products),
-                "unbilled_task_origins": UNBILLED_TASK_ORIGIN_PRODUCTS,
+                "excluded_task_origins": tuple(excluded_task_origin_products),
+                "required_task_origins": tuple(required_task_origin_products or ()),
                 **region_filter_params,
             },
             workload=Workload.OFFLINE,
@@ -1977,6 +2005,7 @@ def get_teams_with_posthog_code_credits_used_in_period(
     """PostHog Desktop billing credits — only events tagged with ai_product='posthog_code'.
 
     Billed as pure pass-through of model costs (no markup), unlike PostHog AI's 20%.
+    Workflow-origin task runs are excluded: they bill under the workflow AI credits counter.
     """
     return _get_teams_with_ai_credits_for_products(
         begin,
@@ -1985,6 +2014,30 @@ def get_teams_with_posthog_code_credits_used_in_period(
         usage_report_tag="posthog_code_credits",
         product_tag=Product.POSTHOG_CODE,
         markup_percent=POSTHOG_CODE_COST_MARKUP_PERCENT,
+        excluded_task_origin_products=POSTHOG_CODE_EXCLUDED_TASK_ORIGIN_PRODUCTS,
+    )
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_teams_with_workflow_ai_credits_used_in_period(
+    begin: datetime,
+    end: datetime,
+) -> list[tuple[int, int]]:
+    """Workflows billing credits: LLM spend of agent tasks created by the workflows product.
+
+    Same gateway product as PostHog Desktop (ai_product='posthog_code'), split out by
+    task_origin_product='workflow' and billed at 20% markup under workflows. The posthog_code
+    counter excludes these origins, so each generation bills exactly once.
+    """
+    return _get_teams_with_ai_credits_for_products(
+        begin,
+        end,
+        ai_products=POSTHOG_CODE_AI_PRODUCTS,
+        usage_report_tag="workflow_ai_credits",
+        product_tag=Product.WORKFLOWS,
+        markup_percent=WORKFLOW_AI_COST_MARKUP_PERCENT,
+        required_task_origin_products=WORKFLOW_TASK_ORIGIN_PRODUCTS,
     )
 
 
@@ -2783,6 +2836,7 @@ def has_non_zero_usage(report: UsageReportCounters) -> bool:
         or report.workflow_push_sent_in_period > 0
         or report.workflow_sms_sent_in_period > 0
         or report.workflow_billable_invocations_in_period > 0
+        or report.workflow_ai_credits_used_in_period > 0
         or report.replay_vision_credits_used_in_period > 0
     )
 
@@ -3084,6 +3138,9 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_workflow_billable_invocations_in_period": get_teams_with_workflow_billable_invocations_in_period(
             period_start, period_end
         ),
+        "teams_with_workflow_ai_credits_used_in_period": get_teams_with_workflow_ai_credits_used_in_period(
+            period_start, period_end
+        ),
         "teams_with_logs_bytes_in_period": get_teams_with_logs_bytes_in_period(period_start, period_end),
         "teams_with_logs_retention_14d_bytes_in_period": logs_retention_by_tier["14d"],
         "teams_with_logs_retention_30d_bytes_in_period": logs_retention_by_tier["30d"],
@@ -3315,6 +3372,7 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         workflow_billable_invocations_in_period=all_data["teams_with_workflow_billable_invocations_in_period"].get(
             team.id, 0
         ),
+        workflow_ai_credits_used_in_period=all_data["teams_with_workflow_ai_credits_used_in_period"].get(team.id, 0),
         logs_bytes_in_period=all_data["teams_with_logs_bytes_in_period"].get(team.id, 0),
         logs_records_in_period=all_data["teams_with_logs_records_in_period"].get(team.id, 0),
         logs_mb_in_period=int(all_data["teams_with_logs_bytes_in_period"].get(team.id, 0) // 1_000_000),

--- a/posthog/temporal/tests/usage_report/test_aggregator.py
+++ b/posthog/temporal/tests/usage_report/test_aggregator.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 from posthog.tasks.usage_report import InstanceMetadata, OrgReport, UsageReportCounters
 from posthog.temporal.usage_report.aggregator import (
     add_pre_sandbox_compute_patch_defaults,
+    add_pre_workflow_billing_patch_defaults,
     batched,
     build_manifest,
     filter_org_reports,
@@ -168,6 +169,27 @@ def test_load_all_data_does_not_default_compute_for_patched_workflow_history() -
     all_data: dict[str, dict[int, int]] = {}
     results = [RunQueryToS3Result(query_name="sandbox_compute_usage", s3_key="unused", duration_ms=1)]
     add_pre_sandbox_compute_patch_defaults(all_data, results)
+
+    assert all_data == {}
+
+
+def test_load_all_data_defaults_workflow_billing_for_pre_patch_history() -> None:
+    all_data: dict[str, dict[int, int]] = {}
+    add_pre_workflow_billing_patch_defaults(all_data, [])
+
+    assert all_data["teams_with_workflow_ai_credits_used_in_period"] == {}
+    assert all_data["teams_with_workflow_compute_credits_used_in_period"] == {}
+    assert all_data["teams_with_workflow_compute_cpu_millicore_seconds_in_period"] == {}
+    assert all_data["teams_with_workflow_compute_memory_mib_seconds_in_period"] == {}
+
+
+def test_load_all_data_does_not_default_workflow_billing_for_patched_history() -> None:
+    all_data: dict[str, dict[int, int]] = {}
+    results = [
+        RunQueryToS3Result(query_name="teams_with_workflow_ai_credits_used_in_period", s3_key="unused", duration_ms=1),
+        RunQueryToS3Result(query_name="workflow_compute_usage", s3_key="unused", duration_ms=1),
+    ]
+    add_pre_workflow_billing_patch_defaults(all_data, results)
 
     assert all_data == {}
 

--- a/posthog/temporal/tests/usage_report/test_workflow.py
+++ b/posthog/temporal/tests/usage_report/test_workflow.py
@@ -30,8 +30,10 @@ from posthog.temporal.usage_report.types import (
 )
 from posthog.temporal.usage_report.workflow import (
     SANDBOX_COMPUTE_QUERY_NAME,
+    WORKFLOW_BILLING_QUERY_NAMES,
     RunUsageReportsWorkflow,
     _queries_for_sandbox_compute_patch,
+    _queries_for_workflow_billing_patch,
     build_context,
 )
 
@@ -39,6 +41,12 @@ from posthog.temporal.usage_report.workflow import (
 def test_sandbox_compute_query_is_versioned_for_existing_histories() -> None:
     assert SANDBOX_COMPUTE_QUERY_NAME not in [spec.name for spec in _queries_for_sandbox_compute_patch(False)]
     assert SANDBOX_COMPUTE_QUERY_NAME in [spec.name for spec in _queries_for_sandbox_compute_patch(True)]
+
+
+@parameterized.expand([(name,) for name in sorted(WORKFLOW_BILLING_QUERY_NAMES)])
+def test_workflow_billing_query_is_versioned_for_existing_histories(name: str) -> None:
+    assert name not in [spec.name for spec in _queries_for_workflow_billing_patch(QUERIES, False)]
+    assert name in [spec.name for spec in _queries_for_workflow_billing_patch(QUERIES, True)]
 
 
 @parameterized.expand(

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -23,6 +23,7 @@ from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.metrics import ExecutionTimeRecorder
 from posthog.temporal.usage_report.aggregator import (
     add_pre_sandbox_compute_patch_defaults,
+    add_pre_workflow_billing_patch_defaults,
     batched,
     build_manifest,
     build_org_reports,
@@ -131,6 +132,7 @@ async def aggregate_and_chunk_org_reports(inputs: AggregateInputs) -> AggregateR
         ):
             all_data = await sync_to_async(load_all_data)(inputs.query_results)
             add_pre_sandbox_compute_patch_defaults(all_data, inputs.query_results)
+            add_pre_workflow_billing_patch_defaults(all_data, inputs.query_results)
 
             @database_sync_to_async
             def aggregate_per_org() -> dict[str, Any]:

--- a/posthog/temporal/usage_report/aggregator.py
+++ b/posthog/temporal/usage_report/aggregator.py
@@ -41,6 +41,14 @@ _SANDBOX_COMPUTE_DESTINATION_KEYS = (
     "teams_with_sandbox_compute_memory_mib_seconds_in_period",
 )
 
+_WORKFLOW_AI_CREDITS_QUERY_NAME = "teams_with_workflow_ai_credits_used_in_period"
+_WORKFLOW_COMPUTE_QUERY_NAME = "workflow_compute_usage"
+_WORKFLOW_COMPUTE_DESTINATION_KEYS = (
+    "teams_with_workflow_compute_credits_used_in_period",
+    "teams_with_workflow_compute_cpu_millicore_seconds_in_period",
+    "teams_with_workflow_compute_memory_mib_seconds_in_period",
+)
+
 
 def load_all_data(query_results: list[RunQueryToS3Result]) -> dict[str, dict[int, int]]:
     """Reconstruct the legacy `all_data` map from per-query S3 files.
@@ -68,6 +76,22 @@ def add_pre_sandbox_compute_patch_defaults(
 ) -> None:
     if not any(result.query_name == _SANDBOX_COMPUTE_QUERY_NAME for result in query_results):
         for key in _SANDBOX_COMPUTE_DESTINATION_KEYS:
+            all_data[key] = {}
+
+
+def add_pre_workflow_billing_patch_defaults(
+    all_data: dict[str, dict[int, int]], query_results: list[RunQueryToS3Result]
+) -> None:
+    """Default the workflow-billing keys to empty when their gated queries are
+    absent from a pre-patch replay, mirroring the sandbox-compute defaults.
+    `_get_team_report` reads these keys by direct subscript, so a skipped query
+    would otherwise raise KeyError during aggregation.
+    """
+    ran = {result.query_name for result in query_results}
+    if _WORKFLOW_AI_CREDITS_QUERY_NAME not in ran:
+        all_data[_WORKFLOW_AI_CREDITS_QUERY_NAME] = {}
+    if _WORKFLOW_COMPUTE_QUERY_NAME not in ran:
+        for key in _WORKFLOW_COMPUTE_DESTINATION_KEYS:
             all_data[key] = {}
 
 

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -228,6 +228,7 @@ def _sandbox_compute_usage(begin: datetime, end: datetime) -> dict[str, list[tup
     }
 
 
+# nosemgrep: tuple-return-prefer-dataclass -- matches the (team_id, value) row pairs this module already returns
 def _workflow_compute_usage(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
     usage = get_teams_with_workflow_compute_usage_in_period(begin, end)
     return {

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -89,6 +89,7 @@ from posthog.tasks.usage_report import (
     get_teams_with_task_sandbox_usage_in_period,
     get_teams_with_workflow_ai_credits_used_in_period,
     get_teams_with_workflow_billable_invocations_in_period,
+    get_teams_with_workflow_compute_usage_in_period,
     get_teams_with_workflow_emails_sent_in_period,
     get_teams_with_workflow_push_sent_in_period,
     get_teams_with_workflow_sms_sent_in_period,
@@ -220,6 +221,15 @@ def _task_sandbox_usage(begin: datetime, end: datetime) -> dict[str, list[tuple[
 
 def _sandbox_compute_usage(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
     usage = get_teams_with_billable_sandbox_compute_usage_in_period(begin, end)
+    return {
+        "credits": usage.credits,
+        "cpu_millicore_seconds": usage.cpu_millicore_seconds,
+        "memory_mib_seconds": usage.memory_mib_seconds,
+    }
+
+
+def _workflow_compute_usage(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
+    usage = get_teams_with_workflow_compute_usage_in_period(begin, end)
     return {
         "credits": usage.credits,
         "cpu_millicore_seconds": usage.cpu_millicore_seconds,
@@ -518,6 +528,16 @@ QUERIES: list[QuerySpec] = [
             "credits": "teams_with_sandbox_compute_credits_used_in_period",
             "cpu_millicore_seconds": "teams_with_sandbox_compute_cpu_millicore_seconds_in_period",
             "memory_mib_seconds": "teams_with_sandbox_compute_memory_mib_seconds_in_period",
+        },
+    ),
+    QuerySpec(
+        name="workflow_compute_usage",
+        fn=_workflow_compute_usage,
+        output="multi",
+        multi_keys_mapping={
+            "credits": "teams_with_workflow_compute_credits_used_in_period",
+            "cpu_millicore_seconds": "teams_with_workflow_compute_cpu_millicore_seconds_in_period",
+            "memory_mib_seconds": "teams_with_workflow_compute_memory_mib_seconds_in_period",
         },
     ),
     # ---- ClickHouse: workflows / messaging ----------------------------------

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -87,6 +87,7 @@ from posthog.tasks.usage_report import (
     get_teams_with_signals_credits_used_in_period,
     get_teams_with_survey_responses_count_in_period,
     get_teams_with_task_sandbox_usage_in_period,
+    get_teams_with_workflow_ai_credits_used_in_period,
     get_teams_with_workflow_billable_invocations_in_period,
     get_teams_with_workflow_emails_sent_in_period,
     get_teams_with_workflow_push_sent_in_period,
@@ -493,6 +494,10 @@ QUERIES: list[QuerySpec] = [
     QuerySpec(
         name="teams_with_posthog_code_credits_used_in_period",
         fn=get_teams_with_posthog_code_credits_used_in_period,
+    ),
+    QuerySpec(
+        name="teams_with_workflow_ai_credits_used_in_period",
+        fn=get_teams_with_workflow_ai_credits_used_in_period,
     ),
     # ---- Postgres: task sandbox compute -------------------------------------
     QuerySpec(

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -46,11 +46,26 @@ QUERY_CONCURRENCY = 4
 SANDBOX_COMPUTE_QUERY_PATCH_ID = "usage-report-sandbox-compute-query-2026-08"
 SANDBOX_COMPUTE_QUERY_NAME = "sandbox_compute_usage"
 
+# Workflow-billing queries (token credits + compute) were added to QUERIES after
+# the workflow shipped, so they are gated behind their own version patch. On
+# deploy, in-flight executions replay their recorded history against the new
+# code; a pre-patch history must skip these queries or it schedules activities
+# it never recorded and fails replay with a non-determinism error. See
+# `.claude/rules/temporal-workflow-versioning.md`.
+WORKFLOW_BILLING_QUERY_PATCH_ID = "usage-report-workflow-billing-query-2026-08"
+WORKFLOW_BILLING_QUERY_NAMES = frozenset({"teams_with_workflow_ai_credits_used_in_period", "workflow_compute_usage"})
+
 
 def _queries_for_sandbox_compute_patch(patch_applied: bool) -> list[QuerySpec]:
     if patch_applied:
         return QUERIES
     return [spec for spec in QUERIES if spec.name != SANDBOX_COMPUTE_QUERY_NAME]
+
+
+def _queries_for_workflow_billing_patch(queries: list[QuerySpec], patch_applied: bool) -> list[QuerySpec]:
+    if patch_applied:
+        return queries
+    return [spec for spec in queries if spec.name not in WORKFLOW_BILLING_QUERY_NAMES]
 
 
 def build_context(inputs: RunUsageReportsInputs, run_id: str, now: datetime) -> WorkflowContext:
@@ -99,6 +114,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
         try:
             ctx = build_context(inputs, run_id=workflow.info().run_id, now=started_at)
             queries = _queries_for_sandbox_compute_patch(workflow.patched(SANDBOX_COMPUTE_QUERY_PATCH_ID))
+            queries = _queries_for_workflow_billing_patch(queries, workflow.patched(WORKFLOW_BILLING_QUERY_PATCH_ID))
             workflow.logger.info(
                 "Starting usage reports workflow",
                 extra={

--- a/products/tasks/backend/facade/billing.py
+++ b/products/tasks/backend/facade/billing.py
@@ -9,6 +9,7 @@ from products.tasks.backend.logic.services.sandbox_usage import (
     SandboxComputeUsageByTeam,
     SandboxUsageByTeam,
     get_billable_sandbox_compute_usage_by_team,
+    get_billable_workflow_sandbox_compute_usage_by_team,
     get_task_sandbox_usage_by_team,
 )
 from products.tasks.backend.logic.services.task_usage import (
@@ -29,6 +30,7 @@ __all__ = [
     "TASK_USAGE_SIGNATURE_HEADER",
     "TASK_USAGE_TIMESTAMP_HEADER",
     "get_billable_sandbox_compute_usage_by_team",
+    "get_billable_workflow_sandbox_compute_usage_by_team",
     "get_local_task_token_cost",
     "get_task_sandbox_usage_by_team",
     "get_task_usage",

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -11,7 +11,7 @@ The write helpers swallow and log every failure: the ledger must never break
 sandbox provisioning, cleanup, or user-message delivery.
 """
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import ROUND_HALF_EVEN, Decimal
@@ -290,6 +290,34 @@ class SandboxComputeUsageByTeam:
     memory_mib_seconds: list[tuple[int, int]]
 
 
+def _accumulate_sandbox_compute_usage(
+    sessions: Iterator[SandboxSession],
+    begin: datetime,
+    end: datetime,
+    rate_cards: Sequence[ComputeRateCard],
+) -> SandboxComputeUsageByTeam:
+    """Price already-filtered, already-billable sessions and aggregate per team."""
+    usage: dict[int, list[Decimal]] = {}
+    calculated_at = timezone.now()
+    for session in sessions:
+        cost = calculate_sandbox_compute_cost(session, begin, end, calculated_at=calculated_at, rate_cards=rate_cards)
+        totals = usage.setdefault(session.team_id, [Decimal(0) for _ in range(3)])
+        totals[0] += cost.cpu_core_seconds
+        totals[1] += cost.memory_gib_seconds
+        totals[2] += cost.cpu_cost_usd + cost.memory_cost_usd
+
+    credits: list[tuple[int, int]] = []
+    cpu_millicore_seconds: list[tuple[int, int]] = []
+    memory_mib_seconds: list[tuple[int, int]] = []
+    for team_id, totals in usage.items():
+        cpu_quantity, memory_quantity, total_usd = totals
+        credits.append((team_id, int((total_usd * 100).to_integral_value(rounding=ROUND_HALF_EVEN))))
+        cpu_millicore_seconds.append((team_id, int((cpu_quantity * 1000).to_integral_value(rounding=ROUND_HALF_EVEN))))
+        memory_mib_seconds.append((team_id, int((memory_quantity * 1024).to_integral_value(rounding=ROUND_HALF_EVEN))))
+
+    return SandboxComputeUsageByTeam(credits, cpu_millicore_seconds, memory_mib_seconds)
+
+
 def get_billable_sandbox_compute_usage_by_team(
     begin: datetime,
     end: datetime,
@@ -314,34 +342,55 @@ def get_billable_sandbox_compute_usage_by_team(
         .filter(Q(ended_at__isnull=True, ttl_expires_at__gt=begin) | Q(ended_at__gt=begin))
     )
 
-    usage: dict[int, list[Decimal]] = {}
-    calculated_at = timezone.now()
-    for session in sessions.iterator():
-        task = session.task_run.task
-        source_loop = task.loop if task.loop_id is not None else None
-        if not is_billable_compute(
-            origin_product=session.origin_product,
-            client_provenance=session.client_provenance,
-            source_loop_id=task.loop_id,
-            source_loop_internal=source_loop.internal if source_loop is not None else None,
-        ):
-            continue
-        cost = calculate_sandbox_compute_cost(session, begin, end, calculated_at=calculated_at, rate_cards=cards)
-        totals = usage.setdefault(session.team_id, [Decimal(0) for _ in range(3)])
-        totals[0] += cost.cpu_core_seconds
-        totals[1] += cost.memory_gib_seconds
-        totals[2] += cost.cpu_cost_usd + cost.memory_cost_usd
+    def _billable_sessions() -> Iterator[SandboxSession]:
+        for session in sessions.iterator():
+            task = session.task_run.task
+            source_loop = task.loop if task.loop_id is not None else None
+            if is_billable_compute(
+                origin_product=session.origin_product,
+                client_provenance=session.client_provenance,
+                source_loop_id=task.loop_id,
+                source_loop_internal=source_loop.internal if source_loop is not None else None,
+            ):
+                yield session
 
-    credits: list[tuple[int, int]] = []
-    cpu_millicore_seconds: list[tuple[int, int]] = []
-    memory_mib_seconds: list[tuple[int, int]] = []
-    for team_id, totals in usage.items():
-        cpu_quantity, memory_quantity, total_usd = totals
-        credits.append((team_id, int((total_usd * 100).to_integral_value(rounding=ROUND_HALF_EVEN))))
-        cpu_millicore_seconds.append((team_id, int((cpu_quantity * 1000).to_integral_value(rounding=ROUND_HALF_EVEN))))
-        memory_mib_seconds.append((team_id, int((memory_quantity * 1024).to_integral_value(rounding=ROUND_HALF_EVEN))))
+    return _accumulate_sandbox_compute_usage(_billable_sessions(), begin, end, cards)
 
-    return SandboxComputeUsageByTeam(credits, cpu_millicore_seconds, memory_mib_seconds)
+
+def get_billable_workflow_sandbox_compute_usage_by_team(
+    begin: datetime,
+    end: datetime,
+    *,
+    rate_cards: Sequence[ComputeRateCard] | None = None,
+) -> SandboxComputeUsageByTeam:
+    """Sandbox compute cost of workflow-created tasks (`Task.OriginProduct.WORKFLOW`).
+
+    Workflow runs are unattended: the workflow engine creates them directly, with no
+    inbound OAuth request, so they never carry `client_provenance=POSTHOG_DESKTOP`, the
+    signal `is_billable_compute` uses to prove a real desktop-consented session. Origin
+    alone identifies workflow compute as billable here instead.
+
+    Deliberately does not call `is_billable_compute`: that predicate also gates live
+    compute-quota denial (see `is_task_billable_compute` and
+    `get_compute_quota_denial_reason`), and billing workflow compute must not make
+    workflow task runs newly subject to that live gate.
+    """
+    validate_reporting_window(begin, end)
+    rate_cards = COMPUTE_RATE_CARDS if rate_cards is None else rate_cards
+    if not rate_cards:
+        return SandboxComputeUsageByTeam([], [], [])
+
+    cards = validate_compute_rate_cards(rate_cards)
+    sessions = (
+        SandboxSession.objects.unscoped()
+        .filter(
+            origin_product=Task.OriginProduct.WORKFLOW,
+            user_attributed_at__isnull=False,
+            user_attributed_at__lt=end,
+        )
+        .filter(Q(ended_at__isnull=True, ttl_expires_at__gt=begin) | Q(ended_at__gt=begin))
+    )
+    return _accumulate_sandbox_compute_usage(sessions.iterator(), begin, end, cards)
 
 
 def get_task_sandbox_usage_by_team(begin: datetime, end: datetime) -> SandboxUsageByTeam:

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -16,6 +16,7 @@ from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCar
 from products.tasks.backend.logic.services.sandbox_usage import (
     close_sandbox_session,
     get_billable_sandbox_compute_usage_by_team,
+    get_billable_workflow_sandbox_compute_usage_by_team,
     get_task_sandbox_usage_by_team,
     measure_task_run_cpu_attribution,
     open_sandbox_session,
@@ -386,6 +387,23 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
 
         assert usage.cpu_millicore_seconds == [(self.team.id, 14_400_000)]
         assert usage.credits == [(self.team.id, 2016)]
+
+    def test_billable_workflow_compute_includes_workflow_origin_without_desktop_provenance(self):
+        self._session(origin_product=Task.OriginProduct.WORKFLOW, client_provenance=None)
+
+        usage = get_billable_workflow_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
+
+        assert usage.cpu_millicore_seconds == [(self.team.id, 14_400_000)]
+        assert usage.memory_mib_seconds == [(self.team.id, 58_982_400)]
+        assert usage.credits == [(self.team.id, 2016)]
+
+    def test_billable_workflow_compute_excludes_non_workflow_origins(self):
+        self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)
+        self._loop_session(internal=False)
+
+        usage = get_billable_workflow_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
+
+        assert usage.credits == []
 
     def test_billable_compute_uses_session_snapshot_after_task_changes(self):
         session = self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)


### PR DESCRIPTION
## Problem

Workflow-created tasks bill their AI token cost to PostHog Code, not Workflows. Their compute cost is not billed at all.

## Changes

- Workflow token cost now bills under Workflows, at cost, with no markup.
- Workflow compute cost now bills too. It was free until this change.
- Compute billing uses a new, separate check.
- The existing check also blocks a task run when its quota runs out, so workflow tasks need their own check to avoid that.

## How did you test this code

- Added tests: workflow compute now bills, and workflow tokens bill at cost with no markup.
- Not tested in a running app. This is a backend batch job with no UI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal billing code only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Built with Claude Code across two sessions. Skills used: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*