### PR TITLE
fix(desktop): keep the last-used mode when a space composer opens

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -33,14 +33,10 @@ import {
   type AgentAdapter,
   useSettingsStore,
 } from "../../settings/settingsStore";
-import {
-  type WorkspaceMode,
-  WorkspaceModeSelect,
-} from "../../task-detail/components/WorkspaceModeSelect";
-import { useCloudModeEnabled } from "../../task-detail/hooks/useCloudModeEnabled";
+import { WorkspaceModeSelect } from "../../task-detail/components/WorkspaceModeSelect";
 import { usePreviewConfig } from "../../task-detail/hooks/usePreviewConfig";
+import { useResolvedWorkspaceMode } from "../../task-detail/hooks/useResolvedWorkspaceMode";
 import { useTaskCreation } from "../../task-detail/hooks/useTaskCreation";
-import { resolveWorkspaceModePreference } from "../../task-detail/hooks/workspaceModePreference";
 import { useUpdateTaskChannelRepositories } from "../hooks/useTaskChannels";
 import {
   resolveTaskRepositoryDraft,
@@ -109,9 +105,6 @@ export const ChannelHomeComposer = forwardRef<
     setLastUsedAgentRuntime,
     lastUsedPiModel,
     setLastUsedPiModel,
-    lastUsedWorkspaceMode,
-    setLastUsedWorkspaceMode,
-    setLastUsedLocalWorkspaceMode,
     allowBypassPermissions,
     defaultInitialTaskMode,
     lastUsedInitialTaskMode,
@@ -150,19 +143,14 @@ export const ChannelHomeComposer = forwardRef<
     );
   }, [flagsLoaded, lastUsedAgentRuntime, piHarnessEnabled]);
 
-  const cloudModeEnabled = useCloudModeEnabled();
-  const { hasGithubIntegration } = useUserRepositoryIntegration();
+  const { hasGithubIntegration, isLoadingIntegrations } =
+    useUserRepositoryIntegration();
 
-  // Repo-less channel tasks only run local or cloud (worktree needs a repo), so
-  // collapse any lingering worktree preference down to local for the initial pick.
-  const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() =>
-    resolveWorkspaceModePreference({
-      preferredMode: lastUsedWorkspaceMode === "cloud" ? "cloud" : "local",
-      cloudModeEnabled,
-      hasGithubIntegration,
-      lastUsedLocalWorkspaceMode: "local",
-    }),
-  );
+  const { workspaceMode, setWorkspaceMode } = useResolvedWorkspaceMode({
+    hasGithubIntegration,
+    isLoadingIntegrations,
+    allowWorktree: false,
+  });
   const [selectedCloudEnvId, setSelectedCloudEnvId] = useState<string | null>(
     null,
   );
@@ -184,14 +172,6 @@ export const ChannelHomeComposer = forwardRef<
     channelGithubIntegration,
   );
   const updateChannelRepositories = useUpdateTaskChannelRepositories();
-  const setWorkspaceMode = useCallback(
-    (mode: WorkspaceMode) => {
-      setWorkspaceModeState(mode);
-      setLastUsedWorkspaceMode(mode);
-      if (mode !== "cloud") setLastUsedLocalWorkspaceMode(mode);
-    },
-    [setLastUsedWorkspaceMode, setLastUsedLocalWorkspaceMode],
-  );
 
   const {
     modeOption,

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -567,6 +567,7 @@ export function useUserRepositoryIntegration() {
     getInstallationIdForRepo,
     isRepoInIntegration: repoInIntegration,
     isLoadingRepos: liveLoading && !servingFromCache,
+    isLoadingIntegrations: integrationsPending,
     isRefreshingRepos: isRefreshingRepos || servingFromCache,
     refreshRepositories,
     hasGithubIntegration:

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -48,7 +48,6 @@ import { useConnectivity } from "../../../hooks/useConnectivity";
 import { DotPatternBackground } from "../../../primitives/DotPatternBackground";
 import { toast } from "../../../primitives/toast";
 import { useActiveRepoStore } from "../../../shell/activeRepoStore";
-import { useHostCapabilities } from "../../../shell/useHostCapabilities";
 import { FOCUSABLE_SELECTOR } from "../../../utils/overlay";
 import { useAuthStateValue } from "../../auth/store";
 import { AutoresearchComposerControls } from "../../autoresearch/AutoresearchComposerControls";
@@ -100,19 +99,17 @@ import { ReasoningLevelSelector } from "../../sessions/components/ReasoningLevel
 import { getCurrentModeFromConfigOptions } from "../../sessions/sessionStore";
 import {
   type AgentAdapter,
-  DEFAULT_WORKSPACE_MODE,
   useSettingsStore,
 } from "../../settings/settingsStore";
 import { useSkills } from "../../skills/useSkills";
-import { useCloudModeEnabled } from "../hooks/useCloudModeEnabled";
 import {
   areReposReady,
   useInitialRepoSelectionFromFolderId,
 } from "../hooks/useInitialRepoSelectionFromFolderId";
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
+import { useResolvedWorkspaceMode } from "../hooks/useResolvedWorkspaceMode";
 import { useTaskCreation } from "../hooks/useTaskCreation";
 import { useWarmTask } from "../hooks/useWarmTask";
-import { resolveWorkspaceModePreference } from "../hooks/workspaceModePreference";
 import { ChannelContextChip } from "./ChannelContextChip";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
 import { NewTaskSuggestions } from "./ContinueCliSessions";
@@ -120,7 +117,7 @@ import {
   type SuggestedPrompt,
   SuggestedPromptCard,
 } from "./SuggestedPromptCard";
-import { type WorkspaceMode, WorkspaceModeSelect } from "./WorkspaceModeSelect";
+import { WorkspaceModeSelect } from "./WorkspaceModeSelect";
 
 interface TaskInputProps {
   sessionId?: string;
@@ -267,10 +264,7 @@ export function TaskInput({
     trpc.folders.getMostRecentlyAccessedRepository.queryOptions(),
   );
   const {
-    setLastUsedLocalWorkspaceMode,
     lastUsedLocalWorkspaceMode,
-    lastUsedWorkspaceMode,
-    setLastUsedWorkspaceMode,
     lastUsedAgentRuntime,
     setLastUsedAgentRuntime,
     lastUsedAdapter,
@@ -442,14 +436,12 @@ export function TaskInput({
     getInstallationIdForRepo,
     getUserIntegrationIdForRepo,
     isLoadingRepos,
+    isLoadingIntegrations,
     isRefreshingRepos,
     refreshRepositories,
     hasGithubIntegration,
   } = useUserRepositoryIntegration();
 
-  // Force cloud mode on cloud-only hosts (web).
-  const { localWorkspaces } = useHostCapabilities();
-  const cloudModeEnabled = useCloudModeEnabled();
   const piHarnessEnabled = useFeatureFlag("pi-harness");
   const flagsLoaded = useFeatureFlagsLoaded();
   const reposReady = areReposReady({
@@ -468,63 +460,13 @@ export function TaskInput({
     );
   }, [flagsLoaded, lastUsedAgentRuntime, piHarnessEnabled, settingsHydrated]);
 
-  const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() => {
-    if (initialCloudRepository) return "cloud";
-    if (!localWorkspaces) return "cloud";
-    return resolveWorkspaceModePreference({
-      preferredMode: lastUsedWorkspaceMode || DEFAULT_WORKSPACE_MODE,
-      cloudModeEnabled,
+  const { workspaceMode, setWorkspaceMode, overrideWorkspaceMode } =
+    useResolvedWorkspaceMode({
       hasGithubIntegration,
-      lastUsedLocalWorkspaceMode,
+      isLoadingIntegrations,
+      pinCloud: !!initialCloudRepository,
     });
-  });
 
-  // A positive flag or integration signal is final, but a negative one may
-  // just mean the async flag fetch or integrations query hasn't landed yet, so
-  // a cloud preference only resolves once each negative signal is settled.
-  const cloudSignalsSettled =
-    (cloudModeEnabled || flagsLoaded) &&
-    (hasGithubIntegration || !isLoadingRepos);
-
-  const didResolveWorkspaceModeRef = useRef(false);
-  useEffect(() => {
-    if (didResolveWorkspaceModeRef.current) return;
-    if (!settingsHydrated) return;
-    if (initialCloudRepository) {
-      didResolveWorkspaceModeRef.current = true;
-      return;
-    }
-    const preferredMode = lastUsedWorkspaceMode || DEFAULT_WORKSPACE_MODE;
-    if (preferredMode === "cloud" && !cloudSignalsSettled) return;
-    didResolveWorkspaceModeRef.current = true;
-    if (!localWorkspaces) return;
-    setWorkspaceModeState(
-      resolveWorkspaceModePreference({
-        preferredMode,
-        cloudModeEnabled,
-        hasGithubIntegration,
-        lastUsedLocalWorkspaceMode,
-      }),
-    );
-  }, [
-    settingsHydrated,
-    lastUsedWorkspaceMode,
-    initialCloudRepository,
-    localWorkspaces,
-    cloudSignalsSettled,
-    cloudModeEnabled,
-    hasGithubIntegration,
-    lastUsedLocalWorkspaceMode,
-  ]);
-
-  const setWorkspaceMode = (mode: WorkspaceMode) => {
-    didResolveWorkspaceModeRef.current = true;
-    setWorkspaceModeState(mode);
-    setLastUsedWorkspaceMode(mode);
-    if (mode !== "cloud") {
-      setLastUsedLocalWorkspaceMode(mode);
-    }
-  };
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,
@@ -653,9 +595,9 @@ export function TaskInput({
 
   useEffect(() => {
     if (!initialCloudRepository) return;
-    setWorkspaceModeState("cloud");
+    overrideWorkspaceMode("cloud");
     setSelectedRepository(initialCloudRepository.toLowerCase());
-  }, [initialCloudRepository]);
+  }, [initialCloudRepository, overrideWorkspaceMode]);
 
   const handleRefreshRepositories = useCallback(() => {
     void refreshRepositories().catch((error) => {
@@ -776,14 +718,6 @@ export function TaskInput({
     setLastUsedCloudRepository,
   ]);
 
-  // Switch mode for a folder-scoped prefill ("+" in the sidebar) without persisting it as
-  // the user's mode preference. Marks the mode as resolved so the last-used resolver above
-  // doesn't override the explicit pick.
-  const switchWorkspaceModeForFolder = useCallback((mode: WorkspaceMode) => {
-    didResolveWorkspaceModeRef.current = true;
-    setWorkspaceModeState(mode);
-  }, []);
-
   useInitialRepoSelectionFromFolderId({
     folderId: view.folderId,
     folderRepository: view.folderRepository,
@@ -797,7 +731,7 @@ export function TaskInput({
     mostRecentEnvironment: view.folderRunEnvironment,
     setSelectedDirectory,
     setSelectedRepository,
-    switchWorkspaceMode: switchWorkspaceModeForFolder,
+    switchWorkspaceMode: overrideWorkspaceMode,
   });
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useResolvedWorkspaceMode.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useResolvedWorkspaceMode.test.tsx
@@ -1,0 +1,176 @@
+import type { WorkspaceMode } from "@posthog/shared";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LocalWorkspaceMode } from "../../settings/settingsStore";
+
+const hostState = vi.hoisted(() => ({ localWorkspaces: true }));
+const cloudState = vi.hoisted(() => ({ enabled: false, flagsLoaded: false }));
+const settingsState = vi.hoisted(() => ({
+  lastUsedWorkspaceMode: "cloud" as WorkspaceMode,
+  lastUsedLocalWorkspaceMode: "local" as LocalWorkspaceMode,
+  setLastUsedWorkspaceMode: vi.fn(),
+  setLastUsedLocalWorkspaceMode: vi.fn(),
+  _hasHydrated: true,
+}));
+
+vi.mock("../../../shell/useHostCapabilities", () => ({
+  useHostCapabilities: () => hostState,
+}));
+vi.mock("./useCloudModeEnabled", () => ({
+  useCloudModeEnabled: () => cloudState.enabled,
+}));
+vi.mock("../../feature-flags/useFeatureFlagsLoaded", () => ({
+  useFeatureFlagsLoaded: () => cloudState.flagsLoaded,
+}));
+vi.mock("../../settings/settingsStore", () => ({
+  DEFAULT_WORKSPACE_MODE: "cloud",
+  useSettingsStore: () => settingsState,
+}));
+
+import { useResolvedWorkspaceMode } from "./useResolvedWorkspaceMode";
+
+const PENDING = {
+  hasGithubIntegration: false,
+  isLoadingIntegrations: true,
+};
+const SETTLED = {
+  hasGithubIntegration: true,
+  isLoadingIntegrations: false,
+};
+
+describe("useResolvedWorkspaceMode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hostState.localWorkspaces = true;
+    cloudState.enabled = false;
+    cloudState.flagsLoaded = false;
+    settingsState.lastUsedWorkspaceMode = "cloud";
+    settingsState.lastUsedLocalWorkspaceMode = "local";
+    settingsState._hasHydrated = true;
+  });
+
+  it("honors a cloud preference once the flag and integration land", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useResolvedWorkspaceMode>[0]) =>
+        useResolvedWorkspaceMode(props),
+      { initialProps: PENDING },
+    );
+
+    expect(result.current.workspaceMode).toBe("local");
+
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+    rerender(SETTLED);
+
+    expect(result.current.workspaceMode).toBe("cloud");
+  });
+
+  it.each([
+    ["local" as WorkspaceMode, "local"],
+    ["worktree" as WorkspaceMode, "worktree"],
+  ])("keeps a sticky %s pick when the signals settle", (stored, expected) => {
+    settingsState.lastUsedWorkspaceMode = stored;
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+
+    const { result } = renderHook(() => useResolvedWorkspaceMode(SETTLED));
+
+    expect(result.current.workspaceMode).toBe(expected);
+  });
+
+  it("falls back to local when GitHub is not connected", () => {
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+
+    const { result } = renderHook(() =>
+      useResolvedWorkspaceMode({
+        hasGithubIntegration: false,
+        isLoadingIntegrations: false,
+      }),
+    );
+
+    expect(result.current.workspaceMode).toBe("local");
+  });
+
+  it("ignores a cached integration until the live query settles", () => {
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useResolvedWorkspaceMode>[0]) =>
+        useResolvedWorkspaceMode(props),
+      {
+        initialProps: {
+          hasGithubIntegration: true,
+          isLoadingIntegrations: true,
+        },
+      },
+    );
+
+    expect(result.current.workspaceMode).toBe("local");
+
+    rerender({
+      hasGithubIntegration: false,
+      isLoadingIntegrations: false,
+    });
+
+    expect(result.current.workspaceMode).toBe("local");
+  });
+
+  it("collapses a worktree preference to local where worktrees can't run", () => {
+    settingsState.lastUsedWorkspaceMode = "worktree";
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+
+    const { result } = renderHook(() =>
+      useResolvedWorkspaceMode({ ...SETTLED, allowWorktree: false }),
+    );
+
+    expect(result.current.workspaceMode).toBe("local");
+  });
+
+  it("remembers a user pick but not a context-driven override", () => {
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+    const { result } = renderHook(() => useResolvedWorkspaceMode(SETTLED));
+
+    act(() => result.current.setWorkspaceMode("worktree"));
+    expect(result.current.workspaceMode).toBe("worktree");
+    expect(settingsState.setLastUsedWorkspaceMode).toHaveBeenCalledWith(
+      "worktree",
+    );
+    expect(settingsState.setLastUsedLocalWorkspaceMode).toHaveBeenCalledWith(
+      "worktree",
+    );
+
+    vi.clearAllMocks();
+    act(() => result.current.overrideWorkspaceMode("local"));
+    expect(result.current.workspaceMode).toBe("local");
+    expect(settingsState.setLastUsedWorkspaceMode).not.toHaveBeenCalled();
+  });
+
+  it("waits for the settings store to hydrate before resolving", () => {
+    settingsState._hasHydrated = false;
+    settingsState.lastUsedWorkspaceMode = "local";
+    cloudState.enabled = true;
+    cloudState.flagsLoaded = true;
+
+    const { result, rerender } = renderHook(() =>
+      useResolvedWorkspaceMode(SETTLED),
+    );
+
+    settingsState._hasHydrated = true;
+    rerender();
+
+    expect(result.current.workspaceMode).toBe("local");
+  });
+
+  it("pins cloud on a cloud-only host", () => {
+    hostState.localWorkspaces = false;
+    settingsState.lastUsedWorkspaceMode = "local";
+
+    const { result } = renderHook(() => useResolvedWorkspaceMode(SETTLED));
+
+    expect(result.current.workspaceMode).toBe("cloud");
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useResolvedWorkspaceMode.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useResolvedWorkspaceMode.ts
@@ -1,0 +1,115 @@
+import type { WorkspaceMode } from "@posthog/shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useHostCapabilities } from "../../../shell/useHostCapabilities";
+import { useFeatureFlagsLoaded } from "../../feature-flags/useFeatureFlagsLoaded";
+import {
+  DEFAULT_WORKSPACE_MODE,
+  type LocalWorkspaceMode,
+  useSettingsStore,
+} from "../../settings/settingsStore";
+import { useCloudModeEnabled } from "./useCloudModeEnabled";
+import {
+  areCloudSignalsSettled,
+  resolveWorkspaceModePreference,
+} from "./workspaceModePreference";
+
+export interface UseResolvedWorkspaceModeInput {
+  hasGithubIntegration: boolean;
+  isLoadingIntegrations: boolean;
+  pinCloud?: boolean;
+  allowWorktree?: boolean;
+}
+
+export interface ResolvedWorkspaceMode {
+  workspaceMode: WorkspaceMode;
+  setWorkspaceMode: (mode: WorkspaceMode) => void;
+  overrideWorkspaceMode: (mode: WorkspaceMode) => void;
+}
+
+export function useResolvedWorkspaceMode({
+  hasGithubIntegration,
+  isLoadingIntegrations,
+  pinCloud = false,
+  allowWorktree = true,
+}: UseResolvedWorkspaceModeInput): ResolvedWorkspaceMode {
+  const {
+    lastUsedWorkspaceMode,
+    lastUsedLocalWorkspaceMode,
+    setLastUsedWorkspaceMode,
+    setLastUsedLocalWorkspaceMode,
+    _hasHydrated: settingsHydrated,
+  } = useSettingsStore();
+  const { localWorkspaces } = useHostCapabilities();
+  const cloudModeEnabled = useCloudModeEnabled();
+  const flagsLoaded = useFeatureFlagsLoaded();
+
+  const storedMode = lastUsedWorkspaceMode || DEFAULT_WORKSPACE_MODE;
+  const preferredMode: WorkspaceMode =
+    allowWorktree || storedMode === "cloud" ? storedMode : "local";
+  const localFallback: LocalWorkspaceMode = allowWorktree
+    ? lastUsedLocalWorkspaceMode
+    : "local";
+
+  const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() => {
+    if (pinCloud || !localWorkspaces) return "cloud";
+    return resolveWorkspaceModePreference({
+      preferredMode,
+      cloudModeEnabled,
+      hasGithubIntegration: hasGithubIntegration && !isLoadingIntegrations,
+      lastUsedLocalWorkspaceMode: localFallback,
+    });
+  });
+
+  const cloudSignalsSettled = areCloudSignalsSettled({
+    cloudModeEnabled,
+    flagsLoaded,
+    isLoadingIntegrations,
+  });
+
+  const didResolveRef = useRef(false);
+  useEffect(() => {
+    if (didResolveRef.current) return;
+    if (!settingsHydrated) return;
+    if (pinCloud) {
+      didResolveRef.current = true;
+      return;
+    }
+    if (preferredMode === "cloud" && !cloudSignalsSettled) return;
+    didResolveRef.current = true;
+    if (!localWorkspaces) return;
+    setWorkspaceModeState(
+      resolveWorkspaceModePreference({
+        preferredMode,
+        cloudModeEnabled,
+        hasGithubIntegration,
+        lastUsedLocalWorkspaceMode: localFallback,
+      }),
+    );
+  }, [
+    settingsHydrated,
+    pinCloud,
+    preferredMode,
+    cloudSignalsSettled,
+    localWorkspaces,
+    cloudModeEnabled,
+    hasGithubIntegration,
+    localFallback,
+  ]);
+
+  const setWorkspaceMode = useCallback(
+    (mode: WorkspaceMode) => {
+      didResolveRef.current = true;
+      setWorkspaceModeState(mode);
+      setLastUsedWorkspaceMode(mode);
+      if (mode !== "cloud") setLastUsedLocalWorkspaceMode(mode);
+    },
+    [setLastUsedWorkspaceMode, setLastUsedLocalWorkspaceMode],
+  );
+
+  const overrideWorkspaceMode = useCallback((mode: WorkspaceMode) => {
+    didResolveRef.current = true;
+    setWorkspaceModeState(mode);
+  }, []);
+
+  return { workspaceMode, setWorkspaceMode, overrideWorkspaceMode };
+}

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
@@ -23,3 +23,17 @@ export function resolveWorkspaceModePreference({
   }
   return "cloud";
 }
+
+export interface CloudSignalsInput {
+  cloudModeEnabled: boolean;
+  flagsLoaded: boolean;
+  isLoadingIntegrations: boolean;
+}
+
+export function areCloudSignalsSettled({
+  cloudModeEnabled,
+  flagsLoaded,
+  isLoadingIntegrations,
+}: CloudSignalsInput): boolean {
+  return (cloudModeEnabled || flagsLoaded) && !isLoadingIntegrations;
+}


### PR DESCRIPTION
## Problem

Starting a session from a space's prompt box in PostHog Desktop puts the run on local, even for someone whose last run was cloud and who has GitHub connected.

- `ChannelHomeComposer` picked the mode once, in a `useState` initializer, with no effect to re-resolve it.
- At that moment the `twig-cloud-mode-toggle` flag and the GitHub integrations query are both still pending, and both read as negative.
- A cloud preference therefore downgraded to local, and stayed there for the whole mount.

The task composer already waited for those signals. The space composer never got that gate.

## Changes

- A space's prompt box now opens on the mode you last used, so the picker reads "Cloud" instead of "Local" for a cloud user with GitHub connected.
- Your pick stays sticky: choosing local still keeps local for the next session, on that machine.
- Cloud still falls back to local when the flag is off or GitHub is not connected, so nobody starts behind a connect-GitHub prompt.
- Mechanical: the resolution moved into a shared `useResolvedWorkspaceMode` hook that both composers call, replacing the duplicated state, effect, and setter. The task composer's behavior is unchanged.

