### PR TITLE
fix(data-imports): skip billing check instead of crashing when the job is missing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/check_billing_limits.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/check_billing_limits.py
@@ -45,7 +45,16 @@ def check_billing_limits_activity(inputs: CheckBillingLimitsActivityInputs) -> b
     logger = LOGGER.bind()
     close_old_connections()
 
-    job = ExternalDataJob.objects.get(id=inputs.job_id)
+    try:
+        job = ExternalDataJob.objects.get(id=inputs.job_id)
+    except ExternalDataJob.DoesNotExist:
+        # job_id can be None (or point at a job that no longer exists) when this input came
+        # from an older worker's create_external_data_job_model_activity result — that legacy
+        # compatibility path doesn't guarantee a job was created. Nothing to bill for, so let
+        # the sync proceed rather than fail the whole workflow.
+        logger.info("Skipping billing limits check: job does not exist", job_id=inputs.job_id)
+        return False
+
     source: ExternalDataSource = job.pipeline
 
     if not job.billable:

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_check_billing_limits.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_check_billing_limits.py
@@ -1,0 +1,32 @@
+import uuid
+
+import pytest
+
+from posthog.models import Organization, Team
+
+from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.check_billing_limits import (
+    CheckBillingLimitsActivityInputs,
+    check_billing_limits_activity,
+)
+
+
+def _team() -> Team:
+    return Team.objects.create(organization=Organization.objects.create(name="org"), name="t")
+
+
+# transaction=True: the activity calls close_old_connections(), which breaks the atomic wrapper
+# a plain django_db test relies on for rollback (same reason test_calculate_table_size.py's
+# activity-level test uses it).
+@pytest.mark.django_db(transaction=True)
+class TestCheckBillingLimitsActivity:
+    def test_skips_check_when_job_does_not_exist(self) -> None:
+        # job_id can arrive as None (or point at a job that's gone) from a legacy
+        # create_external_data_job_model_activity result — this used to raise
+        # ExternalDataJob.DoesNotExist and crash the whole workflow instead of skipping the check.
+        team = _team()
+
+        result = check_billing_limits_activity(
+            CheckBillingLimitsActivityInputs(team_id=team.id, job_id=str(uuid.uuid4()))
+        )
+
+        assert result is False


### PR DESCRIPTION
## Problem

A data warehouse sync crashed outright when its billing-limit check couldn't find the job it was checking, instead of skipping the check like every other guard in that function.

- `check_billing_limits_activity` looks up the sync's `ExternalDataJob` by id and raised `ExternalDataJob.DoesNotExist` when that id didn't resolve to a row.
- The calling workflow already tolerates a missing job id elsewhere (`update_inputs.job_id = str(job_id) if job_id is not None else None`), so a missing job is an expected, not exceptional, state at this point in the pipeline.
- [Error tracking](https://us.posthog.com/project/2/error_tracking/01a03847-8293-79a1-b720-329474e89d7e) shows a single burst of 74 occurrences across 74 distinct teams, each with a null `job_id` on the exception, consistent with the known compatibility path for job-creation results from an older worker.

## Changes

- `check_billing_limits_activity` now catches `ExternalDataJob.DoesNotExist`, logs it, and returns `False` (not billing-limited), matching the function's other skip branches (non-billable job, newly created source, free period).
- Mechanical: added a regression test.

## How did you test this code?

- Added `test_skips_check_when_job_does_not_exist`, asserting the activity returns `False` instead of raising when the job id doesn't resolve to a row.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_check_billing_limits.py`: 1 passed.
- Ran `ruff check` and `ruff format --check` on the changed files: clean.
- Not run: a live Temporal worker end-to-end, since reproducing the originating condition (a job id from an older worker's response shape) needs a real rolling deploy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal activity behavior, no documented workflow, config, or API contract change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a production error tracking issue using Claude Code. Pulled the issue, stack trace, and sampled exception properties via the PostHog MCP error-tracking tools, traced the call path from the workflow into `check_billing_limits_activity`, and confirmed the workflow already treats a missing job id as tolerable elsewhere in the same function. Invoked `/triaging-error-issues`, `/writing-tests` before adding the regression case, and `/writing-pr-descriptions` before this body. Checked for duplicate human-authored open PRs by exception type, module path, and the maintainer's other open PRs — several address unrelated read-only-transaction/failover errors in other files (`row_tracking.py`, `db_errors.py`, `db_retry.py`), but none touch `check_billing_limits.py` or this exception type.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*