### PR TITLE
fix(cohorts): document MCP filter nesting

### DIFF
--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -92,6 +92,15 @@ tools:
             {"name": "Viewed pricing last 7d", "is_static": true, "query": {"kind": "ActorsQuery", "source": {"kind":
             "InsightActorsQuery", "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event":
             "$pageview"}], "dateRange": {"date_from": "-7d"}}}}}
+        param_overrides:
+            filters:
+                description: >-
+                    Define dynamic cohort membership using exactly two group levels so the cohort editor can display and
+                    edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be
+                    an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put
+                    another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer
+                    OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C`
+                    becomes `(A AND C) OR (B AND C)`.
         exclude_params:
             - groups
             - deleted
@@ -172,6 +181,17 @@ tools:
             ActorsQuery through its matching 'query-*-actors' tool (e.g. 'query-trends-actors') — and only save one that
             returned successfully. Prefer this over 'cohorts-add-persons-to-static-cohort-partial-update' for anything
             beyond a handful (~20) of people.
+        param_overrides:
+            filters:
+                description: >-
+                    Define dynamic cohort membership using exactly two group levels so the cohort editor can display and
+                    edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be
+                    an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put
+                    another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer
+                    OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C`
+                    becomes `(A AND C) OR (B AND C)`.
+            id:
+                cast: string-int
         exclude_params:
             - groups
             - version
@@ -184,9 +204,6 @@ tools:
             - last_error_message
             - count
             - experiment_set
-        param_overrides:
-            id:
-                cast: string-int
         ui_app: cohort
     cohorts-persons-retrieve:
         operation: cohorts_persons_retrieve

--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -92,15 +92,6 @@ tools:
             {"name": "Viewed pricing last 7d", "is_static": true, "query": {"kind": "ActorsQuery", "source": {"kind":
             "InsightActorsQuery", "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event":
             "$pageview"}], "dateRange": {"date_from": "-7d"}}}}}
-        param_overrides:
-            filters:
-                description: >-
-                    Define dynamic cohort membership using exactly two group levels so the cohort editor can display and
-                    edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be
-                    an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put
-                    another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer
-                    OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C`
-                    becomes `(A AND C) OR (B AND C)`.
         exclude_params:
             - groups
             - deleted
@@ -114,6 +105,15 @@ tools:
             - last_error_message
             - count
             - experiment_set
+        param_overrides:
+            filters:
+                description:
+                    "Define dynamic cohort membership using exactly two group levels so the cohort editor can display and edit
+                    every condition. Set `properties` to the outer group. Every item in `properties.values` must be an
+                    inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put
+                    another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer
+                    OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C`
+                    becomes `(A AND C) OR (B AND C)`."
         ui_app: cohort
     cohorts-destroy:
         operation: cohorts_destroy
@@ -181,17 +181,6 @@ tools:
             ActorsQuery through its matching 'query-*-actors' tool (e.g. 'query-trends-actors') — and only save one that
             returned successfully. Prefer this over 'cohorts-add-persons-to-static-cohort-partial-update' for anything
             beyond a handful (~20) of people.
-        param_overrides:
-            filters:
-                description: >-
-                    Define dynamic cohort membership using exactly two group levels so the cohort editor can display and
-                    edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be
-                    an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put
-                    another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer
-                    OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C`
-                    becomes `(A AND C) OR (B AND C)`.
-            id:
-                cast: string-int
         exclude_params:
             - groups
             - version
@@ -204,6 +193,17 @@ tools:
             - last_error_message
             - count
             - experiment_set
+        param_overrides:
+            filters:
+                description:
+                    "Define dynamic cohort membership using exactly two group levels so the cohort editor can display and edit
+                    every condition. Set `properties` to the outer group. Every item in `properties.values` must be an
+                    inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put
+                    another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer
+                    OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C`
+                    becomes `(A AND C) OR (B AND C)`."
+            id:
+                cast: string-int
         ui_app: cohort
     cohorts-persons-retrieve:
         operation: cohorts_persons_retrieve

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -43,7 +43,13 @@ const cohortsAddPersonsToStaticCohortPartialUpdate = (): ToolBase<
     },
 })
 
-const CohortsCreateSchema = CohortsCreateBody.omit({ _create_in_folder: true, _create_static_person_ids: true })
+const CohortsCreateSchema = CohortsCreateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).extend(
+    {
+        filters: CohortsCreateBody.shape['filters'].describe(
+            "Define dynamic cohort membership using exactly two group levels so the cohort editor can display and edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C` becomes `(A AND C) OR (B AND C)`."
+        ),
+    }
+)
 
 const cohortsCreate = (): ToolBase<typeof CohortsCreateSchema, WithPostHogUrl<Schemas.Cohort>> =>
     withUiApp('cohort', {
@@ -128,7 +134,12 @@ const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schema
 
 const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({ project_id: true })
     .extend(CohortsPartialUpdateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).shape)
-    .extend({ id: z.preprocess(castStringToInt, CohortsPartialUpdateParams.shape['id']) })
+    .extend({
+        filters: CohortsPartialUpdateBody.shape['filters'].describe(
+            "Define dynamic cohort membership using exactly two group levels so the cohort editor can display and edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C` becomes `(A AND C) OR (B AND C)`."
+        ),
+        id: z.preprocess(castStringToInt, CohortsPartialUpdateParams.shape['id']),
+    })
 
 const cohortsPartialUpdate = (): ToolBase<typeof CohortsPartialUpdateSchema, WithPostHogUrl<Schemas.Cohort>> =>
     withUiApp('cohort', {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-create.json
@@ -469,7 +469,8 @@
                 {
                     "type": "null"
                 }
-            ]
+            ],
+            "description": "Define dynamic cohort membership using exactly two group levels so the cohort editor can display and edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C` becomes `(A AND C) OR (B AND C)`."
         },
         "is_static": {
             "type": "boolean"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cohorts-partial-update.json
@@ -472,7 +472,8 @@
                 {
                     "type": "null"
                 }
-            ]
+            ],
+            "description": "Define dynamic cohort membership using exactly two group levels so the cohort editor can display and edit every condition. Set `properties` to the outer group. Every item in `properties.values` must be an inner AND/OR group, and every item in an inner group's `values` must be a leaf filter. Never put another group inside an inner group. For mixed boolean logic, use disjunctive normal form: an outer OR of inner AND groups, duplicating shared leaf filters when needed. For example, `(A OR B) AND C` becomes `(A AND C) OR (B AND C)`."
         },
         "id": {
             "description": "A unique integer value identifying this cohort.",


### PR DESCRIPTION
## Problem

Agents can create nested cohort filters that the cohort editor cannot display or edit.

The MCP schema accepted recursive filter groups without explaining the supported editor shape.

## Changes

- Cohort create and update tools now require two group levels in their filter guidance.
- The guidance explains how to convert mixed logic into an outer OR of inner AND groups.
- Generated MCP schemas and snapshots include the new guidance.
- This changes agent instructions only. The cohort editor has no visual change.

## How did you test this code?

- Schema snapshots verify both cohort mutation tools expose the nesting guidance.
- MCP type checking, formatting, and tool-name validation pass.
- Repository preflight was unavailable because this environment lacks hogli and flox.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing documentation change. This updates MCP tool guidance and generated schemas.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the change with the /implementing-mcp-tools and /writing-pr-descriptions skills. The live cohort was left unchanged during this code task.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*