### PR TITLE
fix(tasks): include agent-shadow sources in the local Modal build context

### DIFF
--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -282,6 +282,8 @@ LOCAL_MODAL_GH_GUARD_SCRIPT = Path("products/tasks/backend/sandbox/images/gh-gua
 LOCAL_MODAL_NOTEBOOK_KERNEL_MODULE = Path("products/notebooks/backend/kernel_package.py")
 LOCAL_MODAL_NOTEBOOK_KERNEL_DIR = Path("products/notebooks/backend/sandbox/kernel")
 LOCAL_MODAL_CPU_BILLING_SAMPLER = Path("products/tasks/backend/sandbox/images/cpu_billing_sampler.py")
+# The base image builds the agent-shadow observer from source in its first stage.
+LOCAL_MODAL_AGENT_SHADOW_DIR = Path("products/desktop/packages/agent-shadow")
 
 
 _image_ref_cache: TTLCache = TTLCache(maxsize=3, ttl=300)
@@ -640,6 +642,8 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
         # latest rendered output.
         LocalSkillsCache(base_dir).ensure_built()
         populate_skills_directory(context_dir / LOCAL_BUILT_SKILLS_PATH, base_dir=base_dir)
+
+        shutil.copytree(base_dir / LOCAL_MODAL_AGENT_SHADOW_DIR, context_dir / LOCAL_MODAL_AGENT_SHADOW_DIR)
 
     elif template == SandboxTemplate.NOTEBOOK_BASE:
         destination_kernel_module_path = context_dir / LOCAL_MODAL_NOTEBOOK_KERNEL_MODULE

--- a/products/tasks/backend/logic/services/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/test_modal_sandbox.py
@@ -2,7 +2,7 @@ import shutil
 from pathlib import Path
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from products.tasks.backend.constants import (
     DEFAULT_SANDBOX_WORKING_DIR,
@@ -11,6 +11,7 @@ from products.tasks.backend.constants import (
 )
 from products.tasks.backend.logic.services.modal_sandbox import (
     DEFAULT_MODAL_APP_NAME,
+    LOCAL_MODAL_AGENT_SHADOW_DIR,
     LOCAL_MODAL_NOTEBOOK_KERNEL_DIR,
     LOCAL_MODAL_NOTEBOOK_KERNEL_MODULE,
     NOTEBOOK_MODAL_APP_NAME,
@@ -233,6 +234,23 @@ class TestSelfDrivingWorkloadMapping:
 
 
 class TestLocalModalBuildContext:
+    def test_base_context_carries_the_agent_shadow_sources(self):
+        # The base Dockerfile's first stage COPYs and builds the agent-shadow observer, so the
+        # trimmed DEBUG context must carry its sources or every local sandbox fails at image build.
+        _prepare_local_modal_build_context.cache_clear()
+        with (
+            patch("products.tasks.backend.logic.services.modal_sandbox.LocalSkillsCache"),
+            patch("products.tasks.backend.logic.services.modal_sandbox.populate_skills_directory"),
+        ):
+            _dockerfile_path, context_dir = _prepare_local_modal_build_context(SandboxTemplate.DEFAULT_BASE)
+        try:
+            root = Path(context_dir)
+            assert (root / LOCAL_MODAL_AGENT_SHADOW_DIR / "go.mod").is_file()
+            assert (root / LOCAL_MODAL_AGENT_SHADOW_DIR / "main.go").is_file()
+        finally:
+            shutil.rmtree(context_dir, ignore_errors=True)
+            _prepare_local_modal_build_context.cache_clear()
+
     def test_notebook_context_carries_the_baked_kernel_package(self):
         # DEBUG builds the notebook image from this trimmed context, not the repo root, so a
         # Dockerfile COPY whose source is missing here fails the build and no notebook


### PR DESCRIPTION
## Problem

- Local sandboxes don't start since #88274: the Modal image build fails.
- #88274 made the sandbox Dockerfile copy `products/desktop/packages/agent-shadow/`. The local build only hands Modal a short list of files, and that folder isn't on it, so the `COPY` finds nothing.
- Prod is fine: it uses the prebuilt image.

## Changes

- Local sandboxes start again: the folder is added to the list.
- Mechanical: a test asserts the folder lands in the build context.

## How did you test this code?

- New test: fails without the copy, passes with it.
- Live: the local Modal image rebuilt and a sandbox session ran end to end after the change.
- Not checked: the notebook, VM and streamlit templates (unchanged).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills invoked: `/writing-pr-descriptions`.
- Found when a sandbox smoke run on fresh master hit the failed image build; `modal image logs` pointed at the `COPY` step.
