### PR TITLE
fix(settings): import object storage helper directly

### DIFF
--- a/posthog/settings/object_storage.py
+++ b/posthog/settings/object_storage.py
@@ -1,8 +1,8 @@
 import os
 from typing import Optional
 
-from posthog.settings import get_from_env
 from posthog.settings.base_variables import DEBUG, TEST
+from posthog.settings.utils import get_from_env
 from posthog.utils import str_to_bool
 
 if TEST or DEBUG:


### PR DESCRIPTION
🤖 Robot-authored pull request.

## Problem

The Python type check cannot infer object storage settings because their module imports a helper through the settings package.

The settings package is still loading when the object storage module imports it.

## Changes

- The object storage module imports `get_from_env` from its defining module.
- Mypy can infer every object storage setting without extra annotations.
- Runtime behavior does not change.

No screenshots: this change has no user interface.

## How did you test this code?

- `uv run mypy --cache-fine-grained .`
- `uv run ruff check posthog/settings/object_storage.py`
- `uv run ruff format --check posthog/settings/object_storage.py`
- `bin/hogli ci:preflight --fix`

`bin/hogli test --changed` found no related test files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Runtime behavior does not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi found this existing failure while checking another change. The first fix added one annotation.

A follow-up review found the indirect settings import caused the failure. The final change fixes that cause instead of adding annotations to every value.

The session used `/writing-pr-descriptions` and `/writing-simplified-technical-english`.
