### PR TITLE
fix(ingestion): stop rewriting the team row after the first event

### DIFF
--- a/nodejs/src/common/utils/team-manager.test.ts
+++ b/nodejs/src/common/utils/team-manager.test.ts
@@ -10,8 +10,15 @@ import { Hub, Team } from '~/types'
 
 import { defaultConfig } from '../config/config'
 import { closeHub, createHub } from './db/hub'
-import { PostgresRouter } from './db/postgres'
+import { PostgresRouter, PostgresUse } from './db/postgres'
+import { captureTeamEvent } from './posthog'
 import { TeamManager } from './team-manager'
+
+jest.mock('~/common/utils/posthog', () => ({
+    captureTeamEvent: jest.fn(),
+}))
+
+const mockCaptureTeamEvent = captureTeamEvent as jest.Mock
 
 describe('TeamManager()', () => {
     let hub: Hub
@@ -260,6 +267,83 @@ describe('TeamManager()', () => {
             ])
             const result = await teamManager.hasAvailableFeature(teamId, 'data_pipelines')
             expect(result).toBe(true)
+        })
+    })
+
+    describe('setTeamIngestedEvent()', () => {
+        const newTeamToken = 'token-for-a-team-with-no-events-yet'
+        let newTeam: Team
+
+        const readIngestedEvent = async (id: Team['id']): Promise<boolean> => {
+            const result = await postgres.query<{ ingested_event: boolean }>(
+                PostgresUse.COMMON_READ,
+                'SELECT ingested_event FROM posthog_team WHERE id = $1',
+                [id],
+                'test-read-ingested-event'
+            )
+            return result.rows[0].ingested_event
+        }
+
+        beforeEach(async () => {
+            await createTeam(postgres, organizationId, newTeamToken, { ingested_event: false })
+            const loaded = await teamManager.getTeamByToken(newTeamToken)
+            expect(loaded?.ingested_event).toBe(false)
+            newTeam = loaded as Team
+        })
+
+        it('flips the flag and captures the first event for each org member', async () => {
+            await teamManager.setTeamIngestedEvent(newTeam, { $lib: 'web' })
+
+            expect(await readIngestedEvent(newTeam.id)).toBe(true)
+            expect(mockCaptureTeamEvent).toHaveBeenCalledTimes(1)
+            expect(mockCaptureTeamEvent).toHaveBeenCalledWith(
+                newTeam,
+                'first team event ingested',
+                expect.objectContaining({ sdk: 'web' }),
+                expect.any(String)
+            )
+        })
+
+        it('does nothing on a repeat call through a stale team object', async () => {
+            await teamManager.setTeamIngestedEvent(newTeam, { $lib: 'web' })
+            mockCaptureTeamEvent.mockClear()
+
+            // `newTeam` still reads ingested_event=false, which is the stale-cache case exactly.
+            await teamManager.setTeamIngestedEvent(newTeam, { $lib: 'web' })
+
+            expect(mockCaptureTeamEvent).not.toHaveBeenCalled()
+            expect(await readIngestedEvent(newTeam.id)).toBe(true)
+        })
+
+        it('captures exactly once when two workers race on the same new team', async () => {
+            await Promise.all([
+                teamManager.setTeamIngestedEvent(newTeam, { $lib: 'web' }),
+                teamManager.setTeamIngestedEvent({ ...newTeam }, { $lib: 'web' }),
+            ])
+
+            expect(mockCaptureTeamEvent).toHaveBeenCalledTimes(1)
+            expect(await readIngestedEvent(newTeam.id)).toBe(true)
+        })
+
+        it('refreshes the token cache entry so the next lookup sees the flag', async () => {
+            await teamManager.setTeamIngestedEvent(newTeam, { $lib: 'web' })
+            fetchTeamsSpy.mockClear()
+
+            // Ingestion only ever looks teams up by token, so the token entry is the one that has
+            // to be invalidated. `Date.now` is frozen here, so nothing else can expire it.
+            const reloaded = await teamManager.getTeamByToken(newTeamToken)
+
+            expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
+            expect(reloaded?.ingested_event).toBe(true)
+        })
+
+        it('issues no query at all for a team already flagged as ingested', async () => {
+            const querySpy = jest.spyOn(postgres, 'query')
+
+            await teamManager.setTeamIngestedEvent({ ...newTeam, ingested_event: true }, { $lib: 'web' })
+
+            expect(querySpy).not.toHaveBeenCalled()
+            expect(mockCaptureTeamEvent).not.toHaveBeenCalled()
         })
     })
 })

--- a/nodejs/src/common/utils/team-manager.ts
+++ b/nodejs/src/common/utils/team-manager.ts
@@ -60,15 +60,25 @@ export class TeamManager {
 
     public async setTeamIngestedEvent(team: Team, properties: Properties): Promise<void> {
         if (!team.ingested_event) {
-            await this.postgres.query(
+            // The cached team can be stale: during backfills many workers see ingested_event=false
+            // long after the first write, and an unguarded UPDATE rewrites the same hot posthog_team
+            // row (exclusive row lock + dead tuple) thousands of times. The WHERE guard makes the
+            // repeat writes match zero rows, which takes no row lock and writes nothing.
+            const updateResult = await this.postgres.query(
                 PostgresUse.COMMON_WRITE,
-                `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`,
+                `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2 AND NOT ingested_event`,
                 [true, team.id],
                 'setTeamIngestedEvent'
             )
 
             // Invalidate the cache for this team
             this.lazyLoader.markForRefresh(String(team.id))
+
+            if (!updateResult.rowCount) {
+                // Another worker (or an earlier event seen through a stale cache) already flipped
+                // the flag - skip the first-event side effects so they fire exactly once per team.
+                return
+            }
 
             const organizationMembers = await this.postgres.query(
                 PostgresUse.COMMON_WRITE,

--- a/nodejs/src/common/utils/team-manager.ts
+++ b/nodejs/src/common/utils/team-manager.ts
@@ -3,6 +3,7 @@ import { OrganizationAvailableFeature, ProjectId, Team } from '~/types'
 
 import { PostgresRouter, PostgresUse } from './db/postgres'
 import { LazyLoader, LoaderRetryOptions } from './lazy-loader'
+import { logger } from './logger'
 import { captureTeamEvent } from './posthog'
 
 type RawTeam = Omit<Team, 'available_features'> & {
@@ -60,10 +61,9 @@ export class TeamManager {
 
     public async setTeamIngestedEvent(team: Team, properties: Properties): Promise<void> {
         if (!team.ingested_event) {
-            // The cached team can be stale: during backfills many workers see ingested_event=false
-            // long after the first write, and an unguarded UPDATE rewrites the same hot posthog_team
-            // row (exclusive row lock + dead tuple) thousands of times. The WHERE guard makes the
-            // repeat writes match zero rows, which takes no row lock and writes nothing.
+            // The cached team can be stale long after the first write, so this fires repeatedly for
+            // a team that is already flagged. The guard makes those repeats match zero rows, which
+            // writes nothing and leaves no dead tuple behind on a hot row.
             const updateResult = await this.postgres.query(
                 PostgresUse.COMMON_WRITE,
                 `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2 AND NOT ingested_event`,
@@ -71,34 +71,41 @@ export class TeamManager {
                 'setTeamIngestedEvent'
             )
 
-            // Invalidate the cache for this team
-            this.lazyLoader.markForRefresh(String(team.id))
+            // Both keys, because a team is cached under its id and its token but ingestion only ever
+            // looks it up by token - refreshing the id alone leaves the entry this worker reads stale.
+            this.lazyLoader.markForRefresh([String(team.id), team.api_token])
 
-            if (!updateResult.rowCount) {
+            if ((updateResult.rowCount ?? 0) === 0) {
                 // Another worker (or an earlier event seen through a stale cache) already flipped
                 // the flag - skip the first-event side effects so they fire exactly once per team.
                 return
             }
 
-            const organizationMembers = await this.postgres.query(
-                PostgresUse.COMMON_WRITE,
-                'SELECT distinct_id FROM posthog_user JOIN posthog_organizationmembership ON posthog_user.id = posthog_organizationmembership.user_id WHERE organization_id = $1',
-                [team.organization_id],
-                'posthog_organizationmembership'
-            )
-
-            const distinctIds: { distinct_id: string }[] = organizationMembers.rows
-            for (const { distinct_id } of distinctIds) {
-                captureTeamEvent(
-                    team,
-                    'first team event ingested',
-                    {
-                        sdk: properties.$lib,
-                        realm: properties.realm,
-                        host: properties.$host,
-                    },
-                    distinct_id
+            // The flag is already committed and no later event retries these, so a throw here loses
+            // the team's first-event capture for good. Swallow it and leave a trail instead.
+            try {
+                const organizationMembers = await this.postgres.query(
+                    PostgresUse.COMMON_WRITE,
+                    'SELECT distinct_id FROM posthog_user JOIN posthog_organizationmembership ON posthog_user.id = posthog_organizationmembership.user_id WHERE organization_id = $1',
+                    [team.organization_id],
+                    'posthog_organizationmembership'
                 )
+
+                const distinctIds: { distinct_id: string }[] = organizationMembers.rows
+                for (const { distinct_id } of distinctIds) {
+                    captureTeamEvent(
+                        team,
+                        'first team event ingested',
+                        {
+                            sdk: properties.$lib,
+                            realm: properties.realm,
+                            host: properties.$host,
+                        },
+                        distinct_id
+                    )
+                }
+            } catch (error) {
+                logger.error('⚠️', 'Failed to capture first team event ingested', { teamId: team.id, error })
             }
         }
     }


### PR DESCRIPTION
## Problem

Every event for a team whose cache entry is stale rewrites that team's `posthog_team` row and re-fires the first-event side effects. Nothing a user sees breaks, but the cost lands on the row that almost every team-scoped write already contends for.

`setTeamIngestedEvent` guarded on the cached team, so it skipped work only when the cache was fresh.

- The guard reads `team.ingested_event` from a cache entry that can lag the database by up to two and a half minutes.
- The SQL had no guard: `UPDATE posthog_team SET ingested_event = true WHERE id = $2`. It writes `true` over `true` and leaves a dead tuple each time.
- Raw SQL writes this column, so it never bumps `updated_at`. The row accumulates versions without the usual signal that anything changed.
- The org-member query and the `first team event ingested` capture re-ran on every such event. Racing workers could double-fire the capture.
- `markForRefresh` received the team id, but ingestion resolves teams by token. The entry the worker actually reads was never invalidated, so it stayed stale for its full refresh window and kept re-firing.

## Changes

Nothing user-visible changes. The flag reaches the same value by the same path, and only the redundant repeats stop.

- Repeat writes now match zero rows. They take no row lock, write no tuple, and leave no dead tuple.
- The first-event capture fires exactly once per team. It previously fired once per stale-cache worker.
- A stale worker corrects itself after one query, because both cache keys refresh. Without the token key the guard stops the writes but not the queries.
- A failure in the side effects is logged, not thrown. The flag is already committed by then and nothing retries, so a throw silently lost that team's capture.
- `rowCount ?? 0` matches the idiom in the other nodejs Postgres callers.

The `rowCount` gate is the part worth review. The rest is mechanical.

### Why the guard is safe

- `ingested_event` is `NOT NULL`, so `AND NOT ingested_event` has no three-valued-logic case.
- The flag is one-way. Every writer in the codebase sets it to `true`.
- Concurrent racers on a new team stay correct. The blocked racer re-evaluates the predicate against the committed row version, fails it, and reports zero rows.

## How did you test this code?

`setTeamIngestedEvent` had no tests. Five were added, each catching a regression no existing test caught.

- The first call flips the flag and captures once per org member.
- A repeat call through a stale team object matches zero rows and captures nothing. This covers the new gate.
- Two workers racing on the same new team capture exactly once.
- The token cache entry refreshes, so the next lookup sees the flag. This test fails on the previous commit, which shows the cache-key fix changes behavior.
- A team already flagged issues no query at all.

Not run: the wider nodejs suites and the Django suites, which CI covers. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) reviewed the first commit against the schema and production query statistics, then wrote the follow-up commit. Skills invoked: `/writing-pr-descriptions`.

The first commit framed this as a lock-contention fix. That mechanism does not hold: the foreign key check on `posthog_team` takes `FOR KEY SHARE`, a non-key update takes `FOR NO KEY UPDATE`, and those two lock modes do not conflict. The description now rests on the redundant-write argument, which the schema and the write pattern support directly.

The `markForRefresh` token-key bug surfaced while checking the first commit's claim that a stale worker corrects itself. It did not.
