### PR TITLE
fix(ingestion): stop blocking refused merges on the warning ack

### DIFF
--- a/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
@@ -1,22 +1,17 @@
 import { DateTime } from 'luxon'
 
-import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
+import { INGESTION_WARNINGS_OUTPUT } from '~/common/outputs'
+import { parseJSON } from '~/common/utils/json-parse'
 import { InternalPerson } from '~/types'
 
 import { PersonContext } from './person-context'
 import { PersonMergeService } from './person-merge-service'
 import { createDefaultSyncMergeMode } from './person-merge-types'
 
-jest.mock('~/ingestion/common/ingestion-warnings', () => ({
-    emitIngestionWarning: jest.fn(),
-}))
-
-const mockEmitIngestionWarning = emitIngestionWarning as jest.MockedFunction<typeof emitIngestionWarning>
-
 describe('PersonMergeService', () => {
-    const teamId = 123
+    let teamCounter = 1000
 
-    function person(uuid: string, isIdentified: boolean): InternalPerson {
+    function person(uuid: string, isIdentified: boolean, teamId: number): InternalPerson {
         return {
             id: uuid,
             uuid,
@@ -32,73 +27,81 @@ describe('PersonMergeService', () => {
         }
     }
 
-    function service(eventName: string): PersonMergeService {
-        const context = new PersonContext(
-            { uuid: 'event-uuid', event: eventName, distinct_id: 'target', properties: {} } as any,
-            { id: teamId } as any,
-            'target',
-            DateTime.now(),
-            true,
-            { produce: jest.fn().mockResolvedValue(undefined) } as any,
-            {} as any,
-            0,
-            createDefaultSyncMergeMode(),
-            false,
-            false
-        )
-        return new PersonMergeService(context)
-    }
-
     describe('mergePeople with an already identified source', () => {
-        let warningResolve: (emitted: boolean) => void
+        let teamId: number
+        let queueMessages: jest.Mock
 
         beforeEach(() => {
-            jest.clearAllMocks()
-            mockEmitIngestionWarning.mockReturnValue(
-                new Promise<boolean>((resolve) => {
-                    warningResolve = resolve
-                })
-            )
+            teamId = teamCounter++
+            queueMessages = jest.fn().mockResolvedValue(undefined)
         })
 
-        it('returns before the warning is acked and hands the ack back as kafkaAck', async () => {
-            const mergeInto = person('target-uuid', true)
-            const otherPerson = person('source-uuid', true)
-
-            const result = await service('$identify').mergePeople({
-                mergeInto,
-                mergeIntoDistinctId: 'target',
-                otherPerson,
+        function refuseMerge(targetDistinctId: string) {
+            const context = new PersonContext(
+                { uuid: 'event-uuid', event: '$identify', distinct_id: targetDistinctId, properties: {} } as any,
+                { id: teamId } as any,
+                targetDistinctId,
+                DateTime.now(),
+                true,
+                { queueMessages } as any,
+                {} as any,
+                0,
+                createDefaultSyncMergeMode(),
+                false,
+                false
+            )
+            return new PersonMergeService(context).mergePeople({
+                mergeInto: person('target-uuid', true, teamId),
+                mergeIntoDistinctId: targetDistinctId,
+                otherPerson: person('source-uuid', true, teamId),
                 otherPersonDistinctId: 'source',
             })
+        }
 
-            expect(result).toMatchObject({ success: true, person: mergeInto, needsPersonUpdate: true })
+        it('returns before the warning is acked and hands the ack back as kafkaAck', async () => {
+            let ackWarning!: () => void
+            queueMessages.mockReturnValue(new Promise<void>((resolve) => (ackWarning = resolve)))
+
+            const result = await refuseMerge('target')
+
+            expect(result).toMatchObject({ success: true, needsPersonUpdate: true })
             if (!result.success) {
                 throw new Error('unreachable')
             }
+            expect(result.person?.uuid).toBe('target-uuid')
+            expect(queueMessages).toHaveBeenCalledWith(INGESTION_WARNINGS_OUTPUT, [{ value: expect.any(Buffer) }])
 
             let acked = false
             void result.kafkaAck.then(() => (acked = true))
             await Promise.resolve()
             expect(acked).toBe(false)
 
-            warningResolve(true)
+            ackWarning()
             await result.kafkaAck
             expect(acked).toBe(true)
         })
 
-        it('rate limits the warning per target distinct id', async () => {
-            await service('$create_alias').mergePeople({
-                mergeInto: person('target-uuid', true),
-                mergeIntoDistinctId: 'target',
-                otherPerson: person('source-uuid', true),
-                otherPersonDistinctId: 'source',
-            })
+        it('emits one warning per target distinct id', async () => {
+            await refuseMerge('target-a')
+            await refuseMerge('target-a')
+            await refuseMerge('target-b')
 
-            expect(mockEmitIngestionWarning).toHaveBeenCalledTimes(1)
-            const warning = mockEmitIngestionWarning.mock.calls[0][2]
-            expect(warning).toMatchObject({ type: 'cannot_merge_already_identified', key: 'target' })
-            expect(warning.alwaysSend).toBeUndefined()
+            expect(queueMessages).toHaveBeenCalledTimes(2)
+            const emittedFor = queueMessages.mock.calls.map(
+                ([, [message]]) => parseJSON(parseJSON(message.value.toString()).details).distinctId
+            )
+            expect(emittedFor).toEqual(['target-a', 'target-b'])
+        })
+
+        it('does not fail the event when the warning produce fails', async () => {
+            queueMessages.mockRejectedValue(new Error('broker down'))
+
+            const result = await refuseMerge('target')
+
+            expect(result.success).toBe(true)
+            if (result.success) {
+                await expect(result.kafkaAck).resolves.toBeUndefined()
+            }
         })
     })
 })

--- a/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
@@ -1,7 +1,6 @@
 import { DateTime } from 'luxon'
 
 import { INGESTION_WARNINGS_OUTPUT } from '~/common/outputs'
-import { parseJSON } from '~/common/utils/json-parse'
 import { InternalPerson } from '~/types'
 
 import { PersonContext } from './person-context'
@@ -79,18 +78,6 @@ describe('PersonMergeService', () => {
             ackWarning()
             await result.kafkaAck
             expect(acked).toBe(true)
-        })
-
-        it('emits one warning per target distinct id', async () => {
-            await refuseMerge('target-a')
-            await refuseMerge('target-a')
-            await refuseMerge('target-b')
-
-            expect(queueMessages).toHaveBeenCalledTimes(2)
-            const emittedFor = queueMessages.mock.calls.map(
-                ([, [message]]) => parseJSON(parseJSON(message.value.toString()).details).distinctId
-            )
-            expect(emittedFor).toEqual(['target-a', 'target-b'])
         })
 
         it('does not fail the event when the warning produce fails', async () => {

--- a/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
@@ -1,0 +1,104 @@
+import { DateTime } from 'luxon'
+
+import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
+import { InternalPerson } from '~/types'
+
+import { PersonContext } from './person-context'
+import { PersonMergeService } from './person-merge-service'
+import { createDefaultSyncMergeMode } from './person-merge-types'
+
+jest.mock('~/ingestion/common/ingestion-warnings', () => ({
+    emitIngestionWarning: jest.fn(),
+}))
+
+const mockEmitIngestionWarning = emitIngestionWarning as jest.MockedFunction<typeof emitIngestionWarning>
+
+describe('PersonMergeService', () => {
+    const teamId = 123
+
+    function person(uuid: string, isIdentified: boolean): InternalPerson {
+        return {
+            id: uuid,
+            uuid,
+            team_id: teamId,
+            properties: {},
+            created_at: DateTime.now(),
+            version: 0,
+            is_identified: isIdentified,
+            is_user_id: null,
+            last_seen_at: null,
+            properties_last_updated_at: {},
+            properties_last_operation: {},
+        }
+    }
+
+    function service(eventName: string): PersonMergeService {
+        const context = new PersonContext(
+            { uuid: 'event-uuid', event: eventName, distinct_id: 'target', properties: {} } as any,
+            { id: teamId } as any,
+            'target',
+            DateTime.now(),
+            true,
+            { produce: jest.fn().mockResolvedValue(undefined) } as any,
+            {} as any,
+            0,
+            createDefaultSyncMergeMode(),
+            false,
+            false
+        )
+        return new PersonMergeService(context)
+    }
+
+    describe('mergePeople with an already identified source', () => {
+        let warningResolve: (emitted: boolean) => void
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            mockEmitIngestionWarning.mockReturnValue(
+                new Promise<boolean>((resolve) => {
+                    warningResolve = resolve
+                })
+            )
+        })
+
+        it('returns before the warning is acked and hands the ack back as kafkaAck', async () => {
+            const mergeInto = person('target-uuid', true)
+            const otherPerson = person('source-uuid', true)
+
+            const result = await service('$identify').mergePeople({
+                mergeInto,
+                mergeIntoDistinctId: 'target',
+                otherPerson,
+                otherPersonDistinctId: 'source',
+            })
+
+            expect(result).toMatchObject({ success: true, person: mergeInto, needsPersonUpdate: true })
+            if (!result.success) {
+                throw new Error('unreachable')
+            }
+
+            let acked = false
+            void result.kafkaAck.then(() => (acked = true))
+            await Promise.resolve()
+            expect(acked).toBe(false)
+
+            warningResolve(true)
+            await result.kafkaAck
+            expect(acked).toBe(true)
+        })
+
+        it('rate limits the warning per target distinct id', async () => {
+            await service('$create_alias').mergePeople({
+                mergeInto: person('target-uuid', true),
+                mergeIntoDistinctId: 'target',
+                otherPerson: person('source-uuid', true),
+                otherPersonDistinctId: 'source',
+            })
+
+            expect(mockEmitIngestionWarning).toHaveBeenCalledTimes(1)
+            const warning = mockEmitIngestionWarning.mock.calls[0][2]
+            expect(warning).toMatchObject({ type: 'cannot_merge_already_identified', key: 'target' })
+            expect(warning.alwaysSend).toBeUndefined()
+        })
+    })
+})

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -701,7 +701,7 @@ export class PersonMergeService {
 
         // If merge isn't allowed, we will ignore it, log an ingestion warning and return success with original person
         if (!mergeAllowed) {
-            await emitIngestionWarning(this.context.outputs, this.context.team.id, {
+            const warningAck = emitIngestionWarning(this.context.outputs, this.context.team.id, {
                 type: 'cannot_merge_already_identified',
                 details: {
                     sourcePersonDistinctId: otherPersonDistinctId,
@@ -712,12 +712,12 @@ export class PersonMergeService {
                     otherPersonId: otherPerson.uuid,
                 },
                 pipelineStep: 'person-merge',
-                alwaysSend: true,
-            })
+                key: mergeIntoDistinctId,
+            }).then(() => undefined)
             logger.warn('🤔', 'refused to merge an already identified user via an $identify or $create_alias call', {
                 team_id: this.context.team.id,
             })
-            return mergeSuccess(mergeInto, Promise.resolve(), true)
+            return mergeSuccess(mergeInto, warningAck, true)
         }
 
         // How the merge works:

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -712,7 +712,7 @@ export class PersonMergeService {
                     otherPersonId: otherPerson.uuid,
                 },
                 pipelineStep: 'person-merge',
-                key: mergeIntoDistinctId,
+                alwaysSend: true,
             }).then(() => undefined)
             logger.warn('🤔', 'refused to merge an already identified user via an $identify or $create_alias call', {
                 team_id: this.context.team.id,

--- a/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
@@ -8,6 +8,7 @@ import {
     KAFKA_PERSON_DISTINCT_ID,
     KAFKA_PERSON_MERGE_EVENTS,
 } from '~/common/config/kafka-topics'
+import { TopicMessage } from '~/common/kafka/producer'
 import { INGESTION_WARNINGS_OUTPUT } from '~/common/outputs'
 import { ASYNC_OUTPUT } from '~/common/outputs'
 import { PERSONS_OUTPUT, PERSON_DISTINCT_IDS_OUTPUT, PERSON_MERGE_EVENTS_OUTPUT } from '~/common/outputs'
@@ -17,6 +18,7 @@ import { PostgresPersonRepository } from '~/common/persons/repositories/postgres
 import { fetchDistinctIdValues, fetchDistinctIds } from '~/common/persons/repositories/test-helpers'
 import { PostgresUse } from '~/common/utils/db/postgres'
 import { normalizeEvent, normalizeProcessPerson } from '~/common/utils/event'
+import { parseJSON } from '~/common/utils/json-parse'
 import { UUIDT } from '~/common/utils/utils'
 import { BatchWritingPersonsStore } from '~/ingestion/common/persons/batch-writing-person-store'
 import { PersonOutputs } from '~/ingestion/common/persons/person-context'
@@ -308,6 +310,75 @@ describe('createProcessPersonsStep', () => {
         expect(result.type).toBe(PipelineResultType.DLQ)
         if (isDlqResult(result)) {
             expect(result.reason).toBe('Merge limit exceeded')
+        }
+    })
+
+    it('returns a refused merge before its warning is acked and defers the ack to the side effects', async () => {
+        for (const distinctId of ['identified-source', 'target']) {
+            const created = await personRepository.createPerson(
+                DateTime.utc(),
+                {},
+                {},
+                {},
+                teamId,
+                null,
+                true,
+                new UUIDT().toString(),
+                { distinctId }
+            )
+            expect(created.success).toBe(true)
+        }
+
+        let ackWarning!: () => void
+        const heldWarning = new Promise<void>((resolve) => (ackWarning = resolve))
+        const topicOf = (batch: TopicMessage | TopicMessage[]) => (Array.isArray(batch) ? batch[0] : batch).topic
+        const queueMessages = jest.spyOn(mockProducer, 'queueMessages').mockImplementation((batch) => {
+            return topicOf(batch) === KAFKA_INGESTION_WARNINGS ? heldWarning : Promise.resolve()
+        })
+
+        try {
+            const step = createProcessPersonsStep(options, personOutputs)
+            const result = await step(
+                createInput({
+                    normalizedEvent: {
+                        ...pluginEvent,
+                        event: '$identify',
+                        distinct_id: 'target',
+                        properties: { $anon_distinct_id: 'identified-source' },
+                    },
+                })
+            )
+
+            expect(isOkResult(result)).toBe(true)
+            if (!isOkResult(result)) {
+                return
+            }
+
+            const warningBatches = queueMessages.mock.calls
+                .map(([batch]) => (Array.isArray(batch) ? batch[0] : batch))
+                .filter((batch) => batch.topic === KAFKA_INGESTION_WARNINGS)
+            expect(warningBatches).toHaveLength(1)
+            expect(parseJSON(warningBatches[0].messages[0].value!.toString())).toMatchObject({
+                team_id: teamId,
+                type: 'cannot_merge_already_identified',
+            })
+
+            let settled = false
+            void Promise.all(result.sideEffects).then(() => (settled = true))
+            await new Promise((resolve) => setImmediate(resolve))
+            expect(settled).toBe(false)
+
+            ackWarning()
+            await Promise.all(result.sideEffects)
+            expect(settled).toBe(true)
+        } finally {
+            queueMessages.mockRestore()
+        }
+
+        const persons = await fetchPostgresPersons(infra.postgres, teamId)
+        expect(persons).toHaveLength(2)
+        for (const person of persons) {
+            expect(await fetchDistinctIdValues(infra.postgres, person)).toHaveLength(1)
         }
     })
 


### PR DESCRIPTION
## Problem

- A team that sends a steady stream of `$identify` or `$create_alias` events for distinct IDs that are already identified slows the whole ingestion lane for its own events.
- Each refused merge awaited the Kafka ack of its `cannot_merge_already_identified` warning before returning the event.
- Events for one distinct_id run sequentially, so a hot key was capped at about one event per produce round-trip.

## Changes

- Refused merges no longer wait for the warning to be acked. The warning produce flows back as the merge's `kafkaAck`, which the pipeline awaits at batch end like every other person write.
- Nothing user-visible changes. Every refused merge still produces its warning.

## How did you test this code?

- New `person-merge-service.test.ts` drives `mergePeople` through the real `emitIngestionWarning` and limiter with a fake warning output.
- `mergePeople` returns while the warning ack is still pending and hands that ack back as `kafkaAck`. Fails on the old code, which hangs on the await.
- A rejected warning produce still resolves `kafkaAck`, so the batch cannot fail on a warning. Guards the new contract; passes on the old code too.
- New case in `process-persons-step.integration.test.ts` runs a refused `$identify` through the full step with the warning produce held open. The step returns while the produce is pending, the warning is in the result's side effects, and those settle only after the produce does. Fails on the old code, which hangs. Guards against a refactor that drops the ack from the batch and makes the warning fire-and-forget.
- Ran `tests/ingestion/person-state-batch.test.ts` locally. The refused-merge cases pass. Four unrelated cases failed on a local ClickHouse missing the `person` table; not checked further, CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) wrote the change and the test from a written fix plan; the human chose the scope. An earlier revision also rate limited the warning per target distinct_id; review flagged the unbounded limiter map, so that part was dropped and left for a follow-up. Skills invoked: `/writing-pr-descriptions`. The change and test data are invented and carry no customer material. Session: https://claude.ai/code/session_01Eok5EJ87SBeCXzwgiut9Ne
