### PR TITLE
fix(warehouse-sources): make Plaid findable by "bank" in source search

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plaid/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plaid/source.py
@@ -59,6 +59,7 @@ class PlaidSource(ResumableSource[PlaidSourceConfig, PlaidResumeConfig]):
             name=SchemaExternalDataSourceType.PLAID,
             category=DataWarehouseSourceCategory.PAYMENTS___BILLING,
             label="Plaid",
+            keywords=["bank", "banking", "open banking", "financial", "fintech", "transactions"],
             caption="""Connect a Plaid Item to pull its accounts and transactions into the PostHog Data warehouse.
 
 You can find your client ID and secret in the [Plaid dashboard](https://dashboard.plaid.com/developers/keys). The access token identifies one linked Item (institution connection), obtained when a user completes Plaid Link — add one source per Item.""",


### PR DESCRIPTION
## Problem

Someone adding a data warehouse source who searches "bank" or "banking" to find Plaid gets no result. Plaid is an open-banking connector, but its catalog entry carried no search keywords, so the wizard's fuzzy search only matched its name ("Plaid"), label, and category ("Payments & billing") — none of which contain the words a user reaches for.

## Changes

- Searching "bank", "banking", "open banking", "financial", "fintech", or "transactions" in the New source catalog now surfaces Plaid.
- Mechanical: adds a `keywords` list to Plaid's `SourceConfig`. The value flows to the catalog search through the existing wizard endpoint — no new plumbing. Follows the convention already set by the `mono` connector, which lists "open banking" and "fintech".

## How did you test this code?

No manual testing was performed in this environment. The change is a static config value consumed by the existing catalog search; `ruff check` and `ruff format --check` pass on the touched file. No existing test asserts Plaid's config, so none needed updating.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent reviewing Replay Vision session summaries of the data-warehouse new-source onboarding flow. One session showed a user searching for a banking connector by category term rather than brand name and failing to find Plaid. Cross-referenced the connector catalog and confirmed Plaid declared no `keywords`, unlike comparable fintech connectors. Scope was kept to the one connector with direct evidence rather than a broad keyword sweep.

No customer data, names, or session content is included in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
