### PR TITLE
chore(tasks): move codex/claude routing docstring onto runtime_adapter

### DIFF
--- a/products/tasks/backend/logic/services/custom_prompt_internals.py
+++ b/products/tasks/backend/logic/services/custom_prompt_internals.py
@@ -104,11 +104,13 @@ class CustomPromptSandboxContext:
     agent server's default when ``None``. Used by evals to pin a specific
     model so cross-run comparisons are stable."""
     runtime_adapter: str | None = None
+    """The agent harness that serves ``model`` (``"claude"`` → Anthropic, ``"codex"`` → OpenAI).
+    Set it alongside a non-default ``model``: the agent server derives the provider from the
+    adapter, so a model handed over with no adapter can't be routed and falls back to the server
+    default. ``None`` keeps the agent server's default harness (only valid when ``model`` is also
+    ``None``)."""
     runtime: str = "acp"
-    """The agent runtime that serves ``model`` (``"claude"`` → Anthropic, ``"codex"`` → OpenAI).
-    Set it alongside a non-default ``model``: the agent server derives the provider from the runtime,
-    so a model handed over with no runtime can't be routed and falls back to the server default.
-    ``None`` keeps the agent server's default runtime (only valid when ``model`` is also ``None``)."""
+    """The agent protocol driving the task's runs (``Task.Runtime``: ``"acp"`` or ``"pi"``)."""
     reasoning_effort: str | None = None
     """Reasoning-effort tier for ``model`` (e.g. ``"xhigh"``). Only meaningful alongside a pinned
     ``model`` + ``runtime_adapter``; ``None`` keeps the model's default effort. The supported tiers


### PR DESCRIPTION
## Problem

Engineers checking whether multi-turn sandbox sessions support Codex models read the routing rules on the wrong field and can conclude the runner is Anthropic-only.

- The claude/codex docstring sits on `CustomPromptSandboxContext.runtime`, which selects the agent protocol (`acp` / `pi`).
- The field it describes, `runtime_adapter`, has no docstring.

## Changes

- The harness-routing docstring (`"claude"` → Anthropic, `"codex"` → OpenAI) moves onto `runtime_adapter`, the field it describes.
- `runtime` gets a correct one-line docstring naming the protocol choice.
- Comment-only. Nothing user-visible changes.

## How did you test this code?

Docstring-only diff. `ruff check` and `ruff format --check` pass on the file. Pytest was not run, because comments cannot change behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Produced while investigating whether `MultiTurnSession` is limited to Anthropic models. It is not: the turn log it polls is runtime-agnostic ACP, and Codex-routed runs complete in production. This misplaced docstring was the likely seed of the Anthropic-only impression. A defensive change that defaulted headless Codex custom-prompt runs to the `full-access` permission mode was implemented, then reverted, because production Codex runs complete MCP tool calls under the default `auto` mode. Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`. Directed by Alex Lebedev; assignee left unset because no verified GitHub handle is available in this session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
