### PR TITLE
fix(desktop): report main app drops back to the loading screen

### DIFF
--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -39,6 +39,7 @@ import {
   rememberStartupLocation,
   resolveStartupLocation,
 } from "@posthog/ui/shell/startupLocation";
+import { useAppLoadingGateTelemetry } from "@posthog/ui/shell/useAppLoadingGateTelemetry";
 import { useAppVisibilityWatchdog } from "@posthog/ui/shell/useAppVisibilityWatchdog";
 import { RouterProvider } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
@@ -182,6 +183,16 @@ function App({ devToolbar }: AppProps) {
   // Mirrors the "main" branch of renderContent() below; keep the two in sync.
   const showingMainApp = readyForMainApp && initialRouteLoaded;
   useAppVisibilityWatchdog(mainRef, showingMainApp);
+  useAppLoadingGateTelemetry(showingMainApp, {
+    isBootstrapped,
+    isCheckingAccess,
+    readyForMainApp,
+    initialRouteLoaded,
+    authStatus: authState.status,
+    desktopAccessStatus: desktopAccess.status,
+    desktopAccessIsCurrent,
+    consentStatus: consent.status,
+  });
 
   // Single gate for every state where the whole app is still loading.
   if (

--- a/products/desktop/packages/ui/src/shell/useAppLoadingGateTelemetry.test.ts
+++ b/products/desktop/packages/ui/src/shell/useAppLoadingGateTelemetry.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/shell/analytics", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/shell/logger", () => ({
+  logger: {
+    scope: () => ({
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+import { captureException } from "@posthog/ui/shell/analytics";
+import {
+  type AppLoadingGateState,
+  useAppLoadingGateTelemetry,
+} from "./useAppLoadingGateTelemetry";
+
+const baseState: AppLoadingGateState = {
+  isBootstrapped: true,
+  isCheckingAccess: false,
+  readyForMainApp: true,
+  initialRouteLoaded: true,
+  authStatus: "authenticated",
+  desktopAccessStatus: "allowed",
+  desktopAccessIsCurrent: true,
+  consentStatus: "resolved",
+};
+
+describe("useAppLoadingGateTelemetry", () => {
+  beforeEach(() => {
+    vi.mocked(captureException).mockClear();
+  });
+
+  it("reports only when the main app drops back to the loading screen", () => {
+    const { rerender } = renderHook(
+      ({ showing, state }) => useAppLoadingGateTelemetry(showing, state),
+      { initialProps: { showing: false, state: baseState } },
+    );
+    expect(captureException).not.toHaveBeenCalled();
+
+    rerender({ showing: true, state: baseState });
+    rerender({
+      showing: true,
+      state: { ...baseState, consentStatus: "loading" },
+    });
+    expect(captureException).not.toHaveBeenCalled();
+
+    const hidden = {
+      ...baseState,
+      isCheckingAccess: true,
+      desktopAccessStatus: "checking",
+    };
+    rerender({ showing: false, state: hidden });
+    rerender({
+      showing: false,
+      state: { ...hidden, consentStatus: "loading" },
+    });
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        isCheckingAccess: true,
+        desktopAccessStatus: "checking",
+        source: "app-loading-gate",
+      }),
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/shell/useAppLoadingGateTelemetry.ts
+++ b/products/desktop/packages/ui/src/shell/useAppLoadingGateTelemetry.ts
@@ -1,0 +1,45 @@
+import { captureException } from "@posthog/ui/shell/analytics";
+import { logger } from "@posthog/ui/shell/logger";
+import { useEffect, useRef } from "react";
+
+const log = logger.scope("app-loading-gate");
+
+export interface AppLoadingGateState {
+  isBootstrapped: boolean;
+  isCheckingAccess: boolean;
+  readyForMainApp: boolean;
+  initialRouteLoaded: boolean;
+  authStatus: string;
+  desktopAccessStatus: string;
+  desktopAccessIsCurrent: boolean;
+  consentStatus: string;
+}
+
+// Reports the main app dropping back to the full-window loading screen after
+// it was already showing, with the gate inputs that caused it. Users see this
+// as a brief logo flash, and the inputs are the only way to tell which one
+// flipped.
+export function useAppLoadingGateTelemetry(
+  showingMainApp: boolean,
+  state: AppLoadingGateState,
+): void {
+  const wasShowingMainApp = useRef(false);
+  // Read through a ref so the effect fires on the transition only, not on
+  // every input change while the app stays hidden.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  useEffect(() => {
+    if (showingMainApp) {
+      wasShowingMainApp.current = true;
+      return;
+    }
+    if (!wasShowingMainApp.current) return;
+    wasShowingMainApp.current = false;
+    const detail = { ...stateRef.current, route: window.location.hash };
+    log.warn("Main app returned to loading screen", detail);
+    captureException(new Error("Main app returned to loading screen"), {
+      ...detail,
+      source: "app-loading-gate",
+    });
+  }, [showingMainApp]);
+}


### PR DESCRIPTION
## Problem

Desktop users report a brief full-window PostHog logo flash while switching between task tabs, then the task screen returns. That screen is the app-level loading gate in `App.tsx`, which only shows when one of its inputs flips: bootstrap state, the desktop access check, the consent query, or the initial route load.

The flash does not reproduce on a dev build. About 40 tab switches over the tab strip, the activity list, and the keyboard shortcuts never mounted the loading screen (checked with a DOM observer over CDP). Static reading rules out tab switching itself: tabs are router navigations in one renderer, and the access check only re-runs on login or an explicit project or org switch. Without the flipping input, there is nothing to fix yet.

## Changes

- Nothing changes on screen.
- When the main app was showing and drops back to the loading screen, the app now logs a warning and sends an exception to error tracking with every gate input: bootstrap, access check, consent status, initial route, auth status, and the route.
- A `useAppLoadingGateTelemetry` hook next to `useAppVisibilityWatchdog` holds the logic; `App.tsx` only passes the inputs.
- The exception fires once per drop, not on each input change while the app stays hidden.

## How did you test this code?

- New test `useAppLoadingGateTelemetry.test.ts` catches the hook firing on initial mount or on input churn instead of on the visible-to-hidden transition only.
- `pnpm turbo run typecheck --filter=@posthog/ui`, Biome on the changed files.
- Not reproduced: the flash itself, on the dev build over CDP with agent-browser. Users see it on the packaged app.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code traced the logo screen to the `App.tsx` loading gate, tried to reproduce the tab switch flash on the running dev app with agent-browser over CDP, and could not. The user asked for the telemetry so the next report names the flipping input. Skills invoked: `/posthog-desktop`, `test-electron-app`, `/writing-code-comments`, `/writing-pr-descriptions`.

Related: #88835 (skip renderer recovery during shutdown) covers a different reload path and does not affect this flash.
