### PR TITLE
feat(autoresearch): cache hypothesis constants pool in backend CI

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -60,6 +60,11 @@
 #   shards fall back to the union .test_durations
 # - actions/cache reads/writes route to Depot Cache, not GitHub Actions Cache,
 #   so shared keys with canonical (schema, uv, pnpm) do not collide
+# - hypothesis constants cache: the restore and save steps mirror canonical verbatim, but the
+#   save only fires on master test-matrix runs and the shadow skips those, so the Depot Cache
+#   entry only exists after a master workflow_dispatch. Sampled PR shards run cold (they rebuild
+#   the pool, as canonical did before this cache existed) until then: bounded, documented, and
+#   harmless because the shadow never gates merges.
 # - GITHUB_TOKEN / OTEL_SERVICE_NAME neutralized (ambient on Depot, not on GHA)
 # - Three data-modeling tests deselected (Depot-only MinIO 403 quarantine)
 # - COMPOSE_PROJECT_NAME pinned to posthog because bin/wait-for-docker filters by that
@@ -135,6 +140,10 @@ env:
     # and HEAD (push) key computations below can't drift.
     # ci-e2e-playwright.yml, ci-dagster.yml, ci-mcp.yml and ci-rust-flags-integration.yml restore by the same key; keep their copies in sync when bumping.
     SCHEMA_CACHE_EPOCH: v2
+    # Hypothesis constants cache epoch. Bump to abandon every shared entry at once
+    # (key is posthog-hypothesis-constants-<version>-<epoch>-<isoyear>-<isoweek>); used by
+    # the Django test shards below.
+    HYPOTHESIS_CONSTANTS_EPOCH: v1
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     COMPOSE_PROJECT_NAME: posthog
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
@@ -2172,6 +2181,37 @@ jobs:
                   key: posthog-segment-durations-${{ github.run_id }}
                   restore-keys: |
                       posthog-segment-durations-
+            - name: Compute hypothesis constants cache key
+              # hypothesis builds its constants pool of property-test inputs by
+              # AST-parsing every local module in sys.modules. It caches the result
+              # in .hypothesis/constants under a hash of each source file, so the
+              # pool is content-addressed: restoring a stale copy is safe, because a
+              # changed file reads as a miss and rebuilds. CI otherwise pays the full
+              # parse on every shard's pytest collection (about 10 s per shard).
+              id: hyp-constants-key
+              shell: bash
+              run: |
+                  # The key includes the installed hypothesis version because the
+                  # entry format is an implementation detail, and rotates weekly so
+                  # entries for deleted or rewritten files expire. The restore prefix
+                  # covers the gap until the first master run of a new week saves.
+                  hyp_version=$(python -c "import hypothesis; print(hypothesis.__version__)")
+                  prefix="posthog-hypothesis-constants-${hyp_version}-${HYPOTHESIS_CONSTANTS_EPOCH}-"
+                  {
+                      echo "key=${prefix}$(date -u +%G-%V)"
+                      echo "restore_prefix=${prefix}"
+                  } >> "$GITHUB_OUTPUT"
+            - name: Restore hypothesis constants cache
+              id: hyp-constants
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  # Constants only. Do NOT add .hypothesis/examples: the example
+                  # database decides which inputs property tests replay, so reusing
+                  # one across runs changes what the tests check.
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.hyp-constants-key.outputs.restore_prefix }}
             # Tests
             - name: Set snapshot update flags
               if: ${{ needs.changes.outputs.backend == 'true' && (needs.detect-snapshot-mode.outputs.mode == 'update' || matrix.person-on-events) }}
@@ -2428,6 +2468,27 @@ jobs:
                   else
                       exit $exit_code
                   fi
+            - name: Save hypothesis constants cache
+              # One Core shard per master run writes the weekly entry: a save from
+              # every shard would race on the same key and churn the shared cache
+              # budget. cache-hit != 'true' skips the save once this week's entry
+              # exists, which keeps later master runs cheap.
+              # continue-on-error: overlapping master runs at week rollover fail its
+              # reservation check when an earlier run has saved the same key, and a
+              # cache miss must never red a green run.
+              continue-on-error: true
+              if: |
+                  github.ref == 'refs/heads/master' &&
+                  matrix.segment == 'Core' &&
+                  matrix.group == 1 &&
+                  !matrix.person-on-events &&
+                  !matrix.new-events-schema &&
+                  !matrix.compat &&
+                  steps.hyp-constants.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
             # Post tests
             - name: Show docker compose logs on failure
               if: failure() && (needs.changes.outputs.backend == 'true' && steps.run-core-tests.outcome != 'failure' && steps.run-temporal-tests.outcome != 'failure')

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -44,6 +44,10 @@ env:
     # between the merge-base (PR) and HEAD (push) key computations below.
     # ci-e2e-playwright.yml, ci-dagster.yml, ci-mcp.yml and ci-rust-flags-integration.yml restore by the same key; keep their copies in sync when bumping.
     SCHEMA_CACHE_EPOCH: v2
+    # Hypothesis constants cache epoch. Bump to abandon every shared entry at once
+    # (key is posthog-hypothesis-constants-<version>-<epoch>-<isoyear>-<isoweek>); used by
+    # the Django test shards below.
+    HYPOTHESIS_CONSTANTS_EPOCH: v1
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'
@@ -3131,6 +3135,39 @@ jobs:
                   restore-keys: |
                       posthog-segment-durations-
 
+            - name: Compute hypothesis constants cache key
+              # hypothesis builds its constants pool of property-test inputs by
+              # AST-parsing every local module in sys.modules. It caches the result
+              # in .hypothesis/constants under a hash of each source file, so the
+              # pool is content-addressed: restoring a stale copy is safe, because a
+              # changed file reads as a miss and rebuilds. CI otherwise pays the full
+              # parse on every shard's pytest collection (about 10 s per shard).
+              id: hyp-constants-key
+              shell: bash
+              run: |
+                  # The key includes the installed hypothesis version because the
+                  # entry format is an implementation detail, and rotates weekly so
+                  # entries for deleted or rewritten files expire. The restore prefix
+                  # covers the gap until the first master run of a new week saves.
+                  hyp_version=$(python -c "import hypothesis; print(hypothesis.__version__)")
+                  prefix="posthog-hypothesis-constants-${hyp_version}-${HYPOTHESIS_CONSTANTS_EPOCH}-"
+                  {
+                      echo "key=${prefix}$(date -u +%G-%V)"
+                      echo "restore_prefix=${prefix}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Restore hypothesis constants cache
+              id: hyp-constants
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  # Constants only. Do NOT add .hypothesis/examples: the example
+                  # database decides which inputs property tests replay, so reusing
+                  # one across runs changes what the tests check.
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.hyp-constants-key.outputs.restore_prefix }}
+
             - name: Download the run's sharding plan snapshot
               # Pin every attempt to the plan turbo-discover snapshotted (rationale on
               # that step); a missing snapshot falls back to the floating caches above.
@@ -3486,6 +3523,28 @@ jobs:
                   else
                       exit $exit_code
                   fi
+
+            - name: Save hypothesis constants cache
+              # One Core shard per master run writes the weekly entry: a save from
+              # every shard would race on the same key and churn the shared cache
+              # budget. cache-hit != 'true' skips the save once this week's entry
+              # exists, which keeps later master runs cheap.
+              # continue-on-error: overlapping master runs at week rollover fail its
+              # reservation check when an earlier run has saved the same key, and a
+              # cache miss must never red a green run.
+              continue-on-error: true
+              if: |
+                  github.ref == 'refs/heads/master' &&
+                  matrix.segment == 'Core' &&
+                  matrix.group == 1 &&
+                  !matrix.person-on-events &&
+                  !matrix.new-events-schema &&
+                  !matrix.compat &&
+                  steps.hyp-constants.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
 
             # Post tests
             - name: Show docker compose logs on failure


### PR DESCRIPTION
## Problem

People waiting on backend CI pay about 10 extra seconds on every Django test shard, on every run. The full master matrix is 100+ shards, and PR shards pay it too.

hypothesis (the property-testing library) builds a constants pool of interesting test inputs by AST-parsing every local module in `sys.modules`. It caches the result under `.hypothesis/constants`, keyed by a hash of each source file. That directory is `.gitignore`d and was never cached in CI, so each shard rebuilt the whole pool during pytest collection. #88759 identified the same cost during collection (~4.5s there) and left caching `.hypothesis/` as the follow-up.

Measured locally over the exact collect targets `ci-backend.yml` uses for Core (`posthog ee/` with its ignores, 31,707 tests): 31.9 s collect-only cold, 22.4 s collect-only warm, steady across runs.

## Changes

- Every Django shard now restores `.hypothesis/constants` from GitHub Actions cache before tests run. A hit lands in under a second.
- One Core shard (group 1, default schema legs) saves the cache on master runs only, matching how the repo gates its other cache writes.
- The key rotates by ISO week and embeds the installed hypothesis version (`posthog-hypothesis-constants-<version>-<epoch>-<isoyear>-<isoweek>`). A prefix restore-key keeps runs warm until the first master save of a new week.
- Entries are content-addressed by source hash, so a week-old restore is safe: a changed file reads as a cache miss and rebuilds once. It never feeds stale constants.
- Only `.hypothesis/constants` is cached. `.hypothesis/examples` (the example database that decides which inputs property tests replay) is excluded by path scope, since reusing it across runs would change what tests check.
- The `.depot` shadow of `ci-backend.yml` mirrors both steps; its header documents that the save stays dormant there because shadow master runs skip the test matrices.

```mermaid
flowchart TD
    A["Django shard (any run)"] --> B["pytest collection"]
    B --> C["hypothesis AST-parses all local modules"]
    C --> D["about 10 s per shard, every run"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phRed;
    class D phGray;
```
```mermaid
flowchart TD
    A["Django shard"] --> R["restore .hypothesis/constants"]
    R -->|"hit (under 1 s)"| B["pytest collection"]
    R -->|"miss (changed sources only)"| C["rebuilds just those entries"]
    B --> T["tests run"]
    C --> T
    T --> S["master Core group 1 saves the weekly key"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,S phYellow;
    class R,B phBlue;
    class C,T phGray;
```

Rejected alternatives:

- A run-unique cache key: a fresh 19 MB entry per master run would churn the shared 10 GB cache budget; weekly rotation keeps one entry per week.
- Pruning dead entries before save: measured 4,698 files / 1.9 MB content (19 MB on disk from block rounding); too small to matter, and a missing sentinel entry would trigger an expensive re-parse of capped files.
- Caching per-product `turbo-tests` shards: only hypothesis-using products build a pool (~2.7 s each, measured on `products/logs`); hypothesis-free products build none. Left out of this PR to keep the review small.

## How did you test this code?

Verified locally (no way to exercise the GitHub Actions cache service from a sandbox):

- Cold vs warm `pytest --collect-only` over the exact Core CI targets: 31.9 s → 22.4 s, both repeated; `.hypothesis/constants` held 4,698 entries / 19 MB, matching the reported sizes.
- Real hypothesis tests (`posthog/hogql/printer/test_printer_pbt.py`, `RUN_PBT=1`) pass against a warm, previously built constants cache.
- `bin/hogli lint:workflows`: all 8 checks pass (includes WF006 cache-write gating).
- `actionlint` with the repo config and the CI workflow's flattening script: canonical file clean; the `.depot` shadow shows only pre-existing findings (unchanged count vs the base file).
- `hogli ci:preflight`: green, including the depot shadow-drift gate.
- On the ready-for-review Backend CI run ([link](https://github.com/PostHog/posthog/actions/runs/32908963488)): a Core shard computed `key: posthog-hypothesis-constants-6.151.9-v1-2026-35` and logged the expected first-ever miss (`Cache not found for input keys`), then ran green. The save step correctly skipped (master-gated).
- Backwards compatibility: the steps are inline and reference nothing but hypothesis's own output directory, so unrebased PRs run them unchanged.

Not yet verifiable from a sandbox or a PR run: the master save, which only fires after merge as designed. On the first master run, the Core group-1 shard's `Save hypothesis constants cache` step should succeed (or warn benignly at a week-boundary race). Every later run then logs `Cache restored from key: posthog-hypothesis-constants-...` and saves about 10 s of collection per shard; a miss leaves the shard exactly where it is today, so nothing needs rolling back beyond reverting.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. CI-internal caching; no documented user workflow changes. `skip-inkeep-docs` applies if desired.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Agent-authored (Claude via PostHog Desktop). Skills invoked: `/authoring-ci-workflows` (mandatory for workflow edits), `/writing-code-comments`, `/writing-pr-descriptions`; `hogli lint:workflows`, `actionlint`, and `hogli ci:preflight` run as the repo's own gates. The task specified the hypothesis caching goal, the constants-only cache boundary, and the one-writer-many-restorers shape.

Decisions made along the way: weekly key rotation + prefix restore-keys chosen over run-unique keys (cache-budget churn) and over a static key (stale entries never expire); save gated to one master Core shard per repo cache-write conventions (`WF006`); save step made `continue-on-error` because overlapping master runs at a week boundary can lose the cache reservation race, and a cache miss must never red a green run; the depot shadow mirror was added after preflight flagged drift, with its dormant-save delta documented in the shadow header.

Everything in the diff and this description comes from this public repository and from locally run measurements; no customer data, tickets, or internal threads were used. Labels applied: none (no assignee, no mentions, per the task).

Created with Autoresearch.
