### PR TITLE
fix(batch-exports): increase databricks sdk retry duration

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -89,6 +89,7 @@ DatabricksField = tuple[str, str]
 
 # Common operation timeouts (seconds)
 ONE_MINUTE = 60
+TWO_MINUTES = 2 * 60
 FIVE_MINUTES = 5 * 60
 THIRTY_MINUTES = 30 * 60
 ONE_HOUR = 60 * 60
@@ -357,10 +358,14 @@ class DatabricksClient:
                 enable_telemetry=False,
                 # Per-RPC, not per-query — long queries poll via repeated status RPCs.
                 _socket_timeout=ONE_MINUTE,
-                _retry_stop_after_attempts_count=2,
+                # The SDK floors each retry wait at `_retry_delay_max` and skips the retry if that
+                # wait would exceed `_retry_stop_after_attempts_duration`, so the delay must stay
+                # under the budget.
+                _retry_delay_max=10,
+                _retry_stop_after_attempts_count=4,
                 # Cap the SDK's synchronous retry loop so a cancelled caller doesn't leave
                 # the worker thread polling for ~15 minutes (the SDK's 900s default).
-                _retry_stop_after_attempts_duration=ONE_MINUTE,
+                _retry_stop_after_attempts_duration=TWO_MINUTES,
                 session_configuration=(
                     {"STATEMENT_TIMEOUT": str(int(self.statement_timeout_seconds))}
                     if self.statement_timeout_seconds is not None


### PR DESCRIPTION
## Problem

Sometimes Databricks batch exports fail due to a retry budget being exceeded:

```
RequestError: Error during request to server. Retry request would exceed
Retry policy max retry duration of 60.0 seconds
```

## Changes

- Raises the retry duration budget and lowers the per-retry delay cap, so the Databricks SDK's own retry loop can actually run instead of exceeding its budget on the first attempt.
- Bumps the retry count to match the larger budget.

## How did you test this code?

Ran Databricks test suite locally

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal retry tuning, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated via Claude Code, using the local `debugging-temporal-cloud-workflows` skill to pull the Temporal Cloud workflow history and identify the failing activity, then PostHog MCP tools (`execute-sql` against the dogfood warehouse) to confirm the batch export's config and run history. Traced the failure into the vendored `databricks-sql-connector` source to find the retry-budget arithmetic bug. The user chose the fix direction (raise the duration budget, lower the delay cap) after reviewing the connector internals together; the final constants and scope (no test, minimal comment) were set per explicit user feedback during planning.