### PR TITLE
fix(insights): show full previous period for weekly/monthly compare

### DIFF
--- a/posthog/hogql_queries/utils/query_previous_period_date_range.py
+++ b/posthog/hogql_queries/utils/query_previous_period_date_range.py
@@ -1,11 +1,23 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
+from dateutil.relativedelta import relativedelta
+
 from posthog.schema import DateRange, IntervalType
 
 from posthog.hogql_queries.utils.query_date_range import DateRangeBounds, QueryDateRange
 from posthog.models.team import Team
 from posthog.utils import get_compare_period_dates, relative_date_parse_with_delta_mapping
+
+# Calendar-anchored ranges that run to now ("This week/month/quarter/year"). Their previous period
+# is the full prior calendar unit, so the length is a calendar delta rather than a fixed span of
+# days — months, quarters and years vary in length, so sizing by elapsed days can't express them.
+_FULL_PREVIOUS_CALENDAR_UNITS = {
+    "wStart": {"weeks": 1},
+    "mStart": {"months": 1},
+    "qStart": {"months": 3},
+    "yStart": {"years": 1},
+}
 
 
 # Originally similar to posthog/queries/query_date_range.py but rewritten to be used in HogQL queries
@@ -58,9 +70,31 @@ class QueryPreviousPeriodDateRange(QueryDateRange):
             return delta_mapping
         return None
 
+    def full_previous_calendar_period(self, current_period_date_from: datetime) -> Optional[DateRangeBounds]:
+        """The full prior calendar unit for a "This week/month/quarter/year" range that runs to now.
+
+        A partial current period (e.g. this month so far) is then charted against the complete
+        previous one, matching how hour/minute day-anchored ranges already behave. The end is the
+        moment before the current period starts and the start is one calendar unit before that, so
+        months, quarters and years come back whole regardless of their varying lengths.
+        """
+        if not self._date_range or self._date_range.date_to:
+            return None
+        unit = _FULL_PREVIOUS_CALENDAR_UNITS.get(self._date_range.date_from) if self._date_range.date_from else None
+        if unit is None:
+            return None
+        return DateRangeBounds(
+            date_from=current_period_date_from - relativedelta(**unit),  # type: ignore[arg-type]
+            date_to=current_period_date_from - timedelta(microseconds=1),
+        )
+
     def dates(self) -> DateRangeBounds:
         current_period_date_from = super().date_from()
         current_period_date_to = super().date_to()
+
+        full_previous = self.full_previous_calendar_period(current_period_date_from)
+        if full_previous is not None:
+            return full_previous
 
         if self._date_range and self._date_range.date_from == "all":
             # "All time" starts at the earliest event, whose time of day is arbitrary, while

--- a/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py
@@ -84,6 +84,37 @@ class TestQueryPreviousPeriodDateRange(APIBaseTest):
         self.assertEqual(query_date_range.date_from(), parser.isoparse(expected_from))
         self.assertEqual(query_date_range.date_to(), parser.isoparse(expected_to))
 
+    @parameterized.expand(
+        [
+            # "This week/month/quarter/year" run to now, so the current period is partial. The previous
+            # period is the full prior calendar unit (weekday/day-of-month aligned, complete), matching
+            # how day-anchored hour/minute ranges already behave — not the trailing slice of it.
+            ("this_week", "2021-08-25T12:34:00Z", "wStart", "2021-08-15T00:00:00Z", "2021-08-21T23:59:59.999999Z"),
+            ("this_month", "2021-08-25T12:34:00Z", "mStart", "2021-07-01T00:00:00Z", "2021-07-31T23:59:59.999999Z"),
+            # A shorter previous month must still come back whole: diff-in-days sizing can't express this.
+            (
+                "this_month_february",
+                "2021-03-15T12:34:00Z",
+                "mStart",
+                "2021-02-01T00:00:00Z",
+                "2021-02-28T23:59:59.999999Z",
+            ),
+            ("this_quarter", "2021-08-25T12:34:00Z", "qStart", "2021-04-01T00:00:00Z", "2021-06-30T23:59:59.999999Z"),
+            ("this_year", "2021-08-25T12:34:00Z", "yStart", "2020-01-01T00:00:00Z", "2020-12-31T23:59:59.999999Z"),
+        ]
+    )
+    def test_previous_period_for_calendar_anchored_range_is_full_prior_unit(
+        self, _name: str, now: str, date_from: str, expected_from: str, expected_to: str
+    ):
+        query_date_range = QueryPreviousPeriodDateRange(
+            team=self.team,
+            date_range=DateRange(date_from=date_from),
+            interval=IntervalType.DAY,
+            now=parser.isoparse(now),
+        )
+        self.assertEqual(query_date_range.date_from(), parser.isoparse(expected_from))
+        self.assertEqual(query_date_range.date_to(), parser.isoparse(expected_to))
+
     def test_explicit_timezone_info_overrides_team_timezone(self):
         # The previous-period delta parsing used to read directly from
         # `self._team.timezone_info`, so a `timezone_info=UTC` override on the constructor


### PR DESCRIPTION
## Problem

Someone charting "This week" or "This month" with compare-to-previous on saw the previous line compared against the wrong days. On Wednesday, "This week" (Mon–Wed so far) was compared against Fri–Sun of last week, not the full previous week. The previous period was sized to the elapsed span and shifted back, so it landed on a trailing, weekday-misaligned slice.

This is the calendar-range counterpart of the hour/minute fix in #88428, which made "Today" show the full previous day. Day and coarser calendar ranges kept the old trailing-slice behavior.

## Changes

- "This week/month/quarter/year" with compare-to-previous now charts against the **complete** previous calendar unit — full previous week, month, quarter, or year — weekday and day-of-month aligned. The current period keeps its shorter, in-progress tail.
- The previous period is computed as one calendar unit before the current period's start (`relativedelta`), instead of shifting back by the elapsed span in days. A span of days cannot represent a full previous month/quarter/year, whose lengths vary — e.g. "This month" in March now returns all of February, not January 29 – February 28.
- Backend-only. Rolling ranges (`-7d`, `-24h`) and explicit date ranges are untouched: the new path only fires for `wStart`/`mStart`/`qStart`/`yStart` with no explicit end. The frontend needs no change — the axis extension added in #88428 already fits a previous series longer than the current one, for any interval.

## How did you test this code?

`posthog/hogql_queries/utils/test/test_query_previous_period_date_range.py` — added a parameterized case asserting the four calendar units resolve to the full prior unit, including "This month" in March resolving to a full February (the case a day-span shift gets wrong). The existing `-7d`/`-24h`/`dStart` cases in the same file stand as the assertion that non-calendar ranges are unchanged.

Not run: repo-wide `mypy` (OOM-prone in this sandbox, as in #88428). The one new `# type: ignore[arg-type]` matches the existing `relativedelta(**...)` pattern in `query_date_range.py`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #88428, which a reviewer asked whether the same behavior should extend to "This week" and "This month". Investigation confirmed those ranges did not have the visual halving bug (equal bucket counts), but did compare against a trailing, misaligned slice rather than the full previous period. The chosen design computes the prior calendar unit directly rather than extending the shared `get_compare_period_dates` diff-shift, which cannot express variable-length months. The full-previous vs same-days-last-period semantic was a product decision confirmed before implementing.

Tools: Claude Code (Opus 4.8). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
