### PR TITLE
fix: clustering workflow logger kwargs

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -396,7 +396,7 @@ class GenerateAndDeliverEvalReportWorkflow(PostHogWorkflow):
             except WorkflowAlreadyStartedError:
                 # Same parent workflow replayed/retried with the same report_run_id.
                 # Safe to skip — the previous run is already handling emission.
-                temporalio.workflow.logger.info(
+                logger.info(
                     "Eval report signal workflow already started for this run",
                     evaluation_id=context.evaluation_id,
                     team_id=context.team_id,

--- a/posthog/temporal/ai_observability/evaluation_clustering/workflow.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/workflow.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 
+import structlog
 import temporalio.exceptions
 from temporalio import workflow
 
@@ -28,6 +29,8 @@ from posthog.temporal.ai_observability.trace_clustering.metrics import (
     record_noise_points,
 )
 from posthog.temporal.common.base import PostHogWorkflow
+
+logger = structlog.get_logger(__name__)
 
 
 @workflow.defn(name=SAMPLER_WORKFLOW_NAME)
@@ -181,7 +184,7 @@ class AIObservabilityEvaluationClusteringWorkflow(PostHogWorkflow):
         )
 
         if compute_result.skip_reason or not compute_result.eval_ids:
-            workflow.logger.info(
+            logger.info(
                 "skipping eval clustering run",
                 reason=compute_result.skip_reason,
                 job_id=inputs.job_id,

--- a/posthog/temporal/ai_observability/run_evaluation.py
+++ b/posthog/temporal/ai_observability/run_evaluation.py
@@ -4,6 +4,7 @@ from typing import Any, NotRequired, Required, TypedDict
 
 from django.conf import settings
 
+import structlog
 import temporalio
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import ApplicationError
@@ -50,6 +51,8 @@ from products.signals.backend.temporal.emit_eval_signal import (
     EmitEvalSignalWorkflow,
     emit_eval_signal_activity,
 )
+
+logger = structlog.get_logger(__name__)
 
 __all__ = [
     "BooleanEvalResult",
@@ -218,7 +221,7 @@ async def handle_terminal_user_error_result(
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
         except Exception:
-            temporalio.workflow.logger.exception(
+            logger.exception(
                 "Failed to send evaluation disabled email",
                 evaluation_id=evaluation["id"],
                 team_id=evaluation["team_id"],
@@ -365,7 +368,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                         execution_timeout=timedelta(minutes=5),
                     )
                 except Exception:
-                    temporalio.workflow.logger.exception(
+                    logger.exception(
                         "Failed to start eval signal workflow",
                         evaluation_id=evaluation["id"],
                         team_id=evaluation["team_id"],
@@ -379,7 +382,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                         retry_policy=RetryPolicy(maximum_attempts=2),
                     )
                 except Exception:
-                    temporalio.workflow.logger.exception(
+                    logger.exception(
                         "Failed to emit eval signal",
                         evaluation_id=evaluation["id"],
                         team_id=evaluation["team_id"],

--- a/posthog/temporal/ai_observability/tests/test_workflow_logger_kwargs.py
+++ b/posthog/temporal/ai_observability/tests/test_workflow_logger_kwargs.py
@@ -1,0 +1,46 @@
+import ast
+import pathlib
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+STDLIB_LOG_KWARGS = frozenset({"exc_info", "stack_info", "stacklevel", "extra"})
+LOG_METHODS = frozenset({"debug", "info", "warning", "warn", "error", "exception", "critical", "log"})
+
+
+def _targets_workflow_logger(node: ast.expr) -> bool:
+    if not isinstance(node, ast.Attribute) or node.attr != "logger":
+        return False
+    owner = node.value
+    if isinstance(owner, ast.Name):
+        return owner.id == "workflow"
+    return isinstance(owner, ast.Attribute) and owner.attr == "workflow"
+
+
+def _find_offenders() -> list[str]:
+    offenders = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            if node.func.attr not in LOG_METHODS or not _targets_workflow_logger(node.func.value):
+                continue
+            extras = sorted(k.arg for k in node.keywords if k.arg and k.arg not in STDLIB_LOG_KWARGS)
+            if extras:
+                rel = path.relative_to(PACKAGE_ROOT)
+                offenders.append(f"{rel}:{node.lineno} .{node.func.attr}({', '.join(f'{k}=' for k in extras)})")
+    return offenders
+
+
+def test_workflow_logger_is_never_called_with_structlog_kwargs() -> None:
+    offenders = _find_offenders()
+    assert not offenders, (
+        "temporalio's workflow.logger is a stdlib LoggerAdapter, so it raises TypeError on "
+        "structlog-style keyword arguments. The raise happens in workflow code, which fails the "
+        "workflow task and retries it forever, so the workflow hangs until its execution timeout "
+        "instead of failing fast.\n\n"
+        "Use this package's module-level structlog logger instead, which keeps the fields "
+        "queryable:\n"
+        "    logger = structlog.get_logger(__name__)\n"
+        "    logger.info('message', team_id=team_id)\n\n"
+        "Offending calls:\n" + "\n".join(f"  {line}" for line in offenders)
+    )

--- a/posthog/temporal/ai_observability/trace_clustering/workflow.py
+++ b/posthog/temporal/ai_observability/trace_clustering/workflow.py
@@ -3,6 +3,7 @@
 import json
 from datetime import timedelta
 
+import structlog
 import temporalio.exceptions
 from temporalio import workflow
 
@@ -51,6 +52,8 @@ from posthog.temporal.ai_observability.trace_clustering.models import (
     TraceLabelingMetadata,
 )
 from posthog.temporal.common.base import PostHogWorkflow
+
+logger = structlog.get_logger(__name__)
 
 
 def _compute_item_labeling_metadata(
@@ -200,7 +203,7 @@ class DailyTraceClusteringWorkflow(PostHogWorkflow):
         record_noise_points(compute_result.num_noise_points, analysis_level)
 
         if not compute_result.items:
-            workflow.logger.info(
+            logger.info(
                 "Skipping label/aggregates/emit: compute returned no items",
                 team_id=inputs.team_id,
                 analysis_level=analysis_level,


### PR DESCRIPTION
## Problem

Trace, generation, and evaluation clustering stopped producing results for most teams, and evaluation workflows hang whenever certain error handlers fire.

- `workflow.logger` is a stdlib `LoggerAdapter`. It raises `TypeError` on structlog-style keyword arguments.
- The raise happens in workflow code, so Temporal fails the workflow task and retries it forever. The workflow never completes and burns its full execution timeout, which is 45 minutes for a clustering child.
- The clustering coordinator awaits every child with a concurrency limit of 2, so each affected team holds a slot for that whole timeout.
- Three of the six calls are `.exception` inside `except Exception:` handlers on the evaluation path. `.exception` logs at ERROR, which is enabled at every configured level, so nothing gates them. When one fires the `TypeError` replaces the original exception, destroying the diagnostic the log existed to capture, and hangs the workflow.

These calls were no-ops until recently. A second `django.setup()` in the worker's import path re-ran `dictConfig` with `disable_existing_loggers: True`, which disabled the `temporalio` loggers. #86772 removed that accidental bootstrap, the loggers stayed enabled, and the latent calls started raising.

## Changes

- Six calls across four files now use each module's structlog logger, so the workflows complete and `team_id` stays a queryable field rather than text inside a message.
- The structlog logger is already the convention in this package: `trace_clustering/coordinator.py` logs `team_id` and `analysis_level` that way from workflow code today.
- A new guard, `posthog/temporal/ai_observability/tests/test_workflow_logger_kwargs.py`, fails if any call in the package passes structlog-style kwargs to `workflow.logger`.
- Tradeoff: `workflow.logger` suppresses logs during replay and a structlog logger does not, so these lines repeat on replay. The coordinator already accepts that, and losing the queryable field is worse.
- No UI changes.

## How did you test this code?

The guard catches a regression nothing else did: `test_empty_compute_skips_label_aggregates_and_emit` already executes the buggy line and passes either way, because the test-time root log level leaves INFO disabled. Verified the guard both directions - it fails on a reintroduced call, naming file and line, and passes once reverted.

Ran the affected suites locally: `trace_clustering/tests/test_workflow.py`, `evaluation_clustering/tests/test_workflow.py`, `test_run_evaluation.py`, `eval_reports/test/`, and the new guard. Repo-wide `mypy --cache-fine-grained .` clean.

Not checked: production behavior, and the claim that most teams were affected comes from production telemetry rather than anything reproduced here. The next scheduled run confirms the fix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.

The first version fixed only the two clustering sites and put the values in an f-string. An independent review pass found the four evaluation sites, including the three ungated `.exception` calls, and pointed at the structlog logger already used by the sibling coordinator module. Both changes came from that.

`extra={...}` was considered and rejected: `foreign_pre_chain` in `posthog/settings/logs.py` has no `ExtraAdder`, so `extra` keys never reach the rendered output. Worth noting separately that this silently affects every `workflow.logger` call in the repo that passes `extra`.

Diagnosis came from production telemetry. No operational figures, team identifiers, or customer data appear in this diff or description.
