### PR TITLE
fix(ci): declare the usage_ingestion proto tree

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -1350,6 +1350,7 @@ const PROTO_TREES = new Map([
     ['kafka_assigner', { crates: ['kafka-assigner-proto'], domains: [] }],
     ['personhog', { crates: ['personhog-proto'], domains: [PYTHON, NODE] }],
     ['prometheus', { crates: ['prometheus-rw-proto'], domains: [] }],
+    ['usage_ingestion', { crates: ['usage-ingestion-proto'], domains: [] }],
 ])
 
 // A file directly under proto/ is treated as impacting all trees, since it's not

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -256,6 +256,7 @@ test('proto configuration at the root claims every tree', () => {
         'proto/ingestion/worker/v1/worker.proto',
         'proto/kafka_assigner/v1/service.proto',
         'proto/prometheus/v1/remote_write.proto',
+        'proto/usage_ingestion/v1/service.proto',
     ]) {
         for (const target of computeTargets([file], PROTO_CONTEXT)) {
             union.add(target)

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -9,6 +9,9 @@ on:
             - .github/scripts/**
             - .github/auto-assign-labels.json
             - .github/workflows/ci-scripts.yml
+            # trunk-impacted-targets.test.js reads proto/ and fails on a tree the
+            # table does not declare, so adding one has to run these tests.
+            - proto/**
             # turbo-discover.test.js pins the Django segment table to these.
             - .github/workflows/ci-backend.yml
             - .depot/workflows/ci-backend.yml


### PR DESCRIPTION
## Problem

Anyone opening a PR that touches `.github/scripts` gets a red `.github/scripts unit tests` check for a reason unrelated to their change.

- `trunk-impacted-targets.test.js` reads `proto/` and asserts every tree is declared in the impacted-targets table. `proto/usage_ingestion` is not, so the test fails.
- The tree landed in #86962. `ci-scripts.yml` only triggers on `.github/scripts/**` and a few named files, so that PR never ran the test that guards the table.
- The failure is in the safe direction. An undeclared tree widens to every target rather than claiming lanes it cannot name, so nothing was mis-selected in the meantime — the check just fails.

## Changes

- The check goes green again for PRs touching `.github/scripts`, and a change under `proto/usage_ingestion` now narrows to the crate that compiles it instead of widening to everything.
- `usage_ingestion` claims `usage-ingestion-proto` and no language lane. The tree has no checked-in node or python stubs; its only consumer is the Rust crate.
- `proto/**` joins `ci-scripts.yml`'s triggers, so the next tree added without a declaration fails on its own PR rather than on someone else's.
- One line added to the union list in the root-config test, which asserts `proto/buf.yaml` claims every tree and so needs one file per tree. Mechanical.

## How did you test this code?

- `node --test .github/scripts/trunk-impacted-targets.test.js` — 94 pass, 0 fail. Both guard tests fail without the table entry, and the second one fails again if the union list is left alone.
- `bin/hogli lint:workflows` passes.
- No new test: the two that exist are exactly the guards for this, and they were already correct. They were simply never run against this tree.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code while investigating an unrelated CI failure on #88431, which is blocked by this check.

The crate half of the entry was read from `rust/usage-ingestion-proto/build.rs`, which is the file that compiles the tree, and the absence of node and python stubs was confirmed against `master` rather than a feature branch.

Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.
