### PR TITLE
fix(postgres): map Supavisor ENETUNREACH to a non-retryable host-unreachable error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/errors.py
@@ -34,10 +34,13 @@ _AUTH_MARKERS = (
 # reachable and the failure is plausibly transient — these are deterministic for the configured
 # host (e.g. it resolves to a private or otherwise non-routable address, such as an IPv6 address
 # PostHog can't route to), so retrying re-hits the same wall. Mirrors the non-retryable treatment
-# on the batch path (PostgresSource.get_non_retryable_errors).
+# on the batch path (PostgresSource.get_non_retryable_errors). "enetunreach" is Supabase Supavisor's
+# erlang-tuple wording of the same condition ("{:error, :enetunreach}"), which never contains the
+# libpq phrasing above.
 _HOST_UNREACHABLE_MARKERS = (
     "network is unreachable",
     "no route to host",
+    "enetunreach",
 )
 
 # sshtunnel raises BaseSSHTunnelForwarderError("Could not establish session to SSH gateway") when it

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_errors.py
@@ -56,6 +56,16 @@ class TestClassifyPostgresCDCError:
                 CDCErrorCategory.HOST_UNREACHABLE,
             ),
             (
+                # Supavisor reports the same routing failure with its erlang-tuple wording, which
+                # never contains the libpq phrases above.
+                "supavisor_enetunreach_is_non_retryable_host",
+                psycopg.OperationalError(
+                    "connection to server at example.invalid, port 5432 failed: FATAL:  "
+                    "Failed to connect to database: {:error, :enetunreach}"
+                ),
+                CDCErrorCategory.HOST_UNREACHABLE,
+            ),
+            (
                 "slot_missing",
                 psycopg.errors.UndefinedObject('replication slot "posthog_slot" does not exist'),
                 CDCErrorCategory.SLOT_MISSING,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -361,6 +361,15 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 '("nxdomain"). This usually means the database project is paused or deleted. Check '
                 "that your database is active, then re-enable the sync."
             ),
+            # Supabase's Supavisor pooler reports a routing failure to its upstream backend as
+            # "FATAL: Failed to connect to database: {:error, :enetunreach}" — Erlang's wording for
+            # ENETUNREACH, the same OS condition libpq surfaces as "Network is unreachable" (handled
+            # below). Unlike the sibling ":etimedout"/":econnrefused" tuples in
+            # `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` — a transient blip reaching a backend that's up —
+            # there's no route to the backend's network at all, which is deterministic for the
+            # configured host (an IPv6-only backend PostHog can't route to, or a firewall dropping our
+            # IPs), so retrying re-hits the same wall. Match the stable erlang-tuple fragment.
+            "{:error, :enetunreach}": _HOST_UNREACHABLE_ERROR,
             # Supabase/Supavisor poolers reject a connection that carries no tenant identifier with
             # "FATAL: (ENOIDENTIFIER) no tenant identifier provided (external_id or sni_hostname
             # required)". The shared regional pooler host (e.g. aws-0-<region>.pooler.supabase.com)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -761,6 +761,22 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Supavisor reports ENETUNREACH (no route to the upstream backend's network) with its
+            # erlang-tuple wording, which never contains libpq's "Network is unreachable". Distinct
+            # from the sibling ":etimedout"/":econnrefused" tuples, which are transient and retryable.
+            'connection failed: connection to server at "203.0.113.10", port 5432 failed: FATAL:  Failed to connect to database: {:error, :enetunreach}',
+            'connection failed: connection to server at "203.0.113.20", port 6543 failed: FATAL:  Failed to connect to database: {:error, :enetunreach}',
+        ],
+    )
+    def test_supavisor_enetunreach_pooler_routing_failure_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, f"Supavisor enetunreach routing failure should surface an actionable message: {error_msg}"
+        assert "IPv4" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Supabase Supavisor rejects a connection with no tenant identifier when the pooler
             # username omits the project ref. The host/IP and port are volatile; the message is stable.
             'connection failed: connection to server at "54.255.219.82", port 5432 failed: FATAL:  (ENOIDENTIFIER) no tenant identifier provided (external_id or sni_hostname required)',


### PR DESCRIPTION
## Problem

A customer whose Postgres data warehouse source connects through Supabase's Supavisor pooler saw syncs fail with a raw driver message when the pooler had no network route to its upstream database backend. The pooler reports this routing failure (ENETUNREACH) with an erlang-tuple wording — `connection failed: ... FATAL: Failed to connect to database: {:error, :enetunreach}` — that never contains libpq's own "Network is unreachable" phrasing we already classify.

Because neither the batch sync path nor the change-data-capture classifier recognized that wording, the failure fell through as unclassified: the sync retried a deterministic, host-unreachable condition its full retry budget and then stored the raw driver text as the error a customer reads. This class was among the highest-impact warehouse sync failures over a recent day.

## Changes

- A source hitting this pooler routing failure now gets a clear, actionable message (check IPv4 reachability / firewall allowlist, or use an IPv4-reachable pooler) instead of the raw driver text, and the sync stops retrying a failure that can't recover on its own until the customer fixes routing.
- Added `{:error, :enetunreach}` to the Postgres source's non-retryable error map, reusing the existing host-unreachable guidance. Inherited by the Supabase source.
- Added `enetunreach` to the CDC host-unreachable marker set so the streaming path classifies it the same way.

This mirrors the existing treatment of the sibling `{:error, :nxdomain}` tuple and libpq's "Network is unreachable". The transient `:etimedout` / `:econnrefused` tuples stay retryable.

## How did you test this code?

Automated tests only (no manual/live sync run):

- Added a parameterized batch-path test asserting the pooler ENETUNREACH message is non-retryable and surfaces the actionable host-unreachable guidance. Catches a regression where removing the mapping would silently return this to being retried and surfaced raw.
- Added a CDC-classifier case asserting the erlang-tuple ENETUNREACH classifies as `HOST_UNREACHABLE` (non-retryable), not the retryable `CONNECTION_FAILED` fallback.
- Ran the Postgres and Supabase source error tests and the CDC error tests locally; all pass. `ruff check`/`ruff format` clean on touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent triaging a batch of warehouse-source sync failure classes. Tools: Claude Code (Explore subagents for investigation, Bash/Edit/Read). Skills invoked: `/writing-tests`.

The example error that motivated this was recorded verbatim from a customer environment; it was not copied into code, tests, or this description. Test fixtures use reserved documentation IP ranges (`203.0.113.0/24`, `example.invalid`) and invented values only. The decision to classify as non-retryable (rather than keep retrying) follows the existing `:nxdomain` precedent: ENETUNREACH is a deterministic routing failure for the configured host, unlike the transient `:etimedout`/`:econnrefused` siblings, which stay retryable.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
