### PR TITLE
fix(cohorts): persist the filter out internal and test users toggle

### DIFF
--- a/frontend/src/models/cohortsModel.test.ts
+++ b/frontend/src/models/cohortsModel.test.ts
@@ -353,5 +353,24 @@ describe('cohortsModel', () => {
                 explicit_datetime: '-30d',
             })
         })
+
+        it('keeps the filterTestAccounts flag the API returned', () => {
+            // processCohort rebuilds `filters` on every load. Rebuilding only `properties`
+            // drops the flag, so the switch reads back off on a cohort that has it saved.
+            const cohort = {
+                id: 7,
+                name: 'Cohort excluding internal users',
+                count: 0,
+                groups: [],
+                is_calculating: false,
+                is_static: false,
+                filters: {
+                    filterTestAccounts: true,
+                    properties: { type: FilterLogicalOperator.And, values: [] },
+                },
+            } as unknown as CohortType
+
+            expect(processCohort(cohort).filters.filterTestAccounts).toBe(true)
+        })
     })
 })

--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -64,6 +64,7 @@ export function processCohort(cohort: CohortType): CohortType {
 
         /* Populate value_property with value and overwrite value with corresponding behavioral filter type */
         filters: {
+            ...cohort.filters,
             properties: {
                 ...cohort.filters.properties,
                 values: (cohort.filters.properties?.values?.map((group) =>

--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -1351,5 +1351,33 @@ describe('cohortEditLogic', () => {
                 }),
             })
         })
+
+        // Every criteria edit rebuilds `filters` through applyAllCriteriaGroup or
+        // applyAllNestedCriteria, so the flag has to survive the rebuild. Otherwise turning the
+        // switch on and then touching any criterion silently turns it back off before saving.
+        it.each([
+            ['setInnerGroupType', (l: typeof logic) => l.actions.setInnerGroupType(FilterLogicalOperator.Or, 0)],
+            ['addFilter (group)', (l: typeof logic) => l.actions.addFilter()],
+            ['addFilter (criterion)', (l: typeof logic) => l.actions.addFilter(0)],
+            ['duplicateFilter', (l: typeof logic) => l.actions.duplicateFilter(0)],
+            ['removeFilter', (l: typeof logic) => l.actions.removeFilter(0, 0)],
+            [
+                'setCriteria',
+                (l: typeof logic) =>
+                    l.actions.setCriteria(
+                        { type: BehavioralFilterKey.Behavioral, value: BehavioralEventType.PerformEvent },
+                        0,
+                        0
+                    ),
+            ],
+        ])('%s preserves the filterTestAccounts flag', async (_name, editCriteria) => {
+            await initCohortLogic({ id: 'new' })
+            await expectLogic(logic, () => {
+                logic.actions.setFilterTestAccounts(true)
+                editCriteria(logic)
+            }).toMatchValues({
+                cohort: partial({ filters: partial({ filterTestAccounts: true }) }),
+            })
+        })
     })
 })

--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -223,6 +223,7 @@ describe('cohortEditLogic', () => {
     describe('form validation', () => {
         it('save with valid cohort', async () => {
             await initCohortLogic({ id: 1 })
+            const updateSpy = jest.spyOn(api.cohorts, 'update')
             await expectLogic(logic, async () => {
                 logic.actions.setCohort({
                     ...mockCohort,
@@ -248,11 +249,15 @@ describe('cohortEditLogic', () => {
                         },
                     },
                 })
+                logic.actions.setFilterTestAccounts(true)
                 logic.actions.submitCohort()
             })
                 .toDispatchActions(['setCohort', 'submitCohort', 'submitCohortSuccess', 'saveCohortSuccess'])
                 .toNotHaveDispatchedActions(['loadUsedIn'])
             expect(api.update).toHaveBeenCalledTimes(1)
+            const updatePayload = updateSpy.mock.calls[0][1] as FormData
+            const filters = JSON.parse(updatePayload.get('filters') as string)
+            expect(filters.filterTestAccounts).toBe(true)
         })
 
         it('do not save with invalid name', async () => {

--- a/frontend/src/scenes/cohorts/cohortUtils.test.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.test.tsx
@@ -3,12 +3,19 @@ import { BehavioralFilterKey, CohortClientErrors } from 'scenes/cohorts/CohortFi
 import {
     cleanBehavioralTypeCriteria,
     cleanCriteria,
+    createCohortFormData,
     criteriaToHumanSentence,
     determineFilterType,
     validateGroup,
 } from 'scenes/cohorts/cohortUtils'
 
-import { AnyCohortCriteriaType, BehavioralEventType, CohortCriteriaGroupFilter, FilterLogicalOperator } from '~/types'
+import {
+    AnyCohortCriteriaType,
+    BehavioralEventType,
+    CohortCriteriaGroupFilter,
+    CohortType,
+    FilterLogicalOperator,
+} from '~/types'
 
 describe('validateGroup', () => {
     function groupWithNegatedCriteria(criteria: AnyCohortCriteriaType[]): CohortCriteriaGroupFilter {
@@ -228,4 +235,44 @@ describe('criteria whose value collides with an Object.prototype key', () => {
             expect(criteriaToHumanSentence(criteria(value), {}, {})).toEqual(<></>)
         }
     )
+})
+
+describe('createCohortFormData', () => {
+    const cohort = (filterTestAccounts?: boolean): CohortType =>
+        ({
+            id: 1,
+            name: 'Test cohort',
+            is_static: false,
+            filters: {
+                filterTestAccounts,
+                properties: {
+                    type: FilterLogicalOperator.Or,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    type: BehavioralFilterKey.Behavioral,
+                                    value: BehavioralEventType.PerformEvent,
+                                    key: '$pageview',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        }) as unknown as CohortType
+
+    // The switch only lives in `filters` alongside `properties`, so a payload built from
+    // `properties` alone silently discards it and the saved cohort comes back with the
+    // switch off, however many times the user toggles it.
+    it.each([[true], [false]])('sends filterTestAccounts=%s to the API', (filterTestAccounts) => {
+        const filters = JSON.parse(createCohortFormData(cohort(filterTestAccounts)).get('filters') as string)
+        expect(filters.filterTestAccounts).toBe(filterTestAccounts)
+    })
+
+    it('sends filterTestAccounts=false when the cohort has never had it set', () => {
+        const filters = JSON.parse(createCohortFormData(cohort(undefined)).get('filters') as string)
+        expect(filters.filterTestAccounts).toBe(false)
+    })
 })

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -142,6 +142,7 @@ export function createCohortFormData(
                   }
                 : /* Overwrite value with value_property for cases where value is not a behavior enum (i.e., cohort and person filters) */
                   {
+                      filterTestAccounts: !!cohort.filters.filterTestAccounts,
                       properties: {
                           ...applyAllCriteriaGroup(
                               applyAllNestedCriteria(cohort, (criteriaList) =>
@@ -564,6 +565,7 @@ export function applyAllCriteriaGroup(
     return {
         ...oldCohort,
         filters: {
+            ...oldCohort.filters,
             properties: {
                 ...oldCohort.filters.properties,
                 values: fn(oldCohort.filters.properties.values) as AnyCohortCriteriaType[],
@@ -580,6 +582,7 @@ export function applyAllNestedCriteria(
     return {
         ...oldCohort,
         filters: {
+            ...oldCohort.filters,
             properties: {
                 ...oldCohort.filters.properties,
                 values: (oldCohort.filters.properties.values?.map((group, groupI) =>

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -142,7 +142,7 @@ export function createCohortFormData(
                   }
                 : /* Overwrite value with value_property for cases where value is not a behavior enum (i.e., cohort and person filters) */
                   {
-                      filterTestAccounts: !!cohort.filters.filterTestAccounts,
+                      ...(cohort.is_static ? {} : { filterTestAccounts: !!cohort.filters.filterTestAccounts }),
                       properties: {
                           ...applyAllCriteriaGroup(
                               applyAllNestedCriteria(cohort, (criteriaList) =>


### PR DESCRIPTION
## Problem

Turning on "Filter out internal and test users" on a cohort and saving looks like it works, the cohort recalculates, then the switch reads back off. The flag never persisted, so the exclusion never applied to any cohort.

- `createCohortFormData` built the `filters` payload from `filters.properties` alone, so the flag never reached the API.
- `processCohort` rebuilt `filters` from `properties` on every load, so a saved flag would still render as off.
- `applyAllCriteriaGroup` and `applyAllNestedCriteria` rebuilt `filters` the same way, so adding or editing any criterion cleared the flag from local state before the save.

The backend already accepted, validated and applied the flag. Only the frontend round trip was missing.

## Changes

- The switch now survives a save and a reload, and the team's person-scoped test account filters apply to the cohort's calculation.
- `createCohortFormData` sends `filterTestAccounts` alongside `properties` for dynamic cohorts. Static cohorts still submit empty filters.
- `processCohort`, `applyAllCriteriaGroup` and `applyAllNestedCriteria` spread the existing `filters` object instead of rebuilding it, so sibling keys survive.

> [!NOTE]
> The flag joins the existing set of filter choices that put a cohort on the batch calculation path rather than realtime — alongside a leaf filter that won't compile to bytecode, a `person_metadata` filter, a reference to a non-realtime cohort, and exceeding the realtime person-count ceiling. Realtime bytecode is compiled from the cohort's own leaf filters and can't see the team filters injected at calculation time, so `validate_filters_and_compute_realtime_support` already clears `cohort_type`. Filtering itself works on either path; only flag targeting reads realtime membership, and it falls back to batch membership rather than breaking.

No visual change. The switch already rendered; only its persistence changed.

## How did you test this code?

Added Jest coverage for each broken link in the round trip. Reverting the three source files fails all of it, and every case passes with the fix.

- `cohortUtils.test.tsx`: `createCohortFormData` puts `filterTestAccounts` in the submitted `filters` JSON, for on, off, and never-set.
- `cohortsModel.test.ts`: `processCohort` keeps a flag the API returned.
- `cohortEditLogic.test.ts`: six criteria-editing actions each keep the flag, extending the existing guard that only covered `setOuterGroupsType`.

Not run: the app itself, and the backend cohort suites. This sandbox has no dev stack, and the diff is frontend only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack report of the toggle reverting after save. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first trace found the save-path gap in `createCohortFormData`. Fixing only that still left the switch reading off after a reload, and still let a criterion edit clear it, so all three call sites moved to spreading `filters` rather than rebuilding it. Spreading was chosen over threading the flag through each helper's signature, because the helpers are about `properties` and any future sibling key would hit the same bug.

The affected cohort in the report has a failing calculation for unrelated reasons (memory limit), which this PR does not address.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787658576059399?thread_ts=1787658576.059399&cid=C0ACRAMJUAG)*

