### PR TITLE
fix(agent): refresh Codex MCP servers on follow-up

### DIFF
--- a/products/desktop/packages/agent/e2e/session-lifecycle.e2e.test.ts
+++ b/products/desktop/packages/agent/e2e/session-lifecycle.e2e.test.ts
@@ -334,8 +334,7 @@ for (const adapter of ADAPTERS) {
           // call reaches the handler.
           await expect(call).rejects.toThrow(/MCP injection/i);
         } else {
-          // codex doesn't implement extMethod — the call rejects cleanly (known adapter divergence).
-          await expect(call).rejects.toThrow();
+          await expect(call).resolves.toEqual({ refreshed: true });
         }
       } finally {
         await s.cleanup();


### PR DESCRIPTION
## Problem

Codex follow-ups must reconnect PostHog MCP without replacing the existing thread.

**Why:** A disconnected MCP server leaves desktop users without an easy recovery path.

Refs #76198

## Changes

- The lifecycle contract now expects Codex to refresh MCP servers successfully, matching the shipped adapter behavior.
- Codex still preserves the thread and refuses refresh while a turn is active.
- This PR adds regression coverage only; the adapter implementation already exists on `master`.

## How did you test this code?

The focused Codex tests and agent package type-check passed before publication. The updated lifecycle test covers successful Codex session refresh.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This PR completes automated coverage for existing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex via PostHog Desktop prepared the missing lifecycle coverage and PR. The `/writing-pr-descriptions` skill shaped this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
