### PR TITLE
feat(loops): expose sandbox environment selection

### DIFF
--- a/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
@@ -10,6 +10,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useBluebirdFlag } from "@posthog/ui/features/feature-flags/useBluebirdFlag";
 import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
+import { useSandboxEnvironments } from "@posthog/ui/features/settings/sections/environments/useSandboxEnvironments";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { Button } from "@posthog/ui/primitives/Button";
@@ -170,6 +171,29 @@ export function LoopForm({
   const channelsEnabled =
     useSidebarStore((s) => s.channelsEnabled) && bluebirdEnabled;
   const showContextField = channelsEnabled || !!values.contextTarget;
+  const { environments, isLoading: environmentsLoading } =
+    useSandboxEnvironments();
+  const sandboxEnvironmentOptions = useMemo(() => {
+    const options = [
+      { value: "", label: "Default environment" },
+      ...environments.map((environment) => ({
+        value: environment.id,
+        label: environment.name,
+      })),
+    ];
+    if (
+      values.sandboxEnvironmentId &&
+      !environments.some(
+        (environment) => environment.id === values.sandboxEnvironmentId,
+      )
+    ) {
+      options.push({
+        value: values.sandboxEnvironmentId,
+        label: "Unavailable environment",
+      });
+    }
+    return options;
+  }, [environments, values.sandboxEnvironmentId]);
 
   const createLoop = useCreateLoop();
   const updateLoop = useUpdateLoop(loop?.id ?? "");
@@ -434,6 +458,25 @@ export function LoopForm({
                       ? [repository, ...prev.repositories.slice(1)]
                       : prev.repositories.slice(1),
                   }))
+                }
+              />
+            </Field>
+
+            <Field
+              label="Sandbox environment"
+              hint="Applies its environment variables, network access, and image to every run."
+            >
+              <SettingsOptionSelect
+                value={values.sandboxEnvironmentId ?? ""}
+                options={sandboxEnvironmentOptions}
+                disabled={isSubmitting || environmentsLoading}
+                size="lg"
+                ariaLabel="Sandbox environment"
+                placeholder={
+                  environmentsLoading ? "Loading environments…" : undefined
+                }
+                onValueChange={(value) =>
+                  patch({ sandboxEnvironmentId: value || null })
                 }
               />
             </Field>

--- a/products/desktop/packages/ui/src/features/loops/loopFormTypes.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopFormTypes.test.ts
@@ -376,6 +376,24 @@ function baseLoop(): LoopSchemas.Loop {
 }
 
 describe("loopToFormValues round trip", () => {
+  it("preserves a loop's sandbox environment in the write payload", () => {
+    const values = loopToFormValues({
+      ...baseLoop(),
+      sandbox_environment_id: "environment-123",
+    });
+
+    expect(values.sandboxEnvironmentId).toBe("environment-123");
+    expect(formValuesToLoopWrite(values).sandbox_environment).toBe(
+      "environment-123",
+    );
+  });
+
+  it("writes null when the loop uses the default sandbox environment", () => {
+    expect(
+      formValuesToLoopWrite(validFormValues()).sandbox_environment,
+    ).toBeNull();
+  });
+
   it("maps a loop back into form values that write the same shape", () => {
     const loop = {
       id: "loop-1",

--- a/products/desktop/packages/ui/src/features/loops/loopFormTypes.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopFormTypes.ts
@@ -51,6 +51,7 @@ export interface LoopFormValues {
    * unrelated change never drops a loop's other repository associations.
    */
   repositories: LoopSchemas.LoopRepositoryEntry[];
+  sandboxEnvironmentId: string | null;
   triggers: LoopTriggerDraft[];
   behaviors: LoopSchemas.LoopBehaviors;
   notifications: LoopSchemas.LoopNotifications;
@@ -240,6 +241,7 @@ export function emptyLoopFormValues(): LoopFormValues {
     model: "",
     reasoningEffort: null,
     repositories: [],
+    sandboxEnvironmentId: null,
     triggers: [defaultLoopScheduleTrigger()],
     behaviors: defaultLoopBehaviors(),
     notifications: defaultLoopNotifications(),
@@ -280,6 +282,7 @@ export function loopToFormValues(loop: LoopSchemas.Loop): LoopFormValues {
     model: loop.model,
     reasoningEffort: loop.reasoning_effort,
     repositories: [...loop.repositories],
+    sandboxEnvironmentId: loop.sandbox_environment_id,
     triggers: loop.triggers.map((trigger) => ({
       key: trigger.id,
       id: trigger.id,
@@ -313,6 +316,7 @@ export function formValuesToLoopWrite(
     model: values.model.trim(),
     reasoning_effort: values.reasoningEffort,
     repositories: values.repositories,
+    sandbox_environment: values.sandboxEnvironmentId,
     triggers: values.triggers.map((trigger) => ({
       id: trigger.id,
       type: trigger.type,


### PR DESCRIPTION
## Problem

People configuring unattended Loops cannot select a custom sandbox environment in Desktop. This prevents Loops from using required environment variables, network policy, and custom images.

**Why:** Environment-dependent Loops otherwise fail before doing useful work.

## Changes

- Adds a sandbox environment selector to Loop options.
- Persists custom or default environment choices through create and edit flows.
- Preserves existing selections when environment metadata is temporarily unavailable.
