### PR TITLE
fix(desktop): preserve onboarding concierge title

### DIFF
--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -208,6 +208,7 @@ def start_onboarding_session(team: Team, user: User) -> UUID | None:
             created = create_and_run_task(
                 team=team,
                 title=ONBOARDING_SESSION_TITLE,
+                title_manually_set=True,
                 description=description,
                 origin_product=Task.OriginProduct.USER_CREATED,
                 user_id=user.id,

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -725,6 +725,7 @@ class Task(DeletedMetaFields, models.Model):
         description: str,
         origin_product: "Task.OriginProduct",
         user_id: int,
+        title_manually_set: bool = False,
         repository: str | None = None,
         channel: Channel | None = None,
         slack_thread_context: Optional["SlackThreadContext"] = None,
@@ -850,6 +851,7 @@ class Task(DeletedMetaFields, models.Model):
         task = Task.objects.create(
             team=team,
             title=title,
+            title_manually_set=title_manually_set,
             description=description,
             origin_product=origin_product,
             client_provenance=client_provenance,
@@ -1040,6 +1042,7 @@ class Task(DeletedMetaFields, models.Model):
         description: str,
         origin_product: "Task.OriginProduct",
         user_id: int,
+        title_manually_set: bool = False,
         repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
         channel: Channel | None = None,
         create_pr: bool = True,
@@ -1091,6 +1094,7 @@ class Task(DeletedMetaFields, models.Model):
             description=description,
             origin_product=origin_product,
             user_id=user_id,
+            title_manually_set=title_manually_set,
             repository=repository,
             channel=channel,
             slack_thread_context=slack_thread_context,

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -115,6 +115,7 @@ class TestOnboardingSessionIdempotency(TestCase):
             self.assertEqual(kwargs["origin_key"], _origin_key(self.user.id))
             self.assertEqual(kwargs["client_provenance"], TaskClientProvenance.POSTHOG_DESKTOP)
             self.assertEqual(kwargs["model"], expected_model)
+            self.assertTrue(kwargs["title_manually_set"])
             return contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
 
         started, create_calls = self._start(create_side_effect=succeed)


### PR DESCRIPTION
## Problem

New PostHog Desktop users see the onboarding concierge session renamed from “Getting set up” to a title derived from its internal prompt.

## Changes

- The onboarding concierge session keeps its intentional “Getting set up” title.
- The task creation path now supports locking a server-selected title.

## How did you test this code?

- Extended the nearest onboarding creation test to catch a missing title lock.
- Ruff, formatting, compilation, and `hogli ci:preflight --fix` pass.
- Not run: the Django test requires the unavailable local Postgres service.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the change using the `posthog-desktop`, `writing-tests`, and `writing-pr-descriptions` skills. The change locks the server-selected title instead of adding onboarding-specific logic to the client title generator.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*