### PR TITLE
fix(cli): alert on any Release CLI job failure

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -286,30 +286,6 @@ jobs:
                   release_tag="posthog-cli/v$NEW_VERSION"
                   echo "release-tag=$release_tag" >> "$GITHUB_OUTPUT"
 
-            - name: Send failure event to PostHog
-              if: failure()
-              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
-              with:
-                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-                  event: 'posthog-cli-github-release-workflow-failure'
-                  properties: >-
-                      {
-                        "commitSha": "${{ github.sha }}",
-                        "jobStatus": "${{ job.status }}",
-                        "ref": "${{ github.ref }}",
-                        "version": "${{ steps.prepare-release.outputs.new-version }}"
-                      }
-
-            - name: Notify Slack - Failed
-              if: failure() && needs.notify-approval-needed.outputs.slack_ts != ''
-              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
-              with:
-                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
-                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
-                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: 'Failed to prepare posthog-cli release. View logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-                  emoji_reaction: 'x'
-
     # Keep cargo-dist publishing in this workflow so the Release approval gates the full release path.
     # Run 'dist plan' (or host) to determine what tasks we need to do
     plan-release:
@@ -796,3 +772,76 @@ jobs:
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
                   message: 'posthog-cli release ${{ needs.release.outputs.new-version }} published for ${{ needs.release.outputs.release-tag }}.'
                   emoji_reaction: 'rocket'
+
+    notify-failed:
+        name: Notify Slack - Release Failed
+        needs:
+            - check-changesets
+            - cli-release-preview
+            - notify-approval-needed
+            - release
+            - plan-release
+            - build-local-artifacts
+            - build-global-artifacts
+            - host-release
+            - publish-npm
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        # Covers every job in the release path, so a failure after the approval gate still alerts.
+        if: always() && contains(needs.*.result, 'failure')
+        steps:
+            - name: Collect failure metadata
+              id: failure-metadata
+              env:
+                  NEEDS_JSON: ${{ toJSON(needs) }}
+                  NEW_VERSION: ${{ needs.release.outputs.new-version }}
+              run: |
+                  set -euo pipefail
+
+                  failed_jobs=$(printf '%s' "$NEEDS_JSON" | jq -r '
+                      to_entries | map(select(.value.result == "failure") | .key) | join(", ")
+                  ')
+                  [ -n "$failed_jobs" ] || failed_jobs='unknown'
+
+                  package_ref='posthog-cli'
+                  if [ -n "$NEW_VERSION" ]; then
+                      package_ref="posthog-cli@v$NEW_VERSION"
+                  fi
+
+                  {
+                      echo "failed-jobs=$failed_jobs"
+                      echo "package-ref=$package_ref"
+                      echo "package-version=${NEW_VERSION:-unknown}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Send failure event to PostHog
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-sdk-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "failure",
+                        "ref": "${{ github.ref }}",
+                        "repository": "${{ github.repository }}",
+                        "sdk": "posthog-cli",
+                        "jobName": "${{ steps.failure-metadata.outputs.failed-jobs }}",
+                        "packageName": "posthog-cli",
+                        "packageVersion": "${{ steps.failure-metadata.outputs.package-version }}",
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "alertText": ":rotating_light: Failed to release ${{ steps.failure-metadata.outputs.package-ref }} :rotating_light:",
+                        "alertContext": "These jobs failed in the posthog-cli release workflow: ${{ steps.failure-metadata.outputs.failed-jobs }}."
+                      }
+
+            - name: Notify Slack - Failed
+              continue-on-error: true # A Slack outage must not hide the PostHog alert
+              if: needs.notify-approval-needed.outputs.slack_ts != ''
+              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
+              with:
+                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+                  message: '❌ Failed to release `${{ steps.failure-metadata.outputs.package-ref }}` (${{ steps.failure-metadata.outputs.failed-jobs }}). <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>'
+                  emoji_reaction: 'x'

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -44,6 +44,29 @@ jobs:
                       echo "No CLI changesets to release"
                   fi
 
+            # No thread reply here: the approval message does not exist yet.
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-sdk-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}",
+                        "repository": "${{ github.repository }}",
+                        "sdk": "posthog-cli",
+                        "jobName": "check-changesets",
+                        "packageName": "posthog-cli",
+                        "packageVersion": "unknown",
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "alertText": ":rotating_light: Failed to check posthog-cli changesets :rotating_light:",
+                        "alertContext": "The release stopped before it asked for approval. The changesets stay on master until another CLI change lands."
+                      }
+
     notify-approval-needed:
         name: Notify Slack - Approval Needed
         needs: [check-changesets, cli-release-preview]
@@ -122,6 +145,30 @@ jobs:
                     echo "\`\`\`"
                     echo "</details>"
                   } >> "$GITHUB_STEP_SUMMARY"
+
+            # No thread reply here: notify-approval-needed depends on this job, so the approval
+            # message does not exist yet.
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-sdk-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}",
+                        "repository": "${{ github.repository }}",
+                        "sdk": "posthog-cli",
+                        "jobName": "cli-release-preview",
+                        "packageName": "posthog-cli",
+                        "packageVersion": "unknown",
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "alertText": ":rotating_light: Failed to build the posthog-cli release preview :rotating_light:",
+                        "alertContext": "The release stopped before it asked for approval. The changesets stay on master until another CLI change lands."
+                      }
 
     release:
         name: Prepare CLI release

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -351,7 +351,7 @@ jobs:
                         "packageName": "posthog-cli",
                         "packageVersion": "${{ steps.prepare-release.outputs.new-version || 'unknown' }}",
                         "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "alertText": ":rotating_light: Failed to prepare release posthog-cli@v${{ steps.prepare-release.outputs.new-version }} :rotating_light:",
+                        "alertText": ":rotating_light: Failed to prepare release posthog-cli@v${{ steps.prepare-release.outputs.new-version || 'unknown' }} :rotating_light:",
                         "alertContext": "The version bump step failed before cargo-dist ran."
                       }
 
@@ -363,7 +363,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to prepare `posthog-cli@v${{ steps.prepare-release.outputs.new-version }}`. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>'
+                  message: "❌ Failed to prepare `posthog-cli@v${{ steps.prepare-release.outputs.new-version || 'unknown' }}`. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
                   emoji_reaction: 'x'
 
     # Keep cargo-dist publishing in this workflow so the Release approval gates the full release path.
@@ -904,7 +904,7 @@ jobs:
                         "packageName": "posthog-cli",
                         "packageVersion": "${{ needs.release.outputs.new-version || 'unknown' }}",
                         "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "alertText": ":rotating_light: Failed to publish posthog-cli@v${{ needs.release.outputs.new-version }} :rotating_light:",
+                        "alertText": ":rotating_light: Failed to publish posthog-cli@v${{ needs.release.outputs.new-version || 'unknown' }} :rotating_light:",
                         "alertContext": "The release commit landed, so master carries a version cargo-dist did not publish. Failed jobs: ${{ steps.failure-metadata.outputs.failed-jobs }}."
                       }
 
@@ -916,5 +916,5 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to publish `posthog-cli@v${{ needs.release.outputs.new-version }}` (${{ steps.failure-metadata.outputs.failed-jobs }}). <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>'
+                  message: "❌ Failed to publish `posthog-cli@v${{ needs.release.outputs.new-version || 'unknown' }}` (${{ steps.failure-metadata.outputs.failed-jobs }}). <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
                   emoji_reaction: 'x'

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -806,11 +806,9 @@ jobs:
                   message: 'posthog-cli release ${{ needs.release.outputs.new-version }} published for ${{ needs.release.outputs.release-tag }}.'
                   emoji_reaction: 'rocket'
 
-    # The other SDK repos put this step inside each job. cargo-dist generates the jobs below from
-    # dist-workspace.toml, so steps added there do not survive a regeneration, and one failure in the
-    # 7-target build matrix would alert 7 times. One job watching them keeps the alert per release.
-    # It excludes the release job, which alerts for itself: a rejected approval marks that job failed,
-    # and a rejection must not raise a release-failure alert.
+    # cargo-dist generates the jobs below, so per-job failure steps do not survive `dist generate`,
+    # and the 7-target matrix would alert 7 times. The release job stays out of the condition: a
+    # rejected approval marks it failed, and a rejection must not raise a release-failure alert.
     notify-publish-failed:
         name: Notify Slack - Publish Failed
         needs:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -286,6 +286,39 @@ jobs:
                   release_tag="posthog-cli/v$NEW_VERSION"
                   echo "release-tag=$release_tag" >> "$GITHUB_OUTPUT"
 
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-sdk-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}",
+                        "repository": "${{ github.repository }}",
+                        "sdk": "posthog-cli",
+                        "jobName": "release",
+                        "packageName": "posthog-cli",
+                        "packageVersion": "${{ steps.prepare-release.outputs.new-version || 'unknown' }}",
+                        "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "alertText": ":rotating_light: Failed to prepare release posthog-cli@v${{ steps.prepare-release.outputs.new-version }} :rotating_light:",
+                        "alertContext": "The version bump step failed before cargo-dist ran."
+                      }
+
+            - name: Notify Slack - Failed
+              continue-on-error: true # A Slack outage must not hide the PostHog alert
+              if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
+              uses: posthog/.github/.github/actions/slack-thread-reply@03565438486849ac0d19543de36c248a27d32a2f
+              with:
+                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+                  message: '❌ Failed to prepare `posthog-cli@v${{ steps.prepare-release.outputs.new-version }}`. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>'
+                  emoji_reaction: 'x'
+
     # Keep cargo-dist publishing in this workflow so the Release approval gates the full release path.
     # Run 'dist plan' (or host) to determine what tasks we need to do
     plan-release:
@@ -773,11 +806,14 @@ jobs:
                   message: 'posthog-cli release ${{ needs.release.outputs.new-version }} published for ${{ needs.release.outputs.release-tag }}.'
                   emoji_reaction: 'rocket'
 
-    notify-failed:
-        name: Notify Slack - Release Failed
+    # The other SDK repos put this step inside each job. cargo-dist generates the jobs below from
+    # dist-workspace.toml, so steps added there do not survive a regeneration, and one failure in the
+    # 7-target build matrix would alert 7 times. One job watching them keeps the alert per release.
+    # It excludes the release job, which alerts for itself: a rejected approval marks that job failed,
+    # and a rejection must not raise a release-failure alert.
+    notify-publish-failed:
+        name: Notify Slack - Publish Failed
         needs:
-            - check-changesets
-            - cli-release-preview
             - notify-approval-needed
             - release
             - plan-release
@@ -787,14 +823,15 @@ jobs:
             - publish-npm
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        # Covers every job in the release path, so a failure after the approval gate still alerts.
-        if: always() && contains(needs.*.result, 'failure')
+        if: >-
+            always() && (needs.plan-release.result == 'failure' || needs.build-local-artifacts.result == 'failure'
+            || needs.build-global-artifacts.result == 'failure' || needs.host-release.result == 'failure'
+            || needs.publish-npm.result == 'failure')
         steps:
-            - name: Collect failure metadata
+            - name: Collect failed jobs
               id: failure-metadata
               env:
                   NEEDS_JSON: ${{ toJSON(needs) }}
-                  NEW_VERSION: ${{ needs.release.outputs.new-version }}
               run: |
                   set -euo pipefail
 
@@ -802,17 +839,7 @@ jobs:
                       to_entries | map(select(.value.result == "failure") | .key) | join(", ")
                   ')
                   [ -n "$failed_jobs" ] || failed_jobs='unknown'
-
-                  package_ref='posthog-cli'
-                  if [ -n "$NEW_VERSION" ]; then
-                      package_ref="posthog-cli@v$NEW_VERSION"
-                  fi
-
-                  {
-                      echo "failed-jobs=$failed_jobs"
-                      echo "package-ref=$package_ref"
-                      echo "package-version=${NEW_VERSION:-unknown}"
-                  } >> "$GITHUB_OUTPUT"
+                  echo "failed-jobs=$failed_jobs" >> "$GITHUB_OUTPUT"
 
             - name: Send failure event to PostHog
               continue-on-error: true
@@ -827,12 +854,13 @@ jobs:
                         "ref": "${{ github.ref }}",
                         "repository": "${{ github.repository }}",
                         "sdk": "posthog-cli",
-                        "jobName": "${{ steps.failure-metadata.outputs.failed-jobs }}",
+                        "jobName": "cargo-dist",
+                        "failedJobs": "${{ steps.failure-metadata.outputs.failed-jobs }}",
                         "packageName": "posthog-cli",
-                        "packageVersion": "${{ steps.failure-metadata.outputs.package-version }}",
+                        "packageVersion": "${{ needs.release.outputs.new-version || 'unknown' }}",
                         "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                        "alertText": ":rotating_light: Failed to release ${{ steps.failure-metadata.outputs.package-ref }} :rotating_light:",
-                        "alertContext": "These jobs failed in the posthog-cli release workflow: ${{ steps.failure-metadata.outputs.failed-jobs }}."
+                        "alertText": ":rotating_light: Failed to publish posthog-cli@v${{ needs.release.outputs.new-version }} :rotating_light:",
+                        "alertContext": "The release commit landed, so master carries a version cargo-dist did not publish. Failed jobs: ${{ steps.failure-metadata.outputs.failed-jobs }}."
                       }
 
             - name: Notify Slack - Failed
@@ -843,5 +871,5 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to release `${{ steps.failure-metadata.outputs.package-ref }}` (${{ steps.failure-metadata.outputs.failed-jobs }}). <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>'
+                  message: '❌ Failed to publish `posthog-cli@v${{ needs.release.outputs.new-version }}` (${{ steps.failure-metadata.outputs.failed-jobs }}). <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>'
                   emoji_reaction: 'x'

--- a/cli/RELEASING.md
+++ b/cli/RELEASING.md
@@ -28,6 +28,7 @@ Do not run `sampo publish`; cargo-dist owns publishing for `posthog-cli`.
 If you need to cut a release by hand, merge a CLI changeset to `master` and let `Release CLI` run from there.
 Do not push `posthog-cli/vX.Y.Z` tags manually; cargo-dist tag-push releases are disabled.
 If cargo-dist fails after `Release CLI` commits the release bump, rerun the failed jobs from the same workflow run.
+Any failed job in `Release CLI` posts to the approval thread and to the [#alerts-posthog-js channel in Slack](https://posthog.slack.com/archives/C07HTMN9X47).
 
 The release workflow also builds `services/mcp` into `cli/lib/posthog-api-cli.mjs` before cargo-dist packages artifacts.
 This keeps `posthog-cli api` aligned with the generated MCP tool catalog at release time.


### PR DESCRIPTION
## Problem

- A posthog-cli release can fail without anyone finding out. Nothing reaches #alerts-posthog-js, so the release stalls until a person notices by hand.
- That happened on [run 32743642672](https://github.com/PostHog/posthog/actions/runs/32743642672): `build-local-artifacts (x86_64-apple-darwin)` failed, and v0.15.1 published the next day after a manual re-run. Origin: [Slack thread](https://posthog.slack.com/archives/C0A3UEVDDNF/p1787584492070889).
- `Release CLI` had one failure hook, and it sat inside the `release` job. Every other job could fail unwatched, both before the approval gate and after it.
- That hook sent the event `posthog-cli-github-release-workflow-failure`. That name is left over from a per-repo convention the SDK repos dropped on 2026-07-02. The [Slack destination](https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe) behind #alerts-posthog-js never matched it, so the ten events it sent since June routed nowhere.
- Nine other SDK repos already alert correctly. `Release CLI` was the outlier.

## Changes

- A failed release now posts to #alerts-posthog-js. The alert says whether the release stopped before the approval gate, failed the version bump, or failed to publish.
- Four jobs send the failure event, each with its own `jobName` and alert line: `check-changesets`, `cli-release-preview`, `release`, and the cargo-dist group.
- The three hand-written jobs carry the step inline, matching posthog-ios, posthog-android, posthog-python and six other SDK repos.
- A new `notify-publish-failed` job watches the five cargo-dist jobs. `dist` generates those from `dist-workspace.toml`, so steps added inside them do not survive a regeneration, and one failure in the seven-target build matrix would alert seven times.
- That job excludes the `release` job on purpose. A rejected approval marks `release` as failed, and a rejection must not raise a release-failure alert. posthog-ios keys its `notify-rejected` job on the same signal.
- `release` and the cargo-dist group also reply in the approval thread. The two pre-approval jobs do not, because that message does not exist yet.
- The event name changes to `posthog-sdk-github-release-workflow-failure`, so the destination needs no change. It matches on event name only.
- `cli/RELEASING.md` gains one line pointing at the channel. That part is mechanical.

Before:

```mermaid
flowchart LR
    C[check-changesets] --> V[cli-release-preview] --> R[release] --> D[cargo-dist jobs]
    R -. failure .-> X([unrouted event, no alert])
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class C,V,R,D phBlue;
    class X phRed;
```

After:

```mermaid
flowchart LR
    C[check-changesets] --> V[cli-release-preview] --> R[release] --> D[cargo-dist jobs]
    C & V & R -. failure .-> A([#alerts-posthog-js])
    D -. failure .-> F{{notify-publish-failed}}
    F --> A
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class C,V,R,D phBlue;
    class F phYellow;
    class A phGray;
```

## How did you test this code?

- No tests. A workflow failure path only runs on a real failed release.
- `actionlint` and `hogli lint:workflows` pass. The four remaining shellcheck style hits predate this change.
- The destination config was read directly. It matches on event name only, with no property conditions, so an event from `PostHog/posthog` is delivered the same as one from `PostHog/posthog-js`. Its Slack blocks read `alertText`, `alertContext`, `repository`, `packageName`, `packageVersion`, `jobName`, `jobStatus`, `ref`, `commitSha`, and `actionUrl`.
- The old event name was queried in the receiving project. It arrived ten times between June and August and produced no Slack message.
- The property shape was compared against the nine SDK repos that already send this event.
- Not verified end to end: no alert has fired from this branch, because that needs a real failed release.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`cli/RELEASING.md` names the alert channel.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, Opus 5. Skills invoked: `/writing-pr-descriptions`, `/claude-in-chrome`.

The first version used one watcher job for every job in the workflow. Comparing against the nine SDK repos that already send this event showed two problems with that: `jobName` became a comma-joined list, which is useless for grouping in PostHog, and the watcher would have fired on a rejected approval. The split above keeps the house pattern where jobs are hand-written and uses a watcher only where cargo-dist generates them. Greptile then caught that narrowing the watcher left the two pre-approval jobs unobserved, which the inline steps on those jobs fix.

`Release CLI` still has no `notify-rejected` job, which posthog-ios, posthog-android, posthog-kmp and posthog-js all have. That is a separate gap and not part of this PR.

Public artifact: nothing here carries non-public session material. The linked run, destination, and Slack thread are origin context, and no thread content is quoted. The destination URL already appears in PostHog/posthog-js workflow files.
