### PR TITLE
feat(tasks): expose onboarding domain research outcomes

### DIFF
--- a/products/tasks/backend/facade/domain_research.py
+++ b/products/tasks/backend/facade/domain_research.py
@@ -49,6 +49,7 @@ def research_domain(url: str) -> DomainResearch:
     try:
         scraped = scrape(url, source=EGRESS_SOURCE, formats=("markdown",), timeout=SCRAPE_TIMEOUT)
     except FirecrawlNotConfigured:
+        logger.warning("domain_research_firecrawl_not_configured")
         return DomainResearch(outcome="not_configured", url=url)
     except FirecrawlEgressBudgetExhausted:
         return DomainResearch(outcome="busy", url=url)

--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -236,4 +236,13 @@ def start_onboarding_session(team: Team, user: User) -> UUID | None:
         sources_enabled=facts.sources_enabled,
         sources_newly_enabled=facts.sources_newly_enabled,
     )
+    posthoganalytics.capture(
+        distinct_id=str(user.distinct_id),
+        event="Onboarding domain research completed",
+        properties={
+            "task_id": str(created.task_id),
+            "outcome": facts.research.outcome if facts.research else "not_applicable",
+        },
+        groups=groups(team.organization, team),
+    )
     return created.task_id

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -153,12 +153,29 @@ class TestOnboardingSessionIdempotency(TestCase):
             started, _ = self._start(create_side_effect=succeed)
 
         self.assertEqual(started, task_id)
-        capture.assert_called_once()
-        self.assertEqual(capture.call_args.kwargs["event"], "Onboarding prompt fallback used")
-        self.assertEqual(capture.call_args.kwargs["properties"]["reason"], "missing_placeholders")
+        fallback = next(
+            call for call in capture.call_args_list if call.kwargs["event"] == "Onboarding prompt fallback used"
+        )
+        self.assertEqual(fallback.kwargs["properties"]["reason"], "missing_placeholders")
         self.assertEqual(
-            capture.call_args.kwargs["properties"]["missing_placeholders"],
+            fallback.kwargs["properties"]["missing_placeholders"],
             ("brief", "channel_id", "followup", "homepage"),
+        )
+
+    def test_domain_research_outcome_is_captured_for_the_started_session(self) -> None:
+        task_id = uuid4()
+
+        with patch(f"{MODULE}.posthoganalytics.capture") as capture:
+            started, _ = self._start(
+                create_side_effect=contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
+            )
+
+        self.assertEqual(started, task_id)
+        capture.assert_called_once()
+        self.assertEqual(capture.call_args.kwargs["event"], "Onboarding domain research completed")
+        self.assertEqual(
+            capture.call_args.kwargs["properties"],
+            {"task_id": str(task_id), "outcome": "not_configured"},
         )
 
     def test_a_seeded_tour_reaches_the_prompt_with_both_ids(self) -> None:

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -164,11 +164,10 @@ class TestOnboardingSessionIdempotency(TestCase):
 
     def test_domain_research_outcome_is_captured_for_the_started_session(self) -> None:
         task_id = uuid4()
+        created = contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
 
         with patch(f"{MODULE}.posthoganalytics.capture") as capture:
-            started, _ = self._start(
-                create_side_effect=contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
-            )
+            started, _ = self._start(create_side_effect=lambda **_kwargs: created)
 
         self.assertEqual(started, task_id)
         capture.assert_called_once()


### PR DESCRIPTION
## Problem

PostHog Desktop operators cannot measure whether onboarding domain research succeeds or degrades.

**Why:** Concierge quality depends on reliable company context, and silent configuration failures make regressions hard to detect.

## Changes

- Operators can query each started concierge session's research outcome in Product Analytics.
- Missing Firecrawl configuration now produces a dedicated warning.
- The event captures only the task ID and outcome. It excludes domains and scraped content.

## How did you test this code?

- Domain research unit tests passed.
- Ruff lint and formatting checks passed.
- Database-backed onboarding tests could not start because the cloud checkout had no database host.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is needed because this change adds internal observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used PostHog production logs, Product Analytics, and AI Observability to diagnose the degraded path. Skills invoked: /exploring-llm-traces, /investigating-logs, /posthog-desktop, /instrument-product-analytics, and /writing-pr-descriptions.

The production secret remains an operational deployment change and is not included in this public repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*