### PR TITLE
fix(replay_vision): retry stranded reconciler activities instead

### DIFF
--- a/products/replay_vision/backend/temporal/activities/backfill.py
+++ b/products/replay_vision/backend/temporal/activities/backfill.py
@@ -360,6 +360,8 @@ async def reap_backfill_schedules_activity() -> None:
     seen: set[UUID] = set()
     fixes = []
     async for listing in await client.list_schedules(query=f'PostHogScheduleType = "{BACKFILL_SCHEDULE_TYPE}"'):
+        # The SDK throttles the RPCs, so per-listing is cheap.
+        activity.heartbeat({"phase": "listing_schedules", "seen": len(seen)})
         if not listing.id.startswith(prefix):
             continue
         try:
@@ -376,4 +378,5 @@ async def reap_backfill_schedules_activity() -> None:
             logger.info("replay_vision.backfill_reaper.recreating_missing", backfill_id=str(backfill_id))
             fixes.append(_recreate_schedule(backfill_id, team_id, scanner_id, row_status, client))
     if fixes:
+        activity.heartbeat({"phase": "applying_fixes", "fixes": len(fixes)})
         await asyncio.gather(*fixes)

--- a/products/replay_vision/backend/temporal/activities/reap_orphaned_observations.py
+++ b/products/replay_vision/backend/temporal/activities/reap_orphaned_observations.py
@@ -122,6 +122,9 @@ async def _reap_observations(temporal: Client, rows: list[dict[str, Any]]) -> in
         scanner_type = snapshot.get("scanner_type") or "unknown"
         if await database_sync_to_async(_mark_orphaned, thread_sensitive=False)(row["id"], scanner_type):
             reaped += 1
+        # Per-row so the heartbeat timeout distinguishes a big legitimate batch from a dead worker;
+        # the SDK throttles the actual RPCs.
+        activity.heartbeat({"phase": "observations_reaping", "reaped": reaped})
     logger.info(
         "replay_vision.reap_orphaned_observations",
         scanned=len(rows),
@@ -139,6 +142,7 @@ async def _reap_evaluations(temporal: Client, rows: list[dict[str, Any]]) -> int
     for row in reapable:
         if await database_sync_to_async(_fail_evaluation, thread_sensitive=False)(row["id"]):
             reaped += 1
+        activity.heartbeat({"phase": "evaluations_reaping", "reaped": reaped})
     logger.info("replay_vision.reap_stuck_evaluations", scanned=len(rows), reaped=reaped)
     return reaped
 

--- a/products/replay_vision/backend/temporal/activities/reap_orphaned_observations.py
+++ b/products/replay_vision/backend/temporal/activities/reap_orphaned_observations.py
@@ -122,8 +122,7 @@ async def _reap_observations(temporal: Client, rows: list[dict[str, Any]]) -> in
         scanner_type = snapshot.get("scanner_type") or "unknown"
         if await database_sync_to_async(_mark_orphaned, thread_sensitive=False)(row["id"], scanner_type):
             reaped += 1
-        # Per-row so the heartbeat timeout distinguishes a big legitimate batch from a dead worker;
-        # the SDK throttles the actual RPCs.
+        # The SDK throttles the RPCs, so per-row is cheap.
         activity.heartbeat({"phase": "observations_reaping", "reaped": reaped})
     logger.info(
         "replay_vision.reap_orphaned_observations",

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -30,9 +30,8 @@ def on_demand_priority(team_id: int) -> Priority:
 OBSERVATION_ORPHAN_CUTOFF = APPLY_SCANNER_EXECUTION_TIMEOUT + dt.timedelta(minutes=30)
 # Bounds one reaper pass; a backlog beyond this drains across subsequent reconciler ticks.
 REAP_ORPHANED_OBSERVATIONS_BATCH_SIZE = 500
-REAP_ORPHANED_OBSERVATIONS_TIMEOUT = dt.timedelta(minutes=3)
-# The reaper heartbeats between phases; a pass that goes quiet this long is stalled, not slow.
-REAP_ORPHANED_OBSERVATIONS_HEARTBEAT_TIMEOUT = dt.timedelta(seconds=60)
+# The orphan reaper heartbeats as it works; an attempt quiet this long is stranded or stalled, not slow.
+REAP_ORPHANED_OBSERVATIONS_HEARTBEAT_TIMEOUT = dt.timedelta(seconds=30)
 
 # Per-action vision-action child, fire-and-forgot by the sweep. Name + timeout live here (not in the
 # workflow-def module) so the sweep can start it without cross-importing another @wf.defn module.
@@ -43,13 +42,11 @@ PROCESS_VISION_ACTION_EXECUTION_TIMEOUT = dt.timedelta(hours=1)
 # update activity failed or the workflow was terminated without reaching it).
 VISION_ACTION_RUN_STUCK_CUTOFF = PROCESS_VISION_ACTION_EXECUTION_TIMEOUT * 2
 REAP_STUCK_VISION_ACTION_RUNS_BATCH_SIZE = 500
-REAP_STUCK_VISION_ACTION_RUNS_TIMEOUT = dt.timedelta(minutes=3)
 
 # An inline scanner is minted just before its scans start, so anything still childless well after a
 # scan could have persisted its first observation never had one.
 INLINE_SCANNER_REAP_GRACE = APPLY_SCANNER_EXECUTION_TIMEOUT + dt.timedelta(minutes=30)
 INLINE_SCANNER_REAP_BATCH_SIZE = 500
-INLINE_SCANNER_REAP_TIMEOUT = dt.timedelta(minutes=3)
 
 
 def build_process_vision_action_workflow_id(vision_action_id: UUID) -> str:
@@ -143,6 +140,20 @@ LIST_ENABLED_SCANNERS_TIMEOUT = dt.timedelta(seconds=60)
 LIST_SCANNER_SCHEDULES_TIMEOUT = dt.timedelta(seconds=120)
 RECONCILE_SCHEDULE_OP_TIMEOUT = dt.timedelta(seconds=60)
 
+# Shared budgets for the reconciler's reaper activities. Each pass is short, so a stranded attempt
+# (worker killed mid-drain during a scale-down) is cut off fast and retried on a live worker instead
+# of holding the tick; schedule-to-close caps queue wait plus retries so no single reaper can spend
+# the tick's whole execution budget.
+REAPER_OP_TIMEOUT = dt.timedelta(seconds=45)
+REAPER_OP_SCHEDULE_TO_CLOSE = dt.timedelta(minutes=2)
+REAPER_MAX_ATTEMPTS = 3
+
+# The reconciler's activities are tiny control-plane ops; priority 1 lets them jump the sweep and
+# backfill backlog so a saturated queue cannot starve schedule sync past the tick's execution
+# timeout. A dedicated fairness key gives them their own share of priority-1 dispatch instead of
+# competing inside one team's on-demand key.
+RECONCILER_ACTIVITY_PRIORITY = Priority(priority_key=1, fairness_key="replay-vision-scanner-reconciler")
+
 
 # Bounded so broker errors surface as activity failures instead of getting lost in the producer buffer.
 KAFKA_DELIVERY_TIMEOUT_S = 10.0
@@ -200,7 +211,6 @@ PREPARE_BACKFILL_TICK_TIMEOUT = dt.timedelta(seconds=30)
 FIND_BACKFILL_CANDIDATES_TIMEOUT = dt.timedelta(seconds=200)
 ADVANCE_BACKFILL_CURSOR_TIMEOUT = dt.timedelta(seconds=30)
 BACKFILL_SCHEDULE_OP_TIMEOUT = dt.timedelta(seconds=60)
-REAP_BACKFILL_SCHEDULES_TIMEOUT = dt.timedelta(minutes=3)
 
 # A backfill's dispatches count toward the shared per-scanner/per-team caps but never fill more than
 # this many slots, so live sweeps always retain rasterizer + provider capacity.

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -30,7 +30,7 @@ def on_demand_priority(team_id: int) -> Priority:
 OBSERVATION_ORPHAN_CUTOFF = APPLY_SCANNER_EXECUTION_TIMEOUT + dt.timedelta(minutes=30)
 # Bounds one reaper pass; a backlog beyond this drains across subsequent reconciler ticks.
 REAP_ORPHANED_OBSERVATIONS_BATCH_SIZE = 500
-# The orphan reaper heartbeats as it works; an attempt quiet this long is stranded or stalled, not slow.
+# The reaper heartbeats as it works, so an attempt quiet this long is stranded or stalled, not slow.
 REAP_ORPHANED_OBSERVATIONS_HEARTBEAT_TIMEOUT = dt.timedelta(seconds=30)
 
 # Per-action vision-action child, fire-and-forgot by the sweep. Name + timeout live here (not in the
@@ -140,18 +140,12 @@ LIST_ENABLED_SCANNERS_TIMEOUT = dt.timedelta(seconds=60)
 LIST_SCANNER_SCHEDULES_TIMEOUT = dt.timedelta(seconds=120)
 RECONCILE_SCHEDULE_OP_TIMEOUT = dt.timedelta(seconds=60)
 
-# Shared budgets for the reconciler's reaper activities. Each pass is short, so a stranded attempt
-# (worker killed mid-drain during a scale-down) is cut off fast and retried on a live worker instead
-# of holding the tick; schedule-to-close caps queue wait plus retries so no single reaper can spend
-# the tick's whole execution budget.
+# Short attempts so one stranded on a dying worker reruns on a live one instead of holding the tick.
 REAPER_OP_TIMEOUT = dt.timedelta(seconds=45)
 REAPER_OP_SCHEDULE_TO_CLOSE = dt.timedelta(minutes=2)
 REAPER_MAX_ATTEMPTS = 3
 
-# The reconciler's activities are tiny control-plane ops; priority 1 lets them jump the sweep and
-# backfill backlog so a saturated queue cannot starve schedule sync past the tick's execution
-# timeout. A dedicated fairness key gives them their own share of priority-1 dispatch instead of
-# competing inside one team's on-demand key.
+# Priority 1 so a saturated sweep/backfill backlog cannot queue the tick past its execution timeout.
 RECONCILER_ACTIVITY_PRIORITY = Priority(priority_key=1, fairness_key="replay-vision-scanner-reconciler")
 
 

--- a/products/replay_vision/backend/temporal/constants.py
+++ b/products/replay_vision/backend/temporal/constants.py
@@ -145,6 +145,12 @@ REAPER_OP_TIMEOUT = dt.timedelta(seconds=45)
 REAPER_OP_SCHEDULE_TO_CLOSE = dt.timedelta(minutes=2)
 REAPER_MAX_ATTEMPTS = 3
 
+# The backfill reaper pages through every backfill schedule and only applies fixes at the end, so a
+# healthy pass needs minutes; per-page heartbeats catch a dead worker instead of a short attempt cap.
+REAP_BACKFILL_SCHEDULES_TIMEOUT = dt.timedelta(minutes=3)
+REAP_BACKFILL_SCHEDULES_SCHEDULE_TO_CLOSE = dt.timedelta(minutes=4)
+REAP_BACKFILL_SCHEDULES_HEARTBEAT_TIMEOUT = dt.timedelta(seconds=30)
+
 # Priority 1 so a saturated sweep/backfill backlog cannot queue the tick past its execution timeout.
 RECONCILER_ACTIVITY_PRIORITY = Priority(priority_key=1, fairness_key="replay-vision-scanner-reconciler")
 

--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -15,6 +15,9 @@ from posthog.temporal.common.base import PostHogWorkflow
 from products.replay_vision.backend.temporal.constants import (
     LIST_ENABLED_SCANNERS_TIMEOUT,
     LIST_SCANNER_SCHEDULES_TIMEOUT,
+    REAP_BACKFILL_SCHEDULES_HEARTBEAT_TIMEOUT,
+    REAP_BACKFILL_SCHEDULES_SCHEDULE_TO_CLOSE,
+    REAP_BACKFILL_SCHEDULES_TIMEOUT,
     REAP_ORPHANED_OBSERVATIONS_HEARTBEAT_TIMEOUT,
     REAPER_MAX_ATTEMPTS,
     REAPER_OP_SCHEDULE_TO_CLOSE,
@@ -81,7 +84,14 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
 
         if workflow.patched("reap-backfill-schedules-2026-08"):
             try:
-                await self._run_reaper(reap_backfill_schedules_activity)
+                # A full schedule listing outlives the short reaper attempt, so this one keeps a long
+                # attempt and leans on heartbeats to detect a dead worker.
+                await self._run_reaper(
+                    reap_backfill_schedules_activity,
+                    heartbeat_timeout=REAP_BACKFILL_SCHEDULES_HEARTBEAT_TIMEOUT,
+                    start_to_close_timeout=REAP_BACKFILL_SCHEDULES_TIMEOUT,
+                    schedule_to_close_timeout=REAP_BACKFILL_SCHEDULES_SCHEDULE_TO_CLOSE,
+                )
             except Exception:
                 workflow.logger.exception("replay_vision.reap_backfill_schedules_failed")
 
@@ -151,12 +161,17 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
         return result
 
     async def _run_reaper(
-        self, reaper_activity: Callable[[], Any], *, heartbeat_timeout: dt.timedelta | None = None
+        self,
+        reaper_activity: Callable[[], Any],
+        *,
+        heartbeat_timeout: dt.timedelta | None = None,
+        start_to_close_timeout: dt.timedelta = REAPER_OP_TIMEOUT,
+        schedule_to_close_timeout: dt.timedelta = REAPER_OP_SCHEDULE_TO_CLOSE,
     ) -> None:
         await workflow.execute_activity(
             reaper_activity,
-            start_to_close_timeout=REAPER_OP_TIMEOUT,
-            schedule_to_close_timeout=REAPER_OP_SCHEDULE_TO_CLOSE,
+            start_to_close_timeout=start_to_close_timeout,
+            schedule_to_close_timeout=schedule_to_close_timeout,
             heartbeat_timeout=heartbeat_timeout,
             retry_policy=RetryPolicy(maximum_attempts=REAPER_MAX_ATTEMPTS),
             priority=RECONCILER_ACTIVITY_PRIORITY,

--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -153,8 +153,6 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
     async def _run_reaper(
         self, reaper_activity: Callable[[], Any], *, heartbeat_timeout: dt.timedelta | None = None
     ) -> None:
-        """A short per-attempt budget with retries: an attempt stranded on a dying worker (autoscaler
-        scale-down) is cut off fast and rerun on a live one, instead of holding the tick for minutes."""
         await workflow.execute_activity(
             reaper_activity,
             start_to_close_timeout=REAPER_OP_TIMEOUT,

--- a/products/replay_vision/backend/temporal/reconciler.py
+++ b/products/replay_vision/backend/temporal/reconciler.py
@@ -1,8 +1,9 @@
 """Syncs per-scanner schedules with the ReplayScanner table on every tick, and reaps orphaned observations."""
 
 import asyncio
+import datetime as dt
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from temporalio import workflow
@@ -12,14 +13,14 @@ from temporalio.exceptions import ApplicationError
 from posthog.temporal.common.base import PostHogWorkflow
 
 from products.replay_vision.backend.temporal.constants import (
-    INLINE_SCANNER_REAP_TIMEOUT,
     LIST_ENABLED_SCANNERS_TIMEOUT,
     LIST_SCANNER_SCHEDULES_TIMEOUT,
-    REAP_BACKFILL_SCHEDULES_TIMEOUT,
     REAP_ORPHANED_OBSERVATIONS_HEARTBEAT_TIMEOUT,
-    REAP_ORPHANED_OBSERVATIONS_TIMEOUT,
-    REAP_STUCK_VISION_ACTION_RUNS_TIMEOUT,
+    REAPER_MAX_ATTEMPTS,
+    REAPER_OP_SCHEDULE_TO_CLOSE,
+    REAPER_OP_TIMEOUT,
     RECONCILE_SCHEDULE_OP_TIMEOUT,
+    RECONCILER_ACTIVITY_PRIORITY,
     RECONCILER_EXECUTION_TIMEOUT,
     RECONCILER_INTERVAL,
     RECONCILER_SCHEDULE_ID,
@@ -59,44 +60,28 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
     async def run(self, inputs: ReconcileScannerSchedulesInputs) -> ReconcileScannerSchedulesResult:
         # Best-effort and first: a schedule-sync failure below must not starve the reapers, and vice versa.
         try:
-            await workflow.execute_activity(
+            await self._run_reaper(
                 reap_orphaned_observations_activity,
-                start_to_close_timeout=REAP_ORPHANED_OBSERVATIONS_TIMEOUT,
-                # The activity heartbeats between phases, so a stalled pass is cut loose before it burns
-                # the whole tick budget.
                 heartbeat_timeout=REAP_ORPHANED_OBSERVATIONS_HEARTBEAT_TIMEOUT,
-                retry_policy=RetryPolicy(maximum_attempts=1),
             )
         except Exception:
             workflow.logger.exception("replay_vision.reap_orphaned_observations_failed")
 
         if workflow.patched("reap-stuck-vision-action-runs-2026-07"):
             try:
-                await workflow.execute_activity(
-                    reap_stuck_vision_action_runs_activity,
-                    start_to_close_timeout=REAP_STUCK_VISION_ACTION_RUNS_TIMEOUT,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
+                await self._run_reaper(reap_stuck_vision_action_runs_activity)
             except Exception:
                 workflow.logger.exception("replay_vision.reap_stuck_vision_action_runs_failed")
 
         if workflow.patched("reap-childless-inline-scanners-2026-08"):
             try:
-                await workflow.execute_activity(
-                    reap_childless_inline_scanners_activity,
-                    start_to_close_timeout=INLINE_SCANNER_REAP_TIMEOUT,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
+                await self._run_reaper(reap_childless_inline_scanners_activity)
             except Exception:
                 workflow.logger.exception("replay_vision.reap_childless_inline_scanners_failed")
 
         if workflow.patched("reap-backfill-schedules-2026-08"):
             try:
-                await workflow.execute_activity(
-                    reap_backfill_schedules_activity,
-                    start_to_close_timeout=REAP_BACKFILL_SCHEDULES_TIMEOUT,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
+                await self._run_reaper(reap_backfill_schedules_activity)
             except Exception:
                 workflow.logger.exception("replay_vision.reap_backfill_schedules_failed")
 
@@ -106,11 +91,13 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
                 list_enabled_scanners_activity,
                 start_to_close_timeout=LIST_ENABLED_SCANNERS_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=3),
+                priority=RECONCILER_ACTIVITY_PRIORITY,
             ),
             workflow.execute_activity(
                 list_scanner_schedules_activity,
                 start_to_close_timeout=LIST_SCANNER_SCHEDULES_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=3),
+                priority=RECONCILER_ACTIVITY_PRIORITY,
             ),
         )
         enabled = {entry.scanner_id: entry for entry in enabled_entries}
@@ -128,6 +115,7 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
                     UpsertScannerScheduleActivityInputs(scanner_id=sid, team_id=enabled[sid].team_id),
                     start_to_close_timeout=RECONCILE_SCHEDULE_OP_TIMEOUT,
                     retry_policy=RetryPolicy(maximum_attempts=3),
+                    priority=RECONCILER_ACTIVITY_PRIORITY,
                 ),
             ),
             self._fan_out(
@@ -137,6 +125,7 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
                     DeleteScannerScheduleActivityInputs(scanner_id=sid),
                     start_to_close_timeout=RECONCILE_SCHEDULE_OP_TIMEOUT,
                     retry_policy=RetryPolicy(maximum_attempts=3),
+                    priority=RECONCILER_ACTIVITY_PRIORITY,
                 ),
             ),
         )
@@ -160,6 +149,20 @@ class ReconcileScannerSchedulesWorkflow(PostHogWorkflow):
         if attempted > 0 and succeeded == 0:
             raise ApplicationError(f"reconciler: all {attempted} fan-out activities failed")
         return result
+
+    async def _run_reaper(
+        self, reaper_activity: Callable[[], Any], *, heartbeat_timeout: dt.timedelta | None = None
+    ) -> None:
+        """A short per-attempt budget with retries: an attempt stranded on a dying worker (autoscaler
+        scale-down) is cut off fast and rerun on a live one, instead of holding the tick for minutes."""
+        await workflow.execute_activity(
+            reaper_activity,
+            start_to_close_timeout=REAPER_OP_TIMEOUT,
+            schedule_to_close_timeout=REAPER_OP_SCHEDULE_TO_CLOSE,
+            heartbeat_timeout=heartbeat_timeout,
+            retry_policy=RetryPolicy(maximum_attempts=REAPER_MAX_ATTEMPTS),
+            priority=RECONCILER_ACTIVITY_PRIORITY,
+        )
 
     async def _fan_out(self, scanner_ids: list[UUID], make_coro: Callable[[UUID], Awaitable[None]]) -> list[bool]:
         if not scanner_ids:


### PR DESCRIPTION
## Problem

- Scanner schedule sync stalls whenever the vision worker fleet churns or saturates: the reconciler tick times out before the sync runs, so new or edited scanners do not start sweeping, and disabled scanners keep sweeping.
- In the 2026-08-25 incident, reconciler activities waited 2-3 minutes in the saturated task queue before any worker picked them up. Two waits exhaust the tick's 5-minute budget.
- The reconciler ran four reaper activities before the sync, each with a 3-minute start-to-close and a single attempt; a worker killed mid-activity strands the attempt until start-to-close expires.

## Changes

- Every reconciler activity runs at priority 1 with its own fairness key, so a saturated sweep and backfill backlog cannot queue the tick past its budget. This addresses the observed incident mechanism directly.
- Three reaper attempts are cut off after 45 seconds and retry up to 3 times under a 2-minute schedule-to-close, so work resumes on a live worker within seconds. All three are single-batch and idempotent, so a cut-off attempt loses no state.
- The backfill schedule reaper keeps a 3-minute attempt: a healthy pass pages through every backfill schedule and applies fixes at the end (a healthy tick was measured at 2m52s), so a 45-second cap would make it fail permanently and silently. It now heartbeats per listing with a 30-second heartbeat timeout, so a dead worker is still caught in seconds.
- The orphan reaper heartbeats per reaped row (the SDK throttles the RPCs), with a 30-second heartbeat timeout.
- No `workflow.patched()` gate is needed: only activity options change, so the command sequence that in-flight executions replay is unchanged.
- Mechanical: the per-reaper timeout constants collapse into shared `REAPER_OP_*` constants plus a backfill-specific set, and the call sites move into one `_run_reaper` helper.

## How did you test this code?

- `hogli test products/replay_vision/backend/tests/test_reconciler.py` - 21 passed.
- Existing reconciler tests mock the activity layer, so no new test can observe the option changes without asserting call kwargs, which would be a change detector.
- Not run: the workflow against a live Temporal server. Priority support on this queue is already proven by the on-demand trigger path, which passes `priority_key=1` in production.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Adopted from the original author's branch; the backfill-reaper carve-out and heartbeats were added after incident analysis showed the queue-wait mechanism and the backfill reaper's multi-minute healthy runtime.