### PR TITLE
feat(autoresearch): add the dataset templates (5/22)

### DIFF
--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -1,0 +1,308 @@
+"""
+Built-in autoresearch prediction templates.
+
+Each template resolves to the same pipeline config shape as a custom pipeline,
+so validation and creation work identically whether the user started from a template
+or built a fully custom definition.
+
+Population specs use a semantic format compiled to HogQL by
+labeling._build_population_kind_conditions. Supported kinds:
+  performed_event_within_days   users who did `event` (any event when omitted) in
+                                the last `days` days
+  person_first_seen_within_days users whose first-seen date is within `days` days
+  active_not_performed_target   active users (any event in `active_within_days`) who
+                                have NOT performed the pipeline's target
+  ever_performed_event          users who have performed `event` at least once
+  ever_performed_target         users who have performed the pipeline's target at least once
+
+"Ever" and "has not performed" are bounded to the pipeline's training lookback
+window. The target-relative kinds compile against the pipeline's target
+predicate, so an action target matches by its matcher rather than its name.
+Every kind is evaluated per user at T0 during training and as of the cutoff at
+inference — see the compiler's docstring for the semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import structlog
+
+from posthog.schema import HogQLQuery
+
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.dataclasses import frozen
+from posthog.models.team.team import Team
+
+from products.autoresearch.backend.dataset.labeling import _identified_users_and_clause
+from products.autoresearch.backend.query import run_hogql_rows
+
+logger = structlog.get_logger(__name__)
+
+# Checked in this order when resolving an activity event for universal templates
+_PREFERRED_ACTIVITY_EVENTS = ["$pageview", "$screen", "$autocapture"]
+
+# Internal / noisy events that should never be chosen as the activity signal
+_NOISY_EVENTS: frozenset[str] = frozenset(
+    {
+        "$feature_flag_called",
+        "$decide",
+        "$set",
+        "$identify",
+        "$rageclick",
+        "$$heatmap",
+        "$web_vitals",
+        "$exception",
+        "$pageview_autocapture",
+        "$$plugin_metrics",
+    }
+)
+
+
+@frozen
+class AutoresearchTemplate:
+    key: str
+    display_name: str
+    description: str
+    default_horizon_days: int
+    output_property_prefix: str
+    requires_user_event: bool  # user must supply target_event override
+    requires_activity_resolution: bool  # target_event resolved from schema
+    training_population_spec: dict[str, Any]
+    inference_population_spec: dict[str, Any]
+    notes: str = ""
+
+
+TEMPLATES: dict[str, AutoresearchTemplate] = {
+    "likely_active_soon": AutoresearchTemplate(
+        key="likely_active_soon",
+        display_name="Likely active soon",
+        description=(
+            "Predict which active users will be active again in the next 7 days. "
+            "Best universal starter template — works for any product with pageview or session data."
+        ),
+        default_horizon_days=7,
+        output_property_prefix="predicted_p_active_soon",
+        requires_user_event=False,
+        requires_activity_resolution=True,
+        training_population_spec={"kind": "performed_event_within_days", "days": 30},
+        inference_population_spec={"kind": "performed_event_within_days", "days": 30},
+        notes=(
+            "Activity event is resolved from your event schema — prefers $pageview, $screen, "
+            "then any high-volume identified-user event. You can override the resolved event."
+        ),
+    ),
+    "at_risk_of_inactivity": AutoresearchTemplate(
+        key="at_risk_of_inactivity",
+        display_name="At risk of inactivity",
+        description=(
+            "Identify users unlikely to be active in the next 14 days. "
+            "Models future activity probability — low-probability users are the at-risk cohort. "
+            "Good for retention campaigns."
+        ),
+        default_horizon_days=14,
+        output_property_prefix="predicted_p_active_next",
+        requires_user_event=False,
+        requires_activity_resolution=True,
+        training_population_spec={"kind": "performed_event_within_days", "days": 60},
+        inference_population_spec={"kind": "performed_event_within_days", "days": 60},
+        notes=(
+            "Predicts activity probability. Users with a low score (e.g. p < 0.2) are at risk. "
+            "Create the 'At risk of inactivity' cohort using a low threshold on the prediction score, "
+            "not by modeling the absence of an event directly."
+        ),
+    ),
+    "return_after_first_use": AutoresearchTemplate(
+        key="return_after_first_use",
+        display_name="Likely to return after first use",
+        description=(
+            "Predict which new users will have a second active session within 7 days. "
+            "Works without a custom signup event — uses first-seen date. Good for onboarding."
+        ),
+        default_horizon_days=7,
+        output_property_prefix="predicted_p_return_after_signup",
+        requires_user_event=False,
+        requires_activity_resolution=True,
+        training_population_spec={"kind": "person_first_seen_within_days", "days": 14},
+        inference_population_spec={"kind": "person_first_seen_within_days", "days": 14},
+        notes=(
+            "Population is users first seen in the last 14 days. "
+            "Target event (second-session activity) is resolved from your event schema."
+        ),
+    ),
+    "feature_adoption": AutoresearchTemplate(
+        key="feature_adoption",
+        display_name="Likely to adopt a feature",
+        description=(
+            "Predict which active users will use a selected feature for the first time within 14 days. "
+            "Requires you to choose the feature's event or action."
+        ),
+        default_horizon_days=14,
+        output_property_prefix="predicted_p_adopt",
+        requires_user_event=True,
+        requires_activity_resolution=False,
+        training_population_spec={"kind": "active_not_performed_target", "active_within_days": 30},
+        inference_population_spec={"kind": "active_not_performed_target", "active_within_days": 30},
+        notes=(
+            "Population automatically excludes users who have already performed the selected event/action — "
+            "adoption mode predicts first-time use. Circular population is caught by validation."
+        ),
+    ),
+    "repeat_key_behavior": AutoresearchTemplate(
+        key="repeat_key_behavior",
+        display_name="Likely to repeat a key behavior",
+        description=(
+            "Predict which users who have already done a key action will do it again within 7 days. "
+            "Good for feature retention, power usage, and repeat purchases."
+        ),
+        default_horizon_days=7,
+        output_property_prefix="predicted_p_repeat",
+        requires_user_event=True,
+        requires_activity_resolution=False,
+        training_population_spec={"kind": "ever_performed_target"},
+        inference_population_spec={"kind": "ever_performed_target"},
+        notes=(
+            "Population includes only users who have performed the selected event/action at least once. "
+            "Continuation mode predicts repeat occurrence."
+        ),
+    ),
+}
+
+
+def resolve_activity_event(team: Team) -> tuple[str, list[str]]:
+    """
+    Discover the best activity event for universal activity templates.
+
+    Queries the last 30 days of events, checks for preferred activity events
+    ($pageview, $screen, $autocapture) in priority order, and falls back to the
+    highest-volume non-noisy event if none of the preferred events exist.
+
+    Returns (resolved_event, alternatives) where alternatives are other viable
+    events the user can choose as an override.
+    """
+    try:
+        # Training and scoring only ever see identified users, so rank candidates on that
+        # same population: anonymous-only traffic must not choose the activity event.
+        identified_clause = _identified_users_and_clause()
+        query = HogQLQuery(
+            query=f"""
+                SELECT event, count() AS c
+                FROM events
+                WHERE timestamp >= now() - toIntervalDay(30)
+                  AND timestamp < now(){identified_clause}
+                GROUP BY event
+                ORDER BY c DESC
+                LIMIT 100
+            """,
+        )
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        rows = run_hogql_rows(team=team, query=query)
+
+        seen: dict[str, int] = {}
+        if rows:
+            for row in rows:
+                event_name = str(row[0])
+                count = int(row[1] or 0)
+                if event_name not in _NOISY_EVENTS:
+                    seen[event_name] = count
+
+        for preferred in _PREFERRED_ACTIVITY_EVENTS:
+            if preferred in seen:
+                alts = [e for e in _PREFERRED_ACTIVITY_EVENTS if e in seen and e != preferred]
+                for event, _ in sorted(seen.items(), key=lambda x: x[1], reverse=True):
+                    if event not in alts and event != preferred and len(alts) < 4:
+                        alts.append(event)
+                return preferred, alts
+
+        if seen:
+            sorted_events = sorted(seen.items(), key=lambda x: x[1], reverse=True)
+            resolved = sorted_events[0][0]
+            return resolved, [e for e, _ in sorted_events[1:4]]
+
+    except Exception:
+        logger.exception("autoresearch_activity_resolver_error", team_id=team.pk)
+
+    return "$pageview", []
+
+
+@frozen
+class ResolvedTemplate:
+    template_key: str
+    display_name: str
+    description: str
+    target_event: str
+    resolved_activity_event: Optional[str]
+    activity_event_alternatives: list[str]
+    horizon_days: int
+    training_population: dict[str, Any]
+    inference_population: dict[str, Any]
+    output_person_property: str
+    suggested_name: str
+    notes: str
+
+
+def resolve_template(
+    team: Team,
+    template_key: str,
+    target_event_override: Optional[str] = None,
+    horizon_days_override: Optional[int] = None,
+) -> ResolvedTemplate:
+    """
+    Resolve a template key + optional overrides into a concrete pipeline config.
+
+    Raises ValueError if template_key is unknown or a required override is missing.
+    The returned ResolvedTemplate can be passed directly to pipeline creation.
+    """
+    template = TEMPLATES.get(template_key)
+    if template is None:
+        raise ValueError(f"Unknown template '{template_key}'. Available: {', '.join(TEMPLATES)}")
+
+    if template.requires_user_event and not target_event_override:
+        raise ValueError(
+            f"Template '{template_key}' requires a target_event override. "
+            "Provide the event or action name you want to predict."
+        )
+
+    resolved_activity: Optional[str] = None
+    alternatives: list[str] = []
+
+    if template.requires_activity_resolution:
+        resolved_activity, alternatives = resolve_activity_event(team)
+        target_event = target_event_override or resolved_activity
+    else:
+        target_event = target_event_override or ""
+
+    horizon_days = horizon_days_override if horizon_days_override is not None else template.default_horizon_days
+
+    # Append the horizon so two pipelines on the same target but different horizons write to
+    # distinct person properties instead of clobbering one another. The horizon lives in the
+    # suffix (not the prefix) so it tracks a horizon override rather than the template default.
+    if template.requires_user_event and target_event:
+        safe_name = target_event.lstrip("$").replace(" ", "_").lower()
+        output_person_property = f"{template.output_property_prefix}_{safe_name}_{horizon_days}d"
+    else:
+        output_person_property = f"{template.output_property_prefix}_{horizon_days}d"
+
+    training_population = dict(template.training_population_spec)
+    inference_population = dict(template.inference_population_spec)
+
+    if template.requires_user_event and target_event:
+        safe_label = target_event.lstrip("$").replace("_", " ")
+        suggested_name = f"{template.display_name}: {safe_label}"
+    else:
+        suggested_name = template.display_name
+
+    return ResolvedTemplate(
+        template_key=template_key,
+        display_name=template.display_name,
+        description=template.description,
+        target_event=target_event,
+        resolved_activity_event=resolved_activity,
+        activity_event_alternatives=alternatives,
+        horizon_days=horizon_days,
+        training_population=training_population,
+        inference_population=inference_population,
+        output_person_property=output_person_property,
+        suggested_name=suggested_name,
+        notes=template.notes,
+    )

--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -33,6 +33,7 @@ from posthog.schema import HogQLQuery
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.dataclasses import frozen
 from posthog.models.team.team import Team
+from posthog.models.user import User
 
 from products.autoresearch.backend.dataset.labeling import _identified_users_and_clause
 from products.autoresearch.backend.query import run_hogql_rows
@@ -169,7 +170,7 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
 }
 
 
-def resolve_activity_event(team: Team) -> tuple[str, list[str]]:
+def resolve_activity_event(team: Team, user: Optional[User] = None) -> tuple[str, list[str]]:
     """
     Discover the best activity event for universal activity templates.
 
@@ -178,7 +179,8 @@ def resolve_activity_event(team: Team) -> tuple[str, list[str]]:
     highest-volume non-noisy event if none of the preferred events exist.
 
     Returns (resolved_event, alternatives) where alternatives are other viable
-    events the user can choose as an override.
+    events the user can choose as an override. `user` is the person HogQL applies
+    access control for; see `query.run_hogql`.
     """
     try:
         # Training and scoring only ever see identified users, so rank candidates on that
@@ -196,7 +198,7 @@ def resolve_activity_event(team: Team) -> tuple[str, list[str]]:
             """,
         )
         tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
-        rows = run_hogql_rows(team=team, query=query)
+        rows = run_hogql_rows(team=team, query=query, user=user)
 
         seen: dict[str, int] = {}
         if rows:
@@ -246,6 +248,7 @@ def resolve_template(
     template_key: str,
     target_event_override: Optional[str] = None,
     horizon_days_override: Optional[int] = None,
+    user: Optional[User] = None,
 ) -> ResolvedTemplate:
     """
     Resolve a template key + optional overrides into a concrete pipeline config.
@@ -267,7 +270,7 @@ def resolve_template(
     alternatives: list[str] = []
 
     if template.requires_activity_resolution:
-        resolved_activity, alternatives = resolve_activity_event(team)
+        resolved_activity, alternatives = resolve_activity_event(team, user=user)
         target_event = target_event_override or resolved_activity
     else:
         target_event = target_event_override or ""

--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -20,13 +20,16 @@ window. The target-relative kinds compile against the pipeline's target
 predicate, so an action target matches by its matcher rather than its name.
 Every kind is evaluated per user at T0 during training and as of the cutoff at
 inference — see the compiler's docstring for the semantics.
+
+Templates take an event name as their target. An action target is set through the
+pipeline's `target_definition` at creation, outside template resolution.
 """
 
 from __future__ import annotations
 
+import re
+import hashlib
 from typing import Any, Optional
-
-import structlog
 
 from posthog.schema import HogQLQuery
 
@@ -38,33 +41,22 @@ from posthog.models.user import User
 from products.autoresearch.backend.dataset.labeling import _identified_users_and_clause
 from products.autoresearch.backend.query import run_hogql_rows
 
-logger = structlog.get_logger(__name__)
-
 # Checked in this order when resolving an activity event for universal templates
 _PREFERRED_ACTIVITY_EVENTS = ["$pageview", "$screen", "$autocapture"]
+_MAX_ACTIVITY_ALTERNATIVES = 4
 
-# Internal / noisy events that should never be chosen as the activity signal
-_NOISY_EVENTS: frozenset[str] = frozenset(
-    {
-        "$feature_flag_called",
-        "$decide",
-        "$set",
-        "$identify",
-        "$rageclick",
-        "$$heatmap",
-        "$web_vitals",
-        "$exception",
-        "$pageview_autocapture",
-        "$$plugin_metrics",
-    }
-)
+# The resolver hands its result to pipeline creation, so it must fit the pipeline's columns:
+# `AutoresearchPipeline.target_event`, `.name` and `.output_person_property` are all 255 wide.
+_PIPELINE_FIELD_MAX_LENGTH = 255
+
+_UNSAFE_PROPERTY_CHARS = re.compile(r"[^a-z0-9._-]+")
 
 
 @frozen
 class AutoresearchTemplate:
     key: str
     display_name: str
-    description: str
+    description_template: str
     default_horizon_days: int
     output_property_prefix: str
     requires_user_event: bool  # user must supply target_event override
@@ -73,14 +65,21 @@ class AutoresearchTemplate:
     inference_population_spec: dict[str, Any]
     notes: str = ""
 
+    @property
+    def description(self) -> str:
+        return self.describe(self.default_horizon_days)
+
+    def describe(self, horizon_days: int) -> str:
+        return self.description_template.format(horizon_days=horizon_days)
+
 
 TEMPLATES: dict[str, AutoresearchTemplate] = {
     "likely_active_soon": AutoresearchTemplate(
         key="likely_active_soon",
         display_name="Likely active soon",
-        description=(
-            "Predict which active users will be active again in the next 7 days. "
-            "Best universal starter template — works for any product with pageview or session data."
+        description_template=(
+            "Predict which active users will be active again in the next {horizon_days} days. "
+            "Works for any product that sends pageview or screen events."
         ),
         default_horizon_days=7,
         output_property_prefix="predicted_p_active_soon",
@@ -89,17 +88,16 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
         training_population_spec={"kind": "performed_event_within_days", "days": 30},
         inference_population_spec={"kind": "performed_event_within_days", "days": 30},
         notes=(
-            "Activity event is resolved from your event schema — prefers $pageview, $screen, "
-            "then any high-volume identified-user event. You can override the resolved event."
+            "The activity event is resolved from your event schema, preferring $pageview, then $screen, "
+            "then $autocapture, then the custom event with the most identified users. You can override it."
         ),
     ),
     "at_risk_of_inactivity": AutoresearchTemplate(
         key="at_risk_of_inactivity",
         display_name="At risk of inactivity",
-        description=(
-            "Identify users unlikely to be active in the next 14 days. "
-            "Models future activity probability — low-probability users are the at-risk cohort. "
-            "Good for retention campaigns."
+        description_template=(
+            "Find users who are unlikely to be active in the next {horizon_days} days. "
+            "The model predicts the probability of activity, so users with a low score are the at-risk group."
         ),
         default_horizon_days=14,
         output_property_prefix="predicted_p_active_next",
@@ -108,17 +106,16 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
         training_population_spec={"kind": "performed_event_within_days", "days": 60},
         inference_population_spec={"kind": "performed_event_within_days", "days": 60},
         notes=(
-            "Predicts activity probability. Users with a low score (e.g. p < 0.2) are at risk. "
-            "Create the 'At risk of inactivity' cohort using a low threshold on the prediction score, "
-            "not by modeling the absence of an event directly."
+            "The score is the probability of activity. Build the at-risk cohort with a low threshold "
+            "on the score, for example below 0.2, instead of modeling the absence of an event."
         ),
     ),
     "return_after_first_use": AutoresearchTemplate(
         key="return_after_first_use",
         display_name="Likely to return after first use",
-        description=(
-            "Predict which new users will have a second active session within 7 days. "
-            "Works without a custom signup event — uses first-seen date. Good for onboarding."
+        description_template=(
+            "Predict which new users will be active again within {horizon_days} days. "
+            "Uses the person's first-seen date, so it does not need a signup event."
         ),
         default_horizon_days=7,
         output_property_prefix="predicted_p_return_after_signup",
@@ -127,16 +124,17 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
         training_population_spec={"kind": "person_first_seen_within_days", "days": 14},
         inference_population_spec={"kind": "person_first_seen_within_days", "days": 14},
         notes=(
-            "Population is users first seen in the last 14 days. "
-            "Target event (second-session activity) is resolved from your event schema."
+            "The population is users first seen in the last 14 days. The activity event is resolved "
+            "from your event schema. Any activity after the sampled anchor point counts, including "
+            "activity later in the same first session."
         ),
     ),
     "feature_adoption": AutoresearchTemplate(
         key="feature_adoption",
         display_name="Likely to adopt a feature",
-        description=(
-            "Predict which active users will use a selected feature for the first time within 14 days. "
-            "Requires you to choose the feature's event or action."
+        description_template=(
+            "Predict which active users will use a selected feature for the first time within {horizon_days} days. "
+            "Choose the feature's event."
         ),
         default_horizon_days=14,
         output_property_prefix="predicted_p_adopt",
@@ -145,16 +143,16 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
         training_population_spec={"kind": "active_not_performed_target", "active_within_days": 30},
         inference_population_spec={"kind": "active_not_performed_target", "active_within_days": 30},
         notes=(
-            "Population automatically excludes users who have already performed the selected event/action — "
-            "adoption mode predicts first-time use. Circular population is caught by validation."
+            "The population is users active in the last 30 days who have not performed the selected event "
+            "within the training lookback window. Use before that window does not exclude a user."
         ),
     ),
     "repeat_key_behavior": AutoresearchTemplate(
         key="repeat_key_behavior",
         display_name="Likely to repeat a key behavior",
-        description=(
-            "Predict which users who have already done a key action will do it again within 7 days. "
-            "Good for feature retention, power usage, and repeat purchases."
+        description_template=(
+            "Predict which users who have already done a key action will do it again within {horizon_days} days. "
+            "Useful for feature retention, power usage, and repeat purchases."
         ),
         default_horizon_days=7,
         output_property_prefix="predicted_p_repeat",
@@ -163,68 +161,74 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
         training_population_spec={"kind": "ever_performed_target"},
         inference_population_spec={"kind": "ever_performed_target"},
         notes=(
-            "Population includes only users who have performed the selected event/action at least once. "
-            "Continuation mode predicts repeat occurrence."
+            "The population is users who performed the selected event at least once within the training "
+            "lookback window."
         ),
     ),
 }
 
 
-def resolve_activity_event(team: Team, user: Optional[User] = None) -> tuple[str, list[str]]:
+def _is_activity_candidate(event: str) -> bool:
+    # PostHog's own events carry a `$` prefix. Outside the preferred activity events they are
+    # SDK bookkeeping ($identify, $feature_flag_called, $groupidentify, ...), not user behavior.
+    if event in _PREFERRED_ACTIVITY_EVENTS:
+        return True
+    return not event.startswith("$") and len(event) <= _PIPELINE_FIELD_MAX_LENGTH
+
+
+def resolve_activity_event(team: Team, user: Optional[User] = None) -> tuple[Optional[str], list[str]]:
     """
     Discover the best activity event for universal activity templates.
 
-    Queries the last 30 days of events, checks for preferred activity events
-    ($pageview, $screen, $autocapture) in priority order, and falls back to the
-    highest-volume non-noisy event if none of the preferred events exist.
+    Ranks the last 30 days of events by identified persons, checks for preferred
+    activity events ($pageview, $screen, $autocapture) in priority order, and falls
+    back to the custom event with the widest identified-person coverage.
 
     Returns (resolved_event, alternatives) where alternatives are other viable
-    events the user can choose as an override. `user` is the person HogQL applies
-    access control for; see `query.run_hogql`.
+    events the user can choose as an override. `resolved_event` is None when the
+    team has no candidate. `user` is the person HogQL applies access control for;
+    see `query.run_hogql`.
     """
-    try:
-        # Training and scoring only ever see identified users, so rank candidates on that
-        # same population: anonymous-only traffic must not choose the activity event.
-        identified_clause = _identified_users_and_clause()
-        query = HogQLQuery(
-            query=f"""
-                SELECT event, count() AS c
-                FROM events
-                WHERE timestamp >= now() - toIntervalDay(30)
-                  AND timestamp < now(){identified_clause}
-                GROUP BY event
-                ORDER BY c DESC
-                LIMIT 100
-            """,
-        )
-        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
-        rows = run_hogql_rows(team=team, query=query, user=user)
+    # Training and scoring only ever see identified users, so rank candidates on that
+    # same population: anonymous-only traffic must not choose the activity event.
+    identified_clause = _identified_users_and_clause()
+    preferred_literal = ", ".join(f"'{event}'" for event in _PREFERRED_ACTIVITY_EVENTS)
+    # Preferred events sort first so the row limit cannot drop them on teams with many event names.
+    query = HogQLQuery(
+        query=f"""
+            SELECT event, uniq(person_id) AS c
+            FROM events
+            WHERE timestamp >= now() - toIntervalDay(30)
+              AND timestamp < now(){identified_clause}
+              AND (event IN ({preferred_literal}) OR event NOT LIKE '$%')
+            GROUP BY event
+            ORDER BY event IN ({preferred_literal}) DESC, c DESC, event
+            LIMIT 100
+        """,
+    )
+    tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+    rows = run_hogql_rows(team=team, query=query, user=user)
 
-        seen: dict[str, int] = {}
-        if rows:
-            for row in rows:
-                event_name = str(row[0])
-                count = int(row[1] or 0)
-                if event_name not in _NOISY_EVENTS:
-                    seen[event_name] = count
+    seen: dict[str, int] = {}
+    for row in rows or []:
+        event_name = str(row[0])
+        if _is_activity_candidate(event_name):
+            seen[event_name] = int(row[1] or 0)
+    ranked = [event for event, _ in sorted(seen.items(), key=lambda item: (-item[1], item[0]))]
 
-        for preferred in _PREFERRED_ACTIVITY_EVENTS:
-            if preferred in seen:
-                alts = [e for e in _PREFERRED_ACTIVITY_EVENTS if e in seen and e != preferred]
-                for event, _ in sorted(seen.items(), key=lambda x: x[1], reverse=True):
-                    if event not in alts and event != preferred and len(alts) < 4:
-                        alts.append(event)
-                return preferred, alts
+    resolved = next((preferred for preferred in _PREFERRED_ACTIVITY_EVENTS if preferred in seen), None)
+    if resolved is None:
+        if not ranked:
+            return None, []
+        resolved = ranked[0]
 
-        if seen:
-            sorted_events = sorted(seen.items(), key=lambda x: x[1], reverse=True)
-            resolved = sorted_events[0][0]
-            return resolved, [e for e, _ in sorted_events[1:4]]
-
-    except Exception:
-        logger.exception("autoresearch_activity_resolver_error", team_id=team.pk)
-
-    return "$pageview", []
+    alternatives = [event for event in _PREFERRED_ACTIVITY_EVENTS if event in seen and event != resolved]
+    for event in ranked:
+        if len(alternatives) >= _MAX_ACTIVITY_ALTERNATIVES:
+            break
+        if event != resolved and event not in alternatives:
+            alternatives.append(event)
+    return resolved, alternatives
 
 
 @frozen
@@ -243,6 +247,29 @@ class ResolvedTemplate:
     notes: str
 
 
+def _safe_target_name(target_event: str) -> str:
+    raw = target_event.lstrip("$")
+    safe = _UNSAFE_PROPERTY_CHARS.sub("_", raw.lower()).strip("_") or "target"
+    if safe == raw:
+        return safe
+    # Normalization is lossy ("Checkout Started" and "checkout_started" collapse to one name),
+    # so a stable digest of the original keeps two such targets on separate person properties.
+    digest = hashlib.sha1(target_event.encode()).hexdigest()[:6]
+    return f"{safe}_{digest}"
+
+
+def _output_person_property(prefix: str, target_event: str, horizon_days: int) -> str:
+    # The target and the horizon are both part of the name: two pipelines that share one
+    # but not the other must not $set the same person property and clobber each other's scores.
+    suffix = f"_{horizon_days}d"
+    name = f"{prefix}_{_safe_target_name(target_event)}"
+    room = _PIPELINE_FIELD_MAX_LENGTH - len(suffix)
+    if len(name) > room:
+        digest = hashlib.sha1(target_event.encode()).hexdigest()[:6]
+        name = f"{name[: room - len(digest) - 1].rstrip('_')}_{digest}"
+    return f"{name}{suffix}"
+
+
 def resolve_template(
     team: Team,
     template_key: str,
@@ -253,7 +280,8 @@ def resolve_template(
     """
     Resolve a template key + optional overrides into a concrete pipeline config.
 
-    Raises ValueError if template_key is unknown or a required override is missing.
+    Raises ValueError if template_key is unknown, a required override is missing, the
+    horizon is not positive, or no activity event can be resolved for the team.
     The returned ResolvedTemplate can be passed directly to pipeline creation.
     """
     template = TEMPLATES.get(template_key)
@@ -262,50 +290,54 @@ def resolve_template(
 
     if template.requires_user_event and not target_event_override:
         raise ValueError(
-            f"Template '{template_key}' requires a target_event override. "
-            "Provide the event or action name you want to predict."
+            f"Template '{template_key}' requires a target_event override. Provide the event name you want to predict."
         )
+
+    if horizon_days_override is not None and horizon_days_override < 1:
+        raise ValueError("horizon_days must be at least 1.")
 
     resolved_activity: Optional[str] = None
     alternatives: list[str] = []
 
     if template.requires_activity_resolution:
         resolved_activity, alternatives = resolve_activity_event(team, user=user)
-        target_event = target_event_override or resolved_activity
+        target_event = target_event_override or resolved_activity or ""
+        if not target_event:
+            raise ValueError(
+                f"Template '{template_key}' could not resolve an activity event: no identified users "
+                "sent a usable event in the last 30 days. Provide target_event to choose one."
+            )
     else:
         target_event = target_event_override or ""
 
     horizon_days = horizon_days_override if horizon_days_override is not None else template.default_horizon_days
 
-    # Append the horizon so two pipelines on the same target but different horizons write to
-    # distinct person properties instead of clobbering one another. The horizon lives in the
-    # suffix (not the prefix) so it tracks a horizon override rather than the template default.
-    if template.requires_user_event and target_event:
-        safe_name = target_event.lstrip("$").replace(" ", "_").lower()
-        output_person_property = f"{template.output_property_prefix}_{safe_name}_{horizon_days}d"
-    else:
-        output_person_property = f"{template.output_property_prefix}_{horizon_days}d"
-
     training_population = dict(template.training_population_spec)
     inference_population = dict(template.inference_population_spec)
+    if template.requires_activity_resolution:
+        # "Active" means the resolved activity event, for the population as much as for the label.
+        # Without the event key the kind admits anyone who sent any event, bookkeeping included.
+        for population in (training_population, inference_population):
+            if population["kind"] == "performed_event_within_days":
+                population["event"] = target_event
 
-    if template.requires_user_event and target_event:
+    if template.requires_user_event:
         safe_label = target_event.lstrip("$").replace("_", " ")
-        suggested_name = f"{template.display_name}: {safe_label}"
+        suggested_name = f"{template.display_name}: {safe_label}"[:_PIPELINE_FIELD_MAX_LENGTH]
     else:
         suggested_name = template.display_name
 
     return ResolvedTemplate(
         template_key=template_key,
         display_name=template.display_name,
-        description=template.description,
+        description=template.describe(horizon_days),
         target_event=target_event,
         resolved_activity_event=resolved_activity,
         activity_event_alternatives=alternatives,
         horizon_days=horizon_days,
         training_population=training_population,
         inference_population=inference_population,
-        output_person_property=output_person_property,
+        output_person_property=_output_person_property(template.output_property_prefix, target_event, horizon_days),
         suggested_name=suggested_name,
         notes=template.notes,
     )

--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -247,6 +247,10 @@ class ResolvedTemplate:
     notes: str
 
 
+def _target_digest(target_event: str) -> str:
+    return hashlib.sha256(target_event.encode()).hexdigest()[:6]
+
+
 def _safe_target_name(target_event: str) -> str:
     raw = target_event.lstrip("$")
     safe = _UNSAFE_PROPERTY_CHARS.sub("_", raw.lower()).strip("_") or "target"
@@ -254,8 +258,7 @@ def _safe_target_name(target_event: str) -> str:
         return safe
     # Normalization is lossy ("Checkout Started" and "checkout_started" collapse to one name),
     # so a stable digest of the original keeps two such targets on separate person properties.
-    digest = hashlib.sha1(target_event.encode()).hexdigest()[:6]
-    return f"{safe}_{digest}"
+    return f"{safe}_{_target_digest(target_event)}"
 
 
 def _output_person_property(prefix: str, target_event: str, horizon_days: int) -> str:
@@ -265,7 +268,7 @@ def _output_person_property(prefix: str, target_event: str, horizon_days: int) -
     name = f"{prefix}_{_safe_target_name(target_event)}"
     room = _PIPELINE_FIELD_MAX_LENGTH - len(suffix)
     if len(name) > room:
-        digest = hashlib.sha1(target_event.encode()).hexdigest()[:6]
+        digest = _target_digest(target_event)
         name = f"{name[: room - len(digest) - 1].rstrip('_')}_{digest}"
     return f"{name}{suffix}"
 

--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -248,7 +248,9 @@ class ResolvedTemplate:
 
 
 def _target_digest(target_event: str) -> str:
-    return hashlib.sha256(target_event.encode()).hexdigest()[:6]
+    # Upper case on purpose: a normalized name is all lower case, so a name that carries a
+    # digest can never equal an event name that needed no normalization.
+    return hashlib.sha256(target_event.encode()).hexdigest()[:6].upper()
 
 
 def _safe_target_name(target_event: str) -> str:
@@ -298,6 +300,9 @@ def resolve_template(
 
     if horizon_days_override is not None and horizon_days_override < 1:
         raise ValueError("horizon_days must be at least 1.")
+
+    if target_event_override and len(target_event_override) > _PIPELINE_FIELD_MAX_LENGTH:
+        raise ValueError(f"target_event must be at most {_PIPELINE_FIELD_MAX_LENGTH} characters.")
 
     resolved_activity: Optional[str] = None
     alternatives: list[str] = []

--- a/products/autoresearch/backend/dataset/templates.py
+++ b/products/autoresearch/backend/dataset/templates.py
@@ -118,7 +118,7 @@ TEMPLATES: dict[str, AutoresearchTemplate] = {
             "Uses the person's first-seen date, so it does not need a signup event."
         ),
         default_horizon_days=7,
-        output_property_prefix="predicted_p_return_after_signup",
+        output_property_prefix="predicted_p_return_after_first_use",
         requires_user_event=False,
         requires_activity_resolution=True,
         training_population_spec={"kind": "person_first_seen_within_days", "days": 14},
@@ -250,7 +250,10 @@ class ResolvedTemplate:
 def _target_digest(target_event: str) -> str:
     # Upper case on purpose: a normalized name is all lower case, so a name that carries a
     # digest can never equal an event name that needed no normalization.
-    return hashlib.sha256(target_event.encode()).hexdigest()[:6].upper()
+    # Twelve hex characters give 48 bits, so two distinct targets that normalize alike do not
+    # share one person property in practice. A six-character prefix collides within a few
+    # thousand names.
+    return hashlib.sha256(target_event.encode()).hexdigest()[:12].upper()
 
 
 def _safe_target_name(target_event: str) -> str:

--- a/products/autoresearch/backend/dataset/test_templates.py
+++ b/products/autoresearch/backend/dataset/test_templates.py
@@ -1,0 +1,166 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from products.autoresearch.backend.dataset.labeling import _build_population_kind_conditions
+from products.autoresearch.backend.dataset.templates import (
+    TEMPLATES,
+    ResolvedTemplate,
+    resolve_activity_event,
+    resolve_template,
+)
+
+
+class TestTemplateDefinitions(TestCase):
+    def test_all_five_templates_present(self) -> None:
+        self.assertEqual(
+            set(TEMPLATES.keys()),
+            {
+                "likely_active_soon",
+                "at_risk_of_inactivity",
+                "return_after_first_use",
+                "feature_adoption",
+                "repeat_key_behavior",
+            },
+        )
+
+    @parameterized.expand(list(TEMPLATES.keys()))
+    def test_template_has_required_fields(self, key: str) -> None:
+        t = TEMPLATES[key]
+        self.assertTrue(t.display_name)
+        self.assertTrue(t.description)
+        self.assertGreater(t.default_horizon_days, 0)
+        self.assertTrue(t.output_property_prefix)
+        self.assertIsInstance(t.training_population_spec, dict)
+        self.assertIsInstance(t.inference_population_spec, dict)
+
+    @parameterized.expand(
+        [
+            ("likely_active_soon", 7, False, True),
+            ("at_risk_of_inactivity", 14, False, True),
+            ("return_after_first_use", 7, False, True),
+            ("feature_adoption", 14, True, False),
+            ("repeat_key_behavior", 7, True, False),
+        ]
+    )
+    def test_template_config(
+        self,
+        key: str,
+        expected_horizon: int,
+        requires_user_event: bool,
+        requires_activity_resolution: bool,
+    ) -> None:
+        t = TEMPLATES[key]
+        self.assertEqual(t.default_horizon_days, expected_horizon)
+        self.assertEqual(t.requires_user_event, requires_user_event)
+        self.assertEqual(t.requires_activity_resolution, requires_activity_resolution)
+
+
+class TestTemplateSpecsCompile(TestCase):
+    # Drift guard: every template's population spec must have a compiler branch in
+    # labeling.py, in both row mode (inference/eligible count) and anchor mode (training).
+
+    @parameterized.expand(list(TEMPLATES.keys()))
+    def test_population_specs_compile_in_both_modes(self, key: str) -> None:
+        t = TEMPLATES[key]
+        for population in (t.training_population_spec, t.inference_population_spec):
+            row = _build_population_kind_conditions(population, target_cond="event = {target}")
+            anchor = _build_population_kind_conditions(population, anchor_mode=True, target_cond="event = {target}")
+            self.assertTrue(row.where_parts)
+            self.assertTrue(anchor.anchor_having_parts)
+
+
+class TestResolveActivityEvent(TestCase):
+    def test_ranks_candidates_over_identified_users_only(self) -> None:
+        # Training and scoring only see identified users, so an event that only anonymous
+        # traffic emits must not be chosen as the activity signal.
+        team = MagicMock()
+        team.pk = 1
+        with patch(
+            "products.autoresearch.backend.dataset.templates.run_hogql_rows",
+            return_value=[["$pageview", 10]],
+        ) as mock_run:
+            resolved, _alternatives = resolve_activity_event(team)
+        self.assertEqual(resolved, "$pageview")
+        self.assertIn("person.is_identified", mock_run.call_args.kwargs["query"].query)
+
+
+class TestResolveTemplate(TestCase):
+    def _make_team(self) -> MagicMock:
+        team = MagicMock()
+        team.pk = 1
+        return team
+
+    def test_unknown_template_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="Unknown template"):
+            resolve_template(self._make_team(), "nonexistent_template")
+
+    def test_feature_adoption_without_target_event_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="requires a target_event override"):
+            resolve_template(self._make_team(), "feature_adoption")
+
+    def test_repeat_key_behavior_without_target_event_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_template(self._make_team(), "repeat_key_behavior")
+
+    @patch(
+        "products.autoresearch.backend.dataset.templates.resolve_activity_event",
+        return_value=("$pageview", ["$screen"]),
+    )
+    def test_likely_active_soon_resolves(self, mock_resolve: MagicMock) -> None:
+        team = self._make_team()
+        result = resolve_template(team, "likely_active_soon")
+        self.assertIsInstance(result, ResolvedTemplate)
+        self.assertEqual(result.target_event, "$pageview")
+        self.assertEqual(result.resolved_activity_event, "$pageview")
+        self.assertEqual(result.horizon_days, 7)
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_7d")
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
+    def test_activity_event_override_respected(self, mock_resolve: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "likely_active_soon", target_event_override="$screen")
+        self.assertEqual(result.target_event, "$screen")
+        # resolved_activity_event still shows what the schema resolver found
+        self.assertEqual(result.resolved_activity_event, "$pageview")
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
+    def test_horizon_override_respected(self, _: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "likely_active_soon", horizon_days_override=14)
+        self.assertEqual(result.horizon_days, 14)
+        # Horizon is part of the output property so the same target over a different horizon
+        # does not clobber another pipeline's score.
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_14d")
+
+    def test_feature_adoption_with_target_event(self) -> None:
+        result = resolve_template(self._make_team(), "feature_adoption", target_event_override="feature_clicked")
+        self.assertEqual(result.target_event, "feature_clicked")
+        self.assertEqual(result.horizon_days, 14)
+        self.assertIn("predicted_p_adopt_feature_clicked", result.output_person_property)
+        self.assertEqual(result.training_population, {"kind": "active_not_performed_target", "active_within_days": 30})
+        self.assertIsNone(result.resolved_activity_event)
+
+    def test_repeat_key_behavior_with_target_event(self) -> None:
+        result = resolve_template(self._make_team(), "repeat_key_behavior", target_event_override="$pageview")
+        self.assertEqual(result.target_event, "$pageview")
+        self.assertEqual(result.training_population, {"kind": "ever_performed_target"})
+        self.assertIn("pageview", result.output_person_property)
+
+    def test_feature_adoption_suggested_name_includes_event(self) -> None:
+        result = resolve_template(self._make_team(), "feature_adoption", target_event_override="my_feature")
+        self.assertIn("my feature", result.suggested_name)
+
+    @patch(
+        "products.autoresearch.backend.dataset.templates.resolve_activity_event",
+        return_value=("$pageview", ["$screen"]),
+    )
+    def test_activity_alternatives_returned(self, _: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "at_risk_of_inactivity")
+        self.assertIn("$screen", result.activity_event_alternatives)
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
+    def test_return_after_first_use_population_is_first_seen(self, _: MagicMock) -> None:
+        result = resolve_template(self._make_team(), "return_after_first_use")
+        self.assertEqual(result.training_population["kind"], "person_first_seen_within_days")
+        self.assertEqual(result.training_population["days"], 14)

--- a/products/autoresearch/backend/dataset/test_templates.py
+++ b/products/autoresearch/backend/dataset/test_templates.py
@@ -78,13 +78,15 @@ class TestResolveActivityEvent(TestCase):
         # traffic emits must not be chosen as the activity signal.
         team = MagicMock()
         team.pk = 1
+        user = MagicMock()
         with patch(
             "products.autoresearch.backend.dataset.templates.run_hogql_rows",
             return_value=[["$pageview", 10]],
         ) as mock_run:
-            resolved, _alternatives = resolve_activity_event(team)
+            resolved, _alternatives = resolve_activity_event(team, user=user)
         self.assertEqual(resolved, "$pageview")
         self.assertIn("person.is_identified", mock_run.call_args.kwargs["query"].query)
+        self.assertIs(mock_run.call_args.kwargs["user"], user)
 
 
 class TestResolveTemplate(TestCase):
@@ -111,7 +113,9 @@ class TestResolveTemplate(TestCase):
     )
     def test_likely_active_soon_resolves(self, mock_resolve: MagicMock) -> None:
         team = self._make_team()
-        result = resolve_template(team, "likely_active_soon")
+        user = MagicMock()
+        result = resolve_template(team, "likely_active_soon", user=user)
+        mock_resolve.assert_called_once_with(team, user=user)
         self.assertIsInstance(result, ResolvedTemplate)
         self.assertEqual(result.target_event, "$pageview")
         self.assertEqual(result.resolved_activity_event, "$pageview")

--- a/products/autoresearch/backend/dataset/test_templates.py
+++ b/products/autoresearch/backend/dataset/test_templates.py
@@ -200,6 +200,14 @@ class TestResolveTemplate(SimpleTestCase):
         self.assertTrue(lossy.output_person_property.startswith("predicted_p_adopt_checkout_started_"))
         self.assertEqual(exact.output_person_property, "predicted_p_adopt_checkout_started_14d")
         self.assertNotEqual(lossy.output_person_property, exact.output_person_property)
+        # An event literally named like the encoded form of another event still gets its own property.
+        encoded = lossy.output_person_property.removeprefix("predicted_p_adopt_").removesuffix("_14d")
+        literal = resolve_template(self._make_team(), "feature_adoption", target_event_override=encoded)
+        self.assertNotEqual(literal.output_person_property, lossy.output_person_property)
+
+    def test_overlong_target_override_raises(self) -> None:
+        with self.assertRaises(ValueError, msg="target_event must be at most 255 characters"):
+            resolve_template(self._make_team(), "feature_adoption", target_event_override="a" * 256)
 
     def test_long_target_fits_pipeline_columns(self) -> None:
         result = resolve_template(self._make_team(), "feature_adoption", target_event_override="a" * 250)

--- a/products/autoresearch/backend/dataset/test_templates.py
+++ b/products/autoresearch/backend/dataset/test_templates.py
@@ -204,6 +204,10 @@ class TestResolveTemplate(SimpleTestCase):
         encoded = lossy.output_person_property.removeprefix("predicted_p_adopt_").removesuffix("_14d")
         literal = resolve_template(self._make_team(), "feature_adoption", target_event_override=encoded)
         self.assertNotEqual(literal.output_person_property, lossy.output_person_property)
+        # Two lossy names that normalize to the same string rely on the digest alone to stay apart.
+        first = resolve_template(self._make_team(), "feature_adoption", target_event_override="CHEckOUTstARted")
+        second = resolve_template(self._make_team(), "feature_adoption", target_event_override="ChecKoutStARted")
+        self.assertNotEqual(first.output_person_property, second.output_person_property)
 
     def test_overlong_target_override_raises(self) -> None:
         with self.assertRaises(ValueError, msg="target_event must be at most 255 characters"):

--- a/products/autoresearch/backend/dataset/test_templates.py
+++ b/products/autoresearch/backend/dataset/test_templates.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
@@ -13,7 +13,7 @@ from products.autoresearch.backend.dataset.templates import (
 )
 
 
-class TestTemplateDefinitions(TestCase):
+class TestTemplateDefinitions(SimpleTestCase):
     def test_all_five_templates_present(self) -> None:
         self.assertEqual(
             set(TEMPLATES.keys()),
@@ -30,7 +30,8 @@ class TestTemplateDefinitions(TestCase):
     def test_template_has_required_fields(self, key: str) -> None:
         t = TEMPLATES[key]
         self.assertTrue(t.display_name)
-        self.assertTrue(t.description)
+        self.assertIn(f"{t.default_horizon_days} days", t.description)
+        self.assertNotIn("{", t.description)
         self.assertGreater(t.default_horizon_days, 0)
         self.assertTrue(t.output_property_prefix)
         self.assertIsInstance(t.training_population_spec, dict)
@@ -58,7 +59,7 @@ class TestTemplateDefinitions(TestCase):
         self.assertEqual(t.requires_activity_resolution, requires_activity_resolution)
 
 
-class TestTemplateSpecsCompile(TestCase):
+class TestTemplateSpecsCompile(SimpleTestCase):
     # Drift guard: every template's population spec must have a compiler branch in
     # labeling.py, in both row mode (inference/eligible count) and anchor mode (training).
 
@@ -72,7 +73,7 @@ class TestTemplateSpecsCompile(TestCase):
             self.assertTrue(anchor.anchor_having_parts)
 
 
-class TestResolveActivityEvent(TestCase):
+class TestResolveActivityEvent(SimpleTestCase):
     def test_ranks_candidates_over_identified_users_only(self) -> None:
         # Training and scoring only see identified users, so an event that only anonymous
         # traffic emits must not be chosen as the activity signal.
@@ -85,11 +86,30 @@ class TestResolveActivityEvent(TestCase):
         ) as mock_run:
             resolved, _alternatives = resolve_activity_event(team, user=user)
         self.assertEqual(resolved, "$pageview")
-        self.assertIn("person.is_identified", mock_run.call_args.kwargs["query"].query)
+        query = mock_run.call_args.kwargs["query"].query
+        self.assertIn("person.is_identified", query)
+        self.assertIn("uniq(person_id)", query)
         self.assertIs(mock_run.call_args.kwargs["user"], user)
 
+    @parameterized.expand(
+        [
+            # A preferred event wins over a busier custom event; bookkeeping never wins.
+            ([["$identify", 50], ["clicked", 20], ["$pageview", 10]], "$pageview", ["clicked"]),
+            # Equal coverage breaks ties by name, so a cache refresh cannot flip the target.
+            ([["$identify", 50], ["heartbeat", 20], ["clicked", 20]], "clicked", ["heartbeat"]),
+            ([["x" * 300, 40], ["clicked", 20]], "clicked", []),
+            ([["$identify", 50]], None, []),
+            ([], None, []),
+        ]
+    )
+    def test_ranking(self, rows: list[list[object]], expected: str | None, expected_alternatives: list[str]) -> None:
+        with patch("products.autoresearch.backend.dataset.templates.run_hogql_rows", return_value=rows):
+            resolved, alternatives = resolve_activity_event(MagicMock())
+        self.assertEqual(resolved, expected)
+        self.assertEqual(alternatives, expected_alternatives)
 
-class TestResolveTemplate(TestCase):
+
+class TestResolveTemplate(SimpleTestCase):
     def _make_team(self) -> MagicMock:
         team = MagicMock()
         team.pk = 1
@@ -107,6 +127,18 @@ class TestResolveTemplate(TestCase):
         with self.assertRaises(ValueError):
             resolve_template(self._make_team(), "repeat_key_behavior")
 
+    @parameterized.expand([(0,), (-3,)])
+    def test_non_positive_horizon_raises(self, horizon: int) -> None:
+        with self.assertRaises(ValueError, msg="horizon_days must be at least 1"):
+            resolve_template(self._make_team(), "feature_adoption", "signed_up", horizon_days_override=horizon)
+
+    @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=(None, []))
+    def test_unresolved_activity_event_raises_without_override(self, _: MagicMock) -> None:
+        with self.assertRaises(ValueError, msg="could not resolve an activity event"):
+            resolve_template(self._make_team(), "likely_active_soon")
+        result = resolve_template(self._make_team(), "likely_active_soon", target_event_override="$screen")
+        self.assertEqual(result.target_event, "$screen")
+
     @patch(
         "products.autoresearch.backend.dataset.templates.resolve_activity_event",
         return_value=("$pageview", ["$screen"]),
@@ -120,12 +152,18 @@ class TestResolveTemplate(TestCase):
         self.assertEqual(result.target_event, "$pageview")
         self.assertEqual(result.resolved_activity_event, "$pageview")
         self.assertEqual(result.horizon_days, 7)
-        self.assertEqual(result.output_person_property, "predicted_p_active_soon_7d")
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_pageview_7d")
+        self.assertEqual(
+            result.training_population, {"kind": "performed_event_within_days", "days": 30, "event": "$pageview"}
+        )
+        self.assertEqual(result.inference_population["event"], "$pageview")
 
     @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
     def test_activity_event_override_respected(self, mock_resolve: MagicMock) -> None:
         result = resolve_template(self._make_team(), "likely_active_soon", target_event_override="$screen")
         self.assertEqual(result.target_event, "$screen")
+        self.assertEqual(result.training_population["event"], "$screen")
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_screen_7d")
         # resolved_activity_event still shows what the schema resolver found
         self.assertEqual(result.resolved_activity_event, "$pageview")
 
@@ -133,15 +171,16 @@ class TestResolveTemplate(TestCase):
     def test_horizon_override_respected(self, _: MagicMock) -> None:
         result = resolve_template(self._make_team(), "likely_active_soon", horizon_days_override=14)
         self.assertEqual(result.horizon_days, 14)
+        self.assertIn("14 days", result.description)
         # Horizon is part of the output property so the same target over a different horizon
         # does not clobber another pipeline's score.
-        self.assertEqual(result.output_person_property, "predicted_p_active_soon_14d")
+        self.assertEqual(result.output_person_property, "predicted_p_active_soon_pageview_14d")
 
     def test_feature_adoption_with_target_event(self) -> None:
         result = resolve_template(self._make_team(), "feature_adoption", target_event_override="feature_clicked")
         self.assertEqual(result.target_event, "feature_clicked")
         self.assertEqual(result.horizon_days, 14)
-        self.assertIn("predicted_p_adopt_feature_clicked", result.output_person_property)
+        self.assertEqual(result.output_person_property, "predicted_p_adopt_feature_clicked_14d")
         self.assertEqual(result.training_population, {"kind": "active_not_performed_target", "active_within_days": 30})
         self.assertIsNone(result.resolved_activity_event)
 
@@ -155,6 +194,19 @@ class TestResolveTemplate(TestCase):
         result = resolve_template(self._make_team(), "feature_adoption", target_event_override="my_feature")
         self.assertIn("my feature", result.suggested_name)
 
+    def test_targets_that_normalize_alike_keep_distinct_properties(self) -> None:
+        lossy = resolve_template(self._make_team(), "feature_adoption", target_event_override="Checkout Started")
+        exact = resolve_template(self._make_team(), "feature_adoption", target_event_override="checkout_started")
+        self.assertTrue(lossy.output_person_property.startswith("predicted_p_adopt_checkout_started_"))
+        self.assertEqual(exact.output_person_property, "predicted_p_adopt_checkout_started_14d")
+        self.assertNotEqual(lossy.output_person_property, exact.output_person_property)
+
+    def test_long_target_fits_pipeline_columns(self) -> None:
+        result = resolve_template(self._make_team(), "feature_adoption", target_event_override="a" * 250)
+        self.assertLessEqual(len(result.output_person_property), 255)
+        self.assertTrue(result.output_person_property.endswith("_14d"))
+        self.assertLessEqual(len(result.suggested_name), 255)
+
     @patch(
         "products.autoresearch.backend.dataset.templates.resolve_activity_event",
         return_value=("$pageview", ["$screen"]),
@@ -166,5 +218,4 @@ class TestResolveTemplate(TestCase):
     @patch("products.autoresearch.backend.dataset.templates.resolve_activity_event", return_value=("$pageview", []))
     def test_return_after_first_use_population_is_first_seen(self, _: MagicMock) -> None:
         result = resolve_template(self._make_team(), "return_after_first_use")
-        self.assertEqual(result.training_population["kind"], "person_first_seen_within_days")
-        self.assertEqual(result.training_population["days"], 14)
+        self.assertEqual(result.training_population, {"kind": "person_first_seen_within_days", "days": 14})


### PR DESCRIPTION
## Problem

Nothing changes for a person yet: the product stays behind the `autoresearch` flag with no endpoint and no scene. Layer 5 of 31 in the split of [#88464](https://github.com/PostHog/posthog/pull/88464). Layer 4 (#88792) added the labeler that compiles population specs. This layer adds the five built-in templates that produce them, and the resolver that picks a team's activity event.

## Changes

- Adds `backend/dataset/templates.py` with five templates: likely active soon, at risk of inactivity, return after first use, feature adoption, repeat key behavior. A template resolves to the same pipeline shape as a custom pipeline, so creation and validation share one path.
- The activity resolver ranks candidates by identified persons, keeps `$pageview`, `$screen` and `$autocapture` ahead of the row limit, breaks ties by name, and excludes every other `$`-prefixed event. A team with no candidate gets an error that asks for a target, not a guessed `$pageview`.
- The "active" populations name the resolved activity event, so a person who only sent `$identify` is not in the population.
- The suggested person property is `{prefix}_{target}_{horizon}d`, with a short digest when normalization changed the target name. Two pipelines that differ in target or horizon never share a property.
- Resolution rejects a horizon below 1, renders the description for the resolved horizon, and keeps the property, the target and the suggested name inside the pipeline's 255-wide columns.
- The resolver takes the acting `user`, which layer 4's query helper needs for HogQL access control.
- Templates take an event target only. An action target is set through `target_definition` at creation.
- Template descriptions and notes are rewritten in product voice.

> [!NOTE]
> 19 review threads are fixed and resolved with a reply each. Three stay open on purpose: carrying an action definition through template resolution (two threads) and a session-aware label for the return template. Both are recorded as open questions in the design notes.

## How did you test this code?

No manual testing.

- `test_templates.py` keeps the drift guard that compiles every template's population in both modes.
- A parameterized ranking case covers each resolver rule: a preferred event beats a busier custom event, `$identify` never wins, ties break by name, an overlong name is skipped, and no candidate returns `None`.
- New resolve cases cover the unresolved-activity error, a non-positive horizon, the property name for two targets that normalize alike, and a 250-character target fitting the columns.
- Every class is a `SimpleTestCase`; nothing in the file touches a database.
- The ranking query ran once against a real ClickHouse through a throwaway test, which was not committed.

Ran locally on this layer: the product's tests, repo invariants, `hogli product:lint --all`, tach, import-linter, repo-wide mypy, and `hogli ci:preflight --strict`.

Not run: the wider Django suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The templates section of `backend/dataset/AGENTS.md` landed in layer 4.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) cut this layer from `autoresearch-integration` by path, per the skill's `stack-split-plan.md`, cascaded it onto master after layer 4 merged, and worked the review threads. Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

Public artifact: no session material reached the diff.

https://claude.ai/code/session_01YSihJ4gdm1o1UwThr5p7yu
