### PR TITLE
perf(usage): drop the team_id partition key on usage records

### DIFF
--- a/rust/usage-ingestion/src/service.rs
+++ b/rust/usage-ingestion/src/service.rs
@@ -94,10 +94,10 @@ impl UsageIngestion for UsageIngestionService {
             .iter()
             .map(|record| record.record_id.clone())
             .collect::<Vec<_>>();
+        // No key: nothing downstream reads per-team order, and a team key crowds one partition.
         let payloads = prepared.into_iter().map(|record| {
-            let key = Some(record.team_id.to_string());
             serde_json::to_vec(&record)
-                .map(|payload| (key, payload))
+                .map(|payload| (None, payload))
                 .map_err(|error| {
                     Status::internal(format!("failed to encode usage record: {error}"))
                 })


### PR DESCRIPTION
## Problem

Usage records from a high-volume team queue behind one Kafka partition, so their billing rows reach ClickHouse later than everyone else's.

- The service keys every record on `team_id`, so one team hashes to one of the topic's 8 partitions.
- No consumer reads usage records in per-team order, so that placement buys nothing.

## Changes

- Usage records carry no partition key, so Kafka spreads a busy team over all 8 partitions.
- Billing totals stay identical. ClickHouse deduplicates on `record_id`, and the distributed table shards on `cityHash64(team_id)`. Neither reads the Kafka partition.
- A ClickHouse insert block now spans more teams, so it fans out to more shards. This topic is low volume, so that cost stays small.
- Nothing user-visible changes. No UI is involved, so there is nothing to screenshot.

## How did you test this code?

- Not run: the crate's e2e and load tests. Both are `#[ignore]`d and need the local Kafka and ClickHouse stack, which this session did not have. `ci-rust.yml` runs them for this crate with `--run-ignored only`.
- No new test. Partition placement is not a property any test asserts, and `tests/e2e.rs` already checks that a retried record collapses to one row wherever it lands.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The crate README already states that a key which moves to a different partition cannot change the result.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote this change. @benjackwhite proposed dropping the key and asked whether it was load-bearing.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
- The session checked three things before editing: the `ReplacingMergeTree` sorting key on `sharded_billing_usage_records`, the sharding key on both distributed tables, and whether any consumer other than the ClickHouse Kafka engine table reads the topic. All three cleared.
- An earlier draft also added a paragraph to the crate README. It came out again to keep that file short.
