### PR TITLE
feat(tasks): include origin_key in task analytics events

### DIFF
--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -504,6 +504,8 @@ class Task(DeletedMetaFields, models.Model):
                 "repository": self.repository,
                 "repositories": self.repositories or ([self.repository] if self.repository else []),
             }
+            if self.origin_key:
+                all_properties["origin_key"] = self.origin_key
             if properties:
                 all_properties.update(properties)
             (capture_fn or posthoganalytics.capture)(

--- a/products/tasks/backend/tests/test_task_capture.py
+++ b/products/tasks/backend/tests/test_task_capture.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+from posthog.models.user import User
+
+from products.tasks.backend.models import Task
+
+
+class TestTaskCaptureEvent(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name="Northwind")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create(email="ada@northwind.example", distinct_id="ada-distinct")
+
+    def _task(self, **kwargs) -> Task:
+        return Task.objects.create(
+            team=self.team,
+            title="Getting set up",
+            description="prompt",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.user,
+            **kwargs,
+        )
+
+    def test_origin_key_reaches_analytics_only_when_set(self):
+        capture = MagicMock()
+
+        keyed = self._task(origin_key="desktop_onboarding_session:1")
+        keyed.capture_event("task_created", capture_fn=capture)
+        self.assertEqual(
+            capture.call_args.kwargs["properties"]["origin_key"],
+            "desktop_onboarding_session:1",
+        )
+
+        capture.reset_mock()
+        unkeyed = self._task()
+        unkeyed.capture_event("task_created", capture_fn=capture)
+        self.assertNotIn("origin_key", capture.call_args.kwargs["properties"])


### PR DESCRIPTION
## Problem

Analytics cannot reliably identify desktop onboarding concierge sessions.
The `task_created` event carries the task's title but not its `origin_key`, so dashboards find concierge sessions by matching the user-facing string "Getting set up".
A copy change breaks those queries silently, and any user task with the same title is a false positive.

## Changes

- Task analytics events (`task_created` and the other `Task.capture_event` events) now carry `origin_key` when the task has one, e.g. `desktop_onboarding_session:<user id>`.
- Dashboards and canvases can filter on the durable key instead of the title.
- Tasks without an `origin_key` are unchanged: the property is omitted, not sent as null.

## How did you test this code?

- `test_task_capture.py` guards one regression: dropping `origin_key` from the capture payload silently reverts concierge dashboards to title matching. No existing test asserts the `Task.capture_event` payload, and the onboarding-session tests mock task creation, so the case could not extend them.
- Not run locally: the test needs a Django test database, and creating one timed out in this sandbox. CI runs it.
- `hogli ci:preflight --fix` passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, during a desktop-onboarding analytics session that found the title string was the only way to identify concierge sessions in events.
Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
