### PR TITLE
fix(managed-warehouse): move the lifecycle fence off the hot organization row

### DIFF
--- a/products/managed_warehouse/backend/logic/connection.py
+++ b/products/managed_warehouse/backend/logic/connection.py
@@ -108,9 +108,11 @@ class _LifecycleSnapshot:
 
 
 def _lifecycle_snapshot(organization_id: str | UUID, *, lock: bool = False) -> _LifecycleSnapshot:
+    # The organization existence check is deliberately a plain read: FOR UPDATE on a
+    # posthog_organization row conflicts with the FK KEY SHARE every org-scoped INSERT
+    # takes, so locking it from these sweeps dams unrelated writers org-wide. The
+    # lifecycle row below is the serialization fence.
     organization_queryset = Organization.objects.only("id")
-    if lock:
-        organization_queryset = organization_queryset.select_for_update()
     if not organization_queryset.filter(id=organization_id).exists():
         return _LifecycleSnapshot(organization_exists=False, desired_active=False, generation=None)
     lifecycle_queryset = ManagedWarehouseSourceLifecycle.objects.filter(organization_id=organization_id)
@@ -273,12 +275,17 @@ def _ensure_managed_source_locked(
 
 
 def _locked_source_lifecycle(organization_id: str | UUID) -> ManagedWarehouseSourceLifecycle:
-    # The organization row serializes first-time lifecycle-row creation as well as all
-    # later generation reads/writes. This avoids relying on DuckgresServer for lifecycle
-    # coordination and gives every team in an organization one common fence.
-    organization = Organization.objects.select_for_update().only("id").get(id=organization_id)
-    lifecycle, _created = ManagedWarehouseSourceLifecycle.objects.get_or_create(organization=organization)
-    return lifecycle
+    # The lifecycle row itself is the common fence for every team in the organization:
+    # a quiet per-org singleton (OneToOne), so locking it serializes generation
+    # reads/writes without touching the hot posthog_organization row (whose FOR UPDATE
+    # would conflict with the FK KEY SHARE every org-scoped INSERT takes). First-time
+    # creation is race-safe via the OneToOne unique constraint; a freshly inserted row
+    # is already exclusively owned by this transaction.
+    organization = Organization.objects.only("id").get(id=organization_id)
+    lifecycle, created = ManagedWarehouseSourceLifecycle.objects.get_or_create(organization=organization)
+    if created:
+        return lifecycle
+    return ManagedWarehouseSourceLifecycle.objects.select_for_update().get(pk=lifecycle.pk)
 
 
 def get_active_managed_warehouse_source_generation(*, organization_id: str | UUID) -> int | None:
@@ -313,10 +320,10 @@ def deactivate_managed_warehouse_source_lifecycle(
 ) -> int | None:
     """Mark the lifecycle inactive once and return the cleanup operation generation."""
     with transaction.atomic():
-        organization = Organization.objects.select_for_update().only("id").filter(id=organization_id).first()
-        if organization is None:
+        try:
+            lifecycle = _locked_source_lifecycle(organization_id)
+        except Organization.DoesNotExist:
             return None
-        lifecycle, _created = ManagedWarehouseSourceLifecycle.objects.get_or_create(organization=organization)
         if lifecycle.generation != expected_generation:
             return None
         if lifecycle.desired_active:
@@ -507,10 +514,12 @@ def soft_delete_managed_warehouse_sources(*, organization_id: str | UUID, expect
     now = timezone.now()
     cleanup_error: Exception | None = None
     with transaction.atomic():
-        organization = Organization.objects.select_for_update().only("id").filter(id=organization_id).first()
-        if organization is None:
+        # Fence on the lifecycle row, not the hot organization row (see _locked_source_lifecycle).
+        if not Organization.objects.only("id").filter(id=organization_id).exists():
             return
-        lifecycle = ManagedWarehouseSourceLifecycle.objects.filter(organization=organization).first()
+        lifecycle = (
+            ManagedWarehouseSourceLifecycle.objects.select_for_update().filter(organization_id=organization_id).first()
+        )
         if lifecycle is None or lifecycle.desired_active or lifecycle.generation != expected_generation:
             return
 
@@ -533,10 +542,13 @@ def soft_delete_managed_warehouse_sources(*, organization_id: str | UUID, expect
 def soft_delete_legacy_managed_warehouse_sources(*, organization_id: str | UUID) -> None:
     now = timezone.now()
     with transaction.atomic():
-        organization = Organization.objects.select_for_update().only("id").filter(id=organization_id).first()
-        if organization is None:
+        # Fence on the lifecycle row when present; the legacy fallback below serializes on
+        # the source rows it tombstones. Never the hot organization row.
+        if not Organization.objects.only("id").filter(id=organization_id).exists():
             return
-        lifecycle = ManagedWarehouseSourceLifecycle.objects.filter(organization=organization).first()
+        lifecycle = (
+            ManagedWarehouseSourceLifecycle.objects.select_for_update().filter(organization_id=organization_id).first()
+        )
         if lifecycle is not None:
             _soft_delete_sources_for_inactive_generation_locked(
                 organization_id=organization_id,


### PR DESCRIPTION
## Problem

Follow-up to #88480, which removed the reconcile's `FOR UPDATE` on `posthog_team` and eliminated the twice-hourly team-level lock convoys on prod-us (verified: per-wave blocked queries went ~200–350 → 0 on deploy). The same file still takes **`FOR UPDATE` on the `posthog_organization` row** in five places, and that is the residual convoy igniter we're now catching live at :16/:46:

- 2026-08-25 23:46 UTC (writer log): the reconcile's `SELECT 1 … FROM posthog_organization WHERE id=… FOR UPDATE` (`_lifecycle_snapshot(lock=True)`) queued ~50s behind six transactions holding shared FK pins on that org row — and Postgres lock fairness then queued **every new** org-scoped writer behind it (121–240 blocked per wave, mostly replay-vision commits).
- The org row is even hotter than a team row: every org-scoped INSERT in every team of the org takes an FK `KEY SHARE` on it. An exclusive waiter on it dams the whole organization.
- A 38-minute org-row hold from the same worker role was observed on 2026-08-25 20:07–20:45 during a writer-health census — consistent with this lock queued behind shared pins under load.

## Change

Move the serialization fence from the organization row to the **`ManagedWarehouseSourceLifecycle` row** — the quiet per-org singleton (OneToOne) these code paths actually coordinate through:

- `_lifecycle_snapshot(lock=True)`: org existence check becomes a plain read; the lifecycle-row lock (already taken) remains the fence.
- `_locked_source_lifecycle`: locks the lifecycle row itself. First-time creation is race-safe via the OneToOne unique constraint (`get_or_create`), and a freshly inserted row is already exclusively owned by its transaction; existing rows are re-read under `select_for_update`. `Organization.DoesNotExist` semantics preserved.
- `deactivate_…`: now uses `_locked_source_lifecycle` (DoesNotExist → `None`, as before).
- The two soft-delete paths: plain org existence check + lifecycle-row lock; the legacy fallback keeps serializing on the source rows it tombstones.

Net: zero `Organization.objects.select_for_update()` remain in this module.

## Why it's safe

- Every mutual-exclusion property these functions rely on is preserved — they all coordinate through the lifecycle singleton, which is now locked directly instead of indirectly via the org row. Generation compare-and-advance, deactivation, and tombstoning all still serialize per org.
- The only behavior that changes is that unrelated org-scoped writers (error tracking, replay-vision, ingestion for any team in the org) no longer queue behind warehouse lifecycle operations.
- Same recipe as #88480, which has been verified in production for the team-row half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaTSvi7eD23WDB6azeKJYT
