### PR TITLE
chore(ci): skip the devex new-warnings ratchet on trunk merge queue branches

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -442,8 +442,18 @@ jobs:
             # --baseline-commit diffs against the PR base (first parent of the
             # merge commit), so the pass-1 backlog is grandfathered while new
             # violations block. See .semgrep/rules/devex/README.md.
+            # trunk-merge/** heads are skipped: every constituent PR already ran
+            # this ratchet on its own head, where the branch ruleset enforces it.
+            # In the queue it re-judges in-flight PRs with rules added after
+            # their green run, so each new devex rule kicked whole batches of
+            # unrelated PRs. The skip is scoped to same-repo heads so a fork
+            # cannot opt out by naming its branch trunk-merge/**.
             - name: New warnings (blocking)
-              if: github.event_name == 'pull_request'
+              if: |
+                  github.event_name == 'pull_request' && !(
+                      github.event.pull_request.head.repo.full_name == github.repository &&
+                      startsWith(github.head_ref, 'trunk-merge/')
+                  )
               run: |
                   docker run --rm -v "${{ github.workspace }}:/src" -w /src \
                     -e SEMGREP_ENABLE_VERSION_CHECK=false \


### PR DESCRIPTION
## Problem

The `semgrep-devex` "New warnings" ratchet is the top merge queue kicker: 414 failed Security runs on `trunk-merge/**` heads across 162 PRs in 14 days, 44% of all queue-kicked PRs. Each kick restarts every batch speculated behind it.

The failures are bursty, not chronic: 79% came from two days (95 on Aug 12, 234 across 73 PRs on Aug 18) while master Security stayed green on both. The Aug 18 burst follows the `tuple-return-prefer-dataclass` rule landing on Aug 14 ([667bd6dedf5](https://github.com/PostHog/posthog/commit/667bd6dedf5)): a PR opened before the rule earns a green "Semgrep Checks Pass" under the old ruleset, then the queue reruns the ratchet with the new rule against its diff and kicks it. The author sees a green PR and a red queue with nothing to act on except the restart.

Sampled failing queue run: [semgrep-devex blocking on a queue batch](https://github.com/PostHog/posthog/actions/runs/32838818415).

## Changes

- A new devex rule no longer kicks already-open PRs out of the merge queue: the "New warnings (blocking)" step in `semgrep-devex` skips on same-repo `trunk-merge/**` heads.
- Enforcement stays where the author can act on it: the ratchet still runs on every PR head, and the branch ruleset requires "Semgrep Checks Pass" green there before the PR can merge.
- The ERROR pass, the informational WARNING pass, and every other Security job still run on queue branches, so batch-merge regressions in blocking rules are still caught.
- The skip is scoped to same-repo heads, so a fork cannot opt out by naming its branch `trunk-merge/**`.

> [!NOTE]
> A PR whose CI predates a new rule can now land code the new rule flags. That code shows up in the informational WARNING pass and stays grandfathered, which matches the ratchet's stated contract ("pre-existing findings are grandfathered") for code written before the rule existed. The alternative, keeping the queue rerun, prices each new devex rule at a day of queue kicks (73 PRs on Aug 18).

## How did you test this code?

- `bin/hogli lint:workflows` passes (8/8 across 128 workflows); `actionlint` clean on the edited file.
- Failure attribution comes from 14 days of warehouse CI data (runs on `trunk-merge/**` by workflow and day) plus sampled queue job logs confirming `semgrep-devex` fails the required "Semgrep Checks Pass" gate.
- Not run: a live queue batch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Fourth PR from a Claude Code session investigating merge queue p95 (with #88754, #88757, #88762). The first hypothesis was a baseline-resolution bug in pass 3 on queue branches; sampling disproved it (the sampled finding was genuinely new, and its author later fixed it), and the day-by-day failure distribution plus the rule-change timeline pointed to ruleset drift between a PR's green run and its queue run. Skills invoked: /authoring-ci-workflows, /writing-pr-descriptions, posthog:diagnosing-ci-and-merge-bottlenecks.
