### PR TITLE
fix(tasks): send every spend-gate block to the upgrade modal

### DIFF
--- a/products/desktop/packages/core/src/task-detail/taskService.test.ts
+++ b/products/desktop/packages/core/src/task-detail/taskService.test.ts
@@ -5,7 +5,11 @@ import type { PiRunner } from "../pi-runtime/piRunner";
 import type { TaskCreationEffects } from "./taskCreationEffects";
 import type { ITaskCreationHost } from "./taskCreationHost";
 import { buildWorktreeAdoptionInput } from "./taskInput";
-import { TaskService } from "./taskService";
+import {
+  type CreateTaskResult,
+  TaskService,
+  usageLimitCauseForResult,
+} from "./taskService";
 
 const scopedLog = {
   debug: vi.fn(),
@@ -206,5 +210,59 @@ describe("TaskService.createTask validation", () => {
     expect(result.success).toBe(false);
     if (result.success) throw new Error("expected task_creation failure");
     expect(result.failedStep).toBe("task_creation");
+  });
+});
+
+describe("usageLimitCauseForResult", () => {
+  it.each([
+    {
+      name: "the local pre-flight sentinel",
+      result: {
+        success: false,
+        error: "Cloud usage limit reached",
+        failedStep: "usage_limit",
+      },
+      expected: "org_limit",
+    },
+    {
+      name: "a backend spend-gate block reduced to prose",
+      result: {
+        success: false,
+        error: "You've reached your PostHog Desktop usage limit.",
+        failedStep: "task_creation",
+      },
+      expected: "org_limit",
+    },
+    {
+      name: "an organization-level compute-quota block",
+      result: {
+        success: false,
+        error: "Your organization reached its PostHog Desktop usage limit.",
+        failedStep: "task_creation",
+      },
+      expected: "org_limit",
+    },
+    {
+      name: "an unrelated failure",
+      result: {
+        success: false,
+        error: "Repository not found",
+        failedStep: "task_creation",
+      },
+      expected: null,
+    },
+  ])("maps $name to $expected", ({ result, expected }) => {
+    expect(
+      usageLimitCauseForResult(result as unknown as CreateTaskResult),
+    ).toBe(expected);
+  });
+
+  it("reports no limit for a successful creation", () => {
+    expect(
+      usageLimitCauseForResult({
+        success: true,
+        data: {},
+      } as unknown as CreateTaskResult),
+    ).toBeNull();
   });
 });

--- a/products/desktop/packages/core/src/task-detail/taskService.ts
+++ b/products/desktop/packages/core/src/task-detail/taskService.ts
@@ -7,10 +7,12 @@ import {
   type SessionService,
 } from "@posthog/core/sessions/sessionService";
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
-import type {
-  SagaResult,
-  TaskCreationInput,
-  TaskCreationOutput,
+import {
+  classifyGatewayLimitError,
+  type GatewayLimitCause,
+  type SagaResult,
+  type TaskCreationInput,
+  type TaskCreationOutput,
 } from "@posthog/shared";
 import type { Task, TaskRun } from "@posthog/shared/domain-types";
 import { inject, injectable } from "inversify";
@@ -29,15 +31,22 @@ export { TASK_SERVICE } from "./identifiers";
 export type CreateTaskResult = SagaResult<TaskCreationOutput>;
 
 /**
- * True when a failed createTask was blocked by the usage limit. The upgrade modal is
- * already shown in this case, so callers should suppress their own error toast.
+ * The limit a failed createTask was blocked by, or null when it failed for another
+ * reason. Callers show the upgrade modal for this cause instead of a plain toast, so
+ * the block always comes with a route to billing.
+ *
+ * The local pre-flight fails with a known sentinel, but the backend can also block a
+ * run the pre-flight let through (a compute-quota stop, a deactivated organization, a
+ * gateway bucket the pre-flight can't see). Those arrive only as prose, so the message
+ * is classified too.
  */
-export function isUsageLimitResult(result: CreateTaskResult): boolean {
-  return (
-    !result.success &&
-    (result.failedStep === "usage_limit" ||
-      result.error === CLOUD_USAGE_LIMIT_ERROR_MESSAGE)
-  );
+export function usageLimitCauseForResult(
+  result: CreateTaskResult,
+): GatewayLimitCause | null {
+  if (result.success) return null;
+  if (result.failedStep === "usage_limit") return "org_limit";
+  if (result.error === CLOUD_USAGE_LIMIT_ERROR_MESSAGE) return "org_limit";
+  return result.error ? classifyGatewayLimitError(result.error) : null;
 }
 
 @injectable()

--- a/products/desktop/packages/shared/src/errors.test.ts
+++ b/products/desktop/packages/shared/src/errors.test.ts
@@ -108,6 +108,11 @@ describe("classifyGatewayLimitError", () => {
       "org_limit",
     ],
     [
+      // The task API's own wording, which says "your" where the gateway says "its".
+      "You've reached your PostHog Desktop usage limit.",
+      "org_limit",
+    ],
+    [
       // Pre-rename wording still sent by older gateway deployments.
       "Rate limit exceeded: Your team has reached its PostHog Code usage limit for this billing period. See https://app.posthog.com/organization/billing for your usage and limits.",
       "org_limit",

--- a/products/desktop/packages/shared/src/errors.ts
+++ b/products/desktop/packages/shared/src/errors.ts
@@ -80,9 +80,11 @@ const MODEL_GATE_PATTERNS = ["needs a paid posthog plan"] as const;
 
 const ORG_LIMIT_PATTERNS = [
   "cloud usage limit reached",
-  "reached its posthog desktop usage limit",
+  // Matched without the possessive so both wordings land here: the gateway says
+  // "its" ("your team has reached its …") and the task API says "your".
+  "posthog desktop usage limit",
   // Older gateway deployments still send the pre-rename wording.
-  "reached its posthog code usage limit",
+  "posthog code usage limit",
   "reached its usage limit for this billing period",
   // Per-user free valves — billed orgs have none, so these always mean the
   // free tier is used up.

--- a/products/desktop/packages/ui/src/features/billing/usageLimitPrompt.ts
+++ b/products/desktop/packages/ui/src/features/billing/usageLimitPrompt.ts
@@ -1,0 +1,21 @@
+import { classifyGatewayLimitError, getErrorMessage } from "@posthog/shared";
+import { useUsageLimitStore } from "./usageLimitStore";
+
+/**
+ * Show the upgrade modal when `error` is a spend-gate block, so the user gets the
+ * billing route instead of a toast that only names the limit. Returns false for
+ * anything else, leaving the caller's own error handling to run.
+ *
+ * Use this on paths that receive an already-stringified failure — a saga result, a
+ * rejected mutation, a run's error message — where the typed CloudUsageLimitError
+ * has been reduced to prose.
+ */
+export function showUsageLimitPromptForError(error: unknown): boolean {
+  // getErrorMessage only unwraps Error-shaped values; these paths often hand us the
+  // bare string a saga or an API row already reduced the failure to.
+  const message = typeof error === "string" ? error : getErrorMessage(error);
+  const cause = classifyGatewayLimitError(message);
+  if (!cause) return false;
+  useUsageLimitStore.getState().show({ cause });
+  return true;
+}

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -4,10 +4,10 @@ import {
   type ReportModelResolver,
 } from "@posthog/core/inbox/identifiers";
 import {
-  isUsageLimitResult,
   TASK_SERVICE,
   type TaskCreationInput,
   type TaskService,
+  usageLimitCauseForResult,
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import {
@@ -18,6 +18,8 @@ import {
 } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { showUsageLimitPromptForError } from "@posthog/ui/features/billing/usageLimitPrompt";
+import { useUsageLimitStore } from "@posthog/ui/features/billing/usageLimitStore";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
 import { resolveDefaultModel } from "@posthog/ui/features/inbox/hooks/resolveDefaultModel";
 import { useUserRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
@@ -268,8 +270,16 @@ export function useInboxCloudTaskRunner({
         });
       } else {
         toast.dismiss(toastId);
-        // Usage-limit blocks already show the upgrade modal; don't double-toast.
-        if (!isUsageLimitResult(result)) {
+        // A spend-gate block gets the upgrade modal, which carries the route to
+        // billing; a toast naming the limit would leave nothing to act on.
+        const limitCause = usageLimitCauseForResult(result);
+        if (limitCause) {
+          useUsageLimitStore.getState().show({ cause: limitCause });
+          log.warn("Cloud-task creation blocked by usage limit", {
+            cause: limitCause,
+            reportId,
+          });
+        } else {
           toastError(copy.errorTitle, result.error);
           log.error("Cloud-task creation failed", {
             failedStep: result.failedStep,
@@ -281,7 +291,9 @@ export function useInboxCloudTaskRunner({
       }
     } catch (error) {
       toast.dismiss(toastId);
-      toastError(copy.errorTitle, error);
+      if (!showUsageLimitPromptForError(error)) {
+        toastError(copy.errorTitle, error);
+      }
       log.error("Unexpected error during cloud-task creation", {
         error,
         reportId,

--- a/products/desktop/packages/ui/src/features/loops/components/LoopRunRow.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopRunRow.tsx
@@ -12,7 +12,9 @@ import {
 } from "@phosphor-icons/react";
 import type { LoopSchemas } from "@posthog/api-client/loops";
 import { cn } from "@posthog/quill";
+import { classifyGatewayLimitError } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useUsageLimitStore } from "@posthog/ui/features/billing/usageLimitStore";
 import { StopCloudRunDialog } from "@posthog/ui/features/sessions/components/StopCloudRunDialog";
 import { Badge } from "@posthog/ui/primitives/Badge";
 import { Button } from "@posthog/ui/primitives/Button";
@@ -134,6 +136,11 @@ export function LoopRunRow({
   const triggered = Boolean(run.loop_trigger_id);
   const stoppable = isStoppable(run);
   const [stopOpen, setStopOpen] = useState(false);
+  // A run stopped by the spend gate reports the limit as prose; the row offers the
+  // way to raise it, since the loop's paused notice only appears once it pauses.
+  const limitCause = run.error_message
+    ? classifyGatewayLimitError(run.error_message)
+    : null;
 
   return (
     <Flex
@@ -171,7 +178,7 @@ export function LoopRunRow({
           </MetaItem>
         </Flex>
         {run.error_message ? (
-          <Flex align="center" gap="1" className="min-w-0">
+          <div className="flex min-w-0 items-center gap-1">
             <Warning
               size={12}
               weight="bold"
@@ -180,7 +187,20 @@ export function LoopRunRow({
             <Text className="truncate text-(--red-11) text-[11.5px]">
               {run.error_message}
             </Text>
-          </Flex>
+            {limitCause ? (
+              <Button
+                variant="ghost"
+                color="red"
+                size="1"
+                className="shrink-0"
+                onClick={() =>
+                  useUsageLimitStore.getState().show({ cause: limitCause })
+                }
+              >
+                Manage plan
+              </Button>
+            ) : null}
+          </div>
         ) : null}
       </Flex>
       <Flex align="center" gap="2" className="shrink-0">

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -4,9 +4,9 @@ import {
   prepareTaskInput,
 } from "@posthog/core/task-detail/taskInput";
 import {
-  isUsageLimitResult,
   TASK_SERVICE,
   type TaskService,
+  usageLimitCauseForResult,
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import type { HostTrpcClient } from "@posthog/host-router/client";
@@ -44,6 +44,7 @@ import {
 import { titleAttachmentStoreApi } from "../../../shell/titleAttachmentStore";
 import { useAuthStateValue } from "../../auth/store";
 import { assertCloudUsageAvailable } from "../../billing/preflightCloudUsage";
+import { showUsageLimitPromptForError } from "../../billing/usageLimitPrompt";
 import { useUsageLimitStore } from "../../billing/usageLimitStore";
 import { useLocalMcpCloudServers } from "../../local-mcp/useLocalMcpCloudServers";
 import {
@@ -558,10 +559,14 @@ export function useTaskCreation({
               error_type: "task_creation_failed",
               failed_step: result.failedStep,
             });
-            // Usage-limit blocks already show the upgrade modal; don't also toast an error.
-            if (isUsageLimitResult(result)) {
-              useUsageLimitStore.getState().show({ cause: "org_limit" });
-              log.warn("Cloud task creation blocked by usage limit");
+            // A spend-gate block gets the upgrade modal, which carries the route to
+            // billing; a toast naming the limit would leave nothing to act on.
+            const limitCause = usageLimitCauseForResult(result);
+            if (limitCause) {
+              useUsageLimitStore.getState().show({ cause: limitCause });
+              log.warn("Cloud task creation blocked by usage limit", {
+                cause: limitCause,
+              });
             } else {
               const title = getErrorTitle(result.failedStep);
               toastError(title, result.error);
@@ -583,7 +588,9 @@ export function useTaskCreation({
           track(ANALYTICS_EVENTS.TASK_CREATION_FAILED, {
             error_type: "unexpected_error",
           });
-          toastError("Failed to create task", error);
+          if (!showUsageLimitPromptForError(error)) {
+            toastError("Failed to create task", error);
+          }
           log.error("Unexpected error during task creation", { error });
           if (pendingTaskKey) {
             pendingTaskPromptStoreApi.clear(pendingTaskKey);


### PR DESCRIPTION
## Problem

A user whose run is blocked by the PostHog Desktop usage limit can get a plain error toast that names the limit and offers no way to act on it. Starting a run from the Inbox can show nothing at all.

- Only two failures counted as usage-limit blocks: the local pre-flight sentinel, and `failedStep === "usage_limit"`.
- A block the backend raised instead (compute quota, deactivated organization, a gateway bucket the pre-flight cannot see) arrived as prose the client never classified, so it fell through to the generic toast.
- The message classifier missed the task API's wording. It matched "reached **its** PostHog Desktop usage limit" but not "reached **your** PostHog Desktop usage limit".
- The Inbox runner suppressed its toast for a usage-limit result and relied on the pre-flight to have opened the modal. When the backend raised the block, neither appeared.

## Changes

- A blocked run now always opens the upgrade modal, which carries the billing button and the admin-aware copy, instead of a toast the user cannot act on.
- Starting a run from the Inbox no longer fails silently when the backend raises the block.
- A loop run stopped by the gate gets a "Manage plan" button beside its error line, so the row does not wait for the loop to pause before offering the route.
- `usageLimitCauseForResult` replaces `isUsageLimitResult` and returns the cause, so a model-gate block no longer shows organization-limit copy.
- The wording of the limit message is unchanged. This PR only adds the route out of it.

Mechanical: the classifier pattern drops the possessive so both wordings match, and the loop run's error line moves from a Radix `Flex` to a `div`.

Nothing else looks different. The modal and the button are the existing components used elsewhere for this block, at their existing sizes.

## How did you test this code?

- `pnpm --filter @posthog/shared test`, `pnpm --filter @posthog/core test`, `pnpm --filter @posthog/ui test`, and typecheck on all three.
- New cases in `taskService.test.ts` cover the classification fallback: a backend block reduced to prose now resolves to `org_limit`, where it previously resolved to `null` and produced the linkless toast. A case in `errors.test.ts` locks in the "your" wording.
- Not checked: the rendered UI. This sandbox ran no app or Storybook, so the new "Manage plan" button and the modal were not viewed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread on a P2 inbox report about the block's copy. The direction narrowed it: the wording is a specific, correct limit name and stays as-is, so the only question worth fixing was whether the error can appear with no route to billing. Mapping the surfaces found that it can, in more than one way.

The first shape considered was adding a billing action to the failed-run session banner. That surface turned out not to render the message at all, because a terminally failed run leaves the session status untouched, so the work moved to the creation paths where the message actually reaches a user.

Tools: Claude Code (Read, Grep, Edit, Bash, Agent). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787671930936989?thread_ts=1787671930.936989&cid=C09G8Q32R6F)*
