### PR TITLE
fix(property-filter): make is_set exclude explicit-null property values

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -1752,6 +1752,22 @@ def test_prop_filter_json_extract_nullable_materialized_is_set_uses_json(
         assert uuids == expected
 
 
+def test_prop_filter_json_extract_is_set_excludes_explicit_null():
+    # `is_set` previously only checked `JSONHas(...)`, which is true even when the
+    # property's value is JSON `null` -- so a person/event whose property was
+    # explicitly nulled out still matched "is set". `is_not_set` already guards
+    # against the mirror case via `isNull(...)`; `is_set` must too, otherwise
+    # "set" and "not set" can both match the same explicit-null row.
+    query, _ = prop_filter_json_extract(
+        Property(key="email", operator="is_set", value="is_set"),
+        0,
+        allow_denormalized_props=False,
+    )
+
+    assert "JSONHas" in query
+    assert "isNull" in query
+
+
 @pytest.mark.parametrize("property,expected_event_indexes", TEST_PROPERTIES)
 @freeze_time("2021-04-01T01:00:00.000Z")
 def test_prop_filter_json_extract_person_on_events_materialized(

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -526,10 +526,11 @@ def prop_filter_json_extract(
                 params,
             )
         return (
-            " {property_operator} JSONHas({prop_var}, %(k{prepend}_{idx})s)".format(
+            " {property_operator} (JSONHas({prop_var}, %(k{prepend}_{idx})s) AND NOT isNull({left}))".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,
+                left=property_expr,
                 property_operator=property_operator,
             ),
             params,


### PR DESCRIPTION
## What

Fixes #29916: the `is_set` property filter operator incorrectly matches persons/events whose property is explicitly `null`, when it should behave like the logical opposite of `is_not_set`.

## Root cause

`prop_filter_json_extract()` (`posthog/models/property/util.py`) generates the SQL clause for `is_set` from just:

```python
JSONHas({prop_var}, %(k{prepend}_{idx})s)
```

`JSONHas` only checks whether the JSON *key* exists in the properties blob -- it's `true` even when the value stored at that key is JSON `null`. So a person whose property was explicitly nulled out (as opposed to never set) still matches `is_set`.

The mirror operator, `is_not_set`, already accounts for this:

```python
isNull({left}) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s)
```

-- matching when the value is null *or* the key is absent. `is_set` was never given the corresponding guard, so it isn't actually the negation of `is_not_set`: both can match the same explicit-null row.

## Fix

By De Morgan's, the negation of `is_not_set`'s condition is `NOT isNull(left) AND JSONHas(...)`. Added exactly that:

```python
(JSONHas({prop_var}, %(k{prepend}_{idx})s) AND NOT isNull({left}))
```

Cohorts route through this same function (`products.cohorts.backend.models.util.format_filter_query` → `parse_prop_grouped_clauses` → `prop_filter_json_extract`), which is why the issue reports it specifically for Cohorts.

## How did you test this code?

Added `test_prop_filter_json_extract_is_set_excludes_explicit_null`, asserting the generated SQL string for `is_set` now contains the `isNull` guard (mirroring the assertion style already used for `is_not_set` a few lines up in this file, e.g. `assert "JSONHas" in query`). Scoped to the pure query-string generation rather than the ClickHouse-fixture-backed integration tests elsewhere in this file (e.g. `test_prop_filter_json_extract_nullable_materialized_is_set_uses_json`), since no live ClickHouse instance was available to validate row-level behavior here -- the fix was traced by reading `prop_filter_json_extract` directly and checking it's the exact De Morgan's negation of the already-correct `is_not_set` branch, but CI/review should be the first real execution of this.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Anthropic), operating unsupervised on an open-ended "find and fix issues" session against the repo owner's fork. No human directed this specific fix.
- Skills invoked: none.
- Fix derived by applying De Morgan's law to the already-correct `is_not_set` branch a few lines away in the same file, rather than guessing at a standalone null-check -- confirmed the two branches are now exact logical negations of each other.
- No customer data, tickets, or internal PostHog information was used; all reasoning is from public repository source and the public linked issue.
