### PR TITLE
fix(google_search_console): retry read timeouts inline like other transient network errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -340,17 +340,18 @@ def _query_search_analytics(
         _throttle(site_url)
         try:
             response = session.post(url, json=body)
-        except requests.ConnectionError:
-            # A dropped connection (RemoteDisconnected / connection reset) is raised before any
-            # response, so the quota/5xx handling below never sees it, and the tracked adapter's
-            # retry skips it because searchAnalytics.query is a POST. It's transient, so retry
-            # inline like a 5xx; once the inline budget is spent, let it bubble so Temporal
-            # retries the activity (resuming from the last saved date).
+        except (requests.ConnectionError, requests.Timeout):
+            # A dropped connection (RemoteDisconnected / connection reset) or a read timeout is
+            # raised before any response, so the quota/5xx handling below never sees it, and the
+            # tracked adapter's retry skips it because searchAnalytics.query is a POST. `Timeout`
+            # covers `ReadTimeout`, which isn't a `ConnectionError` subclass. Both are transient,
+            # so retry inline like a 5xx; once the inline budget is spent, let it bubble so
+            # Temporal retries the activity (resuming from the last saved date).
             if attempt == QUOTA_MAX_RETRIES:
                 raise
             wait = QUOTA_BACKOFF_BASE_SECONDS * (2**attempt)
             logger.warning(
-                "GSC request connection error, backing off",
+                "GSC request connection/timeout error, backing off",
                 site_url=site_url,
                 attempt=attempt,
                 wait_seconds=wait,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -848,6 +848,38 @@ def test_query_connection_error_bubbles_after_max_retries(monkeypatch):
     assert session.post.call_count == QUOTA_MAX_RETRIES + 1
 
 
+def test_query_retries_read_timeout_then_succeeds(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    session = mock.MagicMock()
+    session.post.side_effect = [
+        requests.ReadTimeout("Read timed out."),
+        requests.ReadTimeout("Read timed out."),
+        _fake_response(200, {"rows": [{"keys": ["2026-04-15"], "clicks": 1}]}),
+    ]
+
+    rows = _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert rows == [{"keys": ["2026-04-15"], "clicks": 1}]
+    assert session.post.call_count == 3
+
+
+def test_query_read_timeout_bubbles_after_max_retries(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    session = mock.MagicMock()
+    session.post.side_effect = requests.ReadTimeout("Read timed out.")
+
+    # A persistent read timeout exhausts the inline budget and surfaces the real
+    # ReadTimeout (retryable at the activity level).
+    with pytest.raises(requests.ReadTimeout):
+        _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert session.post.call_count == QUOTA_MAX_RETRIES + 1
+
+
 def test_query_retries_transient_token_refresh_error_then_succeeds(monkeypatch):
     monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
     monkeypatch.setattr(gsc, "_throttle", lambda _site: None)


### PR DESCRIPTION
## Problem

A Google Search Console sync can fail on a read timeout from Google's Search
Analytics API, even though the same kind of transient network failure (a
dropped connection) already gets an inline retry.
[Error tracking caught one occurrence](https://us.posthog.com/project/2/error_tracking/01a03904-67ac-7552-b312-ec43616a6cc3):
`ReadTimeout: HTTPSConnectionPool(host='searchconsole.googleapis.com', port=443): Read timed out. (read timeout=120)`.

## Changes

- `_query_search_analytics` now retries a `requests.Timeout` (which covers
  `ReadTimeout`) inline with the same backoff as a dropped connection, instead
  of letting it bubble immediately.
- `ReadTimeout` extends `requests.Timeout`, not `requests.ConnectionError`, so
  it slipped past the existing dropped-connection handler.
- The failure is still retryable at the Temporal activity level either way;
  this only restores the faster inline retry that a dropped connection
  already gets, so the resumable sync doesn't drop back to the slower
  activity-level retry for a blip that clears in seconds.

## How did you test this code?

Added `test_query_retries_read_timeout_then_succeeds` and
`test_query_read_timeout_bubbles_after_max_retries`, mirroring the existing
connection-error tests, to cover both the inline-retry-then-succeed path and
the bubble-after-exhausted-retries path.

Ran the full `google_search_console` test suite locally (205 passed) plus
`ruff check`/`ruff format --check` on the changed files (clean).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via Claude Code (Sonnet 5) using PostHog's error-tracking MCP
tools to pull the issue's stack trace, confirming the failure originates in
`_query_search_analytics`. Traced the `requests` exception hierarchy to find
that `ReadTimeout` is not a `ConnectionError` subclass, which is why the
existing dropped-connection retry missed it. Applied `/writing-pr-descriptions`
while authoring this description.

---

_Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)_