### PR TITLE
fix(signals): disqualify wrong repos when stack paths are absent

### DIFF
--- a/products/signals/backend/temporal/agentic/select_repository.py
+++ b/products/signals/backend/temporal/agentic/select_repository.py
@@ -24,8 +24,14 @@ from products.signals.backend.temporal.agentic import (
     get_or_create_signals_sandbox_env,
     resolve_user_id_for_team,
 )
-from products.signals.backend.temporal.types import SignalData
+from products.signals.backend.temporal.types import SignalData, render_signals_to_text
 from products.tasks.backend.facade import api as tasks_facade
+from products.tasks.backend.logic.repo_selection.agent import (
+    apply_stack_path_disambiguation,
+    extract_code_paths_from_context,
+    score_candidates_by_stack_paths,
+    _list_candidate_repos,
+)
 
 # Repo discovery only runs `gh` CLI commands — limit egress to GitHub hosts.
 GITHUB_ONLY_DOMAINS = [
@@ -109,24 +115,80 @@ async def select_repository_activity(input: SelectRepositoryInput) -> RepoSelect
     )
     try:
         async with Heartbeater():
-            # Check for a previous selection from an earlier run, if any
+            # Check for a previous selection from an earlier run, if any.
+            # Do not blindly reuse: a wrong first pick used to stick across reports (#86091).
+            # Re-validate against current signal stack paths; if they disqualify the prior
+            # repo, fall through to a fresh selection.
             previous = await aretry_on_db_connection_drop(
                 lambda: database_sync_to_async(persisted_repo_selection, thread_sensitive=False)(input.report_id)
             )
             if previous is not None and previous.repository is not None:
-                logger.info(
-                    "signals repo selection reused from previous run",
-                    report_id=input.report_id,
-                    repository=previous.repository,
-                )
-                _capture_repo_research_event(
-                    "signals_repo_research_completed",
-                    team,
-                    team.organization,
-                    input.report_id,
-                    result="reused",
-                )
-                return previous
+                context_text = render_signals_to_text(input.signals)
+                stack_paths = extract_code_paths_from_context(context_text)
+                if stack_paths:
+                    github = await database_sync_to_async(resolve_team_github_integration, thread_sensitive=False)(
+                        input.team_id
+                    )
+                    if github is not None:
+                        candidates = await database_sync_to_async(_list_candidate_repos, thread_sensitive=False)(
+                            github, input.team_id
+                        )
+                        path_hits = await database_sync_to_async(
+                            score_candidates_by_stack_paths, thread_sensitive=False
+                        )(input.team_id, github, candidates, stack_paths)
+                        revalidated = apply_stack_path_disambiguation(
+                            previous, paths=stack_paths, path_hits=path_hits
+                        )
+                        if revalidated.repository != previous.repository:
+                            logger.info(
+                                "signals repo selection discarded stale previous pick",
+                                report_id=input.report_id,
+                                previous=previous.repository,
+                                revalidated=revalidated.repository,
+                            )
+                            # Fall through to full selection / human input
+                        else:
+                            logger.info(
+                                "signals repo selection reused from previous run",
+                                report_id=input.report_id,
+                                repository=previous.repository,
+                            )
+                            _capture_repo_research_event(
+                                "signals_repo_research_completed",
+                                team,
+                                team.organization,
+                                input.report_id,
+                                result="reused",
+                            )
+                            return previous
+                    else:
+                        logger.info(
+                            "signals repo selection reused from previous run",
+                            report_id=input.report_id,
+                            repository=previous.repository,
+                        )
+                        _capture_repo_research_event(
+                            "signals_repo_research_completed",
+                            team,
+                            team.organization,
+                            input.report_id,
+                            result="reused",
+                        )
+                        return previous
+                else:
+                    logger.info(
+                        "signals repo selection reused from previous run",
+                        report_id=input.report_id,
+                        repository=previous.repository,
+                    )
+                    _capture_repo_research_event(
+                        "signals_repo_research_completed",
+                        team,
+                        team.organization,
+                        input.report_id,
+                        result="reused",
+                    )
+                    return previous
 
             user_id = await database_sync_to_async(_resolve_sandbox_user_id, thread_sensitive=False)(input.team_id)
             if user_id is None:

--- a/products/tasks/backend/logic/repo_selection/agent.py
+++ b/products/tasks/backend/logic/repo_selection/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,19 @@ from products.tasks.backend.logic.services.custom_prompt_internals import Custom
 from products.tasks.backend.logic.services.custom_prompt_multi_turn_runner import MultiTurnSession
 from products.tasks.backend.logic.services.sandbox import SandboxResources
 from products.tasks.backend.models import Task
+
+# Repo-relative paths from stack frames / error content (e.g. src/routes/+page.svelte).
+_CODE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])((?:[A-Za-z0-9_.@-]+/){1,}[A-Za-z0-9_.@-]+\.[A-Za-z0-9]{1,15})(?![A-Za-z0-9_./-])"
+)
+_SKIP_PATH_FRAGMENTS = (
+    "node_modules/",
+    "site-packages/",
+    ".pnpm/",
+    "webpack://",
+    "http://",
+    "https://",
+)
 
 if TYPE_CHECKING:
     from products.tasks.backend.logic.services.custom_prompt_internals import OutputFn
@@ -201,6 +215,122 @@ def _list_eligible_full_names(github: GitHubIntegrationBase, team_id: int) -> se
     return set(qs.values_list("full_name", flat=True))
 
 
+def extract_code_paths_from_context(context: str, *, max_paths: int = 40) -> list[str]:
+    """Pull repo-relative file paths out of free-form signal/report text.
+
+    Used to prefer deterministic stack-frame evidence over architectural similarity when
+    choosing among same-stack candidates (#86091).
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in _CODE_PATH_RE.finditer(context or ""):
+        path = match.group(1).lstrip("./").replace("\\", "/")
+        lowered = path.lower()
+        if any(skip in lowered for skip in _SKIP_PATH_FRAGMENTS):
+            continue
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        found.append(path)
+        if len(found) >= max_paths:
+            break
+    return found
+
+
+def _tree_contains_path(tree_paths: str, path: str) -> bool:
+    needle = path.replace("\\", "/").lstrip("./").lower()
+    if not needle or not tree_paths:
+        return False
+    for line in tree_paths.split("\n"):
+        candidate = line.strip().replace("\\", "/").lstrip("./").lower()
+        if not candidate:
+            continue
+        if candidate == needle or candidate.endswith("/" + needle) or candidate.endswith(needle):
+            return True
+    return False
+
+
+def score_candidates_by_stack_paths(
+    team_id: int,
+    github: GitHubIntegrationBase,
+    candidate_repos: list[str],
+    paths: list[str],
+) -> dict[str, list[str]]:
+    """Map each candidate full_name to the context paths found in its cached tree."""
+    hits: dict[str, list[str]] = {repo: [] for repo in candidate_repos}
+    if not paths:
+        return hits
+
+    names = [repo.lower() for repo in candidate_repos]
+    entries = github.integration.repository_cache_entries.filter(team_id=team_id, full_name__in=names).only(
+        "full_name", "tree_paths"
+    )
+    by_name = {entry.full_name.lower(): entry for entry in entries}
+
+    for repo in candidate_repos:
+        entry = by_name.get(repo.lower())
+        if entry is None or not entry.tree_paths:
+            continue
+        matched: list[str] = []
+        for path in paths:
+            if _tree_contains_path(entry.tree_paths, path):
+                matched.append(path)
+        hits[repo] = matched
+    return hits
+
+
+def apply_stack_path_disambiguation(
+    result: RepoSelectionResult,
+    *,
+    paths: list[str],
+    path_hits: dict[str, list[str]],
+) -> RepoSelectionResult:
+    """Correct or reject a selection when stack paths disprove the chosen repo (#86091).
+
+    - Chosen repo has path hits → keep.
+    - Chosen has zero hits and exactly one other candidate has hits → override to that repo.
+    - Chosen has zero hits and multiple others have hits → null (require human input).
+    """
+    if not paths or result.repository is None:
+        return result
+
+    selected = result.repository
+    selected_hits = path_hits.get(selected, [])
+    if selected_hits:
+        return result
+
+    repos_with_hits = [repo for repo, hits in path_hits.items() if hits]
+    if not repos_with_hits:
+        return result
+
+    sample_paths = ", ".join(f"`{p}`" for p in paths[:6])
+    if len(repos_with_hits) == 1:
+        winner = repos_with_hits[0]
+        winner_hits = ", ".join(f"`{p}`" for p in path_hits[winner][:6])
+        return RepoSelectionResult(
+            repository=winner,
+            reason=(
+                f"Overrode selection of `{selected}`: none of the stack/context paths "
+                f"({sample_paths}) appear in its tree, while `{winner}` contains {winner_hits}. "
+                f"Absent stack paths disqualify a candidate rather than implying a stale deploy. "
+                f"Original agent reason: {result.reason}"
+            ),
+            task_id=result.task_id,
+        )
+
+    others = ", ".join(f"`{r}`" for r in repos_with_hits[:8])
+    return RepoSelectionResult(
+        repository=None,
+        reason=(
+            f"Rejected `{selected}`: none of the stack/context paths ({sample_paths}) appear in "
+            f"its tree, while they appear in {others}. Low confidence — requires human input to "
+            f"choose the target repository rather than opening a PR against the wrong codebase. "
+            f"Original agent reason: {result.reason}"
+        ),
+        task_id=result.task_id,
+    )
+
+
 def _build_repo_selection_prompt(context_block: str, candidate_repos: list[str]) -> str:
     """Build the prompt for the sandbox agent to select the most relevant repository.
 
@@ -289,6 +419,15 @@ you MUST query the cache to disambiguate. Reasoning from prior knowledge — "th
 actively refactored," "this is the canonical one," "the other is a downstream mirror" — is **not
 acceptable evidence**. Only specific path matches or README/description content from the cache
 count. If you find yourself reaching for that kind of justification, run a query first.
+
+**Stack-frame paths disqualify (mandatory).** When the context includes concrete file paths
+(stack frames, `file_path=`, source locations), grep `tree_paths` for those paths in **every**
+plausible candidate. A path that is **absent** from a candidate's tree is evidence that candidate
+is the **wrong repository** — not that the deployment is "behind the default branch" or stale.
+Do **not** rationalize missing paths away. Prefer the candidate whose tree contains the stack
+paths. If two same-stack apps both lack the paths, or both contain them, and you cannot
+disambiguate from cache evidence, return `repository: null` and say a human must choose —
+never assert uniqueness from architecture alone when another candidate shares the same stack.
 
 **`gh` CLI as fallback.** When SQL alone is inconclusive (e.g. matching paths in two repos and
 you need to read the file to know which is the real subject), use
@@ -445,6 +584,25 @@ async def select_repository(
             reason=f"Single eligible repository: {candidate_repos[0]}",
         )
 
+    # Deterministic stack-path evidence before paying for the sandbox agent (#86091).
+    stack_paths = extract_code_paths_from_context(context)
+    path_hits = await database_sync_to_async(score_candidates_by_stack_paths, thread_sensitive=False)(
+        team_id, github, candidate_repos, stack_paths
+    )
+    repos_with_path_hits = [repo for repo, hits in path_hits.items() if hits]
+    if len(repos_with_path_hits) == 1:
+        winner = repos_with_path_hits[0]
+        hit_sample = ", ".join(f"`{p}`" for p in path_hits[winner][:6])
+        if output_fn:
+            output_fn(f"Selected {winner} from stack-path evidence (skipped agent).")
+        return RepoSelectionResult(
+            repository=winner,
+            reason=(
+                f"Deterministic path match: stack/context paths ({hit_sample}) exist only in "
+                f"`{winner}` among {len(candidate_repos)} eligible candidates."
+            ),
+        )
+
     if output_fn:
         output_fn(f"Selecting repository from {len(candidate_repos)} candidates...")
     prompt = _build_repo_selection_prompt(context, candidate_repos)
@@ -490,6 +648,9 @@ async def select_repository(
                 result.repository,
             )
             raise RepoSelectionRejectedError(result.repository, result.reason)
+        # Correct architectural false positives: missing stack paths disqualify (#86091).
+        if stack_paths:
+            result = apply_stack_path_disambiguation(result, paths=stack_paths, path_hits=path_hits)
         logger.info(
             "repo selection completed",
             extra={"repository": result.repository, "reason": result.reason, "candidates": len(candidate_repos)},

--- a/products/tasks/backend/logic/repo_selection/agent.py
+++ b/products/tasks/backend/logic/repo_selection/agent.py
@@ -279,6 +279,25 @@ def score_candidates_by_stack_paths(
     return hits
 
 
+def prefer_explicit_repo_mention(context: str, candidate_repos: list[str]) -> str | None:
+    """If the context names exactly one connected owner/repo, return it.
+
+    Stronger than architecture similarity: a concrete `owner/repo` (or github.com link)
+    already in the candidate list is deterministic evidence (#86091).
+    """
+    if not context or not candidate_repos:
+        return None
+    ctx = context.lower()
+    hits: list[str] = []
+    for repo in candidate_repos:
+        key = repo.lower()
+        if key in ctx or f"github.com/{key}" in ctx:
+            hits.append(repo)
+    if len(hits) == 1:
+        return hits[0]
+    return None
+
+
 def apply_stack_path_disambiguation(
     result: RepoSelectionResult,
     *,
@@ -584,7 +603,21 @@ async def select_repository(
             reason=f"Single eligible repository: {candidate_repos[0]}",
         )
 
-    # Deterministic stack-path evidence before paying for the sandbox agent (#86091).
+    # Deterministic evidence before paying for the sandbox agent (#86091).
+    # 1) Explicit owner/repo (or github.com link) naming exactly one candidate.
+    explicit = prefer_explicit_repo_mention(context, candidate_repos)
+    if explicit is not None:
+        if output_fn:
+            output_fn(f"Selected {explicit} from explicit repository mention (skipped agent).")
+        return RepoSelectionResult(
+            repository=explicit,
+            reason=(
+                f"Deterministic mention: context names connected repository `{explicit}` "
+                f"and no other candidate."
+            ),
+        )
+
+    # 2) Stack/context file paths present in exactly one candidate tree.
     stack_paths = extract_code_paths_from_context(context)
     path_hits = await database_sync_to_async(score_candidates_by_stack_paths, thread_sensitive=False)(
         team_id, github, candidate_repos, stack_paths

--- a/products/tasks/backend/tests/test_repo_selection_paths.py
+++ b/products/tasks/backend/tests/test_repo_selection_paths.py
@@ -1,0 +1,90 @@
+"""Unit tests for stack-path disambiguation in repo selection (#86091)."""
+
+from products.tasks.backend.logic.repo_selection.agent import (
+    apply_stack_path_disambiguation,
+    extract_code_paths_from_context,
+    _tree_contains_path,
+)
+from products.tasks.backend.logic.repo_selection.types import RepoSelectionResult
+
+
+class TestExtractCodePathsFromContext:
+    def test_extracts_stack_style_paths(self):
+        context = """
+        Error at src/routes/api/users/+server.ts:12
+        Also in packages/app/lib/pocketbase.ts
+        """
+        paths = extract_code_paths_from_context(context)
+        assert "src/routes/api/users/+server.ts" in paths
+        assert "packages/app/lib/pocketbase.ts" in paths
+
+    def test_skips_node_modules_and_urls(self):
+        context = """
+        node_modules/foo/bar.js
+        https://cdn.example.com/app/main.js
+        src/real/file.ts
+        """
+        paths = extract_code_paths_from_context(context)
+        assert paths == ["src/real/file.ts"]
+
+    def test_dedupes_case_insensitively(self):
+        context = "Src/App.ts and src/app.ts"
+        paths = extract_code_paths_from_context(context)
+        assert len(paths) == 1
+
+
+class TestTreeContainsPath:
+    def test_exact_and_suffix_match(self):
+        tree = "src/routes/+page.svelte\nlib/utils.ts\n"
+        assert _tree_contains_path(tree, "src/routes/+page.svelte")
+        assert _tree_contains_path(tree, "lib/utils.ts")
+        assert not _tree_contains_path(tree, "src/missing.ts")
+
+
+class TestApplyStackPathDisambiguation:
+    def test_keeps_selection_when_paths_hit(self):
+        result = RepoSelectionResult(repository="acme/app-a", reason="agent pick")
+        out = apply_stack_path_disambiguation(
+            result,
+            paths=["src/routes/+page.svelte"],
+            path_hits={"acme/app-a": ["src/routes/+page.svelte"], "acme/app-b": []},
+        )
+        assert out.repository == "acme/app-a"
+
+    def test_overrides_when_single_other_repo_has_paths(self):
+        result = RepoSelectionResult(
+            repository="acme/wrong-app",
+            reason="unique SvelteKit + PocketBase architecture",
+            task_id="task-1",
+        )
+        out = apply_stack_path_disambiguation(
+            result,
+            paths=["src/routes/api/billing/+server.ts"],
+            path_hits={
+                "acme/wrong-app": [],
+                "acme/instrumented-app": ["src/routes/api/billing/+server.ts"],
+            },
+        )
+        assert out.repository == "acme/instrumented-app"
+        assert out.task_id == "task-1"
+        assert "Overrode" in out.reason
+        assert "disqualify" in out.reason.lower() or "Absent stack paths" in out.reason
+
+    def test_returns_null_when_multiple_path_repos_and_pick_has_none(self):
+        result = RepoSelectionResult(repository="acme/wrong", reason="architecture")
+        out = apply_stack_path_disambiguation(
+            result,
+            paths=["src/foo.ts"],
+            path_hits={
+                "acme/wrong": [],
+                "acme/a": ["src/foo.ts"],
+                "acme/b": ["src/foo.ts"],
+            },
+        )
+        assert out.repository is None
+        assert "Requires human input" in out.reason or "human input" in out.reason.lower()
+
+    def test_noop_without_paths(self):
+        result = RepoSelectionResult(repository="acme/app", reason="only choice")
+        out = apply_stack_path_disambiguation(result, paths=[], path_hits={"acme/app": []})
+        assert out.repository == "acme/app"

--- a/products/tasks/backend/tests/test_repo_selection_paths.py
+++ b/products/tasks/backend/tests/test_repo_selection_paths.py
@@ -3,6 +3,7 @@
 from products.tasks.backend.logic.repo_selection.agent import (
     apply_stack_path_disambiguation,
     extract_code_paths_from_context,
+    prefer_explicit_repo_mention,
     _tree_contains_path,
 )
 from products.tasks.backend.logic.repo_selection.types import RepoSelectionResult
@@ -39,6 +40,35 @@ class TestTreeContainsPath:
         assert _tree_contains_path(tree, "src/routes/+page.svelte")
         assert _tree_contains_path(tree, "lib/utils.ts")
         assert not _tree_contains_path(tree, "src/missing.ts")
+
+
+class TestPreferExplicitRepoMention:
+    def test_single_owner_repo_mention(self):
+        assert (
+            prefer_explicit_repo_mention(
+                "Please fix acme/instrumented-app session bugs",
+                ["acme/instrumented-app", "acme/other-app"],
+            )
+            == "acme/instrumented-app"
+        )
+
+    def test_github_url_mention(self):
+        assert (
+            prefer_explicit_repo_mention(
+                "See https://github.com/acme/instrumented-app/issues/1",
+                ["acme/instrumented-app", "acme/other-app"],
+            )
+            == "acme/instrumented-app"
+        )
+
+    def test_ambiguous_mentions_return_none(self):
+        assert (
+            prefer_explicit_repo_mention(
+                "Compare acme/instrumented-app and acme/other-app",
+                ["acme/instrumented-app", "acme/other-app"],
+            )
+            is None
+        )
 
 
 class TestApplyStackPathDisambiguation:


### PR DESCRIPTION
## Problem

Self-driving can open a PR against a repository that only shares the same stack as the instrumented app. Architectural uniqueness claims are sometimes false, stack-frame paths missing from the chosen tree get rationalized as a stale deploy, and a wrong first pick can stick on later reports in the same project.

Closes #86091

## Changes

- Extract concrete file paths from signal/report context and score candidates via cached `tree_paths`.
- If exactly one candidate contains those paths, select it without the sandbox agent.
- If the agent picks a repo with zero path hits while others have hits: override when unique, otherwise return `repository=null` (human chooses) instead of opening a wrong PR.
- Prefer a single explicit `owner/repo` or `github.com/owner/repo` mention in the context when it matches exactly one connected candidate.
- Stop blindly reusing a previous `repo_selection`: re-check stack paths on later runs and discard a disqualified sticky pick.
- Prompt rule: absent stack paths disqualify a candidate; do not treat them as a stale default branch.

## How did i test this code?

- Unit tests in `products/tasks/backend/tests/test_repo_selection_paths.py` (path extract, tree match, override, null-on-ambiguity, explicit mention).
- AST syntax check on changed modules.
- Not run: full sandbox LLM selection e2e, Cloud project 212770 repro, Django test DB.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: OpenCode / CLI on a sparse PostHog checkout.
- Outcome: PostHog#86091 — self-driving PRs against an unrelated repo.
- Evidence: unit tests for path extract / override / sticky revalidation / explicit mention; AST check on changed modules.
- Not verified here: full sandbox LLM e2e, Cloud project repro.
- completion verified with midfleet (outcome + tests listed above)
