### PR TITLE
fix(web-analytics): share vitals timeseries and path-breakdown precompute buckets

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1900,6 +1900,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             query: {
                                 kind: NodeKind.WebVitalsQuery,
                                 properties: webAnalyticsFilters,
+                                // Match the path-breakdown tile below so both tiles' precompute
+                                // reads hash to the same bucket job and share warm buckets. The
+                                // timeseries merges across all paths, so cleaning is result-neutral
+                                // here, but the hash is not — a mismatch builds a second bucket set.
+                                doPathCleaning: isPathCleaningEnabled,
                                 source: {
                                     kind: NodeKind.TrendsQuery,
                                     dateRange,


### PR DESCRIPTION
## Problem

The Web Vitals tab's timeseries tile falls back to a live query even when its buckets are warm, so enrolled teams never get the precompute speedup on that tile and it rebuilds buckets the path-breakdown tile already built.

- The timeseries and path-breakdown tiles were designed to share one bucket set.
- `doPathCleaning` reaches the bucket INSERT, so cleaning-on and cleaning-off hash to different precompute jobs.
- The path-breakdown tile sends `doPathCleaning`; the `WebVitalsQuery` timeseries tile never did, so it built a second, raw-path bucket set and missed the warm one.

## Changes

- The `WebVitalsQuery` timeseries tile now sends `doPathCleaning: isPathCleaningEnabled`, matching the path-breakdown tile.
- Both tiles now hash to the same bucket job and share warm buckets, so the timeseries serves from precompute and builds nothing extra.
- The timeseries result is unchanged: it merges across all paths, so path cleaning does not affect its numbers, only the bucket identity.

## How did you test this code?

- Verified in production query_log that the timeseries tile served live (`TrendsQuery`) while the path-breakdown tile served from precompute (`web_vitals_paths_lazy_query`) for the dogfood org, confirming the un-shared buckets.
- Confirmed `doPathCleaning` is a valid `WebVitalsQuery` field (inherited from `WebAnalyticsQueryBase`) and reaches the backend inner-query builder.
- Not run: a full local reproduction of the two-tile share; the backend job-hash behavior for `doPathCleaning` is already covered by the existing vitals precompute tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session verifying the vitals precompute deploy (#85944). Found via query_log that the timeseries tile never took the precompute path; traced it to the `doPathCleaning` job-hash mismatch. Skills invoked: /writing-code-comments, /writing-pr-descriptions.
