### PR TITLE
fix(web-analytics): use web analytics date presets on page reports and modal

### DIFF
--- a/frontend/src/scenes/web-analytics/PageReports.tsx
+++ b/frontend/src/scenes/web-analytics/PageReports.tsx
@@ -8,6 +8,7 @@ import { FilterBar } from 'lib/components/FilterBar'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 
+import { webAnalyticsDateMapping } from './constants'
 import { pageReportsLogic } from './pageReportsLogic'
 import { PathCleaningToggle } from './PathCleaningToggle'
 import { Tiles } from './WebAnalyticsDashboard'
@@ -53,7 +54,12 @@ export function PageReportsFilters({ tabs }: { tabs: JSX.Element }): JSX.Element
             top={tabs}
             left={
                 <div className="flex flex-row flex-wrap gap-2 items-center w-full min-w-0">
-                    <DateFilter dateFrom={dateFilter.dateFrom} dateTo={dateFilter.dateTo} onChange={setDates} />
+                    <DateFilter
+                        dateFrom={dateFilter.dateFrom}
+                        dateTo={dateFilter.dateTo}
+                        onChange={setDates}
+                        dateOptions={webAnalyticsDateMapping}
+                    />
                     <WebAnalyticsCompareFilter />
                     <LemonInputSelect
                         className="flex-1 min-w-0"

--- a/frontend/src/scenes/web-analytics/WebAnalyticsModal.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsModal.tsx
@@ -11,6 +11,7 @@ import { WebQuery } from 'scenes/web-analytics/tiles/WebAnalyticsTile'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { ProductTab } from './common'
+import { webAnalyticsDateMapping } from './constants'
 import { WebAnalyticsExport } from './WebAnalyticsExport'
 import { webAnalyticsLogic } from './webAnalyticsLogic'
 import { webAnalyticsModalLogic } from './webAnalyticsModalLogic'
@@ -43,7 +44,12 @@ export const WebAnalyticsModal = (): JSX.Element | null => {
             <div className="WebAnalyticsModal deprecated-space-y-4">
                 <div className="flex flex-row flex-wrap gap-2">
                     {productTab !== ProductTab.MARKETING && <WebPropertyFilters />}
-                    <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
+                    <DateFilter
+                        dateFrom={dateFrom}
+                        dateTo={dateTo}
+                        onChange={setDates}
+                        dateOptions={webAnalyticsDateMapping}
+                    />
                     <div className="ml-auto">
                         <WebAnalyticsExport query={modal.query} insightProps={modal.insightProps} />
                     </div>


### PR DESCRIPTION
## Problem

Picking a date range on a web analytics tab and then switching to Page Reports (or opening a tile's drill-down modal) shows the date picker with the wrong or unmatched preset label.

- The main web analytics tabs offer a "Last 28 days" preset that the default picker options do not include.
- Page Reports and the drill-down modal render the date picker with the default options, so a range set elsewhere has no matching preset there.

## Changes

- Page Reports and the web analytics drill-down modal now pass the shared `webAnalyticsDateMapping` to their date picker, matching every other web analytics tab.
- A range selected on one tab now shows the same preset label after switching tabs or opening the modal.

## How did you test this code?

- Traced the date state: Page Reports and the modal read the same shared `dateFilter` from `webAnalyticsLogic`, so only the picker's preset options differed.
- Confirmed the three other web analytics filter bars already pass `webAnalyticsDateMapping`; these two were the only omissions.
- Not run: a browser reproduction; the fix aligns two call sites with the established pattern.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, user reported a date component bug when changing web analytics tabs. Found two `DateFilter` call sites missing `dateOptions={webAnalyticsDateMapping}`. Skills invoked: /writing-pr-descriptions.
