### PR TITLE
fix(notebooks): stop the kernel poll on canvas notebooks

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
@@ -28,14 +28,22 @@ describe('notebookKernelInfoLogic', () => {
         { mode: 'notebook' as NotebookLogicMode, shortId: 'abc123', shouldPoll: true },
         { mode: undefined, shortId: 'def456', shouldPoll: true },
         { mode: 'canvas' as NotebookLogicMode, shortId: 'canvas-01890abc', shouldPoll: false },
-    ])('mode $mode polls kernel status: $shouldPoll', ({ mode, shortId, shouldPoll }) => {
+    ])('mode $mode polls kernel status: $shouldPoll', async ({ mode, shortId, shouldPoll }) => {
         logic = notebookKernelInfoLogic({ shortId, mode })
         logic.mount()
 
+        // afterMount fetches once on its own, so pin that count before any timer runs. Asserting
+        // only that the spy was called would pass just as well with the refresh loop deleted.
+        expect(kernelStatusSpy).toHaveBeenCalledTimes(shouldPoll ? 1 : 0)
+
         // A canvas has no server row, so a poll would 404 every 10 seconds until the page closes.
-        jest.advanceTimersByTime(30_000)
+        // Advance asynchronously: each tick skips its fetch while the previous one is still in
+        // flight, so the loop only advances if the mocked request settles between ticks.
+        await jest.advanceTimersByTimeAsync(30_000)
 
         if (shouldPoll) {
+            // Strictly more than the mount fetch, which is what shows the loop re-arms.
+            expect(kernelStatusSpy.mock.calls.length).toBeGreaterThan(1)
             expect(kernelStatusSpy).toHaveBeenCalledWith(shortId)
         } else {
             expect(kernelStatusSpy).not.toHaveBeenCalled()

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
@@ -1,0 +1,44 @@
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { notebookKernelInfoLogic } from './notebookKernelInfoLogic'
+import type { NotebookLogicMode } from './notebookLogic'
+
+describe('notebookKernelInfoLogic', () => {
+    let kernelStatusSpy: jest.SpyInstance
+    let logic: ReturnType<typeof notebookKernelInfoLogic.build> | undefined
+
+    beforeEach(() => {
+        initKeaTests()
+        kernelStatusSpy = jest
+            .spyOn(api.notebooks, 'kernelStatus')
+            .mockResolvedValue({ backend: null, status: 'stopped' })
+        jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        logic = undefined
+        jest.useRealTimers()
+        kernelStatusSpy.mockRestore()
+    })
+
+    test.each([
+        { mode: 'notebook' as NotebookLogicMode, shortId: 'abc123', shouldPoll: true },
+        { mode: undefined, shortId: 'def456', shouldPoll: true },
+        { mode: 'canvas' as NotebookLogicMode, shortId: 'canvas-01890abc', shouldPoll: false },
+    ])('mode $mode polls kernel status: $shouldPoll', ({ mode, shortId, shouldPoll }) => {
+        logic = notebookKernelInfoLogic({ shortId, mode })
+        logic.mount()
+
+        // A canvas has no server row, so a poll would 404 every 10 seconds until the page closes.
+        jest.advanceTimersByTime(30_000)
+
+        if (shouldPoll) {
+            expect(kernelStatusSpy).toHaveBeenCalledWith(shortId)
+        } else {
+            expect(kernelStatusSpy).not.toHaveBeenCalled()
+        }
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
@@ -16,6 +16,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
 import { PythonKernelExecuteResponse } from '../Nodes/pythonExecution'
+import type { NotebookLogicMode } from './notebookLogic'
 
 /** A DuckDB object a SQL node can currently SELECT from, as reported by the kernel's last run. */
 export type NotebookKernelFrame = {
@@ -49,6 +50,13 @@ export type NotebookKernelInfo = {
 
 export type NotebookKernelInfoLogicProps = {
     shortId: string
+    /**
+     * Anything other than `'notebook'` disables the kernel poll. A canvas notebook is never
+     * persisted, so `/kernel/status/` always 404s for its client-made short ID, and a canvas
+     * holds no Python or SQL node that could use a kernel. Person and group profile pages
+     * render one, so polling them costs a 404 every 10 seconds for as long as the page is open.
+     */
+    mode?: NotebookLogicMode
 }
 
 export const cpuCoreOptions = [0.125, 0.25, 0.5, 1, 2, 4, 6, 8, 16, 32, 64]
@@ -546,7 +554,10 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
             actions.executeKernelSuccess(null)
         },
     })),
-    afterMount(({ actions, cache, values }) => {
+    afterMount(({ actions, cache, props, values }) => {
+        if (props.mode && props.mode !== 'notebook') {
+            return
+        }
         const scheduleRefresh = (): void => {
             const delayMs = values.isStarting ? 2000 : 10000
             cache.kernelInfoRefresh = window.setTimeout(() => {

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -703,7 +703,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 item_id: props.shortId,
             }),
             ['comments', 'selectedCommentId'],
-            notebookKernelInfoLogic({ shortId: props.shortId }),
+            notebookKernelInfoLogic({ shortId: props.shortId, mode: props.mode }),
             ['kernelInfo'],
             notebookSettingsLogic,
             ['showKernelInfo'],


### PR DESCRIPTION
## Problem

Found lots of 404s coming from canvases here: 
https://grafana.prod-us.posthog.dev/d/notebooks-sqlv2-rollout/notebooks-e28094-rollout-and-errors?orgId=1&from=now-6h&to=now&timezone=utc&var-datasource=victoriametrics&refresh=1m

Every open person or group profile page sends a request that fails, once every 10 seconds, until the page closes.

- Those pages render a notebook in canvas mode with a short ID the client builds, such as `canvas-<person id>`.
- The server never stored that notebook, so `GET /kernel/status/` answers 404 every time.
- `notebookLogic` connects `notebookKernelInfoLogic` for every notebook, and that logic starts the poll in `afterMount`.
- The loader catches the error and returns null. Nobody sees the failure, and the poll never backs off.

A canvas holds no Python or SQL node, so it can never use a kernel.

## Changes

- Canvas notebooks stop requesting kernel status. Nothing a person sees changes, so there is no screenshot.
- `notebookLogic` passes its `mode` to `notebookKernelInfoLogic`.
- `afterMount` returns early when the mode is not `notebook`.
- Real notebooks keep the poll. Props that omit `mode` keep it too, so `NotebookKernelInfo` and `NotebookSQLEditor` behave as before.
- The `connect` entry stays, so `kernelInfo` stays on the consumer surface and reads null on a canvas. Dropping the entry would also mean dropping the `['kernelInfo']` value pull from every consumer.
- This gates canvas mode only. A `template-` or `new` short ID still polls and still 404s.

This re-lands #58923, which a stale bot closed before anyone reviewed it.

## How did you test this code?

`notebookKernelInfoLogic.test.ts` is new. It runs three `test.each` cases: mode `notebook`, mode absent, and mode `canvas`.

The canvas case catches one regression: someone removes the mode gate and every profile page polls kernel status again. Deleting the early return and re-running turned that case red, so the test is not vacuous.

Ran locally: the notebooks Jest suites and `tsgo --noEmit`. The typecheck reports the same 7 pre-existing errors with and without this change, all in `products/cdp`, `products/posthog_ai`, and `products/signals`.

Not done: no manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5), directed by @sinan-ku while tracing 404s on the notebooks rollout dashboard back to their source.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/querying-posthog-data`.

Decisions along the way. #58923 shipped the same gate with three separate test functions; this PR collapses them into one parameterized case, per `/writing-tests`. The gate covers canvas mode alone rather than the broader `isLocalOnly` selector, at the requester's direction.

Public artifact: the diff, the commit message, and this description carry nothing from the session that is not already in this repository. The investigation read production logs and customer analytics, and none of that data appears here.
