### PR TITLE
fix(replay-vision): skip recordings with no replay data before scanning

### DIFF
--- a/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.stories.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.stories.tsx
@@ -8,6 +8,7 @@ const SCAN_ID = '0199c0de-1111-7000-8000-0000000000aa'
 const SESSION_A = '0199c0de-2222-7000-8000-0000000000b1'
 const SESSION_B = '0199c0de-2222-7000-8000-0000000000b2'
 const SESSION_C = '0199c0de-2222-7000-8000-0000000000b3'
+const SESSION_D = '0199c0de-2222-7000-8000-0000000000b4'
 
 const meta: Meta<typeof ReplayVisionScanWidget> = {
     title: 'Scenes-App/Max AI/Replay Vision scan widget',
@@ -21,18 +22,13 @@ export default meta
 
 type Story = StoryObj<typeof ReplayVisionScanWidget>
 
-function observation(
-    sessionId: string,
-    status: string,
-    modelOutput?: Record<string, unknown>,
-    errorReason = 'no_recording:No replay metadata found'
-): Record<string, any> {
+function observation(sessionId: string, status: string, modelOutput?: Record<string, unknown>): Record<string, any> {
     return {
         id: `obs-${sessionId}`,
         scanner_id: SCAN_ID,
         session_id: sessionId,
         status,
-        error_reason: status === 'ineligible' ? errorReason : '',
+        error_reason: status === 'ineligible' ? 'no_recording:No replay metadata found' : '',
         scanner_result: modelOutput ? { model_output: modelOutput, signals_count: 0 } : null,
     }
 }
@@ -86,8 +82,9 @@ export const WithSkipped: Story = {
                 scanId={SCAN_ID}
                 sessionIds={[SESSION_A]}
                 skipped={[
-                    { sessionId: SESSION_B, reason: 'no_replay_data' },
+                    { sessionId: SESSION_B, reason: 'skipped_quota' },
                     { sessionId: SESSION_C, reason: 'skipped_quota' },
+                    { sessionId: SESSION_D, reason: 'no_replay_data' },
                 ]}
             />
         )

--- a/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.stories.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.stories.tsx
@@ -21,13 +21,18 @@ export default meta
 
 type Story = StoryObj<typeof ReplayVisionScanWidget>
 
-function observation(sessionId: string, status: string, modelOutput?: Record<string, unknown>): Record<string, any> {
+function observation(
+    sessionId: string,
+    status: string,
+    modelOutput?: Record<string, unknown>,
+    errorReason = 'no_recording:No replay metadata found'
+): Record<string, any> {
     return {
         id: `obs-${sessionId}`,
         scanner_id: SCAN_ID,
         session_id: sessionId,
         status,
-        error_reason: status === 'ineligible' ? 'too_short:the recording is under five seconds long' : '',
+        error_reason: status === 'ineligible' ? errorReason : '',
         scanner_result: modelOutput ? { model_output: modelOutput, signals_count: 0 } : null,
     }
 }
@@ -81,7 +86,7 @@ export const WithSkipped: Story = {
                 scanId={SCAN_ID}
                 sessionIds={[SESSION_A]}
                 skipped={[
-                    { sessionId: SESSION_B, reason: 'skipped_quota' },
+                    { sessionId: SESSION_B, reason: 'no_replay_data' },
                     { sessionId: SESSION_C, reason: 'skipped_quota' },
                 ]}
             />

--- a/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.tsx
@@ -5,7 +5,13 @@ import { LemonBanner, Link, Spinner } from '@posthog/lemon-ui'
 import { urls } from 'scenes/urls'
 
 import type { ReplayObservationApi } from 'products/replay_vision/frontend/generated/api.schemas'
-import { readErrorKind, readReasoning, readSummary, readTitle } from 'products/replay_vision/frontend/utils/observation'
+import {
+    failureKindDescription,
+    ineligibleKindDescription,
+    parseFailureReason,
+    parseIneligibleReason,
+} from 'products/replay_vision/frontend/replay_scanners/types'
+import { readReasoning, readSummary, readTitle } from 'products/replay_vision/frontend/utils/observation'
 
 import { replayVisionScanWidgetLogic } from './replayVisionScanWidgetLogic'
 
@@ -24,21 +30,20 @@ const SKIP_MESSAGES: Record<string, string> = {
     failed: 'the scan could not be started',
 }
 
-// Keyed on the `error_reason` kind, never the message stored beside it: that half is written for us and
-// reads as internal text in a chat bubble. Kinds come from `products/replay_vision/backend/error_kinds.py`.
-const FAILURE_MESSAGES: Record<string, string> = {
-    no_recording: 'No replay data was saved for it.',
-    no_snapshots: 'It has no video to watch yet. Try again in a few minutes.',
-    no_events: 'It has no events recorded against it.',
-    too_short: 'It is too short to watch.',
-    too_long: 'It is too long to watch.',
-    too_inactive: 'It has too little activity to watch.',
-    provider_transient: 'The AI provider was unavailable. Try again.',
-    provider_rejected: 'The AI provider could not process it.',
-    rasterization_failed: 'It could not be rendered for the AI to watch.',
-    validation_failed: 'The scan did not return a usable result.',
-    infra_transient: 'PostHog was at capacity. Try again.',
-    orphaned: 'The scan stopped before it finished. Try again.',
+const GENERIC_FAILURE = 'Could not watch this recording.'
+
+/** Describes the kind, never the message stored beside it: that half is written for us, not for a reader. */
+function failureDescription(observation: ReplayObservationApi): string {
+    const reason = observation.error_reason
+    if (!reason) {
+        return GENERIC_FAILURE
+    }
+    if (observation.status === 'ineligible') {
+        const parsed = parseIneligibleReason(reason)
+        return parsed ? ineligibleKindDescription(parsed.kind) : GENERIC_FAILURE
+    }
+    const parsed = parseFailureReason(reason)
+    return parsed ? failureKindDescription(parsed.kind) : GENERIC_FAILURE
 }
 
 export function ReplayVisionScanWidget({ scanId, sessionIds, skipped }: ReplayVisionScanWidgetProps): JSX.Element {
@@ -103,12 +108,9 @@ function ObservationRow({ observation }: { observation: ReplayObservationApi }):
     }
 
     if (observation.status !== 'succeeded') {
-        const detail = FAILURE_MESSAGES[readErrorKind(observation) ?? '']
         return (
             <div className="px-3 py-2 text-sm">
-                <p className="m-0 text-secondary">
-                    {['Could not watch this recording.', detail].filter(Boolean).join(' ')}
-                </p>
+                <p className="m-0 text-secondary">{failureDescription(observation)}</p>
             </div>
         )
     }

--- a/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.tsx
+++ b/products/posthog_ai/frontend/components/tool/widgets/ReplayVisionScanWidget.tsx
@@ -5,12 +5,7 @@ import { LemonBanner, Link, Spinner } from '@posthog/lemon-ui'
 import { urls } from 'scenes/urls'
 
 import type { ReplayObservationApi } from 'products/replay_vision/frontend/generated/api.schemas'
-import {
-    readErrorMessage,
-    readReasoning,
-    readSummary,
-    readTitle,
-} from 'products/replay_vision/frontend/utils/observation'
+import { readErrorKind, readReasoning, readSummary, readTitle } from 'products/replay_vision/frontend/utils/observation'
 
 import { replayVisionScanWidgetLogic } from './replayVisionScanWidgetLogic'
 
@@ -25,7 +20,25 @@ const SKIP_MESSAGES: Record<string, string> = {
     skipped_quota: "this project's monthly Replay Vision credits are used up",
     skipped_scanner_limit: 'this scanner reached its own credit limit',
     skipped_limit: 'too many scans were already running',
+    no_replay_data: 'no replay data was saved',
     failed: 'the scan could not be started',
+}
+
+// Keyed on the `error_reason` kind, never the message stored beside it: that half is written for us and
+// reads as internal text in a chat bubble. Kinds come from `products/replay_vision/backend/error_kinds.py`.
+const FAILURE_MESSAGES: Record<string, string> = {
+    no_recording: 'No replay data was saved for it.',
+    no_snapshots: 'It has no video to watch yet. Try again in a few minutes.',
+    no_events: 'It has no events recorded against it.',
+    too_short: 'It is too short to watch.',
+    too_long: 'It is too long to watch.',
+    too_inactive: 'It has too little activity to watch.',
+    provider_transient: 'The AI provider was unavailable. Try again.',
+    provider_rejected: 'The AI provider could not process it.',
+    rasterization_failed: 'It could not be rendered for the AI to watch.',
+    validation_failed: 'The scan did not return a usable result.',
+    infra_transient: 'PostHog was at capacity. Try again.',
+    orphaned: 'The scan stopped before it finished. Try again.',
 }
 
 export function ReplayVisionScanWidget({ scanId, sessionIds, skipped }: ReplayVisionScanWidgetProps): JSX.Element {
@@ -90,10 +103,12 @@ function ObservationRow({ observation }: { observation: ReplayObservationApi }):
     }
 
     if (observation.status !== 'succeeded') {
-        const reason = readErrorMessage(observation)
+        const detail = FAILURE_MESSAGES[readErrorKind(observation) ?? '']
         return (
             <div className="px-3 py-2 text-sm">
-                <p className="m-0 text-secondary">Could not watch this recording{reason ? `: ${reason}` : '.'}</p>
+                <p className="m-0 text-secondary">
+                    {['Could not watch this recording.', detail].filter(Boolean).join(' ')}
+                </p>
             </div>
         )
     }

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 from typing import Any, NoReturn, cast
 from uuid import UUID
 
@@ -944,6 +945,7 @@ class BulkObserveResultSerializer(serializers.Serializer):
             ("skipped_limit", "Skipped, in-flight limit reached"),
             ("skipped_quota", "Skipped, the org's credit quota for this period was reached"),
             ("skipped_scanner_limit", "Skipped, scanner's own credit limit reached"),
+            ("no_replay_data", "Skipped, no replay data is stored for this session"),
             ("failed", "Failed to start"),
         ],
         help_text=(
@@ -953,7 +955,8 @@ class BulkObserveResultSerializer(serializers.Serializer):
             "it back, or use the retry action to run it again); 'skipped_limit' - the in-flight cap was "
             "reached before this session; 'skipped_quota' - the org's credit quota for this period would "
             "be exceeded; 'skipped_scanner_limit' - this scanner's own credit limit would be exceeded; "
-            "'failed' - the workflow failed to start."
+            "'no_replay_data' - no recording is stored for this session, so there is nothing to watch and "
+            "nothing was charged; 'failed' - the workflow failed to start."
         ),
     )
 
@@ -1717,6 +1720,18 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         )
         if scan.scanner is None:
             # Nothing started and nothing already existed, so there is no id to read results through.
+            # Still reported: a scan that starts nothing is the outcome worth counting, and leaving it
+            # silent is what made the failure rate unreadable from product analytics.
+            self._report_inline_scan_requested(
+                user=user,
+                scanner=None,
+                scanner_type=scanner_type,
+                model=model,
+                requested=len(session_ids),
+                started=0,
+                results=scan.results,
+                request=request,
+            )
             # Key off the outcomes: the in-flight cap can bind here too, and that is not exhaustion.
             if any(result["scan_outcome"] == "skipped_quota" for result in scan.results):
                 self._report_quota_exhausted(None, "inline")
@@ -1726,17 +1741,14 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
             )
         scanner, started, results = scan.scanner, scan.started, scan.results
 
-        report_user_action(
-            user,
-            "replay_vision_inline_scan_requested",
-            {
-                "scan_id": str(scanner.id),
-                "scanner_type": scanner.scanner_type,
-                "model": scanner.model,
-                "requested": len(session_ids),
-                "started": started,
-            },
-            team=self.team,
+        self._report_inline_scan_requested(
+            user=user,
+            scanner=scanner,
+            scanner_type=scanner_type,
+            model=model,
+            requested=len(session_ids),
+            started=started,
+            results=results,
             request=request,
         )
         if any(result["scan_outcome"] == "skipped_quota" for result in results):
@@ -1744,6 +1756,40 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         return Response(
             InlineScanResponseSerializer({"scan_id": scanner.id, "started": started, "results": results}).data,
             status=status.HTTP_202_ACCEPTED,
+        )
+
+    def _report_inline_scan_requested(
+        self,
+        *,
+        user: User,
+        scanner: ReplayScanner | None,
+        scanner_type: ScannerType,
+        model: str,
+        requested: int,
+        started: int,
+        results: list[dict[str, str]],
+        request: Request,
+    ) -> None:
+        """An inline scan was asked for, and what came of each session in it.
+
+        `scanner` is None when nothing could start and none existed, which is exactly the case worth
+        seeing. `scan_outcomes` carries the per-outcome counts so a query can read one outcome out of
+        the batch, e.g. `properties.scan_outcomes.no_replay_data`.
+        """
+        report_user_action(
+            user,
+            "replay_vision_inline_scan_requested",
+            {
+                "scan_id": str(scanner.id) if scanner is not None else None,
+                "scanner_type": scanner.scanner_type if scanner is not None else scanner_type,
+                "model": scanner.model if scanner is not None else model,
+                "requested": requested,
+                "started": started,
+                "skipped_count": len(results) - started,
+                "scan_outcomes": dict(Counter(result["scan_outcome"] for result in results)),
+            },
+            team=self.team,
+            request=request,
         )
 
     def _report_quota_exhausted(self, scanner: ReplayScanner | None, trigger: str) -> None:

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -1,5 +1,4 @@
 import json
-from collections import Counter
 from typing import Any, NoReturn, cast
 from uuid import UUID
 
@@ -108,7 +107,13 @@ from products.replay_vision.backend.scanner_config import (
     scanner_config_error,
 )
 from products.replay_vision.backend.scanner_draft import DraftError, draft_scanner_from_goal
-from products.replay_vision.backend.scanning import MAX_SESSIONS_PER_SCAN, run_inline_scan, scan_existing_scanner
+from products.replay_vision.backend.scanning import (
+    MAX_SESSIONS_PER_SCAN,
+    InlineScanResult,
+    inline_scan_event_properties,
+    run_inline_scan,
+    scan_existing_scanner,
+)
 from products.replay_vision.backend.session_limits import MAX_SESSION_ID_LENGTH
 from products.replay_vision.backend.tag_suggestions import SuggestionError, suggest_classifier_tags
 from products.replay_vision.backend.temporal.constants import VISION_SIGNALS_SOURCE_PRODUCT, VISION_SIGNALS_SOURCE_TYPE
@@ -1718,20 +1723,17 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
             scanner_config=scanner_config,
             model=model,
         )
+        # Reported before the branch: a scan that starts nothing is the outcome most worth counting.
+        self._report_inline_scan_requested(
+            user=user,
+            scan=scan,
+            scanner_type=scanner_type,
+            model=model,
+            requested=len(session_ids),
+            request=request,
+        )
         if scan.scanner is None:
             # Nothing started and nothing already existed, so there is no id to read results through.
-            # Still reported: a scan that starts nothing is the outcome worth counting, and leaving it
-            # silent is what made the failure rate unreadable from product analytics.
-            self._report_inline_scan_requested(
-                user=user,
-                scanner=None,
-                scanner_type=scanner_type,
-                model=model,
-                requested=len(session_ids),
-                started=0,
-                results=scan.results,
-                request=request,
-            )
             # Key off the outcomes: the in-flight cap can bind here too, and that is not exhaustion.
             if any(result["scan_outcome"] == "skipped_quota" for result in scan.results):
                 self._report_quota_exhausted(None, "inline")
@@ -1741,16 +1743,6 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
             )
         scanner, started, results = scan.scanner, scan.started, scan.results
 
-        self._report_inline_scan_requested(
-            user=user,
-            scanner=scanner,
-            scanner_type=scanner_type,
-            model=model,
-            requested=len(session_ids),
-            started=started,
-            results=results,
-            request=request,
-        )
         if any(result["scan_outcome"] == "skipped_quota" for result in results):
             self._report_quota_exhausted(scanner, "inline")
         return Response(
@@ -1762,32 +1754,19 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         self,
         *,
         user: User,
-        scanner: ReplayScanner | None,
+        scan: InlineScanResult,
         scanner_type: ScannerType,
         model: str,
         requested: int,
-        started: int,
-        results: list[dict[str, str]],
         request: Request,
     ) -> None:
-        """An inline scan was asked for, and what came of each session in it.
-
-        `scanner` is None when nothing could start and none existed, which is exactly the case worth
-        seeing. `scan_outcomes` carries the per-outcome counts so a query can read one outcome out of
-        the batch, e.g. `properties.scan_outcomes.no_replay_data`.
-        """
+        """An inline scan was asked for, and what came of each session in it."""
         report_user_action(
             user,
             "replay_vision_inline_scan_requested",
-            {
-                "scan_id": str(scanner.id) if scanner is not None else None,
-                "scanner_type": scanner.scanner_type if scanner is not None else scanner_type,
-                "model": scanner.model if scanner is not None else model,
-                "requested": requested,
-                "started": started,
-                "skipped_count": len(results) - started,
-                "scan_outcomes": dict(Counter(result["scan_outcome"] for result in results)),
-            },
+            inline_scan_event_properties(
+                scan=scan, scanner_type=scanner_type, model=model, requested=requested, trigger="inline"
+            ),
             team=self.team,
             request=request,
         )

--- a/products/replay_vision/backend/max_tools.py
+++ b/products/replay_vision/backend/max_tools.py
@@ -792,6 +792,10 @@ def _scan_summary(started: int, results: list[dict[str, str]]) -> str:
         )
     if counts.get("skipped_limit"):
         parts.append(f"{counts['skipped_limit']} were skipped: too many scans already running.")
+    if counts.get("no_replay_data"):
+        parts.append(
+            f"{counts['no_replay_data']} were skipped: no replay data is saved for them, so there is nothing to watch."
+        )
     if counts.get("failed"):
         parts.append(f"{counts['failed']} failed to start.")
     if started:
@@ -930,10 +934,14 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
             model=DEFAULT_SCAN_MODEL,
         )
         if scan.scanner is None:
-            return (
-                "Nothing started: this project's monthly Replay Vision credits are used up.",
-                {"error": "quota_exhausted"},
-            )
+            # No scanner was minted, so there is no id to read results through. Key off the outcomes
+            # rather than naming quota: a batch with no watchable recording in it lands here too, and
+            # telling that user their credits ran out sends them to the wrong place.
+            outcomes = {result["scan_outcome"] for result in scan.results}
+            return _scan_summary(scan.started, scan.results), {
+                "error": "no_replay_data" if outcomes == {"no_replay_data"} else "quota_exhausted",
+                "results": scan.results,
+            }
         return _scan_summary(scan.started, scan.results), {"scan_id": str(scan.scanner.id), "results": scan.results}
 
 

--- a/products/replay_vision/backend/max_tools.py
+++ b/products/replay_vision/backend/max_tools.py
@@ -17,6 +17,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.embedding_worker import async_generate_embedding
 from posthog.clickhouse.client.connection import ClickHouseUser
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.event_usage import report_user_action
 from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -59,7 +60,9 @@ from products.replay_vision.backend.scanner_access import (
 from products.replay_vision.backend.scanner_config import scanner_config_error
 from products.replay_vision.backend.scanning import (
     MAX_SESSIONS_PER_SCAN,
+    InlineScanResult,
     RetryOutcome,
+    inline_scan_event_properties,
     retry_observation,
     run_inline_scan,
     scan_existing_scanner,
@@ -909,6 +912,12 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
             if scanner is None:
                 return f"Scanner {scanner_id} not found.", {"error": "not_found"}
             started, results = scan_existing_scanner(scanner=scanner, session_ids=sessions, user=self._user)
+            self._report_scan_requested(
+                InlineScanResult(scanner=scanner, started=started, results=results),
+                scanner_type=scanner.scanner_type,
+                model=scanner.model,
+                requested=len(sessions),
+            )
             if any(result["scan_outcome"] == "skipped_scanner_limit" for result in results):
                 record_scanner_limit_reached("max_tool")
             return _scan_summary(started, results), {"scan_id": str(scanner.id), "results": results}
@@ -933,6 +942,7 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
             scanner_config=config,
             model=DEFAULT_SCAN_MODEL,
         )
+        self._report_scan_requested(scan, scanner_type=resolved_type, model=DEFAULT_SCAN_MODEL, requested=len(sessions))
         if scan.scanner is None:
             # No scanner was minted, so there is no id to read results through. Key off the outcomes
             # rather than naming quota: a batch with no watchable recording in it lands here too, and
@@ -943,6 +953,21 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
                 "results": scan.results,
             }
         return _scan_summary(scan.started, scan.results), {"scan_id": str(scan.scanner.id), "results": scan.results}
+
+    def _report_scan_requested(self, scan: InlineScanResult, *, scanner_type: str, model: str, requested: int) -> None:
+        """The same event the REST endpoint sends, so one query covers scans however they were asked for.
+
+        Without this a scan started from chat records nothing at all, and the chat surface is the one
+        that spends credits on recordings the user never picked by hand.
+        """
+        report_user_action(
+            self._user,
+            "replay_vision_inline_scan_requested",
+            inline_scan_event_properties(
+                scan=scan, scanner_type=scanner_type, model=model, requested=requested, trigger="max_tool"
+            ),
+            team=self._team,
+        )
 
 
 QUOTA_TOOL_DESCRIPTION = """

--- a/products/replay_vision/backend/scanning.py
+++ b/products/replay_vision/backend/scanning.py
@@ -278,14 +278,20 @@ def scan_existing_scanner(
     *, scanner: ReplayScanner, session_ids: list[str], user: User
 ) -> tuple[int, list[dict[str, str]]]:
     """Point a saved scanner at named sessions."""
-    ineligible = sessions_without_replay_data(team=scanner.team, session_ids=session_ids)
+    # Resolve settled sessions first: a terminal observation keeps its answer even after the recording
+    # expires from ClickHouse, so `already_scanned` outranks `no_replay_data`. Only sessions a scan
+    # could still start on are worth a replay-data lookup.
+    finished = finished_sessions(scanner, session_ids)
+    ineligible = sessions_without_replay_data(
+        team=scanner.team, session_ids=[s for s in session_ids if s not in finished]
+    )
     eligible = [session_id for session_id in session_ids if session_id not in ineligible]
     started, results = start_observations(
         scanner=scanner,
         session_ids=eligible,
         user=user,
         headroom=scan_headroom(team=scanner.team, model=scanner.model, scanner=scanner),
-        finished=finished_sessions(scanner, eligible),
+        finished=finished,
     )
     return started, _merge_ineligible(session_ids=session_ids, ineligible=ineligible, eligible_results=results)
 
@@ -310,10 +316,14 @@ def run_inline_scan(
     config_error = scanner_config_error(scanner_type, scanner_config)
     if config_error is not None:
         raise ValueError(config_error)
-    ineligible = sessions_without_replay_data(team=team, session_ids=session_ids)
-    eligible = [session_id for session_id in session_ids if session_id not in ineligible]
     key = inline_scan_key(scanner_type=scanner_type, scanner_config=scanner_config, model=model)
     scanner = find_inline_scanner(team=team, key=key)
+    # Resolve settled sessions first: a terminal observation keeps its answer even after the recording
+    # expires from ClickHouse, so `already_scanned` outranks `no_replay_data`. A scanner that does not
+    # exist yet has settled nothing; only sessions a scan could still start on are worth the lookup.
+    finished: frozenset[str] = finished_sessions(scanner, session_ids) if scanner is not None else frozenset()
+    ineligible = sessions_without_replay_data(team=team, session_ids=[s for s in session_ids if s not in finished])
+    eligible = [session_id for session_id in session_ids if session_id not in ineligible]
     headroom = scan_headroom(team=team, model=model, scanner=scanner)
     if scanner is None:
         # Mint only once something can actually start. Otherwise an org with no headroom, or a batch
@@ -335,10 +345,6 @@ def run_inline_scan(
             scanner_config=scanner_config,
             model=model,
         )
-        # A scanner that did not exist a statement ago has no observations to have settled.
-        finished: frozenset[str] = frozenset()
-    else:
-        finished = finished_sessions(scanner, eligible)
 
     started, results = start_observations(
         scanner=scanner, session_ids=eligible, user=user, headroom=headroom, finished=finished

--- a/products/replay_vision/backend/scanning.py
+++ b/products/replay_vision/backend/scanning.py
@@ -173,6 +173,14 @@ def _merge_ineligible(
     return merged
 
 
+# The outcomes the product calls a "skip": a session we chose not to spend a credit on. Kept in step
+# with the serializer's "Skipped, ..." labels and the chat summary, where `already_scanned`,
+# `already_running`, and `failed` read as their own outcomes, not skips.
+SKIPPED_OUTCOMES: frozenset[str] = frozenset(
+    {"skipped_limit", "skipped_quota", "skipped_scanner_limit", "no_replay_data"}
+)
+
+
 def inline_scan_event_properties(
     *, scan: InlineScanResult, scanner_type: str, model: str, requested: int, trigger: str
 ) -> dict[str, Any]:
@@ -184,6 +192,7 @@ def inline_scan_event_properties(
     `properties.scan_outcomes.no_replay_data`.
     """
     scanner = scan.scanner
+    outcomes = Counter(result["scan_outcome"] for result in scan.results)
     return {
         "scan_id": str(scanner.id) if scanner is not None else None,
         "scanner_type": scanner.scanner_type if scanner is not None else scanner_type,
@@ -191,8 +200,10 @@ def inline_scan_event_properties(
         "trigger": trigger,
         "requested": requested,
         "started": scan.started,
-        "skipped_count": len(scan.results) - scan.started,
-        "scan_outcomes": dict(Counter(result["scan_outcome"] for result in scan.results)),
+        # A cached batch settles as `already_scanned`, not a skip, so count only the skip outcomes
+        # rather than everything that did not start.
+        "skipped_count": sum(count for outcome, count in outcomes.items() if outcome in SKIPPED_OUTCOMES),
+        "scan_outcomes": dict(outcomes),
     }
 
 

--- a/products/replay_vision/backend/scanning.py
+++ b/products/replay_vision/backend/scanning.py
@@ -9,11 +9,14 @@ Nothing here checks consent or access. Callers do that, because the answer diffe
 explains.
 """
 
+from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
 from django.db import IntegrityError, transaction
+
+import structlog
 
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -35,6 +38,8 @@ from products.replay_vision.backend.temporal.constants import (
     MAX_IN_FLIGHT_APPLIES_PER_TEAM,
     build_apply_scanner_workflow_id,
 )
+
+logger = structlog.get_logger(__name__)
 
 # One page of recordings. Above this the in-flight caps bind long before the batch does.
 MAX_SESSIONS_PER_SCAN = 200
@@ -136,10 +141,17 @@ def sessions_without_replay_data(*, team: Team, session_ids: list[str]) -> froze
     A scan on one of these can only fail: `fetch_session_events` reads the metadata back and raises
     `IneligibleSessionError` the moment it finds none. Answering the question here, in one batched
     lookup, keeps such a session from taking a scan slot and a credit on its way to that failure.
+
+    Fails soft: this is an optimization over a check the activity still makes, so a ClickHouse blip
+    should cost a wasted credit rather than block every scan the project asks for.
     """
     if not session_ids:
         return frozenset()
-    found = SessionReplayEvents().batch_exists(session_ids, team)
+    try:
+        found = SessionReplayEvents().batch_exists(session_ids, team)
+    except Exception:
+        logger.exception("replay_vision_eligibility_lookup_failed", team_id=team.id, sessions=len(session_ids))
+        return frozenset()
     return frozenset(session_id for session_id in session_ids if not found.get(session_id, False))
 
 
@@ -148,14 +160,40 @@ def _merge_ineligible(
 ) -> list[dict[str, str]]:
     """Splice the sessions we never tried back into the caller's order.
 
-    `eligible_results` is in the same relative order as the eligible ids, so walking both together
-    restores the batch the caller passed rather than reordering it around the filter.
+    `start_observations` returns one result per session it was given, in order, so walking both
+    together restores the batch the caller passed rather than reordering it around the filter.
     """
     remaining = iter(eligible_results)
-    return [
-        {"session_id": session_id, "scan_outcome": "no_replay_data"} if session_id in ineligible else next(remaining)
-        for session_id in session_ids
-    ]
+    merged: list[dict[str, str]] = []
+    for session_id in session_ids:
+        if session_id in ineligible:
+            merged.append({"session_id": session_id, "scan_outcome": "no_replay_data"})
+        else:
+            merged.append(next(remaining))
+    return merged
+
+
+def inline_scan_event_properties(
+    *, scan: InlineScanResult, scanner_type: str, model: str, requested: int, trigger: str
+) -> dict[str, Any]:
+    """Properties for `replay_vision_inline_scan_requested`, shared by every surface that starts a scan.
+
+    `scan.scanner` is None when nothing could start and none existed, which is exactly the case worth
+    seeing, so the scanner's identity falls back to what was asked for. `scan_outcomes` carries the
+    per-outcome counts so a query can read one outcome out of the batch, e.g.
+    `properties.scan_outcomes.no_replay_data`.
+    """
+    scanner = scan.scanner
+    return {
+        "scan_id": str(scanner.id) if scanner is not None else None,
+        "scanner_type": scanner.scanner_type if scanner is not None else scanner_type,
+        "model": scanner.model if scanner is not None else model,
+        "trigger": trigger,
+        "requested": requested,
+        "started": scan.started,
+        "skipped_count": len(scan.results) - scan.started,
+        "scan_outcomes": dict(Counter(result["scan_outcome"] for result in scan.results)),
+    }
 
 
 def start_observations(

--- a/products/replay_vision/backend/scanning.py
+++ b/products/replay_vision/backend/scanning.py
@@ -17,6 +17,7 @@ from django.db import IntegrityError, transaction
 
 from posthog.models.team import Team
 from posthog.models.user import User
+from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 
 from products.replay_vision.backend.billing import observation_credits_for_model
 from products.replay_vision.backend.enqueue_claims import (
@@ -129,6 +130,34 @@ def finished_sessions(scanner: ReplayScanner, session_ids: list[str]) -> frozens
     )
 
 
+def sessions_without_replay_data(*, team: Team, session_ids: list[str]) -> frozenset[str]:
+    """Sessions in the batch ClickHouse holds no replay for.
+
+    A scan on one of these can only fail: `fetch_session_events` reads the metadata back and raises
+    `IneligibleSessionError` the moment it finds none. Answering the question here, in one batched
+    lookup, keeps such a session from taking a scan slot and a credit on its way to that failure.
+    """
+    if not session_ids:
+        return frozenset()
+    found = SessionReplayEvents().batch_exists(session_ids, team)
+    return frozenset(session_id for session_id in session_ids if not found.get(session_id, False))
+
+
+def _merge_ineligible(
+    *, session_ids: list[str], ineligible: frozenset[str], eligible_results: list[dict[str, str]]
+) -> list[dict[str, str]]:
+    """Splice the sessions we never tried back into the caller's order.
+
+    `eligible_results` is in the same relative order as the eligible ids, so walking both together
+    restores the batch the caller passed rather than reordering it around the filter.
+    """
+    remaining = iter(eligible_results)
+    return [
+        {"session_id": session_id, "scan_outcome": "no_replay_data"} if session_id in ineligible else next(remaining)
+        for session_id in session_ids
+    ]
+
+
 def start_observations(
     *,
     scanner: ReplayScanner,
@@ -200,13 +229,16 @@ def scan_existing_scanner(
     *, scanner: ReplayScanner, session_ids: list[str], user: User
 ) -> tuple[int, list[dict[str, str]]]:
     """Point a saved scanner at named sessions."""
-    return start_observations(
+    ineligible = sessions_without_replay_data(team=scanner.team, session_ids=session_ids)
+    eligible = [session_id for session_id in session_ids if session_id not in ineligible]
+    started, results = start_observations(
         scanner=scanner,
-        session_ids=session_ids,
+        session_ids=eligible,
         user=user,
         headroom=scan_headroom(team=scanner.team, model=scanner.model, scanner=scanner),
-        finished=finished_sessions(scanner, session_ids),
+        finished=finished_sessions(scanner, eligible),
     )
+    return started, _merge_ineligible(session_ids=session_ids, ineligible=ineligible, eligible_results=results)
 
 
 def run_inline_scan(
@@ -229,17 +261,23 @@ def run_inline_scan(
     config_error = scanner_config_error(scanner_type, scanner_config)
     if config_error is not None:
         raise ValueError(config_error)
+    ineligible = sessions_without_replay_data(team=team, session_ids=session_ids)
+    eligible = [session_id for session_id in session_ids if session_id not in ineligible]
     key = inline_scan_key(scanner_type=scanner_type, scanner_config=scanner_config, model=model)
     scanner = find_inline_scanner(team=team, key=key)
     headroom = scan_headroom(team=team, model=model, scanner=scanner)
     if scanner is None:
-        # Mint only once something can actually start, so an org with no headroom doesn't leave a
-        # scanner behind for every question it was unable to answer.
-        if headroom.max_starts <= 0:
+        # Mint only once something can actually start. Otherwise an org with no headroom, or a batch
+        # with nothing watchable in it, leaves a scanner behind for a question it could not answer.
+        if headroom.max_starts <= 0 or not eligible:
             return InlineScanResult(
                 scanner=None,
                 started=0,
-                results=[{"session_id": s, "scan_outcome": headroom.skip_reason} for s in session_ids],
+                results=_merge_ineligible(
+                    session_ids=session_ids,
+                    ineligible=ineligible,
+                    eligible_results=[{"session_id": s, "scan_outcome": headroom.skip_reason} for s in eligible],
+                ),
             )
         scanner = create_inline_scanner(
             team=team,
@@ -251,12 +289,16 @@ def run_inline_scan(
         # A scanner that did not exist a statement ago has no observations to have settled.
         finished: frozenset[str] = frozenset()
     else:
-        finished = finished_sessions(scanner, session_ids)
+        finished = finished_sessions(scanner, eligible)
 
     started, results = start_observations(
-        scanner=scanner, session_ids=session_ids, user=user, headroom=headroom, finished=finished
+        scanner=scanner, session_ids=eligible, user=user, headroom=headroom, finished=finished
     )
-    return InlineScanResult(scanner=scanner, started=started, results=results)
+    return InlineScanResult(
+        scanner=scanner,
+        started=started,
+        results=_merge_ineligible(session_ids=session_ids, ineligible=ineligible, eligible_results=results),
+    )
 
 
 class RetryOutcome(Enum):

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -3534,12 +3534,19 @@ class TestInlineScanAction(_VisionAPITestCase):
         self._finished_observation(scan_id, "sess-1")
         start_workflow.reset_mock()
 
-        resp = self._scan(session_ids=["sess-1", "sess-3"])
+        with patch("products.replay_vision.backend.api.scanners.report_user_action") as report:
+            resp = self._scan(session_ids=["sess-1", "sess-3"])
 
         outcomes = {r["session_id"]: r["scan_outcome"] for r in resp.json()["results"]}
         self.assertEqual(outcomes["sess-1"], "already_scanned")
         self.assertEqual(outcomes["sess-3"], "started")
         self.assertEqual(start_workflow.call_count, 1)
+        # A cached answer is reused at no charge, not skipped, so it stays out of skipped_count.
+        props = next(
+            call.args[2] for call in report.call_args_list if call.args[1] == "replay_vision_inline_scan_requested"
+        )
+        self.assertEqual(props["skipped_count"], 0)
+        self.assertEqual(props["scan_outcomes"], {"already_scanned": 1, "started": 1})
 
     def test_results_are_readable_through_the_scan_id(
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -17,6 +17,7 @@ from posthog.models import Organization, PersonalAPIKey, Team, User
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.utils import generate_random_token_personal, hash_key_value, uuid7
 from posthog.redis import get_client
+from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 
 from products.replay_vision.backend.api.scanners import ReplayScannerSerializer
@@ -65,8 +66,18 @@ class _VisionAPITestCase(APIBaseTest):
         # Scanner saves recompute the volume estimate against ClickHouse; keep CRUD tests off that path.
         self.refresh_estimate_patcher = patch("products.replay_vision.backend.api.scanners.refresh_scanner_estimate")
         self.mock_refresh_estimate = self.refresh_estimate_patcher.start()
+        # Scans now filter out sessions with no replay data before starting. These tests name sessions
+        # that were never ingested, so without this every batch would be ineligible and the behavior each
+        # test is actually about would never run. A test about eligibility overrides this.
+        self.batch_exists_patcher = patch.object(
+            SessionReplayEvents,
+            "batch_exists",
+            side_effect=lambda session_ids, team: dict.fromkeys(session_ids, True),
+        )
+        self.mock_batch_exists = self.batch_exists_patcher.start()
 
     def tearDown(self) -> None:
+        self.batch_exists_patcher.stop()
         self.refresh_estimate_patcher.stop()
         super().tearDown()
 
@@ -3478,6 +3489,39 @@ class TestInlineScanAction(_VisionAPITestCase):
         self.assertEqual([r["scan_outcome"] for r in body["results"]], ["skipped_quota", "skipped_quota"])
         self.assertFalse(ReplayScanner.all_origins.filter(origin=ScannerOrigin.INLINE).exists())
         start_workflow.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("some_watchable", {"sess-1"}, 1, {"started": 1, "no_replay_data": 1}),
+            ("none_watchable", set(), 0, {"no_replay_data": 2}),
+        ]
+    )
+    def test_the_requested_event_reports_what_came_of_each_session(
+        self,
+        mock_sync_connect: MagicMock,
+        mock_async_to_sync: MagicMock,
+        _label: str,
+        watchable: set[str],
+        expected_started: int,
+        expected_outcomes: dict[str, int],
+    ) -> None:
+        # Without the outcome counts a scan that watched nothing is indistinguishable from one that
+        # watched everything, which is why the ineligible rate could not be read at all. The second case
+        # also guards that the event still fires when no scanner was minted.
+        mock_sync_connect.return_value = MagicMock()
+        mock_async_to_sync.return_value = MagicMock()
+        self.mock_batch_exists.side_effect = lambda session_ids, team: {s: s in watchable for s in session_ids}
+
+        with patch("products.replay_vision.backend.api.scanners.report_user_action") as report:
+            self._scan(session_ids=["sess-1", "sess-2"])
+
+        props = next(
+            call.args[2] for call in report.call_args_list if call.args[1] == "replay_vision_inline_scan_requested"
+        )
+        self.assertEqual(props["requested"], 2)
+        self.assertEqual(props["started"], expected_started)
+        self.assertEqual(props["skipped_count"], 2 - expected_started)
+        self.assertEqual(props["scan_outcomes"], expected_outcomes)
 
     def test_a_finished_session_reports_already_scanned_without_starting_a_workflow(
         self, mock_sync_connect: MagicMock, mock_async_to_sync: MagicMock

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -66,9 +66,9 @@ class _VisionAPITestCase(APIBaseTest):
         # Scanner saves recompute the volume estimate against ClickHouse; keep CRUD tests off that path.
         self.refresh_estimate_patcher = patch("products.replay_vision.backend.api.scanners.refresh_scanner_estimate")
         self.mock_refresh_estimate = self.refresh_estimate_patcher.start()
-        # Scans now filter out sessions with no replay data before starting. These tests name sessions
-        # that were never ingested, so without this every batch would be ineligible and the behavior each
-        # test is actually about would never run. A test about eligibility overrides this.
+        # Scans filter out sessions with no replay data before starting. These tests name sessions that
+        # were never ingested, so without this every batch is ineligible and the behavior each test is
+        # about never runs. A test about eligibility overrides this.
         self.batch_exists_patcher = patch.object(
             SessionReplayEvents,
             "batch_exists",
@@ -3506,8 +3506,7 @@ class TestInlineScanAction(_VisionAPITestCase):
         expected_outcomes: dict[str, int],
     ) -> None:
         # Without the outcome counts a scan that watched nothing is indistinguishable from one that
-        # watched everything, which is why the ineligible rate could not be read at all. The second case
-        # also guards that the event still fires when no scanner was minted.
+        # watched everything. The second case guards that the event fires when no scanner was minted.
         mock_sync_connect.return_value = MagicMock()
         mock_async_to_sync.return_value = MagicMock()
         self.mock_batch_exists.side_effect = lambda session_ids, team: {s: s in watchable for s in session_ids}

--- a/products/replay_vision/backend/tests/test_max_tools.py
+++ b/products/replay_vision/backend/tests/test_max_tools.py
@@ -562,10 +562,9 @@ class TestReplayVisionChargeConfirmation(BaseTest):
         assert "AI analysis" in content
 
 
-class _AllSessionsWatchableMixin:
-    """Scans filter out sessions with no replay data before starting. These tests name sessions that
-    were never ingested, so treat every one as present; each test is about what happens after that."""
-
+# Scans filter out sessions with no replay data before starting. These tests name sessions that were
+# never ingested, so treat every one as present; each test is about what happens after that.
+class _WatchableSessionsTestCase(BaseTest):
     def setUp(self) -> None:
         super().setUp()
         self._batch_exists_patcher = patch.object(
@@ -580,7 +579,7 @@ class _AllSessionsWatchableMixin:
         super().tearDown()
 
 
-class TestScanReplayVisionSessionsScannerLimit(_AllSessionsWatchableMixin, BaseTest):
+class TestScanReplayVisionSessionsScannerLimit(_WatchableSessionsTestCase):
     """A capped scanner's skips have to be explained to the user and counted, like bulk_observe does."""
 
     def _tool(self) -> ScanReplayVisionSessionsTool:
@@ -614,6 +613,24 @@ class TestScanReplayVisionSessionsScannerLimit(_AllSessionsWatchableMixin, BaseT
         assert "2 were skipped: this scanner reached its own credit limit." in content
         assert "billing period resets" in content
         record.assert_called_once_with("max_tool")
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_a_scan_started_from_chat_reports_its_outcomes(self):
+        # The chat path emitted no analytics at all, so the surface that spends credits on recordings
+        # the user never picked by hand was the one surface that could not be measured.
+        scanner = await sync_to_async(self._capped_scanner)()
+        with patch("products.replay_vision.backend.max_tools.report_user_action") as report:
+            await self._tool()._arun_impl(session_ids=["s1", "s2"], scanner_id=str(scanner.id))
+
+        props = next(
+            call.args[2] for call in report.call_args_list if call.args[1] == "replay_vision_inline_scan_requested"
+        )
+        assert props["trigger"] == "max_tool"
+        assert props["requested"] == 2
+        assert props["started"] == 0
+        assert props["skipped_count"] == 2
+        assert props["scan_outcomes"] == {"skipped_scanner_limit": 2}
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
@@ -862,7 +879,7 @@ class TestReplayVisionToolAuthorization(BaseTest):
         assert artifact["error"] == "invalid_config"
 
 
-class TestReplayVisionApprovalFlowEndToEnd(_AllSessionsWatchableMixin, BaseTest):
+class TestReplayVisionApprovalFlowEndToEnd(_WatchableSessionsTestCase):
     """Through `_arun_with_context`, the entry point the agent actually calls.
 
     Every other test here calls `_arun_impl` directly, which skips the approval machinery entirely, so

--- a/products/replay_vision/backend/tests/test_max_tools.py
+++ b/products/replay_vision/backend/tests/test_max_tools.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnableConfig
 from parameterized import parameterized
 
 from posthog.models.team import Team
+from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 
 import products.replay_vision.backend.max_tools as max_tools_module
 from products.access_control.backend.facade.user_access_control import UserAccessControl
@@ -561,7 +562,25 @@ class TestReplayVisionChargeConfirmation(BaseTest):
         assert "AI analysis" in content
 
 
-class TestScanReplayVisionSessionsScannerLimit(BaseTest):
+class _AllSessionsWatchableMixin:
+    """Scans filter out sessions with no replay data before starting. These tests name sessions that
+    were never ingested, so treat every one as present; each test is about what happens after that."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._batch_exists_patcher = patch.object(
+            SessionReplayEvents,
+            "batch_exists",
+            side_effect=lambda session_ids, team: dict.fromkeys(session_ids, True),
+        )
+        self._batch_exists_patcher.start()
+
+    def tearDown(self) -> None:
+        self._batch_exists_patcher.stop()
+        super().tearDown()
+
+
+class TestScanReplayVisionSessionsScannerLimit(_AllSessionsWatchableMixin, BaseTest):
     """A capped scanner's skips have to be explained to the user and counted, like bulk_observe does."""
 
     def _tool(self) -> ScanReplayVisionSessionsTool:
@@ -843,7 +862,7 @@ class TestReplayVisionToolAuthorization(BaseTest):
         assert artifact["error"] == "invalid_config"
 
 
-class TestReplayVisionApprovalFlowEndToEnd(BaseTest):
+class TestReplayVisionApprovalFlowEndToEnd(_AllSessionsWatchableMixin, BaseTest):
     """Through `_arun_with_context`, the entry point the agent actually calls.
 
     Every other test here calls `_arun_impl` directly, which skips the approval machinery entirely, so

--- a/products/replay_vision/backend/tests/test_scanning.py
+++ b/products/replay_vision/backend/tests/test_scanning.py
@@ -52,8 +52,6 @@ class TestInlineScanServiceBounds(BaseTest):
 
 
 class TestScanEligibility(BaseTest):
-    """A session with no replay data can only fail, so no scan may start on one."""
-
     def _with_replay_data(self, present: set[str]):
         return patch.object(
             SessionReplayEvents,

--- a/products/replay_vision/backend/tests/test_scanning.py
+++ b/products/replay_vision/backend/tests/test_scanning.py
@@ -4,11 +4,15 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.utils import timezone
+
 from parameterized import parameterized
 
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 
 from products.replay_vision.backend.api.trigger import WorkflowStartOutcome
+from products.replay_vision.backend.inline_scan import create_inline_scanner, inline_scan_key
+from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
 from products.replay_vision.backend.scanning import MAX_SESSIONS_PER_SCAN, run_inline_scan, scan_existing_scanner
 
@@ -69,6 +73,28 @@ class TestScanEligibility(BaseTest):
             model=ScannerModel.GEMINI_3_7_FLASH,
         )
 
+    def _existing_scanner(self, entry_point: str) -> ReplayScanner:
+        # Match `_start_inline`'s config so `run_inline_scan` resolves to this scanner via its inline key.
+        config = {"prompt": "did the user check out?"}
+        if entry_point == "inline":
+            key = inline_scan_key(
+                scanner_type=ScannerType.MONITOR, scanner_config=config, model=ScannerModel.GEMINI_3_7_FLASH
+            )
+            return create_inline_scanner(
+                team=self.team,
+                key=key,
+                scanner_type=ScannerType.MONITOR,
+                scanner_config=config,
+                model=ScannerModel.GEMINI_3_7_FLASH,
+            )
+        return ReplayScanner.objects.create(
+            team=self.team,
+            name="my-scanner",
+            scanner_type=ScannerType.MONITOR,
+            scanner_config=config,
+            model=ScannerModel.GEMINI_3_7_FLASH,
+        )
+
     @parameterized.expand(["inline", "saved"])
     @pytest.mark.django_db
     def test_a_session_with_no_replay_data_never_starts_a_workflow(self, entry_point: str):
@@ -94,6 +120,38 @@ class TestScanEligibility(BaseTest):
         # Order matters: the caller reads outcomes back positionally against the batch it sent.
         assert [r["session_id"] for r in results] == ["watchable", "gone"]
         assert results[1]["scan_outcome"] == "no_replay_data"
+        assert [call.args[1] for call in mock_start.call_args_list] == ["watchable"]
+
+    @parameterized.expand(["inline", "saved"])
+    @pytest.mark.django_db
+    def test_a_settled_session_reports_already_scanned_even_after_its_recording_expires(self, entry_point: str):
+        # A recording drops out of ClickHouse at retention while its terminal observation lives on in
+        # Postgres. The answer is still readable, so the session must keep reporting `already_scanned`
+        # rather than being relabeled `no_replay_data`, and no fresh workflow may start for it.
+        scanner = self._existing_scanner(entry_point)
+        ReplayObservation.objects.create(
+            team=self.team,
+            scanner=scanner,
+            session_id="settled",
+            status=ObservationStatus.SUCCEEDED,
+            completed_at=timezone.now(),
+        )
+        with (
+            self._with_replay_data({"watchable"}),
+            patch("products.replay_vision.backend.api.trigger.start_apply_scanner_workflow") as mock_start,
+        ):
+            mock_start.return_value = (None, WorkflowStartOutcome.STARTED)
+            if entry_point == "inline":
+                results = self._start_inline(["settled", "watchable"]).results
+            else:
+                _, results = scan_existing_scanner(
+                    scanner=scanner, session_ids=["settled", "watchable"], user=self.user
+                )
+
+        outcomes = {r["session_id"]: r["scan_outcome"] for r in results}
+        assert outcomes["settled"] == "already_scanned"
+        assert outcomes["watchable"] == "started"
+        # Only the watchable session reaches the workflow starter; the settled one is served from Postgres.
         assert [call.args[1] for call in mock_start.call_args_list] == ["watchable"]
 
     @pytest.mark.django_db

--- a/products/replay_vision/backend/tests/test_scanning.py
+++ b/products/replay_vision/backend/tests/test_scanning.py
@@ -2,9 +2,15 @@ from typing import Any
 
 import pytest
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
+from parameterized import parameterized
+
+from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
+
+from products.replay_vision.backend.api.trigger import WorkflowStartOutcome
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
-from products.replay_vision.backend.scanning import MAX_SESSIONS_PER_SCAN, run_inline_scan
+from products.replay_vision.backend.scanning import MAX_SESSIONS_PER_SCAN, run_inline_scan, scan_existing_scanner
 
 
 class TestInlineScanServiceBounds(BaseTest):
@@ -42,4 +48,64 @@ class TestInlineScanServiceBounds(BaseTest):
                 scanner_config=self._config(),
                 model=ScannerModel.GEMINI_3_7_FLASH,
             )
+        assert not ReplayScanner.all_origins.filter(team=self.team).exists()
+
+
+class TestScanEligibility(BaseTest):
+    """A session with no replay data can only fail, so no scan may start on one."""
+
+    def _with_replay_data(self, present: set[str]):
+        return patch.object(
+            SessionReplayEvents,
+            "batch_exists",
+            side_effect=lambda session_ids, team: {s: s in present for s in session_ids},
+        )
+
+    def _start_inline(self, session_ids: list[str]):
+        return run_inline_scan(
+            team=self.team,
+            user=self.user,
+            session_ids=session_ids,
+            scanner_type=ScannerType.MONITOR,
+            scanner_config={"prompt": "did the user check out?"},
+            model=ScannerModel.GEMINI_3_7_FLASH,
+        )
+
+    @parameterized.expand(["inline", "saved"])
+    @pytest.mark.django_db
+    def test_a_session_with_no_replay_data_never_starts_a_workflow(self, entry_point: str):
+        # The whole point of the pre-flight check: without it the workflow starts, spends a credit, and
+        # only then finds there is nothing to watch.
+        with (
+            self._with_replay_data({"watchable"}),
+            patch("products.replay_vision.backend.api.trigger.start_apply_scanner_workflow") as mock_start,
+        ):
+            mock_start.return_value = (None, WorkflowStartOutcome.STARTED)
+            if entry_point == "inline":
+                results = self._start_inline(["watchable", "gone"]).results
+            else:
+                scanner = ReplayScanner.objects.create(
+                    team=self.team,
+                    name="my-scanner",
+                    scanner_type=ScannerType.MONITOR,
+                    scanner_config={"prompt": "did the user check out?"},
+                    model=ScannerModel.GEMINI_3_7_FLASH,
+                )
+                _, results = scan_existing_scanner(scanner=scanner, session_ids=["watchable", "gone"], user=self.user)
+
+        # Order matters: the caller reads outcomes back positionally against the batch it sent.
+        assert [r["session_id"] for r in results] == ["watchable", "gone"]
+        assert results[1]["scan_outcome"] == "no_replay_data"
+        assert [call.args[1] for call in mock_start.call_args_list] == ["watchable"]
+
+    @pytest.mark.django_db
+    def test_a_batch_with_nothing_watchable_leaves_no_scanner_behind(self):
+        # Same rule the used-up-quota path already follows: don't mint a scanner for a question that
+        # could never be answered, or every such ask leaves a row behind.
+        with self._with_replay_data(set()):
+            scan = self._start_inline(["gone-1", "gone-2"])
+
+        assert scan.scanner is None
+        assert scan.started == 0
+        assert {r["scan_outcome"] for r in scan.results} == {"no_replay_data"}
         assert not ReplayScanner.all_origins.filter(team=self.team).exists()

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -1085,6 +1085,7 @@ export interface BulkObserveRequestApi {
  * * `skipped_limit` - Skipped, in-flight limit reached
  * * `skipped_quota` - Skipped, the org's credit quota for this period was reached
  * * `skipped_scanner_limit` - Skipped, scanner's own credit limit reached
+ * * `no_replay_data` - Skipped, no replay data is stored for this session
  * * `failed` - Failed to start
  */
 export type ScanOutcomeEnumApi = (typeof ScanOutcomeEnumApi)[keyof typeof ScanOutcomeEnumApi]
@@ -1096,6 +1097,7 @@ export const ScanOutcomeEnumApi = {
     SkippedLimit: 'skipped_limit',
     SkippedQuota: 'skipped_quota',
     SkippedScannerLimit: 'skipped_scanner_limit',
+    NoReplayData: 'no_replay_data',
     Failed: 'failed',
 } as const
 
@@ -1105,7 +1107,7 @@ export const ScanOutcomeEnumApi = {
 export interface BulkObserveResultApi {
     /** The session recording this outcome is for. */
     session_id: string
-    /** 'started' - a scan workflow was kicked off; 'already_running' - a scan for this session is already in flight (no-op, not recharged); 'already_scanned' - this scanner already has a finished observation for this session, so nothing was started and nothing was charged (read it back, or use the retry action to run it again); 'skipped_limit' - the in-flight cap was reached before this session; 'skipped_quota' - the org's credit quota for this period would be exceeded; 'skipped_scanner_limit' - this scanner's own credit limit would be exceeded; 'failed' - the workflow failed to start.
+    /** 'started' - a scan workflow was kicked off; 'already_running' - a scan for this session is already in flight (no-op, not recharged); 'already_scanned' - this scanner already has a finished observation for this session, so nothing was started and nothing was charged (read it back, or use the retry action to run it again); 'skipped_limit' - the in-flight cap was reached before this session; 'skipped_quota' - the org's credit quota for this period would be exceeded; 'skipped_scanner_limit' - this scanner's own credit limit would be exceeded; 'no_replay_data' - no recording is stored for this session, so there is nothing to watch and nothing was charged; 'failed' - the workflow failed to start.
      *
      * * `started` - Started
      * * `already_running` - Already running
@@ -1113,6 +1115,7 @@ export interface BulkObserveResultApi {
      * * `skipped_limit` - Skipped, in-flight limit reached
      * * `skipped_quota` - Skipped, the org's credit quota for this period was reached
      * * `skipped_scanner_limit` - Skipped, scanner's own credit limit reached
+     * * `no_replay_data` - Skipped, no replay data is stored for this session
      * * `failed` - Failed to start */
     scan_outcome: ScanOutcomeEnumApi
 }

--- a/products/replay_vision/frontend/replay_scanners/scannerRunTabLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerRunTabLogic.ts
@@ -29,13 +29,14 @@ export interface RowObservation {
 
 export const IN_PROGRESS_STATUSES = new Set<string>(['pending', 'running'])
 
-type BulkSkipOutcome = 'skipped_limit' | 'skipped_quota' | 'skipped_scanner_limit'
+type BulkSkipOutcome = 'skipped_limit' | 'skipped_quota' | 'skipped_scanner_limit' | 'no_replay_data'
 
 const BULK_SKIP_MESSAGES: Record<BulkSkipOutcome, string> = {
     skipped_limit: 'No scans started. Too many scans are already running. Wait for some to finish, then try again.',
     skipped_quota:
         "No scans started. Your organization's Replay vision credit limit for this billing period is used up.",
     skipped_scanner_limit: 'No scans started. This scanner reached its credit limit for this billing period.',
+    no_replay_data: 'No scans started. No replay data is saved for these recordings, so there is nothing to watch.',
 }
 
 // Headroom per visible session for the observations a retry stacks on top of the original scan.
@@ -236,6 +237,7 @@ export const scannerRunTabLogic = kea<scannerRunTabLogicType>([
                         skipped_limit: 0,
                         skipped_quota: 0,
                         skipped_scanner_limit: 0,
+                        no_replay_data: 0,
                     }
                     for (const r of results) {
                         if (r.scan_outcome && r.scan_outcome in skipCounts) {
@@ -244,9 +246,12 @@ export const scannerRunTabLogic = kea<scannerRunTabLogicType>([
                     }
                     const limited =
                         skipCounts.skipped_limit + skipCounts.skipped_quota + skipCounts.skipped_scanner_limit
+                    // Kept apart from the limits: nothing was spent and raising a limit would not help.
+                    const unwatchable = skipCounts.no_replay_data
                     const failed = results.filter((r) => r.scan_outcome === 'failed').length
                     const extras = [
                         limited ? `${limited} skipped (limit reached)` : null,
+                        unwatchable ? `${unwatchable} skipped (no recording)` : null,
                         failed ? `${failed} failed to start` : null,
                     ]
                         .filter(Boolean)
@@ -261,6 +266,8 @@ export const scannerRunTabLogic = kea<scannerRunTabLogicType>([
                             ['skipped_scanner_limit', 'skipped_quota', 'skipped_limit'] as BulkSkipOutcome[]
                         ).reduce((a, b) => (skipCounts[b] > skipCounts[a] ? b : a))
                         lemonToast.warning(BULK_SKIP_MESSAGES[dominant])
+                    } else if (unwatchable > 0) {
+                        lemonToast.warning(BULK_SKIP_MESSAGES.no_replay_data)
                     } else {
                         lemonToast.error('No scans started. Please try again.')
                     }

--- a/products/replay_vision/frontend/utils/observation.test.ts
+++ b/products/replay_vision/frontend/utils/observation.test.ts
@@ -1,5 +1,5 @@
 import type { ReplayObservationApi } from '../generated/api.schemas'
-import { ObservationSeekbarMark, observationClipboardText, observationSeekbarMarks, readErrorKind } from './observation'
+import { ObservationSeekbarMark, observationClipboardText, observationSeekbarMarks } from './observation'
 
 const summarizerEntry = { scannerName: 'Session summarizer', headline: null, snippet: 'Rage clicked pay' }
 const longSentence = 'x'.repeat(200)
@@ -148,22 +148,6 @@ describe('observation utils', () => {
             },
         ])('$name', ({ observations, expected }) => {
             expect(observationSeekbarMarks(observations)).toEqual(expected)
-        })
-    })
-
-    describe('readErrorKind', () => {
-        const withReason = (error_reason: string | null): ReplayObservationApi =>
-            ({ error_reason }) as unknown as ReplayObservationApi
-
-        // Reads back the kind, never the message: surfaces key their own user copy on the kind, so a
-        // revert to returning the message half would leak internal text into a chat bubble again.
-        it.each([
-            ['no_recording:No replay metadata found', 'no_recording'],
-            ['too_short:the recording is under five seconds long', 'too_short'],
-            ['internal_error', 'internal_error'],
-            [null, null],
-        ])('reads the kind from %p', (reason, expected) => {
-            expect(readErrorKind(withReason(reason))).toBe(expected)
         })
     })
 })

--- a/products/replay_vision/frontend/utils/observation.test.ts
+++ b/products/replay_vision/frontend/utils/observation.test.ts
@@ -1,5 +1,5 @@
 import type { ReplayObservationApi } from '../generated/api.schemas'
-import { ObservationSeekbarMark, observationClipboardText, observationSeekbarMarks } from './observation'
+import { ObservationSeekbarMark, observationClipboardText, observationSeekbarMarks, readErrorKind } from './observation'
 
 const summarizerEntry = { scannerName: 'Session summarizer', headline: null, snippet: 'Rage clicked pay' }
 const longSentence = 'x'.repeat(200)
@@ -148,6 +148,22 @@ describe('observation utils', () => {
             },
         ])('$name', ({ observations, expected }) => {
             expect(observationSeekbarMarks(observations)).toEqual(expected)
+        })
+    })
+
+    describe('readErrorKind', () => {
+        const withReason = (error_reason: string | null): ReplayObservationApi =>
+            ({ error_reason }) as unknown as ReplayObservationApi
+
+        // Reads back the kind, never the message: surfaces key their own user copy on the kind, so a
+        // revert to returning the message half would leak internal text into a chat bubble again.
+        it.each([
+            ['no_recording:No replay metadata found', 'no_recording'],
+            ['too_short:the recording is under five seconds long', 'too_short'],
+            ['internal_error', 'internal_error'],
+            [null, null],
+        ])('reads the kind from %p', (reason, expected) => {
+            expect(readErrorKind(withReason(reason))).toBe(expected)
         })
     })
 })

--- a/products/replay_vision/frontend/utils/observation.ts
+++ b/products/replay_vision/frontend/utils/observation.ts
@@ -47,13 +47,14 @@ export function readSummary(obs: ReplayObservationApi): string | null {
     return typeof raw === 'string' && raw ? raw : null
 }
 
-/** `error_reason` is stored as `kind:message`; the message is the half worth showing a person. */
-export function readErrorMessage(obs: ReplayObservationApi): string | null {
+/** `error_reason` is stored as `kind:message`. The message half is written for us, not for a reader,
+ *  so surfaces key their own copy on the kind. See `products/replay_vision/backend/error_kinds.py`. */
+export function readErrorKind(obs: ReplayObservationApi): string | null {
     if (!obs.error_reason) {
         return null
     }
     const separator = obs.error_reason.indexOf(':')
-    return separator === -1 ? obs.error_reason : obs.error_reason.slice(separator + 1)
+    return separator === -1 ? obs.error_reason : obs.error_reason.slice(0, separator)
 }
 
 function readStringArray(value: unknown): string[] {

--- a/products/replay_vision/frontend/utils/observation.ts
+++ b/products/replay_vision/frontend/utils/observation.ts
@@ -47,16 +47,6 @@ export function readSummary(obs: ReplayObservationApi): string | null {
     return typeof raw === 'string' && raw ? raw : null
 }
 
-/** `error_reason` is stored as `kind:message`. The message half is written for us, not for a reader,
- *  so surfaces key their own copy on the kind. See `products/replay_vision/backend/error_kinds.py`. */
-export function readErrorKind(obs: ReplayObservationApi): string | null {
-    if (!obs.error_reason) {
-        return null
-    }
-    const separator = obs.error_reason.indexOf(':')
-    return separator === -1 ? obs.error_reason : obs.error_reason.slice(0, separator)
-}
-
 function readStringArray(value: unknown): string[] {
     if (!Array.isArray(value)) {
         return []

--- a/products/replay_vision/mcp/apps/InlineScanView.tsx
+++ b/products/replay_vision/mcp/apps/InlineScanView.tsx
@@ -22,6 +22,7 @@ const outcomeLabel: Record<string, string> = {
     skipped_limit: 'Skipped, too many running',
     skipped_quota: 'Skipped, out of credits',
     skipped_scanner_limit: 'Skipped, scanner limit',
+    no_replay_data: 'Skipped, no recording',
     failed: 'Failed to start',
 }
 
@@ -32,6 +33,7 @@ const outcomeVariant: Record<string, 'success' | 'destructive' | 'warning' | 'de
     skipped_limit: 'warning',
     skipped_quota: 'warning',
     skipped_scanner_limit: 'warning',
+    no_replay_data: 'warning',
     failed: 'destructive',
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14445,6 +14445,7 @@ export namespace Schemas {
      * * `skipped_limit` - Skipped, in-flight limit reached
      * * `skipped_quota` - Skipped, the org's credit quota for this period was reached
      * * `skipped_scanner_limit` - Skipped, scanner's own credit limit reached
+     * * `no_replay_data` - Skipped, no replay data is stored for this session
      * * `failed` - Failed to start
      */
     export type ScanOutcomeEnum = typeof ScanOutcomeEnum[keyof typeof ScanOutcomeEnum];
@@ -14457,6 +14458,7 @@ export namespace Schemas {
       SkippedLimit: 'skipped_limit',
       SkippedQuota: 'skipped_quota',
       SkippedScannerLimit: 'skipped_scanner_limit',
+      NoReplayData: 'no_replay_data',
       Failed: 'failed',
     } as const;
 
@@ -14466,7 +14468,7 @@ export namespace Schemas {
     export interface BulkObserveResult {
       /** The session recording this outcome is for. */
       session_id: string;
-      /** 'started' - a scan workflow was kicked off; 'already_running' - a scan for this session is already in flight (no-op, not recharged); 'already_scanned' - this scanner already has a finished observation for this session, so nothing was started and nothing was charged (read it back, or use the retry action to run it again); 'skipped_limit' - the in-flight cap was reached before this session; 'skipped_quota' - the org's credit quota for this period would be exceeded; 'skipped_scanner_limit' - this scanner's own credit limit would be exceeded; 'failed' - the workflow failed to start.
+      /** 'started' - a scan workflow was kicked off; 'already_running' - a scan for this session is already in flight (no-op, not recharged); 'already_scanned' - this scanner already has a finished observation for this session, so nothing was started and nothing was charged (read it back, or use the retry action to run it again); 'skipped_limit' - the in-flight cap was reached before this session; 'skipped_quota' - the org's credit quota for this period would be exceeded; 'skipped_scanner_limit' - this scanner's own credit limit would be exceeded; 'no_replay_data' - no recording is stored for this session, so there is nothing to watch and nothing was charged; 'failed' - the workflow failed to start.
        *
        * * `started` - Started
        * * `already_running` - Already running
@@ -14474,6 +14476,7 @@ export namespace Schemas {
        * * `skipped_limit` - Skipped, in-flight limit reached
        * * `skipped_quota` - Skipped, the org's credit quota for this period was reached
        * * `skipped_scanner_limit` - Skipped, scanner's own credit limit reached
+       * * `no_replay_data` - Skipped, no replay data is stored for this session
        * * `failed` - Failed to start */
       scan_outcome: ScanOutcomeEnum;
     }


### PR DESCRIPTION
## Problem

A user who asks Max to watch session recordings gets broken rows back when any of the named sessions has no replay stored. The scan started anyway, spent a paid credit, and only failed deep in the Temporal activity. The chat bubble then showed the internal string "Could not watch this recording: No replay metadata found".

- `ScanReplayVisionSessionsTool` started a scan on whatever session ids the model supplied, checking only count, dedupe, and consent.
- Eligibility was tested per session inside `fetch_session_events`, which raises `IneligibleSessionError("No replay metadata found")` when the recording is missing.
- The inline-scan event `replay_vision_inline_scan_requested` recorded no outcome, so the failure rate could not be read from product analytics at all.

This came from inbox report [01a019d3](https://us.posthog.com/project/2/inbox/01a019d3-4191-70b9-ae0d-44a98af1a14d). The report's second finding (a player-inspector crash) is left to open PR [#80165](https://github.com/PostHog/posthog/pull/80165) and is not touched here.

## Changes

- A user who names a mix of watchable and unwatchable recordings now sees the watchable ones scan and a plain banner line for the rest: "N recordings were not scanned because no replay data was saved." No credit is spent on the skipped ones.
- A recording that fails for any reason now reads as product copy ("No recording was found for this session.") instead of leaking the internal message. The bubble reuses the existing `failureKindDescription` / `ineligibleKindDescription` helpers, so it cannot drift from the rest of Replay Vision.
- The pre-flight filter lives in `scanning.py`, so both callers get it: the Max chat tool and the REST `inline_scan` / `bulk_observe` endpoints. It calls `SessionReplayEvents.batch_exists` once, before headroom, and marks missing sessions `no_replay_data`.
- The filter runs before a scanner is minted, so a batch with nothing watchable leaves no scanner behind, matching the existing used-up-quota rule.
- `replay_vision_inline_scan_requested` now carries `skipped_count`, a `scan_outcomes` count map, and a `trigger`, and fires even when no scanner was minted. `properties.scan_outcomes.no_replay_data` is now queryable.
- Scans started from Max chat now emit that event at all. They previously emitted nothing, so the surface that spends credits on recordings a user never picked by hand was the one surface that could not be measured. `trigger` separates it from the REST path.
- The replay lookup fails soft. It is an optimization over a check the Temporal activity still makes, so a ClickHouse error costs a wasted credit rather than blocking every scan a project asks for.
- Mechanical: the `scan_outcome` serializer enum, generated API types, the scanner-run-tab toast copy, and the MCP `InlineScanView` badge gain the new `no_replay_data` value.

No screenshot: Storybook was not built in this session. The change is text-only within the existing widget layout; the exact strings are quoted above, and `ReplayVisionScanWidget.stories.tsx` gains a `no_replay_data` case.

## How did you test this code?

- `test_scanning.py`: a session with no replay data comes back `no_replay_data` and never reaches `start_observations`, across both `run_inline_scan` and `scan_existing_scanner`; an all-ineligible inline scan mints no scanner. No existing test covered eligibility.
- `test_api.py`: the `replay_vision_inline_scan_requested` event carries the outcome counts and `skipped_count`, including the no-scanner path. No existing test asserted the event's properties.
- `test_max_tools.py`: a scan started from chat reports its outcome counts under `trigger: max_tool`. No existing test asserted the chat path emits anything, because it did not.
- The scan-path tests in `test_api.py` and `test_max_tools.py` name sessions that were never ingested; they now default `batch_exists` to "present" so each keeps testing its own behavior.
- Ran the affected backend files and the frontend tests locally; repo-wide mypy and frontend typecheck pass. Not run: the full backend suite (long-running Temporal and ClickHouse tests), left to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs cover this internal behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (PostHog Desktop). The work started from re-verifying inbox report 01a019d3 against master: all four code claims still held, the player crash was still firing, and no PR covered this finding.
- Skills invoked: `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/code-review`.
- The filter was placed in `scanning.py` rather than the Max tool so the REST endpoints get it too, and before the headroom check so an ineligible session never consumes a scan slot. A residual race stays possible (a session can pass `batch_exists` and lose its recording before the activity runs); the existing `fetch_session_events` guard remains the backstop, now with readable copy.
- A two-axis review pass (standards and spec) ran over the diff before review was requested. It replaced a hand-written 12-entry copy map with the product's existing description helpers, caught that the chat path emitted no analytics at all, and caught that the new lookup could turn a ClickHouse error into a failed scan. The first two commits show that before and after.
- Known gap left alone: the `observe` and retry endpoints can still send an ineligible session to Temporal. Those sit outside the report's scope, so the "no credit on an unwatchable recording" property is not yet global.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
