### PR TITLE
feat(experiments): restyle the replay vision banner as an upsell

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
@@ -47,6 +47,10 @@ import { VariantTag } from './VariantTag'
 // variant — a variant literally named "all" just renders as its own option after the built-in "All".
 const ALL_VARIANTS = '$all'
 
+// Unchanged from the earlier cross-sell wording, so a dismissal there still holds. Someone who
+// turned down scanners for this experiment did not ask to be told again in purple.
+const SCANNER_CROSS_SELL_DISMISS_KEY = 'experiment-replay-vision-scanner-cross-sell'
+
 // What the unfiltered list is, said once above it. The second sentence carries the part that
 // isn't guessable: exposure is resolved per person, matching who the analysis counts, so
 // sessions appear even when the exposure event fired server-side or in an earlier session.
@@ -317,18 +321,17 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
                     />
                 ) : (
                     <LemonBanner
-                        type="info"
+                        type="ai"
                         className="mb-2"
-                        dismissKey="experiment-replay-vision-scanner-cross-sell"
+                        dismissKey={SCANNER_CROSS_SELL_DISMISS_KEY}
                         action={{
-                            children: 'Set up a scanner',
+                            children: 'Set up scanner for this experiment',
                             to: scannerSetupUrl,
                             onClick: () => scannerCrossSellClicked(),
                             'data-attr': 'experiment-recordings-scanner-cross-sell',
                         }}
                     >
-                        Replay vision can watch new recordings from this experiment for you. Scanners check each session
-                        and report what they find.
+                        Replay vision is here. Scanners watch your recordings for you and surface what matters.
                     </LemonBanner>
                 ))}
             <div className="mb-2 flex flex-wrap gap-2">


### PR DESCRIPTION
## Problem

The Replay vision banner on an experiment's recordings tab reads as a neutral notice, so people scroll past the one entry point that sets up a scanner for their experiment. Replay home announces the same product in a purple launch banner that draws the eye.

Its call to action, "Set up a scanner", also does not say the scanner is scoped to the experiment being viewed, even though the link prefills that targeting.

## Changes

- The banner now renders in purple with the sparkles icon, matching the Replay vision banner on Replay home.
- The copy matches Replay home: "Replay vision is here. Scanners watch your recordings for you and surface what matters."
- The call to action reads "Set up scanner for this experiment", naming the scope the link already prefills.
- The dismiss key does not change, so anyone who dismissed the earlier banner still does not see this one. Bumping the key would re-show it to people who turned it down; that seemed like the wrong default for a cross-sell.

Mechanical: the dismiss key moves to a named constant, matching how Replay home holds its own key.

The purple comes from `type="ai"` on the shared `LemonBanner`, not from new CSS.

Before:

![banner-before](https://raw.githubusercontent.com/PostHog/pr-assets/10bf08fc13012f01fb8e2f2b1284845cdb3c870c/2026/08/b69167d2-710f-486a-bd96-1be9bbd544c2.png)

After:

![banner-after](https://raw.githubusercontent.com/PostHog/pr-assets/92b3c3cf0a149f26f7e481ffdfa97b1ec04a13a5/2026/08/7053bd50-6c2d-41ef-b23c-895d05274b23.png)

## How did you test this code?

No new tests. The change sets props on a shared component that its own stories already cover.

Rendered both states in Storybook at scene width and captured the screenshots above, using temporary stories that are not part of this diff.

Ran `pnpm --filter=@posthog/frontend fix`; it passes.

Not run: `typescript:check`. It ran clean earlier in this sandbox, then started getting OOM-killed and would not finish. The diff sets `type="ai"`, which `LemonBannerProps` already allows, and passes a string to `dismissKey`, so CI should settle it.

Not checked: how the banner reads in dark mode.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop cloud task. Skills invoked: `/writing-pr-descriptions`.

This is the second of two PRs from one session. The first, #88744, removes the "Summarize recordings" button from the same toolbar, on the grounds that the recording player already offers an inline scan. The two do not share code and can land in either order.

The dismiss key was the one real decision. Reusing it respects an earlier dismissal but means the relaunch copy never reaches those people. Changing it is a one-line edit if that trade should go the other way.

Worth considering separately: the banner tracks clicks but not impressions, so its conversion rate cannot be computed. Replay home wraps its banner in `PostHogCaptureOnViewed` for exactly that. Left out here to keep this diff to the restyle.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
