### PR TITLE
fix(capture-logs): charge decompressed bytes on remote-write ingestion

### DIFF
--- a/rust/capture-logs/src/endpoints/prometheus.rs
+++ b/rust/capture-logs/src/endpoints/prometheus.rs
@@ -38,7 +38,8 @@ const ROW_OVERHEAD_BYTES: u64 = 256;
 /// below this; only expansion-bomb payloads exceed it.
 const MAX_EXPANSION_FACTOR: u64 = 16;
 
-/// Decode a snappy-compressed Prometheus remote-write v1 payload.
+/// Decode a snappy-compressed Prometheus remote-write v1 payload, returning the
+/// request and its decompressed size in bytes.
 ///
 /// Prometheus sends `Content-Encoding: snappy` using the snappy *block* format
 /// (not the framed format), so we decode the raw body ourselves — the global
@@ -47,7 +48,15 @@ const MAX_EXPANSION_FACTOR: u64 = 16;
 /// The block format's length header is sender-controlled, so the claimed
 /// decompressed size is checked against `max_decompressed_bytes` before any
 /// allocation happens.
-pub fn decode_write_request(body: &[u8], max_decompressed_bytes: usize) -> Result<WriteRequest> {
+///
+/// The size is returned because this route bypasses `RequestDecompressionLayer`,
+/// so the request body is still compressed when the handler sees it. The OTLP and
+/// logs paths report a body that layer already decompressed, and all three feed
+/// the same quota and rate-limiting counters, so the measure has to match.
+pub fn decode_write_request(
+    body: &[u8],
+    max_decompressed_bytes: usize,
+) -> Result<(WriteRequest, u64)> {
     let claimed =
         snap::raw::decompress_len(body).map_err(|e| anyhow!("snappy decode failed: {e}"))?;
     if claimed > max_decompressed_bytes {
@@ -58,8 +67,10 @@ pub fn decode_write_request(body: &[u8], max_decompressed_bytes: usize) -> Resul
     let decompressed = snap::raw::Decoder::new()
         .decompress_vec(body)
         .map_err(|e| anyhow!("snappy decode failed: {e}"))?;
-    WriteRequest::decode(decompressed.as_slice())
-        .map_err(|e| anyhow!("remote-write protobuf decode failed: {e}"))
+    let uncompressed_bytes = decompressed.len() as u64;
+    let request = WriteRequest::decode(decompressed.as_slice())
+        .map_err(|e| anyhow!("remote-write protobuf decode failed: {e}"))?;
+    Ok((request, uncompressed_bytes))
 }
 
 /// Translate a decoded remote-write request into `KafkaMetricRow` records — the
@@ -378,16 +389,17 @@ pub async fn export_prometheus_remote_write_http(
 
     tracing::Span::current().record("token", &token);
 
-    let write_request = match decode_write_request(&body, service.max_request_body_size_bytes) {
-        Ok(request) => request,
-        Err(e) => {
-            error!("Failed to decode remote-write request: {e}");
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": format!("{e}") })),
-            ));
-        }
-    };
+    let (write_request, uncompressed_bytes) =
+        match decode_write_request(&body, service.max_request_body_size_bytes) {
+            Ok(decoded) => decoded,
+            Err(e) => {
+                error!("Failed to decode remote-write request: {e}");
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "error": format!("{e}") })),
+                ));
+            }
+        };
 
     // 400, not 5xx: a batch that expands past the limit will never fit, so the
     // sender must drop it rather than retry it forever.
@@ -410,7 +422,7 @@ pub async fn export_prometheus_remote_write_http(
 
     if let Err(e) = service
         .sink
-        .write_metrics(&token, rows, body.len() as u64, timestamps_overridden)
+        .write_metrics(&token, rows, uncompressed_bytes, timestamps_overridden)
         .await
     {
         error!("Failed to send remote-write metrics to Kafka: {e}");

--- a/rust/capture-logs/tests/prometheus_remote_write_test.rs
+++ b/rust/capture-logs/tests/prometheus_remote_write_test.rs
@@ -272,7 +272,7 @@ fn snappy_round_trip_decodes_and_maps() {
     req.encode(&mut encoded).unwrap();
     let compressed = snap::raw::Encoder::new().compress_vec(&encoded).unwrap();
 
-    let decoded =
+    let (decoded, _) =
         decode_write_request(&compressed, MAX_DECOMPRESSED).expect("snappy+protobuf decode");
     let (rows, _) = write_request_to_kafka_rows(decoded);
 
@@ -311,6 +311,41 @@ fn rejects_decompression_bomb_before_allocating() {
     // The same payload passes with an adequate cap, so the rejection above is
     // the cap and not a decode failure.
     assert!(decode_write_request(&compressed, encoded.len()).is_ok());
+}
+
+/// Quota and rate limiting charge the payload size the handler reports. This
+/// route bypasses `RequestDecompressionLayer`, so that size has to come from the
+/// decoder: reporting the request body length charges the snappy-compressed
+/// size, while the OTLP and logs paths charge the decompressed size.
+#[test]
+fn reports_decompressed_payload_size() {
+    let req = WriteRequest {
+        timeseries: vec![series(
+            vec![label("__name__", "up"), label("job", "prometheus")],
+            (0..200)
+                .map(|i| Sample {
+                    value: 1.0,
+                    timestamp: now_ms() + i,
+                })
+                .collect(),
+        )],
+        metadata: vec![],
+    };
+    let mut encoded = Vec::new();
+    req.encode(&mut encoded).unwrap();
+    let compressed = snap::raw::Encoder::new().compress_vec(&encoded).unwrap();
+
+    let (_, uncompressed_bytes) =
+        decode_write_request(&compressed, MAX_DECOMPRESSED).expect("snappy+protobuf decode");
+
+    assert_eq!(uncompressed_bytes, encoded.len() as u64);
+    // Keeps the assertion above from passing vacuously: a payload that did not
+    // compress would satisfy it whichever size the decoder reported.
+    assert!(
+        uncompressed_bytes > compressed.len() as u64,
+        "fixture did not compress: {uncompressed_bytes} decompressed vs {} compressed",
+        compressed.len()
+    );
 }
 
 /// The prometheus route is deliberately kept off `RequestDecompressionLayer`, so


### PR DESCRIPTION
## Problem

A project sending Prometheus remote-write is metered on its snappy-compressed payload instead of the data it sent, so quota and rate limiting let through several times the volume they should.

- The remote-write route deliberately bypasses `RequestDecompressionLayer`, which rejects `Content-Encoding: snappy` with a 415. The body is therefore still compressed when the handler reads `body.len()`.
- The OTLP metrics and logs routes report a body that layer already decompressed.
- All three feed `metrics_ingestion_bytes_received_total`, so one counter mixed compressed and decompressed measures. The metrics ingestion consumer reads it for quota and rate limiting, and it also drives the volume figures for that path.
- On the fixture in the new test the gap is 1,058 bytes reported against 3,638 actual, a 3.4x under-charge. The real ratio tracks how well a sender's payload compresses.

No traffic reaches this route in production yet, so nothing is mis-metered today. It is worth fixing before any sender is pointed at it.

## Changes

- Remote-write senders are now charged the payload size they actually sent, matching how OTLP and logs are charged. `decode_write_request` returns the decompressed size next to the request, and the handler reports that to `write_metrics`. The size was already computed and then discarded.
- Mechanical: the function returns a tuple now, so its callers and one existing test destructure it. No other behavior changes, and the decompression cap is untouched.

## How did you test this code?

I am an agent. Everything below I ran; I did not test manually in a browser or against a live sender.

- Added `reports_decompressed_payload_size`. The regression it catches: someone reporting the request body length again, which no existing test noticed because the previous ones only assert decode success and the mapping to rows.
- Verified the test actually catches that, rather than passing by construction. Reintroducing the bug fails it (`left: 1058, right: 3638`); reverting passes it. That is also where the 3.4x figure comes from.
- The test asserts the decompressed size exceeds the compressed size, so it cannot pass on a fixture that failed to compress.
- Ran the crate's tests, clippy and `cargo fmt --check` locally. CI reports those with more authority.

Not checked: no remote-write traffic exists in production, so the corrected counter has not been observed against a real sender.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The counter's documented meaning ("Total uncompressed bytes received") is what this restores.

## 🤖 Agent context

Human-driven (agent-assisted).

Found while auditing metrics ingestion volume: comparing bytes per record across the logs and metrics paths surfaced that the two paths were not measuring the same thing. Scope was kept to the accounting bug. The `metrics1` per-sample `uuid` column and the ClickHouse row-rate limits found in the same audit are separate follow-ups, not touched here.
