### PR TITLE
chore(product-analytics): let a product stop watching a decoupled garage

### DIFF
--- a/products/architecture.md
+++ b/products/architecture.md
@@ -99,6 +99,11 @@ These cross the boundary as classes — allowed only under all three rules:
    DRF viewsets are not part of this channel: they live in `presentation/`, register through `routes.py`, and never pass through the facade (a facade must not import DRF, and not its own `presentation/`; the `facade must not import presentation or DRF` import-linter contract enforces both, with the existing violations grandfathered in its TODO list) — their soundness is governed by the presentation rules above.
 2. **Designated location.**
    The implementation lives in the product's wiring location — `backend/hogql_queries/`, `backend/max_tools.py`, `backend/temporal/`, `backend/tasks/` (a flat `backend/tasks.py` also qualifies) — and isolated products keep those locations in their `backend:contract-check` inputs, so any change to a wiring implementation still re-runs the full suite.
+   A product may stop watching a wiring location once no test under `posthog/` or `ee/` executes the implementations wired through it (construct-only and mocked uses do not count).
+   At that point a change there can only fail the product's own lane, which every product change runs, while core changes keep exercising the wiring because any `posthog/`/`ee/` edit runs every product lane.
+   The declaration lives in `DECOUPLED_GARAGES` (`tools/hogli-commands/hogli_commands/product/isolation.py`), keyed `(product, location)` and default-deny like `MODEL_CROSSINGS`.
+   The entry lands together with the input drop — a declared garage that is still watched fails lint — and adding one requires demonstrating the no-core-test-executes bar in the PR.
+   `product_analytics` holds the first entry, `backend/hogql_queries/` (paths, paths_v2, stickiness).
 3. **Validated registration.**
    Registration points check `issubclass(cls, Base)` and reject anything else.
    Import linters (tach, import-linter) see only the import graph; _what an object is_ can only be checked at runtime, at the door.
@@ -531,7 +536,7 @@ Turbo uses file-based inputs to determine cache validity. The key distinction:
 
 - `backend/facade/contracts.py` — frozen dataclasses (enums can live here too)
 - `backend/facade/enums.py` — optional, for exported enums/constants/shared types when contracts.py grows
-- the product's wiring locations (`backend/hogql_queries/`, `backend/max_tools.py`, `backend/temporal/`, `backend/tasks/`) — implementations core registers and drives (see [Wiring couplings](#wiring-couplings))
+- the product's wiring locations (`backend/hogql_queries/`, `backend/max_tools.py`, `backend/temporal/`, `backend/tasks/`) — implementations core registers and drives, unless declared decoupled in `DECOUPLED_GARAGES` (see [Wiring couplings](#wiring-couplings))
 
 **Implementation inputs** (used by `backend:test`):
 

--- a/products/product_analytics/turbo.json
+++ b/products/product_analytics/turbo.json
@@ -7,9 +7,7 @@
                 "backend/presentation/**",
                 "backend/routes.py",
                 "backend/models/**",
-                "backend/migrations/**",
-                "backend/hogql_queries/**",
-                "!backend/hogql_queries/*/test/**"
+                "backend/migrations/**"
             ],
             "outputs": [],
             "cache": true

--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -889,7 +889,18 @@ class IsolationChainCheck(ProductCheck):
             result.issues.append(
                 "turbo.json narrows contract-check inputs but omits the wiring location(s) "
                 f"{', '.join(status.unwatched_garages)} — implementations core registers and drives live there, "
-                f"so a change to them would skip the Django suite. Add the matching input(s) ({globs})"
+                f"so a change to them would skip the Django suite. Add the matching input(s) ({globs}); if no "
+                "core test executes what lives there, a DECOUPLED_GARAGES entry may drop the location instead "
+                "(see products/architecture.md § Wiring couplings)"
+            )
+
+        # A decoupled-garage declaration must describe reality: the entry and the input drop land
+        # together, so a declared garage that is still watched (or absent) is a stale claim.
+        if has_narrowed and status.stale_decoupled_garages:
+            result.issues.append(
+                f"DECOUPLED_GARAGES declares {', '.join(status.stale_decoupled_garages)} decoupled, but the "
+                "location is absent or turbo.json still watches it — remove the entry or drop the matching "
+                "input(s) in the same PR"
             )
 
         # Watching the carve-out modules: a sanctioned model-registry carve-out crosses the facade by
@@ -929,7 +940,10 @@ class IsolationChainCheck(ProductCheck):
             # An unqualified permanent exposure is a defect in the tach.toml marker itself, so point
             # there; it takes precedence because it's the most fundamental of these issues.
             turbo_omission = has_narrowed and (
-                status.unwatched_garages or status.uncovered_carveout_modules or status.uncovered_model_surface
+                status.unwatched_garages
+                or status.uncovered_carveout_modules
+                or status.uncovered_model_surface
+                or status.stale_decoupled_garages
             )
             if status.unqualified_permanent_exposures:
                 result.file = "tach.toml"

--- a/tools/hogli-commands/hogli_commands/product/isolation.py
+++ b/tools/hogli-commands/hogli_commands/product/isolation.py
@@ -308,6 +308,22 @@ GARAGE_PREFIXES: tuple[str, ...] = (
     "backend/tasks/",
 )
 
+# Garages a product may drop from its contract-check inputs, keyed (product, location) and
+# default-deny like MODEL_CROSSINGS: an unlisted garage must stay watched. A garage is contract
+# surface because core tests execute the implementations wired through it; once no test under
+# posthog/ or ee/ executes them (construct-only and mocked uses don't count), a change there can
+# only fail the product's own lane — which every product change runs — so re-running the Django
+# suite buys nothing. Core production still dispatches into the wiring, and core changes keep
+# exercising it because any posthog/ or ee/ edit runs every product lane. An entry lands together
+# with the input drop (a declared garage still watched fails lint as a stale claim), and adding
+# one requires demonstrating the no-core-test-executes bar in the PR. The bar and rationale live
+# in products/architecture.md § Wiring couplings.
+DECOUPLED_GARAGES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("product_analytics", "backend/hogql_queries/"),
+    }
+)
+
 
 def _glob_targets(glob: str, prefixes: tuple[str, ...]) -> bool:
     """Anchored prefix test for a contract-check input glob. removeprefix (not lstrip, which strips
@@ -785,9 +801,24 @@ def _unwatched_present_locations(product_dir: Path, prefixes: tuple[str, ...]) -
     return _uncovered_locations(product_dir, {p: (p,) for p in present})
 
 
-def unwatched_garages(product_dir: Path) -> set[str]:
-    """Garage locations present in the product but missing from its (narrowed) contract-check inputs."""
-    return _unwatched_present_locations(product_dir, GARAGE_PREFIXES)
+def unwatched_garages(product_dir: Path, name: str) -> set[str]:
+    """Garage locations present in the product but missing from its (narrowed) contract-check
+    inputs. Locations declared decoupled for this product (DECOUPLED_GARAGES) are exempt."""
+    decoupled = {garage for product, garage in DECOUPLED_GARAGES if product == name}
+    return _unwatched_present_locations(product_dir, tuple(p for p in GARAGE_PREFIXES if p not in decoupled))
+
+
+def stale_decoupled_garages(product_dir: Path, name: str) -> set[str]:
+    """DECOUPLED_GARAGES entries for this product that do not hold: the garage is absent from the
+    product, or the contract-check inputs still watch it. The declaration and the input drop land
+    together, so either state is a stale claim."""
+    declared = {garage for product, garage in DECOUPLED_GARAGES if product == name}
+    if not declared:
+        return set()
+    absent = {garage for garage in declared if not (product_dir / garage.rstrip("/")).exists()}
+    present = declared - absent
+    uncovered = _uncovered_locations(product_dir, {garage: (garage,) for garage in present})
+    return absent | (present - uncovered)
 
 
 def uncovered_carveout_modules(product_dir: Path, carveout_modules: frozenset[str]) -> set[str]:
@@ -867,6 +898,9 @@ class IsolationStatus:
     # and carve-out modules missing the same way. Both keep the skip sound and block when narrowed.
     unwatched_garages: tuple[str, ...] = ()
     uncovered_carveout_modules: tuple[str, ...] = ()
+    # DECOUPLED_GARAGES entries that do not hold for this product — the garage is absent, or the
+    # inputs still watch it. Blocks when narrowed: the registry must describe reality.
+    stale_decoupled_garages: tuple[str, ...] = ()
     # Model classes the facade hands out under the watched-models allowance (see
     # MODEL_CROSSINGS). uncovered_model_surface lists the model/migration locations a narrowed
     # product fails to keep in its contract-check inputs; every narrowed product must watch them.
@@ -940,8 +974,9 @@ def compute_isolation_status(
             sorted(unqualified_permanent_modules(module_path, permanent_modules, repo_root=repo_root))
         ),
         facade_leaks=reexports.leaks,
-        unwatched_garages=tuple(sorted(unwatched_garages(product_dir))),
+        unwatched_garages=tuple(sorted(unwatched_garages(product_dir, name))),
         uncovered_carveout_modules=tuple(sorted(uncovered_carveout_modules(product_dir, carveout_modules))),
+        stale_decoupled_garages=tuple(sorted(stale_decoupled_garages(product_dir, name))),
         model_crossings=reexports.model_crossings,
         uncovered_model_surface=tuple(sorted(unwatched_model_surface(product_dir))),
     )

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -1920,10 +1920,14 @@ class TestStaleDecoupledGarages:
             assert stale_decoupled_garages(product_dir, "other_product") == set()
 
     def test_registry_entries_name_real_products_and_garages(self) -> None:
-        # a typoed location or product would silently exempt nothing while claiming a decoupling
+        # a typoed location or product would silently exempt nothing while claiming a decoupling.
+        # The staleness issue in checks.py only fires once the product narrows its inputs, so an
+        # entry that never held — or stopped holding — is caught here instead, unconditionally.
         for product, garage in DECOUPLED_GARAGES:
             assert garage in GARAGE_PREFIXES
-            assert (REPO_ROOT / "products" / product).is_dir()
+            product_dir = REPO_ROOT / "products" / product
+            assert product_dir.is_dir()
+            assert stale_decoupled_garages(product_dir, product) == set()
 
 
 class TestNarrowedTurboWiringSurface:

--- a/tools/hogli-commands/hogli_commands/tests/test_checks.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_checks.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+from unittest import mock
 
 from hogli_commands.product import (
     checks as checks_module,
@@ -31,6 +32,8 @@ from hogli_commands.product.checks import (
     validate_tach_references,
 )
 from hogli_commands.product.isolation import (
+    DECOUPLED_GARAGES,
+    GARAGE_PREFIXES,
     MODEL_SURFACE_PREFIXES,
     facade_carveout_modules,
     facade_class_imports,
@@ -38,12 +41,14 @@ from hogli_commands.product.isolation import (
     has_narrowed_turbo_inputs,
     permanent_interface_modules,
     routes_in_turbo_inputs,
+    stale_decoupled_garages,
     uncovered_carveout_modules,
     uncovered_permanent_modules,
     unqualified_permanent_modules,
     unwatched_garages,
     unwatched_model_surface,
 )
+from hogli_commands.product.paths import REPO_ROOT
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1878,7 +1883,47 @@ class TestUnwatchedGarages:
         self, tmp_path: Path, garage_file: str, turbo_inputs: list[str] | None, expected: set[str]
     ) -> None:
         product_dir, _ = _write_facade_product(tmp_path, sources={garage_file: ""}, turbo_inputs=turbo_inputs)
-        assert unwatched_garages(product_dir) == expected
+        assert unwatched_garages(product_dir, "my_product") == expected
+
+    def test_decoupled_garage_is_exempt_for_its_product_only(self, tmp_path: Path) -> None:
+        product_dir, _ = _write_facade_product(
+            tmp_path, sources={"tasks/tasks.py": ""}, turbo_inputs=["backend/facade/**"]
+        )
+        with mock.patch(
+            "hogli_commands.product.isolation.DECOUPLED_GARAGES", frozenset({("my_product", "backend/tasks/")})
+        ):
+            assert unwatched_garages(product_dir, "my_product") == set()
+            assert unwatched_garages(product_dir, "other_product") == {"backend/tasks/"}
+
+
+class TestStaleDecoupledGarages:
+    @pytest.mark.parametrize(
+        "garage_file, turbo_inputs, expected",
+        [
+            # holds: garage present and dropped from the inputs
+            ("tasks/tasks.py", ["backend/facade/**"], set()),
+            # stale: the inputs still watch the declared garage
+            ("tasks/tasks.py", ["backend/facade/**", "backend/tasks/**"], {"backend/tasks/"}),
+            # stale: the declared garage does not exist in the product
+            (None, ["backend/facade/**"], {"backend/tasks/"}),
+        ],
+    )
+    def test_declaration_must_describe_reality(
+        self, tmp_path: Path, garage_file: str | None, turbo_inputs: list[str], expected: set[str]
+    ) -> None:
+        sources = {garage_file: ""} if garage_file else None
+        product_dir, _ = _write_facade_product(tmp_path, sources=sources, turbo_inputs=turbo_inputs)
+        with mock.patch(
+            "hogli_commands.product.isolation.DECOUPLED_GARAGES", frozenset({("my_product", "backend/tasks/")})
+        ):
+            assert stale_decoupled_garages(product_dir, "my_product") == expected
+            assert stale_decoupled_garages(product_dir, "other_product") == set()
+
+    def test_registry_entries_name_real_products_and_garages(self) -> None:
+        # a typoed location or product would silently exempt nothing while claiming a decoupling
+        for product, garage in DECOUPLED_GARAGES:
+            assert garage in GARAGE_PREFIXES
+            assert (REPO_ROOT / "products" / product).is_dir()
 
 
 class TestNarrowedTurboWiringSurface:


### PR DESCRIPTION
## Problem

- A product-analytics query runner edit re-runs the whole Django suite. After this PR it runs the product's own lane instead.
- Backend test selection does not cover this case, by design. [#88265](https://github.com/PostHog/posthog/pull/88265) narrows both matrices on direct `posthog`/`ee` edits, but when legacy impact is inferred from a contract change, `decideSelection` falls back to the full matrix with reason `untrusted` — the diff-based selector cannot see the class-registry dispatch behind the cascade. Removing the runners from the contract surface is the sound path, and it needs the lint to allow it.
- A product must keep its wiring locations in its contract-check inputs, because core tests execute the implementations wired through them. The lint had no way to record that this stopped being true.
- For product-analytics it stopped being true in [#88867](https://github.com/PostHog/posthog/pull/88867), now merged. No core test executes a paths, paths_v2 or stickiness query.

## Changes

- Product-analytics contract-check inputs drop to 56 files, none under `backend/hogql_queries/`. Facade, migrations, models, presentation and routes stay.
- `DECOUPLED_GARAGES` declares the exemption, keyed by product and location, default-deny like `MODEL_CROSSINGS`.
- `stale_decoupled_garages` blocks when a declared garage is absent or still watched. A registry alone rots, because an entry whose condition lapsed keeps granting the exemption in silence.
- The unwatched-garage lint message now names the escape hatch, so the next person to hit that wall reads the bar rather than only the block.
- Soundness has two halves. The no-core-test-executes audit covers product edits. Core edits stay covered because the product's runner tests import core statically, so the backend test selector reaches them on narrowed ready PRs ([#88265](https://github.com/PostHog/posthog/pull/88265)), and drafts, master and the merge queue keep the full product matrix.
- `products/architecture.md` carries the bar and that argument, so the next product does not have to rediscover it.
- Mechanical: the status dataclass gains a field, and the garage predicate gains the product name.

## How did you test this code?

- The input drop is verified by reading `tasks[0].inputs` from turbo's `--dry=json` for the product: 56 files, zero under `backend/hogql_queries/`. Comparing task hashes does not work here, because `backend/**` globs also match `__pycache__/*.pyc`.
- Three test cases were added, each for a failure this machinery can have.
  - Dropping the per-product filter would exempt every product's garage at once.
  - A declared garage that is absent, or still watched, is a stale claim that must block.
  - A typo in a product name makes an entry inert, which reads as a decoupling but grants nothing. That same registry test also asserts every real entry still holds, which is the unconditional half of the anti-rot guard: the lint's staleness issue only fires once a product narrows its inputs, so an entry added before that, or one whose garage was later deleted, would otherwise sit unreported.
- The audit behind the `DECOUPLED_GARAGES` entry also covered sibling products, whose lanes stop re-running on a runner edit too. No product outside `products/product_analytics/` imports its runners, and the only references elsewhere are kind-name strings, one endpoints test asserting these kinds are rejected for materialization, and one notebooks dict-normalization test.
- Note on this PR's own CI: the diff touches no `posthog/` or `ee/` file, so the backend lanes have little to select and a green `Django Tests Pass` says little here. The backend signal for this work came from [#88867](https://github.com/PostHog/posthog/pull/88867), which touched `posthog/` and has merged.
- Not run: the full Django suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/architecture.md` is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). The PR is unassigned because the driver's GitHub handle was not verified in this session.

- Authored by Claude Code in a PostHog Desktop task. It was stacked on [#88867](https://github.com/PostHog/posthog/pull/88867), which had to land first because the entry here is only true once no core test executes one of these runners. That PR merged, and this branch is rebased onto master.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The registry shape follows `MODEL_CROSSINGS` rather than a per-product flag, so an unlisted garage stays watched and each exemption costs a reviewed entry. The staleness guard was added after noting that a registry with no anti-rot check silently outlives the condition it records.
- The relationship to [#88265](https://github.com/PostHog/posthog/pull/88265) was checked against its merged code, not assumed: the `untrusted` fallback in `decideSelection` (turbo-discover.js) is what keeps contract cascades on the full matrix, which is why this registry is complementary to selection rather than redundant with it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

