### PR TITLE
fix(tasks): preserve dropped database connection errors

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -13,8 +13,9 @@ from posthog.models import Integration
 from posthog.models.integration import GitHubIntegration
 from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
 from posthog.temporal.common.activity_context import current_activity_attempt
+from posthog.temporal.common.db_errors import is_transient_db_error
 from posthog.temporal.common.logger import get_logger
-from posthog.temporal.common.utils import asyncify
+from posthog.temporal.common.utils import asyncify, retry_on_db_connection_drop
 from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.exceptions import OAuthTokenError, SandboxExecutionError, SandboxMissingRepositoryError
@@ -232,13 +233,15 @@ def _include_personal_mcp_for_task(task: Task) -> bool:
 
 
 def _prepare_launch(ctx: TaskProcessingContext, scopes: PosthogMcpScopes, sandbox_id: str) -> _LaunchParams:
+    task = retry_on_db_connection_drop(lambda: Task.objects.select_related("created_by", "team").get(id=ctx.task_id))
     try:
-        task = Task.objects.select_related("created_by", "team").get(id=ctx.task_id)
         actor_user = get_task_run_credential_user(task, ctx.state)
         access_token = create_oauth_access_token_for_run(task, ctx.state, scopes=scopes)
     except OAuthTokenError:
         raise
     except Exception as e:
+        if is_transient_db_error(e):
+            raise
         raise OAuthTokenError(
             f"Failed to create OAuth access token for MCP auth in task {ctx.task_id}",
             {"task_id": ctx.task_id, "error": str(e)},

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -1,7 +1,9 @@
 import pytest
 from freezegun import freeze_time
 
-from products.tasks.backend.exceptions import SandboxExecutionError, SandboxMissingRepositoryError
+from django.db import OperationalError
+
+from products.tasks.backend.exceptions import OAuthTokenError, SandboxExecutionError, SandboxMissingRepositoryError
 from products.tasks.backend.logic.services.sandbox import ExecutionResult, sandbox_repo_path
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.start_agent_server import (
@@ -11,6 +13,7 @@ from products.tasks.backend.temporal.process_task.activities.start_agent_server 
     _include_personal_mcp_for_task,
     _LaunchParams,
     _network_enforcement_observation,
+    _prepare_launch,
     _record_boot_total,
     _resolve_protected_base_branch,
     await_agent_server_ready,
@@ -304,6 +307,46 @@ def _mock_github_integration(mocker, pr_base: str | None):
 def test_include_personal_mcp_for_task(mocker, internal, expected) -> None:
     task = mocker.Mock(internal=internal)
     assert _include_personal_mcp_for_task(task) is expected
+
+
+def test_prepare_launch_retries_task_read_and_keeps_db_drop_identity(mocker) -> None:
+    task_get = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Task.objects.select_related"
+    ).return_value.get
+    task_get.side_effect = [
+        OperationalError("server conn crashed?"),
+        OperationalError("server conn crashed?"),
+    ]
+
+    with pytest.raises(OperationalError):
+        _prepare_launch(_context(), mocker.Mock(), "sandbox-id")
+
+    assert task_get.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "raised,expected",
+    [
+        (OperationalError("server conn crashed?"), OperationalError),
+        (RuntimeError("token mint failed"), OAuthTokenError),
+    ],
+)
+def test_prepare_launch_relabels_only_non_transient_token_errors(mocker, raised, expected) -> None:
+    task = mocker.Mock(internal=True, created_by_id=None, team_id=1)
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Task.objects.select_related"
+    ).return_value.get.return_value = task
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.get_task_run_credential_user",
+        return_value=None,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.create_oauth_access_token_for_run",
+        side_effect=raised,
+    )
+
+    with pytest.raises(expected):
+        _prepare_launch(_context(), mocker.Mock(), "sandbox-id")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

A dropped database connection during task agent-server startup can appear as an OAuth failure, which sends triage toward the wrong subsystem.

## Changes

- Task startup retries its initial database read once after a dropped connection.
- Transient database errors retain their original type instead of becoming OAuth token errors.

