### PR TITLE
fix(surveys): give the SDK survey payload a deterministic order

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3516,7 +3516,13 @@ def get_surveys_response(team: Team) -> dict[str, Any]:
         # external_survey case in their type enums at all.
         .exclude(type=Survey.SurveyType.EXTERNAL_SURVEY)
         .select_related("linked_flag", "targeting_flag", "internal_targeting_flag")
-        .prefetch_related("actions"),
+        .prefetch_related("actions")
+        # The order decides which survey wins when several match the same person, because SDKs show
+        # the first one in this list that the person is eligible for, and a survey wait period then
+        # blocks the others for the whole period. Order by start date to keep that winner stable and
+        # to give it to the survey that started first. An unordered queryset returns Postgres heap
+        # order instead, which any row update can change, so the winner flips with no survey edit.
+        .order_by("start_date", "id"),
         many=True,
     ).data
 

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -487,6 +487,26 @@ class TestSurvey(APIBaseTest):
 
         assert (str(survey.id) in payload_ids) is expected_in_payload
 
+    def test_sdk_payload_orders_surveys_by_start_date(self) -> None:
+        started_second = Survey.objects.create(
+            team=self.team,
+            name="Started second",
+            type="popover",
+            questions=[{"type": "open", "id": "q1", "question": "How are you?"}],
+            start_date=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        started_first = Survey.objects.create(
+            team=self.team,
+            name="Started first",
+            type="popover",
+            questions=[{"type": "open", "id": "q1", "question": "How are you?"}],
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        payload_ids = [str(item["id"]) for item in get_surveys_response(self.team)["surveys"]]
+
+        assert payload_ids == [str(started_first.id), str(started_second.id)]
+
     def test_sdk_payload_strips_non_runtime_question_fields(self) -> None:
         self.team.survey_config = {"appearance": {"backgroundColor": "black"}}
         self.team.save(update_fields=["survey_config"])


### PR DESCRIPTION
## Problem

Two surveys that can both match the same person will only ever show one of them, and today which one wins is arbitrary.

- A survey wait period blocks every *other* survey, not just its own, because `$last_seen_survey_date` is one person property shared by all surveys.
- SDKs arm the first popover in the payload that the person is eligible for, so payload order picks the winner.
- `get_surveys_response` had no `ORDER BY`, so the payload carried Postgres heap order.
- Any row update can reorder the heap. The cached team config then serves that new order until the next survey save, so the winner flips with no survey edit.

Support cannot explain a reach gap between two overlapping surveys while the answer is "whichever row Postgres returned first".

Refs #30379

## Changes

- The survey that started first now wins the collision, identically on every client.
- `get_surveys_response` orders by `start_date`, then `id` to break ties.
- Eligibility is untouched. Nobody becomes eligible or ineligible for a survey they were not before.

`start_date` beats `created_at` as the key because the queryset already filters out unstarted surveys, so `start_date` is never null. Ordering oldest-first also means launching a new survey does not silently take the audience from one already collecting.

> [!NOTE]
> This makes the winner stable and explainable. It does not make it fair. The losing survey still gets none of the shared audience. Spreading collisions across people needs a per-person tiebreak in the SDK, which lives in PostHog/posthog-js and is not in this PR.

## How did you test this code?

`test_sdk_payload_orders_surveys_by_start_date` catches a dropped `ORDER BY`. It creates the later-starting survey first, so heap order and start-date order disagree. Reverting the `order_by` fails it; keeping it passes. No existing test asserts payload order, and the multi-survey ones sort by id first, so this was uncovered.

Ran locally against the dev stack: the `sdk_payload` tests in `TestSurvey`, and `TestRemoteConfigSurveys`, which builds the same list into the cached team config.

Not checked: the wider backend suites, and the SDK half of this behavior, which lives in PostHog/posthog-js. `hogli build:openapi` changed no generated file, but its final MCP-types step failed locally on an unresolved `@posthog/openapi-codegen` import that this branch does not touch.

## Automatic notifications

- [ ] Publish to changelog?

Left unchecked. The affected set is teams running two or more overlapping surveys with a wait period, and for most of them heap order already matched start-date order.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). The driver's GitHub handle was not available in this session, so the PR is left unassigned rather than assigned to a guessed account.

Written by Claude (Claude Code) while investigating a support question about two surveys targeting the same audience reaching very different numbers of people. That reach gap is customer configuration: two independently bucketed 50% targeting flags, plus a shared wait period that makes the surveys mutually exclusive. It needs no code change. This PR fixes the one part that is ours, which is that the tiebreak between colliding surveys was never defined.

Skills invoked: `/debugging-surveys`, `/writing-tests`, `/writing-code-comments`, `/announcing-behavior-changes`, `/writing-pr-descriptions`.

`/announcing-behavior-changes` ruled out an in-app notice. Its narrowing test needs a client-side predicate for "you are affected", and the old heap order is not recoverable, so no such predicate exists.

The winner-take-all behavior was read from the SDK source rather than assumed: `callSurveysAndEvaluateDisplayLogic` arms only the first eligible popover per cycle, and `_addSurveyToFocus` claims the display slot before the popup delay timer starts, so the runner-up never arms.

No customer material appears in this diff or description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
