### PR TITLE
chore(replay-vision): graduate the send-reasoning flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -485,7 +485,6 @@ export const FEATURE_FLAGS = {
     REPLAY_VISION_ANALYSIS_NUDGE: 'replay-vision-analysis-nudge', // owner: #team-replay, in-player nudge offering an AI-drafted scanner after analyzing several recordings
     REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT: 'replay-vision-model-tier-naming-experiment', // owner: #team-replay multivariate=control,test,lite-standard-pro
     REPLAY_VISION_SCOUT_DIGESTS: 'replay-vision-scout-digests', // owner: #team-replay, scanner digests backed by Signals scouts instead of vision actions
-    REPLAY_VISION_SEND_REASONING: 'replay-vision-send-reasoning', // owner: #team-replay, gates the "include reasoning" checkbox on scanner alerts
     REVAMPED_PY_NOTEBOOKS: 'revamped-py-notebooks', // owner: #team-data-tools
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     REVIEW_HOG: 'review-hog', // owner: #team-devex, gates the Code review menu entry and scene (staff bypass the flag)

--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -12,14 +12,12 @@ import {
 } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSearchableSelect } from 'lib/lemon-ui/LemonSelect/LemonSearchableSelect'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
 import { Spinner } from 'lib/lemon-ui/Spinner'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { timeZoneLabel } from 'lib/utils/timezones'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -415,7 +413,6 @@ function ConditionSection({ scannerId }: { scannerId: string }): JSX.Element {
     const { actionForm, actionFormErrors } = useValues(actionEditorSceneLogic)
     const { setActionFormValue } = useActions(actionEditorSceneLogic)
     const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const everyMatch = actionForm.alert_frequency === AlertConfigFrequencyEnumApi.EveryMatch
     const isScorer = scanner?.scanner_type === 'scorer'
@@ -532,14 +529,12 @@ function ConditionSection({ scannerId }: { scannerId: string }): JSX.Element {
             {actionFormErrors?.min_score ? (
                 <span className="text-xs text-danger">{String(actionFormErrors.min_score)}</span>
             ) : null}
-            {featureFlags[FEATURE_FLAGS.REPLAY_VISION_SEND_REASONING] ? (
-                <LemonCheckbox
-                    checked={actionForm.alert_include_reasoning}
-                    onChange={(checked) => setActionFormValue('alert_include_reasoning', checked)}
-                    label="Include the observation's reasoning in the message"
-                    data-attr="vision-action-alert-include-reasoning"
-                />
-            ) : null}
+            <LemonCheckbox
+                checked={actionForm.alert_include_reasoning}
+                onChange={(checked) => setActionFormValue('alert_include_reasoning', checked)}
+                label="Include the observation's reasoning in the message"
+                data-attr="vision-action-alert-include-reasoning"
+            />
             <span className="text-xs text-muted">
                 {everyMatch
                     ? 'Checked every few minutes; each notification covers the new matches since the last check.'


### PR DESCRIPTION
## Problem

The `replay-vision-send-reasoning` flag gated the "Include the observation's reasoning in the message" checkbox on Replay Vision scanner alerts. It sat at 100% rollout with no targeting conditions, so the gate no longer decided anything — every user already saw the checkbox. Leaving it in place keeps a flag on the books that a future reader has to look up before touching this form.

## Changes

- No visible change: the reasoning checkbox stays exactly where it is, for the same people who already see it.
- Mechanical: removes the flag conditional, its `FEATURE_FLAGS` entry, and the now-unused `featureFlagLogic` wiring in `ConditionSection`.

Follow-up, once this is deployed: delete the flag in PostHog. Deleting it before the deploy lands would hide the checkbox for users still on the old bundle.

## How did you test this code?

Automated only — no manual testing was done, and the app was not run.

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in either changed file (the run reports pre-existing errors elsewhere from an unbuilt `@posthog/quill` workspace).
- `npx jest replay_scanners` — the existing `replay_scanners` suites pass. They already cover `alert_include_reasoning` round-tripping through `buildActionBody` and the form, which is the behavior this diff has to preserve.
- No new tests. A flag removal that preserves behavior has no new regression to catch that the existing suites don't.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-visible behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Desktop) at the assignee's direction. No repo skills were invoked; the diff is a flag removal with no migration, DRF, or new-component surface.

The starting question was whether the gated control had a `data-attr` worth pulling usage stats for, with flag cleanup as the fallback if it didn't. It does — `vision-action-alert-include-reasoning` — and autocapture shows the checkbox is actively used, more than any sibling control in the same alert form. That pointed at graduating the flag rather than removing the feature, so `result = true`: keep the checkbox, drop the gate. The usage figures stayed out of this description per the public-repo rule.

`hogli ci:preflight` could not run in this environment (no Python env on the box); `pnpm --filter=@posthog/frontend fix` was run instead and left the diff unchanged.

Public artifact: nothing here carries non-public material. No customer conversation, ticket, or log fed the change, and no fixtures or sample data were added.
