### PR TITLE
fix(data-modeling): stop reporting cdp row-staging permission gaps to error tracking

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -160,6 +160,19 @@ def _resolve_write_plan(saved_query: DataWarehouseSavedQuery, team_id: int) -> W
     )
 
 
+def _is_s3_permission_denied(error: BaseException) -> bool:
+    """True for an S3 access-denied error on our own bucket, from either client this pipeline uses.
+
+    `s3fs`/aiobotocore (used by `CDPProducer._list_files_to_produce`) maps an AccessDenied response
+    onto the builtin `PermissionError`. pyarrow's `S3FileSystem` (used by `stage_chunk`'s parquet
+    write) doesn't set an errno for it, so the same AWS error surfaces as a plain `OSError` with the
+    AWS error code embedded in the message instead.
+    """
+    if isinstance(error, PermissionError):
+        return True
+    return isinstance(error, OSError) and "ACCESS_DENIED" in str(error)
+
+
 class _CDPRowSink:
     """Stages the rows a run wrote so CDP destinations and workflows subscribed to the view can act
     on them.
@@ -195,7 +208,11 @@ class _CDPRowSink:
             await self._producer.stage_chunk(self._chunk, batch)
             self._chunk += 1
         except Exception as e:
-            capture_exception(e)
+            # A missing write grant on the cdp_producer/ prefix is the same anticipated
+            # provisioning gap `_list_files_to_produce` already tolerates quietly for reads (see its
+            # `except PermissionError` branch) — not a bug worth paging on.
+            if not _is_s3_permission_denied(e):
+                capture_exception(e)
             await self._logger.awarning(f"Failed to stage rows for CDP; discarding this run's staged rows: {e}")
             self.enabled = False
             await self.discard()

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_staging.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_staging.py
@@ -1,9 +1,10 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pyarrow as pa
+from parameterized import parameterized
 
-from posthog.temporal.data_modeling.activities.materialize_view import _stage_person_property_batch
+from posthog.temporal.data_modeling.activities.materialize_view import _CDPRowSink, _stage_person_property_batch
 
 pytestmark = pytest.mark.asyncio
 
@@ -14,6 +15,10 @@ def _sink() -> MagicMock:
 
 def _batch() -> pa.RecordBatch:
     return pa.RecordBatch.from_arrays([pa.array(["a"])], names=["distinct_id"])
+
+
+def _producer() -> MagicMock:
+    return MagicMock(stage_chunk=AsyncMock(), clear=AsyncMock())
 
 
 class TestStagePersonPropertyBatch:
@@ -35,3 +40,36 @@ class TestStagePersonPropertyBatch:
         await _stage_person_property_batch(sink, 0, _batch(), fatal=False)
 
         sink.logger.awarning.assert_awaited_once()
+
+
+class TestCDPRowSinkStage:
+    @parameterized.expand(
+        [
+            ("permission_error", PermissionError("Access Denied"), False),
+            (
+                "s3_access_denied_oserror",
+                OSError(
+                    "When initiating multiple part upload for key 'chunk_0.parquet' in bucket "
+                    "'data-warehouse': AWS Error ACCESS_DENIED during CreateMultipartUpload operation: "
+                    "Access Denied (Request ID: ABCDEF)"
+                ),
+                False,
+            ),
+            ("other_error", RuntimeError("staging blew up"), True),
+        ]
+    )
+    async def test_stage_reports_only_non_permission_failures(self, _name, error, expect_capture) -> None:
+        # A missing write grant on the cdp_producer/ prefix is an anticipated provisioning gap, not a
+        # bug — reporting it would page someone for nothing actionable. Any other failure is still a
+        # real bug and must keep reaching error tracking.
+        producer = _producer()
+        producer.stage_chunk.side_effect = error
+        sink = _CDPRowSink(producer, MagicMock(awarning=AsyncMock()))
+        sink.enabled = True
+
+        with patch("posthog.temporal.data_modeling.activities.materialize_view.capture_exception") as mock_capture:
+            await sink.stage(_batch())
+
+        assert mock_capture.called is expect_capture
+        assert sink.enabled is False
+        producer.clear.assert_awaited_once()


### PR DESCRIPTION
## Problem

Staging materialized-view rows for a CDP trigger is best effort: a staging failure never fails the run, by design. The read side of this staging area already treats a missing S3 write grant on the `cdp_producer/` prefix as an anticipated condition and stays quiet about it. The write side had no equivalent, so the same permission gap reported a scary-looking `OSError` to error tracking every time a chunk write hit it — see the linked [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a03908-6594-78b0-96c8-5133a8ac7dbc) (AWS `ACCESS_DENIED` on `CreateMultipartUpload`).

## Changes

- `_CDPRowSink.stage()` now skips the error-tracking report when the failure is an S3 permission-denied error on this bucket, matching the reasoning `CDPProducer._list_files_to_produce` already applies on the read side for the same prefix.
- Any other exception still reports to error tracking, same as before.
- No behavior change to run outcome: staging was already best effort and never failed the run; this only changes whether a non-actionable permission gap gets reported.
- Mechanical: added a helper, `_is_s3_permission_denied`, to recognize the failure shape from either S3 client this pipeline uses (`s3fs`'s typed `PermissionError`, or pyarrow's plain `OSError` carrying the AWS error code in its message).

## How did you test this code?

Added a parameterized case to `TestCDPRowSinkStage` in `posthog/temporal/tests/data_modeling/test_materialize_view_staging.py`, covering a `PermissionError`, a pyarrow-shaped `ACCESS_DENIED` `OSError`, and an unrelated exception — asserting error tracking is skipped only for the first two, while staging still disables itself and discards rows in every case.

Ran locally: `pytest posthog/temporal/tests/data_modeling/test_materialize_view_staging.py` (5 passed), `ruff check`/`ruff format` (clean), `mypy` repo-wide (clean).

Not run: no manual/deployed testing against a live S3 bucket or Temporal worker.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled exception event with full stack trace) to find the real code path, then read the surrounding pipeline code to confirm the write path's own sibling method already treats this exact permission gap as non-actionable. No duplicate open PR found (searched by exception type, message substring, and module path; also checked the maintainer's open PRs).

Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.