### PR TITLE
fix(clerk): skip the OAuth applications table when the plan lacks it

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
@@ -83,7 +83,13 @@ CLERK_ENDPOINTS: dict[str, ClerkEndpointConfig] = {
         name="enterprise_connections", path="/enterprise_connections", is_wrapped_response=True
     ),
     "oauth_applications": ClerkEndpointConfig(
-        name="oauth_applications", path="/oauth_applications", is_wrapped_response=True
+        name="oauth_applications",
+        path="/oauth_applications",
+        is_wrapped_response=True,
+        # Clerk answers 404 resource_not_found for the OAuth applications list on instances that
+        # haven't switched the feature on — the same feature-off signal the Restrictions endpoints
+        # give. Skip zero rows instead of failing the schema every run.
+        gated_feature="OAuth applications",
     ),
     "machines": ClerkEndpointConfig(name="machines", path="/machines", is_wrapped_response=True),
     # /api_keys and /m2m_tokens cap `limit` at 100 rather than 500.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -520,6 +520,8 @@ class TestClerkFeatureGatedEndpoints:
             ("commerce_plans", 403, {"errors": [{"code": "feature_not_enabled"}]}),
             # Restrictions off: the allow-list endpoint answers 404 resource_not_found, not a 4xx code.
             ("allowlist_identifiers", 404, {"errors": [{"code": "resource_not_found"}]}),
+            # OAuth applications off: the list endpoint answers the same 404 resource_not_found.
+            ("oauth_applications", 404, {"errors": [{"code": "resource_not_found"}]}),
         ],
     )
     def test_feature_not_enabled_syncs_no_rows_instead_of_failing(


### PR DESCRIPTION
## Problem

Clerk data warehouse sources that select the `oauth_applications` table failed on every scheduled run when the connected Clerk instance doesn't have the OAuth applications feature enabled. Clerk answers that table's list endpoint with `404 resource_not_found` — the same feature-off signal the Restrictions (allow-list / block-list) endpoints return.

Because `oauth_applications` had no feature gate, this deterministic 404 was treated as an ordinary failure: the sync retried it its full retry budget every run, never disabled, and surfaced a raw HTTP error as the message a customer reads. This was one of the higher-impact Clerk sync failure classes over a recent day.

## Changes

- A Clerk source whose instance lacks OAuth applications now syncs that table as zero rows with a clear warning ("OAuth applications is not enabled on this Clerk account…") instead of failing the schema and retrying a 404 it can never satisfy. If the customer later enables the feature, the table starts syncing on its own.
- Set `gated_feature="OAuth applications"` on the `oauth_applications` endpoint config, reusing the existing gated-feature handling that already special-cases a 404 `resource_not_found`.

## How did you test this code?

Automated tests only (no manual/live Clerk sync):

- Extended the parameterized gated-feature test with an `oauth_applications` 404 `resource_not_found` case, asserting it syncs no rows and logs the warning. Catches a regression where dropping the gate returns this table to failing/retrying every run.
- Existing negative cases still assert that an unrelated 404 code (not the feature-off signal) still fails the sync.
- Ran the Clerk source and Clerk endpoint tests locally; all pass. `ruff check`/`ruff format` clean on touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent triaging a batch of warehouse-source sync failure classes. Tools: Claude Code (Explore subagents for investigation, Bash/Edit/Read). Skills invoked: `/writing-tests`.

The example error that motivated this was recorded verbatim from a customer environment; it was not copied into code, tests, or this description. Chose the `gated_feature` path (sync zero rows, keep the table enabled, warn) over a non-retryable disable, because OAuth applications is a toggleable Clerk feature — matching how the Restrictions endpoints, which return the identical 404 signal, are already handled.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
