### PR TITLE
fix(data-warehouse): show auto-disabled failing syncs in pipeline health view

### DIFF
--- a/products/data_warehouse/backend/presentation/views/data_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/data_warehouse.py
@@ -676,13 +676,14 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                     }
                 )
 
-            # Get failed syncs from ExternalDataSchema
-            # Only show syncs that are actively enabled but failing
+            # Get failed syncs from ExternalDataSchema, including schemas PostHog auto-disabled after
+            # a non-retryable error (should_sync=False): those are the most persistent failures, so
+            # filtering them out empties the health view exactly when the problem became permanent.
+            # Schemas the user turned off while healthy have status Completed and stay hidden.
             problem_syncs = (
                 ExternalDataSchema.objects.filter(
                     team_id=self.team_id,
                     deleted=False,
-                    should_sync=True,
                 )
                 .filter(
                     Q(status=ExternalDataSchema.Status.FAILED)
@@ -695,6 +696,9 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 sync_status = "failed"
                 if schema.status == ExternalDataSchema.Status.BILLING_LIMIT_REACHED:
                     sync_status = "billing_limit"
+                elif not schema.should_sync:
+                    # PostHog gave up on this sync; report it as disabled rather than failed.
+                    sync_status = "disabled"
 
                 results.append(
                     {

--- a/products/data_warehouse/backend/tests/api/test_data_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_data_warehouse.py
@@ -691,6 +691,91 @@ class TestDataWarehouseAPI(APIBaseTest):
         self.assertNotEqual(new_id, first_id)
         self.assertIsNotNone(new_id)
 
+    @parameterized.expand(
+        [
+            ("failed_still_retrying", "Failed", True, True, "failed"),
+            ("auto_disabled_after_failures", "Failed", False, True, "disabled"),
+            ("billing_limit_still_retrying", "BillingLimitReached", True, True, "billing_limit"),
+            ("billing_limit_disabled", "BillingLimitReached", False, True, "billing_limit"),
+            ("disabled_while_healthy", "Completed", False, False, None),
+        ]
+    )
+    def test_data_health_issues_sync_visibility(
+        self,
+        _name: str,
+        schema_status: str,
+        should_sync: bool,
+        expect_visible: bool,
+        expected_status: str | None,
+    ) -> None:
+        source = ExternalDataSource.objects.create(
+            source_id="test-id", connection_id="conn-id", destination_id="dest-id", team=self.team, source_type="Stripe"
+        )
+        failed = schema_status in ("Failed", "BillingLimitReached")
+        schema = ExternalDataSchema.objects.create(
+            name="customers",
+            team=self.team,
+            source=source,
+            status=schema_status,
+            should_sync=should_sync,
+            latest_error="connection refused" if failed else None,
+            last_synced_at=timezone.now() if not failed else None,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/data_health_issues/")
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(data["count"], len(data["results"]))
+
+        results_by_id = {result["id"]: result for result in data["results"]}
+        if expect_visible:
+            result = results_by_id[str(schema.id)]
+            self.assertEqual(result["type"], "external_data_sync")
+            self.assertEqual(result["status"], expected_status)
+            self.assertEqual(result["name"], "customers")
+            self.assertEqual(result["error"], "connection refused")
+            self.assertEqual(result["url"], f"/data-warehouse/sources/{source.pk}")
+        else:
+            self.assertNotIn(str(schema.id), results_by_id)
+
+    def test_data_health_issues_excludes_deleted_and_foreign_team_syncs(self):
+        source = ExternalDataSource.objects.create(
+            source_id="test-id", connection_id="conn-id", destination_id="dest-id", team=self.team, source_type="Stripe"
+        )
+        ExternalDataSchema.objects.create(
+            name="deleted_table",
+            team=self.team,
+            source=source,
+            status="Failed",
+            should_sync=False,
+            latest_error="connection refused",
+            deleted=True,
+        )
+        other_team = self.organization.team_set.create(name="other team")
+        other_source = ExternalDataSource.objects.create(
+            source_id="other-id",
+            connection_id="conn-id",
+            destination_id="dest-id",
+            team=other_team,
+            source_type="Stripe",
+        )
+        ExternalDataSchema.objects.create(
+            name="foreign_table",
+            team=other_team,
+            source=other_source,
+            status="Failed",
+            should_sync=False,
+            latest_error="connection refused",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/data_health_issues/")
+        self.assertEqual(response.status_code, 200)
+
+        names = [result["name"] for result in response.json()["results"]]
+        self.assertNotIn("deleted_table", names)
+        self.assertNotIn("foreign_table", names)
+
 
 class TestDataHealthIssuesPersonalAPIKey(APIBaseTest):
     """Verify the data_health_issues action is reachable via personal API keys.


### PR DESCRIPTION
## Problem

Non-retryable sync failures leave ExternalDataSchema rows as `should_sync=False`
+ `status=Failed`. The `data_health_issues` sync branch filtered on
`should_sync=True`, so these failures disappeared from the Pipeline status view
at the exact moment PostHog stopped retrying them (#88061). On one measured team,
2 failing syncs were visible while 384 Failed schemas were hidden.

The daily `ExternalDataFailureCheck` health check already treats these same rows
as alert-worthy via `Q(should_sync=False, latest_error__isnull=False)`; the
endpoint contradicted that precedent.

## Solution

Remove the `should_sync=True` restriction from the sync branch. Selection stays
non-deleted schemas of the requesting team with
`status IN (Failed, BillingLimitReached)`. A `Failed` schema with
`should_sync=False` is reported with the existing `"disabled"` health-issue
status instead of `"failed"`. `BillingLimitReached` keeps its `"billing_limit"`
label either way. Schemas turned off while healthy (`status=Completed`) never
match the filter and stay hidden.

## Tests

Added content tests to `TestDataWarehouseAPI`:

- Parameterized visibility matrix: failed+retrying visible as `"failed"`;
  failed+auto-disabled visible as `"disabled"` (fails under the previous
  implementation); billing-limit cases keep `"billing_limit"`; healthy opt-out
  stays hidden.
- Deleted and cross-team schemas excluded; `count` matches list length.

## Validation

Honest limitation: these tests have not been executed locally. Native Windows
cannot install the dependency lockfile (`chdb`, `deltalake`, `pyroscope-io`
have no win_amd64 wheels; `hogql-parser` refuses Windows builds), and inside
WSL an unresolved Django migration startup hang blocked execution despite a
working Postgres/Redis/ClickHouse stack. Both changed files pass syntax checks,
and the tests were traced statically against the old and new implementations.
CI validation on this draft PR is required before merge.

## Known follow-ups (deliberately not in this PR)

- Pagination if expanded result sets require it (issue AC4)
- Disabled-first ordering if urgency should be reflected in sort (AC2)
- Strict user-disabled vs system-auto-disabled separation via a persisted
  marker, if maintainers require exact AC3 behavior for failing tables the
  user switched off manually

## context

- Issue: #88061
- Approach discussed on the issue before implementation
- Local execution impossible on contributor hardware; see Validation section
