### PR TITLE
chore(ci): measure github api cost of ci steps

### DIFF
--- a/.github/scripts/gh-api-cost-probe.sh
+++ b/.github/scripts/gh-api-cost-probe.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Measures how many GitHub REST requests a CI step costs, by reading the token's
+# own /rate_limit bucket before and after it.
+#
+# GitHub documents /rate_limit as not counting against the limit it reports, so
+# sampling is free and can bracket every step under test. The bucket belongs to
+# whichever token authenticates the sample, so PROBE_TOKEN must be the same token
+# the step under test uses, or the reading describes a different bucket.
+#
+# Throwaway: this exists for the rate-limit investigation and is deleted with it.
+
+set -euo pipefail
+
+STATE_DIR="${RUNNER_TEMP:-/tmp}/gh-api-cost-probe"
+POSTHOG_HOST='https://us.i.posthog.com'
+EVENT_NAME='github_api_cost_probe'
+SUMMARY_HEADER_SENTINEL="$STATE_DIR/.summary-header-written"
+
+die() {
+    echo "::error::$*"
+    exit 1
+}
+
+require_token() {
+    # A silent fall back to github.token would still produce a plausible-looking
+    # delta, measured against the wrong bucket. Fail instead.
+    [[ -n "${PROBE_TOKEN:-}" ]] || die 'PROBE_TOKEN is empty; the App token mint failed and the measurement would read the wrong bucket'
+}
+
+# sample <name> — records the core bucket's counters under <name>.
+sample() {
+    local name="$1"
+    require_token
+    mkdir -p "$STATE_DIR"
+
+    local body
+    body=$(curl -fsS --connect-timeout 10 \
+        -H "Authorization: Bearer ${PROBE_TOKEN}" \
+        -H 'Accept: application/vnd.github+json' \
+        -H 'X-GitHub-Api-Version: 2022-11-28' \
+        https://api.github.com/rate_limit)
+
+    local used limit reset
+    used=$(jq -er '.resources.core.used' <<<"$body")
+    limit=$(jq -er '.resources.core.limit' <<<"$body")
+    reset=$(jq -er '.resources.core.reset' <<<"$body")
+
+    printf '%s %s %s\n' "$used" "$reset" "$limit" >"$STATE_DIR/$name"
+    echo "sample[$name] used=$used limit=$limit reset=$reset"
+
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        {
+            echo "${name}_used=$used"
+            echo "${name}_reset=$reset"
+        } >>"$GITHUB_OUTPUT"
+    fi
+}
+
+# calibrate [n] — spends n requests on a known-cost call and asserts the bucket
+# moved by exactly n.
+#
+# /rate_limit cannot be assumed to describe the token that asks. Measured against
+# a GitHub CLI user-to-server token, it reported used=0 and reset=now+3600 on
+# every call while `X-RateLimit-Used` on real endpoints read 1132 and climbed by
+# one per request: for that token type the endpoint tracks a different, empty
+# bucket. Installation tokens are the case this harness measures and they are
+# believed to report correctly, but "believed" is not a measurement. Every job
+# proves its instrument before trusting a single number out of it.
+calibrate() {
+    local n="${1:-3}"
+    require_token
+    [[ -n "${GITHUB_REPOSITORY:-}" ]] || die 'GITHUB_REPOSITORY is required to calibrate'
+
+    sample cal_before >/dev/null
+
+    local header_used='' i
+    for ((i = 0; i < n; i++)); do
+        header_used=$(curl -fsS -o /dev/null -D - \
+            -H "Authorization: Bearer ${PROBE_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}" |
+            tr -d '\r' | awk 'tolower($1) == "x-ratelimit-used:" {print $2}')
+    done
+
+    sample cal_after >/dev/null
+
+    local before after reset_before reset_after _limit
+    read -r before reset_before _limit <"$STATE_DIR/cal_before"
+    read -r after reset_after _limit <"$STATE_DIR/cal_after"
+    local observed=$((after - before))
+
+    record instrument_calibration "$before" "$after" "$reset_before" "$reset_after" \
+        "expected $n; X-RateLimit-Used header last read $header_used"
+
+    if ((observed != n)); then
+        die "instrument calibration failed: $n known requests moved /rate_limit by $observed. Every delta in this job is untrustworthy."
+    fi
+    echo "calibration ok: $n requests moved the bucket by $observed"
+}
+
+summary_header() {
+    [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+    [[ -f "$SUMMARY_HEADER_SENTINEL" ]] && return 0
+    mkdir -p "$STATE_DIR"
+    {
+        echo "### API cost: ${GITHUB_JOB:-unknown job}"
+        echo
+        echo '| Measurement | Bucket | used before | used after | Requests consumed | Note |'
+        echo '| --- | --- | ---: | ---: | ---: | --- |'
+    } >>"$GITHUB_STEP_SUMMARY"
+    touch "$SUMMARY_HEADER_SENTINEL"
+}
+
+# record <measurement> <used_before> <used_after> <reset_before> <reset_after> [note]
+# The raw-number form, so a job can report a delta spanning two other jobs.
+record() {
+    local measurement="$1" before="$2" after="$3" reset_before="$4" reset_after="$5" note="${6:-}"
+    local bucket="${PROBE_BUCKET:-unknown}"
+    local delta=$((after - before))
+    local rolled=false
+
+    # The bucket resets hourly, and a reset between the two samples zeroes `used`,
+    # which makes the subtraction meaningless. `reset` alone cannot detect that:
+    # on a bucket sitting at used=0 GitHub reports reset as now+3600, so the field
+    # advances every second without any window having rolled. A drop in `used` is
+    # the signal that survives. Both reset stamps are published so the call can be
+    # audited rather than taken on trust.
+    if ((after < before)); then
+        rolled=true
+        note="${note:+$note; }used decreased, so the reset window rolled between samples and the delta is meaningless"
+        echo "::warning::[$measurement] rate-limit window rolled between samples"
+    fi
+
+    echo "result[$measurement] delta=$delta (before=$before after=$after bucket=$bucket reset_before=$reset_before reset_after=$reset_after)"
+
+    summary_header
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        local shown="$delta"
+        [[ "$rolled" == true ]] && shown='n/a'
+        echo "| $measurement | $bucket | $before | $after | $shown | ${note:--} |" >>"$GITHUB_STEP_SUMMARY"
+    fi
+
+    capture "$measurement" "$before" "$after" "$delta" "$rolled" "$note" "$reset_before" "$reset_after"
+}
+
+# delta <measurement> <before_name> <after_name> [note] — the two-samples-in-one-job form.
+delta() {
+    local measurement="$1" before_name="$2" after_name="$3" note="${4:-}"
+    local before_used before_reset after_used after_reset _limit
+    read -r before_used before_reset _limit <"$STATE_DIR/$before_name"
+    read -r after_used after_reset _limit <"$STATE_DIR/$after_name"
+    record "$measurement" "$before_used" "$after_used" "$before_reset" "$after_reset" "$note"
+}
+
+# note <text> — free-form line under the job's table, for evidence that isn't a delta.
+note() {
+    [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+    summary_header
+    printf '\n%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+}
+
+capture() {
+    local measurement="$1" before="$2" after="$3" delta_value="$4" rolled="$5" note_text="$6"
+    local reset_before="$7" reset_after="$8"
+    [[ -n "${POSTHOG_DEVEX_PROJECT_API_TOKEN:-}" ]] || {
+        echo 'POSTHOG_DEVEX_PROJECT_API_TOKEN not set; skipping capture'
+        return 0
+    }
+
+    local payload
+    payload=$(jq -n \
+        --arg api_key "$POSTHOG_DEVEX_PROJECT_API_TOKEN" \
+        --arg event "$EVENT_NAME" \
+        --arg distinct_id "${GITHUB_REPOSITORY:-unknown}" \
+        --arg measurement "$measurement" \
+        --arg bucket "${PROBE_BUCKET:-unknown}" \
+        --arg note "$note_text" \
+        --arg job "${GITHUB_JOB:-unknown}" \
+        --arg runner "${RUNNER_LABEL:-unknown}" \
+        --arg repo "${GITHUB_REPOSITORY:-unknown}" \
+        --arg run_id "${GITHUB_RUN_ID:-}" \
+        --arg run_attempt "${GITHUB_RUN_ATTEMPT:-}" \
+        --argjson used_before "$before" \
+        --argjson used_after "$after" \
+        --argjson requests "$delta_value" \
+        --argjson window_rolled "$rolled" \
+        --argjson reset_before "$reset_before" \
+        --argjson reset_after "$reset_after" \
+        '{api_key: $api_key, event: $event, distinct_id: $distinct_id, properties: {
+            measurement: $measurement, bucket: $bucket, used_before: $used_before,
+            used_after: $used_after, requests: $requests, window_rolled: $window_rolled,
+            reset_before: $reset_before, reset_after: $reset_after,
+            note: $note, job: $job, runner: $runner, repo: $repo,
+            workflow_run_id: $run_id, workflow_run_attempt: $run_attempt
+        }}')
+
+    # Telemetry, not idempotent — a retry would double-count the measurement.
+    curl -fsS --connect-timeout 10 -o /dev/null \
+        -X POST -H 'Content-Type: application/json' \
+        -d "$payload" "$POSTHOG_HOST/capture/" ||
+        echo "::warning::failed to capture $measurement to PostHog"
+}
+
+command="${1:-}"
+shift || true
+case "$command" in
+sample | record | delta | note | calibrate) "$command" "$@" ;;
+*) die "unknown command '${command}' (expected: sample | record | delta | note | calibrate)" ;;
+esac

--- a/.github/scripts/gh-api-cost-probe.sh
+++ b/.github/scripts/gh-api-cost-probe.sh
@@ -117,6 +117,14 @@ summary_header() {
 record() {
     local measurement="$1" before="$2" after="$3" reset_before="$4" reset_after="$5" note="${6:-}"
     local bucket="${PROBE_BUCKET:-unknown}"
+
+    # A job that failed before it sampled hands its reader an empty output, and
+    # bash would read that as zero and publish a confident wrong number.
+    local field
+    for field in "$before" "$after" "$reset_before" "$reset_after"; do
+        [[ "$field" =~ ^[0-9]+$ ]] || die "[$measurement] missing or non-numeric sample; an upstream job did not report one"
+    done
+
     local delta=$((after - before))
     local rolled=false
 

--- a/.github/workflows/zz-investigate-ratelimit.yml
+++ b/.github/workflows/zz-investigate-ratelimit.yml
@@ -31,6 +31,15 @@ name: ZZ Investigate GitHub API cost
 # across a week of half-hourly samples. Per-invocation cost does not depend on
 # which App pays for it, so measuring on the quiet bucket measures the same
 # thing as measuring on the busy one, with a readable signal.
+#
+# The jobs then run one at a time, chained on `needs`. Run in parallel they drew
+# from that one bucket at once and each read the others' requests as its own: two
+# jobs calibrating together saw 5 and 6 where they had spent 3. `!cancelled()`
+# keeps the chain moving when a link fails, so one bad measurement does not hide
+# the rest.
+#
+# Contamination can only inflate a delta, never shrink one, so a measured 0 holds
+# even when the bucket is not exclusive.
 
 on:
     pull_request:
@@ -115,6 +124,20 @@ jobs:
                   PROBE_TOKEN: ${{ steps.token.outputs.token }}
               run: .github/scripts/gh-api-cost-probe.sh sample after_second
 
+            - uses: ./.github/actions/paths-filter
+              id: third
+              with:
+                  token: ${{ steps.token.outputs.token }}
+                  list-files: json
+                  filters: |
+                      everything:
+                          - '**'
+
+            - name: Sample after third invocation
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_third
+
             - name: Report
               env:
                   PROBE_TOKEN: ${{ steps.token.outputs.token }}
@@ -124,11 +147,13 @@ jobs:
                   probe=.github/scripts/gh-api-cost-probe.sh
                   "$probe" delta paths_filter_invocation_1 before_first between "first invocation, ${FILE_COUNT:-?} changed files"
                   "$probe" delta paths_filter_invocation_2 between after_second "second invocation, same token, same job"
+                  "$probe" delta paths_filter_invocation_3 after_second after_third "third invocation, same token, same job"
                   "$probe" note "PR files reported by the action: \`${FILE_COUNT:-unknown}\`. The action paginates \`GET /repos/{o}/{r}/pulls/{n}/files\` at 100 per page, so cost scales with PR size."
 
     filter-git-cost:
         name: paths-filter via git diff
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        needs: filter-api-cost
+        if: ${{ !cancelled() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         env:
@@ -233,7 +258,8 @@ jobs:
     # appear in both and cancel.
     revoke-1-skip:
         name: Revoke chain 1 (skip-token-revoke)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        needs: filter-git-cost
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         env:
@@ -268,7 +294,7 @@ jobs:
     revoke-2-control:
         name: Revoke chain 2 (skip-token-revoke)
         needs: revoke-1-skip
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         env:
@@ -310,7 +336,7 @@ jobs:
     revoke-3-norevoke:
         name: Revoke chain 3 (revoke enabled)
         needs: revoke-2-control
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         env:
@@ -353,7 +379,7 @@ jobs:
     revoke-4-observe:
         name: Revoke chain 4 (observe the revoke)
         needs: revoke-3-norevoke
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         env:
@@ -390,7 +416,7 @@ jobs:
     revoke-report:
         name: Revoke chain report
         needs: [revoke-1-skip, revoke-2-control, revoke-3-norevoke, revoke-4-observe]
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         env:
@@ -425,13 +451,20 @@ jobs:
     # ---------------------------------------------------------------- Fix 2 --
     toolcache-probe:
         name: setup-* against a cold tool cache
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        needs: revoke-report
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 15
         env:
             RUNNER_LABEL: depot-ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Resolve the pinned versions
+              id: versions
+              run: |
+                  echo "node=$(tr -d 'v \n' <.nvmrc)" >>"$GITHUB_OUTPUT"
+                  echo "python=3.13.13" >>"$GITHUB_OUTPUT"
 
             - name: Show the tool cache before any setup step
               run: |
@@ -513,20 +546,26 @@ jobs:
               continue-on-error: true
               with:
                   path: |
-                      /opt/hostedtoolcache/node
-                      /opt/hostedtoolcache/Python
+                      /opt/hostedtoolcache/node/${{ steps.versions.outputs.node }}
+                      /opt/hostedtoolcache/Python/${{ steps.versions.outputs.python }}
                   key: zz-investigate-toolcache-${{ github.run_id }}-${{ github.run_attempt }}
 
     toolcache-cached:
         name: setup-* against a restored tool cache
         needs: toolcache-probe
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 15
         env:
             RUNNER_LABEL: depot-ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Resolve the pinned versions
+              id: versions
+              run: |
+                  echo "node=$(tr -d 'v \n' <.nvmrc)" >>"$GITHUB_OUTPUT"
+                  echo "python=3.13.13" >>"$GITHUB_OUTPUT"
 
             # Depot backs the Actions cache API with Depot Cache, so this restore
             # does not touch GitHub's 10 GB pool.
@@ -535,8 +574,8 @@ jobs:
               continue-on-error: true
               with:
                   path: |
-                      /opt/hostedtoolcache/node
-                      /opt/hostedtoolcache/Python
+                      /opt/hostedtoolcache/node/${{ steps.versions.outputs.node }}
+                      /opt/hostedtoolcache/Python/${{ steps.versions.outputs.python }}
                   key: zz-investigate-toolcache-${{ github.run_id }}-${{ github.run_attempt }}
 
             - name: Show the restored tool cache

--- a/.github/workflows/zz-investigate-ratelimit.yml
+++ b/.github/workflows/zz-investigate-ratelimit.yml
@@ -1,0 +1,605 @@
+name: ZZ Investigate GitHub API cost
+
+# THROWAWAY measurement harness. Do not merge, do not depend on it.
+#
+# It answers two questions with numbers instead of estimates:
+#   1. What does one `.github/actions/paths-filter` invocation cost in REST
+#      requests, what does the equivalent `git diff` cost, and do the two
+#      produce the same file list? ~30 workflows run the filter per PR, and its
+#      App bucket peaks at 65% of 15k/hr.
+#   2. Do `setup-node` and `setup-python` spend requests because the pinned
+#      versions are absent from the runner's tool cache, and does restoring the
+#      tool cache take that to zero?
+# Plus: `create-github-app-token` revokes its token in a post step unless
+#      `skip-token-revoke: true`. Every paths-filter mint in the tree omits it
+#      while every setup-action mint sets it, so the revoke's cost is measured too.
+#
+# Method. /rate_limit is documented as not counting against the limit it
+# reports, so every step under test is bracketed by a free sample of `used`.
+# The bucket read belongs to whichever token authenticates the sample, so each
+# probe authenticates with the same token the step under test uses.
+#
+# The endpoint cannot simply be trusted, though: against a GitHub CLI
+# user-to-server token it reports used=0 forever while `X-RateLimit-Used` on real
+# endpoints climbs by one per request. So every job first spends 3 requests on a
+# known-cost call and fails unless the bucket moves by exactly 3. A run that
+# reports zero for everything is then a result, not a broken instrument.
+#
+# Instrument. A shared bucket is noisy: other runs draw from it concurrently and
+# a single-digit delta drowns. Every measurement here therefore runs on the
+# `posthog-product-tests` App, whose core bucket peaked at 8 of 15,000 used
+# across a week of half-hourly samples. Per-invocation cost does not depend on
+# which App pays for it, so measuring on the quiet bucket measures the same
+# thing as measuring on the busy one, with a readable signal.
+
+on:
+    pull_request:
+        paths:
+            - '.github/workflows/zz-investigate-ratelimit.yml'
+            - '.github/scripts/gh-api-cost-probe.sh'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+    contents: read
+
+env:
+    PROBE_BUCKET: posthog-product-tests
+
+jobs:
+    # ---------------------------------------------------------------- Fix 1 --
+    filter-api-cost:
+        name: paths-filter via REST
+        # Needs a real PR: the action only reaches the API on pull_request events.
+        # Forks get no secrets, so the App token could not be minted there.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  # The revoke is measured on its own below; here it would land
+                  # inside another job's measurement window.
+                  skip-token-revoke: true
+
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample before first invocation
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample before_first
+
+            - uses: ./.github/actions/paths-filter
+              id: first
+              with:
+                  token: ${{ steps.token.outputs.token }}
+                  list-files: json
+                  filters: |
+                      everything:
+                          - '**'
+
+            - name: Sample between invocations
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample between
+
+            # A second invocation with the same token in the same job: if the cost
+            # is per-invocation, ~30 filter jobs per PR each pay it, and the fix is
+            # worth its size. If something memoizes, the fleet cost is lower.
+            - uses: ./.github/actions/paths-filter
+              id: second
+              with:
+                  token: ${{ steps.token.outputs.token }}
+                  list-files: json
+                  filters: |
+                      everything:
+                          - '**'
+
+            - name: Sample after second invocation
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_second
+
+            - name: Report
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  FILE_COUNT: ${{ steps.first.outputs.everything_count }}
+              run: |
+                  probe=.github/scripts/gh-api-cost-probe.sh
+                  "$probe" delta paths_filter_invocation_1 before_first between "first invocation, ${FILE_COUNT:-?} changed files"
+                  "$probe" delta paths_filter_invocation_2 between after_second "second invocation, same token, same job"
+                  "$probe" note "PR files reported by the action: \`${FILE_COUNT:-unknown}\`. The action paginates \`GET /repos/{o}/{r}/pulls/{n}/files\` at 100 per page, so cost scales with PR size."
+
+    filter-git-cost:
+        name: paths-filter via git diff
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        steps:
+            # `refs/pull/N/merge` plus one generation, so HEAD^1 is the base tip
+            # the merge was computed against. That is all `git diff HEAD^1 HEAD`
+            # needs, and it is two objects rather than a deep clone.
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 2
+
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample before git diff
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample before_git
+
+            - name: Compute the changed-file list with git
+              run: |
+                  git diff --name-only HEAD^1 HEAD | sort >"$RUNNER_TEMP/files-git.txt"
+                  echo "git found $(wc -l <"$RUNNER_TEMP/files-git.txt") changed files"
+
+            - name: Sample after git diff
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_git
+
+            # Outside the measured window on purpose: this is the reference list
+            # the git list has to match, and its own cost is the bonus reading.
+            - name: Fetch the same list from the REST API
+              env:
+                  GH_TOKEN: ${{ steps.token.outputs.token }}
+                  PR: ${{ github.event.pull_request.number }}
+              run: |
+                  gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR/files" --jq '.[].filename' |
+                      sort >"$RUNNER_TEMP/files-api.txt"
+                  echo "API found $(wc -l <"$RUNNER_TEMP/files-api.txt") changed files"
+
+            - name: Sample after REST fetch
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_api
+
+            - name: Report
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: |
+                  probe=.github/scripts/gh-api-cost-probe.sh
+                  "$probe" delta git_diff_changed_files before_git after_git 'expected 0'
+                  "$probe" delta rest_pulls_files_paginated after_git after_api 'raw endpoint the action calls, for comparison'
+
+            # The two lists can legitimately diverge: the API returns the merge-base
+            # three-dot diff, while HEAD^1..HEAD is the merge result against the base
+            # tip. They agree unless master moved the same files under the PR. Fail
+            # loudly, because a silent divergence is what would break the fix.
+            - name: Assert the git list matches the API list
+              run: |
+                  {
+                      echo '<details><summary>Changed-file lists</summary>'
+                      echo
+                      echo '```'
+                      echo "--- git (HEAD^1..HEAD) ---"
+                      cat "$RUNNER_TEMP/files-git.txt"
+                      echo "--- REST (pulls/N/files) ---"
+                      cat "$RUNNER_TEMP/files-api.txt"
+                      echo '```'
+                      echo '</details>'
+                  } >>"$GITHUB_STEP_SUMMARY"
+
+                  if diff -u "$RUNNER_TEMP/files-api.txt" "$RUNNER_TEMP/files-git.txt"; then
+                      echo 'Lists match.'
+                  else
+                      echo "::error::git-derived and API-derived changed-file lists differ; the git replacement is not equivalent on this PR"
+                      exit 1
+                  fi
+
+    # -------------------------------------------------- Token revoke cost ----
+    # A revoke happens in the action's post step, after every observable step in
+    # its own job, so no in-job delta can see it. The next job's first sample can.
+    #
+    # Four jobs run strictly in order, each minting then immediately sampling, so
+    # every gap between jobs contains exactly one post-step phase and one mint:
+    #   1 -> 2  no revoke   (control)
+    #   2 -> 3  no revoke   (control, second reading, gives the spread)
+    #   3 -> 4  one revoke  (treatment)
+    # Revoke cost is treatment minus control: the mint and the inter-job noise
+    # appear in both and cancel.
+    revoke-1-skip:
+        name: Revoke chain 1 (skip-token-revoke)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        outputs:
+            end_used: ${{ steps.end.outputs.end_used }}
+            end_reset: ${{ steps.end.outputs.end_reset }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts/gh-api-cost-probe.sh
+                  sparse-checkout-cone-mode: false
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample at end of job
+              id: end
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample end
+
+    revoke-2-control:
+        name: Revoke chain 2 (skip-token-revoke)
+        needs: revoke-1-skip
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        outputs:
+            start_used: ${{ steps.start.outputs.start_used }}
+            start_reset: ${{ steps.start.outputs.start_reset }}
+            end_used: ${{ steps.end.outputs.end_used }}
+            end_reset: ${{ steps.end.outputs.end_reset }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts/gh-api-cost-probe.sh
+                  sparse-checkout-cone-mode: false
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+            - name: Sample at start of job
+              id: start
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample start
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample at end of job
+              id: end
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample end
+
+    revoke-3-norevoke:
+        name: Revoke chain 3 (revoke enabled)
+        needs: revoke-2-control
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        outputs:
+            start_used: ${{ steps.start.outputs.start_used }}
+            start_reset: ${{ steps.start.outputs.start_reset }}
+            end_used: ${{ steps.end.outputs.end_used }}
+            end_reset: ${{ steps.end.outputs.end_reset }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts/gh-api-cost-probe.sh
+                  sparse-checkout-cone-mode: false
+            # The one arm without skip-token-revoke. Its post step issues
+            # DELETE /installation/token authenticated as this installation.
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+            - name: Sample at start of job
+              id: start
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample start
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample at end of job
+              id: end
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample end
+
+    revoke-4-observe:
+        name: Revoke chain 4 (observe the revoke)
+        needs: revoke-3-norevoke
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        outputs:
+            start_used: ${{ steps.start.outputs.start_used }}
+            start_reset: ${{ steps.start.outputs.start_reset }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts/gh-api-cost-probe.sh
+                  sparse-checkout-cone-mode: false
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+            - name: Sample at start of job
+              id: start
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample start
+
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+    # hogli-lint: not-a-required-gate -- reads the chain's samples to subtract two
+    # inter-job deltas; it reports a measurement and gates nothing.
+    revoke-report:
+        name: Revoke chain report
+        needs: [revoke-1-skip, revoke-2-control, revoke-3-norevoke, revoke-4-observe]
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        env:
+            RUNNER_LABEL: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/scripts/gh-api-cost-probe.sh
+                  sparse-checkout-cone-mode: false
+            - name: Report control and treatment gaps
+              env:
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  C1_END_USED: ${{ needs.revoke-1-skip.outputs.end_used }}
+                  C1_END_RESET: ${{ needs.revoke-1-skip.outputs.end_reset }}
+                  C2_START_USED: ${{ needs.revoke-2-control.outputs.start_used }}
+                  C2_START_RESET: ${{ needs.revoke-2-control.outputs.start_reset }}
+                  C2_END_USED: ${{ needs.revoke-2-control.outputs.end_used }}
+                  C2_END_RESET: ${{ needs.revoke-2-control.outputs.end_reset }}
+                  C3_START_USED: ${{ needs.revoke-3-norevoke.outputs.start_used }}
+                  C3_START_RESET: ${{ needs.revoke-3-norevoke.outputs.start_reset }}
+                  C3_END_USED: ${{ needs.revoke-3-norevoke.outputs.end_used }}
+                  C3_END_RESET: ${{ needs.revoke-3-norevoke.outputs.end_reset }}
+                  C4_START_USED: ${{ needs.revoke-4-observe.outputs.start_used }}
+                  C4_START_RESET: ${{ needs.revoke-4-observe.outputs.start_reset }}
+              run: |
+                  probe=.github/scripts/gh-api-cost-probe.sh
+                  "$probe" record revoke_control_gap_1_2 "$C1_END_USED" "$C2_START_USED" "$C1_END_RESET" "$C2_START_RESET" 'job handoff, no revoke, one mint'
+                  "$probe" record revoke_control_gap_2_3 "$C2_END_USED" "$C3_START_USED" "$C2_END_RESET" "$C3_START_RESET" 'job handoff, no revoke, one mint'
+                  "$probe" record revoke_treatment_gap_3_4 "$C3_END_USED" "$C4_START_USED" "$C3_END_RESET" "$C4_START_RESET" 'job handoff, ONE revoke, one mint'
+                  "$probe" note "Revoke cost = treatment gap minus control gap. Controls also bound the inter-job noise floor on this bucket: if they are not both 0, read the treatment number with that spread in mind."
+
+    # ---------------------------------------------------------------- Fix 2 --
+    toolcache-probe:
+        name: setup-* against a cold tool cache
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 15
+        env:
+            RUNNER_LABEL: depot-ubuntu-24.04
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Show the tool cache before any setup step
+              run: |
+                  {
+                      echo '<details><summary>/opt/hostedtoolcache before setup-*</summary>'
+                      echo
+                      echo '```'
+                      ls -la /opt/hostedtoolcache/node/ 2>&1 || true
+                      ls -la /opt/hostedtoolcache/Python/ 2>&1 || true
+                      echo '```'
+                      echo '</details>'
+                  } | tee -a "$GITHUB_STEP_SUMMARY"
+
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample before setup-node
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample before_node
+
+            - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  token: ${{ steps.token.outputs.token }}
+
+            - name: Sample after setup-node
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_node
+
+            - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: 3.13.13
+                  token: ${{ steps.token.outputs.token }}
+
+            - name: Sample after setup-python
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_python
+
+            # A version directory that exists now and did not before is a download,
+            # independent of whether the runner logged "Attempting to download".
+            - name: Show the tool cache after setup-*
+              run: |
+                  {
+                      echo '<details><summary>/opt/hostedtoolcache after setup-*</summary>'
+                      echo
+                      echo '```'
+                      ls -la /opt/hostedtoolcache/node/ 2>&1 || true
+                      ls -la /opt/hostedtoolcache/Python/ 2>&1 || true
+                      echo '```'
+                      echo '</details>'
+                  } | tee -a "$GITHUB_STEP_SUMMARY"
+
+            - name: Report
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: |
+                  probe=.github/scripts/gh-api-cost-probe.sh
+                  "$probe" delta setup_node_cold before_node after_node "$(cat .nvmrc)"
+                  "$probe" delta setup_python_cold after_node after_python '3.13.13'
+
+            # Written under the run id, so this cache serves only the paired job
+            # below and cannot evict a shared master cache.
+            - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              continue-on-error: true
+              with:
+                  path: |
+                      /opt/hostedtoolcache/node
+                      /opt/hostedtoolcache/Python
+                  key: zz-investigate-toolcache-${{ github.run_id }}-${{ github.run_attempt }}
+
+    toolcache-cached:
+        name: setup-* against a restored tool cache
+        needs: toolcache-probe
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 15
+        env:
+            RUNNER_LABEL: depot-ubuntu-24.04
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            # Depot backs the Actions cache API with Depot Cache, so this restore
+            # does not touch GitHub's 10 GB pool.
+            - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              id: restore
+              continue-on-error: true
+              with:
+                  path: |
+                      /opt/hostedtoolcache/node
+                      /opt/hostedtoolcache/Python
+                  key: zz-investigate-toolcache-${{ github.run_id }}-${{ github.run_attempt }}
+
+            - name: Show the restored tool cache
+              env:
+                  CACHE_HIT: ${{ steps.restore.outputs.cache-hit }}
+              run: |
+                  {
+                      echo '<details><summary>/opt/hostedtoolcache after restore</summary>'
+                      echo
+                      echo '```'
+                      echo "cache-hit: ${CACHE_HIT:-false}"
+                      ls -la /opt/hostedtoolcache/node/ 2>&1 || true
+                      ls -la /opt/hostedtoolcache/Python/ 2>&1 || true
+                      echo '```'
+                      echo '</details>'
+                  } | tee -a "$GITHUB_STEP_SUMMARY"
+
+            - name: Mint measurement token
+              id: token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
+            - name: Calibrate the instrument
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+              run: .github/scripts/gh-api-cost-probe.sh calibrate 3
+
+            - name: Sample before setup-node
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample before_node
+
+            - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  token: ${{ steps.token.outputs.token }}
+
+            - name: Sample after setup-node
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_node
+
+            - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: 3.13.13
+                  token: ${{ steps.token.outputs.token }}
+
+            - name: Sample after setup-python
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+              run: .github/scripts/gh-api-cost-probe.sh sample after_python
+
+            - name: Report
+              env:
+                  PROBE_TOKEN: ${{ steps.token.outputs.token }}
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  CACHE_HIT: ${{ steps.restore.outputs.cache-hit }}
+              run: |
+                  probe=.github/scripts/gh-api-cost-probe.sh
+                  "$probe" delta setup_node_warm before_node after_node "cache-hit=${CACHE_HIT:-false}"
+                  "$probe" delta setup_python_warm after_node after_python "cache-hit=${CACHE_HIT:-false}"
+                  "$probe" note "A restore that missed makes these numbers a repeat of the cold job, not a warm reading. Check cache-hit above before reading them as the fix's result."


### PR DESCRIPTION
## Problem

Two proposed rate-limit fixes were unvalidated: nobody had measured what a paths-filter step or a setup-* step costs in GitHub API requests. The `posthog-paths-filter` App bucket peaks at 65% of its hourly limit, so the numbers decide whether the fixes are worth building.

## Changes

> [!WARNING]
> Throwaway measurement harness. Do not merge.

Verdict from [run 32868852517](https://github.com/PostHog/posthog/actions/runs/32868852517), all nine jobs green:

- Replacing the REST call with `git diff` saves 1 request per filter job, and the two file lists match.
- Adding `skip-token-revoke: true` to the paths-filter mints saves nothing. The revoke costs 0.
- Pre-baking the tool cache saves 2 requests per `setup-node` job. `setup-python` already costs 0.

What the harness does:

- Reports per-step request cost as a job-summary table and as `github_api_cost_probe` events.
- Compares each paths-filter invocation against `git diff HEAD^1 HEAD`, and fails if the file lists differ.
- Isolates the post-step token revoke across four sequential jobs, three without a revoke and one with.
- Measures `setup-node` and `setup-python` cold, then against a restored tool cache.
- Calibrates first: each job spends 3 requests on a known call and fails unless the bucket moves by 3.
- Runs the jobs one at a time on `posthog-product-tests`, the quietest App bucket.

## How did you test this code?

| Measurement | Requests |
| --- | ---: |
| paths-filter invocation, three in a row | 1, 1, 1 |
| `git diff HEAD^1 HEAD` | 0 |
| `GET /repos/{o}/{r}/pulls/{n}/files` direct | 1 |
| Token revoke in the post step | 0 |
| `setup-node`, cold tool cache | 2 |
| `setup-python`, cold tool cache | 0 |
| `setup-node`, restored tool cache | 0 |
| `setup-python`, restored tool cache | 0 |

- Every calibration read exactly 3, so the instrument was sound in all nine jobs.
- The cold job logged `Attempting to download 24.13.0`, so Node 24.13.0 is absent from the Depot tool cache.
- Only the treatment job logged `Token revoked`. The other three logged `Token revocation was skipped`.
- This PR changes 2 files, so the filter paginates one page. Cost grows by 1 per 100 changed files.
- An earlier parallel run failed calibration: jobs sharing the bucket read each other's requests. Serializing them fixed it. Contamination only inflates a delta, so the zeros above hold regardless.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.
- The instrument was picked by querying the existing `github_rate_limit_observed` series per App bucket, not assumed.
- Calibration was added after local testing found `/rate_limit` reporting `used: 0` for a token whose response headers read 1132 and climbed by one per request.

https://claude.ai/code/session_01H5AtJ2S1AudzHVzfWmFV5q
