### PR TITLE
chore(customer-analytics): pin the mocked clock in the summaries deadline test

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/accountSummariesLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountSummariesLogic.test.ts
@@ -174,8 +174,10 @@ describe('accountSummariesLogic', () => {
         mockList.mockResolvedValue({ count: 0, next: null, previous: null, results: [] })
         mockPatch.mockResolvedValue(CADENCE_OFF)
         await mount('acc-deadline')
+        // Pin the clock before setCadence: the deadline is written with Date.now() inside the
+        // listener, and any real-clock drift past startedAt would put the mocked "now" below it.
         const startedAt = Date.now()
-        const nowSpy = jest.spyOn(Date, 'now')
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(startedAt)
 
         logic.actions.setCadence('daily')
         await expectLogic(logic).toFinishAllListeners()


### PR DESCRIPTION
## Problem

The jest test `accountSummariesLogic › stops waiting at the deadline even when no summary ever lands` is the highest blast-radius flaky test in CI right now: 438 failed runs across 297 PRs and 63 master runs in the last 7 days ([engineering analytics test health](https://us.posthog.com/project/2/engineering-analytics)). Frontend tests are a required merge-queue check, so each master/queue failure kicks a batch and restarts every PR behind it.

The test reads `startedAt` from the real clock, then `setCadence`'s listener writes the poll deadline with a second real `Date.now()` call. The test then mocks the clock to `startedAt + FIRST_SUMMARY_POLL_TIMEOUT_MS + 1`. Any scheduling delay over 1 ms between the two reads puts the mocked "now" before the deadline, so the logic keeps polling and the assertion fails.

## Changes

- The test pins `Date.now()` to `startedAt` before dispatching `setCadence`, so the deadline computes from the same mocked clock the assertion uses.
- Test-only change; no product behavior changes.

## How did you test this code?

- Reproduced deterministically by delaying the mocked PATCH by 5 ms, which fails the test with the exact CI assertion (`Expected: false, Received: true`).
- With the fix, 20/20 passes under the same injected delay, and the full file passes with the delay removed.
- The sibling quiet-window test computes every checked timestamp from the mocked clock, so it does not carry this race.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session investigating merge-queue p95; this test surfaced as the top queue-kicker in the engineering analytics flaky-test queue. Skills invoked: /fixing-flaky-tests, /writing-pr-descriptions, posthog:diagnosing-ci-and-merge-bottlenecks. Root cause confirmed by injecting a 5 ms delay into the mocked PATCH before writing the fix.
