### PR TITLE
fix(desktop): enlarge spaces navigation icon

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
@@ -81,7 +81,7 @@ function NavIcon({
             aria-label={label}
             data-selected={isActive || undefined}
             onClick={onClick}
-            className="group relative shrink-0 text-muted-foreground data-selected:bg-fill-selected data-selected:text-foreground"
+            className="group relative shrink-0 pl-0 text-muted-foreground data-selected:bg-fill-selected data-selected:text-foreground"
           >
             {icon}
             {badge}
@@ -170,6 +170,7 @@ function ActivityNavItem({
       isActive={isActive}
       onClick={onClick}
       badge={badge}
+      className="pl-0"
     />
   );
 
@@ -278,7 +279,13 @@ export function NavRail() {
           return (
             <NavIcon
               key={pane}
-              icon={<Icon size={16} weight={isActive ? "fill" : "regular"} />}
+              icon={
+                <Icon
+                  className={pane === "spaces" ? "size-5" : undefined}
+                  size={pane === "spaces" ? 20 : 16}
+                  weight={isActive ? "fill" : "regular"}
+                />
+              }
               label={label}
               shortcut={destination.shortcut}
               isActive={isActive}


### PR DESCRIPTION
## Problem

The Spaces destination looks undersized beside the other icons in the desktop navigation rail.

## Changes

- The Spaces glyph now renders at 20px while other rail glyphs remain at 16px.
- Rail buttons remove extra left padding so their glyphs remain centered.
- Navigation behavior and button hit targets remain unchanged.

| Before | After |
| --- | --- |
| ![Spaces icon before](https://raw.githubusercontent.com/PostHog/pr-assets/758a1b032f4e1cf585bd165304290bb6b54b8fea/2026/08/332f689a-0161-4e90-bbb0-33c19d6b4f5c.png) | ![Spaces icon after](https://raw.githubusercontent.com/PostHog/pr-assets/b5ffdceb4cd08caaef111b867c6c55798e1770b4/2026/08/3112979f-1278-4566-b090-abc6d8fd7bee.png) |

## How did you test this code?

- Verified the before-and-after appearance in the running desktop app.
- Ran the desktop UI typecheck, Biome, and UI unit suite.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This visual adjustment does not change documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the requested adjustment with the local desktop app and repository tooling.
- Skills invoked: `/writing-ui-components`, `/posthog-desktop`, and `/writing-pr-descriptions`.
- Public artifact check: the screenshots show local development UI without customer data or secrets.