### PR TITLE
feat(insights): runtime kill switch for the shared insight database

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -144,6 +144,7 @@ from posthog.hogql_queries.validation.validation import (
     run_validation_rules,
 )
 from posthog.models import Team, User
+from posthog.models.instance_setting import get_instance_setting
 from posthog.models.team import WeekStartDay
 from posthog.models.team.event_retention import events_retention_months_for_team
 from posthog.query_cache import QueryCache, count_query_cache_hit
@@ -1680,6 +1681,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         Building the database is the dominant compile cost on teams with many warehouse
         tables, and it is identical for every query in one run. Built lazily so cache hits
         never pay for it; dropped by _on_user_changed so access control follows the user."""
+        if not get_instance_setting("HOGQL_SHARED_INSIGHT_DATABASE_ENABLED"):
+            # Kill switch: build per access so query threads never share schema state. No timings
+            # measure here because concurrent threads reach this path and HogQLTimings is not
+            # thread-safe.
+            return Database.create_for(team=self.team, user=self.user, modifiers=self.modifiers)
         if self._shared_database is None:
             # Concurrent query threads (funnels compare mode) can first-touch this property at the
             # same time. The lock makes the build run once, and keeps the measure on the single

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -64,6 +64,7 @@ from posthog.hogql_queries.query_runner import (
     shared_insights_execution_mode,
 )
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.instance_setting import override_instance_config
 from posthog.models.organization import OrganizationMembership
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.team.team import Team, WeekStartDay
@@ -253,6 +254,17 @@ class TestQueryRunner(BaseTest):
         assert results[0] is results[1]
         timing_keys = [key for key in runner.timings.to_dict() if "build_shared_database" in key]
         assert timing_keys == ["./build_shared_database"]
+
+    def test_shared_database_kill_switch_disables_sharing(self):
+        TestQueryRunner = self.setup_test_query_runner_class()
+        runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
+
+        with override_instance_config("HOGQL_SHARED_INSIGHT_DATABASE_ENABLED", False):
+            first = runner.shared_database
+            second = runner.shared_database
+
+        assert first is not second
+        assert runner.shared_database is runner.shared_database
 
     def test_init_with_query_dict(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -19,6 +19,12 @@ CONSTANCE_CONFIG = {
         "Number of weeks recording performance events will be kept before removing them (for all projects). Storing performance events for a shorter timeframe can help reduce Clickhouse disk usage.",
         int,
     ),
+    "HOGQL_SHARED_INSIGHT_DATABASE_ENABLED": (
+        get_from_env("HOGQL_SHARED_INSIGHT_DATABASE_ENABLED", True, type_cast=str_to_bool),
+        "Whether insight query runners share one HogQL database across execution, response printing, "
+        "and series threads. Disable to fall back to building a database per call.",
+        bool,
+    ),
     "MATERIALIZED_COLUMNS_ENABLED": (
         get_from_env("MATERIALIZED_COLUMNS_ENABLED", True, type_cast=str_to_bool),
         "Whether materialized columns should be created or used at query time.",
@@ -339,6 +345,7 @@ CONSTANCE_CONFIG = {
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
+    "HOGQL_SHARED_INSIGHT_DATABASE_ENABLED",
     "RECORDINGS_PERFORMANCE_EVENTS_TTL_WEEKS",
     "AUTO_START_ASYNC_MIGRATIONS",
     "AGGREGATE_BY_DISTINCT_IDS_TEAMS",


### PR DESCRIPTION
## Problem

#88183 shares one HogQL database across an insight run's query threads. If the sharing misbehaves in production, the only rollback is a revert and a redeploy.

## Changes

- Staff can turn the sharing off at runtime: instance setting `HOGQL_SHARED_INSIGHT_DATABASE_ENABLED`, default on, editable via the instance settings API. Workers pick up a change within 60 seconds.
- Off means `shared_database` returns a fresh database per access, so query threads never share schema state. Every wired runner falls back to per-call builds, the pre-#88183 threading profile.
- The off path records no timing because concurrent threads reach it and `HogQLTimings` is not thread-safe.

## How did you test this code?

`test_shared_database_kill_switch_disables_sharing`: with the setting off, two property accesses return different instances; back on, the same instance. Catches a refactor that silently drops the switch and with it the emergency lever.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Staff-only instance setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as a decision aid layered on #88183: the assignee will judge whether the runtime switch earns its complexity, then fold this into the base PR or close it. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.