### PR TITLE
fix(review_hog): let sandbox MCP tokens open a session

### DIFF
--- a/products/review_hog/DECISIONS.md
+++ b/products/review_hog/DECISIONS.md
@@ -3163,9 +3163,13 @@ RATE_LIMITED` (GraphQL's primary signal, invisible to the REST-shaped helper) no
    ReviewHog sandbox session (perspectives, validation, resolution) ran with the context default of **full**
    PostHog MCP access — execute-sql and every write tool — while reading untrusted PR-comment text; no prompt
    ever uses more than `skill-get`/`skill-file-get`. The executor now pins `posthog_mcp_scopes` to
-   `REVIEW_MCP_SCOPES = ["llm_skill:read"]` at both context constructions (internal sandbox-plumbing scopes
-   are re-added by the resolver). A future skill that legitimately needs product data adds its specific read
-   scope with that feature.
+   `REVIEW_MCP_SCOPES = ["llm_skill:read", "user:read"]` at both context constructions (internal sandbox-plumbing
+   scopes are re-added by the resolver). `user:read` is the MCP handshake, not a data grant: the MCP server
+   resolves the calling user (`/api/users/@me/`) when a session opens and refuses the connection without it.
+   The pin shipped on 2026-08-13 with only `llm_skill:read`, so until 2026-08-25 every ReviewHog session
+   (perspectives, blind-spot, validation, resolution) had its MCP connection refused and reviewed without its
+   skill — the agents carry on without MCP instead of failing, so nothing flagged it. A future skill that
+   legitimately needs product data adds its specific read scope with that feature.
    _Same date (fix-commit provenance gate, maintainer decision):_ `commit_on_branch`'s "reachable from the
    branch tip" necessarily accepts every ancestor (later turns and the author push on top mid-run), so a
    steered turn could echo someone's old clean commit and have every check inspect the wrong one. The

--- a/products/review_hog/backend/reviewer/constants.py
+++ b/products/review_hog/backend/reviewer/constants.py
@@ -25,8 +25,10 @@ REVIEW_INITIAL_PERMISSION_MODE = "full-access"
 # untrusted PR-comment text, and their only legitimate MCP use is reading their criteria skill
 # (skill-get / skill-file-get) — without this the context defaults to "full", handing an injectable
 # agent execute-sql and every write tool. Internal sandbox-plumbing scopes are re-added by the
-# resolver, so this cannot break session mechanics.
-REVIEW_MCP_SCOPES: list[str] = ["llm_skill:read"]
+# resolver, so this cannot break session mechanics. `user:read` is the MCP handshake: the MCP
+# server resolves the calling user (`/api/users/@me/`) when a session opens and refuses the whole
+# connection without it, so the agent never gets `skill-get` and silently reviews without its skill.
+REVIEW_MCP_SCOPES: list[str] = ["llm_skill:read", "user:read"]
 
 
 @dataclass(frozen=True)

--- a/products/review_hog/backend/reviewer/tests/test_constants.py
+++ b/products/review_hog/backend/reviewer/tests/test_constants.py
@@ -1,5 +1,7 @@
 import pytest
 
+from posthog.temporal.oauth import has_write_scopes, resolve_scopes
+
 from products.review_hog.backend.reviewer.constants import (
     CHUNKING_MODEL,
     CHUNKING_REASONING_EFFORT,
@@ -9,6 +11,7 @@ from products.review_hog.backend.reviewer.constants import (
     DEDUP_RUNTIME_ADAPTER,
     DEFAULT_REVIEW_ARM,
     REVIEW_EXPERIMENT_ARMS,
+    REVIEW_MCP_SCOPES,
     REVIEW_MODEL,
     REVIEW_REASONING_EFFORT,
     REVIEW_RUNTIME_ADAPTER,
@@ -116,3 +119,13 @@ def test_resolve_review_arm_honors_valid_assignments_and_falls_back(
     persisted: tuple[str | None, str | None, str | None, str | None], expected: ReviewArm
 ) -> None:
     assert resolve_review_arm(*persisted) == expected
+
+
+def test_review_mcp_scopes_open_a_session_and_stay_read_only() -> None:
+    # The MCP server resolves the calling user when a session opens, so a token without `user:read`
+    # is refused outright and the agent runs without its skill. Lock both halves of the pin: the
+    # handshake scope is present, and the token still carries no user-facing write scope.
+    resolved = resolve_scopes(REVIEW_MCP_SCOPES)
+    assert "user:read" in resolved
+    assert "llm_skill:read" in resolved
+    assert not has_write_scopes(REVIEW_MCP_SCOPES)

--- a/products/review_hog/backend/reviewer/tests/test_executor.py
+++ b/products/review_hog/backend/reviewer/tests/test_executor.py
@@ -78,7 +78,7 @@ class TestRunSandboxReview:
         assert (context.team_id, context.user_id, context.repository) == (7, 9, "acme/app")
         # Least privilege: an unset scope list means "full" MCP access for a session that reads
         # untrusted PR-comment text — dropping this pin is a security regression.
-        assert context.posthog_mcp_scopes == ["llm_skill:read"]
+        assert context.posthog_mcp_scopes == ["llm_skill:read", "user:read"]
 
     @parameterized.expand(
         [
@@ -144,7 +144,7 @@ class TestRunSandboxReview:
         assert call_kwargs["ai_stage"] == "validation-c3"
         assert call_kwargs["workflow_id_prefix"] == "review-pr:1:o/r:7/validate:validation-c3"
         # The session path builds its own context, so the least-privilege pin must hold here too.
-        assert call_kwargs["context"].posthog_mcp_scopes == ["llm_skill:read"]
+        assert call_kwargs["context"].posthog_mcp_scopes == ["llm_skill:read", "user:read"]
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- Every ReviewHog sandbox since Aug 13 reviews without its skill. The reviewer, blind-spot, validation and resolution sessions all skip the `skill-get` step.
- The prompt only names the skill and tells the agent to fetch it over the PostHog MCP.
- The MCP server resolves the calling user (`/api/users/@me/`) when a session opens, which needs `user:read`.
- #72074 pinned the sandbox token to `["llm_skill:read"]`, so the MCP server refuses every session with `403 insufficient_scope`.
- The agent does not stop when MCP is missing, so reviews complete and look normal. The MCP server's auth-failure events show the refused sandbox sessions from Aug 13 on.

## Changes

- ReviewHog sandboxes fetch their skills again: `REVIEW_MCP_SCOPES` adds `user:read`. The token still carries no user-facing write scope.
- `DECISIONS.md` records why `user:read` is part of the least-privilege pin.
- Mechanical: the two executor tests assert the new list.

## How did you test this code?

- New test: the resolved token carries `user:read` and no write scope. It fails on the previous pin.
- Live local check: a 3-turn Codex session on the fixed code opened MCP (`200`, previously `403`) and `skill-get` returned `review-hog-validation-criteria` v1 on a follow-up turn. The same session before the fix reported `skill_found: false`.
- Not checked: a full review run on the fixed code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None beyond `DECISIONS.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills invoked: `/writing-pr-descriptions`.
- Found while smoke-testing a Codex multi-turn session for the validator-model experiment: MCP answered `403` with `WWW-Authenticate: insufficient_scope, scope="user:read"`. The local MCP server log and the agent logs of a review run from the same day (zero `skill-get` calls) confirmed it.
- Follow-ups, not in this PR: make sandboxes fail fast when MCP tools are missing; consider adding `user:read` in `resolve_scopes` for every custom scope list.
