### PR TITLE
fix(desktop): skip renderer recovery during shutdown

### DIFF
--- a/products/desktop/apps/code/src/main/index.ts
+++ b/products/desktop/apps/code/src/main/index.ts
@@ -171,6 +171,9 @@ const RECOVERABLE_RENDER_REASONS = new Set([
 const CRASH_LOOP_WINDOW_MS = 30_000;
 const CRASH_LOOP_THRESHOLD = 3;
 const recentCrashTimestamps: number[] = [];
+// Electron reports renderers torn down during quit as "killed", which is also
+// a recoverable reason, so recovery has to be gated on shutdown state instead.
+let shutdownStarted = false;
 
 function isCrashLoop(): boolean {
   const now = Date.now();
@@ -212,6 +215,13 @@ app.on("render-process-gone", (_event, webContents, details) => {
     },
   );
   posthogNodeAnalytics.flush().catch(() => {});
+
+  if (shutdownStarted) {
+    log.info("Skipping renderer recovery during shutdown", {
+      reason: details.reason,
+    });
+    return;
+  }
 
   if (RECOVERABLE_RENDER_REASONS.has(details.reason)) {
     if (isCrashLoop()) {
@@ -468,6 +478,7 @@ const teardownContainer = async (): Promise<void> => {
 };
 
 app.on("before-quit", async (event) => {
+  shutdownStarted = true;
   try {
     container.get<WorkspaceServerService>(WORKSPACE_SERVER_SERVICE).stop();
   } catch {}
@@ -499,6 +510,7 @@ app.on("before-quit", async (event) => {
 
 const handleShutdownSignal = async (signal: string) => {
   log.info(`Received ${signal}, starting shutdown`);
+  shutdownStarted = true;
   try {
     const lifecycleService = container.get<AppLifecycleService>(
       APP_LIFECYCLE_SERVICE,


### PR DESCRIPTION
## Problem

Desktop users see the main window reload while the app quits or restarts. The renderer is torn down during shutdown, Electron reports it as `killed`, and the crash recovery path reloads the window.

#88826 tried to fix this by dropping `killed` from the recoverable reasons. That PR was auto-closed, and the approach has a gap: `killed` is also what Electron reports when the OS or the user kills the renderer outside shutdown (Linux OOM killer, Task Manager "end task"). Those cases still need recovery.

## Changes

- The main window no longer reloads during quit, restart, or a shutdown signal.
- Renderers killed outside shutdown still recover as before, including the crash loop guard.
- Shutdown-time renderer exits still log and report telemetry before recovery is skipped.
- Mechanism: a `shutdownStarted` flag is set in the `before-quit` handler and the SIGTERM/SIGINT/SIGHUP handler, and `render-process-gone` skips recovery when it is set.
- No UI changed, so there are no screenshots.

## How did you test this code?

- `pnpm turbo run typecheck --filter=@posthog/code` and Biome on the changed file.
- Not run: a manual quit/restart on a packaged build. The shutdown path is only reachable in the running Electron app, so this is unchecked here.
- No new tests: the gate lives in the `app` event wiring in `main/index.ts`, which has no unit test harness.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Crash recovery behavior is not a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code reviewed #88826 at the user's request, then respun the fix on a new branch. Skills invoked: `/posthog-desktop`, `/writing-code-comments`, `/writing-pr-descriptions`.

The one design decision: gate recovery on shutdown state rather than on the `killed` reason, so external kills outside shutdown keep recovering. Nothing from the session outside this repository is in the diff or this description.
