### PR TITLE
fix(ingestion): respond to each /ingest batch when it completes

### DIFF
--- a/nodejs/src/servers/http-ingest-pump.ts
+++ b/nodejs/src/servers/http-ingest-pump.ts
@@ -1,0 +1,159 @@
+import { PromiseScheduler } from '~/common/utils/promise-scheduler'
+import { sleep } from '~/common/utils/utils'
+import { FeedRejectionKind } from '~/ingestion/framework/batching-pipeline'
+import { OkResultWithContext } from '~/ingestion/framework/chunk-pipeline.interface'
+import {
+    JoinedIngestionPipelineContext,
+    JoinedIngestionPipelineInput,
+    createJoinedIngestionPipeline,
+} from '~/ingestion/pipelines/analytics/joined-ingestion-pipeline'
+
+/** Batch context fed with each HTTP batch so its completion routes back to the request that fed it. */
+export type HttpBatchContext = { httpBatchSeq: number }
+
+export type HttpIngestPipeline = ReturnType<
+    typeof createJoinedIngestionPipeline<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext, HttpBatchContext>
+>
+
+export type HttpIngestBatch = OkResultWithContext<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext>[]
+
+export type HttpFeedResult =
+    | {
+          ok: true
+          /** Resolves once this batch and its side effects are durably done: the response barrier. */
+          settled: Promise<void>
+      }
+    | { ok: false; kind: FeedRejectionKind; reason: string }
+
+interface Waiter {
+    resolve: () => void
+    reject: (error: Error) => void
+}
+
+/**
+ * Routes each completed HTTP batch back to the request that fed it. The
+ * pipeline's next() hands out completions in completion order with no regard
+ * for who is waiting, so a request that drained next() itself would consume
+ * (and discard) other requests' completions and only get to respond once the
+ * whole pipeline went idle. Under sustained load that never happens. One
+ * pump loop per server drains next() instead, and completions carry the
+ * feeding request's sequence number, so a slow batch only delays its own
+ * response.
+ */
+export class HttpIngestPump {
+    private nextSeq = 0
+    private waiters = new Map<number, Waiter>()
+    private wakePump: (() => void) | null = null
+    private pumpTask: Promise<void> | null = null
+    private stopped = false
+    private fatalError?: Error
+
+    constructor(
+        private pipeline: HttpIngestPipeline,
+        private promiseScheduler: PromiseScheduler,
+        private pumpIdleMs = 20
+    ) {}
+
+    start(): void {
+        this.pumpTask = this.runPump()
+    }
+
+    async stop(): Promise<void> {
+        this.stopped = true
+        this.wake()
+        if (!this.pumpTask) {
+            return
+        }
+        let deadline: NodeJS.Timeout | undefined
+        try {
+            await Promise.race([
+                this.pumpTask,
+                new Promise<void>((resolve) => {
+                    deadline = setTimeout(resolve, 5_000)
+                }),
+            ])
+        } finally {
+            clearTimeout(deadline)
+        }
+    }
+
+    async feed(batch: HttpIngestBatch): Promise<HttpFeedResult> {
+        if (this.fatalError) {
+            throw this.fatalError
+        }
+        if (!this.pumpTask) {
+            this.start()
+        }
+        const seq = this.nextSeq++
+        const settled = new Promise<void>((resolve, reject) => {
+            this.waiters.set(seq, { resolve, reject })
+        })
+        let result: Awaited<ReturnType<HttpIngestPipeline['feed']>>
+        try {
+            result = await this.pipeline.feed(batch, { httpBatchSeq: seq })
+        } catch (error) {
+            this.waiters.delete(seq)
+            throw error
+        }
+        if (!result.ok) {
+            this.waiters.delete(seq)
+            return result
+        }
+        this.wake()
+        return { ok: true, settled }
+    }
+
+    private wake(): void {
+        if (this.wakePump) {
+            const wake = this.wakePump
+            this.wakePump = null
+            wake()
+        }
+    }
+
+    private async runPump(): Promise<void> {
+        while (!this.stopped || this.waiters.size > 0) {
+            if (this.waiters.size === 0) {
+                await new Promise<void>((resolve) => {
+                    this.wakePump = resolve
+                })
+                continue
+            }
+            let completed: Awaited<ReturnType<HttpIngestPipeline['next']>>
+            try {
+                completed = await this.pipeline.next()
+            } catch (error) {
+                this.poison(error instanceof Error ? error : new Error(String(error)))
+                return
+            }
+            if (completed === null) {
+                await sleep(this.pumpIdleMs)
+                continue
+            }
+            const waiter = this.waiters.get(completed.batchContext.httpBatchSeq)
+            this.waiters.delete(completed.batchContext.httpBatchSeq)
+            this.settle(waiter, completed.sideEffects ?? [])
+        }
+    }
+
+    private settle(waiter: Waiter | undefined, sideEffects: Promise<unknown>[]): void {
+        void (async () => {
+            try {
+                await Promise.all(sideEffects)
+                await this.promiseScheduler.waitForAll()
+                waiter?.resolve()
+            } catch (error) {
+                waiter?.reject(error instanceof Error ? error : new Error(String(error)))
+            }
+        })()
+    }
+
+    private poison(error: Error): void {
+        this.fatalError = error
+        const waiters = [...this.waiters.values()]
+        this.waiters.clear()
+        for (const waiter of waiters) {
+            waiter.reject(error)
+        }
+    }
+}

--- a/nodejs/src/servers/ingestion-api-server.test.ts
+++ b/nodejs/src/servers/ingestion-api-server.test.ts
@@ -5,11 +5,63 @@ import { GroupFlushResult } from '~/ingestion/common/groups/group-store.interfac
 
 import { IngestBatchResponse, SerializedKafkaMessage } from '../ingestion/api/types'
 import { CleanupResources } from './base-server'
+import { HttpIngestPump } from './http-ingest-pump'
 import { IngestionApiServer } from './ingestion-api-server'
+
+type Completion = { batchContext: { httpBatchSeq: number }; elements: unknown[]; sideEffects: Promise<unknown>[] }
+type Delivery = { completion: Completion } | { error: Error }
+
+/**
+ * Stands in for the batching pipeline: records the sequence number fed with
+ * each batch and lets a test complete (or crash) batches in any order, the
+ * way the real pipeline returns completions in completion order.
+ */
+class FakePipeline {
+    readonly seqs: number[] = []
+    private parkedNext: { resolve: (c: Completion) => void; reject: (e: Error) => void } | null = null
+    private queued: Delivery[] = []
+
+    feed = jest.fn((_batch: unknown, context: { httpBatchSeq: number }): Promise<{ ok: true }> => {
+        this.seqs.push(context.httpBatchSeq)
+        return Promise.resolve({ ok: true })
+    })
+
+    next = jest.fn((): Promise<Completion> => {
+        const queued = this.queued.shift()
+        if (queued) {
+            return 'error' in queued ? Promise.reject(queued.error) : Promise.resolve(queued.completion)
+        }
+        return new Promise((resolve, reject) => {
+            this.parkedNext = { resolve, reject }
+        })
+    })
+
+    complete(index: number, sideEffects: Promise<unknown>[] = []): void {
+        this.deliver({ completion: { batchContext: { httpBatchSeq: this.seqs[index] }, elements: [], sideEffects } })
+    }
+
+    crash(error: Error): void {
+        this.deliver({ error })
+    }
+
+    private deliver(delivery: Delivery): void {
+        if (!this.parkedNext) {
+            this.queued.push(delivery)
+            return
+        }
+        const parked = this.parkedNext
+        this.parkedNext = null
+        if ('error' in delivery) {
+            parked.reject(delivery.error)
+        } else {
+            parked.resolve(delivery.completion)
+        }
+    }
+}
 
 describe('IngestionApiServer', () => {
     let server: IngestionApiServer
-    let pipeline: { feed: jest.Mock; next: jest.Mock }
+    let pipeline: FakePipeline
     let stopSpy: jest.SpyInstance
 
     function makeMessage(): SerializedKafkaMessage {
@@ -20,6 +72,7 @@ describe('IngestionApiServer', () => {
         status: (code: number) => { json: (body: IngestBatchResponse) => void }
         statusCode: () => number
         body: () => IngestBatchResponse
+        responded: () => boolean
     } {
         const json = jest.fn()
         const status = jest.fn().mockReturnValue({ json })
@@ -27,6 +80,7 @@ describe('IngestionApiServer', () => {
             status,
             statusCode: () => status.mock.calls[0][0],
             body: () => json.mock.calls[0][0],
+            responded: () => status.mock.calls.length > 0,
         }
     }
 
@@ -34,6 +88,20 @@ describe('IngestionApiServer', () => {
         const messages = Array.from({ length: messageCount }, makeMessage)
         const req = { body: { batch_id: 'b1', messages } }
         return (server as any).handleIngestRequest(req, res)
+    }
+
+    // Let pending callbacks run so a started request is fed and the pump is
+    // waiting on next() before the test acts.
+    function flush(): Promise<void> {
+        return new Promise((resolve) => setImmediate(resolve))
+    }
+
+    // Starts a batch and returns its completion promise. Deliberately not
+    // async: an async wrapper's promise would adopt this one, so awaiting
+    // the helper would wait for the batch to finish instead of starting it.
+    // Callers `await flush()` once the batches they want in flight are up.
+    function start(messageCount: number): Promise<void> {
+        return handle(makeRes(), messageCount)
     }
 
     async function eventSecondsInFlight(): Promise<number> {
@@ -52,17 +120,26 @@ describe('IngestionApiServer', () => {
         return (server as any).isHealthy()
     }
 
-    beforeEach(() => {
-        server = new IngestionApiServer()
-        pipeline = { feed: jest.fn(), next: jest.fn() }
-        ;(server as any).httpPipeline = pipeline
-        ;(server as any).promiseScheduler = { schedule: jest.fn(), waitForAll: jest.fn().mockResolvedValue(undefined) }
+    function setup(concurrentBatches: number): void {
+        server = new IngestionApiServer({ INGESTION_WORKER_CONCURRENT_BATCHES: concurrentBatches })
+        pipeline = new FakePipeline()
+        const promiseScheduler = { schedule: jest.fn(), waitForAll: jest.fn().mockResolvedValue(undefined) }
+        ;(server as any).promiseScheduler = promiseScheduler
+        ;(server as any).httpPump = new HttpIngestPump(pipeline as any, promiseScheduler as any, 1)
         ;(server as any).hogTransformer = { processInvocationResults: jest.fn().mockResolvedValue(undefined) }
         // stop() would call process.exit; stub it so the test only observes that it was invoked.
         stopSpy = jest.spyOn(server, 'stop').mockResolvedValue(undefined)
+    }
+
+    beforeEach(() => {
+        setup(16)
         // The gauge is a module-level singleton shared across tests in this file.
         register.getSingleMetric('ingestion_api_events_in_flight')?.reset()
         register.getSingleMetric('ingestion_api_event_seconds_in_flight_total')?.reset()
+    })
+
+    afterEach(async () => {
+        await (server as any).httpPump.stop()
     })
 
     it('reports healthy before any failure', () => {
@@ -70,11 +147,11 @@ describe('IngestionApiServer', () => {
     })
 
     it('crashes and rebuilds on an unexpected pipeline error', async () => {
-        pipeline.feed.mockResolvedValue({ ok: true })
-        pipeline.next.mockRejectedValue(new Error('pipeline poisoned'))
-
         const res = makeRes()
-        await handle(res)
+        const req = handle(res)
+        await flush()
+        pipeline.crash(new Error('pipeline poisoned'))
+        await req
 
         // Retriable 500 so the Rust consumer redelivers the batch.
         expect(res.statusCode()).toBe(500)
@@ -84,8 +161,12 @@ describe('IngestionApiServer', () => {
         expect(stopSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('returns 503 backpressure at capacity without crashing', async () => {
-        pipeline.feed.mockResolvedValue({ ok: false, kind: 'at_capacity', reason: 'at concurrent batch capacity (1)' })
+    it('returns 503 backpressure when the pipeline is at capacity, without crashing', async () => {
+        pipeline.feed.mockResolvedValueOnce({
+            ok: false,
+            kind: 'at_capacity',
+            reason: 'at concurrent batch capacity (1)',
+        } as any)
 
         const res = makeRes()
         await handle(res)
@@ -97,11 +178,11 @@ describe('IngestionApiServer', () => {
     })
 
     it('processes a successful batch and stays healthy', async () => {
-        pipeline.feed.mockResolvedValue({ ok: true })
-        pipeline.next.mockResolvedValue(null)
-
         const res = makeRes()
-        await handle(res)
+        const req = handle(res)
+        await flush()
+        pipeline.complete(0)
+        await req
 
         expect(res.statusCode()).toBe(200)
         expect(res.body()).toMatchObject({ status: 'ok', accepted: 1 })
@@ -109,46 +190,107 @@ describe('IngestionApiServer', () => {
         expect(stopSpy).not.toHaveBeenCalled()
     })
 
-    type Gate = { resolve: () => void; reject: (error: Error) => void }
+    describe('per-batch completion', () => {
+        it('responds to a batch as soon as it completes while others are still in flight', async () => {
+            const [resA, resB, resC] = [makeRes(), makeRes(), makeRes()]
+            const reqA = handle(resA)
+            const reqB = handle(resB)
+            const reqC = handle(resC)
+            await flush()
 
-    describe('events in flight gauge', () => {
-        // One gate per in-flight batch. The handler calls next() exactly once
-        // (the mock resolves to null, ending its drain loop), so holding that
-        // promise open holds the batch in flight and lets a test decide the
-        // order batches finish in.
-        let gates: Gate[]
+            pipeline.complete(1)
+            await reqB
+            expect(resB.statusCode()).toBe(200)
+            expect(resA.responded()).toBe(false)
+            expect(resC.responded()).toBe(false)
 
-        beforeEach(() => {
-            gates = []
+            pipeline.complete(2)
+            await reqC
+            expect(resA.responded()).toBe(false)
+
+            pipeline.complete(0)
+            await reqA
+            expect(resA.statusCode()).toBe(200)
         })
 
-        function gateBatches(): void {
-            pipeline.feed.mockResolvedValue({ ok: true })
-            pipeline.next.mockImplementation(
-                () =>
-                    new Promise<null>((resolve, reject) => {
-                        gates.push({ resolve: () => resolve(null), reject })
-                    })
-            )
-        }
+        it('responds only once the batch side effects have settled', async () => {
+            let releaseSideEffect!: () => void
+            const sideEffect = new Promise<void>((resolve) => {
+                releaseSideEffect = resolve
+            })
+            const res = makeRes()
+            const req = handle(res)
+            await flush()
 
-        // Let pending callbacks run so a started request reaches next() before
-        // the test reads the gauge.
-        function flush(): Promise<void> {
-            return new Promise((resolve) => setImmediate(resolve))
-        }
+            pipeline.complete(0, [sideEffect])
+            await flush()
+            expect(res.responded()).toBe(false)
 
-        // Starts a batch and returns its completion promise. Deliberately not
-        // async: an async wrapper's promise would adopt this one, so awaiting
-        // the helper would wait for the batch to finish instead of starting it.
-        // Callers `await flush()` once the batches they want in flight are up.
-        function start(messageCount: number): Promise<void> {
-            return handle(makeRes(), messageCount)
-        }
+            releaseSideEffect()
+            await req
+            expect(res.statusCode()).toBe(200)
+        })
 
+        it('fails every in-flight batch when the pipeline crashes, and shuts down once', async () => {
+            const [resA, resB] = [makeRes(), makeRes()]
+            const reqA = handle(resA)
+            const reqB = handle(resB)
+            await flush()
+
+            pipeline.crash(new Error('pipeline poisoned'))
+            await Promise.all([reqA, reqB])
+
+            expect(resA.statusCode()).toBe(500)
+            expect(resB.statusCode()).toBe(500)
+            expect(await eventsInFlight()).toBe(0)
+            expect(stopSpy).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('capacity at the door', () => {
+        beforeEach(() => {
+            setup(2)
+        })
+
+        it('rejects with 503 once accepted batches await a response, before feeding the pipeline', async () => {
+            const first = start(1)
+            const second = start(1)
+            await flush()
+
+            const rejected = makeRes()
+            await handle(rejected)
+
+            expect(rejected.statusCode()).toBe(503)
+            expect(rejected.body()).toMatchObject({ status: 'error', accepted: 0 })
+            expect(pipeline.feed).toHaveBeenCalledTimes(2)
+            expect(isHealthy().status).toBe('ok')
+
+            pipeline.complete(0)
+            pipeline.complete(1)
+            await Promise.all([first, second])
+        })
+
+        it('admits a batch again once one has responded', async () => {
+            const first = start(1)
+            const second = start(1)
+            await flush()
+            pipeline.complete(0)
+            await first
+
+            const res = makeRes()
+            const third = handle(res)
+            await flush()
+            expect(pipeline.feed).toHaveBeenCalledTimes(3)
+
+            pipeline.complete(1)
+            pipeline.complete(2)
+            await Promise.all([second, third])
+            expect(res.statusCode()).toBe(200)
+        })
+    })
+
+    describe('events in flight gauge', () => {
         it('sums events across concurrent batches of different sizes', async () => {
-            gateBatches()
-
             const small = start(5)
             const medium = start(100)
             const large = start(1000)
@@ -157,14 +299,14 @@ describe('IngestionApiServer', () => {
             // 3 if it counted batches; the sum is the point of the metric.
             expect(await eventsInFlight()).toBe(1105)
 
-            gates.forEach((gate) => gate.resolve())
+            pipeline.complete(0)
+            pipeline.complete(1)
+            pipeline.complete(2)
             await Promise.all([small, medium, large])
             expect(await eventsInFlight()).toBe(0)
         })
 
         it('releases exactly the finished batch, leaving the others in flight', async () => {
-            gateBatches()
-
             const first = start(100)
             const second = start(5)
             const third = start(20)
@@ -173,48 +315,32 @@ describe('IngestionApiServer', () => {
 
             // Finish out of order: a decrement keyed to the wrong request would
             // subtract someone else's count and drift the gauge.
-            gates[1].resolve()
+            pipeline.complete(1)
             await second
             expect(await eventsInFlight()).toBe(120)
 
-            gates[2].resolve()
+            pipeline.complete(2)
             await third
             expect(await eventsInFlight()).toBe(100)
 
-            gates[0].resolve()
+            pipeline.complete(0)
             await first
             expect(await eventsInFlight()).toBe(0)
         })
 
         it('leaves in-flight batches untouched when another is rejected at capacity', async () => {
-            gateBatches()
             const accepted = start(100)
             await flush()
 
-            pipeline.feed.mockResolvedValueOnce({ ok: false, kind: 'at_capacity', reason: 'at capacity' })
+            pipeline.feed.mockResolvedValueOnce({ ok: false, kind: 'at_capacity', reason: 'at capacity' } as any)
             const rejectedRes = makeRes()
             await handle(rejectedRes, 50)
 
             expect(rejectedRes.statusCode()).toBe(503)
             expect(await eventsInFlight()).toBe(100)
 
-            gates[0].resolve()
+            pipeline.complete(0)
             await accepted
-            expect(await eventsInFlight()).toBe(0)
-        })
-
-        it('releases a crashed batch while a concurrent batch stays in flight', async () => {
-            gateBatches()
-            const crashing = start(100)
-            const surviving = start(7)
-            await flush()
-
-            gates[0].reject(new Error('pipeline poisoned'))
-            await crashing
-            expect(await eventsInFlight()).toBe(7)
-
-            gates[1].resolve()
-            await surviving
             expect(await eventsInFlight()).toBe(0)
         })
 
@@ -231,28 +357,35 @@ describe('IngestionApiServer', () => {
         it.each([
             {
                 outcome: 'success',
-                arrange: () => {
-                    pipeline.feed.mockResolvedValue({ ok: true })
-                    pipeline.next.mockResolvedValue(null)
+                act: async () => {
+                    const req = handle(makeRes(), 5)
+                    await flush()
+                    pipeline.complete(0)
+                    await req
                 },
             },
             {
                 outcome: 'capacity rejection',
-                arrange: () => {
-                    pipeline.feed.mockResolvedValue({ ok: false, kind: 'at_capacity', reason: 'at capacity' })
+                act: async () => {
+                    pipeline.feed.mockResolvedValueOnce({
+                        ok: false,
+                        kind: 'at_capacity',
+                        reason: 'at capacity',
+                    } as any)
+                    await handle(makeRes(), 5)
                 },
             },
             {
                 outcome: 'pipeline crash',
-                arrange: () => {
-                    pipeline.feed.mockResolvedValue({ ok: true })
-                    pipeline.next.mockRejectedValue(new Error('pipeline poisoned'))
+                act: async () => {
+                    const req = handle(makeRes(), 5)
+                    await flush()
+                    pipeline.crash(new Error('pipeline poisoned'))
+                    await req
                 },
             },
-        ])('returns to zero after a $outcome', async ({ arrange }) => {
-            arrange()
-
-            await handle(makeRes(), 5)
+        ])('returns to zero after a $outcome', async ({ act }) => {
+            await act()
 
             expect(await eventsInFlight()).toBe(0)
         })
@@ -273,31 +406,14 @@ describe('IngestionApiServer', () => {
             clock.mockRestore()
         })
 
-        function gateBatches(): Gate[] {
-            const gates: Gate[] = []
-            pipeline.feed.mockResolvedValue({ ok: true })
-            pipeline.next.mockImplementation(
-                () =>
-                    new Promise<null>((resolve, reject) => {
-                        gates.push({ resolve: () => resolve(null), reject })
-                    })
-            )
-            return gates
-        }
-
-        function flush(): Promise<void> {
-            return new Promise((resolve) => setImmediate(resolve))
-        }
-
         it('accumulates events multiplied by seconds in flight', async () => {
-            const gates = gateBatches()
             clock.mockReturnValue(1_000)
 
             const batch = handle(makeRes(), 10)
             await flush()
 
             clock.mockReturnValue(3_500)
-            gates[0].resolve()
+            pipeline.complete(0)
             await batch
 
             // 10 events held for 2.5s.
@@ -305,7 +421,6 @@ describe('IngestionApiServer', () => {
         })
 
         it('credits each concurrent batch its own duration', async () => {
-            const gates = gateBatches()
             clock.mockReturnValue(0)
 
             const long = handle(makeRes(), 100)
@@ -316,13 +431,13 @@ describe('IngestionApiServer', () => {
 
             // short: accepted at 1s, ends at 3s  -> 4 * 2  =   8
             clock.mockReturnValue(3_000)
-            gates[1].resolve()
+            pipeline.complete(1)
             await short
             expect(await eventSecondsInFlight()).toBe(8)
 
             // long: accepted at 0s, ends at 4s   -> 100 * 4 = 400
             clock.mockReturnValue(4_000)
-            gates[0].resolve()
+            pipeline.complete(0)
             await long
             expect(await eventSecondsInFlight()).toBe(408)
         })
@@ -332,13 +447,11 @@ describe('IngestionApiServer', () => {
             // "1 event in flight on average over a minute". A gauge scraped
             // once would report 1 or 60 depending on timing; the counter says
             // 60 event-seconds either way.
-            const gates = gateBatches()
-
             clock.mockReturnValue(0)
             const steady = handle(makeRes(), 1)
             await flush()
             clock.mockReturnValue(60_000)
-            gates[0].resolve()
+            pipeline.complete(0)
             await steady
             const heldLong = await eventSecondsInFlight()
 
@@ -349,7 +462,7 @@ describe('IngestionApiServer', () => {
                 const burst = handle(makeRes(), 60)
                 await flush()
                 clock.mockReturnValue(i * 1_000 + 1_000)
-                gates[gates.length - 1].resolve()
+                pipeline.complete(pipeline.seqs.length - 1)
                 await burst
             }
             const burstsShort = await eventSecondsInFlight()
@@ -363,7 +476,7 @@ describe('IngestionApiServer', () => {
 
         it('does not credit a batch rejected at capacity', async () => {
             clock.mockReturnValue(0)
-            pipeline.feed.mockResolvedValue({ ok: false, kind: 'at_capacity', reason: 'at capacity' })
+            pipeline.feed.mockResolvedValueOnce({ ok: false, kind: 'at_capacity', reason: 'at capacity' } as any)
 
             clock.mockReturnValue(5_000)
             await handle(makeRes(), 10)

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -101,6 +101,7 @@ import {
 } from '../types'
 import { BaseServerConfig, CleanupResources, NodeServer, ServerLifecycle } from './base-server'
 import { GrpcBatchContext, GrpcStreamIngestDriver } from './grpc-stream-ingest-driver'
+import { HttpBatchContext, HttpIngestPump } from './http-ingest-pump'
 
 export type IngestionApiServerConfig = BaseServerConfig &
     IngestionConsumerConfig &
@@ -214,9 +215,7 @@ export class IngestionApiServer implements NodeServer {
     // (moved to caller-side production so create and flush share one path).
     private ingestionOutputs?: FlushBatchStoresOutputs
 
-    private httpPipeline!: ReturnType<
-        typeof createJoinedIngestionPipeline<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext>
-    >
+    private httpPump!: HttpIngestPump
     private grpcServer?: WorkerIngestServer
     private promiseScheduler = new PromiseScheduler()
     private hogTransformer!: HogTransformerService
@@ -230,6 +229,11 @@ export class IngestionApiServer implements NodeServer {
     // Kafka consumer's contract of crashing and rebuilding rather than serving
     // a wedged pipeline forever.
     private fatalError?: Error
+
+    // Admitted /ingest requests that have not responded yet, checked at the
+    // door so a pod that cannot answer stops admitting work even while the
+    // pipeline itself still has room.
+    private batchesAwaitingResponse = 0
 
     constructor(config: Partial<IngestionApiServerConfig> = {}) {
         this.config = {
@@ -514,13 +518,21 @@ export class IngestionApiServer implements NodeServer {
         if (this.config.INGESTION_API_FEED_ORDER_SENTINEL_ENABLED) {
             this.feedOrderSentinel = new FeedOrderSentinel(this.config.INGESTION_API_FEED_ORDER_SENTINEL_MAX_KEYS)
         }
-        this.httpPipeline = createJoinedIngestionPipeline(joinedPipelineConfig, joinedPipelineDeps)
+        this.httpPump = new HttpIngestPump(
+            createJoinedIngestionPipeline<
+                JoinedIngestionPipelineInput,
+                JoinedIngestionPipelineContext,
+                HttpBatchContext
+            >(joinedPipelineConfig, joinedPipelineDeps),
+            this.promiseScheduler
+        )
+        this.httpPump.start()
         this.lifecycle.expressApp.post('/ingest', async (req, res) => {
             await this.handleIngestRequest(req, res)
         })
         if (this.config.INGESTION_API_GRPC_ENABLED) {
-            // Own pipeline instance: sharing httpPipeline would let an HTTP
-            // handler's next() consume a gRPC batch's completion (and its ack).
+            // Own pipeline instance: sharing the HTTP pipeline would let the
+            // HTTP pump consume a gRPC batch's completion (and its ack).
             const grpcPipeline = createJoinedIngestionPipeline<
                 JoinedIngestionPipelineInput,
                 JoinedIngestionPipelineContext,
@@ -556,6 +568,7 @@ export class IngestionApiServer implements NodeServer {
         const service: PluginServerService = {
             id: 'ingestion-api',
             onShutdown: async () => {
+                await this.httpPump.stop()
                 await this.topHog.stop()
                 await this.hogTransformer.stop()
                 await eventFilterManagerStarted.stop()
@@ -585,6 +598,7 @@ export class IngestionApiServer implements NodeServer {
         // while it is not. Holding both (rather than a bool) makes the `finally`
         // credit exactly what was counted, even if `messages` is out of scope.
         let inFlight: { events: number; acceptedAt: number } | null = null
+        let admitted = false
 
         try {
             const messages: Message[] = serializedMessages.map(deserializeKafkaMessage)
@@ -597,7 +611,19 @@ export class IngestionApiServer implements NodeServer {
             // stage processes each key in feed order, so this measures the
             // "processed in order per distinct_id" invariant.
             this.feedOrderSentinel?.check(serializedMessages, consumer_id ?? 'unknown', replay ?? false)
-            const feedResult = await this.httpPipeline.feed(batch, {})
+            if (this.batchesAwaitingResponse >= this.config.INGESTION_WORKER_CONCURRENT_BATCHES) {
+                batchCapacityRejections.inc()
+                res.status(503).json({
+                    batch_id: batch_id ?? '',
+                    status: 'error',
+                    accepted: 0,
+                    error: `at concurrent batch capacity (${this.config.INGESTION_WORKER_CONCURRENT_BATCHES}): ${this.batchesAwaitingResponse} batches awaiting response`,
+                })
+                return
+            }
+            admitted = true
+            this.batchesAwaitingResponse++
+            const feedResult = await this.httpPump.feed(batch)
             if (!feedResult.ok) {
                 // Capacity rejection should not happen under correct consumer
                 // behavior — the Rust consumer holds a per-worker Semaphore
@@ -631,19 +657,11 @@ export class IngestionApiServer implements NodeServer {
             eventsInFlight.inc(messages.length)
             inFlight = { events: messages.length, acceptedAt: Date.now() }
 
-            // The pipeline handles its own side effects (scheduling them on
-            // the promise scheduler), so draining results is all that's left
-            // to do.
-            let result = await this.httpPipeline.next()
-            while (result !== null) {
-                result = await this.httpPipeline.next()
-            }
-
-            // Wait for all side effects — the HTTP response is the ACK to the
-            // Rust consumer, so all work must finish before responding. The hog
-            // transformer drain is scheduled as a side effect by the pipeline's
-            // afterBatch flush step, so it's covered by waitForAll().
-            await this.promiseScheduler.waitForAll()
+            // The HTTP response is the ACK to the Rust consumer, so `settled`
+            // covers this batch's side effects too. The hog transformer drain
+            // is scheduled as a side effect by the pipeline's afterBatch flush
+            // step, so it is included.
+            await feedResult.settled
 
             batchesProcessed.inc()
             messagesProcessed.inc(messages.length)
@@ -667,6 +685,9 @@ export class IngestionApiServer implements NodeServer {
             }
             res.status(500).json({ batch_id, status: 'error', accepted: 0, error: error.message })
         } finally {
+            if (admitted) {
+                this.batchesAwaitingResponse--
+            }
             if (inFlight !== null) {
                 batchesInFlight.dec()
                 eventsInFlight.dec(inFlight.events)


### PR DESCRIPTION
## Problem

- A processor pod under sustained load stops answering `/ingest` requests even though it keeps finishing batches. Its consumer times out, retries, and the pod fills with unanswered requests.
- The handler drained the shared pipeline's `next()` until it returned `null`, which only happens when no batch is in flight.
- `next()` hands out completions in completion order, so a handler that received another batch's completion discarded it and kept waiting.
- Under a continuous stream of batches the pipeline never empties, so no handler responds.
- The pipeline's capacity check counts batches inside the pipeline, not unanswered requests, so the pod kept admitting new batches while handlers piled up.

## Changes

- A processor responds to each batch as soon as that batch and its side effects finish. A slow batch delays only its own response.
- A new `HttpIngestPump` runs one pump loop per server, drains `next()`, and routes each completion to the request that fed it by a per-batch sequence number. This mirrors the pattern the gRPC path already uses.
- The handler refuses with 503 once admitted-and-unanswered requests reach `INGESTION_WORKER_CONCURRENT_BATCHES`, before feeding the pipeline. The pipeline's own capacity check stays as the second layer, and both count in `ingestion_api_batch_capacity_rejections_total`.
- A pipeline error still follows the crash-and-rebuild contract: every in-flight request responds 500 and the server shuts down once.
- The pump stops during service shutdown, bounded at 5 seconds for a wedged pipeline.

```mermaid
flowchart LR
    A[handler A] --> F[feed]
    B[handler B] --> F
    F --> P[(pipeline)]
    P -->|next until null| A
    P -->|next until null| B
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,B phBlue;
    class F,P phGray;
```

```mermaid
flowchart LR
    A[handler A] --> F[feed seq]
    B[handler B] --> F
    F --> P[(pipeline)]
    P --> M{{pump}}
    M -->|seq A settled| A
    M -->|seq B settled| B
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,B,M phBlue;
    class F,P phGray;
```

## How did you test this code?

- `ingestion-api-server.test.ts` now drives the handler through a fake pipeline that completes batches individually and out of order.
- New cases catch: a batch not responding until every other batch finishes, a response sent before the batch's side effects settle, a crash leaving some in-flight requests unanswered or shutting down more than once, and the door not refusing or not re-admitting at the limit.
- The existing gauge and counter tests are ported to per-batch completion.
- Run locally: the server, batching-pipeline, and gRPC server unit tests, and the Rust consumer to Node worker e2e suite (`pnpm test:rust-ingestion-e2e`) against local Kafka, Postgres, and ClickHouse.
- Not run: load testing with many concurrent batches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5), session https://claude.ai/code/session_01Eok5EJ87SBeCXzwgiut9Ne. Skills invoked: `/writing-pr-descriptions`.
- Origin: two items from an internal incident write-up on an overflow lane stall; the committed change and tests carry no incident material.
- Rejected alternative: handler-driven pumping with each handler racing `next()` against its own completion. Abandoned `next()` calls would still need dispatching, so the single pump loop the gRPC server already uses was the safer shape.
- The door counter increments synchronously with its check, so concurrent handlers cannot both pass it while one awaits `feed()`.
