### PR TITLE
fix(logs): honor a filter's attribute type over same-named columns

### DIFF
--- a/nodejs/src/logs/metrics-rules/metric-rules.test.ts
+++ b/nodejs/src/logs/metrics-rules/metric-rules.test.ts
@@ -104,6 +104,45 @@ describe('metric rules compile + tally', () => {
             expect(tallies.valueSkipped).toBe(2)
         })
 
+        it('a log_attribute filter on a column-named key tallies from the attribute map', () => {
+            // Metric rules match through the drop-rule matcher. This pins that they keep doing so,
+            // so a filter picked from the log-attributes list cannot start resolving to the
+            // same-named column and silently tally nothing.
+            const rules = compileMetricRules([
+                ruleRow({
+                    filter_group: {
+                        type: 'AND',
+                        values: [
+                            {
+                                type: 'AND',
+                                values: [
+                                    {
+                                        key: 'service_name',
+                                        type: 'log_attribute',
+                                        operator: 'exact',
+                                        value: ['contour/envoy'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                }),
+            ])
+            const tallies = createBatchTallies()
+            tallyRecords(
+                rules,
+                [
+                    record({ service_name: 'contour', attributes: { service_name: '"contour/envoy"' } }),
+                    record({ service_name: 'contour', attributes: { service_name: '"contour/contour"' } }),
+                ],
+                tallies,
+                NOW_MS
+            )
+            const entries = [...tallies.byRule.get('rule-1')!.values()]
+            expect(entries).toHaveLength(1)
+            expect(entries[0]!.count).toBe(1)
+        })
+
         it('resolves group-by labels, using empty string for missing keys and truncating long values', () => {
             const longValue = 'x'.repeat(MAX_LABEL_VALUE_LENGTH + 50)
             const rules = compileMetricRules([

--- a/nodejs/src/logs/sampling/filter-group-match.test.ts
+++ b/nodejs/src/logs/sampling/filter-group-match.test.ts
@@ -98,6 +98,48 @@ describe('matchFilterGroup', () => {
             expect(matchFilterGroup(g, baseRecord({ resource_attributes: { 'service.name': 'api' } }))).toBe(true)
             expect(matchFilterGroup(g, baseRecord({ resource_attributes: { service_name: 'api' } }))).toBe(false)
         })
+        describe('a key that names both a column and a real attribute', () => {
+            // Envoy access logs carry a log attribute literally called `service_name`, holding
+            // `namespace/container`. That is its own data, not a denormalised copy of the column,
+            // and the filter editor offers its values from the attribute map. Resolving the filter
+            // to the column compares `contour/envoy` against `contour`, so the rule matches nothing.
+            const collidingRecord = () =>
+                baseRecord({
+                    service_name: 'contour',
+                    attributes: { service_name: '"contour/envoy"' },
+                })
+
+            it.each<[string, string, boolean]>([
+                ['log_attribute', 'contour/envoy', true],
+                ['log_attribute', 'contour', false],
+                ['log', 'contour', true],
+                ['log', 'contour/envoy', false],
+            ])('a %s filter for %j matches → %s', (type, value, expected) => {
+                const g = group({
+                    values: [{ key: 'service_name', type, operator: 'exact', value: [value] }],
+                })
+                expect(matchFilterGroup(g, collidingRecord())).toBe(expected)
+            })
+
+            it('log_resource_attribute reads the resource map', () => {
+                const g = group({
+                    values: [
+                        {
+                            key: 'service.name',
+                            type: 'log_resource_attribute',
+                            operator: 'exact',
+                            value: ['contour-canary'],
+                        },
+                    ],
+                })
+                const record = baseRecord({
+                    service_name: 'contour',
+                    resource_attributes: { 'service.name': '"contour-canary"' },
+                })
+                expect(matchFilterGroup(g, record)).toBe(true)
+            })
+        })
+
         it('severity_text resolves to LogRecord.severity_text (first-class column)', () => {
             const g = group({ values: [{ key: 'severity_text', operator: 'in', value: ['error', 'fatal'] }] })
             expect(matchFilterGroup(g, baseRecord({ severity_text: 'error' }))).toBe(true)

--- a/nodejs/src/logs/sampling/filter-group-match.ts
+++ b/nodejs/src/logs/sampling/filter-group-match.ts
@@ -71,6 +71,18 @@ function isGroupNode(node: PropertyFilterLeaf | FilterGroupNode): node is Filter
 function lookupRecordValue(filter: PropertyFilterLeaf, record: LogRecord): string | null | undefined {
     const key = filter.key
 
+    // A filter that declares an attribute type names a map entry, and wins over the column
+    // aliases below whenever that entry exists. An attribute may share a column's name and hold
+    // different data — envoy access logs write a `service_name` attribute holding
+    // `namespace/container`, next to a column holding the resource service name — and the filter
+    // editor offers the map's values, so matching against the column can never succeed.
+    // Falling through when the entry is absent keeps the aliases working, so a `level` or
+    // `service.name` filter still reads the denormalised column.
+    const declaredAttribute = declaredAttributeValue(filter, record)
+    if (declaredAttribute !== undefined) {
+        return declaredAttribute
+    }
+
     // First-class columns win when populated; otherwise fall back to the
     // matching attribute map. Ingestion denormalises service.name + severity_text
     // onto first-class fields, but partial decodes / older records may have only
@@ -109,6 +121,17 @@ function lookupRecordValue(filter: PropertyFilterLeaf, record: LogRecord): strin
         return decodedAttr(record.attributes, key)
     }
     return decodedAttr(record.attributes, key) ?? decodedAttr(record.resource_attributes, key)
+}
+
+/** The value of the map entry a filter's declared attribute type names, if that entry exists. */
+function declaredAttributeValue(filter: PropertyFilterLeaf, record: LogRecord): string | undefined {
+    if (filter.type === PROPERTY_FILTER_TYPE_LOG_ATTRIBUTE) {
+        return decodedAttr(record.attributes, filter.key)
+    }
+    if (filter.type === PROPERTY_FILTER_TYPE_LOG_RESOURCE_ATTRIBUTE) {
+        return decodedAttr(record.resource_attributes, filter.key)
+    }
+    return undefined
 }
 
 /**


### PR DESCRIPTION
## Problem

A logs drop rule or metric rule that filters on a log attribute named `service_name` matches nothing, and nothing in the product says so. The rule reads as configured, the value dropdown offers real values, and the rule silently never fires.

`lookupRecordValue` resolved `service_name` and `severity_text` to their first-class columns before it checked the filter's declared type. An attribute can share a column's name and hold different data — envoy access logs carry a log attribute literally named `service_name` holding `namespace/container`, next to a column holding the resource service name. The filter editor offers the attribute map's values, so the rule compared `contour/envoy` against `contour` and never matched.

Same shape as #88743, one layer up: the surface that tells you a rule is right and the code that evaluates it read different data.

Two products, one matcher — metric rules match through the drop-rule matcher, so both were affected.

## Changes

- A drop rule or metric rule filtered on a log attribute now matches the lines it names. Previously it dropped nothing and tallied nothing.
- The filter's declared type decides which map it reads. `log_attribute` reads `attributes`, `log_resource_attribute` reads `resource_attributes`.
- Filters that name a column are unchanged. When the declared map has no such key the lookup falls through to the existing aliases, so `level` and `service.name` still resolve to the denormalized column, and a `log` filter still reads the column even when a same-named attribute exists.

Deliberately narrow: precedence only changes for a filter that both declares an attribute type and finds that key in the map it named. Every other path keeps its current resolution.

## How did you test this code?

Automated only. I am an agent; nothing here was exercised against a running ingestion pipeline.

- `nodejs/src/logs/sampling/filter-group-match.test.ts` — a parameterized case per (declared type, value) against one record where the column and the attribute hold different values. Catches both directions: an attribute filter resolving to the column, and a fix that over-corrects so a column filter starts reading the attribute.
- Same file — a `log_resource_attribute` case where the resource attribute and the column differ. The existing resource tests only cover records where the two agree, so they cannot catch this.
- `nodejs/src/logs/metrics-rules/metric-rules.test.ts` — one tally case pinning that metric rules keep routing through this matcher, so a future fork of that path can't reintroduce the bug for metrics alone.
- Verified red before the fix: 4 of these fail on the unmodified matcher. Verified green after.
- `pnpm --dir nodejs exec jest src/logs/` — no test failures. 5 suites fail to load on an unbuilt `@posthog/hogvm`; confirmed identical on unmodified master, so it is environmental.
- `tsc --noEmit` reports no errors in any file this PR touches. eslint and prettier clean.
- Not done: no end-to-end run against live ingestion.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Desktop). Repo skills consulted: `/writing-tests` (the value gate collapsed three near-duplicate cases into one parameterized set), `/modifying-taxonomic-filter`, `/improving-drf-endpoints`, `/writing-pr-descriptions`.
- The first diagnosis was wrong and got reverted. It read the bug as the value picker suggesting unmatchable values, and started on a backend change to serve column-backed suggestions. Tracing the frontend showed `propertyFilterMapping` already routes a `log` filter to the Logs group, so the picker had been correct all along and the matcher was at fault. The backend work was reverted rather than shipped alongside.
- An earlier version reordered the type checks above the column branches wholesale. That breaks the deliberate `level` alias, where a `log_attribute` filter on a severity key is meant to resolve to the column. Falling through on a missing key preserves it, which the pre-existing alias tests confirm.
- No customer data or internal material appears in this PR; the fixtures use service names already present in the repo's own logs test fixture.
