### PR TITLE
fix(api): stop the DEBUG response check turning a good response into a 500

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -239,7 +239,29 @@ def validated_request(
                     serializer_class = response_serializer
                     serialized = response_serializer(data=data, context=context)
 
-                if not serialized.is_valid(raise_exception=strict_response_validation):
+                try:
+                    response_matches_serializer = serialized.is_valid(raise_exception=strict_response_validation)
+                except Exception as exc:
+                    # `is_valid` only converts DRF's own ValidationError into a return value, so an
+                    # exception raised while parsing the response escapes it. A DataclassSerializer
+                    # rebuilds its dataclass in `to_internal_value`, and read-only fields are absent
+                    # by then, so a pydantic dataclass raises here for a response that is perfectly
+                    # valid. Under DEBUG alone this check is advisory, so report it the way a
+                    # mismatch is reported rather than failing the request it is only inspecting.
+                    if strict_response_validation:
+                        raise
+                    logger.warning(
+                        "Response serializer could not parse the response it declared for status code "
+                        f"{status_code} in the responses parameter of the @validated_request decorator. "
+                        "The response was returned unchanged; check the declared serializer.",
+                        view_func=view_func.__name__,
+                        status_code=status_code,
+                        serializer_class=serializer_class.__name__,
+                        error=str(exc),
+                    )
+                    return result
+
+                if not response_matches_serializer:
                     logger.warning(
                         f"Response data does not match declared serializer for status code {status_code} declared in responses parameter of the @validated_request decorator. Please update the provided API schema to ensure API docs remain up to date",
                         view_func=view_func.__name__,

--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -242,12 +242,8 @@ def validated_request(
                 try:
                     response_matches_serializer = serialized.is_valid(raise_exception=strict_response_validation)
                 except Exception as exc:
-                    # `is_valid` only converts DRF's own ValidationError into a return value, so an
-                    # exception raised while parsing the response escapes it. A DataclassSerializer
-                    # rebuilds its dataclass in `to_internal_value`, and read-only fields are absent
-                    # by then, so a pydantic dataclass raises here for a response that is perfectly
-                    # valid. Under DEBUG alone this check is advisory, so report it the way a
-                    # mismatch is reported rather than failing the request it is only inspecting.
+                    # `is_valid` only handles DRF's ValidationError. A DataclassSerializer can raise other
+                    # errors for a valid response, and this check is advisory under DEBUG, so warn instead.
                     if strict_response_validation:
                         raise
                     logger.warning(

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -30,6 +30,16 @@ class ErrorResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
 
+class RaisingResponseSerializer(serializers.Serializer):
+    """Stands in for a DataclassSerializer, which rebuilds its dataclass while parsing and so can
+    raise a non-DRF error for a response that is perfectly valid."""
+
+    value = serializers.CharField()
+
+    def to_internal_value(self, data):
+        raise RuntimeError("boom")
+
+
 class TestValidatedRequestDecorator(APIBaseTest):
     def test_request_validation_with_valid_event_data(self):
         """All valid data, should return 200 OK"""
@@ -199,6 +209,60 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["wrong_field"] == "value"
+
+    def test_response_serializer_that_raises_while_parsing_logs_warning(self):
+        """A response serializer raising during parsing should warn, not fail the request"""
+
+        @validated_request(
+            request_serializer=EventCaptureRequestSerializer,
+            responses={
+                200: OpenApiResponse(response=RaisingResponseSerializer),
+            },
+        )
+        def mock_endpoint(view_self, request):
+            return Response({"value": "ok"}, status=status.HTTP_200_OK)
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
+
+        with patch("posthog.api.mixins.settings") as mock_settings:
+            mock_settings.DEBUG = True
+            with patch("posthog.api.mixins.logger") as mock_logger:
+                response = mock_endpoint(view_instance, mock_request)
+
+                mock_logger.warning.assert_called_once()
+                call_args = mock_logger.warning.call_args
+                assert "Response serializer could not parse the response it declared" in call_args[0][0]
+                assert call_args[1]["serializer_class"] == "RaisingResponseSerializer"
+                assert "boom" in call_args[1]["error"]
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["value"] == "ok"
+
+    def test_strict_response_validation_reraises_a_parsing_exception(self):
+        """Strict mode still surfaces a response serializer that raises while parsing"""
+
+        @validated_request(
+            request_serializer=EventCaptureRequestSerializer,
+            responses={
+                200: OpenApiResponse(response=RaisingResponseSerializer),
+            },
+            strict_response_validation=True,
+        )
+        def mock_endpoint(view_self, request):
+            return Response({"value": "ok"}, status=status.HTTP_200_OK)
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
+
+        with pytest.raises(RuntimeError, match="boom"):
+            mock_endpoint(view_instance, mock_request)
 
     def test_no_response_serializers_bypasses_validation(self):
         """No response serializers, should bypass validation"""

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import NoReturn
 
 import pytest
 from posthog.test.base import APIBaseTest
@@ -30,13 +31,12 @@ class ErrorResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
 
+# Stands in for a DataclassSerializer, which rebuilds its dataclass while parsing and so can
+# raise a non-DRF error for a response that is perfectly valid.
 class RaisingResponseSerializer(serializers.Serializer):
-    """Stands in for a DataclassSerializer, which rebuilds its dataclass while parsing and so can
-    raise a non-DRF error for a response that is perfectly valid."""
-
     value = serializers.CharField()
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: object) -> NoReturn:
         raise RuntimeError("boom")
 
 
@@ -211,8 +211,6 @@ class TestValidatedRequestDecorator(APIBaseTest):
         assert response.data["wrong_field"] == "value"
 
     def test_response_serializer_that_raises_while_parsing_logs_warning(self):
-        """A response serializer raising during parsing should warn, not fail the request"""
-
         @validated_request(
             request_serializer=EventCaptureRequestSerializer,
             responses={
@@ -243,8 +241,6 @@ class TestValidatedRequestDecorator(APIBaseTest):
         assert response.data["value"] == "ok"
 
     def test_strict_response_validation_reraises_a_parsing_exception(self):
-        """Strict mode still surfaces a response serializer that raises while parsing"""
-
         @validated_request(
             request_serializer=EventCaptureRequestSerializer,
             responses={

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -31,8 +31,7 @@ class ErrorResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
 
-# Stands in for a DataclassSerializer, which rebuilds its dataclass while parsing and so can
-# raise a non-DRF error for a response that is perfectly valid.
+# Raises a non-DRF error while parsing, as a DataclassSerializer can for a valid response.
 class RaisingResponseSerializer(serializers.Serializer):
     value = serializers.CharField()
 


### PR DESCRIPTION
## Problem

An endpoint that declares a `DataclassSerializer` response returns 500 in local development, after writing its row. The caller cannot tell a successful write from a failed one, and the row is already there.

- `@validated_request` re-parses every response through its declared serializer when `DEBUG` is on.
- `serializer.is_valid()` converts only DRF's own `ValidationError` into a return value.
- A `DataclassSerializer` rebuilds its dataclass in `to_internal_value`, where read-only fields are already stripped, so a pydantic dataclass raises for a response that is perfectly valid.
- That exception escapes `is_valid()` and fails the request the check was only inspecting.

Production is unaffected: the block runs under `DEBUG` or explicit `strict_response_validation`. The test suite never sees it either, because tests run with `DEBUG=False`.

## Changes

- An endpoint whose declared serializer cannot parse its own response now returns that response unchanged, and logs a warning.
- The warning names the view, the status code and the serializer class, matching how a field mismatch is already reported.
- `strict_response_validation` still raises, so the strict callers keep the behavior they opted into.

Nothing user-visible changes in production. The fix only affects requests served with `DEBUG` on, or with strict validation set.

## How did you test this code?

`posthog/api/test/test_mixins.py` gains two cases. Neither is covered today, because every existing case uses a serializer that parses its own output.

- A response serializer that raises a non-DRF exception returns the original response.
- The same serializer under `strict_response_validation` still raises.

Not checked: no manual run against a live server in this session. The 500 was measured earlier on a stable backend against the autoresearch endpoints, same payload and endpoint either side of the fix: 500 before, 201 after.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) found this while running the autoresearch training loop locally: a sandbox agent was probing payload shapes to find one that "worked", because every write it made returned 500 and still succeeded. All six autoresearch `DataclassSerializer`s hit the same path, so it was the decorator, not the product.

The fix is cut fresh onto master from the autoresearch integration branch, ahead of the autoresearch PR stack, because it is core infrastructure that no autoresearch layer should gate.

Skills invoked: `/writing-pr-descriptions`.
