### PR TITLE
fix(logs): rename the pattern body kind invalid_json to plaintext

### DIFF
--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -68,7 +68,7 @@ describe('log-pattern-mask', () => {
             const body = JSON.stringify({ message: 'x'.repeat(100) })
             const result = computeLogPattern(body, 20, NO_CAP)
             expect(result.inputCapped).toEqual(true)
-            expect(result.bodyKind).toEqual('invalid_json')
+            expect(result.bodyKind).toEqual('plaintext')
             expect(result.pattern).toEqual(body.slice(0, 20))
         })
 
@@ -88,7 +88,7 @@ describe('log-pattern-mask', () => {
             ['json array', '[1,2]', 'json_object_or_array', JSON_ARRAY],
             ['json string', '"quoted 7"', 'json_string', 'quoted <N>'],
             ['json number primitive', '42', 'primitive', '<N>'],
-            ['prose body', 'plain text 3', 'invalid_json', 'plain text <N>'],
+            ['prose body', 'plain text 3', 'plaintext', 'plain text <N>'],
         ])('body kind %s', (_name, body, expectedKind, expectedPattern) => {
             const result = computeLogPattern(body, NO_CAP, NO_CAP)
             expect(result.bodyKind).toEqual(expectedKind)

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -59,7 +59,7 @@ export function maskString(input: string): MaskResult {
     return { masked, ruleFires }
 }
 
-export type PatternBodyKind = 'empty' | 'invalid_json' | 'json_object_or_array' | 'json_string' | 'primitive'
+export type PatternBodyKind = 'empty' | 'plaintext' | 'json_object_or_array' | 'json_string' | 'primitive'
 
 export type LogPatternResult = {
     pattern: string
@@ -104,7 +104,8 @@ export function computeLogPattern(
     const inputCapped = body.length > maxInputChars
     const cappedBody = inputCapped ? body.slice(0, maxInputChars) : body
     const parsed = parseLogBodyForIngestion(cappedBody)
-    const bodyKind: PatternBodyKind = parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind
+    const bodyKind: PatternBodyKind =
+        parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind === 'invalid_json' ? 'plaintext' : parsed.kind
 
     let maskInput: string
     switch (parsed.kind) {

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -55,7 +55,7 @@ describe('log-pattern-stage', () => {
         expect(records.map((r) => r.body)).toEqual(bodiesBefore)
         expect(await counterValues(logsPatternBodyKindCounter)).toEqual({
             empty: 1,
-            invalid_json: 2,
+            plaintext: 2,
             json_object_or_array: 1,
         })
         expect(await counterValues(logsPatternRuleFiredCounter)).toEqual({ num: 1 })


### PR DESCRIPTION
## Problem

On the pattern masking dashboard, a large share of measured records show as `invalid_json`, which reads as a data-quality problem. It is not one: the label covers every body that is not JSON - ordinary text log lines, logfmt, key=value - because the classifier inherited the parser's vocabulary, where "invalid JSON" only means "did not parse as JSON".

## Changes

- The `kind` label on `logs_ingestion_pattern_body_kind_total` reports `plaintext` instead of `invalid_json`. `plaintext` states what the classifier knows (the body is not JSON) without implying broken data or natural language.
- The rename happens in `PatternBodyKind` only, at the same mapping that already renames `json_primitive` to `primitive`. The shared body parser keeps its `invalid_json` kind - the avro json-parse path reads it, and its meaning there is literal.
- Renaming now is cheap: only the dogfood teams (dev team 1, prod-eu team 1) emit the label. During deploy rollover both label values appear briefly on the dashboard.

The dashboard wording updates in PostHog/grafana-dashboards#419.

## How did you test this code?

The existing mask and stage suites pin the label values; both pass with the rename (58 tests). No new tests - the rename is covered by the updated expectations.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal metric label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: `/writing-pr-descriptions`.
- Name choice was discussed: `plaintext` over `prose`, because logfmt and key=value lines are in this population and "prose" implies natural language.

