### PR TITLE
feat(workflows): name the workflow on email engagement events

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1485,6 +1485,21 @@
             ],
             "label": "Element text"
         },
+        "$email_subject": {
+            "description": "The subject line of the workflow email.",
+            "examples": [
+                "Welcome to PostHog"
+            ],
+            "label": "Email subject"
+        },
+        "$email_to": {
+            "description": "The address the workflow email was sent to.",
+            "label": "Email recipient"
+        },
+        "$email_tracking_enabled": {
+            "description": "Whether open and click tracking was on for this send. An untracked send can never report an open or a click, so exclude untracked sends when you calculate open and click rates.",
+            "label": "Email tracking enabled"
+        },
         "$enabled_feature_flags": {
             "description": "Keys and multivariate values of the feature flags that were active while this event was sent.",
             "examples": [
@@ -2082,6 +2097,14 @@
                 3
             ],
             "label": "Library version (patch)"
+        },
+        "$link_index": {
+            "description": "The position of the clicked link in the workflow email, counted from the top.",
+            "label": "Email link position"
+        },
+        "$link_url": {
+            "description": "The destination of the link the recipient clicked in a workflow email.",
+            "label": "Email link URL"
         },
         "$locale": {
             "description": "The locale of the device",
@@ -3520,6 +3543,34 @@
             "label": "Window ID",
             "system": true
         },
+        "$workflow_action_id": {
+            "description": "The unique identifier of the step inside the workflow that sent the email.",
+            "label": "Workflow step ID"
+        },
+        "$workflow_action_name": {
+            "description": "The name of the step inside the workflow that sent the email, as it was when the event happened.",
+            "examples": [
+                "Welcome email",
+                "Day 3 reminder"
+            ],
+            "label": "Workflow step name"
+        },
+        "$workflow_id": {
+            "description": "The unique identifier of the workflow that sent the email.",
+            "label": "Workflow ID"
+        },
+        "$workflow_name": {
+            "description": "The name of the workflow that sent the email, as it was when the event happened. Renaming a workflow does not rewrite past events, so break down by workflow ID if you need one bucket per workflow.",
+            "examples": [
+                "Onboarding drip",
+                "Weekly digest"
+            ],
+            "label": "Workflow name"
+        },
+        "$workflow_version": {
+            "description": "The version of the workflow that was published when the email was sent.",
+            "label": "Workflow version"
+        },
         "_kx": {
             "description": "Klaviyo Tracking ID",
             "label": "_kx"
@@ -4096,6 +4147,10 @@
             "ignored_in_assistant": true,
             "label": "Set person properties"
         },
+        "$slack_message_received": {
+            "description": "Fires when a message is posted in a Slack channel PostHog is connected to.",
+            "label": "Slack message received"
+        },
         "$snapshot": {
             "description": "Carries session replay data to the backend. These events do not contribute to event counts.",
             "ignored_in_assistant": true,
@@ -4104,6 +4159,49 @@
         "$web_vitals": {
             "description": "Automatically captured web vitals data.",
             "label": "Web vitals"
+        },
+        "$workflows_email_blocked": {
+            "description": "Fires when a recipient marks a workflow email as spam, so later sends to them are blocked.",
+            "label": "Workflow email blocked",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_bounced": {
+            "description": "Fires when a workflow email is rejected by the recipient's mail server.",
+            "label": "Workflow email bounced",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_delivered": {
+            "description": "Fires when the email provider confirms a workflow email reached the recipient's mailbox.",
+            "label": "Workflow email delivered",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_failed": {
+            "description": "Fires when a workflow email could not be handed to the email provider.",
+            "label": "Workflow email failed",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_link_clicked": {
+            "description": "Fires when a recipient clicks a link in a workflow email. Only tracked emails can report clicks.",
+            "label": "Workflow email link clicked",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_opened": {
+            "description": "Fires when a recipient opens a workflow email. Only tracked emails can report opens.",
+            "label": "Workflow email opened",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_sent": {
+            "description": "Fires when a workflow hands an email to the email provider.",
+            "label": "Workflow email sent",
+            "primary_property": "$workflow_name"
+        },
+        "$workflows_email_tracking_consent_updated": {
+            "description": "Fires when a recipient changes whether workflow emails to them may be tracked.",
+            "label": "Workflow email tracking consent updated"
+        },
+        "$workflows_email_unsubscribed": {
+            "description": "Fires when a recipient unsubscribes from a message category. The unsubscribe link carries no workflow, so this event has no workflow properties.",
+            "label": "Workflow email unsubscribed"
         },
         "All events": {
             "description": "This is a wildcard that matches all events.",
@@ -5992,6 +6090,21 @@
             ],
             "label": "Element text"
         },
+        "$email_subject": {
+            "description": "The subject line of the workflow email.",
+            "examples": [
+                "Welcome to PostHog"
+            ],
+            "label": "Email subject"
+        },
+        "$email_to": {
+            "description": "The address the workflow email was sent to.",
+            "label": "Email recipient"
+        },
+        "$email_tracking_enabled": {
+            "description": "Whether open and click tracking was on for this send. An untracked send can never report an open or a click, so exclude untracked sends when you calculate open and click rates.",
+            "label": "Email tracking enabled"
+        },
         "$enabled_feature_flags": {
             "description": "Keys and multivariate values of the feature flags that were active while this event was sent.",
             "examples": [
@@ -7006,6 +7119,14 @@
                 3
             ],
             "label": "Library version (patch)"
+        },
+        "$link_index": {
+            "description": "The position of the clicked link in the workflow email, counted from the top.",
+            "label": "Email link position"
+        },
+        "$link_url": {
+            "description": "The destination of the link the recipient clicked in a workflow email.",
+            "label": "Email link URL"
         },
         "$locale": {
             "description": "The locale of the device",
@@ -8428,6 +8549,34 @@
             "description": "Unique window ID for session recording disambiguation",
             "label": "Window ID",
             "system": true
+        },
+        "$workflow_action_id": {
+            "description": "The unique identifier of the step inside the workflow that sent the email.",
+            "label": "Workflow step ID"
+        },
+        "$workflow_action_name": {
+            "description": "The name of the step inside the workflow that sent the email, as it was when the event happened.",
+            "examples": [
+                "Welcome email",
+                "Day 3 reminder"
+            ],
+            "label": "Workflow step name"
+        },
+        "$workflow_id": {
+            "description": "The unique identifier of the workflow that sent the email.",
+            "label": "Workflow ID"
+        },
+        "$workflow_name": {
+            "description": "The name of the workflow that sent the email, as it was when the event happened. Renaming a workflow does not rewrite past events, so break down by workflow ID if you need one bucket per workflow.",
+            "examples": [
+                "Onboarding drip",
+                "Weekly digest"
+            ],
+            "label": "Workflow name"
+        },
+        "$workflow_version": {
+            "description": "The version of the workflow that was published when the email was sent.",
+            "label": "Workflow version"
         },
         "_kx": {
             "description": "Klaviyo Tracking ID Data from the last time this user was seen.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2099,7 +2099,7 @@
             "label": "Library version (patch)"
         },
         "$link_index": {
-            "description": "The position of the clicked link in the workflow email, counted from the top.",
+            "description": "The position of the clicked link in the workflow email, counted from the top. The first link is 0.",
             "label": "Email link position"
         },
         "$link_url": {
@@ -3555,8 +3555,27 @@
             ],
             "label": "Workflow step name"
         },
+        "$workflow_conversion_event": {
+            "description": "The name of the event that met the workflow's conversion goal. Only set on event conversions.",
+            "examples": [
+                "purchase_completed"
+            ],
+            "label": "Workflow conversion event"
+        },
+        "$workflow_conversion_event_uuid": {
+            "description": "The unique identifier of the event that met the workflow's conversion goal. Only set on event conversions.",
+            "label": "Workflow conversion event ID"
+        },
+        "$workflow_conversion_type": {
+            "description": "How the conversion was detected. Event conversions come from the conversion goal event firing. Property conversions come from a person property matching the goal.",
+            "examples": [
+                "event",
+                "property"
+            ],
+            "label": "Workflow conversion type"
+        },
         "$workflow_id": {
-            "description": "The unique identifier of the workflow that sent the email.",
+            "description": "The unique identifier of the workflow this event came from.",
             "label": "Workflow ID"
         },
         "$workflow_name": {
@@ -3568,7 +3587,7 @@
             "label": "Workflow name"
         },
         "$workflow_version": {
-            "description": "The version of the workflow that was published when the email was sent.",
+            "description": "The published version of the workflow that was running when this event happened.",
             "label": "Workflow version"
         },
         "_kx": {
@@ -4159,6 +4178,11 @@
         "$web_vitals": {
             "description": "Automatically captured web vitals data.",
             "label": "Web vitals"
+        },
+        "$workflows_conversion": {
+            "description": "Fires when a person in a workflow meets its conversion goal.",
+            "label": "Workflow conversion",
+            "primary_property": "$workflow_id"
         },
         "$workflows_email_blocked": {
             "description": "Fires when a recipient marks a workflow email as spam, so later sends to them are blocked.",
@@ -7121,7 +7145,7 @@
             "label": "Library version (patch)"
         },
         "$link_index": {
-            "description": "The position of the clicked link in the workflow email, counted from the top.",
+            "description": "The position of the clicked link in the workflow email, counted from the top. The first link is 0.",
             "label": "Email link position"
         },
         "$link_url": {
@@ -8562,8 +8586,27 @@
             ],
             "label": "Workflow step name"
         },
+        "$workflow_conversion_event": {
+            "description": "The name of the event that met the workflow's conversion goal. Only set on event conversions.",
+            "examples": [
+                "purchase_completed"
+            ],
+            "label": "Workflow conversion event"
+        },
+        "$workflow_conversion_event_uuid": {
+            "description": "The unique identifier of the event that met the workflow's conversion goal. Only set on event conversions.",
+            "label": "Workflow conversion event ID"
+        },
+        "$workflow_conversion_type": {
+            "description": "How the conversion was detected. Event conversions come from the conversion goal event firing. Property conversions come from a person property matching the goal.",
+            "examples": [
+                "event",
+                "property"
+            ],
+            "label": "Workflow conversion type"
+        },
         "$workflow_id": {
-            "description": "The unique identifier of the workflow that sent the email.",
+            "description": "The unique identifier of the workflow this event came from.",
             "label": "Workflow ID"
         },
         "$workflow_name": {
@@ -8575,7 +8618,7 @@
             "label": "Workflow name"
         },
         "$workflow_version": {
-            "description": "The version of the workflow that was published when the email was sent.",
+            "description": "The published version of the workflow that was running when this event happened.",
             "label": "Workflow version"
         },
         "_kx": {

--- a/nodejs/src/cdp/services/hogflows/hogflow-functions.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-functions.service.ts
@@ -2,6 +2,7 @@ import { HogFlow, HogFlowAction } from '~/cdp/schema/hogflow'
 import {
     CyclotronJobInvocationHogFlow,
     CyclotronJobInvocationHogFunction,
+    CyclotronJobInvocationHogFunctionFromHogFlow,
     CyclotronJobInvocationResult,
     HogFunctionInvocationGlobals,
     HogFunctionType,
@@ -89,7 +90,7 @@ export class HogFlowFunctionsService {
         invocation: CyclotronJobInvocationHogFlow,
         hogFunction: HogFunctionType,
         globals: Omit<HogFunctionInvocationGlobals, 'source' | 'project'>
-    ): Promise<CyclotronJobInvocationHogFunction> {
+    ): Promise<CyclotronJobInvocationHogFunctionFromHogFlow> {
         const teamId = invocation.hogFlow.team_id
         const projectUrl = `${this.siteUrl}/project/${teamId}`
 
@@ -108,7 +109,7 @@ export class HogFlowFunctionsService {
             },
         }
 
-        const hogFunctionInvocation: CyclotronJobInvocationHogFunction = {
+        const hogFunctionInvocation: CyclotronJobInvocationHogFunctionFromHogFlow = {
             ...invocation,
             hogFunction,
             state: invocation.state.currentAction?.hogFunctionState ?? {

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -109,6 +109,35 @@ export const resolveEmailEngagementDistinctId = (
     return invocation.state?.globals?.event?.distinct_id || undefined
 }
 
+/**
+ * The workflow and step names to put on an engagement event, next to `$workflow_id` and
+ * `$workflow_action_id`.
+ *
+ * These are display labels, so that an insight broken down by workflow reads as names instead of a
+ * column of UUIDs. They describe the flow as it is published now, which has two consequences a
+ * reader of the data needs to know:
+ *
+ * 1. A rename splits a name breakdown into two buckets, because past events keep the old name.
+ *    `$workflow_id` stays the stable key for anyone who needs one bucket per workflow.
+ * 2. They float relative to `$workflow_version`. That version comes from the tracking code minted at
+ *    send time, so an engagement event that arrives after a republish carries the version that sent
+ *    it next to names taken from the newer one. A step deleted by that republish has no name at all.
+ *    We accept this because the names are labels and not keys, and because there is no way to load a
+ *    specific published version of a flow.
+ */
+export const resolveWorkflowNameProperties = (
+    hogFlow: HogFlow | undefined | null,
+    actionId: string | undefined
+): { $workflow_name?: string; $workflow_action_name?: string } => {
+    return {
+        $workflow_name: hogFlow?.name,
+        // `actions` is typed as required but flows are read from the database without schema
+        // validation, so keep the optional chain. A throw here would fail a send that already
+        // reached the provider, which the caller would then retry as a duplicate email.
+        $workflow_action_name: actionId ? hogFlow?.actions?.find((action) => action.id === actionId)?.name : undefined,
+    }
+}
+
 // HTML attribute values arrive entity-encoded (e.g. `&amp;`, `&#38;`). Decode before
 // percent-encoding for the tracking redirect, otherwise `?a=1&amp;b=2` round-trips
 // through `target=` as a literal `&amp;` and breaks the destination page's query string.
@@ -293,13 +322,8 @@ export class EmailTrackingService {
                 timestamp,
                 properties: {
                     $workflow_id: appSourceId,
-                    // The names come off the current `hogFlow`, not the tracking code like the version
-                    // above: they are display labels, and the current name is the one the workflows list
-                    // shows. A rename between send and open therefore splits a name breakdown across two
-                    // buckets — `$workflow_id` stays the stable key.
-                    $workflow_name: hogFlow?.name,
                     $workflow_action_id: actionId,
-                    $workflow_action_name: hogFlow?.actions.find((action) => action.id === actionId)?.name,
+                    ...resolveWorkflowNameProperties(hogFlow, actionId),
                     ...(workflowVersion !== undefined ? { $workflow_version: workflowVersion } : {}),
                     ...properties,
                 },

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -293,7 +293,13 @@ export class EmailTrackingService {
                 timestamp,
                 properties: {
                     $workflow_id: appSourceId,
+                    // The names come off the current `hogFlow`, not the tracking code like the version
+                    // above: they are display labels, and the current name is the one the workflows list
+                    // shows. A rename between send and open therefore splits a name breakdown across two
+                    // buckets — `$workflow_id` stays the stable key.
+                    $workflow_name: hogFlow?.name,
                     $workflow_action_id: actionId,
+                    $workflow_action_name: hogFlow?.actions.find((action) => action.id === actionId)?.name,
                     ...(workflowVersion !== undefined ? { $workflow_version: workflowVersion } : {}),
                     ...properties,
                 },

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -2,6 +2,7 @@ import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { MessageRejected, SendingPausedException, TooManyRequestsException } from '@aws-sdk/client-sesv2'
 
+import { FixtureHogFlowBuilder } from '~/cdp/_tests/builders/hogflow.builder'
 import { createExampleInvocation, insertIntegration } from '~/cdp/_tests/fixtures'
 import { CyclotronInvocationQueueParametersEmailType } from '~/cdp/schema/cyclotron'
 import { CyclotronJobInvocationHogFunction } from '~/cdp/types'
@@ -1192,6 +1193,36 @@ describe('EmailService', () => {
                     $email_subject: 'Test Subject',
                     $email_tracking_enabled: true,
                 },
+            })
+        })
+
+        it('names the workflow and the step that sent the email', async () => {
+            // Insights break down by these names instead of a column of UUIDs. The flow's email runs as a
+            // hog function invocation built by spreading the flow invocation, so `hogFlow` is only there at
+            // runtime — narrowing that spread away would drop both names and no other test would notice.
+            jest.spyOn((service as any).teamWorkflowsConfigService, 'shouldCaptureEngagementEvents').mockResolvedValue(
+                true
+            )
+            const hogFlow = new FixtureHogFlowBuilder()
+                .withTeamId(team.id)
+                .withName('Onboarding drip')
+                .withWorkflow({
+                    actions: {
+                        trigger: { type: 'trigger', config: { type: 'event', filters: {} } },
+                        welcome_email: { type: 'function_email', name: 'Welcome email', config: {} as any },
+                    },
+                    edges: [{ from: 'trigger', to: 'welcome_email', type: 'continue' }],
+                })
+                .build()
+            invocation.state.actionId = 'welcome_email'
+            ;(invocation as any).hogFlow = hogFlow
+
+            sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+            const result = await service.executeSendEmail(invocation)
+
+            expect(result.capturedPostHogEvents[0].properties).toMatchObject({
+                $workflow_name: 'Onboarding drip',
+                $workflow_action_name: 'Welcome email',
             })
         })
 

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -1197,9 +1197,10 @@ describe('EmailService', () => {
         })
 
         it('names the workflow and the step that sent the email', async () => {
-            // Insights break down by these names instead of a column of UUIDs. The flow's email runs as a
-            // hog function invocation built by spreading the flow invocation, so `hogFlow` is only there at
-            // runtime — narrowing that spread away would drop both names and no other test would notice.
+            // Covers the send path reading the names off the invocation's flow and putting them on the
+            // captured event, so that an insight breaks down by workflow name instead of by UUID. The
+            // separate guarantee that a workflow step's invocation still carries its flow is held by
+            // the return type of `HogFlowFunctionsService.buildHogFunctionInvocation`, not by this test.
             jest.spyOn((service as any).teamWorkflowsConfigService, 'shouldCaptureEngagementEvents').mockResolvedValue(
                 true
             )

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -6,7 +6,6 @@ import { Counter } from 'prom-client'
 import { CyclotronInvocationQueueParametersEmailType } from '~/cdp/schema/cyclotron'
 import { HogFlowEmailSendingRateLimit, HogFlowEmailSendingRateLimitSchema } from '~/cdp/schema/hogflow'
 import {
-    CyclotronJobInvocationHogFlow,
     CyclotronJobInvocationHogFunction,
     CyclotronJobInvocationResult,
     HogFunctionType,
@@ -14,7 +13,7 @@ import {
     MessageAssetRow,
 } from '~/cdp/types'
 import { createAddLogFunction, logEntry } from '~/cdp/utils'
-import { createInvocationResult } from '~/cdp/utils/invocation-utils'
+import { createInvocationResult, hogFlowOfInvocation } from '~/cdp/utils/invocation-utils'
 import { logger } from '~/common/utils/logger'
 
 import { IntegrationManagerService } from '../managers/integration-manager.service'
@@ -23,7 +22,11 @@ import { TeamWorkflowsConfigService } from '../managers/team-workflows-config.se
 import { RateLimiterService } from '../rate-limiter/rate-limiter.service'
 import { selectEmailSenderIntegrationId } from './email-sender-selection'
 import { EmailSuppressionService } from './email-suppression.service'
-import { addTrackingToEmail, resolveEmailEngagementDistinctId } from './email-tracking.service'
+import {
+    addTrackingToEmail,
+    resolveEmailEngagementDistinctId,
+    resolveWorkflowNameProperties,
+} from './email-tracking.service'
 import { mailDevTransport, mailDevWebUrl } from './helpers/maildev'
 import { maybeAddPreheaderToEmail } from './helpers/preheader'
 import { EmailTrackingCodeSigner, TRACKING_CODE_HEADER_NAME } from './helpers/tracking-code'
@@ -417,11 +420,6 @@ export class EmailService {
             !isTest &&
             (await this.teamWorkflowsConfigService.shouldCaptureEngagementEvents(invocation.teamId))
         ) {
-            // A flow's email runs as a hog function invocation built by spreading the flow invocation, so
-            // `hogFlow` is present at runtime even though the type is the narrower hog function shape.
-            const hogFlow =
-                'hogFlow' in invocation ? (invocation as unknown as CyclotronJobInvocationHogFlow).hogFlow : undefined
-
             result.capturedPostHogEvents.push({
                 team_id: invocation.teamId,
                 timestamp: new Date().toISOString(),
@@ -429,13 +427,8 @@ export class EmailService {
                 event: success ? '$workflows_email_sent' : '$workflows_email_failed',
                 properties: {
                     $workflow_id: invocation.functionId,
-                    // The names are what make an insight readable: broken down by id alone, a chart is a
-                    // column of UUIDs. They're a snapshot of the name at send time, so a later rename splits
-                    // the breakdown into two buckets — the ids stay the stable key for anyone who needs one.
-                    $workflow_name: hogFlow?.name,
                     $workflow_action_id: invocation.state.actionId,
-                    $workflow_action_name: hogFlow?.actions.find((action) => action.id === invocation.state.actionId)
-                        ?.name,
+                    ...resolveWorkflowNameProperties(hogFlowOfInvocation(invocation), invocation.state.actionId),
                     $email_to: params.to.email,
                     $email_subject: params.subject,
                     // Always set, never conditional: an untracked send can never produce a
@@ -682,12 +675,7 @@ export class EmailService {
         // Full signed code (with distinct_id + isTest) rides in the header; the short unsigned
         // carrier (no distinct_id/isTest) goes in the SES EmailTag, guaranteed under the 256-char
         // tag-value limit. The webhook reads the header first and only falls back to the tag.
-        // A flow's email runs as a hog function invocation built by spreading the flow invocation, so
-        // `hogFlow` is present at runtime even though the type is the narrower hog function shape.
-        const workflowVersion =
-            'hogFlow' in result.invocation
-                ? (result.invocation as unknown as CyclotronJobInvocationHogFlow).hogFlow.version
-                : undefined
+        const workflowVersion = hogFlowOfInvocation(result.invocation)?.version
         const trackingCode = this.trackingCodeSigner.generate(
             { ...result.invocation, distinctId, workflowVersion },
             isTest

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -417,6 +417,11 @@ export class EmailService {
             !isTest &&
             (await this.teamWorkflowsConfigService.shouldCaptureEngagementEvents(invocation.teamId))
         ) {
+            // A flow's email runs as a hog function invocation built by spreading the flow invocation, so
+            // `hogFlow` is present at runtime even though the type is the narrower hog function shape.
+            const hogFlow =
+                'hogFlow' in invocation ? (invocation as unknown as CyclotronJobInvocationHogFlow).hogFlow : undefined
+
             result.capturedPostHogEvents.push({
                 team_id: invocation.teamId,
                 timestamp: new Date().toISOString(),
@@ -424,7 +429,13 @@ export class EmailService {
                 event: success ? '$workflows_email_sent' : '$workflows_email_failed',
                 properties: {
                     $workflow_id: invocation.functionId,
+                    // The names are what make an insight readable: broken down by id alone, a chart is a
+                    // column of UUIDs. They're a snapshot of the name at send time, so a later rename splits
+                    // the breakdown into two buckets — the ids stay the stable key for anyone who needs one.
+                    $workflow_name: hogFlow?.name,
                     $workflow_action_id: invocation.state.actionId,
+                    $workflow_action_name: hogFlow?.actions.find((action) => action.id === invocation.state.actionId)
+                        ?.name,
                     $email_to: params.to.email,
                     $email_subject: params.subject,
                     // Always set, never conditional: an untracked send can never produce a

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -362,6 +362,15 @@ export type CyclotronJobInvocationHogFunction = CyclotronJobInvocation & {
     hogFunction: HogFunctionType
 }
 
+// A hog function invocation that a workflow step produced, which keeps the flow it was built from.
+// Services downstream of the step read the flow to describe the workflow that ran, for example the
+// email service names the workflow and the step on the events it captures. The type states that
+// carry so the compiler holds it, because it is otherwise only an object spread in
+// `HogFlowFunctionsService.buildHogFunctionInvocation` that nothing else forces to keep `hogFlow`.
+export type CyclotronJobInvocationHogFunctionFromHogFlow = CyclotronJobInvocationHogFunction & {
+    hogFlow: HogFlow
+}
+
 export type CyclotronJobInvocationHogFlow = CyclotronJobInvocation & {
     state?: HogFlowInvocationContext
     hogFlow: HogFlow

--- a/nodejs/src/cdp/utils/invocation-utils.ts
+++ b/nodejs/src/cdp/utils/invocation-utils.ts
@@ -3,9 +3,11 @@ import { DateTime } from 'luxon'
 
 import { UUIDT } from '~/common/utils/utils'
 
+import type { HogFlow } from '../schema/hogflow'
 import type { HogInputsService } from '../services/hog-inputs.service'
 import {
     CyclotronJobInvocation,
+    CyclotronJobInvocationHogFlow,
     CyclotronJobInvocationHogFunction,
     CyclotronJobInvocationResult,
     HogFunctionFilterGlobals,
@@ -157,6 +159,18 @@ export async function buildHogFunctionInvocations(
         metrics,
         logs,
     }
+}
+
+/**
+ * Returns the workflow an invocation belongs to, or undefined when it does not belong to one.
+ *
+ * A workflow step's hog function invocation keeps the flow it was built from (see
+ * `CyclotronJobInvocationHogFunctionFromHogFlow`), but the services that run the step are typed on
+ * the narrower hog function shape, because the same services also run standalone hog functions.
+ * Reading the flow through here keeps that one runtime check in a single place.
+ */
+export function hogFlowOfInvocation(invocation: CyclotronJobInvocation): HogFlow | undefined {
+    return 'hogFlow' in invocation ? (invocation as CyclotronJobInvocationHogFlow).hogFlow : undefined
 }
 
 /**

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -531,6 +531,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Workflow email tracking consent updated",
             "description": "Fires when a recipient changes whether workflow emails to them may be tracked.",
         },
+        "$workflows_conversion": {
+            "label": "Workflow conversion",
+            "description": "Fires when a person in a workflow meets its conversion goal.",
+            "primary_property": "$workflow_id",
+        },
     },
     "elements": {
         "tag_name": {
@@ -1835,7 +1840,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$workflow_id": {
             "label": "Workflow ID",
-            "description": "The unique identifier of the workflow that sent the email.",
+            "description": "The unique identifier of the workflow this event came from.",
         },
         "$workflow_action_name": {
             "label": "Workflow step name",
@@ -1848,7 +1853,21 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$workflow_version": {
             "label": "Workflow version",
-            "description": "The version of the workflow that was published when the email was sent.",
+            "description": "The published version of the workflow that was running when this event happened.",
+        },
+        "$workflow_conversion_type": {
+            "label": "Workflow conversion type",
+            "description": "How the conversion was detected. Event conversions come from the conversion goal event firing. Property conversions come from a person property matching the goal.",
+            "examples": ["event", "property"],
+        },
+        "$workflow_conversion_event": {
+            "label": "Workflow conversion event",
+            "description": "The name of the event that met the workflow's conversion goal. Only set on event conversions.",
+            "examples": ["purchase_completed"],
+        },
+        "$workflow_conversion_event_uuid": {
+            "label": "Workflow conversion event ID",
+            "description": "The unique identifier of the event that met the workflow's conversion goal. Only set on event conversions.",
         },
         "$email_to": {
             "label": "Email recipient",
@@ -1869,7 +1888,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$link_index": {
             "label": "Email link position",
-            "description": "The position of the clicked link in the workflow email, counted from the top.",
+            "description": "The position of the clicked link in the workflow email, counted from the top. The first link is 0.",
         },
         "$device": {
             "label": "Device",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -488,6 +488,49 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Slack message received",
             "description": "Fires when a message is posted in a Slack channel PostHog is connected to.",
         },
+        "$workflows_email_sent": {
+            "label": "Workflow email sent",
+            "description": "Fires when a workflow hands an email to the email provider.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_failed": {
+            "label": "Workflow email failed",
+            "description": "Fires when a workflow email could not be handed to the email provider.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_delivered": {
+            "label": "Workflow email delivered",
+            "description": "Fires when the email provider confirms a workflow email reached the recipient's mailbox.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_opened": {
+            "label": "Workflow email opened",
+            "description": "Fires when a recipient opens a workflow email. Only tracked emails can report opens.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_link_clicked": {
+            "label": "Workflow email link clicked",
+            "description": "Fires when a recipient clicks a link in a workflow email. Only tracked emails can report clicks.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_bounced": {
+            "label": "Workflow email bounced",
+            "description": "Fires when a workflow email is rejected by the recipient's mail server.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_blocked": {
+            "label": "Workflow email blocked",
+            "description": "Fires when a recipient marks a workflow email as spam, so later sends to them are blocked.",
+            "primary_property": "$workflow_name",
+        },
+        "$workflows_email_unsubscribed": {
+            "label": "Workflow email unsubscribed",
+            "description": "Fires when a recipient unsubscribes from a message category. The unsubscribe link carries no workflow, so this event has no workflow properties.",
+        },
+        "$workflows_email_tracking_consent_updated": {
+            "label": "Workflow email tracking consent updated",
+            "description": "Fires when a recipient changes whether workflow emails to them may be tracked.",
+        },
     },
     "elements": {
         "tag_name": {
@@ -1784,6 +1827,49 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$survey_partially_completed": {
             "description": "If a survey was partially completed (some questions answered) on dismissal, this will be true.",
             "label": "Survey partially completed",
+        },
+        "$workflow_name": {
+            "label": "Workflow name",
+            "description": "The name of the workflow that sent the email, as it was when the event happened. Renaming a workflow does not rewrite past events, so break down by workflow ID if you need one bucket per workflow.",
+            "examples": ["Onboarding drip", "Weekly digest"],
+        },
+        "$workflow_id": {
+            "label": "Workflow ID",
+            "description": "The unique identifier of the workflow that sent the email.",
+        },
+        "$workflow_action_name": {
+            "label": "Workflow step name",
+            "description": "The name of the step inside the workflow that sent the email, as it was when the event happened.",
+            "examples": ["Welcome email", "Day 3 reminder"],
+        },
+        "$workflow_action_id": {
+            "label": "Workflow step ID",
+            "description": "The unique identifier of the step inside the workflow that sent the email.",
+        },
+        "$workflow_version": {
+            "label": "Workflow version",
+            "description": "The version of the workflow that was published when the email was sent.",
+        },
+        "$email_to": {
+            "label": "Email recipient",
+            "description": "The address the workflow email was sent to.",
+        },
+        "$email_subject": {
+            "label": "Email subject",
+            "description": "The subject line of the workflow email.",
+            "examples": ["Welcome to PostHog"],
+        },
+        "$email_tracking_enabled": {
+            "label": "Email tracking enabled",
+            "description": "Whether open and click tracking was on for this send. An untracked send can never report an open or a click, so exclude untracked sends when you calculate open and click rates.",
+        },
+        "$link_url": {
+            "label": "Email link URL",
+            "description": "The destination of the link the recipient clicked in a workflow email.",
+        },
+        "$link_index": {
+            "label": "Email link position",
+            "description": "The position of the clicked link in the workflow email, counted from the top.",
         },
         "$device": {
             "label": "Device",


### PR DESCRIPTION
## Problem

Someone building an insight on workflow emails can only break it down by `$workflow_id`, so the chart reads as a column of UUIDs. A reader has to look up every UUID in the workflows list to know which campaign a bar belongs to. A drip campaign with several email steps has the same problem one level down.

The `$workflows_email_*` events also had no taxonomy entry, so the taxonomic filter offers their properties as raw keys with no label or description.

From https://us.posthog.com/project/2/support/tickets/68357

## Changes

- A breakdown by workflow now reads as workflow names. Sends carry `$workflow_name` and `$workflow_action_name` next to the ids, and so do opens, clicks, deliveries, bounces and blocks.
- The taxonomic filter now labels and describes the nine `$workflows_email_*` events, `$workflows_conversion`, and their properties.
- The names are a snapshot of what the workflow was called when the event happened. A rename splits a name breakdown into two buckets, and `$workflow_id` stays the stable key. Resolving ids to current names at query time would survive a rename, but only inside the insight UI, and would leave SQL, exports and the API on UUIDs.
- Past events keep only the ids. Names appear on events captured after this ships, for teams that opted into `capture_workflows_engagement_events`.

`$workflow_id` and `$workflow_version` are not email-only: `$workflows_conversion` carries them too, and the taxonomic filter resolves a description by property key with no event scoping. Both descriptions therefore cover any workflow event.

A workflow step's email runs as a hog function invocation that carries the flow it was built from. `buildHogFunctionInvocation` returns a type that states that carry, so the compiler fails if the object spread supplying it goes away. `hogFlowOfInvocation` reads it back.

Nothing looks different in the app itself. The visible change is in the taxonomic filter and in insight breakdowns, and both are driven by the data and taxonomy above rather than by a UI edit. The taxonomy JSON under `frontend/src/taxonomy/` is generated by `bin/build-taxonomy-json.py` and is mechanical.

## How did you test this code?

- Added one Jest case in `email.service.test.ts`. It catches the send path dropping either name from the captured event.
- `email.service.test.ts` and `email-tracking.service.test.ts` pass in full against a local stack.
- The compiler guard was checked by removing `hogFlow` from the built invocation and confirming `tsc` fails on it.
- Ran the taxonomy tests under `posthog/taxonomy/test/` and `taxonomicFilterLogic.test.ts`.
- Regenerated the taxonomy JSON with `bin/build-taxonomy-json.py`.
- Not tested manually. No workflow email was sent end to end.
- `hogflow-manager.service.test.ts` has one snapshot failure on this branch. It reproduces without these changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a customer request relayed in Slack, asking for workflow names rather than UUIDs when breaking down insights by workflow. A second agent session reviewed the first, then applied the review findings.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments` and `/writing-pr-descriptions`.

The first shape considered was resolving `$workflow_id` to a name in the frontend, the way cohort breakdowns resolve cohort ids. That handles renames and works on historical data, but it only helps the insight UI and needs a new `formatBreakdownLabel` path that returns a node rather than a string. Emitting the name reaches SQL, exports and the API too, and is the smaller change. The request also asked for clickable breakdown values, which is not in this PR. There is no precedent for a breakdown value that links to an entity page, so that stays a separate piece of work.

The names float relative to `$workflow_version`, which comes from the tracking code minted at send time while the names come from the currently published flow. There is no versioned flow fetch to resolve them against, so the helper documents the gap instead of closing it.

No customer material, Slack quotes, or operational metrics are in this diff. The test fixture names are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1787700436308509)*
