### PR TITLE
fix(organizations): accept personal API keys on teams/data_freshness

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -723,7 +723,15 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response({"success": True, "removed_members": removed})
 
     @extend_schema(request=None, responses={200: OrganizationDataFreshnessSerializer})
-    @action(detail=True, methods=["GET"], url_path="teams/data_freshness", pagination_class=None)
+    @action(
+        detail=True,
+        methods=["GET"],
+        url_path="teams/data_freshness",
+        pagination_class=None,
+        # A scope is only derived for `list` and `retrieve`, so without this the action reaches
+        # APIScopePermission with no required scope and every personal API key is rejected.
+        required_scopes=["organization:read"],
+    )
     def data_freshness(self, request: Request, **kwargs) -> Response:
         """When each project in the organization last received data, broken down by kind of data."""
         organization = self.organization

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -888,6 +888,34 @@ class TestPersonalAPIKeysWithPersonScope(PersonalAPIKeysBaseTest):
         assert response.json()["detail"] == "API key missing required scope 'person:read'"
 
 
+class TestPersonalAPIKeysWithOrganizationScope(PersonalAPIKeysBaseTest):
+    # `teams/data_freshness` is a custom action, so it only accepts a personal API key while it
+    # declares `required_scopes`. Drop that and APIScopePermission rejects every key, including
+    # one scoped `*`, with "This action does not support personal API key access".
+
+    @parameterized.expand(
+        [
+            ("organization:read", status.HTTP_200_OK, None),
+            ("feature_flag:read", status.HTTP_403_FORBIDDEN, "API key missing required scope 'organization:read'"),
+        ]
+    )
+    @patch("posthog.api.organization.get_organization_data_freshness")
+    def test_data_freshness_requires_organization_read_scope(
+        self, scope, expected_status, expected_detail, mock_freshness
+    ):
+        mock_freshness.return_value = []
+        self.key.scopes = [scope]
+        self.key.save()
+
+        response = self._do_request(f"/api/organizations/{self.organization.id}/teams/data_freshness")
+
+        assert response.status_code == expected_status, response.content
+        # Asserting the reason, not just the 403: an unscoped action also rejects this key, but for
+        # the wrong reason, and that is the regression being guarded.
+        if expected_detail:
+            assert response.json()["detail"] == expected_detail
+
+
 class TestPersonalAPIKeysWithApprovalsScope(PersonalAPIKeysBaseTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Problem

- A personal API key cannot read per-project data freshness, as it's a custom action, and a scope is only derived for `list` and `retrieve`.
- `required_scopes` resolves to `None`, so `APIScopePermission` rejects the key before any permission check runs.

## Changes

- A key scoped `organization:read` now reads the endpoint and gets the same response the project switcher uses.
- The action declares `required_scopes=["organization:read"]`. The handler is unchanged.
- A key with `scoped_teams` set still fails, because an org-nested route has no `view.team`. Callers need an org-scoped or all-access key.

## How did you test this code?

- Added `TestPersonalAPIKeysWithOrganizationScope`, parameterized over a granted and an unrelated scope.
- It catches the scope being dropped in a refactor, which would silently 403 every key again.
- Both cases fail without the kwarg: the granted one on status, the denied one on rejection reason. Asserting the reason matters, because an unscoped action also returns 403.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
