### PR TITLE
fix(replay-vision): fail fast on contended scanner admission lock instead of queueing in Postgres

### DIFF
--- a/products/replay_vision/backend/temporal/activities/create_observation.py
+++ b/products/replay_vision/backend/temporal/activities/create_observation.py
@@ -174,12 +174,11 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
             # the cap; uncapped scanners keep the lock-free path. The limit is re-read under the lock.
             if scanner.credit_limit is not None:
                 lock_started = time.monotonic()
-                # nowait: a contended admission fails fast and retries via the activity's backoff
-                # (1s..10s, jittered) instead of camping on the scanner row. Queueing here is what
-                # convoyed the writer during the 2026-08 lock storms: dozens of admissions parked on
-                # one row, each holding its own locks while waiting, and activities killed at
-                # start_to_close (30s) left their statements waiting server-side. Failing fast keeps
-                # cap enforcement fully serialized while letting Temporal spread the herd.
+                # nowait: a contended admission fails fast (retryable ScannerAdmissionBusy) and
+                # retries via the activity's jittered backoff instead of queueing on the scanner
+                # row. Queueing here lets waiters hold their own locks while parked — and an
+                # activity killed at start_to_close leaves its statement waiting server-side —
+                # so failing fast keeps cap enforcement serialized without a lock queue.
                 locked = (
                     ReplayScanner.objects.select_for_update(nowait=True)
                     .filter(pk=scanner.pk)

--- a/products/replay_vision/backend/temporal/activities/create_observation.py
+++ b/products/replay_vision/backend/temporal/activities/create_observation.py
@@ -1,7 +1,7 @@
 import time
 from typing import Any
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, OperationalError, transaction
 from django.utils import timezone
 
 import psycopg.errors
@@ -174,8 +174,17 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
             # the cap; uncapped scanners keep the lock-free path. The limit is re-read under the lock.
             if scanner.credit_limit is not None:
                 lock_started = time.monotonic()
+                # nowait: a contended admission fails fast and retries via the activity's backoff
+                # (1s..10s, jittered) instead of camping on the scanner row. Queueing here is what
+                # convoyed the writer during the 2026-08 lock storms: dozens of admissions parked on
+                # one row, each holding its own locks while waiting, and activities killed at
+                # start_to_close (30s) left their statements waiting server-side. Failing fast keeps
+                # cap enforcement fully serialized while letting Temporal spread the herd.
                 locked = (
-                    ReplayScanner.objects.select_for_update().filter(pk=scanner.pk).only("pk", "credit_limit").first()
+                    ReplayScanner.objects.select_for_update(nowait=True)
+                    .filter(pk=scanner.pk)
+                    .only("pk", "credit_limit")
+                    .first()
                 )
                 # Admissions on a busy capped scanner serialize here; the wait is visible, not guessed at.
                 record_scanner_admission_lock_wait(time.monotonic() - lock_started)
@@ -222,6 +231,17 @@ def _create_observation(inputs: CreateObservationInputs) -> CreateObservationOut
                 session_id=inputs.session_id,
                 **row_fields,
             )
+    except OperationalError as e:
+        if not isinstance(e.__cause__, psycopg.errors.LockNotAvailable):
+            raise
+        activity.logger.info(
+            "Scanner admission lock busy; deferring to activity retry",
+            extra={"scanner_id": str(inputs.scanner_id), "team_id": inputs.team_id},
+        )
+        raise ApplicationError(
+            "Scanner admission lock busy; retried with backoff",
+            type="ScannerAdmissionBusy",
+        ) from e
     except IntegrityError as e:
         # Only swallow the dedup case; FK / CHECK violations should fail the activity.
         if not isinstance(e.__cause__, psycopg.errors.UniqueViolation):

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -546,16 +546,26 @@ class TestCreateObservationActivity:
         def admit(session_id: str) -> None:
             barrier.wait()
             try:
-                created[session_id] = create_observation_activity(
-                    CreateObservationInputs(
-                        scanner_id=scanner.id,
-                        team_id=scanner.team_id,
-                        session_id=session_id,
-                        triggered_by=ObservationTrigger.SCHEDULE,
-                        triggered_by_user_id=None,
-                        workflow_id=f"wf-{session_id}",
-                    )
-                ).was_created
+                # The contended admission now fails fast with a retryable ScannerAdmissionBusy
+                # instead of queueing on the scanner row; retry like Temporal's activity retry
+                # would, then assert the cap invariant exactly as before.
+                for _ in range(50):
+                    try:
+                        created[session_id] = create_observation_activity(
+                            CreateObservationInputs(
+                                scanner_id=scanner.id,
+                                team_id=scanner.team_id,
+                                session_id=session_id,
+                                triggered_by=ObservationTrigger.SCHEDULE,
+                                triggered_by_user_id=None,
+                                workflow_id=f"wf-{session_id}",
+                            )
+                        ).was_created
+                        break
+                    except ApplicationError as e:
+                        if e.type != "ScannerAdmissionBusy":
+                            raise
+                        time.sleep(0.05)
             finally:
                 # Dropping the worker's own connection avoids stranding its lock transaction past teardown.
                 connections.close_all()


### PR DESCRIPTION
## Problem

Capped-scanner admissions serialize on `ReplayScanner.objects.select_for_update()` and run the budget aggregates **while holding the lock**. On a busy capped scanner, dozens of concurrent `create_observation` activities queue on that one row; each waiter holds its own locks while camped, and activities killed at `start_to_close` (30s) leave their statements **waiting server-side** (we measured admission lock waits of 125s+ against the 30s activity timeout).

During the 2026-08 prod-us writer lock storms this made replay-vision a recurring convoy member: a 14-minute same-row chain primed the 08-25 05:16 pile-up, 910-second transactions ran during the 09:08 event, and after the unrelated warehouse-lock fix (#88480) shipped today, the **remaining** lock waves on the writer are replay-vision blocked by replay-vision (2026-08-25 20:16 UTC wave: 71 of 77 blocked queries, 125s max wait).

## Change

Take the admission lock with `select_for_update(nowait=True)`. A contended admission now fails immediately with `ScannerAdmissionBusy` (retryable `ApplicationError`) and defers to the activity's existing retry policy — 5 attempts, 1s→10s exponential backoff with jitter, inside the 3-minute `schedule_to_close`. Non-lock `OperationalError`s re-raise unchanged.

## Why cap enforcement is unaffected

- Admissions are still **fully serialized**: only one transaction can hold the scanner row; nobody computes budget or inserts spend concurrently. `nowait` changes *where contenders wait* (Temporal's backoff queue instead of Postgres's lock queue), not who can proceed.
- The budget design already "fails toward capped" on transient over-counts (see `compute_scanner_budgets` comments) — deferring an admission a few seconds is squarely within its semantics.
- Worst case under sustained contention: an admission exhausts 5 attempts and that session is picked up by the next sweep tick — the same practical outcome as today's activity-timeout kill, minus the orphaned server-side lock wait.

## Ops effect

Converts N-deep Postgres lock queues (each waiter holding its own row/FK locks, feeding writer-wide convoys) into cheap client-side retries. `record_scanner_admission_lock_wait` now measures the uncontended acquire (~0); busy admissions are visible via the `ScannerAdmissionBusy` application error and the existing activity retry metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaTSvi7eD23WDB6azeKJYT
