### PR TITLE
chore(ci): skip desktop suites on trunk merge queue branches

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -9,6 +9,14 @@ name: Desktop CI
 # short detector jobs and skips everything else. A trigger-level `paths:`
 # filter would stop the `Desktop * Pass` checks from ever reporting, leaving
 # any PR that requires them stuck waiting for status.
+#
+# On trunk-merge/** heads (Trunk's merge queue PRs) the suites skip entirely,
+# like merge_group: every constituent PR already ran the full desktop suite,
+# desktop is an isolated workspace, and master pushes rerun the suite on any
+# desktop path change as the post-merge backstop. Skipping keeps a flaky
+# desktop job (or a rate-limited change detector) from kicking a queue batch
+# no desktop author is in. The skip is scoped to same-repo heads so a fork
+# cannot opt out by naming its branch trunk-merge/**.
 
 on:
     pull_request:
@@ -29,24 +37,48 @@ permissions:
 
 jobs:
     build:
+        if: |
+            !(
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.head_ref, 'trunk-merge/')
+            )
         uses: ./.github/workflows/desktop-build.yml
         secrets:
             GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
             GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
 
     quality:
+        if: |
+            !(
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.head_ref, 'trunk-merge/')
+            )
         uses: ./.github/workflows/desktop-quality.yml
         secrets:
             GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
             GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
 
     typecheck:
+        if: |
+            !(
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.head_ref, 'trunk-merge/')
+            )
         uses: ./.github/workflows/desktop-typecheck.yml
         secrets:
             GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
             GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
 
     test:
+        if: |
+            !(
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.head_ref, 'trunk-merge/')
+            )
         uses: ./.github/workflows/desktop-test.yml
         secrets:
             GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}


### PR DESCRIPTION
## Problem

Desktop CI is the top required-workflow failer on merge queue branches: 102 failures on `trunk-merge/**` heads in 14 days, ~3.8% of its completed queue runs. Each failure kicks a PR out of the Trunk queue and restarts every batch behind it, and 42% of queued PRs already need at least one restart.

Sampled queue failures show three shapes, none introduced by the batch being tested: the live-model `test / e2e` job (external LLM gateway), flaky desktop unit/e2e tests, and the paths-filter `changes` job itself failing and failing the aggregator closed.

Every constituent PR already ran the full desktop suite before entering the queue, and `desktop-ci.yml` already skips its `backend-coupling` job on `trunk-merge/**` for exactly this reason.

## Changes

- A queue batch no longer runs the desktop build, quality, typecheck, or test suites, so a flaky desktop job cannot kick unrelated PRs out of the merge queue.
- The four suite jobs in `desktop-ci.yml` skip on same-repo `trunk-merge/**` heads, reusing the guard the `backend-coupling` job already carries. The `Desktop Tests Pass` gate treats skipped as success, so the required check still reports green on queue PRs.
- Desktop coverage for what lands on master stays: each PR runs the full suite before enqueueing, and a master push reruns `desktop-test.yml` on any `products/desktop/**` change as the post-merge backstop.
- The skip is scoped to same-repo heads, so a fork cannot opt out by naming its branch `trunk-merge/**`.

## How did you test this code?

- `bin/hogli lint:workflows` (8/8 checks pass) and `actionlint` on the edited file.
- Not run: a live queue batch; the condition is copied from the `backend-coupling` job in the same file, which already behaves this way on queue branches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session investigating merge-queue p95 (attempt wall clock, per-workflow failure counts on trunk-merge/** from engineering analytics, failing job names sampled via the GitHub API). Skills invoked: /authoring-ci-workflows, /writing-pr-descriptions, posthog:diagnosing-ci-and-merge-bottlenecks. Considered gating only non-desktop batches instead; rejected because the failing jobs include change detection itself, which cannot tell a desktop batch apart when it is the thing failing.
