### PR TITLE
fix(desktop): attribute local pi costs to tasks

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
@@ -95,7 +95,11 @@ describe("DesktopPiRpcClientFactory", () => {
     ).resolves.toBe(client);
     expect(authProxy.start).toHaveBeenCalledWith(
       getLlmGatewayUrl(getCloudUrlFromRegion("eu")),
-      { "X-PostHog-Project-Id": "1" },
+      {
+        "x-posthog-property-task_id": "task-1",
+        "x-posthog-property-$ai_session_id": "task-1",
+        "X-PostHog-Project-Id": "1",
+      },
     );
     expect(authProxy.start).toHaveBeenCalledWith("https://eu.posthog.com");
     expect(createPiRpcClient).toHaveBeenCalledWith({

--- a/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
@@ -8,7 +8,7 @@ import {
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
 import { type CloudRegion, getCloudUrlFromRegion } from "@posthog/shared";
-import { buildPosthogProjectHeaderRecord } from "@posthog/shared/posthog-property-headers";
+import { buildPosthogScopedPropertyHeaderRecord } from "@posthog/shared/posthog-property-headers";
 import { prepareContextWiki } from "@posthog/workspace-server/services/agent/context-wiki";
 import {
   AGENT_AUTH,
@@ -52,7 +52,7 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
     // Four independent round-trips: proxy URL, auth proxy, MCP config, wiki mount.
     const [baseUrl, enrichmentApiUrl, mcpConfiguration, contextWikiPath] =
       await Promise.all([
-        this.getProxyUrl(credentials.region, projectId),
+        this.getProxyUrl(credentials.region, projectId, input.taskId),
         this.authProxy.start(access.apiHost),
         this.mcpServerSource.getMcpRuntimeConfiguration(),
         this.mountContextWiki(projectId),
@@ -111,11 +111,18 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
     }
   }
 
-  private getProxyUrl(region: CloudRegion, projectId: number): Promise<string> {
+  private getProxyUrl(
+    region: CloudRegion,
+    projectId: number,
+    taskId: string,
+  ): Promise<string> {
     const gatewayUrl = getLlmGatewayUrl(getCloudUrlFromRegion(region));
     return this.authProxy.start(
       gatewayUrl,
-      buildPosthogProjectHeaderRecord(projectId),
+      buildPosthogScopedPropertyHeaderRecord(
+        { task_id: taskId, $ai_session_id: taskId },
+        projectId,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Problem

Local Pi tasks show a $0 estimated cost because their gateway generations lack the PostHog task identifier. This follows [#87212](https://github.com/PostHog/posthog/pull/87212), which exposed the server-reported cost in Pi sessions.

**Why:** People need an accurate per-task estimate regardless of whether the task runs locally or in the cloud.

## Changes

- Local Pi gateway requests now carry the PostHog task identifier used by the task-usage API.
- The existing cost display updates without a layout change, so screenshots are unchanged.

## How did you test this code?

- Extended the Pi client factory test to catch requests that omit task attribution headers.
- Ran the Desktop workspace typecheck and lint.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed because this restores the existing cost display.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the reported tasks through PostHog analytics and the Desktop gateway proxy. Skills used: `posthog-desktop`, `querying-posthog-data`, `writing-tests`, and `writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*