### PR TITLE
fix(rbac): fail closed in queryset filter when resource access is none

### DIFF
--- a/ee/hogai/context/entity_search/context.py
+++ b/ee/hogai/context/entity_search/context.py
@@ -395,8 +395,8 @@ class EntitySearchContext:
     def _list_feature_flags_sync(
         self, limit: int = 100, offset: int = 0, active_filter: str | None = None
     ) -> tuple[list[dict[str, Any]], int]:
-        # Resource-level gate: filter_queryset_by_access_level only prunes object-level denials, so a
-        # role without feature flag access would still see flags here (also reachable via list_data).
+        # Stricter than filter_queryset_by_access_level's fail-closed baseline: a caller without
+        # feature flag access gets nothing, not even flags they created (also reachable via list_data).
         if not self.user_access_control.check_access_level_for_resource("feature_flag", "viewer"):
             return [], 0
 

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -890,9 +890,8 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
                 return queryset.none()
             return queryset
 
-        # filter_queryset_by_access_level trusts the view to have enforced resource-level access
-        # already, and this view is authorized as `comment` — so a caller denied the ticket resource
-        # would otherwise get the unfiltered ticket queryset back here.
+        # Stricter than filter_queryset_by_access_level's fail-closed baseline: a caller denied
+        # the ticket resource sees no ticket comments at all, not even on tickets they created.
         if not self.user_access_control.check_access_level_for_resource(
             "ticket", "viewer"
         ) and not self.user_access_control.has_any_specific_access_for_resource("ticket", "viewer"):

--- a/posthog/api/search.py
+++ b/posthog/api/search.py
@@ -124,9 +124,9 @@ class SearchViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     @extend_schema(
         parameters=[QuerySerializer],
         description=(
-            "Full-text search across project entities. Each result includes `user_access_level`, "
-            "the requesting user's resolved access level for that object (`none` means the user "
-            "cannot open it); `null` when access controls don't apply to the entity type."
+            "Full-text search across project entities. Objects the user cannot access are left out. "
+            "Each result includes `user_access_level`, the requesting user's resolved access level for "
+            "that object; `null` when access controls don't apply to the entity type."
         ),
     )
     def list(self, request: Request, **kw) -> HttpResponse:

--- a/posthog/api/test/test_search.py
+++ b/posthog/api/test/test_search.py
@@ -400,18 +400,16 @@ class TestSearchAccessLevels(APIBaseTest):
             if result["type"] == entity_type
         }
 
-    def test_blocked_resource_results_are_annotated_none(self):
+    def test_blocked_resource_results_are_hidden_except_own(self):
         FeatureFlag.objects.create(key="searchable-a", team=self.team, created_by=self.other_user)
-        FeatureFlag.objects.create(key="searchable-b", team=self.team, created_by=self.other_user)
+        own = FeatureFlag.objects.create(key="searchable-b", team=self.team, created_by=self.user)
         EventDefinition.objects.create(team=self.team, name="searchable-event")
         AccessControl.objects.create(team=self.team, resource="feature_flag", resource_id=None, access_level="none")
 
         response = self.client.get("/api/projects/@current/search?q=searchable")
 
         assert response.status_code == 200
-        flag_levels = self._levels_by_result_id(response, "feature_flag")
-        assert len(flag_levels) == 2
-        assert set(flag_levels.values()) == {"none"}
+        assert set(self._levels_by_result_id(response, "feature_flag")) == {str(own.id)}
         assert set(self._levels_by_result_id(response, "event_definition").values()) == {None}
 
     def test_object_grants_resolve_by_pk_for_short_id_entities(self):

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -1124,9 +1124,11 @@ class UserAccessControl:
         decision = self._blocked_and_allowed_object_ids(access_controls)
 
         # Apply filtering logic based on resource-level access
-        if not self.has_resource_access(resource) and decision.allowed_ids:
-            # User has "none" resource access but specific object access
-            # Only show objects they have explicit access to (plus created objects)
+        if not self.has_resource_access(resource):
+            # Resource-level "none": only explicitly granted objects and the user's own are
+            # visible, also when there are no grants at all. This has to hold without a
+            # permission layer above, because logic-layer and background callers reach here
+            # directly.
             if model_has_creator:
                 queryset = queryset.filter(Q(id__in=decision.allowed_ids) | Q(created_by=self._user))
             else:

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -1125,10 +1125,9 @@ class UserAccessControl:
 
         # Apply filtering logic based on resource-level access
         if not self.has_resource_access(resource):
-            # Resource-level "none": only explicitly granted objects and the user's own are
-            # visible, also when there are no grants at all. This has to hold without a
-            # permission layer above, because logic-layer and background callers reach here
-            # directly.
+            # Resource-level "none": show only granted objects and the user's own objects, also
+            # when there are no grants at all. Logic-layer and background callers reach this
+            # filter with no permission layer above it, so it must fail closed on its own.
             if model_has_creator:
                 queryset = queryset.filter(Q(id__in=decision.allowed_ids) | Q(created_by=self._user))
             else:

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -1286,6 +1286,23 @@ class TestSpecificObjectAccessControl(BaseUserAccessControlTest):
         assert self.notebook_3.id in notebook_ids  # Created by user
         assert self.notebook_2.id not in notebook_ids  # No access
 
+    def test_filter_queryset_with_none_resource_and_no_grants_shows_only_created(self):
+        from products.notebooks.backend.models import Notebook
+
+        self._create_access_control(resource="notebook", access_level="none")
+        self._clear_uac_caches()
+
+        notebook_ids = list(
+            self.user_access_control.filter_queryset_by_access_level(Notebook.objects.all()).values_list(
+                "id", flat=True
+            )
+        )
+
+        # Fail closed without object grants: only self-created notebooks, never the unfiltered
+        # queryset. This branch is reachable without any permission layer above (logic-layer and
+        # background callers), so the filter cannot rely on the view having enforced the resource level.
+        assert notebook_ids == [self.notebook_3.id]
+
     def test_filter_queryset_by_access_level_with_resource_access(self):
         """Test queryset filtering when user has resource-level access"""
         from products.notebooks.backend.models import Notebook

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -1299,8 +1299,8 @@ class TestSpecificObjectAccessControl(BaseUserAccessControlTest):
         )
 
         # Fail closed without object grants: only self-created notebooks, never the unfiltered
-        # queryset. This branch is reachable without any permission layer above (logic-layer and
-        # background callers), so the filter cannot rely on the view having enforced the resource level.
+        # queryset. Logic-layer and background callers reach this filter with no permission layer
+        # above it, so it cannot rely on the view to enforce the resource level.
         assert notebook_ids == [self.notebook_3.id]
 
     def test_filter_queryset_by_access_level_with_resource_access(self):

--- a/products/access_control/backend/tests/test_user_access_control_pbt.py
+++ b/products/access_control/backend/tests/test_user_access_control_pbt.py
@@ -466,7 +466,7 @@ def oracle_visible_object_ids(
     has_resource_access = oracle_resource_access_level(resource, resource_specs, is_org_admin) != NO_ACCESS_LEVEL
     creators = creator_ids if model_has_creator else set()
 
-    if not has_resource_access and allowed:
+    if not has_resource_access:
         return (allowed | creators) & all_ids
     if blocked:
         return all_ids - (blocked - creators)
@@ -741,8 +741,13 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
         allowlisted = uac.allowlisted_resource_ids_by_scope.get(resource)
         blocked = uac.blocked_resource_ids_by_scope.get(resource, frozenset())
         model_has_creator = model_has_created_by(model_cls)
+        has_resource_access = uac.has_resource_access(resource)
 
         def guard_admits(object_id: str) -> bool:
+            # No resource access and no allowlist: the schema drops the table (see
+            # Database.create_for), so nothing is readable.
+            if not has_resource_access and not allowlisted:
+                return False
             if model_has_creator and object_id in creator_ids:
                 return True
             if allowlisted:
@@ -750,7 +755,7 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
             return object_id not in blocked
 
         visible = {object_id for object_id in object_specs_by_id if guard_admits(object_id)}
-        assert visible == oracle_visible_object_ids(
+        expected = oracle_visible_object_ids(
             resource,
             resource_specs,
             object_specs_by_id,
@@ -758,6 +763,12 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
             model_has_creator=model_has_creator,
             is_org_admin=False,
         )
+        if has_resource_access or allowlisted:
+            assert visible == expected
+        else:
+            # REST still shows the user's own rows here; HogQL has no table to show them from.
+            assert visible == set()
+            assert expected <= creator_ids
 
     @given(
         data=object_resource_and_rows(),

--- a/products/access_control/backend/tests/test_user_access_control_pbt.py
+++ b/products/access_control/backend/tests/test_user_access_control_pbt.py
@@ -744,8 +744,8 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
         has_resource_access = uac.has_resource_access(resource)
 
         def guard_admits(object_id: str) -> bool:
-            # No resource access and no allowlist: the schema drops the table (see
-            # Database.create_for), so nothing is readable.
+            # No resource access and no allowlist: Database.create_for drops the table, so
+            # nothing is readable.
             if not has_resource_access and not allowlisted:
                 return False
             if model_has_creator and object_id in creator_ids:
@@ -766,7 +766,7 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
         if has_resource_access or allowlisted:
             assert visible == expected
         else:
-            # REST still shows the user's own rows here; HogQL has no table to show them from.
+            # REST still shows the user's own rows here. HogQL has no table to show them from.
             assert visible == set()
             assert expected <= creator_ids
 

--- a/products/engineering_analytics/backend/logic/sources.py
+++ b/products/engineering_analytics/backend/logic/sources.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple
 from uuid import UUID
 
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 
 from posthog.models.team import Team
 
@@ -321,16 +321,6 @@ def _accessible_sources(
     )
     if user_access_control is not None:
         sources = user_access_control.filter_queryset_by_access_level(sources)
-        if not user_access_control.has_resource_access("external_data_source"):
-            # "none" resource-level access: the platform filter drops nothing when the user holds no
-            # object grants, so fail closed here to self-created or explicitly granted sources.
-            granted_ids = [
-                source.id
-                for source in sources
-                if (level := user_access_control.access_level_for_object(source, explicit=True))
-                and level != NO_ACCESS_LEVEL
-            ]
-            sources = sources.filter(Q(created_by=user_access_control.user) | Q(id__in=granted_ids))
     return sources
 
 

--- a/products/engineering_analytics/backend/logic/sources.py
+++ b/products/engineering_analytics/backend/logic/sources.py
@@ -29,7 +29,6 @@ from django.db.models import QuerySet
 
 from posthog.models.team import Team
 
-from products.access_control.backend.facade.user_access_control import NO_ACCESS_LEVEL
 from products.engineering_analytics.backend.facade.contracts import GitHubSource, GitHubSourceNotConnectedError
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 from products.warehouse_sources.backend.facade.sources import github_schema_repo_endpoint

--- a/products/engineering_analytics/backend/tests/test_views.py
+++ b/products/engineering_analytics/backend/tests/test_views.py
@@ -42,9 +42,9 @@ class TestListGithubSourcesAccessControl(BaseTest):
         self.organization.save()
 
     def test_none_resource_access_fails_closed_to_self_created_sources(self) -> None:
-        # Guards filter_queryset_by_access_level's fail-closed baseline through the product
-        # surface: "none" resource access with no object grants must not enumerate the team's
-        # sources (#70825).
+        # A user with "none" resource access and no object grants must not enumerate the
+        # team's sources. The product surface relies on filter_queryset_by_access_level to
+        # fail closed here.
         mine = create_github_source(self.team, prefix="mine_", source_id="gh-mine")
         mine.created_by = self.user
         mine.save()
@@ -59,8 +59,8 @@ class TestListGithubSourcesAccessControl(BaseTest):
         )
         assert [source.id for source in visible] == [str(mine.id)]
 
-        # An explicit object grant survives the fail-closed guard. Only member and role grants count
-        # as grants in the filter; a default ("everyone") object row does not.
+        # An explicit object grant survives the fail-closed guard. The filter counts only member
+        # and role rows as grants. A default ("everyone") object row does not count.
         AccessControl.objects.create(
             team=self.team,
             resource="external_data_source",

--- a/products/engineering_analytics/backend/tests/test_views.py
+++ b/products/engineering_analytics/backend/tests/test_views.py
@@ -59,9 +59,14 @@ class TestListGithubSourcesAccessControl(BaseTest):
         )
         assert [source.id for source in visible] == [str(mine.id)]
 
-        # An explicit object grant survives the fail-closed guard.
+        # An explicit object grant survives the fail-closed guard. Only member and role grants count
+        # as grants in the filter; a default ("everyone") object row does not.
         AccessControl.objects.create(
-            team=self.team, resource="external_data_source", resource_id=str(theirs.id), access_level="editor"
+            team=self.team,
+            resource="external_data_source",
+            resource_id=str(theirs.id),
+            access_level="editor",
+            organization_member=self.organization_membership,
         )
         visible = list_github_sources(
             team=self.team, user_access_control=UserAccessControl(user=self.user, team=self.team)

--- a/products/engineering_analytics/backend/tests/test_views.py
+++ b/products/engineering_analytics/backend/tests/test_views.py
@@ -42,9 +42,9 @@ class TestListGithubSourcesAccessControl(BaseTest):
         self.organization.save()
 
     def test_none_resource_access_fails_closed_to_self_created_sources(self) -> None:
-        # filter_queryset_by_access_level returns the queryset UNFILTERED for a user with "none"
-        # resource access and no object grants — without the guard, such a user enumerates every
-        # GitHub source on the team.
+        # Guards filter_queryset_by_access_level's fail-closed baseline through the product
+        # surface: "none" resource access with no object grants must not enumerate the team's
+        # sources (#70825).
         mine = create_github_source(self.team, prefix="mine_", source_id="gh-mine")
         mine.created_by = self.user
         mine.save()

--- a/products/replay_vision/backend/tests/helpers.py
+++ b/products/replay_vision/backend/tests/helpers.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from django.utils import timezone
 
-from posthog.models import Team
+from posthog.models import Team, User
 from posthog.models.utils import uuid7
 
 from products.experiments.backend.models.experiment import Experiment
@@ -54,11 +54,11 @@ def seed_scanner_spend(scanner: ReplayScanner, credits: int, *, observations: in
     )
 
 
-def create_experiment(team: Team, flag_key: str) -> Experiment:
+def create_experiment(team: Team, flag_key: str, created_by: User | None = None) -> Experiment:
     """A launched-enough experiment with a multivariate flag, for targeting tests."""
     flag = FeatureFlag.objects.create(
         team=team,
         key=flag_key,
         filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
     )
-    return Experiment.objects.create(team=team, name=f"exp-{flag_key}", feature_flag=flag)
+    return Experiment.objects.create(team=team, name=f"exp-{flag_key}", feature_flag=flag, created_by=created_by)

--- a/products/replay_vision/backend/tests/test_access_control.py
+++ b/products/replay_vision/backend/tests/test_access_control.py
@@ -224,7 +224,7 @@ class TestReplayScannerAccessControl(_AccessControlTestCase):
     def test_experiment_targeting_hidden_from_a_viewer_without_experiment_access(self) -> None:
         # A scanner is viewable at a coarser grain than its targeted experiment; a viewer who can't
         # access the experiment must not learn its id or variants from the scanner payload.
-        experiment = create_experiment(self.team, "hidden-flag")
+        experiment = create_experiment(self.team, "hidden-flag", created_by=self.user)
         targeting = {"experiment_id": experiment.id, "variant": "test"}
         scanner = self._create_scanner(name="targeted", experiment_targeting=targeting)
         self._set_resource_default("replay_scanner", "viewer")
@@ -245,7 +245,7 @@ class TestReplayScannerAccessControl(_AccessControlTestCase):
         # The API redacts experiment_targeting to null for such an editor, and the editor form
         # writes the whole object back on save. Without the write-side guard, renaming the scanner
         # would silently clear targeting the caller can't even see.
-        experiment = create_experiment(self.team, "hidden-flag")
+        experiment = create_experiment(self.team, "hidden-flag", created_by=self.user)
         targeting = {"experiment_id": experiment.id, "variant": "test"}
         scanner = self._create_scanner(name="targeted", experiment_targeting=targeting)
         self._set_resource_default("replay_scanner", "editor")
@@ -292,7 +292,7 @@ class TestReplayScannerAccessControl(_AccessControlTestCase):
         # Guards the ?experiment_id= disclosure: a scanner-viewer who can't access the experiment must
         # not confirm a scanner targets it via the filter's match count. Distinct code path from the
         # serializer redaction above — the scanner is hidden from the list entirely, not just nulled.
-        experiment = create_experiment(self.team, "hidden-flag")
+        experiment = create_experiment(self.team, "hidden-flag", created_by=self.user)
         targeting = {"experiment_id": experiment.id, "variant": "test"}
         self._create_scanner(name="targeted", experiment_targeting=targeting)
         self._set_resource_default("replay_scanner", "viewer")


### PR DESCRIPTION
## Problem

A member denied a whole resource (resource-level "none") but holding no object grants sees **every object** on list surfaces that call `filter_queryset_by_access_level` without a DRF permission layer above it: logic-layer resolvers, background jobs, AI context builders, dashboard widgets.

The filter's none-branch only fired when the user held at least one object grant. With zero grants, the queryset came back unfiltered — the least-privileged configuration got the most access. The normal viewset path masks this (`AccessControlPermission` returns 403 before the queryset is built), so the gap only shows on direct callers. [#70825](https://github.com/PostHog/posthog/pull/70825) found it via engineering analytics source enumeration and patched that one product, flagging the root cause for the RBAC owners.

## Changes

- A member with resource-level "none" and no grants now sees only objects they created (or an empty list for models without a creator) on every surface that filters through `filter_queryset_by_access_level`. One condition changed: the fail-closed branch no longer requires grants to exist.
- Removes the engineering-analytics workaround from #70825 — its call site is back to one line, and its regression test now guards the central fix through the product surface.
- Global search no longer lists objects from a resource the member is denied. Before, they appeared with `user_access_level: "none"` so the UI could show them disabled (#69121). The endpoint description now says denied objects are left out.
- Mechanical: two stale comments updated (`posthog/api/comments.py`, `ee/hogai/.../entity_search/context.py`) — both sites keep their own stricter pre-gates; the comments now say the gates are deliberately stricter than the baseline instead of describing the old fail-open contract.

Behavior is unchanged for: viewset list endpoints (the permission layer already blocks resource-"none" callers), users holding any object grant (the branch fired for them before), the `project`/`organization`/`plugin` resources and non-entitled orgs (they resolve to the built-in default, never "none"), and org admins.

> [!WARNING]
> Customer-visible on the direct-caller surfaces: a resource-denied member with no grants currently sees full lists there and will start seeing only their own objects. That is the configured intent of the "none" rule, but it lands as a visibility change. Search results change the same way for the same member.
> The same applies to a user with no membership in the organization, since the resource level resolves to no access for them. Background surfaces that run as a user who left the organization (scheduled exports, subscriptions, Temporal activities) now see that user's own objects instead of every object.

> [!NOTE]
> Follow-up, not in this PR: the filter counts only member and role rows as object grants. An object shared with "everyone" as editor on a resource the member is denied stays hidden from lists, while `access_level_for_object` resolves it to editor and the detail endpoint serves it. Widening `allowed_ids` also changes the HogQL allowlist and subscription checks, so it lands separately.

## How did you test this code?

- New: `test_filter_queryset_with_none_resource_and_no_grants_shows_only_created` — pins the fail-closed baseline ("none" + no grants → created-only, never unfiltered). No existing test covered the zero-grants branch; this is the regression that shipped.
- Kept: the #70825 engineering-analytics test, now exercising the central fix end to end through source enumeration.
- Existing filter tests cover the grants and blocked branches unchanged.
- Property tests: the queryset oracle drops its "grants exist" condition. The HogQL guard model now mirrors the schema gate in `Database.create_for`, which drops the table when there is no resource access and no allowlist, so HogQL shows nothing where REST shows the member's own rows.
- Fixtures that leaned on the fail-open branch: replay vision experiments now name their creator, and the engineering analytics grant is a member grant.
- Search test renamed to assert only the member's own flag comes back.
- Run locally: access control, search, replay vision, and engineering analytics suites. HogQL is not run against a denied-resource query beyond the property test.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Written with Claude Code. The agent found the four failing test groups in Backend CI, proposed the fixes, and applied them after approval; the search behavior and the default-row follow-up were human decisions. Skills invoked: writing-pr-descriptions.

