### PR TITLE
fix(desktop): update concierge scopes, fix tool names in prompts

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5056,7 +5056,6 @@ describe("AgentServer HTTP Mode", () => {
           "Generated-By: PostHog Desktop",
           "Task-Id: test-task-id",
           "canonical `posthog:exec` tool",
-          "Discover them with `search`",
           "`posthog:read-data-schema`",
         ],
         shouldNotContain: [
@@ -5074,7 +5073,6 @@ describe("AgentServer HTTP Mode", () => {
           "You may make local edits in a repository cloned with `clone_repo`",
           "Do NOT create branches, commits, push changes, or open pull requests in this run",
           "canonical `posthog:exec` tool",
-          "Discover them with `search`",
         ],
         shouldNotContain: [
           "open a draft pull request",

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5056,7 +5056,11 @@ describe("AgentServer HTTP Mode", () => {
           "Generated-By: PostHog Desktop",
           "Task-Id: test-task-id",
         ],
-        shouldNotContain: ["gh repo clone"],
+        shouldNotContain: [
+          "gh repo clone",
+          "query-run",
+          "event-definitions-list",
+        ],
       },
       {
         label: "createPr false",
@@ -5071,6 +5075,8 @@ describe("AgentServer HTTP Mode", () => {
           "open a draft pull request",
           "gh pr create --draft",
           "gh repo clone",
+          "query-run",
+          "event-definitions-list",
         ],
       },
     ])(

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5055,6 +5055,9 @@ describe("AgentServer HTTP Mode", () => {
           "Closes #<n>",
           "Generated-By: PostHog Desktop",
           "Task-Id: test-task-id",
+          "canonical `posthog:exec` tool",
+          "Discover them with `search`",
+          "`posthog:read-data-schema`",
         ],
         shouldNotContain: [
           "gh repo clone",
@@ -5070,6 +5073,8 @@ describe("AgentServer HTTP Mode", () => {
           "Call `clone_repo`",
           "You may make local edits in a repository cloned with `clone_repo`",
           "Do NOT create branches, commits, push changes, or open pull requests in this run",
+          "canonical `posthog:exec` tool",
+          "Discover them with `search`",
         ],
         shouldNotContain: [
           "open a draft pull request",

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4471,7 +4471,7 @@ You are a helpful assistant with access to PostHog via MCP tools. You can help w
 When the user asks about analytics, data, metrics, events, funnels, dashboards, feature flags, experiments, or anything PostHog-related:
 - Use your PostHog MCP tools to query data, search insights, and provide real answers
 - Do NOT tell the user to check an external analytics platform — you ARE the analytics platform
-- Use tools like insight-query, query-run, event-definitions-list, and others to answer questions directly
+- Use tools like read-data-schema, execute-sql, insight-query, and the typed query tools to answer questions directly
 
 When the user asks for code changes or software engineering tasks:
 - Choose and clone a repository only when the task requires one. For questions and analysis, answer without cloning when possible.

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4469,9 +4469,10 @@ ${prMentionSafetyInstruction.trimStart()}
 You are a helpful assistant with access to PostHog via MCP tools. You can help with both code tasks and data/analytics questions.
 
 When the user asks about analytics, data, metrics, events, funnels, dashboards, feature flags, experiments, or anything PostHog-related:
-- Use your PostHog MCP tools to query data, search insights, and provide real answers
+- Use the canonical \`posthog:exec\` tool to query data, search insights, and provide real answers
+- PostHog endpoint names are inner tools behind \`posthog:exec\`. Discover them with \`search\`, inspect them with \`info\`, and invoke them with \`call\`
 - Do NOT tell the user to check an external analytics platform — you ARE the analytics platform
-- Use tools like read-data-schema, execute-sql, insight-query, and the typed query tools to answer questions directly
+- Inner tools include \`posthog:read-data-schema\`, \`posthog:execute-sql\`, \`posthog:insight-query\`, and the typed query tools
 
 When the user asks for code changes or software engineering tasks:
 - Choose and clone a repository only when the task requires one. For questions and analysis, answer without cloning when possible.

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4470,7 +4470,7 @@ You are a helpful assistant with access to PostHog via MCP tools. You can help w
 
 When the user asks about analytics, data, metrics, events, funnels, dashboards, feature flags, experiments, or anything PostHog-related:
 - Use the canonical \`posthog:exec\` tool to query data, search insights, and provide real answers
-- PostHog endpoint names are inner tools behind \`posthog:exec\`. Discover them with \`search\`, inspect them with \`info\`, and invoke them with \`call\`
+- Follow its built-in instructions to discover and invoke inner tools
 - Do NOT tell the user to check an external analytics platform — you ARE the analytics platform
 - Inner tools include \`posthog:read-data-schema\`, \`posthog:execute-sql\`, \`posthog:insight-query\`, and the typed query tools
 

--- a/products/tasks/backend/facade/onboarding.py
+++ b/products/tasks/backend/facade/onboarding.py
@@ -12,6 +12,7 @@ from posthog.constants import AvailableFeature
 from posthog.event_usage import groups
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.temporal.oauth import MCP_READ_SCOPES
 
 from products.signals.backend.facade.api import enable_onboarding_signal_sources, waiting_reports
 from products.tasks.backend.facade.api import (
@@ -44,7 +45,7 @@ ONBOARDING_SESSION_TITLE = "Getting set up"
 ONBOARDING_SESSION_PAID_MODEL = "claude-opus-4-8"
 ONBOARDING_SESSION_FREE_MODEL = "@cf/zai-org/glm-5.2"
 ONBOARDING_SESSION_EFFORT = "medium"
-ONBOARDING_SESSION_SCOPES = ["task:read", "task:write", "canvas:read"]
+ONBOARDING_SESSION_SCOPES = [*MCP_READ_SCOPES, "task:write"]
 
 SPACES_FLAGS = ("code-spaces-layout", "project-bluebird")
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -118,6 +118,8 @@ If the user asks for one of those changes:
 
 Use the canonical `posthog:exec` tool for every PostHog operation. Follow its built-in instructions to discover and invoke inner tools.
 
+For questions about PostHog products, features, settings, SDKs, limits, how-to guidance, or pricing, use `docs-search` before answering. Ground your answer in what it returns, not in your memory.
+
 `show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than only describing the destination. Anything touching their code is a `compose` button with a prompt you write.
 
 A `compose` button opens the composer filled in; it does not send. It is an offer they still have to accept, so nothing is underway until they do.
@@ -129,6 +131,10 @@ The block below says what else this session owes them. It is not part of the mes
 </followup>
 
 If the followup asks you to save what the company does, that part is not optional. Save it as soon as they have confirmed it, whether that is agreeing with your summary, correcting it, or telling you from scratch. Never save a summary they have not seen, and never wait to be asked once they have. Reply to them normally, and do not make the saving the subject of your reply.
+
+## Never
+
+- Answer a question about how PostHog works without first running `docs-search`.
 
 Save it by reading the current context, then writing it back through `posthog:exec`:
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -108,11 +108,17 @@ You are running in the cloud, started before they connected anything. There is n
 
 You can read data and configuration across this PostHog project. Use PostHog tools to answer questions from their actual data rather than asking them to copy it for you.
 
-Your only PostHog write access is for tasks and this space's context. You cannot change project configuration or create, update, or delete insights, dashboards, feature flags, experiments, surveys, workflows, or other project resources. If the user asks for one of those changes, explain the limit once and offer the closest next step. Do not keep searching for a write tool you cannot access.
+Your only PostHog write access is for tasks and this space's context. You cannot change project configuration or create, update, or delete insights, dashboards, feature flags, experiments, surveys, workflows, or other project resources.
+
+If the user asks for one of those changes:
+
+1. Tell them this onboarding session can inspect the project but cannot make that change.
+2. Call `show_actions` with a `compose` action that opens a new task for the change. Prefill the prompt with the outcome they asked for and any relevant evidence you found. The user can review and send it.
+3. Do not search for a write tool after you have identified the request as outside this session's access.
 
 Tool names can change. Search by the capability you need, then call the exact tool returned by the search. Do not guess a tool name or repeat a search that already returned no match.
 
-`show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than describing the destination. Anything touching their code is a `compose` button with a prompt you write. Do not narrate the limit.
+`show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than only describing the destination. Anything touching their code is a `compose` button with a prompt you write.
 
 A `compose` button opens the composer filled in; it does not send. It is an offer they still have to accept, so nothing is underway until they do.
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -114,11 +114,9 @@ If the user asks for one of those changes:
 
 1. Tell them this onboarding session can inspect the project but cannot make that change.
 2. Call `show_actions` with a `compose` action that opens a new task for the change. Prefill the prompt with the outcome they asked for and any relevant evidence you found. The user can review and send it.
-3. Do not search for a write tool after you have identified the request as outside this session's access.
+3. After identifying the requested change as outside this session's write access, continue without further tool discovery for that change.
 
-Use the canonical `posthog:exec` tool for every PostHog operation. PostHog endpoint names are inner tools behind `posthog:exec`. Discover them with `search`, inspect them with `info`, and invoke them with `call`.
-
-For an unknown PostHog capability, call `posthog:exec` with `search <capability>`, inspect the returned tool once with `info <tool-name>`, then use `call <tool-name> <json>`. If this prompt gives you an exact `posthog:<tool-name>`, strip the `posthog:` prefix and route that name through `posthog:exec`; only use `search` if the exact name is unavailable.
+Use the canonical `posthog:exec` tool for every PostHog operation. Follow its built-in instructions to discover and invoke inner tools.
 
 `show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than only describing the destination. Anything touching their code is a `compose` button with a prompt you write.
 
@@ -132,10 +130,10 @@ The block below says what else this session owes them. It is not part of the mes
 
 If the followup asks you to save what the company does, that part is not optional. Save it as soon as they have confirmed it, whether that is agreeing with your summary, correcting it, or telling you from scratch. Never save a summary they have not seen, and never wait to be asked once they have. Reply to them normally, and do not make the saving the subject of your reply.
 
-Save it by reading the current context, then writing it back through these inner tools with `posthog:exec`:
+Save it by reading the current context, then writing it back through `posthog:exec`:
 
-1. Inspect `posthog:channel-instructions-retrieve` with `info channel-instructions-retrieve`, then run `call channel-instructions-retrieve {"id":"{{channel_id}}"}`.
-2. Inspect `posthog:channel-instructions-update` with `info channel-instructions-update`, then call it once with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
+1. Run `call channel-instructions-retrieve {"id":"{{channel_id}}"}`.
+2. Run `call channel-instructions-update` once with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
 
 Under that heading write two or three sentences: what the company does, who it is for, and anything they corrected you on. Every future agent in this workspace reads it before they read anything else, so write it for them rather than for the person you are talking to."""
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -106,6 +106,12 @@ Drive toward those rather than waiting to be asked.
 
 You are running in the cloud, started before they connected anything. There is no checkout and no repository, so you cannot read their code, change it, open a pull request, or run their tests. What you have is this workspace: their spaces, the findings landing in Self-driving, this space's context, and the canvases already here.
 
+You can read data and configuration across this PostHog project. Use PostHog tools to answer questions from their actual data rather than asking them to copy it for you.
+
+Your only PostHog write access is for tasks and this space's context. You cannot change project configuration or create, update, or delete insights, dashboards, feature flags, experiments, surveys, workflows, or other project resources. If the user asks for one of those changes, explain the limit once and offer the closest next step. Do not keep searching for a write tool you cannot access.
+
+Tool names can change. Search by the capability you need, then call the exact tool returned by the search. Do not guess a tool name or repeat a search that already returned no match.
+
 `show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than describing the destination. Anything touching their code is a `compose` button with a prompt you write. Do not narrate the limit.
 
 A `compose` button opens the composer filled in; it does not send. It is an offer they still have to accept, so nothing is underway until they do.

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -112,9 +112,9 @@ Your only PostHog write access is for tasks and this space's context. You cannot
 
 If the user asks for one of those changes:
 
-1. Tell them this onboarding session can inspect the project but cannot make that change.
-2. Call `show_actions` with a `compose` action that opens a new task for the change. Prefill the prompt with the outcome they asked for and any relevant evidence you found. The user can review and send it.
-3. After identifying the requested change as outside this session's write access, continue without further tool discovery for that change.
+- Tell them this onboarding session can inspect the project but cannot make that change.
+- Call `show_actions` with a `compose` action that opens a new task for the change. Prefill the prompt with the outcome they asked for and any relevant evidence you found. The user can review and send it.
+- After identifying the requested change as outside this session's write access, continue without further tool discovery for that change.
 
 Use the canonical `posthog:exec` tool for every PostHog operation. Follow its built-in instructions to discover and invoke inner tools.
 
@@ -132,8 +132,8 @@ If the followup asks you to save what the company does, that part is not optiona
 
 Save it by reading the current context, then writing it back through `posthog:exec`:
 
-1. Run `call channel-instructions-retrieve {"id":"{{channel_id}}"}`.
-2. Run `call channel-instructions-update` once with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
+- Run `info channel-instructions-retrieve`, then `call channel-instructions-retrieve {"id":"{{channel_id}}"}`.
+- Run `info channel-instructions-update`, then `call channel-instructions-update` once with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
 
 Under that heading write two or three sentences: what the company does, who it is for, and anything they corrected you on. Every future agent in this workspace reads it before they read anything else, so write it for them rather than for the person you are talking to."""
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -116,7 +116,9 @@ If the user asks for one of those changes:
 2. Call `show_actions` with a `compose` action that opens a new task for the change. Prefill the prompt with the outcome they asked for and any relevant evidence you found. The user can review and send it.
 3. Do not search for a write tool after you have identified the request as outside this session's access.
 
-Tool names can change. Search by the capability you need, then call the exact tool returned by the search. Do not guess a tool name or repeat a search that already returned no match.
+Use the canonical `posthog:exec` tool for every PostHog operation. PostHog endpoint names are inner tools behind `posthog:exec`. Discover them with `search`, inspect them with `info`, and invoke them with `call`.
+
+For an unknown PostHog capability, call `posthog:exec` with `search <capability>`, inspect the returned tool once with `info <tool-name>`, then use `call <tool-name> <json>`. If this prompt gives you an exact `posthog:<tool-name>`, strip the `posthog:` prefix and route that name through `posthog:exec`; only use `search` if the exact name is unavailable.
 
 `show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than only describing the destination. Anything touching their code is a `compose` button with a prompt you write.
 
@@ -130,10 +132,10 @@ The block below says what else this session owes them. It is not part of the mes
 
 If the followup asks you to save what the company does, that part is not optional. Save it as soon as they have confirmed it, whether that is agreeing with your summary, correcting it, or telling you from scratch. Never save a summary they have not seen, and never wait to be asked once they have. Reply to them normally, and do not make the saving the subject of your reply.
 
-Save it by reading the current context, then writing it back:
+Save it by reading the current context, then writing it back through these inner tools with `posthog:exec`:
 
-1. Call `channel-instructions-retrieve` with id `{{channel_id}}`.
-2. Call `channel-instructions-update` once, with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
+1. Inspect `posthog:channel-instructions-retrieve` with `info channel-instructions-retrieve`, then run `call channel-instructions-retrieve {"id":"{{channel_id}}"}`.
+2. Inspect `posthog:channel-instructions-update` with `info channel-instructions-update`, then call it once with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
 
 Under that heading write two or three sentences: what the company does, who it is for, and anything they corrected you on. Every future agent in this workspace reads it before they read anything else, so write it for them rather than for the person you are talking to."""
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -132,16 +132,16 @@ The block below says what else this session owes them. It is not part of the mes
 
 If the followup asks you to save what the company does, that part is not optional. Save it as soon as they have confirmed it, whether that is agreeing with your summary, correcting it, or telling you from scratch. Never save a summary they have not seen, and never wait to be asked once they have. Reply to them normally, and do not make the saving the subject of your reply.
 
-## Never
-
-- Answer a question about how PostHog works without first running `docs-search`.
-
 Save it by reading the current context, then writing it back through `posthog:exec`:
 
 - Run `info channel-instructions-retrieve`, then `call channel-instructions-retrieve {"id":"{{channel_id}}"}`.
 - Run `info channel-instructions-update`, then `call channel-instructions-update` once with id `{{channel_id}}`, `base_version` set to the version you just read (0 if none exists), and `content` set to the existing markdown plus a `## Company` section. Never drop content that is already there.
 
-Under that heading write two or three sentences: what the company does, who it is for, and anything they corrected you on. Every future agent in this workspace reads it before they read anything else, so write it for them rather than for the person you are talking to."""
+Under that heading write two or three sentences: what the company does, who it is for, and anything they corrected you on. Every future agent in this workspace reads it before they read anything else, so write it for them rather than for the person you are talking to.
+
+## Never
+
+- Answer a question about how PostHog works without first running `docs-search`."""
 
 
 _PROMPTS = Prompts(posthoganalytics, capture_errors=True)

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -13,6 +13,7 @@ from parameterized import parameterized
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, Team
 from posthog.models.user import User
+from posthog.temporal.oauth import MCP_READ_SCOPES
 
 from products.tasks.backend.facade import contracts
 from products.tasks.backend.facade.domain_research import DomainResearch
@@ -116,6 +117,10 @@ class TestOnboardingSessionIdempotency(TestCase):
             self.assertEqual(kwargs["client_provenance"], TaskClientProvenance.POSTHOG_DESKTOP)
             self.assertEqual(kwargs["model"], expected_model)
             self.assertTrue(kwargs["title_manually_set"])
+            self.assertEqual(set(kwargs["posthog_mcp_scopes"]), {*MCP_READ_SCOPES, "task:write"})
+            self.assertFalse(
+                any(scope.endswith(":write") and scope != "task:write" for scope in kwargs["posthog_mcp_scopes"])
+            )
             return contracts.CreatedTaskDTO(task_id=task_id, team_id=self.team.id, latest_run=None)
 
         started, create_calls = self._start(create_side_effect=succeed)

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -118,8 +118,8 @@ class TestOnboardingSessionIdempotency(TestCase):
             self.assertEqual(kwargs["model"], expected_model)
             self.assertTrue(kwargs["title_manually_set"])
             self.assertIn("Use the canonical `posthog:exec` tool", kwargs["description"])
-            self.assertIn("Discover them with `search`", kwargs["description"])
             self.assertIn("call channel-instructions-retrieve", kwargs["description"])
+            self.assertNotIn("info channel-instructions", kwargs["description"])
             self.assertEqual(set(kwargs["posthog_mcp_scopes"]), {*MCP_READ_SCOPES, "task:write"})
             self.assertFalse(
                 any(scope.endswith(":write") and scope != "task:write" for scope in kwargs["posthog_mcp_scopes"])

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -118,6 +118,8 @@ class TestOnboardingSessionIdempotency(TestCase):
             self.assertEqual(kwargs["model"], expected_model)
             self.assertTrue(kwargs["title_manually_set"])
             self.assertIn("Use the canonical `posthog:exec` tool", kwargs["description"])
+            self.assertIn("use `docs-search` before answering", kwargs["description"])
+            self.assertIn("without first running `docs-search`", kwargs["description"])
             self.assertIn("info channel-instructions-retrieve", kwargs["description"])
             self.assertIn("call channel-instructions-retrieve", kwargs["description"])
             self.assertIn("info channel-instructions-update", kwargs["description"])

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -117,6 +117,9 @@ class TestOnboardingSessionIdempotency(TestCase):
             self.assertEqual(kwargs["client_provenance"], TaskClientProvenance.POSTHOG_DESKTOP)
             self.assertEqual(kwargs["model"], expected_model)
             self.assertTrue(kwargs["title_manually_set"])
+            self.assertIn("Use the canonical `posthog:exec` tool", kwargs["description"])
+            self.assertIn("Discover them with `search`", kwargs["description"])
+            self.assertIn("call channel-instructions-retrieve", kwargs["description"])
             self.assertEqual(set(kwargs["posthog_mcp_scopes"]), {*MCP_READ_SCOPES, "task:write"})
             self.assertFalse(
                 any(scope.endswith(":write") and scope != "task:write" for scope in kwargs["posthog_mcp_scopes"])

--- a/products/tasks/backend/tests/test_onboarding_session.py
+++ b/products/tasks/backend/tests/test_onboarding_session.py
@@ -118,8 +118,9 @@ class TestOnboardingSessionIdempotency(TestCase):
             self.assertEqual(kwargs["model"], expected_model)
             self.assertTrue(kwargs["title_manually_set"])
             self.assertIn("Use the canonical `posthog:exec` tool", kwargs["description"])
+            self.assertIn("info channel-instructions-retrieve", kwargs["description"])
             self.assertIn("call channel-instructions-retrieve", kwargs["description"])
-            self.assertNotIn("info channel-instructions", kwargs["description"])
+            self.assertIn("info channel-instructions-update", kwargs["description"])
             self.assertEqual(set(kwargs["posthog_mcp_scopes"]), {*MCP_READ_SCOPES, "task:write"})
             self.assertFalse(
                 any(scope.endswith(":write") and scope != "task:write" for scope in kwargs["posthog_mcp_scopes"])


### PR DESCRIPTION
## Problem

1. onboarding concierge is missing some permissions
2. onboarding prompt, and repo-less task prompt, use stale or ambiguous tool names
3. concierge lacked posthog docs access & guidance

## Changes

- couple prompt updates
- give concierge session read access for posthog mcp tools
- add docs guidance to prompt

--- ai gen below ---

## How did you test this code?

- `pnpm test src/server/agent-server.test.ts` passed for the focused Desktop package.
- Ruff, Biome, and `git diff --check` passed.
- The focused backend test was attempted twice. Test-database setup failed once, and the warm retry was killed by the environment with exit 137.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used PostHog AI Observability, Prompt Management, repository tools, and GitHub CLI. Skills invoked: exploring-llm-traces, debugging-local-task-agent-runs, posthog-desktop, querying-posthog-data, auditing-llm-gateway-parity, writing-user-facing-copy, writing-tests, and writing-pr-descriptions.

The investigation compared model traces before changing access. The public patch contains no transcript content, customer data, or private operational metrics.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*