### PR TITLE
fix(metrics): paint the overview layout while its data loads

### DIFF
--- a/products/metrics/frontend/components/MetricsOverview.tsx
+++ b/products/metrics/frontend/components/MetricsOverview.tsx
@@ -58,7 +58,10 @@ const MetricsOverviewSkeleton = (): JSX.Element => (
             dataSource={[]}
             loading
             rowKey="service_name"
-            columns={SERVICE_COLUMN_TITLES.map((title) => ({ title }))}
+            columns={SERVICE_COLUMN_TITLES.map((title) => ({
+                title,
+                align: title === 'Metrics' || title === 'Active series' ? 'right' : undefined,
+            }))}
         />
     </div>
 )

--- a/products/metrics/frontend/components/MetricsOverview.tsx
+++ b/products/metrics/frontend/components/MetricsOverview.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonBanner, LemonTable, LemonTag, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonSkeleton, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
@@ -11,11 +11,55 @@ import { STALE_AFTER_MS, metricsOverviewLogic } from './metricsOverviewLogic'
 
 const isStale = (lastSeen: string): boolean => dayjs().diff(dayjs(lastSeen)) > STALE_AFTER_MS
 
-const OverviewStat = ({ label, value, caption }: { label: string; value: number; caption: string }): JSX.Element => (
+// Shared by the loaded cards and their placeholders, so a rename cannot make the
+// labels change as the data lands.
+const STAT_LABELS = ['Services', 'Metric names', 'Active series'] as const
+
+// Header text only, so the placeholder table has the same columns as the real one.
+const SERVICE_COLUMN_TITLES = ['Service', 'Metrics', 'Active series', 'Last seen']
+
+// `null` renders the placeholder. One component for both states, so the loading
+// card cannot drift from the loaded one and change size when the data lands.
+const OverviewStat = ({
+    label,
+    value,
+    caption,
+}: {
+    label: string
+    value: number | null
+    caption: string | null
+}): JSX.Element => (
     <div className="flex flex-col border rounded p-4 flex-1 min-w-40">
-        <span className="text-2xl font-semibold">{humanFriendlyNumber(value)}</span>
+        {value === null ? (
+            <LemonSkeleton className="h-8 w-20" />
+        ) : (
+            <span className="text-2xl font-semibold">{humanFriendlyNumber(value)}</span>
+        )}
         <span className="text-sm">{label}</span>
-        <span className="text-xs text-secondary">{caption}</span>
+        {caption === null ? (
+            <LemonSkeleton className="h-3 w-24 my-1" />
+        ) : (
+            <span className="text-xs text-secondary">{caption}</span>
+        )}
+    </div>
+)
+
+// The window length arrives with the data, so the captions are placeholders too
+// rather than a hardcoded guess that flashes if the server default ever changes.
+const MetricsOverviewSkeleton = (): JSX.Element => (
+    <div className="flex flex-col gap-4">
+        <LemonSkeleton className="h-8 w-80" />
+        <div className="flex flex-wrap gap-2">
+            {STAT_LABELS.map((label) => (
+                <OverviewStat key={label} label={label} value={null} caption={null} />
+            ))}
+        </div>
+        <LemonTable
+            dataSource={[]}
+            loading
+            rowKey="service_name"
+            columns={SERVICE_COLUMN_TITLES.map((title) => ({ title }))}
+        />
     </div>
 )
 
@@ -65,11 +109,7 @@ export const MetricsOverview = (): JSX.Element => {
     const { viewService } = useActions(metricsOverviewLogic)
 
     if (!overview) {
-        return (
-            <div className="flex justify-center py-8">
-                <Spinner />
-            </div>
-        )
+        return <MetricsOverviewSkeleton />
     }
 
     const windowHours = Math.round(overview.lookback_seconds / 3600)
@@ -79,9 +119,20 @@ export const MetricsOverview = (): JSX.Element => {
         <div className="flex flex-col gap-4">
             <IngestionStatus lastSeen={overview.last_seen} />
             <div className="flex flex-wrap gap-2">
-                <OverviewStat label="Services" value={overview.services.length} caption={windowLabel} />
-                <OverviewStat label="Metric names" value={overview.metric_names} caption={windowLabel} />
-                <OverviewStat label="Active series" value={overview.series} caption={windowLabel} />
+                {STAT_LABELS.map((label) => (
+                    <OverviewStat
+                        key={label}
+                        label={label}
+                        value={
+                            {
+                                Services: overview.services.length,
+                                'Metric names': overview.metric_names,
+                                'Active series': overview.series,
+                            }[label]
+                        }
+                        caption={windowLabel}
+                    />
+                ))}
             </div>
             <LemonTable
                 dataSource={overview.services as _MetricsOverviewServiceApi[]}


### PR DESCRIPTION
## Problem

Opening `/metrics` shows one centred spinner on an otherwise blank page until both rollup queries return. The wait reads as a stall: no status strip, no cards, no table, and then everything appears at once and pushes the page around.

The scene returned early on `!overview`, so nothing rendered until the whole payload landed.

Follow-up to [#87918](https://github.com/PostHog/posthog/pull/87918), which added the overview tab.

## Changes

- The page now has its shape immediately: a placeholder status strip, three placeholder stat cards, and the services table with its headers and skeleton rows. Numbers replace the placeholders in place, so nothing shifts when the data lands.
- `OverviewStat` renders both states from one component, and the card labels and column headers come from one list each. A rename cannot make the labels change as the data arrives.
- Captions are placeholders too. The window length arrives with the data, so hardcoding "Last 24 hours" would have flashed the wrong caption if the server default ever changed.

## What this does not do

This is the perceived-latency half. It does not make the queries faster, and the first paint still shows placeholders for as long as the request takes.

Two follow-ups were explored and deliberately left out:

- **Running the two passes concurrently.** Both scan the same rows, since `last_seen` is not in the `metric_series` sort key, so overlapping them should roughly halve the wait. A `ThreadPoolExecutor` version modelled on `TraceSpansAggregationQueryRunner` failed the existing overview tests with `OperationalError: the connection is closed`: the worker threads leave Django's connection unusable for later tests, and the same mechanism would churn connections in production. It needs a deliberate connection strategy and its own PR, not a quiet ride along with a UI change.
- **Caching the rollup per team.** Cheap to add next to the existing `cached_metric_names`, but it does nothing for the first load, which is the complaint. It also means pickling a contract dataclass into the cache, which is a new failure mode across a deploy.

The measured first-load cost is unknown: no production-scale dataset was available here, so neither follow-up should be sized from guesswork.

## How did you test this code?

- `tsgo` reports no errors in any file this PR touches; the ones it does report are pre-existing, in `cdp`, `posthog_ai`, and `signals`.
- The existing metrics Jest suites pass. No test was added: the change is presentational, `MetricsOverview.tsx` has no test file today, and a test asserting "renders a skeleton while loading" would pin the framework rather than a regression worth catching.
- **Not done: no screenshot and no browser check.** Reproducing the loading state needs a seeded local stack held mid-request; the earlier attempt on #87918 cost about forty minutes and produced nothing usable. Worth a reviewer glancing at it in a preview environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Desktop). Skills invoked: `/writing-tests` (which is what ruled the skeleton test out), `/writing-pr-descriptions`, plus the repo rules for frontend components.
- The session started from the question of whether the overview should lazy-load or load in parts. Reading the schema settled it: `metric_series` is sorted by `(team_id, metric_name, series_fingerprint)` with no date partitioning, so neither pass can prune by time and splitting the endpoint would not let one half arrive meaningfully sooner. Placeholders plus a faster query is the useful pair, and only the first half is verified here.
- `WITH ROLLUP` would fold both passes into one scan and HogQL does support it, but the rollup row collapses `service_name` to the empty string, which collides with the real group for senders that set no service name. That ambiguity was a bug fixed on the overview PR, so it was not worth reintroducing for a single scan.
- No customer data or internal material appears in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
