### PR TITLE
fix(logs): decode attribute values in drop and metric rule matching

### DIFF
--- a/nodejs/src/logs/attribute-value.ts
+++ b/nodejs/src/logs/attribute-value.ts
@@ -1,0 +1,38 @@
+import { parseJSON } from '~/common/utils/json-parse'
+
+/**
+ * Attribute values arrive JSON-encoded from capture (`any_value_to_json`): a string
+ * attribute is stored as `"error"` (with quotes), a number as `123`. The ClickHouse
+ * sink decodes string values with `JSONExtractString`, so that is what users see in
+ * the Logs UI. Every ingestion-time consumer of the attribute maps (transformations,
+ * drop-rule matching, metric-rule tallying) must see the same decoded values —
+ * otherwise `record.attributes['level'] == 'error'` silently never matches.
+ */
+export function decodeLogAttributeValue(value: string): string {
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+        try {
+            const parsed = parseJSON(value)
+            if (typeof parsed === 'string') {
+                return parsed
+            }
+        } catch {
+            // Not valid JSON — treat as a plain string
+        }
+    }
+    return value
+}
+
+/**
+ * Inverse of `decodeLogAttributeValue` for values written back onto the record:
+ * plain strings are JSON-encoded so the ClickHouse sink's `JSONExtractString`
+ * surfaces them; values that are already valid JSON (numbers, booleans, objects,
+ * pre-encoded strings) pass through unchanged.
+ */
+export function encodeLogAttributeValue(value: string): string {
+    try {
+        parseJSON(value)
+        return value
+    } catch {
+        return JSON.stringify(value)
+    }
+}

--- a/nodejs/src/logs/metrics-rules/metric-rules.test.ts
+++ b/nodejs/src/logs/metrics-rules/metric-rules.test.ts
@@ -118,6 +118,31 @@ describe('metric rules compile + tally', () => {
             expect(entries[0]!.labelValues).toEqual([longValue.slice(0, MAX_LABEL_VALUE_LENGTH), '500', ''])
         })
 
+        it('decodes JSON-encoded attribute values for value_attribute sums', () => {
+            // Attribute values arrive JSON-encoded from capture: a numeric string
+            // attribute is `'"7.5"'` on the wire. parseFloat over the raw value is
+            // NaN, so without decoding the record is silently skipped.
+            const rules = compileMetricRules([
+                ruleRow({ value_attribute: 'attributes.duration_ms', filter_group: null }),
+            ])
+            const tallies = createBatchTallies()
+            tallyRecords(rules, [record({ attributes: { duration_ms: '"7.5"' } })], tallies, NOW_MS)
+            const entries = [...tallies.byRule.get('rule-1')!.values()]
+            expect(entries[0]!.count).toBe(1)
+            expect(entries[0]!.sum).toBe(7.5)
+            expect(tallies.valueSkipped).toBe(0)
+        })
+
+        it('decodes JSON-encoded attribute values for group-by labels', () => {
+            const rules = compileMetricRules([
+                ruleRow({ filter_group: null, group_by: ['resource_attributes.k8s.pod'] }),
+            ])
+            const tallies = createBatchTallies()
+            tallyRecords(rules, [record({ resource_attributes: { 'k8s.pod': '"pod-1"' } })], tallies, NOW_MS)
+            const entries = [...tallies.byRule.get('rule-1')!.values()]
+            expect(entries[0]!.labelValues).toEqual(['pod-1'])
+        })
+
         it('accumulates records with identical label values into one entry', () => {
             const rules = compileMetricRules([ruleRow({ filter_group: null, group_by: ['severity_text'] })])
             const tallies = createBatchTallies()

--- a/nodejs/src/logs/metrics-rules/tally.ts
+++ b/nodejs/src/logs/metrics-rules/tally.ts
@@ -1,3 +1,4 @@
+import { decodeLogAttributeValue } from '../attribute-value'
 import type { LogRecord } from '../log-record-avro'
 import { matchFilterGroup } from '../sampling/filter-group-match'
 import type { CompiledMetricRule } from './compile-metric-rules'
@@ -51,12 +52,22 @@ function lookupKey(key: string, record: LogRecord): string | null | undefined {
         return record.event_name
     }
     if (key.startsWith(ATTRIBUTES_PREFIX)) {
-        return record.attributes?.[key.slice(ATTRIBUTES_PREFIX.length)]
+        return decodedAttr(record.attributes, key.slice(ATTRIBUTES_PREFIX.length))
     }
     if (key.startsWith(RESOURCE_ATTRIBUTES_PREFIX)) {
-        return record.resource_attributes?.[key.slice(RESOURCE_ATTRIBUTES_PREFIX.length)]
+        return decodedAttr(record.resource_attributes, key.slice(RESOURCE_ATTRIBUTES_PREFIX.length))
     }
     return undefined
+}
+
+/**
+ * Attribute map values are JSON-encoded on the Avro wire (a string arrives as
+ * `"pod-1"`, quotes included). Decode at the read so labels match what the Logs
+ * UI shows and numeric value attributes parse instead of tallying as NaN.
+ */
+function decodedAttr(map: Record<string, string> | null | undefined, key: string): string | undefined {
+    const raw = map?.[key]
+    return raw === undefined ? undefined : decodeLogAttributeValue(raw)
 }
 
 function resolveLabelValue(key: string, record: LogRecord): string {

--- a/nodejs/src/logs/sampling/filter-group-match.test.ts
+++ b/nodejs/src/logs/sampling/filter-group-match.test.ts
@@ -184,6 +184,62 @@ describe('matchFilterGroup', () => {
         })
     })
 
+    describe('wire-encoded attribute values', () => {
+        // Capture JSON-encodes attribute values onto the Avro wire, so a string
+        // attribute reaches this matcher as `"production"` — quotes included. The
+        // ClickHouse sink and the transformation path both decode before they
+        // compare. The matcher must see the same decoded values: without decoding,
+        // an enabled rule silently never fires, and a negated operator fires on
+        // exactly the lines it was meant to keep.
+        const wireRecord = () =>
+            baseRecord({
+                resource_attributes: { 'deployment.environment': '"production"' },
+                attributes: { 'http.status_code': '500', ratio: '"12.5"' },
+            })
+
+        it.each<[string, string | string[], boolean]>([
+            ['exact', ['production'], true],
+            ['in', ['staging', 'production'], true],
+            // Negation must not fire on the value it names — that would drop
+            // the lines the rule was written to keep.
+            ['is_not', ['production'], false],
+            ['starts_with', 'prod', true],
+            ['ends_with', 'tion', true],
+            ['regex', '^production$', true],
+            ['icontains', 'production', true],
+        ])('%s %j sees the decoded resource attribute → %s', (operator, value, expected) => {
+            const g = group({
+                values: [{ key: 'deployment.environment', type: 'log_resource_attribute', operator, value }],
+            })
+            expect(matchFilterGroup(g, wireRecord())).toBe(expected)
+        })
+
+        it('numeric comparison parses a JSON-encoded numeric string', () => {
+            const g = group({ values: [{ key: 'ratio', type: 'log_attribute', operator: 'gt', value: 10 }] })
+            expect(matchFilterGroup(g, wireRecord())).toBe(true)
+        })
+        it('unquoted JSON numbers pass through unchanged', () => {
+            const g = group({
+                values: [{ key: 'http.status_code', type: 'log_attribute', operator: 'exact', value: '500' }],
+            })
+            expect(matchFilterGroup(g, wireRecord())).toBe(true)
+        })
+        it('severity fallback through the attribute map is decoded', () => {
+            const g = group({ values: [{ key: 'severity_text', operator: 'exact', value: ['error'] }] })
+            expect(matchFilterGroup(g, baseRecord({ attributes: { level: '"error"' } }))).toBe(true)
+        })
+        it('service.name fallback through the resource map is decoded', () => {
+            const g = group({ values: [{ key: 'service.name', operator: 'exact', value: 'api' }] })
+            expect(matchFilterGroup(g, baseRecord({ resource_attributes: { 'service.name': '"api"' } }))).toBe(true)
+        })
+        it('a quoted-but-invalid-JSON value is compared as-is', () => {
+            const g = group({
+                values: [{ key: 'raw', type: 'log_attribute', operator: 'exact', value: '"a"b"' }],
+            })
+            expect(matchFilterGroup(g, baseRecord({ attributes: { raw: '"a"b"' } }))).toBe(true)
+        })
+    })
+
     describe('recursion depth cap', () => {
         // Build a degenerate AND-chain N levels deep wrapping a single matching leaf.
         function deepGroup(depth: number, leaf: { key: string; value: string; operator: string }): FilterGroupNode {

--- a/nodejs/src/logs/sampling/filter-group-match.ts
+++ b/nodejs/src/logs/sampling/filter-group-match.ts
@@ -10,6 +10,7 @@
  * The drop-rule form validates non-empty before submit; this is defense in
  * depth at the worker boundary.
  */
+import { decodeLogAttributeValue } from '~/logs/attribute-value'
 import type { LogRecord } from '~/logs/log-record-avro'
 
 import { type PropertyFilterLeaf, matchPropertyFilter } from './property-filter-match'
@@ -79,7 +80,7 @@ function lookupRecordValue(filter: PropertyFilterLeaf, record: LogRecord): strin
         // (underscore) is only the in-memory Avro field name, never an OTel
         // resource attribute. Looking up `resource_attributes['service_name']`
         // would silently miss real data.
-        return record.service_name ?? record.resource_attributes?.['service.name']
+        return record.service_name ?? decodedAttr(record.resource_attributes, 'service.name')
     }
     if (key === 'severity_text' || key === 'level' || key === 'severity_level') {
         // First-class column wins. Otherwise fall back to attribute storage,
@@ -91,17 +92,32 @@ function lookupRecordValue(filter: PropertyFilterLeaf, record: LogRecord): strin
         // attribute names is populated). `severity_level` is the logs UI / HogQL
         // alias and the key the drop-rule builder writes; without this branch it
         // falls through to the `type: 'log'` body fallback and never matches.
-        return record.severity_text ?? record.attributes?.['level'] ?? record.attributes?.['severity_text']
+        return (
+            record.severity_text ??
+            decodedAttr(record.attributes, 'level') ??
+            decodedAttr(record.attributes, 'severity_text')
+        )
     }
     if (key === 'message' || filter.type === PROPERTY_FILTER_TYPE_LOG) {
         return record.body ?? undefined
     }
 
     if (filter.type === PROPERTY_FILTER_TYPE_LOG_RESOURCE_ATTRIBUTE) {
-        return record.resource_attributes?.[key]
+        return decodedAttr(record.resource_attributes, key)
     }
     if (filter.type === PROPERTY_FILTER_TYPE_LOG_ATTRIBUTE) {
-        return record.attributes?.[key]
+        return decodedAttr(record.attributes, key)
     }
-    return record.attributes?.[key] ?? record.resource_attributes?.[key]
+    return decodedAttr(record.attributes, key) ?? decodedAttr(record.resource_attributes, key)
+}
+
+/**
+ * Attribute map values are JSON-encoded on the Avro wire (a string arrives as
+ * `"production"`, quotes included), while filter values and first-class columns
+ * are plain. Decode at the read so every operator compares like against like —
+ * the same decoding the ClickHouse sink applies before the preview queries it.
+ */
+function decodedAttr(map: Record<string, string> | null | undefined, key: string): string | undefined {
+    const raw = map?.[key]
+    return raw === undefined ? undefined : decodeLogAttributeValue(raw)
 }

--- a/nodejs/src/logs/transformations/hog-log-exec.ts
+++ b/nodejs/src/logs/transformations/hog-log-exec.ts
@@ -3,8 +3,8 @@ import { convertHogToJS } from '@posthog/hogvm'
 import type { HogFunctionType } from '~/cdp/types'
 import { sanitizeLogMessage } from '~/cdp/utils'
 import { execHogImmediate } from '~/cdp/utils/hog-exec'
-import { parseJSON } from '~/common/utils/json-parse'
 
+import { decodeLogAttributeValue, encodeLogAttributeValue } from '../attribute-value'
 import type { LogRecord } from '../log-record-avro'
 import { idToHex } from '../metrics-rules/tally'
 
@@ -72,42 +72,6 @@ export function buildLogRecordGlobals(
             span_id: idToHex(record.span_id, 8),
         },
         inputs,
-    }
-}
-
-/**
- * Attribute values arrive JSON-encoded from capture (`any_value_to_json`): a string
- * attribute is stored as `"error"` (with quotes), a number as `123`. The ClickHouse
- * sink decodes string values with `JSONExtractString`, so that is what users see in
- * the Logs UI. Transformations must see the same decoded values — otherwise
- * `record.attributes['level'] == 'error'` silently never matches.
- */
-export function decodeLogAttributeValue(value: string): string {
-    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
-        try {
-            const parsed = parseJSON(value)
-            if (typeof parsed === 'string') {
-                return parsed
-            }
-        } catch {
-            // Not valid JSON — treat as a plain string
-        }
-    }
-    return value
-}
-
-/**
- * Inverse of `decodeLogAttributeValue` for values written back onto the record:
- * plain strings are JSON-encoded so the ClickHouse sink's `JSONExtractString`
- * surfaces them; values that are already valid JSON (numbers, booleans, objects,
- * pre-encoded strings) pass through unchanged.
- */
-export function encodeLogAttributeValue(value: string): string {
-    try {
-        parseJSON(value)
-        return value
-    } catch {
-        return JSON.stringify(value)
     }
 }
 

--- a/nodejs/src/logs/transformations/logs-transformer.service.ts
+++ b/nodejs/src/logs/transformations/logs-transformer.service.ts
@@ -9,12 +9,11 @@ import { yieldEventLoopIfNeeded } from '~/common/utils/event-loop-yield'
 import { logger } from '~/common/utils/logger'
 import { UUIDT } from '~/common/utils/utils'
 
+import { decodeLogAttributeValue, encodeLogAttributeValue } from '../attribute-value'
 import type { LogRecord } from '../log-record-avro'
 import {
     LogTransformationGlobals,
     buildLogRecordGlobals,
-    decodeLogAttributeValue,
-    encodeLogAttributeValue,
     executeLogTransformation,
     resolveLogTransformationInputs,
 } from './hog-log-exec'


### PR DESCRIPTION
## Problem

- A logs drop rule that filters an attribute with "equals" previews matching lines and drops none of them, and nothing in the product signals that the rule is inert. The team keeps paying to store the volume it configured away.
- Attribute values travel JSON-encoded on the Avro wire: a string arrives as `"production"`, quotes included. The ClickHouse sink decodes with `JSONExtractString`, so the preview (which queries stored rows) matches correctly.
- The ingestion matcher (`lookupRecordValue` in `filter-group-match.ts`) reads the attribute maps raw, so `exact`, `in`, `starts_with`, `ends_with`, anchored `regex`, and every numeric operator compare against the quoted form and never match. Only `icontains` works, by accident, because the quotes sit at the ends.
- Worse than inert: `is_not` / `not_in` rules match every line that carries the attribute, so they drop exactly the lines they were written to keep.
- Log-derived metric rules read the same maps raw in `tally.ts`: group-by labels keep literal quotes, and numeric value attributes parse as NaN and are silently skipped.

## Changes

- Drop rules on log and resource attributes now fire for every operator: attribute map values are decoded at the read, the same decoding the sink applies before the preview queries stored rows. The severity (`level`) and `service.name` attribute fallbacks are decoded too.
- Metric rule group-by labels now match what the Logs UI shows, and JSON-encoded numeric value attributes sum instead of being skipped.
- Mechanical: `decodeLogAttributeValue` / `encodeLogAttributeValue` move from `transformations/hog-log-exec.ts` to a shared `logs/attribute-value.ts` — importing them from `hog-log-exec` into `tally.ts` would be circular and would pull hogvm into the sampling hot path. No behavior change in the transformation path.

> [!WARNING]
> Behavior change for existing rules: negated attribute rules (`is_not`, `not_in`) stop over-dropping, so affected teams will see their stored log volume rise to the correct level. Positive attribute rules start dropping the volume they always previewed.

## How did you test this code?

**End to end on a local stack, through the real pipeline** — OTLP → capture-logs → Kafka → logs-ingestion → ClickHouse, with an enabled `deployment.environment equals production` drop rule and six log lines per run (3 production, 2 staging, 1 with no env attribute).

![drop-rule-before-after](https://raw.githubusercontent.com/PostHog/pr-assets/b91a9448dd9d5bf79e105072e02d181773588380/2026/08/94a4bd34-2364-4259-94cb-0ae183858875.png)

| run | production lines stored | expected | verdict |
| --- | --- | --- | --- |
| Before (`HEAD~1` matcher) | 3 of 3 | 0 | every line the rule targeted was stored anyway |
| After (this branch) | 0 of 3 | 0 | dropped before storage, staging and no-attribute lines untouched |

Both runs used one consumer against the same rule row and differed only in the two matcher files, so the change in behaviour is attributable to the decode.

- TDD: the new tests were written first and failed on the exact symptom (encoded values never matching `exact`, `is_not` inverting, labels keeping quotes, sums skipped as NaN), then passed after the decode.
- New tests pin: every operator against a wire-encoded resource attribute, the negation direction, the severity/service fallbacks, unquoted JSON numbers passing through, quoted-but-invalid JSON compared as-is, and the two tally paths (labels, sums).
- Executed the real matcher before and after against a wire-shaped record; every operator now agrees with the preview semantics.
- Ran the sampling, metrics-rules, and transformations jest suites plus eslint/prettier/tsc on the touched files. The transformation suites that shell out to `bin/hoge` fail identically with and without this change in the sandbox (missing Python venv) — not exercised here, covered by CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Desktop cloud task) directed by the assignee, starting from an inbox report that traced the preview/ingestion divergence.
- Session verified the alternative hypothesis (per-team sampling env gating) is not the cause before touching code: the sampling stage defaults to all teams and drop metrics emit continuously in production.
- Skills applied: repo `/writing-tests` (parameterized the operator matrix) and `/writing-pr-descriptions`.
- The local stack needed `protobuf-compiler` for capture-logs to build, and the six Rust services contend on one cargo build lock — running only capture-logs and the logs consumer avoided the stall. The screenshot is invented demo data: generic service names, no real log content.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr) from [this inbox report](https://us.posthog.com/project/2/inbox/reports/01a0344c-4334-7f4f-b8fd-9c885b2611b1).*

