### PR TITLE
fix(desktop): keep space list filters and tab space across switches

### DIFF
--- a/products/desktop/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
+++ b/products/desktop/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
@@ -166,7 +166,13 @@ export function BrowserTabStrip() {
     ? view.type
     : null;
 
-  const { channels } = useChannels();
+  const { channels, isLoading: channelsLoading } = useChannels();
+  // The scoped space is null until the channel list has loaded and the route
+  // sync has picked one. Writing that null into a tab's memory would clear the
+  // space it was on, so the next switch to it opens on the list instead of the
+  // session. Leave the field absent until there is a real answer.
+  const stampedSpaceId =
+    scopedSpaceId === null && channelsLoading ? undefined : scopedSpaceId;
   // With channel reports on, a restored inbox tab lands on the spaces index
   // (the inbox is gone as a destination).
   const channelReportsEnabled = useChannelReportsEnabled();
@@ -349,14 +355,14 @@ export function BrowserTabStrip() {
     // not make (hotkeys, deep links, links in the content).
     const visit = {
       href: locationHref,
-      ...(railPane === "spaces" ? { listOpen, spaceId: scopedSpaceId } : {}),
+      ...(railPane === "spaces" ? { listOpen, spaceId: stampedSpaceId } : {}),
     };
     const viewState: TabViewState = {
       // Keep the stored name when nothing has resolved yet, so a loading frame
       // does not blank a background tab's label.
       title: routeTitle ?? mirrorActive?.viewState?.title,
       listOpen,
-      spaceId: scopedSpaceId,
+      spaceId: stampedSpaceId,
       lastByPane: {
         ...(mirrorActive?.viewState?.lastByPane ?? {}),
         [railPane]: visit,
@@ -465,7 +471,7 @@ export function BrowserTabStrip() {
     routeTitle,
     railPane,
     listOpen,
-    scopedSpaceId,
+    stampedSpaceId,
     client,
     router,
   ]);

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -1,4 +1,10 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
+import {
+  DEFAULT_CHANNEL_ITEM_FILTERS,
+  DEFAULT_CHANNEL_ITEM_GROUPING,
+  DEFAULT_CHANNEL_ITEM_SORT,
+} from "@posthog/core/canvas/channelItems";
+import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { Theme } from "@radix-ui/themes";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -116,6 +122,14 @@ function renderSidebar() {
   return render(sidebar());
 }
 
+beforeEach(() => {
+  useSidebarStore.setState({
+    channelItemFilters: DEFAULT_CHANNEL_ITEM_FILTERS,
+    channelItemSort: DEFAULT_CHANNEL_ITEM_SORT,
+    channelItemGrouping: DEFAULT_CHANNEL_ITEM_GROUPING,
+  });
+});
+
 describe("ChannelSidebar", () => {
   beforeEach(() => {
     mocks.items = [];
@@ -219,6 +233,35 @@ describe("ChannelSidebar", () => {
 
     expect(screen.getByText("Somewhere else")).toBeInTheDocument();
     expect(screen.queryByText("No matches")).not.toBeInTheDocument();
+  });
+
+  it("keeps a chosen filter across a remount", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    mocks.items = [
+      item({
+        key: "task:slack",
+        id: "slack",
+        title: "Filed from Slack",
+        source: "slack",
+      }),
+      item({ key: "task:local", id: "local", title: "Started here" }),
+    ];
+    const { unmount } = renderSidebar();
+
+    await user.click(screen.getByRole("button", { name: "Filter" }));
+    await user.click(await screen.findByRole("menuitem", { name: /Source/ }));
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "Slack" }),
+    );
+    expect(screen.queryByText("Started here")).not.toBeInTheDocument();
+
+    // A space switch remounts the list; the narrowing is the user's, not the
+    // list's, so it has to come back with it.
+    unmount();
+    renderSidebar();
+
+    expect(screen.getByText("Filed from Slack")).toBeInTheDocument();
+    expect(screen.queryByText("Started here")).not.toBeInTheDocument();
   });
 
   it("shows a single empty state when the last item goes away under a search", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -13,8 +13,6 @@ import {
   channelItemSortEvent,
   channelItemSources,
   DEFAULT_CHANNEL_ITEM_FILTERS,
-  DEFAULT_CHANNEL_ITEM_GROUPING,
-  DEFAULT_CHANNEL_ITEM_SORT,
   filterChannelItems,
   groupChannelItems,
   hasActiveChannelItemFilters,
@@ -67,6 +65,7 @@ import { SidebarKbdHint } from "@posthog/ui/features/sidebar/components/items/Si
 import { MarqueeOverlay } from "@posthog/ui/features/sidebar/components/MarqueeOverlay";
 import { SidebarBulkActionBar } from "@posthog/ui/features/sidebar/components/SidebarBulkActionBar";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { taskDragSiblings } from "@posthog/ui/features/sidebar/taskDrag";
 import { useTaskSelectionStore } from "@posthog/ui/features/sidebar/taskSelectionStore";
 import { useBulkArchiveConfirm } from "@posthog/ui/features/sidebar/useBulkArchiveConfirm";
@@ -356,13 +355,12 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
   const setTab = (next: ChannelTab) => setChosenTab({ channelId, tab: next });
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [rawFilters, setFilters] = useState<ChannelItemFilters>(
-    DEFAULT_CHANNEL_ITEM_FILTERS,
-  );
-  const [sort, setSort] = useState<ChannelItemSort>(DEFAULT_CHANNEL_ITEM_SORT);
-  const [rawGrouping, setGrouping] = useState<ChannelItemGrouping>(
-    DEFAULT_CHANNEL_ITEM_GROUPING,
-  );
+  const rawFilters = useSidebarStore((state) => state.channelItemFilters);
+  const setFilters = useSidebarStore((state) => state.setChannelItemFilters);
+  const sort = useSidebarStore((state) => state.channelItemSort);
+  const setSort = useSidebarStore((state) => state.setChannelItemSort);
+  const rawGrouping = useSidebarStore((state) => state.channelItemGrouping);
+  const setGrouping = useSidebarStore((state) => state.setChannelItemGrouping);
   // Canvases carry no repository, so grouping by one would file the whole tab
   // under a single heading. Neutralised as well as hidden, the way the run
   // filters above are.
@@ -780,7 +778,7 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
               // menu displays: a choice made under one tab has to survive a
               // write made under another.
               onFilterChange={(key, value) =>
-                setFilters((prev) => ({ ...prev, [key]: value }))
+                setFilters({ ...rawFilters, [key]: value })
               }
               onClearFilters={() => setFilters(DEFAULT_CHANNEL_ITEM_FILTERS)}
               sort={sort}

--- a/products/desktop/packages/ui/src/features/sidebar/sidebarStore.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/sidebarStore.ts
@@ -1,3 +1,11 @@
+import {
+  type ChannelItemFilters,
+  type ChannelItemGrouping,
+  type ChannelItemSort,
+  DEFAULT_CHANNEL_ITEM_FILTERS,
+  DEFAULT_CHANNEL_ITEM_GROUPING,
+  DEFAULT_CHANNEL_ITEM_SORT,
+} from "@posthog/core/canvas/channelItems";
 import { ALL_WORKSPACE_MODES } from "@posthog/core/sidebar/buildSidebarData";
 import type { WorkspaceMode } from "@posthog/shared";
 import { create } from "zustand";
@@ -28,6 +36,11 @@ interface SidebarStoreState {
   showAllUsers: boolean;
   showInternal: boolean;
   taskTypeFilter: WorkspaceMode[];
+  // The space session list's narrowing. Held here rather than in the list so a
+  // space switch, which remounts the list, keeps what the user chose.
+  channelItemFilters: ChannelItemFilters;
+  channelItemSort: ChannelItemSort;
+  channelItemGrouping: ChannelItemGrouping;
   // Reveals the Channels feature in the unified sidebar (channel tree replaces
   // the task list, Canvas nav item appears). Off by default — Code merged into
   // the Bluebird chrome ships with channels hidden until the user opts in.
@@ -59,6 +72,9 @@ interface SidebarStoreActions {
   setShowAllUsers: (showAllUsers: boolean) => void;
   setShowInternal: (showInternal: boolean) => void;
   toggleTaskType: (mode: WorkspaceMode) => void;
+  setChannelItemFilters: (filters: ChannelItemFilters) => void;
+  setChannelItemSort: (sort: ChannelItemSort) => void;
+  setChannelItemGrouping: (grouping: ChannelItemGrouping) => void;
   setChannelsEnabled: (channelsEnabled: boolean) => void;
   setNavItemVisible: (item: CustomizableNavItemId, visible: boolean) => void;
   setNavItemOrder: (order: readonly CustomizableNavItemId[]) => void;
@@ -82,6 +98,9 @@ export const useSidebarStore = create<SidebarStore>()(
       showAllUsers: false,
       showInternal: false,
       taskTypeFilter: [...ALL_WORKSPACE_MODES],
+      channelItemFilters: DEFAULT_CHANNEL_ITEM_FILTERS,
+      channelItemSort: DEFAULT_CHANNEL_ITEM_SORT,
+      channelItemGrouping: DEFAULT_CHANNEL_ITEM_GROUPING,
       channelsEnabled: false,
       navItemOverrides: {},
       navItemOrder: [],
@@ -149,6 +168,11 @@ export const useSidebarStore = create<SidebarStore>()(
           navItemOverrides: { ...state.navItemOverrides, [item]: visible },
         })),
       setNavItemOrder: (navItemOrder) => set({ navItemOrder }),
+      setChannelItemFilters: (channelItemFilters) =>
+        set({ channelItemFilters }),
+      setChannelItemSort: (channelItemSort) => set({ channelItemSort }),
+      setChannelItemGrouping: (channelItemGrouping) =>
+        set({ channelItemGrouping }),
     }),
     {
       name: "sidebar-storage",
@@ -165,6 +189,9 @@ export const useSidebarStore = create<SidebarStore>()(
         showAllUsers: state.showAllUsers,
         showInternal: state.showInternal,
         taskTypeFilter: state.taskTypeFilter,
+        channelItemFilters: state.channelItemFilters,
+        channelItemSort: state.channelItemSort,
+        channelItemGrouping: state.channelItemGrouping,
         channelsEnabled: state.channelsEnabled,
         navItemOverrides: state.navItemOverrides,
         navItemOrder: state.navItemOrder,
@@ -183,6 +210,9 @@ export const useSidebarStore = create<SidebarStore>()(
           showAllUsers?: boolean;
           showInternal?: boolean;
           taskTypeFilter?: WorkspaceMode[];
+          channelItemFilters?: Partial<ChannelItemFilters>;
+          channelItemSort?: ChannelItemSort;
+          channelItemGrouping?: ChannelItemGrouping;
           channelsEnabled?: boolean;
           navItemOverrides?: unknown;
           navItemOrder?: unknown;
@@ -209,6 +239,16 @@ export const useSidebarStore = create<SidebarStore>()(
           showInternal: persistedState.showInternal ?? current.showInternal,
           taskTypeFilter:
             persistedState.taskTypeFilter ?? current.taskTypeFilter,
+          // Spread over the defaults so a filter added later starts at its
+          // default instead of undefined for users with older persisted state.
+          channelItemFilters: {
+            ...current.channelItemFilters,
+            ...persistedState.channelItemFilters,
+          },
+          channelItemSort:
+            persistedState.channelItemSort ?? current.channelItemSort,
+          channelItemGrouping:
+            persistedState.channelItemGrouping ?? current.channelItemGrouping,
           channelsEnabled:
             persistedState.channelsEnabled ?? current.channelsEnabled,
           navItemOverrides: sanitizeNavItemOverrides(


### PR DESCRIPTION
## Problem

Two things a person loses when switching between task tabs in the spaces layout:

- The space session list forgets its filter, sort, and grouping. Switching to a task in another space remounts the list, and the choices lived in that component's local state.
- A tab can briefly open on the channel list instead of the task. The tab strip records the scoped space into each tab's memory on every navigation. On a cold start that value is null until the channel list has loaded, so the strip writes `spaceId: null` onto the tab. Restoring that tab later clears its space, and the sidebar slides to the list before the route sync scopes it again.

Both came out of an agent review of the tab switch reports. Related: #88857 adds telemetry for the separate full-window logo flash.

## Changes

- The session list keeps its filter, sort, and grouping across space switches and app restarts.
- Switching to a tab no longer flashes the channel list when the app has not finished loading channels.
- Mechanism: `channelItemFilters`, `channelItemSort`, and `channelItemGrouping` move from `ChannelSidebar` local state into the persisted `sidebarStore`, next to `organizeMode`. Older persisted state merges over the defaults.
- Mechanism: `BrowserTabStrip` leaves `spaceId` absent from a tab's view state while the channel list is loading and no space is scoped. `applyTabViewState` already skips an absent value.
- No screenshots: the visible change is the absence of a flash and a reset.

## How did you test this code?

- New `ChannelSidebar` test: a chosen source filter survives an unmount and remount. It fails on the old local state.
- `pnpm turbo run typecheck --filter=@posthog/ui`, Biome on the changed files, and the `browser-tabs`, `canvas`, and `sidebar` vitest suites.
- Not run: the flash itself on a packaged build. The tab strip has no unit test harness, so the space stamp change is covered by typecheck and the existing `applyTabViewState` tests only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code implemented a fix another agent proposed during triage of the tab switch reports. Skills invoked: `/posthog-desktop`, `/writing-code-comments`, `/writing-pr-descriptions`, `/writing-tests`.

Decision: the null stamp is skipped at the writer (the tab strip) rather than the reader (`applyTabViewState`), because a stored null still has to clear a space when a tab really left one.
