### PR TITLE
fix(postgres): stop retrying a pooler auth-failure circuit breaker

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -255,9 +255,12 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # carrying "(ECIRCUITBREAKER) failed to retrieve database credentials after multiple attempts,
     # new connections are temporarily blocked". Same class as EAUTHQUERY above — the pooler's own
     # bookkeeping failing, not a rejection of the client's credentials — and the breaker resets once
-    # the fetch succeeds again, so a fresh connect after backoff typically recovers. Match the
-    # stable code, distinct from genuine credential-rejection wordings.
-    "(ecircuitbreaker)",
+    # the fetch succeeds again, so a fresh connect after backoff typically recovers. Match the full
+    # "failed to retrieve database credentials" wording, NOT the bare "(ECIRCUITBREAKER)" code —
+    # Supavisor reuses the same code for a different condition ("too many authentication failures",
+    # tripped by repeated bad credentials rather than pooler bookkeeping), which must stay
+    # non-retryable and is matched separately in source.py's `get_non_retryable_errors`.
+    "(ecircuitbreaker) failed to retrieve database credentials",
     # pgcat (a Rust Postgres pooler) refuses to hand out a backend when every server in the pool is
     # currently banned/down — a failed health check bans a server and pgcat auto-unbans it after
     # `ban_time` — reporting it as SQLSTATE 58000 ("could not get connection from the pool -

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -145,6 +145,14 @@ PostgresErrors = {
         "(for example Supabase's transaction pooler) also require a pooler-specific username such "
         "as postgres.<project-ref>. Check your credentials and try again."
     ),
+    # Supavisor's own circuit breaker for repeated authentication failures against a tenant.
+    # `get_non_retryable_errors` already handles this on the streaming path; map it here too so
+    # validation returns an actionable message instead of the generic fallback.
+    "too many authentication failures": (
+        "Your database's connection pooler has temporarily blocked new connections after repeated "
+        'authentication failures ("too many authentication failures"). This usually means the '
+        "username or password is wrong. Check your credentials and try again."
+    ),
     "could not translate host name": "Could not connect to the host",
     # libpq prefixes a DNS-resolution failure with "could not translate host name ..." (matched
     # above), but the same getaddrinfo failure also surfaces as the raw socket wording with no such
@@ -403,6 +411,21 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 '("PAM authentication failed"). Your PostgreSQL server authenticates this user '
                 "through PAM (for example against the system password database or LDAP), and it "
                 "rejected the username or password. Check your credentials, then re-enable the sync."
+            ),
+            # Supavisor trips its own circuit breaker after repeated authentication failures against
+            # a tenant and temporarily refuses new connects, reporting "FATAL:  (ECIRCUITBREAKER) too
+            # many authentication failures, new connections are temporarily blocked". Distinct from
+            # the pooler-bookkeeping "(ECIRCUITBREAKER) failed to retrieve database credentials"
+            # variant kept retryable in postgres.py's `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` — this one
+            # is tripped by the credentials themselves being rejected repeatedly, so it's the same
+            # deterministic class as "password authentication failed" and retrying with the same
+            # credentials just re-trips the breaker. Match the stable message, excluding the volatile
+            # host/port the raw driver text prefixes it with.
+            "too many authentication failures": (
+                "Your database's connection pooler has temporarily blocked new connections after "
+                'repeated authentication failures ("too many authentication failures"). This usually '
+                "means the configured username or password is wrong. Check your credentials, then "
+                "re-enable the sync."
             ),
             "could not translate host name": _DNS_RESOLUTION_ERROR,
             "timeout expired connection to server at": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -714,6 +714,40 @@ class TestPostgresSourceNonRetryableErrors:
         assert friendly, "PAM authentication failure should surface an actionable message"
         assert "credentials" in friendly[0]
 
+    def test_circuit_breaker_too_many_auth_failures_is_non_retryable(self, source):
+        # Supavisor's "(ECIRCUITBREAKER)" code also covers a distinct, transient pooler-bookkeeping
+        # condition ("failed to retrieve database credentials", see postgres.py's
+        # `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`) — confirm that variant does NOT trip this key, so
+        # the two "(ECIRCUITBREAKER)" wordings can't be confused for each other.
+        non_retryable = source.get_non_retryable_errors()
+        pooler_bookkeeping_msg = (
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+            "FATAL:  (ECIRCUITBREAKER) failed to retrieve database credentials after multiple "
+            "attempts, new connections are temporarily blocked"
+        )
+        assert not any(pattern in pooler_bookkeeping_msg for pattern in non_retryable), (
+            "the transient pooler-bookkeeping ECIRCUITBREAKER wording must stay retryable"
+        )
+
+        auth_failure_msg = (
+            'connection failed: connection to server at "18.176.230.146", port 5432 failed: '
+            "FATAL:  (ECIRCUITBREAKER) too many authentication failures, new connections are "
+            "temporarily blocked"
+        )
+        assert "too many authentication failures" in non_retryable
+        assert any(pattern in auth_failure_msg for pattern in non_retryable)
+
+    def test_circuit_breaker_too_many_auth_failures_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = (
+            'connection failed: connection to server at "18.176.230.146", port 5432 failed: '
+            "FATAL:  (ECIRCUITBREAKER) too many authentication failures, new connections are "
+            "temporarily blocked"
+        )
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "the auth-failure circuit breaker should surface an actionable message"
+        assert "credentials" in friendly[0]
+
     def test_supavisor_enotfound_tenant_user_uses_new_key(self, source):
         # The older tenant/user patterns don't cover the newer "(ENOTFOUND) tenant/user" wording,
         # so confirm it's specifically the new key that recognises this message.
@@ -1873,6 +1907,16 @@ class TestIsConnectionDroppedError:
             # permanent rejection — only the "no error details available" variant (a purely local,
             # pre-handshake failure) is transient, so the match must not broaden to the bare prefix.
             psycopg.OperationalError("connection is bad: FATAL: password authentication failed"),
+            # Supavisor reuses the "(ECIRCUITBREAKER)" code for a distinct, permanent condition: its
+            # own circuit breaker tripped by repeated authentication failures against a tenant, not
+            # the transient pooler-bookkeeping variant ("failed to retrieve database credentials")
+            # kept retryable above. Broadening the match to the bare code would wrongly retry a
+            # deterministic credential rejection — see `get_non_retryable_errors` in source.py.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "18.176.230.146", port 5432 failed: '
+                "FATAL:  (ECIRCUITBREAKER) too many authentication failures, new connections are "
+                "temporarily blocked"
+            ),
         ],
     )
     def test_unrelated_errors_are_not_detected(self, error):
@@ -3697,6 +3741,19 @@ class TestValidateCredentialsErrorMapping:
                 "blocking PostHog's IP addresses. Use a host that's reachable over IPv4 (for example a "
                 "connection pooler), enable your provider's IPv4 add-on, or add PostHog's IP addresses to your "
                 "firewall allowlist, then try again.",
+            ),
+            # Supavisor trips its own circuit breaker after repeated authentication failures against
+            # a tenant. Distinct from the "(ECIRCUITBREAKER) failed to retrieve database credentials"
+            # pooler-bookkeeping wording (kept retryable elsewhere) — this one means the credentials
+            # themselves keep being rejected, so it must surface actionable credential guidance
+            # instead of falling through to the generic fallback message below.
+            (
+                'connection failed: connection to server at "18.176.230.146", port 5432 failed: '
+                "FATAL:  (ECIRCUITBREAKER) too many authentication failures, new connections are "
+                "temporarily blocked",
+                "Your database's connection pooler has temporarily blocked new connections after "
+                'repeated authentication failures ("too many authentication failures"). This usually '
+                "means the username or password is wrong. Check your credentials and try again.",
             ),
             # Unmapped errors fall back to the generic message.
             (


### PR DESCRIPTION
## Problem

A Postgres sync whose credentials keep getting rejected by a Supabase/Supavisor pooler retries indefinitely instead of stopping and telling the customer to fix their credentials.

Supavisor reuses its `(ECIRCUITBREAKER)` error code for two different conditions:
- its own bookkeeping cache failing to fetch credentials (transient, self-heals)
- the pooler blocking new connections after too many authentication failures (the credentials themselves are being rejected)

The source only matched the bare `(ECIRCUITBREAKER)` code, so both were treated as the same transient hiccup. That let a persistent bad-credentials failure retry forever, re-tripping the pooler's protection on every attempt and surfacing as an unclassified `OperationalError` in error tracking instead of a friendly message.

Surfaced by [this error tracking issue](https://us.posthog.com/project/2/error_tracking/01a03871-70b9-7c31-84dc-b475c26214c9): `FATAL:  (ECIRCUITBREAKER) too many authentication failures, new connections are temporarily blocked`.

## Changes

- Narrows the transient-retry match to the specific pooler-bookkeeping wording (`failed to retrieve database credentials`), so it no longer also catches the auth-failure variant.
- Adds `too many authentication failures` to `PostgresSource.get_non_retryable_errors`, so a sync hitting this stops retrying and asks the customer to check their credentials.
- Adds the same message to the credential-validation error map, so testing a connection with these credentials also gets an actionable message instead of the generic fallback.

## How did you test this code?

Extended `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py`:
- `TestIsConnectionDroppedError.test_unrelated_errors_are_not_detected` — new case confirms the auth-failure wording is no longer misclassified as a transient drop.
- `TestPostgresSourceNonRetryableErrors.test_circuit_breaker_too_many_auth_failures_is_non_retryable` / `..._returns_friendly_message` — new tests confirm the auth-failure wording is non-retryable with an actionable message, while the pooler-bookkeeping wording stays retryable.
- `TestValidateCredentialsErrorMapping.test_operational_errors_map_to_friendly_messages` — new parametrized case for the validation path.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/` locally: 780 passed. The remaining 58 errors in that file are pre-existing `RealDb`-suffixed tests that need a live Postgres connection unavailable in this sandbox; unrelated to this change. `ruff check` and `ruff format --check` pass on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from a PostHog error tracking webhook. Investigated the issue and stack trace with the PostHog MCP `query-error-tracking-issue` / `query-error-tracking-issue-events` tools, then read `postgres.py` and `source.py` to find that the existing `(ECIRCUITBREAKER)` handling was too broad. Invoked `/writing-tests` before adding coverage and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*