### PR TITLE
feat(workflows): trigger on account tag changes

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.test.ts
@@ -5,11 +5,12 @@ import {
     accountCustomPropertyFrequencyOptions,
     accountRelationshipChangedFilters,
     accountRelationshipFrequencyOptions,
-    accountTagAddedFilters,
+    accountTagChangedFilters,
     customPropertyDisplayTypeToPropertyType,
     getAccountCustomPropertyChangedConditions,
     getAccountCustomPropertyValueFilters,
     getAccountRelationshipChangeType,
+    getAccountTagChangeType,
     getSelectedPropertyNames,
     getSelectedRelationshipNames,
     getSelectedTags,
@@ -25,7 +26,7 @@ describe('customer analytics triggers', () => {
         return triggerType
     }
 
-    it.each(['account_tag_added', 'account_custom_property_changed', 'account_relationship_changed'])(
+    it.each(['account_tag_changed', 'account_custom_property_changed', 'account_relationship_changed'])(
         '%s buildConfig produces a config recognized by matchConfig',
         (value) => {
             const triggerType = getTriggerType(value)
@@ -35,7 +36,7 @@ describe('customer analytics triggers', () => {
 
     it("the account triggers do not claim each other's configs", () => {
         const triggers = [
-            getTriggerType('account_tag_added'),
+            getTriggerType('account_tag_changed'),
             getTriggerType('account_custom_property_changed'),
             getTriggerType('account_relationship_changed'),
         ]
@@ -68,11 +69,48 @@ describe('customer analytics triggers', () => {
         expect(getSelectedTags(config)).toEqual(expected)
     })
 
-    it('omits the tag property filter when no tags are selected', () => {
-        expect(accountTagAddedFilters([]).properties).toEqual([])
-        expect(accountTagAddedFilters(['vip']).properties).toEqual([
+    it('recognizes existing added-only tag triggers and removed-only tag triggers', () => {
+        const triggerType = getTriggerType('account_tag_changed')
+
+        expect(
+            triggerType.matchConfig!({
+                type: 'event',
+                filters: { events: [{ id: '$account_tag_added', type: 'events' }] },
+            })
+        ).toBe(true)
+        expect(
+            triggerType.matchConfig!({
+                type: 'event',
+                filters: { events: [{ id: '$account_tag_removed', type: 'events' }] },
+            })
+        ).toBe(true)
+    })
+
+    it.each([
+        { name: 'both', changeType: null, expectedEvents: ['$account_tag_added', '$account_tag_removed'] },
+        { name: 'added', changeType: 'added' as const, expectedEvents: ['$account_tag_added'] },
+        { name: 'removed', changeType: 'removed' as const, expectedEvents: ['$account_tag_removed'] },
+    ])('builds $name tag change event filters', ({ changeType, expectedEvents }) => {
+        const filters = accountTagChangedFilters([], {}, changeType)
+        const config: EventTriggerConfig = { type: 'event', filters }
+
+        expect(filters.events?.map((event) => event.id)).toEqual(expectedEvents)
+        expect(getAccountTagChangeType(config)).toBe(changeType)
+    })
+
+    it('preserves the tag change type and unrelated filters when the tag selection changes', () => {
+        const filters = accountTagChangedFilters(['vip'], {
+            events: [{ id: '$account_tag_removed', type: 'events' }],
+            properties: [{ key: 'source', value: 'workflow', operator: 'exact', type: 'event' }],
+            filter_test_accounts: true,
+        })
+
+        expect(filters.events?.map((event) => event.id)).toEqual(['$account_tag_removed'])
+        expect(filters.properties).toEqual([
             { key: 'tag', value: ['vip'], operator: 'exact', type: 'event' },
+            { key: 'source', value: 'workflow', operator: 'exact', type: 'event' },
         ])
+        expect(filters.filter_test_accounts).toBe(true)
     })
 
     it.each([

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.test.ts
@@ -69,21 +69,24 @@ describe('customer analytics triggers', () => {
         expect(getSelectedTags(config)).toEqual(expected)
     })
 
-    it('recognizes existing added-only tag triggers and removed-only tag triggers', () => {
+    it.each([
+        { name: 'added-only', events: [{ id: '$account_tag_added', type: 'events' }], expected: true },
+        { name: 'removed-only', events: [{ id: '$account_tag_removed', type: 'events' }], expected: true },
+        {
+            name: 'nested event filter',
+            events: [
+                {
+                    id: '$account_tag_added',
+                    type: 'events',
+                    properties: [{ key: 'source', value: 'workflow', operator: 'exact', type: 'event' }],
+                },
+            ],
+            expected: false,
+        },
+    ])('matches $name tag trigger configs: $expected', ({ events, expected }) => {
         const triggerType = getTriggerType('account_tag_changed')
 
-        expect(
-            triggerType.matchConfig!({
-                type: 'event',
-                filters: { events: [{ id: '$account_tag_added', type: 'events' }] },
-            })
-        ).toBe(true)
-        expect(
-            triggerType.matchConfig!({
-                type: 'event',
-                filters: { events: [{ id: '$account_tag_removed', type: 'events' }] },
-            })
-        ).toBe(true)
+        expect(triggerType.matchConfig!({ type: 'event', filters: { events } })).toBe(expected)
     })
 
     it.each([

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.tsx
@@ -82,10 +82,14 @@ function isAccountTagChangedConfig(config: EventTriggerConfig): boolean {
     if (config.type !== 'event') {
         return false
     }
-    const eventIds = (config.filters?.events ?? []).map((event: any) => event?.id)
+    const events = config.filters?.events ?? []
     return (
-        eventIds.length > 0 &&
-        eventIds.every((eventId) => eventId === ACCOUNT_TAG_ADDED_EVENT || eventId === ACCOUNT_TAG_REMOVED_EVENT)
+        events.length > 0 &&
+        events.every(
+            (event: any) =>
+                (event?.id === ACCOUNT_TAG_ADDED_EVENT || event?.id === ACCOUNT_TAG_REMOVED_EVENT) &&
+                !event?.properties?.length
+        )
     )
 }
 

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/customer_analytics.tsx
@@ -23,6 +23,7 @@ import {
 import { workflowLogic } from 'products/workflows/frontend/Workflows/workflowLogic'
 
 const ACCOUNT_TAG_ADDED_EVENT = '$account_tag_added'
+const ACCOUNT_TAG_REMOVED_EVENT = '$account_tag_removed'
 const ACCOUNT_CUSTOM_PROPERTY_CHANGED_EVENT = '$account_custom_property_changed'
 const ACCOUNT_RELATIONSHIP_CHANGED_EVENT = '$account_relationship_changed'
 
@@ -40,23 +41,65 @@ export function getSelectedTags(config: EventTriggerConfig): string[] {
     return values.filter((tag: unknown): tag is string => typeof tag === 'string')
 }
 
-export function accountTagAddedFilters(tags: string[]): EventTriggerConfig['filters'] {
+const ACCOUNT_TAG_CHANGE_TYPES = ['added', 'removed'] as const
+export type AccountTagChangeType = (typeof ACCOUNT_TAG_CHANGE_TYPES)[number]
+
+export function getAccountTagChangeType(config: EventTriggerConfig): AccountTagChangeType | null {
+    const eventIds = (config.filters?.events ?? []).map((event: any) => event?.id)
+    const includesAdded = eventIds.includes(ACCOUNT_TAG_ADDED_EVENT)
+    const includesRemoved = eventIds.includes(ACCOUNT_TAG_REMOVED_EVENT)
+
+    if (includesAdded === includesRemoved) {
+        return null
+    }
+    return includesAdded ? 'added' : 'removed'
+}
+
+const accountTagChangedEvent = (changeType: AccountTagChangeType): any => ({
+    id: changeType === 'added' ? ACCOUNT_TAG_ADDED_EVENT : ACCOUNT_TAG_REMOVED_EVENT,
+    type: 'events',
+    name: changeType === 'added' ? 'Account tag added' : 'Account tag removed',
+})
+
+export function accountTagChangedFilters(
+    tags: string[],
+    existingFilters: EventTriggerConfig['filters'] = {},
+    changeType: AccountTagChangeType | null = getAccountTagChangeType({ type: 'event', filters: existingFilters })
+): EventTriggerConfig['filters'] {
+    const changeTypes: AccountTagChangeType[] = changeType ? [changeType] : ['added', 'removed']
+
     return {
-        events: [{ id: ACCOUNT_TAG_ADDED_EVENT, type: 'events', name: 'Account tag added' }],
-        properties: tags.length > 0 ? [{ key: 'tag', value: tags, operator: 'exact', type: 'event' }] : [],
+        ...existingFilters,
+        events: changeTypes.map(accountTagChangedEvent),
+        properties: [
+            ...(tags.length > 0 ? [{ key: 'tag', value: tags, operator: 'exact', type: 'event' }] : []),
+            ...(existingFilters.properties ?? []).filter((property: any) => property?.key !== 'tag'),
+        ],
     }
 }
 
-function StepTriggerConfigurationAccountTagAdded({ node }: { node: any }): JSX.Element {
+function isAccountTagChangedConfig(config: EventTriggerConfig): boolean {
+    if (config.type !== 'event') {
+        return false
+    }
+    const eventIds = (config.filters?.events ?? []).map((event: any) => event?.id)
+    return (
+        eventIds.length > 0 &&
+        eventIds.every((eventId) => eventId === ACCOUNT_TAG_ADDED_EVENT || eventId === ACCOUNT_TAG_REMOVED_EVENT)
+    )
+}
+
+function StepTriggerConfigurationAccountTagChanged({ node }: { node: any }): JSX.Element {
     const { setWorkflowActionConfig } = useActions(workflowLogic)
     const { tags, tagsLoading } = useValues(tagsModel)
     const config = node.data.config as EventTriggerConfig
     const selectedTags = getSelectedTags(config)
+    const changeType = getAccountTagChangeType(config)
 
     return (
         <div className="flex flex-col gap-2 w-full">
             <p className="mb-0 text-sm text-muted-alt">
-                This trigger runs when a tag is added to an account. Leave empty to run for any tag.
+                This trigger runs when a tag is added to or removed from an account. Leave empty to run for any tag.
             </p>
             <LemonField.Pure label="Tags">
                 <LemonInputSelect
@@ -69,10 +112,28 @@ function StepTriggerConfigurationAccountTagAdded({ node }: { node: any }): JSX.E
                     onChange={(value) =>
                         setWorkflowActionConfig(node.data.id, {
                             type: 'event',
-                            filters: accountTagAddedFilters(value),
+                            filters: accountTagChangedFilters(value, config.filters),
                         })
                     }
                     data-attr="account-tag-added-trigger-tags"
+                />
+            </LemonField.Pure>
+            <LemonField.Pure label="Change type" info="Limit this trigger to tags that were added or removed.">
+                <LemonSelect<AccountTagChangeType | null>
+                    value={changeType}
+                    placeholder="Any change type"
+                    allowClear
+                    options={[
+                        { label: 'Added', value: 'added' },
+                        { label: 'Removed', value: 'removed' },
+                    ]}
+                    onChange={(value) =>
+                        setWorkflowActionConfig(node.data.id, {
+                            type: 'event',
+                            filters: accountTagChangedFilters(selectedTags, config.filters, value),
+                        })
+                    }
+                    data-attr="account-tag-change-type-filter"
                 />
             </LemonField.Pure>
         </div>
@@ -80,18 +141,18 @@ function StepTriggerConfigurationAccountTagAdded({ node }: { node: any }): JSX.E
 }
 
 registerTriggerType({
-    value: 'account_tag_added',
-    label: 'Account tag added',
+    value: 'account_tag_changed',
+    label: 'Account tag changed',
     icon: <IconBolt />,
-    description: 'Trigger when a tag is added to an account',
+    description: 'Trigger when a tag is added to or removed from an account',
     group: 'Customer analytics',
     featureFlag: FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP,
-    matchConfig: (config) => config.type === 'event' && getEventId(config) === ACCOUNT_TAG_ADDED_EVENT,
+    matchConfig: isAccountTagChangedConfig,
     buildConfig: () => ({
         type: 'event',
-        filters: accountTagAddedFilters([]),
+        filters: accountTagChangedFilters([]),
     }),
-    ConfigComponent: StepTriggerConfigurationAccountTagAdded,
+    ConfigComponent: StepTriggerConfigurationAccountTagChanged,
 })
 
 // Account events carry no person (they use a synthetic distinct_id), so the generic person-keyed


### PR DESCRIPTION
## Problem

Workflow builders can only start an account tag workflow when a tag is added. They cannot select removals or both changes.

## Changes

- The workflow editor now offers an **Account tag changed** trigger with Added and Removed change types.
- Clearing the change type runs the workflow for both additions and removals.
- Existing added-only workflow configurations remain added-only.
- This PR depends on #88828, which emits the removal event.

**Before**

```mermaid
flowchart LR
    A[Account tag added trigger] --> B[Added event filter]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
```

**After**

```mermaid
flowchart LR
    A[Account tag changed trigger] --> B{Change type}
    B --> C[Added event filter]
    B --> D[Removed event filter]
    B --> E[Both event filters]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C,D,E phBlue;
```

Screenshot not captured because the local dev UI failed to start after the phrocs socket timed out.

## How did you test this code?

- The focused Jest suite passed and covers added, removed, both, and existing added-only configurations.
- Frontend lint and format fixes completed successfully.
- The full frontend type check exhausted the sandbox memory after the required workspace packages built.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. The workflow editor describes the new change type control.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog task agent used repository, PostHog MCP, and GitHub tools. It invoked the stacking, UI, test, copy, comment, behavior-change, PR description, simplified English, and shared no-slop skills.