### PR TITLE
feat(desktop): add new window command

### DIFF
--- a/products/desktop/apps/code/src/main/menu.ts
+++ b/products/desktop/apps/code/src/main/menu.ts
@@ -70,10 +70,10 @@ function getSystemInfo(): string {
   ].join("\n");
 }
 
-export function buildApplicationMenu(): void {
+export function buildApplicationMenu(createWindow: () => void): void {
   const template: MenuItemConstructorOptions[] = [
     buildAppMenu(),
-    buildFileMenu(),
+    buildFileMenu(createWindow),
     buildEditMenu(),
     buildViewMenu(),
     buildWindowMenu(),
@@ -138,10 +138,16 @@ function buildAppMenu(): MenuItemConstructorOptions {
   };
 }
 
-function buildFileMenu(): MenuItemConstructorOptions {
+function buildFileMenu(createWindow: () => void): MenuItemConstructorOptions {
   return {
     label: "File",
     submenu: [
+      {
+        label: "New window",
+        accelerator: "CmdOrCtrl+Shift+N",
+        click: createWindow,
+      },
+      { type: "separator" },
       {
         label: "New task",
         accelerator: "CmdOrCtrl+N",

--- a/products/desktop/apps/code/src/main/window.ts
+++ b/products/desktop/apps/code/src/main/window.ts
@@ -109,6 +109,7 @@ export function saveWindowState(window: BrowserWindow): void {
 }
 
 let mainWindow: BrowserWindow | null = null;
+const appWindows = new Set<BrowserWindow>();
 let trpcIpcHandler: ReturnType<typeof createIPCHandler> | null = null;
 
 /**
@@ -133,16 +134,18 @@ export function onMainWindowClosed(listener: () => void): void {
 }
 
 export function focusMainWindow(reason: string): void {
-  if (mainWindow) {
+  const window =
+    [...appWindows].find((candidate) => candidate.isFocused()) ?? mainWindow;
+  if (window) {
     log.info("focusMainWindow called", {
       reason,
-      isMinimized: mainWindow.isMinimized(),
-      isFocused: mainWindow.isFocused(),
-      isVisible: mainWindow.isVisible(),
+      isMinimized: window.isMinimized(),
+      isFocused: window.isFocused(),
+      isVisible: window.isVisible(),
       stack: new Error().stack,
     });
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.focus();
+    if (window.isMinimized()) window.restore();
+    window.focus();
   }
 }
 
@@ -266,7 +269,7 @@ export function createWindow(): void {
         : path.join(app.getAppPath(), "build/app-icon.png")
       : undefined;
 
-  mainWindow = new BrowserWindow({
+  const window = new BrowserWindow({
     ...(savedState.x !== undefined && { x: savedState.x }),
     ...(savedState.y !== undefined && { y: savedState.y }),
     width: savedState.width,
@@ -293,6 +296,8 @@ export function createWindow(): void {
       ...(isDev && { webSecurity: false }),
     },
   });
+  appWindows.add(window);
+  mainWindow = window;
 
   let windowShown = false;
   const showWindow = () => {
@@ -300,45 +305,40 @@ export function createWindow(): void {
     windowShown = true;
     clearTimeout(showFallback);
     if (restoreFullScreen) {
-      mainWindow?.setFullScreen(true);
+      window.setFullScreen(true);
     } else if (savedState.isMaximized) {
-      mainWindow?.maximize();
+      window.maximize();
     }
-    mainWindow?.show();
-    mainWindow?.moveTop();
-    mainWindow?.focus();
+    window.show();
+    window.moveTop();
+    window.focus();
     app.focus({ steal: true });
   };
 
-  mainWindow.once("ready-to-show", showWindow);
+  window.once("ready-to-show", showWindow);
   const showFallback = setTimeout(showWindow, 3000);
 
-  setupWindowZoom(mainWindow);
+  setupWindowZoom(window);
 
   // Persist window state on changes
-  mainWindow.on(
-    "resize",
-    () => mainWindow && scheduleSaveWindowState(mainWindow),
-  );
-  mainWindow.on(
-    "move",
-    () => mainWindow && scheduleSaveWindowState(mainWindow),
-  );
-  mainWindow.on("maximize", () => mainWindow && saveWindowState(mainWindow));
-  mainWindow.on("unmaximize", () => mainWindow && saveWindowState(mainWindow));
-  mainWindow.on("close", () => mainWindow && saveWindowState(mainWindow));
+  window.on("resize", () => scheduleSaveWindowState(window));
+  window.on("move", () => scheduleSaveWindowState(window));
+  window.on("maximize", () => saveWindowState(window));
+  window.on("unmaximize", () => saveWindowState(window));
+  window.on("close", () => saveWindowState(window));
+  window.on("focus", () => {
+    mainWindow = window;
+  });
 
   // Live-track fullscreen (and which display it is on) so the update-quit
   // path can restore the same monitor after the relaunch.
-  mainWindow.on("enter-full-screen", () => {
+  window.on("enter-full-screen", () => {
     saveFullScreenState(true);
-    if (mainWindow) {
-      saveFullScreenDisplayBounds(
-        screen.getDisplayMatching(mainWindow.getBounds()).bounds,
-      );
-    }
+    saveFullScreenDisplayBounds(
+      screen.getDisplayMatching(window.getBounds()).bounds,
+    );
   });
-  mainWindow.on("leave-full-screen", () => saveFullScreenState(false));
+  window.on("leave-full-screen", () => saveFullScreenState(false));
 
   // Only watch for Mission Control while the window could actually show up in
   // it. A hidden or minimized window never appears there, so polling then would
@@ -346,35 +346,52 @@ export function createWindow(): void {
   const missionControl = container.get<MissionControlService>(
     MISSION_CONTROL_SERVICE,
   );
-  mainWindow.on("show", () => missionControl.arm());
-  mainWindow.on("restore", () => missionControl.arm());
-  mainWindow.on("hide", () => missionControl.disarm());
-  mainWindow.on("minimize", () => missionControl.disarm());
-  mainWindow.on("closed", () => missionControl.disarm());
+  const syncMissionControl = (): void => {
+    const hasVisibleWindow = [...appWindows].some(
+      (candidate) =>
+        !candidate.isDestroyed() &&
+        candidate.isVisible() &&
+        !candidate.isMinimized(),
+    );
+    if (hasVisibleWindow) missionControl.arm();
+    else missionControl.disarm();
+  };
+  window.on("show", syncMissionControl);
+  window.on("restore", syncMissionControl);
+  window.on("hide", syncMissionControl);
+  window.on("minimize", syncMissionControl);
 
   container
     .get<ElectronMainWindow>(MAIN_WINDOW_SERVICE)
     .setMainWindowGetter(() => mainWindow);
 
-  trpcIpcHandler = createIPCHandler({
-    router: trpcRouter,
-    windows: [mainWindow],
-    createContext: async () => ({ container }),
-    // Input is deliberately not logged — it can carry tokens or file contents.
-    onError: ({ error, path, type }) => {
-      trpcLog.error(`${type} '${path ?? "<unknown>"}' failed (${error.code})`, {
-        message: error.message,
-        cause: error.cause instanceof Error ? error.cause.stack : error.cause,
-      });
-    },
-    onNavigationCleanup: ({ webContentsId, url, aborted }) => {
-      trpcLog.info("Main-frame navigation committed", {
-        webContentsId,
-        url,
-        abortedOperations: aborted,
-      });
-    },
-  });
+  if (trpcIpcHandler) {
+    trpcIpcHandler.attachWindow(window);
+  } else {
+    trpcIpcHandler = createIPCHandler({
+      router: trpcRouter,
+      windows: [window],
+      createContext: async () => ({ container }),
+      // Input is deliberately not logged — it can carry tokens or file contents.
+      onError: ({ error, path, type }) => {
+        trpcLog.error(
+          `${type} '${path ?? "<unknown>"}' failed (${error.code})`,
+          {
+            message: error.message,
+            cause:
+              error.cause instanceof Error ? error.cause.stack : error.cause,
+          },
+        );
+      },
+      onNavigationCleanup: ({ webContentsId, url, aborted }) => {
+        trpcLog.info("Main-frame navigation committed", {
+          webContentsId,
+          url,
+          abortedOperations: aborted,
+        });
+      },
+    });
+  }
 
   const rendererFilePath = path.join(
     __dirname,
@@ -387,26 +404,32 @@ export function createWindow(): void {
     ? new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL)
     : pathToFileURL(rendererFilePath);
 
-  setupExternalLinkHandlers(mainWindow, appHome);
-  setupArtifactPreviewWebviews(mainWindow);
-  setupEditableContextMenu(mainWindow);
-  setupCrashLogging(mainWindow);
-  buildApplicationMenu();
+  setupExternalLinkHandlers(window, appHome);
+  setupArtifactPreviewWebviews(window);
+  setupEditableContextMenu(window);
+  setupCrashLogging(window);
+  buildApplicationMenu(createWindow);
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
+    window.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
   } else {
-    mainWindow.loadFile(rendererFilePath);
+    window.loadFile(rendererFilePath);
   }
 
-  mainWindow.on("closed", () => {
+  window.on("closed", () => {
     if (saveTimeout) {
       clearTimeout(saveTimeout);
       saveTimeout = null;
     }
-    mainWindow = null;
-    for (const listener of mainWindowClosedListeners) {
-      listener();
+    appWindows.delete(window);
+    syncMissionControl();
+    if (mainWindow === window) {
+      mainWindow = [...appWindows].at(-1) ?? null;
+    }
+    if (appWindows.size === 0) {
+      for (const listener of mainWindowClosedListeners) {
+        listener();
+      }
     }
   });
 }

--- a/products/desktop/packages/ui/src/features/auth/auth.contribution.ts
+++ b/products/desktop/packages/ui/src/features/auth/auth.contribution.ts
@@ -12,7 +12,7 @@ import { withTimeout } from "@posthog/shared";
 import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
 import { inject, injectable } from "inversify";
-import { useAuthStore } from "./store";
+import { syncSharedAuthState, useAuthStore } from "./store";
 
 const log = logger.scope("auth-contribution");
 // boot() starts contributions serially, so a stuck host query must not wedge it.
@@ -31,7 +31,7 @@ export class AuthContribution implements Contribution {
   async start(): Promise<void> {
     this.hostClient.auth.onStateChanged.subscribe(undefined, {
       onData: (state) => {
-        useAuthStore.getState().setAuthState(state);
+        syncSharedAuthState(state);
         this.syncCloudQueueForAuthState(state);
       },
     });

--- a/products/desktop/packages/ui/src/features/auth/authClientImperative.test.ts
+++ b/products/desktop/packages/ui/src/features/auth/authClientImperative.test.ts
@@ -1,0 +1,34 @@
+import type { AuthState } from "@posthog/core/auth/schemas";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAuthenticatedClient } from "./authClientImperative";
+import { getCachedAuthState } from "./authQueries";
+import { ANONYMOUS_AUTH_STATE } from "./store";
+
+vi.mock("./authQueries", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./authQueries")>()),
+  getCachedAuthState: vi.fn(),
+}));
+
+describe("getAuthenticatedClient", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedAuthState).mockReset();
+  });
+
+  it("uses this window's project when creating an imperative client", async () => {
+    vi.mocked(getCachedAuthState).mockReturnValue({
+      ...ANONYMOUS_AUTH_STATE,
+      status: "authenticated",
+      bootstrapComplete: true,
+      cloudRegion: "us",
+      currentProjectId: 41,
+      sessionType: "persistent",
+    } satisfies AuthState);
+
+    const client = await getAuthenticatedClient();
+    const projectClient = client as unknown as {
+      getTeamId(): Promise<number | undefined>;
+    };
+
+    await expect(projectClient.getTeamId()).resolves.toBe(41);
+  });
+});

--- a/products/desktop/packages/ui/src/features/auth/authClientImperative.ts
+++ b/products/desktop/packages/ui/src/features/auth/authClientImperative.ts
@@ -5,7 +5,7 @@ import {
   type HostTrpcClient,
 } from "@posthog/host-router/client";
 import { createAuthenticatedClient as createClient } from "./authClient";
-import { type AuthState, fetchAuthState } from "./authQueries";
+import { type AuthState, getCachedAuthState } from "./authQueries";
 
 function hostClient(): HostTrpcClient {
   return resolveService<HostTrpcClient>(HOST_TRPC_CLIENT);
@@ -28,5 +28,5 @@ export function createAuthenticatedClient(
 }
 
 export async function getAuthenticatedClient(): Promise<PostHogAPIClient | null> {
-  return createAuthenticatedClient(await fetchAuthState());
+  return createAuthenticatedClient(getCachedAuthState());
 }

--- a/products/desktop/packages/ui/src/features/auth/authQueries.ts
+++ b/products/desktop/packages/ui/src/features/auth/authQueries.ts
@@ -8,7 +8,12 @@ import {
   IMPERATIVE_QUERY_CLIENT,
   type ImperativeQueryClient,
 } from "@posthog/ui/shell/queryClient";
-import { ANONYMOUS_AUTH_STATE, getAuthIdentity, useAuthStore } from "./store";
+import {
+  ANONYMOUS_AUTH_STATE,
+  getAuthIdentity,
+  syncSharedAuthState,
+  useAuthStore,
+} from "./store";
 
 export type { AuthState };
 export { ANONYMOUS_AUTH_STATE, getAuthIdentity };
@@ -38,7 +43,7 @@ export function getCachedAuthState(): AuthState {
 
 export async function refreshAuthStateQuery(): Promise<void> {
   const state = await fetchAuthState();
-  useAuthStore.getState().setAuthState(state);
+  syncSharedAuthState(state);
 }
 
 export function clearAuthScopedQueries(): void {

--- a/products/desktop/packages/ui/src/features/auth/store.test.ts
+++ b/products/desktop/packages/ui/src/features/auth/store.test.ts
@@ -1,0 +1,56 @@
+import type { AuthState } from "@posthog/core/auth/schemas";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  ANONYMOUS_AUTH_STATE,
+  syncSharedAuthState,
+  useAuthStore,
+} from "./store";
+
+function authenticatedState(projectId: number): AuthState {
+  return {
+    ...ANONYMOUS_AUTH_STATE,
+    status: "authenticated",
+    bootstrapComplete: true,
+    cloudRegion: "us",
+    currentOrgId: "org-1",
+    currentProjectId: projectId,
+    orgProjectsMap: {
+      "org-1": {
+        orgName: "Example",
+        projects: [
+          { id: 1, name: "One" },
+          { id: 2, name: "Two" },
+        ],
+      },
+    },
+    desktopAccess: { projectId, status: "allowed", reason: null },
+    sessionType: "persistent",
+  };
+}
+
+describe("syncSharedAuthState", () => {
+  beforeEach(() => {
+    useAuthStore.getState().setAuthState(ANONYMOUS_AUTH_STATE);
+  });
+
+  it("keeps this window's project when another window selects a project", () => {
+    useAuthStore.getState().setAuthState(authenticatedState(1));
+
+    syncSharedAuthState(authenticatedState(2));
+
+    expect(useAuthStore.getState().authState.currentProjectId).toBe(1);
+  });
+
+  it("still applies shared logout state", () => {
+    useAuthStore.getState().setAuthState(authenticatedState(1));
+
+    syncSharedAuthState({
+      ...ANONYMOUS_AUTH_STATE,
+      bootstrapComplete: true,
+      cloudRegion: "us",
+    });
+
+    expect(useAuthStore.getState().authState.status).toBe("anonymous");
+    expect(useAuthStore.getState().authState.currentProjectId).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/auth/store.ts
+++ b/products/desktop/packages/ui/src/features/auth/store.ts
@@ -28,6 +28,38 @@ export const useAuthStore = create<AuthStoreState>((set) => ({
   setAuthState: (authState) => set({ authState }),
 }));
 
+export function syncSharedAuthState(incoming: AuthState): void {
+  const current = useAuthStore.getState().authState;
+  const currentProjectId = current.currentProjectId;
+  const currentProjectStillAvailable = Object.values(
+    incoming.orgProjectsMap,
+  ).some((org) =>
+    org.projects.some((project) => project.id === currentProjectId),
+  );
+
+  if (
+    current.status === "authenticated" &&
+    incoming.status === "authenticated" &&
+    current.cloudRegion === incoming.cloudRegion &&
+    currentProjectId !== null &&
+    currentProjectStillAvailable
+  ) {
+    const currentOrgId = Object.entries(incoming.orgProjectsMap).find(
+      ([, org]) =>
+        org.projects.some((project) => project.id === currentProjectId),
+    )?.[0];
+    useAuthStore.getState().setAuthState({
+      ...incoming,
+      currentOrgId: currentOrgId ?? current.currentOrgId,
+      currentProjectId,
+      desktopAccess: current.desktopAccess,
+    });
+    return;
+  }
+
+  useAuthStore.getState().setAuthState(incoming);
+}
+
 export function useAuthState(): AuthState {
   return useAuthStore((s) => s.authState);
 }

--- a/products/desktop/packages/ui/src/features/auth/useAuthMutations.ts
+++ b/products/desktop/packages/ui/src/features/auth/useAuthMutations.ts
@@ -4,6 +4,7 @@ import type { CloudRegion } from "@posthog/shared";
 import { clearCapturedLogs } from "@posthog/ui/shell/logCapture";
 import { useMutation } from "@tanstack/react-query";
 import { AUTH_SIDE_EFFECTS, type IAuthSideEffects } from "./identifiers";
+import { useAuthStore } from "./store";
 
 export function useLoginMutation() {
   const hostClient = useHostTRPCClient();
@@ -35,7 +36,10 @@ export function useSelectProjectMutation() {
       fx.beforeProjectSwitch();
       return hostClient.auth.selectProject.mutate({ projectId });
     },
-    onSuccess: () => fx.onProjectSelected(),
+    onSuccess: (state) => {
+      useAuthStore.getState().setAuthState(state);
+      fx.onProjectSelected();
+    },
   });
 }
 
@@ -47,7 +51,10 @@ export function useSwitchOrgMutation() {
       fx.beforeProjectSwitch();
       return hostClient.auth.switchOrg.mutate({ orgId });
     },
-    onSuccess: () => fx.onProjectSelected(),
+    onSuccess: (state) => {
+      useAuthStore.getState().setAuthState(state);
+      fx.onProjectSelected();
+    },
   });
 }
 

--- a/products/desktop/packages/ui/src/features/setup/setupRunServiceImpl.ts
+++ b/products/desktop/packages/ui/src/features/setup/setupRunServiceImpl.ts
@@ -23,7 +23,7 @@ import {
 import { injectable } from "inversify";
 import { captureException, track } from "../../shell/analytics";
 import { createAuthenticatedClient } from "../auth/authClientImperative";
-import { fetchAuthState } from "../auth/authQueries";
+import { getCachedAuthState } from "../auth/authQueries";
 import { FEATURE_FLAGS, type FeatureFlags } from "../feature-flags/identifiers";
 
 /**
@@ -47,7 +47,7 @@ export class SetupRunServiceImpl implements ISetupRunService {
     projectId: number | null;
     authed: boolean;
   }> {
-    const authState = await fetchAuthState();
+    const authState = getCachedAuthState();
     const apiHost = authState.cloudRegion
       ? getCloudUrlFromRegion(authState.cloudRegion)
       : null;


### PR DESCRIPTION
## Problem

PostHog Code users cannot open independent app views when they need to work across tasks or projects.

**Why:** Multiple windows reduce context switching while users work in parallel.

## Changes

- The File menu now opens a new window with `Cmd/Ctrl+Shift+N`.
- Each window keeps independent navigation while sharing the current signed-in account.
- Closing one window leaves the remaining windows and app services running.

## How did you test this code?

- Ran the desktop app typecheck.
- Ran the `@posthog/code` unit suite.
- Ran Biome and the host-boundary check.
- Not checked manually because this environment has no interactive desktop session.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No matching user documentation exists for native application menu commands.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated the change using the `posthog-desktop` and `writing-pr-descriptions` skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*