### PR TITLE
fix(dashboards): center shared dashboard title

### DIFF
--- a/frontend/src/exporter/Exporter.scss
+++ b/frontend/src/exporter/Exporter.scss
@@ -36,17 +36,18 @@ body.ExporterBody {
         }
 
         @include screen($md) {
-            display: flex;
-            gap: 1rem;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) minmax(0, 50%) minmax(0, 1fr);
             align-items: center;
-            justify-content: space-between;
 
             .SharedDashboard-header-title {
-                max-width: 50%;
+                grid-column: 2;
                 text-align: center;
             }
 
             .SharedDashboard-header-team {
+                grid-column: 3;
+                justify-self: end;
                 margin-top: 0;
             }
         }


### PR DESCRIPTION
## Problem

- People who view a brandless shared dashboard see its title shift left after the logo disappears.



## Changes


<img width="2512" height="1436" alt="CleanShot 2026-08-25 at 12 22 03@2x" src="https://github.com/user-attachments/assets/6c5acbca-1987-46e5-841a-389be54a25c9" />

- Brandless shared dashboards keep the title centered and continue to hide the PostHog logo.
- The desktop header uses three layout columns for branding, title, and team metadata.
- Screenshot not uploaded because the supplied reference image may contain non-public dashboard data.

## How did you test this code?

- The focused exporter suite checks shared dashboard render variants.
- The full TypeScript check remains blocked by unrelated errors outside this change.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. This is a layout-only correction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/writing-ui-components` and `/writing-pr-descriptions`.
- The final patch uses a grid layout instead of reserving a hidden logo element.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*