### PR TITLE
fix(tests): stop two taxonomy test files reaching the database unmarked

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -1922,6 +1922,7 @@ def test_combine_group_properties():
     }
 
 
+@pytest.mark.django_db
 def test_session_property_validation():
     # Property key not valid for type session
     with pytest.raises(ValidationError):

--- a/posthog/hogql_queries/ai/test/test_ai_table_resolver.py
+++ b/posthog/hogql_queries/ai/test/test_ai_table_resolver.py
@@ -84,8 +84,9 @@ class TestQueryAiEvents:
         assert mock_execute.call_count == 2
         assert mock_execute.call_args.kwargs["context"].use_new_events_schema is True
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=False)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_raises_expired_when_ai_events_empty_but_events_has_rows(self, mock_execute):
+    def test_raises_expired_when_ai_events_empty_but_events_has_rows(self, mock_execute, _mock_use_new_events_schema):
         # ai_events empty, events probe finds the row -> the data aged past the TTL.
         mock_execute.side_effect = [self._make_result([]), self._make_result([[1]])]
 
@@ -99,8 +100,9 @@ class TestQueryAiEvents:
             )
         assert mock_execute.call_count == 2
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=False)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_raises_not_found_when_empty_in_both_tables(self, mock_execute):
+    def test_raises_not_found_when_empty_in_both_tables(self, mock_execute, _mock_use_new_events_schema):
         mock_execute.side_effect = [self._make_result([]), self._make_result([])]
 
         team = Mock(id=1, organization_id="org")
@@ -132,8 +134,9 @@ class TestQueryAiEvents:
         assert isinstance(rewritten, ast.Field)
         assert rewritten.chain == ["trace_id"]
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=False)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_rewrites_placeholders_for_events_fallback(self, mock_execute):
+    def test_rewrites_placeholders_for_events_fallback(self, mock_execute, _mock_use_new_events_schema):
         mock_execute.side_effect = [self._make_result([]), self._make_result([["found"]])]
 
         team = Mock(id=1, organization_id="org")
@@ -153,8 +156,9 @@ class TestQueryAiEvents:
         assert isinstance(rewritten, ast.Field)
         assert rewritten.chain == ["properties", "$ai_trace_id"]
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=False)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_rewrites_query_from_clause_for_events_fallback(self, mock_execute):
+    def test_rewrites_query_from_clause_for_events_fallback(self, mock_execute, _mock_use_new_events_schema):
         mock_execute.side_effect = [self._make_result([]), self._make_result([])]
 
         team = Mock(id=1, organization_id="org")


### PR DESCRIPTION
## Problem

Five tests fail with `RuntimeError: Database access not allowed, use the "django_db" mark` in the `events schema legacy` matrix leg. Any PR whose CI runs that leg goes red on `Django tests – Core`, on code it did not touch.

The failure looks intermittent but is deterministic per leg. `use_new_events_schema` returns early on `settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA`, so in the json leg it never reaches its `get_instance_setting` call. With the setting off, that call reads `posthog_instancesetting` from Postgres, and these tests have no database access.

## Changes

- The four `TestQueryAiEvents` fallback cases now patch `use_new_events_schema`. They build a `Mock` team and patch `execute_hogql_query`, so they are unit tests, but the fallback path they exercise also calls `use_new_events_schema`. The sibling `test_falls_back_to_events_with_pinned_schema` already patches it; this matches that rather than granting the tests database access they should not need.
- `test_session_property_validation` is marked `django_db`. It reaches the same read through `parse_prop_grouped_clauses`, where patching would mean reaching several layers down, and the rest of that file already uses the marker.

No production code changes.

## How did you test this code?

- Reproduced all five failures on unmodified `origin/master`: `5 failed, 7 passed`.
- After the change, both files in full: **162 passed**, 8 snapshots passed.
- Re-ran with `CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA=1` to cover the other matrix leg: 12 passed. Pinning the patch to `False` is safe because none of the four cases assert on the schema flag; the one that does patches it to `True` itself.
- `ruff check` and `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) found this while merging master into an unrelated PR, where the newly selected matrix leg turned the shared failure red. Skills invoked: `/writing-pr-descriptions`.

The first diagnosis was that shard composition had changed. That was wrong: the determinant is the matrix leg and its `CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA` value, which is why the tests can pass for a long time and then fail with no change to them.
