### PR TITLE
fix(data-imports): retry a dropped connection before reporting the fanout reuse flag check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/fanout_reuse_flag.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/fanout_reuse_flag.py
@@ -1,7 +1,10 @@
+import django.db
+
 import posthoganalytics
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models.team.team import Team
+from posthog.temporal.common.utils import retry_on_db_connection_drop
 
 FANOUT_WAREHOUSE_REUSE_FLAG = "warehouse-fanout-parent-reuse"
 
@@ -14,8 +17,13 @@ def is_fanout_warehouse_reuse_enabled(team_id: int) -> bool:
     the Delta reader stack into their import graph.
     """
     try:
-        team = Team.objects.only("uuid", "organization_id").get(id=team_id)
+        team = retry_on_db_connection_drop(lambda: Team.objects.only("uuid", "organization_id").get(id=team_id))
     except Team.DoesNotExist:
+        return False
+    except (django.db.OperationalError, django.db.InterfaceError) as e:
+        # retry_on_db_connection_drop already retried once; a second failure is a genuinely
+        # degraded DB, not a bug here (see repartition_controller.py's _is_flag_enabled).
+        capture_exception(e)
         return False
     except Exception as e:
         capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_fanout_reuse_flag.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_fanout_reuse_flag.py
@@ -1,5 +1,9 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import django.db
+
+from posthog.models.team.team import Team
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.fanout_reuse_flag import (
     is_fanout_warehouse_reuse_enabled,
@@ -26,3 +30,43 @@ class TestFanoutReuseFlagFailsClosed:
     @pytest.mark.django_db
     def test_missing_team_returns_false(self):
         assert is_fanout_warehouse_reuse_enabled(999999999) is False
+
+    def test_transient_db_connection_drop_retries_then_succeeds(self):
+        # A pooled connection dropped once (pgbouncer recycle) must not be reported as an
+        # exception nor fail the gate closed — the retry should recover it transparently.
+        mock_team = MagicMock()
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.fanout_reuse_flag.Team"
+            ) as team_cls,
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.fanout_reuse_flag.posthoganalytics.feature_enabled",
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.fanout_reuse_flag.capture_exception"
+            ) as mock_capture,
+        ):
+            team_cls.DoesNotExist = Team.DoesNotExist
+            team_cls.objects.only.return_value.get.side_effect = [
+                django.db.OperationalError("connection closed"),
+                mock_team,
+            ]
+            assert is_fanout_warehouse_reuse_enabled(1) is True
+            mock_capture.assert_not_called()
+
+    def test_persistent_db_connection_drop_returns_false(self):
+        # A second failure after the retry means a genuinely degraded DB, not a transient
+        # blip — this should still be reported and the gate should still fail closed.
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.fanout_reuse_flag.Team"
+            ) as team_cls,
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.fanout_reuse_flag.capture_exception"
+            ) as mock_capture,
+        ):
+            team_cls.DoesNotExist = Team.DoesNotExist
+            team_cls.objects.only.return_value.get.side_effect = django.db.OperationalError("connection closed")
+            assert is_fanout_warehouse_reuse_enabled(1) is False
+            mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

The fan-out warehouse reuse flag check reports a dropped Postgres connection as an unhandled error, even when the sync itself keeps working. [Error tracking caught one occurrence](https://us.posthog.com/project/2/error_tracking/01a0387c-0070-7bc3-bdb8-f970765bf775) during a Sentry incremental sync: `Team.objects.get()` hit `OperationalError: connection ... closed the connection unexpectedly`, which the function's broad `except Exception` already turned into `capture_exception` plus a fail-closed `False`.

The sync never failed and the gate behaved correctly. The only problem is that a transient, single-shot connection blip gets reported next to real bugs, which is noise a reviewer has to triage every time it recurs.

## Changes

- `is_fanout_warehouse_reuse_enabled` now retries the `Team` lookup once via `retry_on_db_connection_drop` before treating an `OperationalError`/`InterfaceError` as exception-worthy.
- A second failure after the retry still calls `capture_exception` and fails closed, unchanged from before.
- This mirrors the existing pattern in `repartition_controller.py`'s `_is_flag_enabled`, which already retries the same lookup for the same reason.

## How did you test this code?

Added two cases to `TestFanoutReuseFlagFailsClosed` in `products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_fanout_reuse_flag.py`:
- a single connection drop retries and succeeds without calling `capture_exception` (the regression this PR fixes)
- two consecutive drops still call `capture_exception` once and fail closed

Ran these two new cases plus the existing `test_flag_service_error_returns_false` locally with mocks (no DB needed) — all pass. `ruff check`/`ruff format` and `mypy` on the changed file are clean.

Not independently re-verified in this sandbox: the pre-existing `test_missing_team_returns_false` case, which needs a live Postgres and a from-scratch Django test-database build that did not finish in time here. It is unmodified by this change and CI will run it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via Claude Code (Sonnet 5), using the PostHog MCP error-tracking tools to pull the issue's stack trace and properties, then two research subagents to trace call sites and locate the existing retry convention in `repartition_controller.py`. Applied the `/writing-tests` and `/writing-pr-descriptions` skills while authoring the test cases and this description.

---

_Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)_