### PR TITLE
feat(tasks): export ExecutionResult from the sandbox facade

### DIFF
--- a/products/tasks/backend/facade/sandbox.py
+++ b/products/tasks/backend/facade/sandbox.py
@@ -16,6 +16,7 @@ from products.tasks.backend.exceptions import (
     SandboxTimeoutError,
 )
 from products.tasks.backend.logic.services.sandbox import (
+    ExecutionResult,
     SandboxBase,
     SandboxClass,
     SandboxConfig,
@@ -28,6 +29,7 @@ from products.tasks.backend.logic.services.sandbox import (
 )
 
 __all__ = [
+    "ExecutionResult",
     "SandboxBase",
     "SandboxCleanupError",
     "SandboxClass",


### PR DESCRIPTION
## Problem

- Autoresearch's sandbox inference layer fakes sandbox executions in its tests with `ExecutionResult`, and the tasks facade does not export it.
- Importing it from `products.tasks.backend.logic.services.sandbox` instead breaks the facade contract that tach enforces.
- #86283 carries the same two lines, but its other changes are still under review, so the export blocks every wave C layer of the autoresearch stack (#88742, context in #88464).

## Changes

- `ExecutionResult` joins the exports of `products.tasks.backend.facade.sandbox`. Mechanical: a re-export, nothing user-visible changes.

## How did you test this code?

- `uv run tach check --dependencies --interfaces` and `uv run lint-imports` pass with the autoresearch sandbox layer importing the name from the facade.
- No new test: the autoresearch stack's tests are the consumer.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Peeled out of #86283 while cutting the autoresearch wave C stack, so the stack does not wait on that PR's review.
- Skills invoked: /phs autoresearch, /stacking-prs, /writing-pr-descriptions.
