### PR TITLE
fix(data-warehouse): show firewall allowlist hint on ClickHouse and Redshift host fields

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -183,6 +183,12 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="play.clickhouse.com",
+                        caption=(
+                            "Must be reachable from the public internet. Add PostHog's egress IP addresses to your "
+                            "firewall allowlist (see the docs above) and use a public host. `localhost` and private "
+                            "IPs (10.x, 172.16-31.x, 192.168.x) can't be reached. For a database that can't be "
+                            "exposed publicly, enable the SSH tunnel below."
+                        ),
                         secret=False,
                     ),
                     SourceFieldInputConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -104,6 +104,12 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="my-cluster.abc123xyz.us-east-1.redshift.amazonaws.com",
+                        caption=(
+                            "Must be reachable from the public internet. Add PostHog's egress IP addresses to your "
+                            "firewall allowlist (see the docs above) and use a public host. `localhost` and private "
+                            "IPs (10.x, 172.16-31.x, 192.168.x) can't be reached. For a database that can't be "
+                            "exposed publicly, enable the SSH tunnel below."
+                        ),
                         secret=False,
                     ),
                     SourceFieldInputConfig(


### PR DESCRIPTION
## Problem

A person connecting a ClickHouse or Redshift database in the data warehouse "new source" wizard saw no hint that PostHog dials out to their database and must be allowlisted through their firewall. The Postgres, MySQL, and MSSQL host fields already show that guidance; ClickHouse and Redshift did not, so users configuring those two sources reached the connection step, hit a failure or a stall at their firewall, and had no inline pointer to the fix.

## Changes

- The ClickHouse and Redshift **Host** fields now show the same caption the other self-managed database connectors already show: allowlist PostHog's egress IP addresses, use a public host (not `localhost` or a private IP range), and enable the SSH tunnel for a database that can't be exposed publicly.
- Copy is reused verbatim from the Postgres/MySQL/MSSQL host-field caption, so guidance is now consistent across all self-managed database sources.

## How did you test this code?

- `caption` is a plain display field on the source config and is not part of the generated typed configs, so no regeneration was needed.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_catalog_invariants.py` (all source configs still build and validate) and linted both touched files. No new test was added: the change is a static string on an existing field, and the catalog invariants already exercise that every source config constructs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (PostHog Desktop). The change came out of reviewing anonymized session-summary themes for the data-warehouse onboarding flow: users connecting self-managed databases repeatedly stalled at the firewall/IP-allowlist step, and ClickHouse and Redshift were the two database connectors missing the host-field guidance that Postgres, MySQL, and MSSQL already had. The fix is a copy-parity change only — no sync behavior or schema changes. No customer-specific data is included; the caption text is copied verbatim from the existing Postgres connector.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
