### PR TITLE
fix(legal-documents): re-send envelopes stranded in PandaDoc draft from the reconcile sweep

### DIFF
--- a/products/legal_documents/backend/facade/api.py
+++ b/products/legal_documents/backend/facade/api.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from uuid import UUID
 
 from django.db import transaction
+from django.utils import timezone
 
 import structlog
 
@@ -297,7 +298,9 @@ def reconcile_pending_signatures() -> contracts.LegalDocumentReconcileResult:
     Safety net for the whole completion path. Polls PandaDoc for every row we
     still think is out for signature and marks the completed ones — recovering
     dropped, throttled, or 204'd `document.completed` webhooks and clearing the
-    backlog. Also re-enqueues the archive for signed rows whose PDF never landed.
+    backlog. Also re-sends envelopes stranded in `document.draft` — PandaDoc's
+    send call can 409 and never dispatch the signing email — and re-enqueues
+    the archive for signed rows whose PDF never landed.
 
     Each row is processed independently: `list_pending_signature_documents` is
     ordered oldest-first, so one row that deterministically errors (a bad
@@ -305,6 +308,7 @@ def reconcile_pending_signatures() -> contracts.LegalDocumentReconcileResult:
     15-minute tick.
     """
     newly_signed = 0
+    drafts_resent = 0
     errors = 0
     pending_seen = 0
     # PandaDoc allows 100 downloads a minute across the whole account, shared with
@@ -320,13 +324,22 @@ def reconcile_pending_signatures() -> contracts.LegalDocumentReconcileResult:
         for document in logic.list_pending_signature_documents():
             pending_seen += 1
             try:
-                if logic.get_pandadoc_document_status(document) == logic.PANDADOC_COMPLETED_STATUS:
+                pandadoc_status = logic.get_pandadoc_document_status(document)
+                if pandadoc_status == logic.PANDADOC_COMPLETED_STATUS:
                     if _try_mark_signed_and_schedule_archive(
                         document, capture=capture, delay_seconds=scheduled_archives
                     ):
                         newly_signed += 1
                         scheduled_archives += 1
                         signed_this_run.add(document.id)
+                elif (
+                    pandadoc_status == logic.PANDADOC_DRAFT_STATUS
+                    and timezone.now() - document.created_at >= logic.RECONCILE_DRAFT_MIN_AGE
+                ):
+                    if logic.send_pandadoc_envelope(document):
+                        drafts_resent += 1
+                    else:
+                        errors += 1
             except Exception as exc:
                 errors += 1
                 logger.exception("legal_document_reconcile_pending_row_failed", document_id=str(document.id))
@@ -358,5 +371,6 @@ def reconcile_pending_signatures() -> contracts.LegalDocumentReconcileResult:
     return contracts.LegalDocumentReconcileResult(
         newly_signed=newly_signed,
         archives_requeued=archives_requeued,
+        drafts_resent=drafts_resent,
         errors=errors,
     )

--- a/products/legal_documents/backend/facade/contracts.py
+++ b/products/legal_documents/backend/facade/contracts.py
@@ -37,6 +37,7 @@ class LegalDocumentReconcileResult:
 
     newly_signed: int
     archives_requeued: int
+    drafts_resent: int
     errors: int
 
 

--- a/products/legal_documents/backend/logic/__init__.py
+++ b/products/legal_documents/backend/logic/__init__.py
@@ -167,6 +167,15 @@ def mark_signed_pdf_stored(document: LegalDocument) -> LegalDocument:
 # PandaDoc status string for a fully-signed envelope. Mirrors the webhook layer.
 PANDADOC_COMPLETED_STATUS = "document.completed"
 
+# PandaDoc status string for an envelope stuck before its signing email ever went
+# out — the state the reconcile sweep re-sends from.
+PANDADOC_DRAFT_STATUS = "document.draft"
+
+# A row created moments ago is normally about to get its own document.draft webhook;
+# re-sending from the sweep at the same time would duplicate the send and produce a
+# spurious 409 in error tracking.
+RECONCILE_DRAFT_MIN_AGE = timedelta(minutes=5)
+
 # The reconciliation sweep polls PandaDoc once per pending row every 15 minutes, so
 # bound the set: only rows created inside this window, capped per run. Two weeks is
 # where the returns stop. Of the pending envelopes older than that, 2 of 162 ever

--- a/products/legal_documents/backend/tasks/tasks.py
+++ b/products/legal_documents/backend/tasks/tasks.py
@@ -45,5 +45,6 @@ def reconcile_pending_legal_documents() -> None:
         "legal_documents.reconcile_swept",
         newly_signed=result.newly_signed,
         archives_requeued=result.archives_requeued,
+        drafts_resent=result.drafts_resent,
         errors=result.errors,
     )

--- a/products/legal_documents/backend/tests/test_api.py
+++ b/products/legal_documents/backend/tests/test_api.py
@@ -920,6 +920,75 @@ class TestLegalDocumentReconciliation(APIBaseTest):
         self.assertEqual(self.document.status, "submitted_for_signature")
 
     @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.get_document_status")
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document")
+    def test_reconcile_resends_stale_draft_document(self, send_mock, status_mock) -> None:
+        status_mock.return_value = "document.draft"
+        LegalDocument.objects.filter(id=self.document.id).update(created_at=timezone.now() - timedelta(minutes=6))
+
+        result = legal_api.reconcile_pending_signatures()
+
+        send_mock.assert_called_once()
+        self.assertEqual(result.drafts_resent, 1)
+        self.assertEqual(result.archives_requeued, 0)
+        self.document.refresh_from_db()
+        self.assertEqual(self.document.status, "submitted_for_signature")
+
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.get_document_status")
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document")
+    def test_reconcile_skips_freshly_created_draft_document(self, send_mock, status_mock) -> None:
+        status_mock.return_value = "document.draft"
+
+        result = legal_api.reconcile_pending_signatures()
+
+        send_mock.assert_not_called()
+        self.assertEqual(result.drafts_resent, 0)
+
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.get_document_status")
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document")
+    def test_reconcile_counts_error_when_draft_resend_fails_and_continues(self, send_mock, status_mock) -> None:
+        from products.legal_documents.backend.logic import pandadoc as pandadoc_module
+
+        later_org = Organization.objects.create(name="Later Co")
+        later = LegalDocument.objects.create(
+            organization=later_org,
+            document_type="DPA",
+            company_name="Later Co",
+            company_address="Elsewhere",
+            representative_email="later@other.example",
+            pandadoc_document_id="doc_later",
+            created_by=self.user,
+        )
+        now = timezone.now()
+        LegalDocument.objects.filter(id=self.document.id).update(created_at=now - timedelta(minutes=10))
+        LegalDocument.objects.filter(id=later.id).update(created_at=now - timedelta(minutes=9))
+
+        def status_side_effect(*, document_id):
+            return "document.draft" if document_id == "doc_123" else "document.completed"
+
+        status_mock.side_effect = status_side_effect
+        send_mock.side_effect = pandadoc_module.PandaDocError("boom")
+
+        with self._fake_pdf_pipeline(), self.captureOnCommitCallbacks(execute=True):
+            result = legal_api.reconcile_pending_signatures()
+
+        self.assertEqual(result.errors, 1)
+        self.assertEqual(result.drafts_resent, 0)
+        self.assertEqual(result.newly_signed, 1)
+        later.refresh_from_db()
+        self.assertEqual(later.status, "signed")
+
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.get_document_status")
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document")
+    def test_reconcile_ignores_document_sent_status(self, send_mock, status_mock) -> None:
+        status_mock.return_value = "document.sent"
+
+        result = legal_api.reconcile_pending_signatures()
+
+        send_mock.assert_not_called()
+        self.assertEqual(result.drafts_resent, 0)
+        self.assertEqual(result.newly_signed, 0)
+
+    @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.get_document_status")
     def test_reconcile_continues_past_a_row_that_raises(self, status_mock) -> None:
         # Each org can only hold one DPA (unique constraint), so the extra pending
         # rows live in separate orgs. list_pending_signature_documents orders

--- a/products/legal_documents/backend/tests/test_api.py
+++ b/products/legal_documents/backend/tests/test_api.py
@@ -20,6 +20,7 @@ from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.organization import Organization, OrganizationMembership
 
 from products.legal_documents.backend.facade import api as legal_api
+from products.legal_documents.backend.logic.pandadoc import PandaDocError
 from products.legal_documents.backend.models import LegalDocument
 
 BAA_PAYLOAD = {
@@ -946,8 +947,6 @@ class TestLegalDocumentReconciliation(APIBaseTest):
     @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.get_document_status")
     @patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document")
     def test_reconcile_counts_error_when_draft_resend_fails_and_continues(self, send_mock, status_mock) -> None:
-        from products.legal_documents.backend.logic import pandadoc as pandadoc_module
-
         later_org = Organization.objects.create(name="Later Co")
         later = LegalDocument.objects.create(
             organization=later_org,
@@ -966,7 +965,7 @@ class TestLegalDocumentReconciliation(APIBaseTest):
             return "document.draft" if document_id == "doc_123" else "document.completed"
 
         status_mock.side_effect = status_side_effect
-        send_mock.side_effect = pandadoc_module.PandaDocError("boom")
+        send_mock.side_effect = PandaDocError("boom")
 
         with self._fake_pdf_pipeline(), self.captureOnCommitCallbacks(execute=True):
             result = legal_api.reconcile_pending_signatures()


### PR DESCRIPTION
## Problem

- A customer requests a DPA or BAA and sometimes never receives the signing email. The legal page shows "Awaiting signature" with no end.
- PandaDoc's `document.draft` webhook can fire before PandaDoc's `/send` endpoint accepts the transition. `/send` then returns 409 "not ready for a status transition yet, please retry".
- The webhook handler logs the 409 and answers 200. PandaDoc does not retry after a 200. The reconcile sweep runs every 15 minutes and only acts on `document.completed`. After that, nothing sends the envelope.
- This 409 hit 13 submissions in the last 90 days, about 2% of all submissions ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019e6a53-4d04-7fd0-91ee-f9375070c8f8)). Most of those customers deleted the row and submitted again.

## Changes

- The reconcile sweep now re-sends each pending envelope with PandaDoc status `document.draft`. A stranded envelope gets its signing email within 15 minutes.
- The sweep skips rows younger than 5 minutes. A row that young normally gets its own draft webhook. A second send would return 409 and add noise to error tracking.
- A failed re-send counts as an error in the sweep result. The result and the `reconcile_swept` log line carry a new `drafts_resent` count.
- I (actually Claude) considered a 500 response from the webhook so that PandaDoc retries. I dropped that option. The sweep covers the case on its own and adds no redelivery noise.
- Not in this PR: an alert on `legal_document_pandadoc_send_failed` from the worker. Also not in this PR: PandaDoc's 60-day expiry, which leaves expired envelopes pending in the app. Both are separate decisions.

## How did you test this code?

- Four new tests in `TestLegalDocumentReconciliation`. The sweep re-sends a draft older than 5 minutes once, and the row stays pending. The sweep leaves a draft created just now alone. A re-send that fails counts as an error, and the sweep still signs the next row. The sweep ignores `document.sent`. Each test fails with the fix removed.
- Not checked: a live PandaDoc account. I re-sent the three envelopes that motivated this change by hand with the existing admin action on 2026-08-25. PandaDoc shows them as Sent.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, Opus 5 session. A Sonnet sub-agent wrote the implementation and tests. Two read-only Sonnet sub-agents started a review of the diff and did not report back, so I reviewed the diff myself. Skills invoked: `/pr-ready`, `writing-pr-descriptions`, `unambiguous-agent-text`.
- The work started from one support report of a stranded DPA. Logs and error tracking showed the 409 chain. The sweep already polls PandaDoc status for each pending row, so that poll was the cheapest place for the fix.
- The diff contains no customer data. Test fixtures are invented.
