### PR TITLE
fix(tasks): wait for the sandbox to shut down after destroy

### DIFF
--- a/products/tasks/backend/logic/services/test_sandbox.py
+++ b/products/tasks/backend/logic/services/test_sandbox.py
@@ -1,8 +1,29 @@
 import os
+import time
 
 import pytest
 
-from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxConfig, SandboxStatus, SandboxTemplate
+from products.tasks.backend.logic.services.sandbox import (
+    Sandbox,
+    SandboxBase,
+    SandboxConfig,
+    SandboxStatus,
+    SandboxTemplate,
+)
+
+SHUTDOWN_TIMEOUT_SECONDS = 120.0
+SHUTDOWN_POLL_SECONDS = 0.5
+
+
+def wait_for_shutdown(sandbox: SandboxBase) -> SandboxStatus:
+    # Modal returns from terminate() before the sandbox leaves the running state,
+    # so get_status() can still read RUNNING right after destroy().
+    deadline = time.monotonic() + SHUTDOWN_TIMEOUT_SECONDS
+    status = sandbox.get_status()
+    while status != SandboxStatus.SHUTDOWN and time.monotonic() < deadline:
+        time.sleep(SHUTDOWN_POLL_SECONDS)
+        status = sandbox.get_status()
+    return status
 
 
 class TestSandboxIntegration:
@@ -29,7 +50,7 @@ class TestSandboxIntegration:
         assert result.stderr == ""
 
         sandbox.destroy()
-        assert sandbox.get_status() == SandboxStatus.SHUTDOWN
+        assert wait_for_shutdown(sandbox) == SandboxStatus.SHUTDOWN
 
     @pytest.mark.parametrize(
         "command,expected_exit_code,expected_in_stdout",
@@ -97,4 +118,4 @@ class TestSandboxIntegration:
             assert result.exit_code == 0
             assert "context test" in result.stdout
 
-        assert sandbox.get_status() == SandboxStatus.SHUTDOWN
+        assert wait_for_shutdown(sandbox) == SandboxStatus.SHUTDOWN


### PR DESCRIPTION
## Problem

Backend CI is red on master, and every PR whose change set includes `products/tasks` fails its required `Django Tests Pass` check.

- Two Modal integration tests assert `SHUTDOWN` on the line after `destroy()`.
- Modal returns from `terminate()` before the sandbox leaves the running state, so `get_status()` still reads `RUNNING`.
- The tests are `test_create_execute_destroy_lifecycle` and `test_context_manager_auto_cleanup` in `products/tasks/backend/logic/services/test_sandbox.py`.

Master run [32859005177](https://github.com/PostHog/posthog/actions/runs/32859005177) fails on both. Every master Backend CI run sampled from 13:10 UTC on 25 August onward is red on the same job.

No commit in this repo caused it. Nothing since 24 August touches `sandbox.py`, `modal_sandbox.py`, or the test, and `modal` stays pinned at `1.5.4`. The service changed under a live-service test.

Trunk marks both tests `BROKEN`, not `FLAKY`, so auto-quarantine does not apply to them.

## Changes

- The two tests now wait for the sandbox to reach `SHUTDOWN` instead of asserting it one line after `destroy()`.
- `wait_for_shutdown` polls `get_status()` every 0.5 seconds and gives up after 120 seconds.
- Nothing user-visible changes. The diff touches one test file.

The wait keeps a ceiling rather than retrying forever, so a sandbox that never terminates still fails the test.

## How did you test this code?

Both tests ran against live Modal, because this environment holds `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`.

- With this change: 2 passed in 36.16s.
- On unmodified master: 2 failed in 5.36s, with the same `RUNNING` vs `SHUTDOWN` assertion CI reports.

The regression the pair still catches: `destroy()` leaving the sandbox running. The 120 second ceiling holds that line.

Not run: the rest of the tasks backend suite, and any suite needing Postgres or ClickHouse.

<details>
<summary>Local run output</summary>

```text
# with this change
..                                                                       [100%]
2 passed in 36.16s

# on unmodified master
>       assert sandbox.get_status() == SandboxStatus.SHUTDOWN
E       AssertionError: assert equals failed
E          -<SandboxStatus.RUNNING: 'runnin   +<SandboxStatus.SHUTDOWN: 'shutd
E          -g'>                               +own'>
FAILED backend/logic/services/test_sandbox.py::TestSandboxIntegration::test_create_execute_destroy_lifecycle
FAILED backend/logic/services/test_sandbox.py::TestSandboxIntegration::test_context_manager_auto_cleanup
2 failed in 5.36s
```

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change touches a test only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code wrote this while babysitting CI for an unrelated stack, whose bottom PR was blocked by this failure. The investigation started from that stack's red checks, confirmed the same two tests fail on master, and ruled out the stack as the cause.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two alternatives lost. Quarantining in Trunk needs the web UI and the repo variable `TRUNK_QUARANTINE_ENABLED`, and Trunk excludes `BROKEN` tests from auto-quarantine anyway. Deleting the assertion would drop the only coverage that `destroy()` works.

The timeout started at 30 seconds and moved to 120 after the local runs showed the shutdown taking a noticeable share of that budget.
