### PR TITLE
chore(product-analytics): stop core tests exercising product-owned runners

### DIFF
--- a/posthog/hogql_queries/test/test_dashboard_filters_overrides.py
+++ b/posthog/hogql_queries/test/test_dashboard_filters_overrides.py
@@ -11,11 +11,8 @@ from posthog.schema import (
     FunnelsQuery,
     IntervalType,
     LifecycleQuery,
-    PathsFilter,
-    PathsQuery,
     RetentionFilter,
     RetentionQuery,
-    StickinessQuery,
     TrendsQuery,
 )
 
@@ -30,10 +27,10 @@ from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQuer
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.models import Team
 
-from products.product_analytics.backend.facade.queries import PathsQueryRunner, StickinessQueryRunner
-
 _TIME_SERIES = [EventsNode(event="$pageview")]
 
+# Only core-owned runners belong here. Product-owned runners (paths, stickiness) cover the
+# same dashboard-filter behavior in their own product tests.
 # Runners whose query model carries an `interval` field.
 INTERVAL_QUERY_RUNNERS: list[tuple[str, Callable[[Team], QueryRunner]]] = [
     (
@@ -43,12 +40,6 @@ INTERVAL_QUERY_RUNNERS: list[tuple[str, Callable[[Team], QueryRunner]]] = [
     (
         "funnels",
         lambda team: FunnelsQueryRunner(query=FunnelsQuery(series=_TIME_SERIES), team=team),
-    ),
-    (
-        "stickiness",
-        lambda team: StickinessQueryRunner(
-            query=StickinessQuery(series=_TIME_SERIES, interval=IntervalType.DAY), team=team
-        ),
     ),
     (
         "lifecycle",
@@ -63,10 +54,6 @@ NON_INTERVAL_QUERY_RUNNERS: list[tuple[str, Callable[[Team], QueryRunner]]] = [
     (
         "retention",
         lambda team: RetentionQueryRunner(query=RetentionQuery(retentionFilter=RetentionFilter()), team=team),
-    ),
-    (
-        "paths",
-        lambda team: PathsQueryRunner(query=PathsQuery(pathsFilter=PathsFilter()), team=team),
     ),
 ]
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1159,55 +1159,6 @@ class TestApplySeriesCustomNames(BaseTest):
     @parameterized.expand(
         [
             (
-                "applies_custom_name_to_stickiness_series",
-                [{"action": {"order": 0, "custom_name": None}, "data": [1, 2, 3]}],
-                [{"action": {"order": 0, "custom_name": "My Stickiness Name"}, "data": [1, 2, 3]}],
-                True,
-            ),
-            (
-                "not_modified_when_stickiness_names_match",
-                [{"action": {"order": 0, "custom_name": "My Stickiness Name"}, "data": [1, 2, 3]}],
-                [{"action": {"order": 0, "custom_name": "My Stickiness Name"}, "data": [1, 2, 3]}],
-                False,
-            ),
-        ]
-    )
-    def test_apply_stickiness_custom_names(
-        self,
-        _name: str,
-        cached_results: list,
-        expected_results: list,
-        expect_modified: bool,
-    ):
-        from posthog.schema import CachedStickinessQueryResponse, StickinessQuery
-
-        from products.product_analytics.backend.facade.queries import StickinessQueryRunner
-
-        query = StickinessQuery(
-            series=[
-                EventsNode(event="$pageview", custom_name="My Stickiness Name"),
-            ]
-        )
-
-        runner = StickinessQueryRunner(query=query, team=self.team)
-
-        cached_response = CachedStickinessQueryResponse(
-            results=cached_results,
-            is_cached=True,
-            last_refresh=datetime.now(UTC),
-            next_allowed_client_refresh=datetime.now(UTC),
-            cache_key="test_key",
-            timezone="UTC",
-        )
-
-        patched_response, was_modified = runner.apply_series_custom_names(cached_response)
-
-        self.assertEqual(patched_response.results, expected_results)
-        self.assertEqual(was_modified, expect_modified)
-
-    @parameterized.expand(
-        [
-            (
                 "patches_all_lifecycle_statuses",
                 [
                     {"action": {"order": 0, "custom_name": None}, "status": "new", "data": [1]},

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -859,8 +859,10 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
         [
             ("query", "query/", {"query": {"kind": "EventsQuery", "select": ["event"]}}),
             ("query_kind", "query/HogQLQuery/", {"query": {"kind": "HogQLQuery", "query": "select 1"}}),
-            # digit-containing kind — the allowlist regex used to miss these
-            ("query_kind_digit", "query/PathsV2Query/", {"query": {"kind": "PathsV2Query"}}),
+            # digit-containing kind — the allowlist regex used to miss these. The kind is
+            # made up on purpose: the middleware matches on the path alone, and a real kind
+            # here would execute a product-owned query runner from a core test.
+            ("query_kind_digit", "query/SomeV2Query/", {"query": {"kind": "SomeV2Query"}}),
             ("query_upgrade", "query/upgrade/", {"query": {"kind": "EventsQuery", "select": ["event"]}}),
             ("endpoint_materialization_preview", "endpoints/some_endpoint/materialization_preview/", {}),
             (

--- a/products/product_analytics/backend/hogql_queries/paths/test/test_paths_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths/test/test_paths_query_runner.py
@@ -3,6 +3,7 @@ import dataclasses
 from freezegun import freeze_time
 from posthog.test.base import (
     APIBaseTest,
+    BaseTest,
     ClickhouseTestMixin,
     _create_event,
     _create_person,
@@ -14,7 +15,7 @@ from django.utils.timezone import now
 from dateutil.relativedelta import relativedelta
 from parameterized import parameterized
 
-from posthog.schema import CachedPathsQueryResponse
+from posthog.schema import CachedPathsQueryResponse, DashboardFilter, IntervalType, PathsFilter, PathsQuery
 
 from posthog.models import Team
 
@@ -1155,3 +1156,33 @@ class TestPaths(ClickhouseTestMixin, APIBaseTest):
         assert "/m/123/orders" in combined
         # The capture groups were substituted, not passed through literally.
         assert "\\1" not in combined
+
+
+class TestPathsDashboardFilters(BaseTest):
+    def _runner(self) -> PathsQueryRunner:
+        return PathsQueryRunner(query=PathsQuery(pathsFilter=PathsFilter()), team=self.team)
+
+    def test_interval_override_silently_skipped_for_non_interval_query(self) -> None:
+        runner = self._runner()
+
+        runner.apply_dashboard_filters(DashboardFilter(interval=IntervalType.WEEK))
+
+        assert not hasattr(runner.query, "interval")
+
+    @parameterized.expand(
+        [
+            ("override_forces_on", None, True, True),
+            ("override_forces_off", True, False, False),
+            ("absent_override_leaves_query_untouched", True, None, True),
+        ]
+    )
+    def test_dashboard_test_accounts_override(
+        self, _name: str, initial: bool | None, dashboard_filter: bool | None, expected: bool
+    ) -> None:
+        runner = self._runner()
+        if initial is not None:
+            runner.query.filterTestAccounts = initial
+
+        runner.apply_dashboard_filters(DashboardFilter(filterTestAccounts=dashboard_filter))
+
+        assert runner.query.filterTestAccounts is expected

--- a/products/product_analytics/backend/hogql_queries/stickiness/test/test_stickiness_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/stickiness/test/test_stickiness_query_runner.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional, Union
 
 from freezegun import freeze_time
 from posthog.test.base import (
     APIBaseTest,
+    BaseTest,
     ClickhouseTestMixin,
     _create_event,
     _create_person,
@@ -19,8 +21,10 @@ from parameterized import parameterized
 
 from posthog.schema import (
     ActionsNode,
+    CachedStickinessQueryResponse,
     CohortPropertyFilter,
     CompareFilter,
+    DashboardFilter,
     DataWarehouseNode,
     DataWarehousePropertyFilter,
     DateRange,
@@ -1516,3 +1520,88 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
         )
         self.assertEqual(len(response.results), 2)  # p2 and p3 were active for <= 2 days
+
+
+class TestStickinessDashboardFilters(BaseTest):
+    def _runner(self) -> StickinessQueryRunner:
+        return StickinessQueryRunner(
+            query=StickinessQuery(series=[EventsNode(event="$pageview")], interval=IntervalType.DAY),
+            team=self.team,
+        )
+
+    @parameterized.expand(
+        [
+            ("override_written_onto_query", IntervalType.WEEK, IntervalType.WEEK),
+            ("absent_override_leaves_query_untouched", None, IntervalType.DAY),
+        ]
+    )
+    def test_dashboard_interval_override(
+        self, _name: str, dashboard_interval: IntervalType | None, expected: IntervalType
+    ) -> None:
+        runner = self._runner()
+
+        runner.apply_dashboard_filters(DashboardFilter(interval=dashboard_interval))
+
+        assert runner.query.interval == expected
+
+    @parameterized.expand(
+        [
+            ("override_forces_on", None, True, True),
+            ("override_forces_off", True, False, False),
+            ("absent_override_leaves_query_untouched", True, None, True),
+        ]
+    )
+    def test_dashboard_test_accounts_override(
+        self, _name: str, initial: bool | None, dashboard_filter: bool | None, expected: bool
+    ) -> None:
+        runner = self._runner()
+        if initial is not None:
+            runner.query.filterTestAccounts = initial
+
+        runner.apply_dashboard_filters(DashboardFilter(filterTestAccounts=dashboard_filter))
+
+        assert runner.query.filterTestAccounts is expected
+
+
+class TestStickinessSeriesCustomNames(BaseTest):
+    @parameterized.expand(
+        [
+            (
+                "applies_custom_name_to_stickiness_series",
+                [{"action": {"order": 0, "custom_name": None}, "data": [1, 2, 3]}],
+                [{"action": {"order": 0, "custom_name": "My Stickiness Name"}, "data": [1, 2, 3]}],
+                True,
+            ),
+            (
+                "not_modified_when_stickiness_names_match",
+                [{"action": {"order": 0, "custom_name": "My Stickiness Name"}, "data": [1, 2, 3]}],
+                [{"action": {"order": 0, "custom_name": "My Stickiness Name"}, "data": [1, 2, 3]}],
+                False,
+            ),
+        ]
+    )
+    def test_apply_stickiness_custom_names(
+        self,
+        _name: str,
+        cached_results: list,
+        expected_results: list,
+        expect_modified: bool,
+    ) -> None:
+        runner = StickinessQueryRunner(
+            query=StickinessQuery(series=[EventsNode(event="$pageview", custom_name="My Stickiness Name")]),
+            team=self.team,
+        )
+
+        cached_response = CachedStickinessQueryResponse(
+            results=cached_results,
+            is_cached=True,
+            last_refresh=datetime.now(UTC),
+            next_allowed_client_refresh=datetime.now(UTC),
+            cache_key="test_key",
+            timezone="UTC",
+        )
+
+        patched_response, was_modified = runner.apply_series_custom_names(cached_response)
+
+        assert patched_response.results == expected_results
+        assert was_modified is expect_modified


### PR DESCRIPTION
## Problem

- Editing a product-analytics query runner (paths, stickiness) re-runs the full Django suite, because core tests still execute those runners.
- Three core test sites did so. Clearing them is the precondition for dropping `backend/hogql_queries/**` from the product's contract-check inputs, so runner edits stop cascading (see products/architecture.md § Wiring couplings).

## Changes

- Test-only. Nothing user-visible changes.
- The read-only impersonation allowlist test uses a made-up digit kind (`SomeV2Query`) instead of running a real PathsV2 query. The middleware matches on the path alone, so the case still guards the digit-regex regression.
- The stickiness custom-names cases move from `test_query_runner.py` into the stickiness runner's own tests, with identical assertions.
- The paths/stickiness dashboard-filter cases move from `test_dashboard_filters_overrides.py` into each runner's own tests, parameterized. The core file keeps the core-owned runners (trends, funnels, lifecycle, retention).

## How did you test this code?

- Ran the six affected suites against a local dev stack: 69 passed (the middleware allowlist class, the dashboard-filter overrides file, the custom-names class, and the new product-side classes).
- The moved tests keep catching the same regressions: a runner that stops honoring dashboard interval or test-account overrides, and stale `custom_name` values no longer patched onto cached stickiness results. They cannot stay in core because that placement is what couples core CI to the product's runners.
- Not checked: the full Django suite (CI covers it).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Test-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — the driver's GitHub handle isn't known to this session, so the PR stays unassigned.

- Authored by Claude Code (PostHog Desktop task) as the first slice of decoupling core tests from product query runners before the insights runners move.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- The candidate list was re-derived on master first. Sharing/alert/caching tests were dropped from scope after verifying every insight serialization surface defaults to `CACHE_ONLY_NEVER_CALCULATE`, so they never execute a runner.
- `hogli ci:preflight --fix` and repo-wide `mypy --cache-fine-grained .` ran clean.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
