### PR TITLE
fix(ingestion-consumer): heartbeat liveness during deferred flush

### DIFF
--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -445,7 +445,12 @@ impl IngestionConsumer {
     /// (nothing routable, or a flapping worker re-deferring every send).
     /// Failing the whole process for a mere slow drain amplified today's
     /// saturation: each restart replayed all its partitions into an already
-    /// overloaded pool.
+    /// overloaded pool. For the same reason the loop heartbeats the liveness
+    /// handle on every iteration: the two mechanisms are meant to answer
+    /// different questions — `deferred_flush_timeout` asks whether the flush is
+    /// making progress, the liveness deadline asks whether this task is alive —
+    /// and a patient flush that never heartbeats gets killed by the latter long
+    /// before the former is reached.
     ///
     /// With eager flushing enabled, some (or all) of the batch's deferred
     /// groups may instead be in flight on the eager path — the loop also waits
@@ -459,6 +464,14 @@ impl IngestionConsumer {
         if self.dispatcher.has_unfinished_flush(batch_id) {
             let mut stall_deadline = Instant::now() + self.deferred_flush_timeout;
             while self.dispatcher.has_unfinished_flush(batch_id) {
+                // This loop is deliberately patient, so it has to keep its own
+                // liveness heartbeat alive: `stall_deadline` is what decides a
+                // wedge here, not the watchdog's wall-clock silence. Without
+                // this, a flush that drains slowly but does make progress trips
+                // the liveness stall threshold and exits the process — the
+                // restart amplification the stall-based deadline above exists to
+                // avoid.
+                self.handle.report_healthy();
                 if Instant::now() >= stall_deadline {
                     anyhow::bail!("deferred messages made no progress within the flush timeout");
                 }


### PR DESCRIPTION
## Problem

`flush_deferred` (`rust/ingestion-consumer/src/consumer.rs`) is the only long-running await path in the consumer that never reports liveness. Under worker saturation that makes the process kill itself while it is still making progress.

The chain:

1. A worker at capacity returns `503` — correctly classified as retriable backpressure (`transport.rs`, `is_retriable`). `send_batch` retries 3× with jittered backoff (~2.4s total) and then returns `ChunkOutcome::Failed`.
2. A failed send doesn't propagate an error. In `scatter`, the `Err` arm calls `dispatcher.defer_failed(...)` and returns normally, so `has_unfinished_flush(batch_id)` stays true and the flush loop spins again.
3. The flush loop is *deliberately* patient. `stall_deadline` (`consumer_deferred_flush_timeout_ms`, 60s) resets on **any** accepted message, so with a large worker pool where only some workers are saturated, partial progress lands nearly every round and the loop can legitimately run for minutes. The doc comment says why: *"Failing the whole process for a mere slow drain amplified today's saturation: each restart replayed all its partitions into an already overloaded pool."*
4. But the liveness watchdog counts **wall-clock silence**. `report_healthy()` sets `healthy_until = now + 60s` (`with_liveness_deadline(60)`), the monitor polls every 5s, and 3 consecutive stalled polls (`with_stall_threshold(3)`) emit `ComponentEvent::Failure` → global shutdown.

**Net: ~75 seconds inside `flush_deferred` exits the process, regardless of progress.**

So the stall-based deadline added to prevent restart amplification is defeated by the watchdog, and the amplification happens anyway: exit → uncommitted offsets replay → workers re-saturate → 503 → `flush_deferred` → 75s → exit.

The contrast is one function away: `await_processed_batch` wraps its await in a `tokio::select!` with a 10s `heartbeat.tick()` that calls `report_healthy()` — exactly the guard `flush_deferred` is missing.

## Production impact

Seen in prod-us today (`ingestion-analytics-overflow`), starting ~11:45 UTC after 19 hours of zero restarts:

- **~90–160 consumer restarts/hour**, sustained, across all 12 pods (~40–47 restarts per pod in 6h)
- Every termination `reason: Error`, never `OOMKilled`; every shutdown logged as `health check stalled (stall count 3/3)`, `trigger_component: "consumer"`
- Worker side: `at concurrent batch capacity (16)`, in-flight batches ~1 → ~24, throughput **153/s → 13/s**, p95 batch duration 960ms → 2.4s
- Processors were **not** resource-bound throughout — 2–8% of CPU limits, `person_flush_latency` p95 flat at ~1ms. The pool was queueing, not working.
- Heavy re-delivery: `Out-of-order message fed to ingestion pipeline` with offsets ~8000 behind `lastSeenOffset`, across 80 of 128 partitions

## Fix

Call `report_healthy()` on every iteration of the flush loop, so the two mechanisms answer the questions they were designed for:

- `deferred_flush_timeout` → is this flush making progress?
- liveness deadline → is this task alive?

Unconditional reporting is safe because `stall_deadline` still bounds the genuinely-wedged case, including the "nothing routable" branch: it bails after a full timeout with nothing landed, and does so with an accurate message (`deferred messages made no progress within the flush timeout`) instead of a misleading `health check stalled`.

## Testing

- `cargo check -p ingestion-consumer` passes
- `cargo clippy -p ingestion-consumer` reports nothing in this crate (the two failures in `lifecycle` / `k8s-awareness` are pre-existing and come from a local rustup toolchain 1.96.0 vs flox 1.91.1 mismatch, not from this diff)
- **No regression test yet.** Covering this needs the `e2e_integration_test` harness, which requires Kafka on `localhost:9092`, unavailable in my environment — I didn't want to add a test I couldn't actually run. The shape would be: an always-busy worker plus a short `liveness_deadline`, asserting the consumer survives while the flush keeps accepting messages. Happy to add it if you can point me at a working local Kafka, or it can follow up.

## Follow-ups worth considering (not in this PR)

- **The 503 retry budget is thin.** ~2.4s across 4 attempts against a 16-deep worker queue holding 500–800-event batches means retries almost always fail during saturation, pushing everything onto the slower re-defer path. The busy-path backoff ceiling (`.min(5_000)`) is probably too low.
- **Retries set `request.replay = true`**, so every 503 retry is counted worker-side as a replay. Some of the `Out-of-order message fed to ingestion pipeline` volume is retry noise rather than post-restart offset replay, which makes that log a noisier saturation signal than it looks.
