### PR TITLE
fix(data-warehouse): retry an ambiguous HeadBucket 403 in the local bucket check

### DIFF
--- a/products/data_warehouse/backend/s3.py
+++ b/products/data_warehouse/backend/s3.py
@@ -1,3 +1,4 @@
+import time
 import contextlib
 from typing import Optional
 from urllib.parse import urlparse
@@ -114,6 +115,14 @@ def get_size_of_folder(path: str) -> float:
                 s3fs.S3FileSystem.close_session(s3.loop, s3._s3creator)
 
 
+# HeadBucket returns no body on either success or failure, so a 403 from it carries only the HTTP
+# status as its "Code" — it can't be told apart from a still-registering local object store (e.g.
+# SeaweedFS's credential bootstrap loop, see docker-compose.base.yml) by message here, same ambiguity
+# `_is_retryable_purge_error` documents for the sibling HeadObject case. Retry the bounded budget below
+# to let that race self-heal; a persistent misconfiguration still raises once it's exhausted.
+_HEAD_BUCKET_MAX_ATTEMPTS = 4
+
+
 def ensure_bucket_exists(s3_url: str, s3_key: str, s3_secret: str, s3_endpoint: Optional[str] = None) -> None:
     try:
         s3_client = boto3.client(
@@ -136,26 +145,36 @@ def ensure_bucket_exists(s3_url: str, s3_key: str, s3_secret: str, s3_endpoint: 
 
     bucket_name = parsed.netloc
 
-    try:
-        s3_client.head_bucket(Bucket=bucket_name)
-    except botocore.exceptions.ClientError as e:
-        error = e.response.get("Error")
-        if not error:
-            raise
+    attempt = 0
+    while True:
+        try:
+            s3_client.head_bucket(Bucket=bucket_name)
+            return
+        except botocore.exceptions.ClientError as e:
+            error = e.response.get("Error")
+            if not error:
+                raise
 
-        error_code = error.get("Code")
-        if not error_code:
-            raise
+            error_code = error.get("Code")
+            if not error_code:
+                raise
 
-        if int(error_code) == 404:
-            try:
-                s3_client.create_bucket(Bucket=bucket_name)
-            except botocore.exceptions.ClientError as create_error:
-                # Concurrent callers can both see the 404 above before either creates the bucket; the
-                # loser's create_bucket then reports it already owns the bucket the winner just made.
-                # That's the intended end state, not a failure.
-                create_error_code = create_error.response.get("Error", {}).get("Code")
-                if create_error_code != "BucketAlreadyOwnedByYou":
-                    raise
-        else:
-            raise
+            if int(error_code) == 404:
+                try:
+                    s3_client.create_bucket(Bucket=bucket_name)
+                except botocore.exceptions.ClientError as create_error:
+                    # Concurrent callers can both see the 404 above before either creates the bucket;
+                    # the loser's create_bucket then reports it already owns the bucket the winner just
+                    # made. That's the intended end state, not a failure.
+                    create_error_code = create_error.response.get("Error", {}).get("Code")
+                    if create_error_code != "BucketAlreadyOwnedByYou":
+                        raise
+                return
+
+            if int(error_code) != 403:
+                raise
+
+            attempt += 1
+            if attempt >= _HEAD_BUCKET_MAX_ATTEMPTS:
+                raise
+            time.sleep(2**attempt)

--- a/products/data_warehouse/backend/tests/test_s3.py
+++ b/products/data_warehouse/backend/tests/test_s3.py
@@ -137,8 +137,9 @@ class TestEnsureBucketExists(SimpleTestCase):
         with self.assertRaises(ValueError):
             ensure_bucket_exists("s3://my-bucket", "key", "secret")
 
+    @patch("products.data_warehouse.backend.s3.time.sleep")
     @patch("products.data_warehouse.backend.s3.boto3.client")
-    def test_reraises_non_404_head_bucket_errors(self, mock_boto3_client) -> None:
+    def test_reraises_non_404_head_bucket_errors(self, mock_boto3_client, mock_sleep) -> None:
         s3_client = MagicMock()
         s3_client.head_bucket.side_effect = _client_error("403")
         mock_boto3_client.return_value = s3_client
@@ -146,4 +147,22 @@ class TestEnsureBucketExists(SimpleTestCase):
         with self.assertRaises(ClientError):
             ensure_bucket_exists("s3://my-bucket", "key", "secret")
 
+        # A persistent 403 retries (it's indistinguishable from a transient one, see
+        # test_retries_head_bucket_403_then_succeeds) but still gives up and raises.
+        assert s3_client.head_bucket.call_count > 1
+        s3_client.create_bucket.assert_not_called()
+
+    @patch("products.data_warehouse.backend.s3.time.sleep")
+    @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_retries_head_bucket_403_then_succeeds(self, mock_boto3_client, mock_sleep) -> None:
+        # HeadBucket carries no body, so a 403 from it can't be told apart from a still-registering
+        # local object store (e.g. SeaweedFS's credential bootstrap loop) by message alone. That
+        # transient race must self-heal on retry instead of surfacing as a hard failure.
+        s3_client = MagicMock()
+        s3_client.head_bucket.side_effect = [_client_error("403"), _client_error("403"), None]
+        mock_boto3_client.return_value = s3_client
+
+        ensure_bucket_exists("s3://my-bucket", "key", "secret")
+
+        assert s3_client.head_bucket.call_count == 3
         s3_client.create_bucket.assert_not_called()


### PR DESCRIPTION
## Problem

The data-warehouse sync's best-effort repartition check failed and reported a spurious [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a03b05-1236-76e3-a7d9-df5b9caed4ed): `ClientError: An error occurred (403) when calling the HeadBucket operation: Forbidden`.

- `ensure_bucket_exists` only ever runs against the local/self-hosted data-warehouse bucket. Every caller gates it behind `USE_LOCAL_SETUP`, so it never touches a customer's own S3 credentials.
- `HeadBucket` returns no response body, so a 403 from it carries only the HTTP status, not a semantic error code. It can't be told apart by message from a still-registering local object store (e.g. SeaweedFS's credential bootstrap loop) versus a genuine permission problem. `_is_retryable_purge_error` already documents and retries this exact ambiguity for the sibling `HeadObject` case.
- `ensure_bucket_exists` raised on the first 403, so that self-healing race surfaced as a hard failure and error-tracking noise instead.

## Changes

- `ensure_bucket_exists` now retries a `HeadBucket` 403 up to 4 attempts, with the same backoff `_purge_s3_prefix` uses for its analogous retry, before giving up and raising.
- The existing 404-then-create-bucket path and non-403 error handling are unchanged.

## How did you test this code?

- Added `test_retries_head_bucket_403_then_succeeds`: a `HeadBucket` 403 that resolves after two retries now succeeds instead of raising — the regression this PR fixes.
- Extended `test_reraises_non_404_head_bucket_errors` to assert the retry still gives up and raises when the 403 persists.
- Ran `pytest products/data_warehouse/backend/tests/test_s3.py` (13 passed) and `ruff check` / `ruff format --check` on both changed files.
- Not run: the wider backend suite and `hogli ci:preflight`, unavailable in this sandbox.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue baseline, sampled exception events, stack trace) to trace the failure from `repartition_table.py`'s best-effort pre-extraction check through `delta_storage_options` into `ensure_bucket_exists`. Confirmed every caller of `ensure_bucket_exists` gates it behind `USE_LOCAL_SETUP`, so the 403 never involves customer credentials. No skills were invoked for the fix itself beyond `/writing-tests` and `/writing-pr-descriptions`.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*