### PR TITLE
perf(ci): skip non-required checks in merge queue

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -31,7 +31,8 @@ jobs:
         # the skills build it would only pay for to fail at the push.
         if: |
             github.repository_owner == 'PostHog' &&
-            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+            !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine if sandbox image needs to be built
         permissions:
             contents: read

--- a/.github/workflows/ci-agent-proxy.yml
+++ b/.github/workflows/ci-agent-proxy.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
     changes:
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run agent-proxy checks

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -19,6 +19,8 @@ jobs:
         permissions:
             contents: read
             pull-requests: read
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run skill checks

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -34,7 +34,8 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: github.event_name == 'pull_request'
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run hobby checks
         outputs:
             should_run: ${{ steps.filter.outputs.hobby == 'true' || steps.check-label.outputs.has_label == 'true' }}

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -20,6 +20,8 @@ jobs:
     # Job to decide if we should run backend ci
     # See .github/actions/paths-filter/README.md for filter semantics
     changes:
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run Hog checks

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
     changes:
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run UI Apps checks

--- a/.github/workflows/ci-ml-mirror-image-scrub-container.yml
+++ b/.github/workflows/ci-ml-mirror-image-scrub-container.yml
@@ -18,7 +18,8 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog'
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: github.repository_owner == 'PostHog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run ml-mirror-image-scrub Docker build
         outputs:
             scrub_files: ${{ steps.filter.outputs.scrub_files }}

--- a/.github/workflows/ci-oauth-proxy.yml
+++ b/.github/workflows/ci-oauth-proxy.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
     changes:
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run oauth-proxy checks

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -17,7 +17,8 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog'
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: github.repository == 'PostHog/posthog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run proto checks
         outputs:
             proto: ${{ steps.filter.outputs.proto || 'true' }}

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -39,7 +39,8 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository_owner == 'PostHog'
+        # The merge queue only waits on the required checks, and this workflow gates none.
+        if: github.repository_owner == 'PostHog' && !startsWith(github.head_ref, 'trunk-merge/')
         name: Determine need to run recording-rasterizer Docker build
         outputs:
             rasterizer_files: ${{ steps.filter.outputs.rasterizer_files }}


### PR DESCRIPTION
## Problem

- The `posthog-paths-filter` App token bucket peaks at 9,804 of 15,000 requests/hr.
- Every merge-queue batch runs 10 workflows that gate none of the 14 required checks, and each spends a paths-filter API call to decide it has nothing to do.

## Changes

- Those 10 workflows now skip their `changes` job on `trunk-merge/**` branches. Downstream jobs read `needs.changes.outputs.*`, so they skip with it.
- `ci-nodejs-container` already carried this guard and is untouched.
- Trade: breakage in these areas now surfaces on master push rather than inside the batch.

## How did you test this code?

- Verified every one of the 14 required checks is emitted by a workflow outside this set.
- `bin/hogli lint:workflows` passes all 8 checks, including `WF007-required-check-gates`. `ci:preflight` reports 0 failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Required-check mapping verified against branch ruleset `6958621`.
- The guard is merged into each job's existing `if:` rather than added as a second key, since a repeated `if:` is a YAML error.
- Nothing here draws on non-public material.
