### PR TITLE
fix(desktop): show filing menu for owned canvases

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -20,6 +20,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   status: null as TaskStatusInput | null,
   currentUserId: 999 as number | undefined,
+  currentUserUuid: "u-1" as string | undefined,
   analysis: {
     canAnalyze: false,
     isPending: false,
@@ -27,7 +28,9 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
-  useCurrentUser: () => ({ data: { id: mocks.currentUserId } }),
+  useCurrentUser: () => ({
+    data: { id: mocks.currentUserId, uuid: mocks.currentUserUuid },
+  }),
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskStatus", () => ({
   useChannelTaskStatus: () => mocks.status,
@@ -514,7 +517,7 @@ describe("ChannelItemRow", () => {
       kind: "canvas",
       id: "c1",
       title: "Web analytics overview",
-      authorUser: { id: 999, uuid: "u-1", email: "owner@example.com" },
+      authorUuid: "u-1",
     });
     renderInList(
       <ChannelItemRow
@@ -544,7 +547,7 @@ describe("ChannelItemRow", () => {
       kind: "canvas",
       id: "c1",
       title: "Web analytics overview",
-      authorUser: { id: 7, uuid: "u-2", email: "creator@example.com" },
+      authorUuid: "u-2",
     });
     renderInList(
       <ChannelItemRow actions={actions} isActive={false} item={canvas} />,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -304,8 +304,8 @@ export function ChannelItemRow({
     currentUser.data?.id === item.authorUser.id;
   const canFileCanvas =
     item.kind === "canvas" &&
-    item.authorUser?.id != null &&
-    currentUser.data?.id === item.authorUser.id;
+    item.authorUuid != null &&
+    currentUser.data?.uuid === item.authorUuid;
   const handleDragStart = useCallback(
     (event: DragEvent) => {
       if (item.kind === "canvas") {
@@ -363,7 +363,7 @@ export function ChannelItemRow({
             onArchive: () => actions.archive(item),
             ...(canHandoff ? { onHandoff: () => setHandoffOpen(true) } : {}),
           },
-    // canHandoff rides on the currentUser query, so it belongs in deps for a
+    // Ownership rides on the currentUser query, so these belong in deps for a
     // sign-in refresh to re-evaluate.
     [
       item,


### PR DESCRIPTION
## Problem

Canvas owners cannot see **File to…** in the sidebar because ownership checks use creator data that canvas rows never contain.

Refs #88718

## Changes

- Canvas owners now see **File to…** when they right-click their canvas in the space sidebar.
- The ownership check uses the creator UUID already supplied by canvas rows.
- Screenshots: Not included because this restores an existing menu item without changing its appearance.

## How did you test this code?

- Updated the existing row-menu test to use the real canvas creator shape, which guards against hiding filing actions for owners.
- Ran the targeted UI test, desktop typechecks, lint, host-boundary validation, and CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix restores the documented sidebar behavior and changes no workflow or API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated this focused follow-up. It used the `/posthog-desktop`, `/writing-tests`, and `/writing-pr-descriptions` skills.

The regression test first reproduced the shipped canvas data shape, then the ownership check changed from user IDs to UUIDs.

The public diff contains no private session material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*