### PR TITLE
fix(demo): mark simulated persons that fired $identify as identified

### DIFF
--- a/products/demo/backend/logic/matrix/manager.py
+++ b/products/demo/backend/logic/matrix/manager.py
@@ -22,7 +22,7 @@ from products.demo.backend.logic.matrix.persons_db_sync import (
 from products.demo.backend.logic.matrix.taxonomy_inference import infer_taxonomy_for_team
 
 from .matrix import Matrix
-from .models import SimEvent, SimPerson
+from .models import EVENT_IDENTIFY, SimEvent, SimPerson
 
 
 class MatrixManager:
@@ -263,10 +263,15 @@ class MatrixManager:
             if not hasattr(subject, "properties_at_now"):
                 subject.take_snapshot_at_now()
 
+            # A person that fired an $identify event during the simulation is identified,
+            # matching real ingestion, which flips is_identified on $identify. Without this the
+            # demo generator leaves every person anonymous (is_identified=False).
+            is_identified = any(event.event == EVENT_IDENTIFY for event in subject.past_events)
             create_person(
                 uuid=str(subject.in_posthog_id),
                 team_id=team.pk,
                 properties=subject.properties_at_now,
+                is_identified=is_identified,
                 version=0,
             )
             self._persons_created += 1

--- a/products/demo/backend/test/test_matrix_manager.py
+++ b/products/demo/backend/test/test_matrix_manager.py
@@ -103,6 +103,19 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
         )
         assert self.team.name == DummyMatrix.PRODUCT_NAME
 
+    def test_run_on_team_marks_persons_that_identified(self):
+        manager = MatrixManager(self.matrix)
+
+        manager.run_on_team(self.team, self.user)
+
+        assert (
+            sync_execute(
+                "SELECT countIf(is_identified = 1) FROM person WHERE team_id = %(team_id)s",
+                {"team_id": self.team.pk},
+            )[0][0]
+            >= 3
+        )
+
     def test_run_on_team_using_pre_save(self):
         manager = MatrixManager(self.matrix, use_pre_save=True)
 


### PR DESCRIPTION
## Problem

Every person in a demo project reads as anonymous. A filter, cohort or insight that selects identified persons returns a fraction of the demo population, or none of it.

- The demo generator calls `create_person` without `is_identified`, so every row lands `False`.
- The simulation does capture `$identify`, and real ingestion flips `is_identified` on that event.
- The flag is therefore derivable from the person's own event history, and was simply never set.

## Changes

- A simulated person that fired `$identify` is now written with `is_identified=True`.
- Demo projects show a realistic split between identified and anonymous people, so anything filtering on identified persons returns what it should.
- `MatrixManager` reads the person's `past_events` for the `$identify` event, matching how ingestion decides the same thing.

Nothing changes for non-demo projects. The code path runs only in the demo data generator.

## How did you test this code?

`test_matrix_manager.py` gains one case: after `run_on_team`, at least one person per cluster is identified in ClickHouse. No existing case looks at `is_identified`.

- Verified the case fails on master and passes with the fix, by reverting `manager.py` and re-running it.
- `uv run pytest products/demo/backend/test/test_matrix_manager.py`, 6 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), driven by @andrewm4894. Found while training a model on demo data: the population query returned far fewer rows than the event counts implied, because it selected identified persons.

This was previously the top layer of a 13-PR autoresearch stack, which is now closed and being re-cut. The fix has no autoresearch dependency, so it is re-cut onto master on its own.

Skills invoked: `/phs autoresearch`, `/writing-tests`, `/writing-pr-descriptions`.
