### PR TITLE
chore(ci): probe runner cpu on playwright jobs

### DIFF
--- a/.github/actions/runner-cpu-probe/action.yml
+++ b/.github/actions/runner-cpu-probe/action.yml
@@ -1,0 +1,77 @@
+name: Runner CPU probe
+description: >
+    Records the runner's CPU identity and a fixed-work benchmark, so a job's wall
+    clock can be attributed to the machine it landed on rather than to the code.
+    Emits one PROBE_RESULT JSON line for log scraping. Never fails the caller.
+
+inputs:
+    seconds:
+        description: Seconds per openssl speed pass. Two passes run (1 thread, then nproc).
+        required: false
+        default: '2'
+    small_files:
+        description: How many small files the disk probe writes and hashes.
+        required: false
+        default: '3000'
+
+runs:
+    using: composite
+    steps:
+        - name: Probe runner CPU and disk
+          id: probe
+          shell: bash
+          env:
+              PROBE_SECONDS: ${{ inputs.seconds }}
+              PROBE_SMALL_FILES: ${{ inputs.small_files }}
+          run: |
+              # Diagnostics only. Every failure path must still exit 0 — this runs inside
+              # the Playwright job, where a broken probe would red every PR.
+              probe() {
+                  lscpu || true
+
+                  local model vendor family stepping hypervisor mhz bogomips cores mem_gb
+                  model=$(lscpu | sed -n 's/^Model name: *//p' | head -1)
+                  vendor=$(lscpu | sed -n 's/^Vendor ID: *//p' | head -1)
+                  family=$(lscpu | sed -n 's/^CPU family: *//p' | head -1)
+                  stepping=$(lscpu | sed -n 's/^Stepping: *//p' | head -1)
+                  hypervisor=$(lscpu | sed -n 's/^Hypervisor vendor: *//p' | head -1)
+                  mhz=$(lscpu | sed -n 's/^CPU max MHz: *//p' | head -1)
+                  bogomips=$(lscpu | sed -n 's/^BogoMIPS: *//p' | head -1)
+                  cores=$(nproc)
+                  mem_gb=$(awk '/MemTotal/ {printf "%.1f", $2/1048576}' /proc/meminfo)
+
+                  # openssl speed does fixed-time work and reports throughput, so a slower
+                  # core reads as a lower number rather than a longer step. The last column
+                  # is the 16384-byte block rate.
+                  local k1 kn
+                  k1=$(openssl speed -seconds "$PROBE_SECONDS" -evp sha256 2>/dev/null \
+                       | tail -1 | awk '{gsub(/k/,"",$NF); print $NF}')
+                  kn=$(openssl speed -seconds "$PROBE_SECONDS" -multi "$cores" -evp sha256 2>/dev/null \
+                       | tail -1 | awk '{gsub(/k/,"",$NF); print $NF}')
+
+                  # Sequential write to separate disk throughput from CPU. direct IO is not
+                  # available on every runner filesystem, so fall back to a flushed write.
+                  local dd_out dd_mbps
+                  dd_out=$(dd if=/dev/zero of=probe.bin bs=1M count=1024 oflag=direct 2>&1 | tail -1) \
+                      || dd_out=$(dd if=/dev/zero of=probe.bin bs=1M count=1024 conv=fdatasync 2>&1 | tail -1)
+                  dd_mbps=$(grep -oE '[0-9.]+ (MB|GB)/s' <<<"$dd_out" | head -1)
+                  rm -f probe.bin
+
+                  # Mirrors what collectstatic does: write many small files, then hash each.
+                  # Pure CPU and disk, no network.
+                  local small_secs
+                  small_secs=$(python3 "$GITHUB_ACTION_PATH/small_files.py")
+
+                  local payload
+                  payload=$(RUNNER_MODEL="$model" RUNNER_VENDOR="$vendor" RUNNER_FAMILY="$family" \
+                            RUNNER_STEPPING="$stepping" RUNNER_HYPERVISOR="$hypervisor" \
+                            RUNNER_MHZ="$mhz" RUNNER_BOGOMIPS="$bogomips" RUNNER_CORES="$cores" \
+                            RUNNER_MEM_GB="$mem_gb" SHA256_1T="$k1" SHA256_NT="$kn" \
+                            DD_WRITE="$dd_mbps" SMALL_SECS="$small_secs" \
+                            python3 "$GITHUB_ACTION_PATH/emit.py")
+
+                  echo "PROBE_RESULT $payload"
+              }
+
+              probe || echo "runner-cpu-probe: probe failed, continuing"
+              exit 0

--- a/.github/actions/runner-cpu-probe/action.yml
+++ b/.github/actions/runner-cpu-probe/action.yml
@@ -8,7 +8,7 @@ inputs:
     seconds:
         description: Seconds per openssl speed pass. Two passes run (1 thread, then nproc).
         required: false
-        default: '2'
+        default: '1'
     small_files:
         description: How many small files the disk probe writes and hashes.
         required: false
@@ -41,12 +41,13 @@ runs:
                   mem_gb=$(awk '/MemTotal/ {printf "%.1f", $2/1048576}' /proc/meminfo)
 
                   # openssl speed does fixed-time work and reports throughput, so a slower
-                  # core reads as a lower number rather than a longer step. The last column
-                  # is the 16384-byte block rate.
+                  # core reads as a lower number rather than a longer step. -seconds applies
+                  # per block size and the default sweep is six of them, so -bytes pins one
+                  # and keeps this step to a couple of seconds.
                   local k1 kn
-                  k1=$(openssl speed -seconds "$PROBE_SECONDS" -evp sha256 2>/dev/null \
+                  k1=$(openssl speed -seconds "$PROBE_SECONDS" -bytes 16384 -evp sha256 2>/dev/null \
                        | tail -1 | awk '{gsub(/k/,"",$NF); print $NF}')
-                  kn=$(openssl speed -seconds "$PROBE_SECONDS" -multi "$cores" -evp sha256 2>/dev/null \
+                  kn=$(openssl speed -seconds "$PROBE_SECONDS" -bytes 16384 -multi "$cores" -evp sha256 2>/dev/null \
                        | tail -1 | awk '{gsub(/k/,"",$NF); print $NF}')
 
                   # Sequential write to separate disk throughput from CPU. direct IO is not

--- a/.github/actions/runner-cpu-probe/emit.py
+++ b/.github/actions/runner-cpu-probe/emit.py
@@ -1,0 +1,26 @@
+"""Serialize the probe readings as one JSON line for log scraping."""
+
+import os
+import json
+
+FIELDS = {
+    "runner_name": "RUNNER_NAME",
+    "cpu_model": "RUNNER_MODEL",
+    "cpu_vendor": "RUNNER_VENDOR",
+    "cpu_family": "RUNNER_FAMILY",
+    "cpu_stepping": "RUNNER_STEPPING",
+    "hypervisor": "RUNNER_HYPERVISOR",
+    "cpu_max_mhz": "RUNNER_MHZ",
+    "bogomips": "RUNNER_BOGOMIPS",
+    "cores": "RUNNER_CORES",
+    "mem_gb": "RUNNER_MEM_GB",
+    "sha256_1t_kbps": "SHA256_1T",
+    "sha256_nt_kbps": "SHA256_NT",
+    "dd_write": "DD_WRITE",
+    "small_files_secs": "SMALL_SECS",
+    "run_id": "GITHUB_RUN_ID",
+    "attempt": "GITHUB_RUN_ATTEMPT",
+    "job": "GITHUB_JOB",
+}
+
+print(json.dumps({key: os.environ.get(source, "") for key, source in FIELDS.items()}))

--- a/.github/actions/runner-cpu-probe/small_files.py
+++ b/.github/actions/runner-cpu-probe/small_files.py
@@ -1,0 +1,23 @@
+"""Time a collectstatic-shaped workload: write many small files, then hash each one."""
+
+import os
+import time
+import shutil
+import hashlib
+import pathlib
+
+count = int(os.environ.get("PROBE_SMALL_FILES", "3000"))
+directory = pathlib.Path("probe_small_files")
+shutil.rmtree(directory, ignore_errors=True)
+directory.mkdir()
+
+blob = b"x" * 4096
+started = time.perf_counter()
+for index in range(count):
+    path = directory / f"f{index}"
+    path.write_bytes(blob)
+    hashlib.sha256(path.read_bytes()).hexdigest()
+elapsed = time.perf_counter() - started
+
+shutil.rmtree(directory, ignore_errors=True)
+print(f"{elapsed:.3f}")

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -549,6 +549,13 @@ jobs:
                       exit 1
                   }
 
+            # Runs before any container starts, so the reading describes the bare machine.
+            # Pairs the hardware with this run's own step timings, which is what separates
+            # "the machine was slower" from "the job did more work".
+            - name: Probe runner CPU
+              uses: ./.github/actions/runner-cpu-probe
+              continue-on-error: true
+
             - name: Clean up data directories with container permissions
               run: |
                   # Use docker to clean up files created by containers

--- a/.github/workflows/ci-runner-cpu-probe.yml
+++ b/.github/workflows/ci-runner-cpu-probe.yml
@@ -7,11 +7,17 @@
 # benchmark. If the label is homogeneous the scores cluster; if it is not, they
 # separate by CPU model.
 #
-# Dispatch only — it must never spend a PR workflow-run dispatch.
+# The pull_request arm is scoped to this probe's own files, so it fires only on a PR
+# that edits the probe and never spends a dispatch on ordinary PRs. It is not a
+# required check, so gating it on trigger paths cannot leave a PR unmergeable.
 #
 name: Runner CPU probe
 
 on:
+    pull_request:
+        paths:
+            - '.github/actions/runner-cpu-probe/**'
+            - '.github/workflows/ci-runner-cpu-probe.yml'
     workflow_dispatch:
         inputs:
             samples:
@@ -59,7 +65,8 @@ jobs:
     probe:
         name: Probe runner ${{ matrix.sample }}
         needs: plan
-        runs-on: ${{ inputs.runner_label }}
+        # inputs.* is empty on the pull_request arm, so the label needs a literal fallback.
+        runs-on: ${{ inputs.runner_label || 'depot-ubuntu-24.04-8' }}
         timeout-minutes: 10
         strategy:
             fail-fast: false

--- a/.github/workflows/ci-runner-cpu-probe.yml
+++ b/.github/workflows/ci-runner-cpu-probe.yml
@@ -1,0 +1,75 @@
+#
+# Samples the CPU behind a Depot runner label.
+#
+# Playwright E2E jobs split into two duration modes on one label, and the split
+# tracks neither the code nor our own CI load. This fans out N throwaway jobs so
+# each lands on a fresh VM, and records what hardware answered plus a fixed-work
+# benchmark. If the label is homogeneous the scores cluster; if it is not, they
+# separate by CPU model.
+#
+# Dispatch only — it must never spend a PR workflow-run dispatch.
+#
+name: Runner CPU probe
+
+on:
+    workflow_dispatch:
+        inputs:
+            samples:
+                description: How many runners to sample (1-30).
+                required: false
+                type: string
+                default: '12'
+            runner_label:
+                description: Runner label to sample.
+                required: false
+                type: choice
+                default: depot-ubuntu-24.04-8
+                options:
+                    - depot-ubuntu-24.04-8
+                    - depot-ubuntu-24.04-4
+                    - depot-ubuntu-24.04
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+    contents: read
+
+jobs:
+    plan:
+        name: Build sample matrix
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        outputs:
+            samples: ${{ steps.build.outputs.samples }}
+        steps:
+            - name: Build sample list
+              id: build
+              env:
+                  SAMPLES: ${{ inputs.samples }}
+              run: |
+                  n=${SAMPLES:-12}
+                  if ! [[ "$n" =~ ^[0-9]+$ ]] || [ "$n" -lt 1 ] || [ "$n" -gt 30 ]; then
+                      echo "::error::samples must be an integer between 1 and 30 (got '$SAMPLES')"
+                      exit 1
+                  fi
+                  echo "samples=$(jq -nc --argjson n "$n" '[range(1; $n + 1)]')" >> "$GITHUB_OUTPUT"
+
+    probe:
+        name: Probe runner ${{ matrix.sample }}
+        needs: plan
+        runs-on: ${{ inputs.runner_label }}
+        timeout-minutes: 10
+        strategy:
+            fail-fast: false
+            matrix:
+                sample: ${{ fromJSON(needs.plan.outputs.samples) }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/runner-cpu-probe
+                  sparse-checkout-cone-mode: false
+            - uses: ./.github/actions/runner-cpu-probe
+              with:
+                  seconds: '3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,6 +385,9 @@ select = [
 # are necessarily lazy / post-path-insert (PLC0415, E402); the planner's small CLI
 # prints its report (T201).
 "rust/deltalite/python/**" = ["PLC0415", "E402", "T201"]
+# The runner probe's helpers are invoked by a shell step that reads their stdout, so
+# printing is the interface (T201).
+".github/actions/runner-cpu-probe/*.py" = ["T201"]
 # Django settings aggregator: star imports are how settings modules merge into one namespace.
 # Not portable to explicit re-exports without losing the settings-loading semantics.
 "posthog/settings/**" = ["F403", "F405"]


### PR DESCRIPTION
## Problem

Engineers wait about 5 extra minutes for Playwright on roughly a third of runs, and nobody could say why. The same job takes 16 minutes or 22 minutes on the same commit, on the same `depot-ubuntu-24.04-8` label.

The work is provably identical across both modes. Over 46 master runs on 2026-08-25:

- Every run reported `138 passed, 3 skipped`, zero retries.
- Every run's collectstatic reported `7010 static files copied, 18891 post-processed`.
- Slow runs consumed 342 CPU-seconds against 253 for the fast ones, at the same CPU utilization.

Depot's telemetry exposes CPU and memory but not the instance type, and its disk fields are null. So the cause could only be inferred, never read.

## Changes

- A new probe step records what CPU answered each Playwright job, so a slow run gets attributed to its machine instead of guessed at. It runs before any container starts, which separates "the machine was slower" from "the job did more work".
- The probe reads `lscpu`, then runs three fixed-work benchmarks: single-thread and all-core `openssl speed sha256`, a direct-IO `dd` write, and a small-file write-and-hash loop shaped like collectstatic.
- Results print as one `PROBE_RESULT` JSON line per run for log scraping. No telemetry endpoint, no secrets.
- `Runner CPU probe` fans out N throwaway jobs to sample the fleet without booting the stack. Its `pull_request` arm is scoped to the probe's own files, so ordinary PRs never dispatch it.
- The step is `continue-on-error`, and the composite exits 0 on every internal failure path. A broken probe cannot red a PR.
- Mechanical: a ruff per-file ignore for `T201`, because the two helpers are shell-invoked and their stdout is the interface.

Cost started at 28 seconds in [run 32903094860](https://github.com/PostHog/posthog/actions/runs/32903094860). `openssl speed -seconds` applies per block size and sweeps six of them, so the two passes spent 24 of those seconds. Pinning `-bytes 16384` cut the step to a 10 second median across 12 runners in [run 32969471101](https://github.com/PostHog/posthog/actions/runs/32969471101).

### First result

One `depot-ubuntu-24.04-8` label answered with three different CPUs, in two performance tiers ([run 32902400607](https://github.com/PostHog/posthog/actions/runs/32902400607), 12 runners, all 8 cores and ~30.7 GB):

| CPU model | n | sha256 1-thread | collectstatic-shaped probe | dd write |
| --- | --- | --- | --- | --- |
| AMD EPYC 9R14 | 2 | 1,796,555 KB/s | 0.086s | 325 MB/s |
| Intel Xeon 6975P-C | 6 | 1,860,049 KB/s | 0.081s | 312 MB/s |
| AMD EPYC 9R45 | 4 | 2,153,649 KB/s | 0.057s | 331 MB/s |

The probe splits 1.44x between tiers. Collectstatic splits 1.63x in the wild. Disk throughput is flat, so this is CPU, not I/O.

A dispatched Playwright run then landed on a slow-tier CPU and behaved like one: Xeon 6975P-C, `small_files 0.081s`, collectstatic 227s against a 131s fast-tier baseline.

A second fleet sample three hours later returned 12 Xeon 6975P-C and no 9R45, against 6, 4 and 2 across three models in the first. The mix a job draws from moves, which is the mechanism a bimodal duration needs. Two samples cannot establish when it moves.

Memory also varies inside one CPU model: the same Xeon 6975P-C reports 30.8 GB on some runners and 61.8 GB on others. Unexplained, and not chased.

Nothing user-visible changes. This adds CI diagnostics only.

## How did you test this code?

- The probe ran on 12 Depot runners in [run 32902400607](https://github.com/PostHog/posthog/actions/runs/32902400607) and produced the table above. That run is the test.
- `bin/hogli lint:workflows` passes all 8 checks across 129 workflows.
- `actionlint` reports 0 findings on `ci-runner-cpu-probe.yml`, and 21 on `ci-e2e-playwright.yml` against 22 for the same file on master, so this adds none.
- `hogli ci:preflight --strict` passed on push.
- The probe ran inside the real Playwright job in [run 32903094860](https://github.com/PostHog/posthog/actions/runs/32903094860), dispatched with `workflow_dispatch` because drafts skip the job. It reported Intel Xeon 6975P-C, `small_files 0.081s`, on a run whose collectstatic took 227s.
- Not measured: the pairing rests on that single run. The correlation across many runs needs this on master, where every push samples one runner.
- No tests added. The probe asserts nothing and gates nothing, so a test would only restate the shell.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, driven by a question about why Playwright runs got slower.

The session first attributed the slowdown to Depot hardware on weak evidence: the cohort split was circular, bucketing runs by duration and then reporting that their steps were longer. Two rounds of pushback replaced it. The split now keys on `Collect static files`, a step that finishes about six minutes before Playwright starts, and the endogenous explanations got tested rather than assumed. Our docker stack was ruled out because the gap is already present before any container starts. Retries and test-count drift were ruled out from the JUnit artifacts.

That history is why this PR exists. The conclusion had rested on inference, and this measures the hardware directly.

Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`, `/writing-code-comments`.
