### PR TITLE
fix(flags): open the edit dialog for a scheduled change

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagScheduleEditLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagScheduleEditLogic.test.ts
@@ -1,0 +1,54 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import { initKeaTests } from '~/test/init'
+import { ScheduledChangeModels, ScheduledChangeOperationType, ScheduledChangeType, UserBasicType } from '~/types'
+
+import { featureFlagScheduleEditLogic } from './featureFlagScheduleEditLogic'
+
+describe('featureFlagScheduleEditLogic', () => {
+    let logic: ReturnType<typeof featureFlagScheduleEditLogic.build>
+
+    const scheduledChange: ScheduledChangeType = {
+        id: 7,
+        team_id: MOCK_DEFAULT_TEAM.id,
+        record_id: 1,
+        model_name: ScheduledChangeModels.FeatureFlag,
+        payload: { operation: ScheduledChangeOperationType.UpdateStatus, value: false },
+        scheduled_at: '2026-06-15T14:30:00.000Z',
+        end_date: '2026-06-30T23:59:59.999Z',
+        executed_at: null,
+        failure_reason: null,
+        created_at: '2026-06-01T09:00:00.000Z',
+        created_by: { id: 1, uuid: 'user-uuid', distinct_id: 'user-distinct-id' } as UserBasicType,
+        is_recurring: true,
+        recurrence_interval: null,
+        cron_expression: '30 14 * * *',
+        last_executed_at: null,
+    }
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    // Guards the dispatch itself. The reducers that fill these dates must not read the store,
+    // because Redux rejects a read while it dispatches and the dialog then never opens.
+    test.each([
+        ['UTC', '2026-06-15 14:30:00.000', '2026-06-30 23:59:59.999'],
+        ['Asia/Tokyo', '2026-06-15 23:30:00.000', '2026-07-01 08:59:59.999'],
+    ])(
+        'openEdit fills the dialog with dates in the %s project timezone',
+        (timezone, expectedScheduledAt, expectedEndDate) => {
+            initKeaTests(true, { ...MOCK_DEFAULT_TEAM, timezone })
+            logic = featureFlagScheduleEditLogic({ id: 1 })
+            logic.mount()
+
+            logic.actions.openEdit(scheduledChange)
+
+            expect(logic.values.isEditOpen).toBe(true)
+            expect(logic.values.editScheduledAt?.format('YYYY-MM-DD HH:mm:ss.SSS')).toBe(expectedScheduledAt)
+            expect(logic.values.editEndDate?.format('YYYY-MM-DD HH:mm:ss.SSS')).toBe(expectedEndDate)
+            expect(logic.values.editCronExpression).toBe('30 14 * * *')
+            expect(logic.values.editPayloadValue).toBe(false)
+        }
+    )
+})

--- a/frontend/src/scenes/feature-flags/featureFlagScheduleEditLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagScheduleEditLogic.ts
@@ -12,12 +12,6 @@ import type { TeamPublicType, TeamType } from '../../types'
 import { teamLogic } from '../teamLogic'
 import { featureFlagLogic, scheduleDateFromStoredISO, scheduleDateToProjectTzISO } from './featureFlagLogic'
 
-// Used from reducers, which don't receive `values` — we still need a synchronous read at
-// action-dispatch time. Selectors and listeners use the reactive `projectTimezone` selector instead.
-function projectTimezoneImperative(): string {
-    return teamLogic.findMounted()?.values.currentTeam?.timezone || 'UTC'
-}
-
 export interface FeatureFlagScheduleEditLogicProps {
     id: number | 'new' | 'link'
 }
@@ -49,6 +43,7 @@ export interface featureFlagScheduleEditLogicActions {
     }
     openEdit: (schedule: ScheduledChangeType) => {
         schedule: ScheduledChangeType
+        timezone: string
     }
     saveEdit: () => {
         value: true
@@ -129,8 +124,11 @@ export const featureFlagScheduleEditLogic = kea<featureFlagScheduleEditLogicType
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
     })),
-    actions({
-        openEdit: (schedule: ScheduledChangeType) => ({ schedule }),
+    actions(({ values }) => ({
+        // The reducers below convert the stored dates into the project timezone, but a reducer may
+        // not read the store while Redux is dispatching. Resolve the timezone into the payload here,
+        // which runs before the dispatch starts.
+        openEdit: (schedule: ScheduledChangeType) => ({ schedule, timezone: values.projectTimezone }),
         closeEdit: true,
         setEditScheduledAt: (date: Dayjs | null) => ({ date }),
         setEditCronExpression: (cron: string | null) => ({ cron }),
@@ -142,7 +140,7 @@ export const featureFlagScheduleEditLogic = kea<featureFlagScheduleEditLogicType
         saveEdit: true,
         saveEditSuccess: true,
         saveEditFailure: true,
-    }),
+    })),
     reducers({
         editingSchedule: [
             null as ScheduledChangeType | null,
@@ -155,10 +153,8 @@ export const featureFlagScheduleEditLogic = kea<featureFlagScheduleEditLogicType
         editScheduledAt: [
             null as Dayjs | null,
             {
-                openEdit: (_, { schedule }) =>
-                    schedule.scheduled_at
-                        ? scheduleDateFromStoredISO(schedule.scheduled_at, projectTimezoneImperative())
-                        : null,
+                openEdit: (_, { schedule, timezone }) =>
+                    schedule.scheduled_at ? scheduleDateFromStoredISO(schedule.scheduled_at, timezone) : null,
                 setEditScheduledAt: (_, { date }) => date,
                 closeEdit: () => null,
             },
@@ -182,10 +178,8 @@ export const featureFlagScheduleEditLogic = kea<featureFlagScheduleEditLogicType
         editEndDate: [
             null as Dayjs | null,
             {
-                openEdit: (_, { schedule }) =>
-                    schedule.end_date
-                        ? scheduleDateFromStoredISO(schedule.end_date, projectTimezoneImperative())
-                        : null,
+                openEdit: (_, { schedule, timezone }) =>
+                    schedule.end_date ? scheduleDateFromStoredISO(schedule.end_date, timezone) : null,
                 setEditEndDate: (_, { date }) => date,
                 closeEdit: () => null,
             },


### PR DESCRIPTION
## Problem

- Clicking the pencil on a scheduled feature flag change does nothing, so nobody can edit a schedule after creating it. The browser console reports `Uncaught Error: Minified Redux error #3`.
- `openEdit` resolved the project timezone inside its reducers, by reading `teamLogic` values.
- Reading a kea logic's values calls `store.getState()`. Redux [rejects that call while it dispatches](https://github.com/reduxjs/redux/blob/v5.0.1/errors.json#L5), so the dispatch throws and no edit state is set.
- Every scheduled change carries a `scheduled_at`, so the throw happens on every click.
- From https://us.posthog.com/project/2/support/tickets/69186

## Changes

- The pencil now opens the edit dialog, with the schedule's dates, cron expression and payload filled in.
- `openEdit` resolves the project timezone into its action payload, which kea builds before the dispatch starts. The two reducers read the timezone from the payload.
- Nothing looks different, so there is no screenshot. The dialog's markup is untouched. Only whether it opens changes.

## How did you test this code?

- Added `featureFlagScheduleEditLogic.test.ts`, which dispatches `openEdit` and asserts the resulting dialog state. Against the unfixed logic it fails with the reported error, and the stack matches the one in the report.
- Two rows cover UTC and a non-UTC project timezone. That catches a regression where the payload carries a fixed default instead of the project's timezone.
- Also ran the two neighbouring feature flag Jest suites, oxlint, oxfmt, kea typegen, and `tsgo --noEmit`. The typecheck reports only pre-existing errors from the unbuilt `@posthog/quill` and `@posthog/hogvm` workspace packages, none under `feature-flags`.
- Not run: the app itself, and `hogli ci:preflight`, which this sandbox does not have.

<details>
<summary>Stack against the unfixed logic</summary>

```
at Object.getState (redux/src/createStore.ts:121:13)
at Object.get [as currentTeam] (kea/lib/index.cjs.js:1527:37)
at projectTimezoneImperative (src/scenes/feature-flags/featureFlagScheduleEditLogic.ts:18:43)
at Object.openEdit [as open edit (...)] (src/scenes/feature-flags/featureFlagScheduleEditLogic.ts:160:76)
at logic.reducers.<computed> (kea/lib/index.cjs.js:1626:40)
at dispatch (redux/src/createStore.ts:214:22)
```

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). No GitHub handle was given for the reporter, so the PR is unassigned.

- A user reported the dead pencil button with a minified console trace. The work started by mapping Redux production error #3 to "You may not call store.getState() while the reducer is executing" against the pinned redux 5.0.1, which pointed straight at the `getState` read in the `openEdit` reducers.
- Passing the timezone down from the component was the other option. Resolving it in the action payload keeps the timezone inside the logic and leaves the `ScheduleCard` `onEdit` signature alone.
- A sweep of every kea `reducers` block under `frontend/src` and `products/*/frontend` found no other store read of this kind.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Public artifact: the test fixture is invented. Nothing from the session appears in the diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
