### PR TITLE
chore(ci): skip non-required workflows on trunk merge queue branches

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -29,8 +29,11 @@ jobs:
         # but its read-only GITHUB_TOKEN cannot push to ghcr.io. Skipping here leaves
         # `sandbox_image` unset so both build jobs skip too, which keeps a fork off
         # the skills build it would only pay for to fail at the push.
+        # trunk-merge/** heads are skipped the same way: merge-queue PRs are ephemeral,
+        # nothing pulls images pushed for them, and each constituent PR already built its own.
         if: |
             github.repository_owner == 'PostHog' &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Determine if sandbox image needs to be built
         permissions:

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -84,6 +84,84 @@ jobs:
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # Deep enough to reach the PR's merge base, which keys the schema cache below.
+                  fetch-depth: 1000
+                  filter: blob:none
+
+            - name: Fetch base branch for merge-base computation
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              # Scoped, blob-less, no-tags: without an explicit refspec, git fetch
+              # falls back to remote.origin.fetch and pulls every branch.
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+            - name: Compute schema cache keys
+              id: schema-key
+              # Restores the schema dump ci-backend saves on master pushes, so the
+              # migrate step below only tops up what is newer instead of replaying the
+              # full migration history. On a PR the migration-set key is the merge-base's;
+              # on a push or dispatch it is HEAD's. A cache miss falls through to a full
+              # migrate, so an absent or wrong key is never a correctness risk.
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  IS_PR: ${{ github.event_name == 'pull_request' }}
+                  # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
+                  # ci-backend.yml, which saves these caches on master pushes.
+                  SCHEMA_CACHE_EPOCH: v2
+              run: |
+                  if [ "$IS_PR" != "true" ]; then
+                      # Pushed or dispatched commit is checked out directly: no merge
+                      # commit, no base ref. The per-SHA key would point at this same
+                      # push's cache (saved concurrently by ci-backend, so racy); rely
+                      # on the stable migration-set key below.
+                      REF=HEAD
+                  else
+                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                      MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                      if [ -z "$MERGE_BASE" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::merge-base not found (branch too stale?), so the schema cache is skipped"
+                          exit 0
+                      fi
+                      # Routing decides which app labels reach the dump, so an edited routing
+                      # config matches no master dump: drop both keys and migrate from scratch.
+                      DB_ROUTING_BASE=$(git ls-tree -r --format='%(objectname) %(path)' "$MERGE_BASE" -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                      DB_ROUTING_HEAD=$(git ls-tree -r --format='%(objectname) %(path)' HEAD -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                      if [ "$DB_ROUTING_BASE" != "$DB_ROUTING_HEAD" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::db routing config or router differs from the merge base, so the schema cache is skipped"
+                          exit 0
+                      fi
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                      REF="$MERGE_BASE"
+                  fi
+                  # Last-resort restore prefix: matches the newest saved dump when the exact
+                  # keys miss. Gated on checkout age because a re-run of an old commit could
+                  # restore a dump newer than its code, which forward-only migrate cannot repair.
+                  HEAD_AGE_SECONDS=$(( $(date +%s) - $(git show -s --format=%ct HEAD) ))
+                  if [ "$HEAD_AGE_SECONDS" -lt 86400 ]; then
+                      echo "prefix_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-" >> $GITHUB_OUTPUT
+                  fi
+                  # Must match ci-backend.yml's save-side computation byte for byte or the key never hits.
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$REF" \
+                      | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
+                      | grep -vE '/(clickhouse|async_migrations)/migrations/' \
+                      | LC_ALL=C sort) || true
+                  # Routing decides which app labels are in the dump, so these inputs belong in the key.
+                  DB_ROUTING=$(git ls-tree -r --format='%(objectname) %(path)' "$REF" -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                  PG_IMAGE=$(git show "${REF}:docker-compose.base.yml" 2>/dev/null \
+                      | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
+                  if [ -z "$MIG_FILES" ]; then
+                      echo "migrations_key=" >> $GITHUB_OUTPUT
+                      echo "::notice::no migration files matched, so restore falls back to the SHA schema key"
+                  else
+                      MIG_HASH=$(printf '%s\n%s\n%s' "$MIG_FILES" "$PG_IMAGE" "$DB_ROUTING" | sha256sum | cut -c1-40)
+                      echo "migrations_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-${MIG_HASH}" >> $GITHUB_OUTPUT
+                  fi
 
             - name: Start Docker services
               env:
@@ -126,6 +204,41 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
               run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              if: steps.schema-key.outputs.migrations_key != '' || steps.schema-key.outputs.key != ''
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  # Prefer the shared content key; fall back to the exact merge-base SHA
+                  # key, then to the newest dump of any migration set.
+                  key: ${{ steps.schema-key.outputs.migrations_key || steps.schema-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.schema-key.outputs.key }}
+                      ${{ steps.schema-key.outputs.prefix_key }}
+
+            - name: Prime posthog from cached schema
+              # db:restore-schema-fresh restores the dump and seeds the RunPython data a
+              # schema-only dump lacks; the migrate step below layers anything newer on
+              # top. On failure it leaves a fresh empty db, so migrate runs the full history.
+              env:
+                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+                  REDIS_URL: 'redis://localhost'
+                  OBJECT_STORAGE_ENABLED: 'False'
+                  TEST: 1
+                  DEBUG: 1
+                  TARGET_DB: posthog
+              run: |
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss, so the migrate step below runs the full history"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ! ./bin/hogli db:restore-schema-fresh; then
+                      echo "::warning::Schema restore failed (stale or incompatible cached dump?), so the migrate step below runs the full history"
+                  fi
 
             - name: Run migrations
               env:

--- a/.github/workflows/ci-agent-proxy.yml
+++ b/.github/workflows/ci-agent-proxy.yml
@@ -18,6 +18,9 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         name: Determine need to run agent-proxy checks
         outputs:
             agent_proxy: ${{ steps.filter.outputs.agent_proxy || 'true' }}

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -16,6 +16,9 @@ concurrency:
 
 jobs:
     changes:
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         permissions:
             contents: read
             pull-requests: read

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -27,6 +27,9 @@ jobs:
         name: Run tests
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         defaults:
             run:
                 working-directory: cli
@@ -50,6 +53,7 @@ jobs:
         name: Clippy
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         defaults:
             run:
                 working-directory: cli
@@ -69,6 +73,7 @@ jobs:
         name: Format
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         defaults:
             run:
                 working-directory: cli
@@ -88,6 +93,7 @@ jobs:
         name: API CLI release bundle
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -32,6 +32,9 @@ jobs:
     multinode-migration-smoke:
         name: Run ClickHouse migrations against per-cluster topology
         runs-on: ubuntu-24.04
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         # The common path primes Postgres from the master schema artifact. The
         # fallback applies every Django migration from scratch and grows with the
         # migration count, so the timeout is sized for the fallback. Raise it if

--- a/.github/workflows/ci-dev-setup.yml
+++ b/.github/workflows/ci-dev-setup.yml
@@ -22,6 +22,9 @@ jobs:
     flox-dev-setup:
         runs-on: ubuntu-24.04
         timeout-minutes: 30
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
 
         steps:
             - name: Checkout code

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -34,7 +34,9 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: github.event_name == 'pull_request'
+        # trunk-merge/** heads are skipped: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run hobby checks
         outputs:
             should_run: ${{ steps.filter.outputs.hobby == 'true' || steps.check-label.outputs.has_label == 'true' }}

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -22,6 +22,9 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         name: Determine need to run Hog checks
         permissions:
             contents: read

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -17,6 +17,9 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         name: Determine need to run UI Apps checks
         outputs:
             ui-apps: ${{ steps.filter.outputs.ui-apps || 'true' }}

--- a/.github/workflows/ci-oauth-proxy.yml
+++ b/.github/workflows/ci-oauth-proxy.yml
@@ -17,6 +17,9 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         name: Determine need to run oauth-proxy checks
         outputs:
             oauth-proxy: ${{ steps.filter.outputs.oauth-proxy || 'true' }}

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -17,7 +17,9 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog'
+        # trunk-merge/** heads are skipped: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: github.repository == 'PostHog/posthog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run proto checks
         outputs:
             proto: ${{ steps.filter.outputs.proto || 'true' }}

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -39,7 +39,9 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog'
+        # trunk-merge/** heads are skipped: merge-queue PRs are ephemeral, nothing
+        # pulls images pushed for them, and each constituent PR already built its own.
+        if: github.repository_owner == 'PostHog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run recording-rasterizer Docker build
         outputs:
             rasterizer_files: ${{ steps.filter.outputs.rasterizer_files }}

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -54,6 +54,9 @@ jobs:
         name: Rust /flags Integration Tests (depot-ubuntu-24.04)
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 30
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
 
         services:
             postgres:

--- a/.github/workflows/desktop-agent-release-verify.yml
+++ b/.github/workflows/desktop-agent-release-verify.yml
@@ -24,6 +24,9 @@ jobs:
         name: Verify agent release build
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         defaults:
             run:
                 working-directory: products/desktop

--- a/.github/workflows/desktop-react-doctor.yml
+++ b/.github/workflows/desktop-react-doctor.yml
@@ -29,6 +29,9 @@ jobs:
     react-doctor:
         runs-on: ubuntu-latest
         timeout-minutes: 15
+        # Skipped on trunk-merge/** heads: merge-queue PRs are ephemeral and every
+        # constituent PR already ran this in full.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:


### PR DESCRIPTION
## Problem

Every Trunk merge queue attempt fires ~90 workflow runs on its `trunk-merge/**` branch, but only 14 checks gate the merge. Over the last 14 days the queue ran 3,422 attempts, and the non-gating workflows burned roughly 1,300 hours of completed run time on branches whose results nothing reads: every constituent PR already ran the same workflows in full, and merge-queue image pushes are pulled by nothing.

That compute competes with the required jobs for runners at merge peaks, and red non-required runs (Agent Skills failed 49 times on queue branches) add noise for anyone babysitting a queued PR.

## Changes

- A queue attempt no longer runs these 15 workflows, freeing their runners for the checks that actually gate the merge: E2E Hobby CI, Agent Skills, MCP UI Apps CI, recording-rasterizer image, Hog CI, CI CLI, Desktop Agent Release Verify, Agent Proxy CI, Proto CI, OAuth Proxy CI, sandbox base image CD, Desktop React Doctor, Dev Setup (Flox), Rust /flags Integration Tests, and ClickHouse Multinode Migration Smoke.
- Each workflow's root job gains `if: !startsWith(github.head_ref, 'trunk-merge/')`, the guard `rust-docker-build.yml` and `ci-nodejs-container.yml` already carry; downstream jobs skip through their existing `needs` conditions.
- The `if: always()` aggregators in these workflows already pass on a skipped `changes` job (verified for Proto, OAuth Proxy, MCP UI Apps, Agent Proxy, and the sandbox image check), so queue PRs show green checks, not missing ones.
- None of these workflows back a required check in the master ruleset, so queue gating is unchanged. Coverage is unchanged too: the same workflows still run on every PR and on master pushes.
- Mechanical throughout: 48 added lines are the same guard and comment repeated across 15 files.

> [!NOTE]
> `head_ref` is empty on push and schedule events, so the guard only affects pull_request runs; master pushes are untouched.

## How did you test this code?

- `bin/hogli lint:workflows` passes (8/8 checks across 128 workflows).
- `actionlint` on the 15 edited files reports only findings that already exist on master (verified by linting the master copy of the noisiest file).
- Not run: a live queue batch.
- Follow-up candidates deliberately left out to keep this reviewable: Desktop PR Build Installer, Desktop Tag Release, PR housekeeping, and the auto-assign workflows also run on queue PRs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session investigating merge-queue p95. Target list came from engineering analytics warehouse data: per-workflow run counts and completed hours on `trunk-merge/**` over 14 days, cross-checked against the master ruleset's required checks (notably: `ci-security.yaml` carries the required "Semgrep Checks Pass" gate, so the Security workflow was excluded from this trim). Skills invoked: /authoring-ci-workflows, /writing-pr-descriptions, posthog:diagnosing-ci-and-merge-bottlenecks.
