### PR TITLE
fix(desktop): reduce report chat action size

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -211,7 +211,6 @@ function ReportChatConversation({
           <Button
             type="button"
             variant="primary"
-            size="lg"
             className="flex-1 rounded-lg"
             loading={sendingPrompt === workPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
@@ -223,7 +222,6 @@ function ReportChatConversation({
           <Button
             type="button"
             variant="outline"
-            size="lg"
             className="flex-1 rounded-lg"
             loading={sendingPrompt === canvasPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
@@ -354,9 +352,8 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
               key={label}
               type="button"
               variant={variant}
-              size="lg"
               left
-              className="rounded-lg px-3"
+              className="rounded-lg"
               // Once the composer holds a typed draft or a quoted passage, the
               // one-click chips step aside — firing a chip must not silently
               // discard what the user wrote or highlighted.

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -207,27 +207,29 @@ function ReportChatConversation({
     <EmbeddedSessionView
       task={task}
       threadActions={({ sendPrompt, isPromptPending }) => (
-        <div className="flex items-center gap-2 border-border border-t px-3 py-3">
+        <div className="flex items-center gap-2 border-border border-t px-3 py-2">
           <Button
             type="button"
             variant="primary"
-            className="h-9 flex-1 rounded-lg px-4 text-[13px]"
+            size="lg"
+            className="flex-1 rounded-lg"
             loading={sendingPrompt === workPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
             onClick={() => void sendSuggestedPrompt(workPrompt, sendPrompt)}
           >
-            <GitPullRequestIcon size={15} />
+            <GitPullRequestIcon />
             {workLabel}
           </Button>
           <Button
             type="button"
             variant="outline"
-            className="h-9 flex-1 rounded-lg px-4 text-[13px]"
+            size="lg"
+            className="flex-1 rounded-lg"
             loading={sendingPrompt === canvasPrompt}
             disabled={isPromptPending || sendingPrompt !== null}
             onClick={() => void sendSuggestedPrompt(canvasPrompt, sendPrompt)}
           >
-            <ShapesIcon size={15} />
+            <ShapesIcon />
             Visualize in a Canvas
           </Button>
         </div>
@@ -352,14 +354,16 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
               key={label}
               type="button"
               variant={variant}
-              className="h-10 justify-start rounded-lg px-4 text-[13px]"
+              size="lg"
+              left
+              className="rounded-lg px-3"
               // Once the composer holds a typed draft or a quoted passage, the
               // one-click chips step aside — firing a chip must not silently
               // discard what the user wrote or highlighted.
               disabled={isDiscussing || starterDraft.trim().length > 0}
               onClick={() => ask(prompt)}
             >
-              <Icon size={16} />
+              <Icon />
               {label}
             </Button>
           ))}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -352,7 +352,6 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
               key={label}
               type="button"
               variant={variant}
-              left
               className="rounded-lg"
               // Once the composer holds a typed draft or a quoted passage, the
               // one-click chips step aside — firing a chip must not silently


### PR DESCRIPTION
## Problem

Report chat actions take too much vertical space in both new and existing conversations.

**Why:** Smaller actions keep the chat compact and leave more room for the report conversation.

## Changes

- Report chat actions now use a consistent 32px height with tighter padding and smaller icons.
- The reduced size applies before a task starts and while an existing task is open.

Before

<img width="3008" height="1824" alt="image" src="https://github.com/user-attachments/assets/5f22dc1c-0fc6-451f-b6c5-d38d9b5f5598" />

<img width="872" height="1848" alt="image" src="https://github.com/user-attachments/assets/ab3e3c56-a9e4-4406-8ebd-118445760863" />

After

<img width="2468" height="1922" alt="image" src="https://github.com/user-attachments/assets/8876542f-7684-4a28-9db7-7e8e6d6762bc" />

<img width="1646" height="1860" alt="image" src="https://github.com/user-attachments/assets/9f4d3671-d5fd-4de9-bf18-7096c1684615" />


## How did you test this code?

I looked at it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed for this visual adjustment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested density change using the posthog-desktop, writing-ui-components, and writing-pr-descriptions skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*