### PR TITLE
feat(dashboards): pick a folder to filter by from a dropdown

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
@@ -1,8 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { IconChevronDown, IconFolder, IconPin, IconPinFilled, IconShare, IconX } from '@posthog/icons'
-import { LemonInput, Popover } from '@posthog/lemon-ui'
+import { IconChevronDown, IconFolder, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
+import { LemonInput, LemonSearchableSelect, Popover } from '@posthog/lemon-ui'
 
 import { MemberSelectMultiplePopover } from 'lib/components/MemberSelectMultiplePopover'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -13,7 +13,7 @@ interface DashboardsFiltersBarProps {
 }
 
 export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps): JSX.Element {
-    const { filters, currentTab, filteredTags, tagSearch, showTagPopover } = useValues(dashboardsLogic)
+    const { filters, currentTab, filteredTags, tagSearch, showTagPopover, folderOptions } = useValues(dashboardsLogic)
     const { setFilters, setTagSearch, setShowTagPopover, setSearch } = useActions(dashboardsLogic)
 
     const createdByIds = filters.createdBy === 'All users' ? [] : filters.createdBy
@@ -146,20 +146,31 @@ export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps
                             Shared
                         </LemonButton>
                     </div>
-                    {filters.folder != null && (
-                        <LemonButton
-                            active
-                            type="secondary"
-                            size="small"
-                            className="max-w-full"
-                            icon={<IconFolder />}
-                            sideIcon={<IconX />}
-                            onClick={() => setFilters({ folder: null })}
-                            tooltip="Clear folder filter"
-                        >
-                            <span className="truncate">{filters.folder || 'Project root'}</span>
-                        </LemonButton>
-                    )}
+                    <LemonSearchableSelect<string | null>
+                        value={filters.folder ?? null}
+                        onChange={(folder) => setFilters({ folder })}
+                        options={[
+                            { value: null, label: 'All folders' },
+                            ...folderOptions.map((folder) => ({
+                                value: folder,
+                                // A dashboard sitting at the top of the project tree has an empty folder path.
+                                label: folder || 'Project root',
+                            })),
+                        ]}
+                        active={filters.folder != null}
+                        type="secondary"
+                        size="small"
+                        icon={<IconFolder />}
+                        disabledReason={
+                            folderOptions.length === 0 ? 'No dashboards are filed in a folder yet' : undefined
+                        }
+                        dropdownMatchSelectWidth={false}
+                        truncateText={{ maxWidthClass: 'max-w-60' }}
+                        searchPlaceholder="Search folders"
+                        noResultsMessage="No matching folders"
+                        searchInputDataAttr="dashboards-folder-filter-search"
+                        data-attr="dashboards-folder-filter"
+                    />
                 </div>
                 {currentTab !== DashboardsTab.Yours && (
                     <MemberSelectMultiplePopover

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
@@ -16,6 +16,7 @@ import { initKeaTests } from '~/test/init'
 import { AppContext, DashboardType, UserBasicType } from '~/types'
 
 import dashboardJson from '../__mocks__/dashboard.json'
+import { UNFILED_DASHBOARDS_FOLDER } from '../dashboardConstants'
 
 let dashboardId = 1234
 const dashboard = (extras: Partial<DashboardType>): DashboardType => {
@@ -207,6 +208,24 @@ describe('dashboardsLogic', () => {
                 (dashboards: DashboardType[]) =>
                     dashboards.length === inFolder.length && dashboards.every((d) => d.folder === 'Marketing/Website')
             ),
+        })
+    })
+
+    describe('folder filter options', () => {
+        it('offers the folders dashboards sit in, and not the unfiled default', async () => {
+            const [freshlyCreated, atTheTop] = allDashboards
+            dashboardsModel.actions.patchDashboardFolders({
+                [freshlyCreated.id]: `${UNFILED_DASHBOARDS_FOLDER}/Freshly created`,
+                [atTheTop.id]: 'At the top',
+            })
+
+            expect(logic.values.folderOptions).toEqual(['', 'Marketing/Website'])
+        })
+
+        it('keeps the filtered folder on offer once nothing is left in it', async () => {
+            logic.actions.setFilters({ folder: 'Revenue/Q3' })
+
+            expect(logic.values.folderOptions).toEqual(['Marketing/Website', 'Revenue/Q3'])
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -22,6 +22,7 @@ import { ActivityScope, Breadcrumb, DashboardBasicType } from '~/types'
 
 import type { FeatureFlagsSet } from '../../../lib/logic/featureFlagLogic'
 import type { UserType } from '../../../types'
+import { UNFILED_DASHBOARDS_FOLDER } from '../dashboardConstants'
 
 export enum DashboardsTab {
     All = 'all',
@@ -81,6 +82,7 @@ export interface dashboardsLogicValues {
     filedDashboardIds: Set<number>
     filteredTags: string[]
     filters: DashboardsFilters
+    folderOptions: string[]
     isFiltering: boolean
     searchedDashboards: DashboardBasicType[] | null
     searchedDashboardsLoading: boolean
@@ -197,6 +199,17 @@ export interface dashboardsLogicMeta {
         ) => DashboardBasicType[]
         dashboardsById: (dashboards: DashboardBasicType[]) => Record<string, DashboardBasicType>
         filedDashboardIds: (dashboards: DashboardBasicType[]) => Set<number>
+        folderOptions: (
+            nameSortedDashboards: (
+                | DashboardBasicType
+                | import('~/types').DashboardType<
+                      import('~/types').QueryBasedInsightModel<
+                          import('~/queries/schema/schema-general').Node<Record<string, any>>
+                      >
+                  >
+            )[],
+            filters: DashboardsFilters
+        ) => string[]
     }
 }
 
@@ -401,6 +414,29 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                     haystack = haystack.filter((d) => d.folder === filters.folder)
                 }
                 return haystack
+            },
+        ],
+
+        // Folders worth offering in the filter: the ones dashboards actually sit in. Built from the
+        // whole project rather than the filtered list, so picking a folder never empties the menu that
+        // picked it, and every option is guaranteed to return at least one row.
+        folderOptions: [
+            (s) => [dashboardsModel.selectors.nameSortedDashboards, s.filters],
+            (allDashboards: DashboardBasicType[], filters: DashboardsFilters): string[] => {
+                const folders = new Set<string>()
+                for (const dashboard of allDashboards) {
+                    // The unfiled default is where dashboards land before anyone files them, so it says
+                    // nothing about how a project is organized. The Folder column hides it for the same reason.
+                    if (dashboard.folder != null && dashboard.folder !== UNFILED_DASHBOARDS_FOLDER) {
+                        folders.add(dashboard.folder)
+                    }
+                }
+                // Keep the active folder selectable even when nothing sits in it any more, so a shared link
+                // to an emptied folder still shows what it is filtering to.
+                if (filters.folder != null) {
+                    folders.add(filters.folder)
+                }
+                return [...folders].sort((a, b) => a.localeCompare(b))
             },
         ],
 


### PR DESCRIPTION
## Problem

Filtering the dashboards list by folder was only reachable by clicking a folder name inside a table row. Nothing marked that cell as clickable, so most people never found the filter.

Once clicked, a chip appeared in the filter bar. That chip was the only visible sign folder filtering existed, and it only showed up after you had already found the hidden way in.

Refs #7934

## Changes

- A folder dropdown now sits in the filter bar next to Pinned, Tags and Shared, so folder filtering is visible before anyone clicks a row.
- The menu lists only folders that hold dashboards, so every option returns at least one row.
- The menu leaves out the unfiled default, which is where dashboards land before anyone files them. The Folder column already hides it for the same reason.
- Typing in the menu filters the folder list, which matters once a project tree gets deep.
- Choosing "All folders" clears the filter, replacing the chip's clear button.
- The dropdown is disabled with a reason when no dashboard is filed anywhere yet.

The obvious alternative was `FolderSelect`, the project-tree picker behind "Move to". It needs a modal, renders every folder in the project, and offers folders holding no dashboards. `LemonSearchableSelect` keeps the control inline and the options meaningful.

Mechanical: the chip and its clear button are gone. The folder cell in the table still applies the filter, and the `folder` URL parameter is unchanged, so existing links keep working.

### Before

The filter bar by default. No folder control:

![before-nofilter](https://raw.githubusercontent.com/PostHog/pr-assets/74c80da39386dbd61f092c2098c4e3ee22ef56d8/2026/08/c65c46d8-9f29-449a-a350-0538a5056e35.png)

After clicking a folder name in a row, a chip appeared:

![before-chip](https://raw.githubusercontent.com/PostHog/pr-assets/9106f1de4390597db6e8fdf99be6fa9072a8b50a/2026/08/d35549ce-cf30-466e-86f6-fde3d71c9bfe.png)

### After

The dropdown is there from the start:

![after-closed](https://raw.githubusercontent.com/PostHog/pr-assets/14630612f2a0e86e1cb618b75889adf305bef645/2026/08/acab761c-3555-41a0-b30f-5f942219bbe4.png)

Open, with search and the folders that hold dashboards:

![after-open](https://raw.githubusercontent.com/PostHog/pr-assets/6ef2a4f67c45eadbb2318daf18815a243d07e066/2026/08/cb2a810a-dac0-4feb-9f88-1e52f8ace414.png)

## How did you test this code?

Two unit tests cover the new `folderOptions` selector in `dashboardsLogic`:

- The option list drops the unfiled default. Without this, the menu offers a folder that says nothing about how a project is organized.
- The option list keeps the folder currently filtered to, even after the last dashboard leaves it. Without this, a shared link to an emptied folder renders a filtered list under a trigger that reads "All folders".

The screenshots above come from the running scene in Storybook, driven by a temporary story with mocked dashboards. That story is not part of this diff.

Not checked: the repo-wide `tsgo --noEmit` pass. It gets OOM-killed in this sandbox, and it does so on a clean `master` checkout too, so CI has to report it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow describes the old folder chip.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop cloud task. The driver's GitHub handle was not available in the session, so the PR is unassigned rather than assigned to a guessed account.

Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions worth flagging. The option list is built from every dashboard in the project rather than the currently filtered list, so choosing a folder never empties the menu that chose it. `LemonSearchableSelect` won over a plain `LemonSelect` because folder paths are long and a project can hold many, so the list needs a search box.

All sample data in the screenshots comes from the repo's own committed dashboard fixture plus invented folder names. Nothing in this PR carries material from the session.
