### PR TITLE
fix(google_sheets): retry a 409 conflict from the Sheets API instead of failing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -70,11 +70,13 @@ max_attempts = 10
 jitter_in_seconds = 10
 sleep_per_attempt_in_seconds = 30
 
-# Transient Google Sheets API failures worth retrying: 429 (per-minute quota exhausted) plus the
-# 5xx server-side errors Google returns intermittently (e.g. "[500]: Internal error encountered.").
-# Google's API guidance is to retry these with backoff — they are not caused by our request and
-# usually clear on the next attempt, so re-raising immediately turns a blip into a failed sync.
-_RETRYABLE_API_ERROR_CODES = {429, 500, 502, 503, 504}
+# Transient Google Sheets API failures worth retrying: 429 (per-minute quota exhausted), the
+# 5xx server-side errors Google returns intermittently (e.g. "[500]: Internal error encountered."),
+# and 409 ("[409]: The operation was aborted.") — Google's ABORTED code, a concurrency conflict
+# (e.g. another process editing the same spreadsheet) rather than a problem with our request.
+# Google's API guidance is to retry these with backoff — they usually clear on the next attempt,
+# so re-raising immediately turns a blip into a failed sync.
+_RETRYABLE_API_ERROR_CODES = {409, 429, 500, 502, 503, 504}
 
 # gspread raises a bare `PermissionError` (with no message) when the Google Sheets
 # API returns 403 — see gspread/client.py: `raise PermissionError from ex`.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -80,6 +80,7 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         # reword. Temporal then retries the whole activity, so the failure is transient and
         # self-recovering.
         return {
+            "APIError: [409]",
             "APIError: [429]",
             "APIError: [500]",
             "APIError: [502]",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -66,7 +66,7 @@ def test_get_worksheet_backoff():
         assert mock_get_worksheet_by_id.call_count == 10
 
 
-@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+@pytest.mark.parametrize("status_code", [409, 429, 500, 502, 503, 504])
 def test_get_worksheet_retries_transient_api_errors(status_code):
     """Transient API errors (quota 429s and 5xx server errors like
     "[500]: Internal error encountered.") should be retried with backoff, not
@@ -102,7 +102,7 @@ def test_get_worksheet_retries_transient_api_errors(status_code):
         assert mock_get_worksheet_by_id.call_count == 10
 
 
-@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+@pytest.mark.parametrize("status_code", [409, 429, 500, 502, 503, 504])
 def test_get_schemas_retries_transient_api_errors(status_code):
     """Schema discovery (`open_by_url`/`worksheets`) hits the Sheets API just like
     `_get_worksheet`, so a transient quota 429 or 5xx server error (e.g.
@@ -231,10 +231,11 @@ def test_reraises_permission_error_with_message(call_site):
         assert "Spreadsheet access denied" in str(exc_info.value)
 
 
-@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+@pytest.mark.parametrize("status_code", [409, 429, 500, 502, 503, 504])
 def test_retry_on_transient_api_error_retries_then_exhausts(status_code):
-    """The shared retry helper must retry transient API errors (quota 429s and 5xx
-    server errors like "[503]: The service is currently unavailable.") with backoff."""
+    """The shared retry helper must retry transient API errors (quota 429s, 5xx
+    server errors like "[503]: The service is currently unavailable.", and 409
+    concurrency conflicts) with backoff."""
     with mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets.time"
     ):
@@ -530,7 +531,7 @@ def test_error_string_matches_a_non_retryable_key(error):
     assert any(key in str(error) for key in non_retryable_errors)
 
 
-@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+@pytest.mark.parametrize("status_code", [409, 429, 500, 502, 503, 504])
 def test_error_string_matches_a_retryable_key(status_code):
     """`_retry_on_transient_api_error` already retries these status codes in-process before
     re-raising; the framework then logs at `warning` instead of `exception` only if the re-raised


### PR DESCRIPTION
## Problem

A Google Sheets import failed outright when Google's Sheets API returned a 409 conflict, even though the error is transient. Error tracking captured `APIError: [409]: The operation was aborted.` raised from `google_sheets.py`, [issue 01a03b90](https://us.posthog.com/project/2/error_tracking/01a03b90-6deb-7552-8765-6acfe08bac60).

A 409 from a Google API is the `ABORTED` status: a concurrency conflict (for example another process editing the same spreadsheet), not a problem with the request. Google's own guidance is to retry it with backoff, the same way this source already retries 429 and 5xx responses.

## Changes

- `_RETRYABLE_API_ERROR_CODES` in `google_sheets.py` now includes 409, so the shared retry helper backs off and retries it like the other transient codes.
- `get_retryable_errors()` in `source.py` now recognizes `APIError: [409]`, so a sync that exhausts its retries logs a warning instead of polluting error tracking as an exception.

Both changes touch the retry classification only; there is no change to what data gets synced.

## How did you test this code?

Extended 4 existing parametrized tests (`test_get_worksheet_retries_transient_api_errors`, `test_get_schemas_retries_transient_api_errors`, `test_retry_on_transient_api_error_retries_then_exhausts`, `test_error_string_matches_a_retryable_key`) with a 409 case, since each already covers this exact retry behavior for the other transient codes. All 93 tests in `test_google_sheets.py` pass locally.

Not run: a live sync against the Google Sheets API, since this sandbox has no network access to it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the error tracking issue linked above, confirmed the stack trace resolves into this source's code, and used web research to confirm Google's ABORTED (409) code is documented as retryable. Skills invoked: `/writing-tests` (confirmed extending existing parametrized cases was the right move, not new tests), `/writing-pr-descriptions`.