### PR TITLE
feat(metrics): show the SDK install paths in the metrics empty state

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6351,7 +6351,7 @@ snapshots:
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--dark:
         hash: v1.k794b7964.980b559b32f54de08e32932b4d9e14e203c2ff084a7dd0fd16bce311dff6540e.RjlN-Zl7Betwf5MoCvu-4XAx75Dqu5OI8f_qbvOsQ20
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--light:
-        hash: v1.k794b7964.367868849fda12a0ca273c93bb6ad407a9b2cf0d76399547554cb9573b148a52.dBY6JqKOHSKACw47AmxmGDfiFgohjeuEVq_JspPeh8k
+        hash: v1.k794b7964.af14f7a5b3dfaf6798b66f81b80bb8ce6feb4e1052f198e93b2049956b2b0ab4.FvGIr17gWYEfiUdDTzI1vdffBD9QoChjzNbJukXbmZI
     scenes-app-experiments--experiment-with-multiple-metrics--dark:
         hash: v1.k794b7964.9a8e12167e506eda2587fc1ff4009fcd04818d71d5ebca5edae3886763cebf4f.pXfxrh4O5h1ylZCuDBDE0p_FcTT05xwy3XxaCdX1Tnw
     scenes-app-experiments--experiment-with-multiple-metrics--light:

--- a/products/metrics/frontend/components/MetricsSetupPrompt.tsx
+++ b/products/metrics/frontend/components/MetricsSetupPrompt.tsx
@@ -10,6 +10,9 @@ import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { useInterval } from 'lib/hooks/useInterval'
 import { apiHostOrigin } from 'lib/utils/apiHost'
+import javascriptImage from 'scenes/onboarding/shared/logos/javascript_web.svg'
+import nodejsImage from 'scenes/onboarding/shared/logos/nodejs.svg'
+import pythonImage from 'scenes/onboarding/shared/logos/python.svg'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
@@ -17,6 +20,20 @@ import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-genera
 import { metricsIngestionLogic } from '../metricsIngestionLogic'
 
 const HedgehogGreek = pngHoggie(greekPng)
+
+// The SDK paths come first: a product engineer on a PaaS reaches for the SDK they
+// already have, where the scrape agent below needs infra they may not run. The
+// agent's own Docker and Kubernetes paths are the tabbed snippets, not links.
+const FRAMEWORK_LINKS: { name: string; image?: string; docsLink: string }[] = [
+    {
+        name: 'JavaScript',
+        image: javascriptImage,
+        docsLink: 'https://posthog.com/docs/metrics/installation/javascript',
+    },
+    { name: 'Node.js', image: nodejsImage, docsLink: 'https://posthog.com/docs/metrics/installation/nodejs' },
+    { name: 'Python', image: pythonImage, docsLink: 'https://posthog.com/docs/metrics/installation/python' },
+    { name: 'Other', docsLink: 'https://posthog.com/docs/metrics/installation/other' },
+]
 
 const POLLING_INTERVAL_MS = 5000
 
@@ -98,7 +115,7 @@ const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | n
             productName="Metrics"
             thingName="metric"
             titleOverride="You haven't sent any metrics yet"
-            description="PostHog metrics works with any OpenTelemetry-compatible client. You don't need any PostHog-specific packages – just use standard OpenTelemetry libraries to send metrics via OTLP."
+            description="Send metrics from the PostHog SDK you already have, from any OpenTelemetry-compatible client over OTLP, or by scraping the Prometheus endpoints you already expose."
             isEmpty={true}
             productKey={ProductKey.METRICS}
             className={className}
@@ -109,8 +126,8 @@ const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | n
                         Read our{' '}
                         <Link to="https://posthog.com/docs/metrics" onClick={() => onDocsLinkClick('Metrics')}>
                             metrics docs
-                        </Link>{' '}
-                        or learn more about{' '}
+                        </Link>
+                        , learn more about{' '}
                         <Link
                             to="https://opentelemetry.io/docs/what-is-opentelemetry/"
                             target="_blank"
@@ -119,8 +136,26 @@ const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | n
                         >
                             OpenTelemetry
                         </Link>
-                        .
+                        , or pick a language to get started:
                     </p>
+                    <div className="flex flex-wrap gap-2">
+                        {FRAMEWORK_LINKS.map(({ name, image, docsLink }) => (
+                            <LemonButton
+                                key={name}
+                                type="secondary"
+                                size="small"
+                                to={docsLink}
+                                onClick={() => onDocsLinkClick(name)}
+                                icon={
+                                    image ? (
+                                        <img src={image} alt="" aria-hidden="true" className="w-5 h-5" />
+                                    ) : undefined
+                                }
+                            >
+                                {name}
+                            </LemonButton>
+                        ))}
+                    </div>
                     <div className="flex flex-col gap-1 w-full max-w-160">
                         <h5 className="m-0">Or scrape your existing Prometheus metrics</h5>
                         <p className="text-sm text-secondary m-0">
@@ -162,22 +197,12 @@ const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | n
                             ]}
                         />
                     </div>
-                    <div className="flex items-center gap-4">
-                        <div className="flex items-center gap-2 px-3 py-1.5 border border-accent rounded">
-                            <div className="relative flex items-center justify-center">
-                                <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
-                                <div className="w-2 h-2 bg-accent rounded-full" />
-                            </div>
-                            <span className="text-sm">Watching for metrics</span>
+                    <div className="flex items-center gap-2 px-3 py-1.5 border border-accent rounded">
+                        <div className="relative flex items-center justify-center">
+                            <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
+                            <div className="w-2 h-2 bg-accent rounded-full" />
                         </div>
-                        <LemonButton
-                            type="secondary"
-                            size="small"
-                            to="https://posthog.com/docs/metrics"
-                            onClick={() => onDocsLinkClick('Docs')}
-                        >
-                            View docs
-                        </LemonButton>
+                        <span className="text-sm">Watching for metrics</span>
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Problem

Someone who lands on an empty `/metrics` and wants to send a metric from their app has no entry point. The empty state links only the top-level `/docs/metrics`, even though six per-path install pages already exist — three of them for the `posthog.metrics` SDK that has shipped in posthog-js, posthog-node, and posthog-python.

The only copy-pasteable thing on the screen is the Prometheus scrape agent, which needs infrastructure a product engineer on a PaaS will never run. Logs and tracing both lead with a row of language buttons pointing at their per-language docs; metrics has none.

This is follow-up to feedback on #87918: check what logs and traces do in their empty states.

## Changes

- Adds the language button row logs and tracing already have, ordered SDK-first so the developer path comes before the collector path: JavaScript, Node.js, Python, then Other for any OTLP exporter. Each points at the matching existing docs page; no new docs were needed.
- Drops the "View docs" button, which duplicated the inline "metrics docs" link a few lines above it in the same panel.
- Rewrites the description to name all three routes. It previously said "You don't need any PostHog-specific packages", which stopped being true when the SDK metrics API shipped — the SDK path *is* a PostHog package.
- The Prometheus agent section keeps its Docker and Kubernetes tabs. Those are the agent's own two paths, and the copy-pasteable snippets serve them better than a link would, so they are deliberately not duplicated as buttons.

Unchanged: the "Watching for metrics" poll, the hedgehog (`greek` is a shared asset used in eight places, not a logs-specific one), and the docs-click telemetry.

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check`: no errors in `products/metrics`. The handful it reports are pre-existing, in `cdp`, `posthog_ai`, and `signals` — none of which this PR touches.
- oxlint and oxfmt pass.
- Verified every one of the four docs URLs resolves to a real page rather than a 404, and that `/docs/metrics/installation/javascript` documents the `posthog.metrics` SDK path this change is meant to surface.
- Read against `products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx` and `products/tracing/.../SetupPrompt.tsx` so the markup, telemetry, and copy shape match the siblings.
- **Not done: no screenshot.** The empty state only renders when a project has never ingested a metric, and the local instance forced a first-run goal picker over the scene that I could not dismiss headlessly. The change is a button row copied structurally from logs, so a reviewer can compare the two files, but it has not been seen rendered. Happy to add one if someone can grab it.

No tests added: this is presentational, `MetricsSetupPrompt` has no test file today, and I could not name a regression a test here would catch that the typecheck does not.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This links docs pages that already exist.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Desktop). Skills used: `/building-product-empty-states`, `/writing-tests`, `/writing-pr-descriptions`.
- Worth flagging for whoever picks up the follow-up: all four observability SetupPrompts (metrics, logs, tracing, error tracking) are built on the deprecated `ProductIntroduction`, while 12 products have moved to the shared `ProductEmptyState` system and AI observability has already migrated off its SetupPrompt. `.claude/skills/building-product-empty-states/SKILL.md` names metrics in the remaining migration list. This PR deliberately does not migrate — doing metrics alone would make it look unlike the two siblings it is here to match. Better as one cross-product change.
- The in-app onboarding is thinner than the empty state and untouched here: `MetricsSDKInstructions` wires one entry (OpenTelemetry) against logs' ten, because `docs/onboarding/metrics/` only has an `opentelemetry.tsx` installer. Adding per-language installers there is real authoring work, not wiring.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
