### PR TITLE
fix(managed-warehouse): stop taking FOR UPDATE on posthog_team in the half-hourly reconcile

### DIFF
--- a/products/managed_warehouse/backend/logic/connection.py
+++ b/products/managed_warehouse/backend/logic/connection.py
@@ -339,7 +339,12 @@ def ensure_managed_warehouse_direct_source(
         lifecycle = _locked_source_lifecycle(organization_id)
         if not lifecycle.desired_active or lifecycle.generation != expected_generation:
             return None
-        Team.objects.select_for_update().only("id").get(id=team_id, organization_id=organization_id)
+        # Deliberately NOT select_for_update: FOR UPDATE on a posthog_team row blocks the
+        # FK KEY SHARE lock every team-scoped INSERT takes, so holding it across this
+        # (network-bound) block queued 80+ writer connections twice an hour on the busiest
+        # teams (prod-us lock convoys, 2026-08-19..25). The lifecycle row lock above is the
+        # serialization anchor; a plain existence check is all the team row provides here.
+        Team.objects.only("id").get(id=team_id, organization_id=organization_id)
         return _ensure_managed_source_locked(
             team_id=team_id,
             convert_active_legacy=lifecycle.legacy_conversion_generation == expected_generation,
@@ -352,7 +357,9 @@ def _reconcile_managed_warehouse_source(*, team_id: int, organization_id: str | 
     if not lifecycle_snapshot.desired_active:
         return
     with transaction.atomic():
-        team = Team.objects.select_for_update().only("id").filter(id=team_id, organization_id=organization_id).first()
+        # Plain read on purpose — see ensure_managed_warehouse_direct_source for why the
+        # team row must never be select_for_update'd from these periodic sweeps.
+        team = Team.objects.only("id").filter(id=team_id, organization_id=organization_id).first()
         if team is None:
             return
 
@@ -400,7 +407,10 @@ def _reconcile_managed_warehouse_source(*, team_id: int, organization_id: str | 
     with transaction.atomic():
         if _lifecycle_snapshot(organization_id, lock=True) != lifecycle_snapshot:
             return
-        team = Team.objects.select_for_update().only("id").filter(id=team_id, organization_id=organization_id).first()
+        # Plain read on purpose — this atomic block runs get_or_create loops and
+        # reconcile_postgres_schemas and was observed holding its locks for ~2 minutes;
+        # taking the team row here is what convoyed every writer for the team.
+        team = Team.objects.only("id").filter(id=team_id, organization_id=organization_id).first()
         if team is None:
             return
         source = (

--- a/products/managed_warehouse/backend/logic/connection.py
+++ b/products/managed_warehouse/backend/logic/connection.py
@@ -340,10 +340,9 @@ def ensure_managed_warehouse_direct_source(
         if not lifecycle.desired_active or lifecycle.generation != expected_generation:
             return None
         # Deliberately NOT select_for_update: FOR UPDATE on a posthog_team row blocks the
-        # FK KEY SHARE lock every team-scoped INSERT takes, so holding it across this
-        # (network-bound) block queued 80+ writer connections twice an hour on the busiest
-        # teams (prod-us lock convoys, 2026-08-19..25). The lifecycle row lock above is the
-        # serialization anchor; a plain existence check is all the team row provides here.
+        # FK KEY SHARE lock every team-scoped INSERT takes, so a long hold here stalls all
+        # writers for the team. The lifecycle row lock above is the serialization anchor;
+        # a plain existence check is all the team row provides here.
         Team.objects.only("id").get(id=team_id, organization_id=organization_id)
         return _ensure_managed_source_locked(
             team_id=team_id,
@@ -358,7 +357,7 @@ def _reconcile_managed_warehouse_source(*, team_id: int, organization_id: str | 
         return
     with transaction.atomic():
         # Plain read on purpose — see ensure_managed_warehouse_direct_source for why the
-        # team row must never be select_for_update'd from these periodic sweeps.
+        # team row must never be locked from these periodic sweeps.
         team = Team.objects.only("id").filter(id=team_id, organization_id=organization_id).first()
         if team is None:
             return
@@ -408,8 +407,8 @@ def _reconcile_managed_warehouse_source(*, team_id: int, organization_id: str | 
         if _lifecycle_snapshot(organization_id, lock=True) != lifecycle_snapshot:
             return
         # Plain read on purpose — this atomic block runs get_or_create loops and
-        # reconcile_postgres_schemas and was observed holding its locks for ~2 minutes;
-        # taking the team row here is what convoyed every writer for the team.
+        # reconcile_postgres_schemas and can hold its locks for minutes; taking the team
+        # row here would stall every writer for the team the whole time.
         team = Team.objects.only("id").filter(id=team_id, organization_id=organization_id).first()
         if team is None:
             return


### PR DESCRIPTION
## Problem

The half-hourly `reconcile_all_managed_warehouse_tables_task` takes `SELECT … FOR UPDATE` on a team's `posthog_team` row and holds it for ~2 minutes while doing network-bound warehouse introspection — mostly sitting **idle in transaction**. `FOR UPDATE` on a team row blocks the FK `FOR KEY SHARE` lock that **every team-scoped INSERT** needs, so twice an hour (cron `:17/:47`) every writer for that team — cymbal stackframe upserts, replay-vision, data-warehouse jobs, web COMMITs — queues behind the reconcile. Worst on team 2 (PostHog's own project, the highest-write team in the fleet).

This is the igniter behind the recurring prod-us writer lock convoys (INC-991/INC-993 era and the ongoing `:16/:46` load sawtooth).

## Evidence

- **Caught live 2026-08-25 12:46 UTC** (`pg_blocking_pids` sampling on the writer): Celery connection opened a transaction, locked team 2's row, went idle-in-transaction cycling introspection queries for **125s**; blocked connections built 7 → 28 → 46 → 65 → **80**, then drained instantly at commit (12:48:05).
- **Writer log** (`log_lock_waits`): 260 `still waiting for ShareLock on transaction 2033311785` lines 12:46–12:48 across replay-vision/data-warehouse/cymbal/web roles, then mass `acquired … after 22000–88000 ms` at 12:48:05.
- **Periodicity**: CloudWatch `DBLoadNonCPU` on the writer spikes at `:16`/`:46` every hour since 08-20 (internal Grafana: `d/team-row-lock-convoy`).
- **Timeline**: the lock shipped in #72368 (07-21, user-action-only), was wired into the half-hourly reconcile in #83784 (merged 08-19 10:09 UTC — INC-991 began 18:43 the same day), and became default-on for all teams in #86483 (merged 08-20 18:16 UTC — **INC-993 began ~45 min later**).

## Change

Drop `select_for_update()` from the three `Team` reads in `products/managed_warehouse/backend/logic/connection.py` (plain existence reads remain, `Team.DoesNotExist` / `None` semantics unchanged). Comments at each site record why the team row must not be locked from these sweeps.

**Why this is safe:**
- The serialization these blocks actually rely on is the **source-lifecycle row lock** (`_locked_source_lifecycle` / `_lifecycle_snapshot(lock=True)`) — a quiet per-org table — plus the `select_for_update` on the `ExternalDataSource` row itself. Both are untouched.
- The team-row lock only ever provided an existence check; it cannot protect the introspection work anyway (that happens over the network while the transaction idles).
- Concurrent task runs are already serialized upstream (per-team dispatch in the reconcile wave task).

## Risk / rollout

Behavior-preserving for the reconcile itself; the only change is that unrelated writers no longer wait. Verification signal is immediate: the `:16/:46` `DBLoadNonCPU` sawtooth on `posthog-cloud-prod-us-east-1` disappears on the first post-deploy cron tick.

Same pattern exists with `Organization.objects.select_for_update()` in this file (L279/L316) — org rows are colder, left for a follow-up to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaTSvi7eD23WDB6azeKJYT
