### PR TITLE
fix(desktop): clarify existing report task errors

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/hooks/inboxCloudTaskErrors.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/inboxCloudTaskErrors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isSignalReportTaskCapError } from "./inboxCloudTaskErrors";
+
+describe("isSignalReportTaskCapError", () => {
+  it("recognizes the task cap in the serialized API error", () => {
+    expect(
+      isSignalReportTaskCapError(
+        'Failed request: [429] {"type":"rate_limit","code":"signal_report_task_cap","error":"A PR task already exists"}',
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat other rate limits as the report task cap", () => {
+    expect(
+      isSignalReportTaskCapError(
+        'Failed request: [429] {"type":"rate_limit","code":"throttled"}',
+      ),
+    ).toBe(false);
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/hooks/inboxCloudTaskErrors.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/inboxCloudTaskErrors.ts
@@ -1,0 +1,10 @@
+export function isSignalReportTaskCapError(error: unknown): boolean {
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : JSON.stringify(error);
+
+  return message?.includes('"code":"signal_report_task_cap"') ?? false;
+}

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -126,6 +126,8 @@ export function useCreatePrReport({
       signedOut: "Sign in to create a PR",
       missingModel:
         "Couldn't resolve a default model. Open the task page once and pick a model, then try again.",
+      existingImplementationTask:
+        "This report already has an implementation task. Open it from the activity section to continue.",
     },
     buildInput,
     analyticsExtras,

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -19,6 +19,7 @@ import {
 import type { Task } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
+import { isSignalReportTaskCapError } from "@posthog/ui/features/inbox/hooks/inboxCloudTaskErrors";
 import { resolveDefaultModel } from "@posthog/ui/features/inbox/hooks/resolveDefaultModel";
 import { useUserRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { toastError } from "@posthog/ui/features/notifications/errorDetails";
@@ -46,6 +47,8 @@ export interface InboxCloudTaskCopy {
   signedOut: string;
   /** Error description when no model can be resolved. */
   missingModel: string;
+  /** Error description when this report already has an implementation task. */
+  existingImplementationTask?: string;
   /**
    * Title for the success toast shown when `redirectOnSuccess` is false and the
    * runner stays in place instead of navigating to the task. Defaults to
@@ -270,7 +273,20 @@ export function useInboxCloudTaskRunner({
         toast.dismiss(toastId);
         // Usage-limit blocks already show the upgrade modal; don't double-toast.
         if (!isUsageLimitResult(result)) {
-          toastError(copy.errorTitle, result.error);
+          if (
+            reportId &&
+            copy.existingImplementationTask &&
+            isSignalReportTaskCapError(result.error)
+          ) {
+            await queryClient.invalidateQueries({
+              queryKey: ["inbox", "report-tasks", reportId],
+            });
+            toast.error(copy.errorTitle, {
+              description: copy.existingImplementationTask,
+            });
+          } else {
+            toastError(copy.errorTitle, result.error);
+          }
           log.error("Cloud-task creation failed", {
             failedStep: result.failedStep,
             error: result.error,

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -21,6 +21,7 @@ import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
 import { isSignalReportTaskCapError } from "@posthog/ui/features/inbox/hooks/inboxCloudTaskErrors";
 import { resolveDefaultModel } from "@posthog/ui/features/inbox/hooks/resolveDefaultModel";
+import { reportKeys } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useUserRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { toastError } from "@posthog/ui/features/notifications/errorDetails";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
@@ -278,9 +279,14 @@ export function useInboxCloudTaskRunner({
             copy.existingImplementationTask &&
             isSignalReportTaskCapError(result.error)
           ) {
-            await queryClient.invalidateQueries({
-              queryKey: ["inbox", "report-tasks", reportId],
-            });
+            await Promise.all([
+              queryClient.invalidateQueries({
+                queryKey: ["inbox", "report-tasks", reportId],
+              }),
+              queryClient.invalidateQueries({
+                queryKey: reportKeys.artefacts(reportId),
+              }),
+            ]);
             toast.error(copy.errorTitle, {
               description: copy.existingImplementationTask,
             });


### PR DESCRIPTION
## Problem

A stale report view can let someone click Create PR after an implementation task already exists, then expose a serialized 429 response.

**Why:** The report should point people back to existing work without weakening the one-report, one-implementation limit.

## Changes

- Desktop now explains that the report already has an implementation task and directs the person to the activity section.
- Desktop refreshes the report tasks after this response so the existing task becomes available.
- Other rate limits keep their current error handling.
- No screenshot: this toast requires a race between the report task lookup and task creation.

## How did you test this code?

Added coverage that distinguishes the report task cap from other 429 responses. The Desktop UI suite and typecheck passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The backend behavior and task limit are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this after product review rejected releasing the backend task cap. Skills invoked: /posthog-desktop, /writing-user-facing-copy, /writing-tests, and /writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*