### PR TITLE
fix(conversations): stop dropping slack events on a slow region hop

### DIFF
--- a/products/conversations/backend/api/slack_events.py
+++ b/products/conversations/backend/api/slack_events.py
@@ -11,9 +11,13 @@ import structlog
 
 from posthog.models.integration import SlackIntegrationError
 
-from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
+from products.conversations.backend.services.region_routing import (
+    capture_replayable_request,
+    is_primary_region,
+    proxy_to_secondary_region,
+)
 from products.conversations.backend.support_slack import team_exists_for_slack_workspace, validate_support_request
-from products.conversations.backend.tasks import process_supporthog_event
+from products.conversations.backend.tasks import process_supporthog_event, replay_supporthog_event_to_secondary_region
 
 logger = structlog.get_logger(__name__)
 
@@ -48,9 +52,21 @@ def _route_event_to_relevant_region(request: HttpRequest, data: dict) -> None:
     if team_exists and not (settings.DEBUG and is_primary_region(request)):
         cast(Any, process_supporthog_event).delay(event=event, slack_team_id=slack_team_id, event_id=event_id)
     elif is_primary_region(request):
-        proxy_to_secondary_region(request, log_prefix="supporthog")
+        if not proxy_to_secondary_region(request, log_prefix="supporthog"):
+            _schedule_secondary_region_replay(request)
     else:
         logger.warning("supporthog_no_team_any_region", slack_team_id=slack_team_id)
+
+
+def _schedule_secondary_region_replay(request: HttpRequest) -> None:
+    """Hand a failed inline forward to a task that keeps trying.
+
+    Without this the webhook is gone, and with it whatever the customer said in Slack.
+    """
+    snapshot = capture_replayable_request(request)
+    if snapshot is None:
+        return
+    cast(Any, replay_supporthog_event_to_secondary_region).delay(snapshot=snapshot, log_prefix="supporthog")
 
 
 @csrf_exempt
@@ -74,15 +90,25 @@ def supporthog_event_handler(request: HttpRequest) -> HttpResponse:
         logger.warning("supporthog_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
-    retry_num = request.headers.get("X-Slack-Retry-Num")
-    if retry_num:
-        logger.info("supporthog_event_retry_skipped", retry_num=retry_num)
-        return HttpResponse(status=200)
-
     try:
         data = json.loads(request.body)
     except json.JSONDecodeError:
         return HttpResponse("Invalid JSON", status=400)
+
+    retry_num = request.headers.get("X-Slack-Retry-Num")
+    if retry_num:
+        # Slack retries when we answer slowly, which is when an event is most at risk of being
+        # lost, so these are worth taking. `event_id` is what makes that safe: the processing
+        # task dedupes on it, and that entry outlives the 5-minute signature window a retry has
+        # to arrive in. With no id to dedupe against, a retry would double-post.
+        if not isinstance(data.get("event_id"), str):
+            logger.info("supporthog_event_retry_skipped", retry_num=retry_num)
+            return HttpResponse(status=200)
+        logger.info(
+            "supporthog_event_retry_accepted",
+            retry_num=retry_num,
+            retry_reason=request.headers.get("X-Slack-Retry-Reason"),
+        )
 
     logger.info("supporthog_event_received", event_type=data.get("type"))
 

--- a/products/conversations/backend/api/tests/test_slack_endpoints.py
+++ b/products/conversations/backend/api/tests/test_slack_endpoints.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -6,7 +7,9 @@ from posthog.test.base import APIBaseTest, BaseTest
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
+from django.test import SimpleTestCase
 
+from celery.exceptions import Retry
 from parameterized import parameterized
 from rest_framework.test import APIClient
 from slack_sdk.errors import SlackApiError
@@ -15,6 +18,8 @@ from posthog.models.integration import SlackIntegrationError
 from posthog.models.organization import OrganizationMembership
 
 from products.conversations.backend.models import TeamConversationsSlackConfig
+from products.conversations.backend.support_slack import SLACK_REQUEST_MAX_AGE_SECONDS
+from products.conversations.backend.tasks import replay_supporthog_event_to_secondary_region
 
 
 class TestSupportSlackEventsAPI(BaseTest):
@@ -48,20 +53,36 @@ class TestSupportSlackEventsAPI(BaseTest):
 
         assert response.status_code == 403
 
+    @parameterized.expand(
+        [
+            ("with_event_id", {"event_id": "Ev_retry"}, 202, 1),
+            ("without_event_id", {}, 200, 0),
+        ]
+    )
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
-    def test_slack_retry_returns_200_without_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
+    def test_slack_retry_is_processed_only_when_dedupable(
+        self,
+        _name: str,
+        extra_payload: dict[str, Any],
+        expected_status: int,
+        expected_delay_calls: int,
+        mock_validate: MagicMock,
+        mock_process: MagicMock,
+    ):
         mock_validate.return_value = None
 
         response = self.client.post(
             "/api/conversations/v1/slack/events",
-            data=json.dumps({"type": "event_callback", "team_id": "T123", "event": {"type": "message"}}),
+            data=json.dumps(
+                {"type": "event_callback", "team_id": "T123", "event": {"type": "message"}, **extra_payload}
+            ),
             content_type="application/json",
             headers={"x-slack-retry-num": "1"},
         )
 
-        assert response.status_code == 200
-        mock_process.delay.assert_not_called()
+        assert response.status_code == expected_status
+        assert mock_process.delay.call_count == expected_delay_calls
 
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_invalid_json_returns_400(self, mock_validate: MagicMock):
@@ -119,13 +140,23 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert response.status_code == 202
         mock_process.delay.assert_called_once()
 
+    @parameterized.expand([("proxy_succeeds", True, 0), ("proxy_fails", False, 1)])
+    @patch("products.conversations.backend.api.slack_events.replay_supporthog_event_to_secondary_region")
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_proxies_to_secondary_when_team_not_found_on_primary(
-        self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
+        self,
+        _name: str,
+        proxy_result: bool,
+        expected_replay_calls: int,
+        mock_validate: MagicMock,
+        mock_process: MagicMock,
+        mock_proxy: MagicMock,
+        mock_replay: MagicMock,
     ):
         mock_validate.return_value = None
+        mock_proxy.return_value = proxy_result
 
         with patch("products.conversations.backend.api.slack_events.is_primary_region", return_value=True):
             response = self._post(
@@ -140,6 +171,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert response.status_code == 202
         mock_process.delay.assert_not_called()
         mock_proxy.assert_called_once()
+        assert mock_replay.delay.call_count == expected_replay_calls
 
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
@@ -397,3 +429,30 @@ class TestSlackChannelPermissions(BaseTest):
             content_type="application/json",
         )
         assert response.status_code == 200
+
+
+class TestSupporthogSecondaryRegionReplay(SimpleTestCase):
+    def _snapshot(self, signed_at: float) -> dict[str, Any]:
+        return {
+            "method": "POST",
+            "url": "https://us.posthog.com/api/conversations/v1/slack/events",
+            "headers": {"X-Slack-Request-Timestamp": str(int(signed_at))},
+            "body_b64": "",
+        }
+
+    @patch("products.conversations.backend.tasks.replay_to_secondary_region")
+    def test_expired_signature_is_not_replayed(self, mock_replay: MagicMock):
+        snapshot = self._snapshot(time.time() - SLACK_REQUEST_MAX_AGE_SECONDS - 1)
+
+        replay_supporthog_event_to_secondary_region(snapshot=snapshot, log_prefix="supporthog")
+
+        mock_replay.assert_not_called()
+
+    @patch("products.conversations.backend.tasks.replay_to_secondary_region", return_value=False)
+    def test_failed_replay_is_retried(self, mock_replay: MagicMock):
+        snapshot = self._snapshot(time.time())
+
+        with self.assertRaises(Retry):
+            replay_supporthog_event_to_secondary_region(snapshot=snapshot, log_prefix="supporthog")
+
+        mock_replay.assert_called_once()

--- a/products/conversations/backend/services/region_routing.py
+++ b/products/conversations/backend/services/region_routing.py
@@ -5,6 +5,7 @@ If the primary region doesn't own the resource, it proxies the
 request to the secondary region (US).
 """
 
+import base64
 from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
@@ -106,3 +107,63 @@ def proxy_to_secondary_region(request: HttpRequest, *, log_prefix: str, timeout:
     """
     status_code = request_secondary_region_status(request, log_prefix=log_prefix, timeout=timeout)
     return status_code is not None and 200 <= status_code < 300
+
+
+def capture_replayable_request(request: HttpRequest) -> dict | None:
+    """Snapshot a webhook so it can be forwarded to the secondary region out of band.
+
+    The proxy above runs inline with a short timeout, so a slow secondary region loses the
+    webhook for good. Callers that can't afford that take a snapshot and hand it to a task
+    that retries. Returns None when the raw body is no longer available, since a signed
+    payload can only be replayed byte for byte.
+    """
+    try:
+        body = request.body
+    except RawPostDataException:
+        logger.warning("region_routing_replay_capture_unavailable", path=request.path)
+        return None
+
+    parsed_url = urlparse(request.build_absolute_uri())
+    return {
+        "method": request.method or "POST",
+        "url": urlunparse(parsed_url._replace(netloc=SECONDARY_REGION_DOMAIN)),
+        "headers": {key: value for key, value in request.headers.items() if key.lower() != "host"},
+        "body_b64": base64.b64encode(body).decode("ascii") if body else "",
+    }
+
+
+def replay_to_secondary_region(snapshot: dict, *, log_prefix: str, timeout: int = 10) -> bool:
+    """Send a `capture_replayable_request` snapshot to the secondary region."""
+    target_url = snapshot["url"]
+    body = base64.b64decode(snapshot["body_b64"]) if snapshot.get("body_b64") else None
+
+    try:
+        response = requests.request(
+            method=snapshot.get("method") or "POST",
+            url=target_url,
+            data=body,
+            headers=snapshot.get("headers") or {},
+            timeout=timeout,
+        )
+    except RequestException as exc:
+        logger.warning(
+            f"{log_prefix}_replay_to_secondary_region_failed",
+            error=str(exc),
+            target_url=target_url,
+        )
+        return False
+
+    if response.ok:
+        logger.info(
+            f"{log_prefix}_replay_to_secondary_region",
+            target_url=target_url,
+            status_code=response.status_code,
+        )
+        return True
+
+    logger.warning(
+        f"{log_prefix}_replay_to_secondary_region_bad_status",
+        target_url=target_url,
+        status_code=response.status_code,
+    )
+    return False

--- a/products/conversations/backend/support_slack.py
+++ b/products/conversations/backend/support_slack.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 
 SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES = ("slack.com", "slack-edge.com", "slack-files.com")
 
+# Slack signs each request with a timestamp and we reject anything older than this, so a
+# signed request can never be usefully replayed (or retried by Slack) past this window.
+SLACK_REQUEST_MAX_AGE_SECONDS = 300
+
 # Attachment sync in both directions depends on these. Older installs were authorized without
 # them, so the settings page asks those teams to reconnect.
 SUPPORT_SLACK_FILE_READ_SCOPE = "files:read"
@@ -85,7 +89,7 @@ def validate_support_request(request: HttpRequest | Request) -> None:
     try:
         timestamp_diff = time.time() - float(slack_time)
         # Reject requests older than 5 minutes OR from the future (with 60s tolerance for clock skew)
-        if timestamp_diff > 300 or timestamp_diff < -60:
+        if timestamp_diff > SLACK_REQUEST_MAX_AGE_SECONDS or timestamp_diff < -60:
             raise SlackIntegrationError("Expired")
     except ValueError:
         raise SlackIntegrationError("Invalid")

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -2,6 +2,7 @@
 
 import html as html_mod
 import json
+import time
 from datetime import datetime, timedelta
 from email.utils import formataddr
 from typing import Any, cast, get_args
@@ -57,6 +58,7 @@ from products.conversations.backend.models import (
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Status
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
+from products.conversations.backend.services.region_routing import replay_to_secondary_region
 from products.conversations.backend.slack import (
     TICKET_CONFIRM_ACTION_DISMISS,
     TICKET_CONFIRM_ACTION_OPEN,
@@ -99,18 +101,65 @@ from products.conversations.backend.teams import (
 from products.conversations.backend.teams_attachments import extract_teams_graph_images
 from products.conversations.backend.teams_formatting import build_teams_reply_html
 
-from .support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES, supporthog_missing_file_scopes
+from .support_slack import (
+    SLACK_REQUEST_MAX_AGE_SECONDS,
+    SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES,
+    supporthog_missing_file_scopes,
+)
 
 logger = structlog.get_logger(__name__)
 SUPPORTHOG_EVENT_IDEMPOTENCY_TTL_SECONDS = 6 * 60
 SUPPORTHOG_EVENT_IDEMPOTENCY_KEY_PREFIX = "supporthog:slack:event:"
 SUPPORTHOG_TEAMS_EVENT_IDEMPOTENCY_KEY_PREFIX = "supporthog:teams:event:"
 SUPPORTHOG_GITHUB_EVENT_IDEMPOTENCY_KEY_PREFIX = "supporthog:github:event:"
+# Retries have to fit inside the Slack signature window, so they stay short and few.
+SUPPORTHOG_REPLAY_MAX_RETRIES = 3
+SUPPORTHOG_REPLAY_RETRY_DELAY_SECONDS = 20
 
 
 def _is_duplicate_supporthog_event(event_id: str) -> bool:
     key = f"{SUPPORTHOG_EVENT_IDEMPOTENCY_KEY_PREFIX}{event_id}"
     return not cache.add(key, True, timeout=SUPPORTHOG_EVENT_IDEMPOTENCY_TTL_SECONDS)
+
+
+def _slack_signature_expired(headers: dict[str, str]) -> bool:
+    """True once the secondary region would reject the snapshot as an expired signature."""
+    raw_timestamp = next((v for k, v in headers.items() if k.lower() == "x-slack-request-timestamp"), None)
+    if raw_timestamp is None:
+        return False
+    try:
+        return time.time() - float(raw_timestamp) > SLACK_REQUEST_MAX_AGE_SECONDS
+    except ValueError:
+        return False
+
+
+@shared_task(
+    bind=True,
+    ignore_result=True,
+    max_retries=SUPPORTHOG_REPLAY_MAX_RETRIES,
+    default_retry_delay=SUPPORTHOG_REPLAY_RETRY_DELAY_SECONDS,
+)
+@skip_team_scope_audit
+def replay_supporthog_event_to_secondary_region(self, snapshot: dict[str, Any], log_prefix: str) -> None:
+    """Retry a cross-region webhook forward that the inline proxy could not complete.
+
+    The inline proxy waits 3 seconds and then gives up, so a slow moment in the secondary
+    region loses a customer message with no way to get it back. Slack signs each payload with
+    a timestamp, so a replay only helps inside that window. After it, the secondary region
+    rejects the signature and there is nothing left to try.
+    """
+    headers = snapshot.get("headers") or {}
+    if _slack_signature_expired(headers):
+        logger.warning("supporthog_replay_signature_expired", log_prefix=log_prefix)
+        return
+
+    if replay_to_secondary_region(snapshot, log_prefix=log_prefix):
+        return
+
+    try:
+        raise cast(Any, self).retry()
+    except MaxRetriesExceededError:
+        logger.exception("supporthog_replay_to_secondary_region_exhausted", log_prefix=log_prefix)
 
 
 def is_duplicate_teams_event(activity_id: str) -> bool:


### PR DESCRIPTION
## Problem

A customer or teammate writes in a Slack support thread, and the message never appears on the ticket. Nobody is told. The thread reads as answered on the Slack side while the ticket is missing the reply, so support answers against a thread they cannot fully see.

Slack sends support events to the primary region. When the workspace belongs to the other region, `slack_events.py` forwards the request inline with `proxy_to_secondary_region`, which allows 3 seconds. A slow moment in the secondary region ends that forward. There is no retry, no queue, and no log on the receiving side.

Slack's own redelivery is the natural recovery, and the handler discarded it: any request carrying `X-Slack-Retry-Num` returned 200 and stopped there. So a single slow response lost the event permanently.

Both halves are reachable together. The forward is slowest exactly when the secondary region is slow, which is also when the primary region answers Slack too late and Slack retries.

## Changes

- A Slack message posted during a slow patch now reaches its ticket instead of disappearing. A failed forward hands a snapshot of the request to `replay_supporthog_event_to_secondary_region`, which retries with a 10 second timeout.
- The snapshot copies the raw body byte for byte, because the secondary region checks Slack's HMAC over it.
- The task stops once the signed timestamp passes the 5 minute window. Past that the secondary region rejects the signature, so a retry cannot succeed.
- A Slack redelivery is now processed rather than discarded. `process_supporthog_event` already dedupes on `event_id`, and that cache entry lasts 6 minutes, which covers the 5 minute window a retry can arrive in.
- A redelivery without an `event_id` is still dropped, since nothing would stop it double-posting.
- `supporthog_event_retry_accepted` records the redeliveries we now accept, so the recovered volume is measurable.
- Mechanical: `validate_support_request` reads its 300 second limit from the new `SLACK_REQUEST_MAX_AGE_SECONDS` constant, which the task shares.

Only the Slack events endpoint is wired to the durable replay. The Teams, GitHub, email, and Slack interactivity handlers call the same inline proxy and have the same exposure, but they are left alone to keep this reviewable.

```mermaid
flowchart LR
    S1{{Slack}} --> P1[Primary region]
    P1 -->|"inline, 3s"| X1[Lost]
    P1 --> S2[Secondary region]
    S1 -.->|"retry"| D1[Dropped on arrival]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class S1 phYellow;
    class P1,S2 phBlue;
    class X1,D1 phRed;
```

```mermaid
flowchart LR
    S1{{Slack}} --> P1[Primary region]
    P1 -->|"inline, 3s"| S2[Secondary region]
    P1 -->|"on failure"| T1[Replay task]
    T1 -->|"retries in the signature window"| S2
    S1 -.->|"retry, deduped on event_id"| P1
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class S1 phYellow;
    class P1,S2,T1 phBlue;
```

> [!NOTE]
> The replay runs on a Celery worker rather than a web pod. Confirm workers in the primary region can reach the secondary region's public hostname before relying on it.

Nothing user-visible changes in the app. No frontend code is touched.

## How did you test this code?

Automated only. This was not exercised against a real Slack workspace, and the cross-region path was not run end to end.

- `test_slack_retry_is_processed_only_when_dedupable` catches a return to the blanket retry drop, which is the behavior that lost the event. It also pins the no-`event_id` case, so a fix for the first does not introduce double-posting.
- `test_proxies_to_secondary_when_team_not_found_on_primary` gains a proxy-fails case. It catches a change that drops a failed forward on the floor again.
- `test_failed_replay_is_retried` catches a replay task that swallows a failure instead of retrying, which would silently restore the original bug.
- `test_expired_signature_is_not_replayed` catches retries burned on a request the secondary region will reject.

<details>
<summary>Local runs</summary>

`products/conversations/backend/api/tests/test_slack_endpoints.py` and the email, Teams, and GitHub webhook suites pass locally against Postgres. Repo-wide mypy and the frontend suites were not run here.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus) from a Slack thread reporting one ticket that was missing its latest reply. The investigation started from the ticket's message list, then compared the Slack channel's synced warehouse table against the `supporthog_*` structured logs, which showed the webhook never reached the receiving region while a message posted seconds later did.

The first plan raised the inline proxy timeout. That was rejected: a longer inline wait pushes the primary region past Slack's own 3 second limit, which trades one drop for another. Moving the forward entirely off the request path was rejected too, because it would break the path outright if primary-region workers lack egress to the secondary region. Attempting inline first and falling back to a task is no worse than today in any case.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
