### PR TITLE
feat(ai-gateway): add per-team product budgets for routed runs

### DIFF
--- a/posthog/llm/gateway_internal_client.py
+++ b/posthog/llm/gateway_internal_client.py
@@ -21,6 +21,15 @@ class AIGatewayNotConfigured(AIGatewayInternalError):
     """AI_GATEWAY_INTERNAL_URL / AI_GATEWAY_INTERNAL_TOKEN are not set."""
 
 
+class AIGatewayBudgetSuperseded(AIGatewayInternalError):
+    """A concurrent write published a newer budget for this node.
+
+    The durable row still committed, so the write happened; the limit now being
+    enforced is someone else's. Separate from a failure so a re-run can report
+    "not mine" instead of retrying a write that cannot win.
+    """
+
+
 @dataclasses.dataclass(frozen=True)
 class LedgerEntry:
     when: str
@@ -41,6 +50,19 @@ class Wallet:
     has_ledger: bool
     balance: str | None
     recent: list[LedgerEntry]
+
+
+@dataclasses.dataclass(frozen=True)
+class Budget:
+    team_id: int
+    scope_type: str
+    # The value the gateway stored. It sanitizes on write (control-strip, length
+    # bound) exactly as admission sanitizes a request's node, so a caller that
+    # sent an unsanitary value gets the stored form back here rather than the one
+    # it asked for — and a budget keyed on the other string would never bind.
+    scope_value: str
+    limit_usd: str
+    window_seconds: int
 
 
 @dataclasses.dataclass(frozen=True)
@@ -140,6 +162,77 @@ def add_credit(team_id: int, amount_usd: str, reason: str, idempotency_key: str)
         balance_usd=data.get("balance_usd", ""),
         duplicate=bool(data.get("duplicate", False)),
     )
+
+
+def _parse_budget(row: dict[str, Any], default_team_id: int) -> Budget:
+    return Budget(
+        team_id=int(row.get("team_id", default_team_id)),
+        scope_type=row.get("scope_type", ""),
+        scope_value=row.get("scope_value", ""),
+        limit_usd=row.get("limit_usd", ""),
+        window_seconds=int(row.get("window_seconds", 0)),
+    )
+
+
+def set_budget(team_id: int, scope_type: str, scope_value: str, limit_usd: str, window_seconds: int) -> Budget:
+    """Upsert one attribution node's spend budget for a team.
+
+    Budgets are per team: every key the enforcer builds is namespaced by team_id,
+    so there is no fleet-wide pool to set here. A node with no row is unbudgeted,
+    and enforcement fails open, so this is a ceiling rather than a hard floor —
+    the team wallet remains the only thing that cannot be bypassed.
+
+    Carries no idempotency key: the write is a config replace, so a re-run is
+    inherently idempotent. Raises AIGatewayBudgetSuperseded when a concurrent
+    write already published a newer limit for the same node.
+    """
+    url, token = _config()
+    try:
+        response = httpx.put(
+            f"{url}/internal/teams/{team_id}/budgets",
+            headers=_auth_headers(token, {INTERNAL_ACTOR_HEADER: ADMIN_ACTOR}),
+            json={
+                "scope_type": scope_type,
+                "scope_value": scope_value,
+                "limit_usd": limit_usd,
+                "window_seconds": window_seconds,
+            },
+            timeout=INTERNAL_API_TIMEOUT_SECONDS,
+            trust_env=False,
+        )
+    except httpx.HTTPError as exc:
+        raise AIGatewayInternalError(f"budget write failed: {exc}") from exc
+
+    if response.status_code == 409:
+        raise AIGatewayBudgetSuperseded(_error_detail(response))
+    if response.status_code >= 400:
+        raise AIGatewayInternalError(_error_detail(response))
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise AIGatewayInternalError(f"budget response was not valid JSON: {exc}") from exc
+    # A 2xx with a partial body would coerce to an empty scope_value, which reads
+    # as a budget on a different node than the one requested.
+    if not data.get("scope_value") or data.get("limit_usd") is None:
+        raise AIGatewayInternalError("budget response missing required fields (scope_value/limit_usd)")
+    return _parse_budget(data, team_id)
+
+
+def list_budgets(team_id: int) -> list[Budget]:
+    url, token = _config()
+    try:
+        response = httpx.get(
+            f"{url}/internal/teams/{team_id}/budgets",
+            headers=_auth_headers(token),
+            timeout=INTERNAL_API_TIMEOUT_SECONDS,
+            trust_env=False,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise AIGatewayInternalError(f"budget read failed: {exc}") from exc
+    return [_parse_budget(row, team_id) for row in data.get("budgets") or []]
 
 
 def _error_detail(response: httpx.Response) -> str:

--- a/posthog/llm/test_gateway_internal_client.py
+++ b/posthog/llm/test_gateway_internal_client.py
@@ -7,10 +7,13 @@ from posthog.llm.gateway_internal_client import (
     ADMIN_ACTOR,
     IDEMPOTENCY_KEY_HEADER,
     INTERNAL_ACTOR_HEADER,
+    AIGatewayBudgetSuperseded,
     AIGatewayInternalError,
     AIGatewayNotConfigured,
     add_credit,
     get_wallet,
+    list_budgets,
+    set_budget,
 )
 
 
@@ -154,6 +157,82 @@ class TestAddCredit:
         with patch("posthog.llm.gateway_internal_client.httpx.post", return_value=_response(200, body)):
             result = add_credit(42, "10", "x", "key-123")
         assert result.balance_usd == "0"
+
+
+class TestSetBudget:
+    @patch("posthog.llm.gateway_internal_client.settings")
+    def test_writes_node_and_returns_stored_row(self, mock_settings):
+        _configured(mock_settings)
+        body = {
+            "team_id": 42,
+            "scope_type": "product",
+            "scope_value": "signals_scout",
+            "limit_usd": "500",
+            "window_seconds": 86400,
+        }
+        with patch("posthog.llm.gateway_internal_client.httpx.put", return_value=_response(200, body)) as mock_put:
+            budget = set_budget(42, "product", "signals_scout", "500", 86400)
+
+        assert mock_put.call_args.args[0] == "http://gw/internal/teams/42/budgets"
+        assert mock_put.call_args.kwargs["headers"][INTERNAL_ACTOR_HEADER] == ADMIN_ACTOR
+        # A config replace is idempotent by nature, so it must not consume an
+        # idempotency key the credit path needs.
+        assert IDEMPOTENCY_KEY_HEADER not in mock_put.call_args.kwargs["headers"]
+        assert mock_put.call_args.kwargs["json"]["scope_value"] == "signals_scout"
+        assert budget.scope_value == "signals_scout"
+        assert budget.window_seconds == 86400
+
+    @patch("posthog.llm.gateway_internal_client.settings")
+    def test_conflict_is_distinct_from_failure(self, mock_settings):
+        # The row committed; a concurrent write's limit is what enforces. A caller
+        # that saw a generic error here would retry a write that cannot win.
+        _configured(mock_settings)
+        body = {"error": "a concurrent update set a newer budget for this node"}
+        with patch("posthog.llm.gateway_internal_client.httpx.put", return_value=_response(409, body)):
+            with pytest.raises(AIGatewayBudgetSuperseded):
+                set_budget(42, "product", "signals_scout", "500", 86400)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"team_id": 42, "limit_usd": "500"},
+            {"team_id": 42, "scope_value": "", "limit_usd": "500"},
+            {"team_id": 42, "scope_value": "signals_scout"},
+        ],
+    )
+    @patch("posthog.llm.gateway_internal_client.settings")
+    def test_partial_success_body_is_an_error(self, mock_settings, body):
+        # Coercing these to empty strings would report a budget on a node that has none.
+        _configured(mock_settings)
+        with patch("posthog.llm.gateway_internal_client.httpx.put", return_value=_response(200, body)):
+            with pytest.raises(AIGatewayInternalError):
+                set_budget(42, "product", "signals_scout", "500", 86400)
+
+
+class TestListBudgets:
+    @patch("posthog.llm.gateway_internal_client.settings")
+    def test_parses_rows(self, mock_settings):
+        _configured(mock_settings)
+        body = {
+            "budgets": [
+                {
+                    "team_id": 42,
+                    "scope_type": "product",
+                    "scope_value": "signals_scout",
+                    "limit_usd": "500",
+                    "window_seconds": 86400,
+                }
+            ]
+        }
+        with patch("posthog.llm.gateway_internal_client.httpx.get", return_value=_response(200, body)):
+            budgets = list_budgets(42)
+        assert [(b.scope_type, b.scope_value) for b in budgets] == [("product", "signals_scout")]
+
+    @patch("posthog.llm.gateway_internal_client.settings")
+    def test_no_budgets_is_empty_not_an_error(self, mock_settings):
+        _configured(mock_settings)
+        with patch("posthog.llm.gateway_internal_client.httpx.get", return_value=_response(200, {})):
+            assert list_budgets(42) == []
 
 
 class TestNotConfigured:

--- a/posthog/management/commands/seed_ai_gateway_budgets.py
+++ b/posthog/management/commands/seed_ai_gateway_budgets.py
@@ -1,0 +1,125 @@
+"""Seed per-team spend budgets on the Go ai-gateway for the products it routes.
+
+A routed sandbox run is bounded per run by its scoped token's cap, but nothing
+bounds how many runs a team starts. This sets a windowed ceiling per (team,
+product) so the aggregate is bounded too.
+
+The product list is derived from SANDBOX_AI_GATEWAY_PRODUCTS rather than
+restated here, so it cannot name a product that is not routed (a budget nothing
+binds to) or miss one that is.
+"""
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.llm.gateway_internal_client import (
+    AIGatewayBudgetSuperseded,
+    AIGatewayInternalError,
+    AIGatewayNotConfigured,
+    set_budget,
+)
+
+# The gateway budgets a "product" attribution node; a routed run's token pins one.
+BUDGET_SCOPE_TYPE = "product"
+
+DEFAULT_LIMIT_USD = "500"
+DEFAULT_WINDOW_SECONDS = 86400
+
+
+def routed_products(products_csv: str) -> list[str]:
+    """The distinct products the allowlist routes, with scout skill qualifiers dropped.
+
+    An entry may narrow a product to one scout skill (``signals_scout:web-analytics``).
+    The budget key is the product node, which carries no skill, so both forms seed
+    the same product and a qualified entry must not become its own budget.
+    """
+    products = {entry.strip().split(":", 1)[0] for entry in products_csv.split(",") if entry.strip()}
+    return sorted(p for p in products if p)
+
+
+class Command(BaseCommand):
+    help = "Seed per-team, per-product spend budgets on the Go ai-gateway for routed products"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            action="append",
+            dest="team_ids",
+            required=True,
+            help="Team to seed. Repeat for several teams.",
+        )
+        parser.add_argument(
+            "--limit-usd",
+            default=DEFAULT_LIMIT_USD,
+            help=f"Ceiling per team per product, in dollars (default {DEFAULT_LIMIT_USD}).",
+        )
+        parser.add_argument(
+            "--window-seconds",
+            type=int,
+            default=DEFAULT_WINDOW_SECONDS,
+            help=f"Window the ceiling applies over (default {DEFAULT_WINDOW_SECONDS}).",
+        )
+        parser.add_argument("--dry-run", action="store_true", help="Print what would be written.")
+
+    def handle(self, *args, **options):
+        products_csv = settings.SANDBOX_AI_GATEWAY_PRODUCTS or ""
+        products = routed_products(products_csv)
+        if not products:
+            raise CommandError(
+                "SANDBOX_AI_GATEWAY_PRODUCTS is empty — no products are routed, so there is nothing to budget"
+            )
+
+        team_ids = options["team_ids"]
+        limit_usd = options["limit_usd"]
+        window_seconds = options["window_seconds"]
+        dry_run = options["dry_run"]
+
+        self.stdout.write(f"Routed products: {', '.join(products)}")
+        self.stdout.write(f"Teams: {', '.join(str(t) for t in team_ids)}")
+        self.stdout.write(f"Budget: ${limit_usd} per {window_seconds}s per team per product")
+
+        failures = 0
+        for team_id in team_ids:
+            for product in products:
+                target = f"team {team_id} {BUDGET_SCOPE_TYPE}/{product}"
+                if dry_run:
+                    self.stdout.write(f"[dry-run] would set {target}")
+                    continue
+                try:
+                    budget = set_budget(
+                        team_id=team_id,
+                        scope_type=BUDGET_SCOPE_TYPE,
+                        scope_value=product,
+                        limit_usd=limit_usd,
+                        window_seconds=window_seconds,
+                    )
+                except AIGatewayNotConfigured as exc:
+                    raise CommandError(str(exc)) from exc
+                except AIGatewayBudgetSuperseded as exc:
+                    # The row committed but a concurrent write's limit is what enforces.
+                    # Not a failure to retry: re-running cannot beat the newer value.
+                    self.stdout.write(self.style.WARNING(f"superseded, left alone: {target} ({exc})"))
+                    continue
+                except AIGatewayInternalError as exc:
+                    failures += 1
+                    self.stderr.write(self.style.ERROR(f"failed: {target} ({exc})"))
+                    continue
+
+                # The gateway sanitizes scope_value on write exactly as admission
+                # sanitizes a request's node. A value that came back different would
+                # be keyed on a string no request ever produces, so the budget would
+                # sit there enforcing nothing.
+                if budget.scope_value != product:
+                    failures += 1
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f"stored scope_value {budget.scope_value!r} differs from {product!r}; "
+                            "this budget would never bind"
+                        )
+                    )
+                    continue
+                self.stdout.write(self.style.SUCCESS(f"set {target} -> ${budget.limit_usd}/{budget.window_seconds}s"))
+
+        if failures:
+            raise CommandError(f"{failures} budget write(s) failed")

--- a/posthog/management/commands/test/test_seed_ai_gateway_budgets.py
+++ b/posthog/management/commands/test/test_seed_ai_gateway_budgets.py
@@ -1,0 +1,23 @@
+import pytest
+
+from posthog.management.commands.seed_ai_gateway_budgets import routed_products
+
+
+class TestRoutedProducts:
+    @pytest.mark.parametrize(
+        "products_csv,expected",
+        [
+            ("signals_scout,signals_research", ["signals_research", "signals_scout"]),
+            # A skill-qualified entry narrows which runs route, but the budget key is
+            # the product node, which carries no skill. Keeping the qualifier would
+            # seed "signals_scout:web-analytics", a string no request ever produces.
+            ("signals_scout:web-analytics", ["signals_scout"]),
+            # Qualified and bare entries for one product are one budget, not two.
+            ("signals_scout:web-analytics,signals_scout", ["signals_scout"]),
+            (" signals_scout , signals_research ", ["signals_research", "signals_scout"]),
+            ("", []),
+            (",,", []),
+        ],
+    )
+    def test_derives_budgetable_products(self, products_csv, expected):
+        assert routed_products(products_csv) == expected


### PR DESCRIPTION
## Problem

A customer whose Signals runs reach the Go ai-gateway can spend without any aggregate ceiling. Each run stops at its scoped token's cap, but nothing limits how many runs the team starts.

- The Python gateway holds a windowed spend pool per product. The Go gateway has no equivalent configured, so routed products sit between the per-run token cap and the team wallet with nothing in between.
- Interactive Signals runs are not affected. They stay on the Python gateway, so their per-run ceiling and per-user budgets still apply.

Closes nothing. No open issue tracks this.

## Changes

- An operator can now set a windowed spend ceiling per team per routed product, with `manage.py seed_ai_gateway_budgets --team-id <id>`.
- The command derives its product list from `SANDBOX_AI_GATEWAY_PRODUCTS`. It cannot budget a product that is not routed, or miss one that is.
- `set_budget` and `list_budgets` reach the gateway's budget admin API, alongside the existing wallet and credit calls.
- A superseded write reports as left alone rather than failed. The durable row committed, and a re-run cannot beat the newer value.
- A write whose stored `scope_value` differs from the requested one fails the command. The gateway sanitizes on write, and a budget keyed on the other string would never bind.
- Nothing changes until an operator runs the command. No user-visible surface changes, and no UI is touched.

> [!NOTE]
> Two limits are worth knowing before this lands. Budgets are per team, because every key the gateway builds is namespaced by team, so this gives per-team isolation and not a fleet-wide pool. Enforcement also fails open on a backend error, so the team wallet stays the only control that cannot be bypassed.

Per-user budgets are out of scope. A user-scoped row needs one row per user, and the gateway's budget key holds no product, so a user ceiling cannot be pre-seeded or split by product. That needs its own design.

## How did you test this code?

Automated tests only, in `posthog/llm/test_gateway_internal_client.py` and `posthog/management/commands/test/test_seed_ai_gateway_budgets.py`. Each group catches a regression no existing test covered:

- A 409 raises `AIGatewayBudgetSuperseded` and not a generic error. A caller that saw a generic error would retry a write that cannot win.
- A 2xx with a partial body raises instead of coercing to empty strings, which would report a budget on a node that has none.
- A skill-qualified allowlist entry such as `signals_scout:web-analytics` seeds `signals_scout`. Keeping the qualifier would write a budget keyed on a string no request produces.

Not run: no ai-gateway instance is reachable from this sandbox, so no write was made against a live budget API and the command was not executed end to end. `--dry-run` prints the intended writes without calling the gateway.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1787655233264019). Skills invoked: `/writing-pr-descriptions`.

The session started from a report that gateway traffic had moved and left the Signals spend controls behind. Reading the routing code showed the opposite for the interactive surface: `is_interactive_signals_run` requires no `ai_stage`, and `resolve_sandbox_ai_product` only returns a mintable product when `ai_stage` is present, so interactive runs never route and keep their existing controls. That narrowed the work from restoring three controls to adding the one that is genuinely absent for the scheduled pipeline.

Deriving the product list from the routing setting replaced an earlier plan to restate the list in the command, which would have drifted from `MINTABLE_PRODUCTS` and needed a cross-product import.

`services/llm-gateway/PARITY.md` still describes this migration inaccurately: it claims the Go gateway has no per-run ceiling and no unforgeable provenance, and both now exist for routed runs via the pinned scoped token. That correction belongs in a separate pass through `/auditing-llm-gateway-parity`, which also refreshes the recorded source revisions.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1787655233264019)*
