### PR TITLE
fix(notebooks): stop a bad children attribute breaking the notebook

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeLogic.ts
@@ -73,7 +73,7 @@ import {
     buildPythonExecutionRunning,
     mergeExecutionVariables,
 } from './pythonExecution'
-import { buildNotebookNodeClipboardHTML } from './utils'
+import { buildNotebookNodeClipboardHTML, getNodeChildren } from './utils'
 
 export type PythonRunMode = 'auto' | 'cell_upstream' | 'cell' | 'cell_downstream'
 export type DuckSqlRunMode = 'auto' | 'cell_upstream' | 'cell' | 'cell_downstream'
@@ -1408,7 +1408,10 @@ export const notebookNodeLogic = kea<notebookNodeLogicType>([
                 (editableTitle ? nodeAttributes.title : null) || titlePlaceholder,
         ],
         // TODO: Fix the typing of nodeAttributes
-        children: [(s) => [s.nodeAttributes], (nodeAttributes): NotebookNodeResource[] => nodeAttributes.children],
+        children: [
+            (s) => [s.nodeAttributes],
+            (nodeAttributes): NotebookNodeResource[] => getNodeChildren(nodeAttributes),
+        ],
 
         exportedGlobals: [
             (s) => [s.nodeAttributes],

--- a/frontend/src/scenes/notebooks/Nodes/utils.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.test.tsx
@@ -1,4 +1,5 @@
-import { buildNotebookNodeClipboardHTML, sortProperties } from './utils'
+import { NotebookNodeType } from '../types'
+import { buildNotebookNodeClipboardHTML, getNodeChildren, sortProperties } from './utils'
 
 // Mock dependencies for Group revenue utilities
 jest.mock('lib/utils/numbers', () => ({
@@ -524,6 +525,32 @@ describe('notebook node utils', () => {
                 const { getLifetimeValue } = require('./utils')
                 expect(getLifetimeValue(group)).toBe(expected)
             })
+        })
+    })
+
+    describe('getNodeChildren', () => {
+        // The right column called `children.forEach` straight off the parsed attributes, so a
+        // notebook that stored anything else here threw on render and took the notebook with it.
+        it.each([
+            { name: 'a string', children: 'a child' },
+            { name: 'a number', children: 3 },
+            { name: 'a plain object', children: { nodeId: 'child-1' } },
+            { name: 'a boolean', children: true },
+            { name: 'null', children: null },
+            { name: 'undefined', children: undefined },
+        ])('reports no children when the attribute is $name', ({ children }) => {
+            expect(getNodeChildren({ children })).toEqual([])
+        })
+
+        it('reports no children when the node has no attributes', () => {
+            expect(getNodeChildren(undefined)).toEqual([])
+        })
+
+        // Returned by reference because the kea selector memoizes on it. A fresh copy each call
+        // re-renders every child node on every notebook update.
+        it('passes a children array through by reference', () => {
+            const children = [{ type: NotebookNodeType.Recording, attrs: { nodeId: 'child-1' } }]
+            expect(getNodeChildren({ children })).toBe(children)
         })
     })
 })

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -8,6 +8,8 @@ import { percentage } from 'lib/utils/numbers'
 import { CurrencyCode } from '~/queries/schema/schema-general'
 import { Group } from '~/types'
 
+import { NotebookNodeResource } from '../types'
+
 type AnsiState = {
     fgClassName?: string
     isBold?: boolean
@@ -150,6 +152,14 @@ export function buildNotebookNodeClipboardHTML(nodeType: string, attrs: Record<s
     }
 
     return element.outerHTML
+}
+
+// Node attributes are parsed from persisted notebook JSON, so `children` can hold any JSON value
+// even though its type says otherwise. Callers render it as a list, so any other value must read
+// as no children. Returns the original array so kea selectors stay memoized and do not re-render.
+export function getNodeChildren(attributes?: { children?: unknown }): NotebookNodeResource[] {
+    const children = attributes?.children
+    return Array.isArray(children) ? children : []
 }
 
 export const getLogicKey = ({

--- a/frontend/src/scenes/notebooks/Notebook/NotebookColumnRight.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookColumnRight.tsx
@@ -48,7 +48,7 @@ const Widgets = ({ nodeLogic }: { nodeLogic: BuiltLogic<notebookNodeLogicType> }
 
     return (
         <>
-            {children?.map((child) => (
+            {children.map((child) => (
                 <NotebookNodeChildRenderer key={child.attrs.nodeId} content={child} />
             ))}
         </>

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -87,6 +87,7 @@ import type {
     SqlV2NodeSummary,
 } from '../Nodes/notebookNodeContent'
 import type { notebookNodeLogicType } from '../Nodes/notebookNodeLogic'
+import { getNodeChildren } from '../Nodes/utils'
 import { NotebookNodeType, NotebookSyncStatus, NotebookTarget, NotebookType } from '../types'
 import type { NotebookListItemType } from '../types'
 import { updateContentHeading } from '../utils'
@@ -1340,7 +1341,9 @@ export const notebookLogic = kea<notebookLogicType>([
             // oxlint-disable-next-line @typescript-eslint/no-unused-vars
             (nodeLogics: Record<string, BuiltLogic<notebookNodeLogicType>>, _content: JSONContent) => {
                 // NOTE: _content is not but is needed to retrigger as it could mean the children have changed
-                return Object.values(nodeLogics).filter((nodeLogic) => nodeLogic.props.attributes?.children)
+                return Object.values(nodeLogics).filter(
+                    (nodeLogic) => getNodeChildren(nodeLogic.props.attributes).length > 0
+                )
             },
         ],
 


### PR DESCRIPTION
## Problem

Opening an affected notebook shows an error where the notebook should be. Every cell goes, not just the one at fault.

- A node can store a `children` attribute that is not an array, because node attributes are parsed from persisted notebook JSON and nothing validates them.
- The right-hand widget column called `children.forEach` on that value, so the render threw and took the whole notebook with it.
- The column picked its nodes by testing `children` for truthiness, so a string or an object passed the test and reached that call.

The app's own error tracking records this on both US and EU Cloud: [TypeError: e.forEach is not a function](https://us.posthog.com/project/2/error_tracking/019f6a6a-58db-7dd3-a821-57fdebfd9127).

## Changes

- An affected notebook renders again. The node with the invalid attribute contributes no widgets, and every other cell loads.
- `getNodeChildren` returns the stored array, or an empty array for any other value.
- The `nodeLogicsWithChildren` selector opens the right column only for nodes that hold at least one child.
- Mechanical: `NotebookColumnRight` drops the optional chain on `children.map`, because the value is always an array now.

The coercion sits in one helper instead of at each call site, so the node logic selector and the column filter cannot drift apart on what counts as valid children.

> [!NOTE]
> This stops the crash. It does not repair a notebook that already stores an invalid `children` value. That value stays in the document until something rewrites it.

## How did you test this code?

- Added 8 cases to `frontend/src/scenes/notebooks/Nodes/utils.test.tsx`.
- They cover each non-array JSON type that reached `forEach`. No existing test covered that path.
- One case pins a valid array to the same reference, which guards the kea selector memoization that stops the child nodes re-rendering on every notebook update.
- Ran the notebooks Jest suite and the frontend TypeScript check.
- Not verified in a browser. This sandbox runs no dev stack, so unit tests are the only coverage of the render path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this during a PostHog support investigation, directed by a PostHog engineer. The PR is unassigned on purpose: the directing engineer's GitHub handle was not verified in the session, so they should self-assign as DRI rather than have a guessed handle attached.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The reported stack trace was minified. Resolving the frame against the deployed bundle located the crash, and the app's error tracking confirmed it. An earlier version of the fix guarded only the `forEach` call. The shared helper replaced it because two other call sites read the same attribute, and one of them spreads it, which silently corrupts a string into an array of characters.

Public artifact: this work started from a support ticket. No customer name, URL, identifier, or metric appears in the diff or in this description. The test fixture is invented.
