### PR TITLE
fix(clickhouse): sort cluster discovery outside distributed read

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -259,9 +259,18 @@ class ClickhouseCluster:
     def __get_cluster_hosts(self, client: Client, cluster: str, retry_policy: RetryPolicy | None = None):
         get_cluster_hosts_fn = lambda client: client.execute(
             f"""
-            SELECT host_name, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
-            FROM clusterAllReplicas(%(name)s, system.clusters)
-            WHERE name = %(name)s and is_local
+            SELECT
+                host_name,
+                port,
+                shard_num,
+                replica_num,
+                host_cluster_type,
+                host_cluster_role
+            FROM (
+                SELECT host_name, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
+                FROM clusterAllReplicas(%(name)s, system.clusters)
+                WHERE name = %(name)s and is_local
+            )
             ORDER BY shard_num, replica_num
             """,
             {"name": cluster},
@@ -281,9 +290,18 @@ class ClickhouseCluster:
     ):
         get_hosts_fn = lambda client: client.execute(
             """
-            SELECT host_name, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
-            FROM clusterAllReplicas(%(satellite_name)s, system.clusters)
-            WHERE is_local AND cluster = %(migrations_cluster)s
+            SELECT
+                host_name,
+                port,
+                shard_num,
+                replica_num,
+                host_cluster_type,
+                host_cluster_role
+            FROM (
+                SELECT host_name, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
+                FROM clusterAllReplicas(%(satellite_name)s, system.clusters)
+                WHERE is_local AND cluster = %(migrations_cluster)s
+            )
             ORDER BY shard_num, replica_num
             """,
             {"satellite_name": satellite_cluster, "migrations_cluster": migrations_cluster},

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -438,6 +438,51 @@ def test_alter_mutation_multiple_commands(cluster: ClickhouseCluster) -> None:
         )
 
 
+def test_cluster_discovery_orders_hosts_outside_distributed_query() -> None:
+    bootstrap_client_mock = Mock()
+    bootstrap_client_mock.execute.return_value = [("host1", "9000", "1", "1", "online", "data")]
+
+    ClickhouseCluster(bootstrap_client_mock, cluster="posthog_migrations")
+
+    query, params = bootstrap_client_mock.execute.call_args.args
+    assert " ".join(query.split()) == (
+        "SELECT host_name, port, shard_num, replica_num, host_cluster_type, host_cluster_role "
+        "FROM ( SELECT host_name, port, shard_num, replica_num, "
+        "getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role "
+        "FROM clusterAllReplicas(%(name)s, system.clusters) WHERE name = %(name)s and is_local ) "
+        "ORDER BY shard_num, replica_num"
+    )
+    assert params == {"name": "posthog_migrations"}
+
+
+def test_satellite_cluster_discovery_orders_hosts_outside_distributed_query() -> None:
+    bootstrap_client_mock = Mock()
+    bootstrap_client_mock.execute.side_effect = [
+        [("host1", "9000", "1", "1", "online", "data")],
+        [("aux-host1", "9000", "1", "1", "online", "aux")],
+    ]
+
+    ClickhouseCluster(
+        bootstrap_client_mock,
+        cluster="posthog_migrations",
+        satellite_clusters=["posthog_aux"],
+    )
+
+    assert bootstrap_client_mock.execute.call_count == 2
+    query, params = bootstrap_client_mock.execute.call_args_list[1].args
+    assert " ".join(query.split()) == (
+        "SELECT host_name, port, shard_num, replica_num, host_cluster_type, host_cluster_role "
+        "FROM ( SELECT host_name, port, shard_num, replica_num, "
+        "getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role "
+        "FROM clusterAllReplicas(%(satellite_name)s, system.clusters) "
+        "WHERE is_local AND cluster = %(migrations_cluster)s ) ORDER BY shard_num, replica_num"
+    )
+    assert params == {
+        "satellite_name": "posthog_aux",
+        "migrations_cluster": "posthog_migrations",
+    }
+
+
 def test_map_hosts_by_role() -> None:
     bootstrap_client_mock = Mock()
     bootstrap_client_mock.execute = Mock()


### PR DESCRIPTION
## Problem

Self-hosted deployments using the default ClickHouse 26.6 image can fail before cluster discovery returns any hosts. The distributed metadata query asks the coordinator to sort blocks whose analyzer-generated alias headers can differ from the headers returned by remote replicas.

Closes #88750

## Changes

- Main and satellite discovery keep macro aliases and filters inside each distributed read, then sort the resulting rows in an outer `SELECT`.
- The six-column row shape, filters, parameters, and deterministic host order stay unchanged.
- Focused tests pin both SQL forms and their parameters so either query moving the sort back into `clusterAllReplicas` is caught.

## How did you test this code?

- `uvx --from 'ruff==0.15.20' ruff format --check posthog/clickhouse/cluster.py posthog/clickhouse/test/test_cluster.py`
- `uvx --from 'ruff==0.15.20' ruff check posthog/clickhouse/cluster.py posthog/clickhouse/test/test_cluster.py`
- `uv run --no-sync python -m py_compile posthog/clickhouse/cluster.py posthog/clickhouse/test/test_cluster.py`
- A static AST check verified both exact SQL forms keep their aliases inside the subquery and place the only `ORDER BY shard_num, replica_num` outside it.

The focused pytest selection could not collect in the intentionally sparse writer checkout because the full PostHog test package and dependency environment were not materialized. CI still needs to run the two native tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex prepared the focused implementation and GitHub publication with local Git and GitHub CLI. No public session link is available, and no repository-provided or public skills were invoked.

The change preserves ClickHouse analyzer behavior rather than disabling it; only deterministic sorting moves outside the distributed read.
