### PR TITLE
fix(data-imports): retry a stale db connection in property sinks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/account_property_row_sink.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/account_property_row_sink.py
@@ -11,6 +11,7 @@ from pyarrow.parquet import ParquetFile, write_table
 from structlog.types import FilteringBoundLogger
 
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.common.utils import aretry_on_db_connection_drop
 
 from products.data_warehouse.backend.facade.api import aget_s3_client, ensure_bucket_exists
 from products.warehouse_sources.backend.temporal.data_imports.external_product_hooks import (
@@ -83,10 +84,16 @@ class AccountPropertyRowSink:
 
     async def _get_projection(self) -> list[AccountPropertySourceProjection] | None:
         """One projection per enabled account source on the binding (key + mapped columns), or None
-        when nothing needs staging. Resolved once per run."""
+        when nothing needs staging. Resolved once per run.
+
+        The resolver reads the app DB (team scoping, enabled profile sources), so a long-lived
+        worker's pooled connection can have gone stale (pooler recycle, failover, deploy) since it
+        was last used. Retry once on a fresh connection rather than let that escape as
+        error-tracking noise, or as a silently skipped account-property sync for the run.
+        """
         if not self._projection_resolved:
-            self._projection = await database_sync_to_async_pool(account_property_projection_for)(
-                self.team_id, self.binding
+            self._projection = await aretry_on_db_connection_drop(
+                lambda: database_sync_to_async_pool(account_property_projection_for)(self.team_id, self.binding)
             )
             self._projection_resolved = True
         return self._projection

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/account_property_row_sink_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/account_property_row_sink_test.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.conf import settings
+from django.db import OperationalError
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -93,6 +94,24 @@ async def test_stages_only_columns_from_sources_with_a_present_key() -> None:
     assert to_thread.await_args.args[1].column_names == ["mrr", "organization_id"]
     expected_root = settings.BUCKET_URL.removeprefix("s3://").rstrip("/")
     assert to_thread.await_args.args[2].startswith(f"{expected_root}/account_property_sync/7/model_")
+
+
+@pytest.mark.asyncio
+async def test_should_run_retries_once_on_a_transient_db_connection_drop() -> None:
+    # A long-lived Temporal worker's pooled app-DB connection can go stale (pooler recycle,
+    # failover, deploy) between syncs. Without a retry, that one-off OperationalError would
+    # propagate and get treated as "no account-property mapping to sync" for the whole run
+    # instead of the transient blip it is.
+    sink = _sink()
+    projection = [
+        AccountPropertySourceProjection(key_column="organization_id", columns=frozenset({"organization_id", "mrr"}))
+    ]
+    resolver = MagicMock(side_effect=[OperationalError("server closed the connection unexpectedly"), projection])
+
+    with patch(f"{_MODULE}.account_property_projection_for", resolver):
+        assert await sink.should_run() is True
+
+    assert resolver.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink.py
@@ -11,6 +11,7 @@ from pyarrow.parquet import write_table
 from structlog.types import FilteringBoundLogger
 
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.common.utils import aretry_on_db_connection_drop
 
 from products.data_warehouse.backend.facade.api import aget_s3_client, ensure_bucket_exists
 from products.warehouse_sources.backend.temporal.data_imports.external_product_hooks import (
@@ -105,10 +106,16 @@ class PersonPropertyRowSink:
 
     async def _get_projection(self) -> list[PersonPropertySourceProjection] | None:
         """One projection per enabled person source on the binding (key + mapped columns), or None
-        when nothing needs staging. Resolved once per run."""
+        when nothing needs staging. Resolved once per run.
+
+        The resolver reads the app DB (team scoping, enabled profile sources), so a long-lived
+        worker's pooled connection can have gone stale (pooler recycle, failover, deploy) since it
+        was last used. Retry once on a fresh connection rather than let that escape as
+        error-tracking noise, or as a silently skipped person-property sync for the run.
+        """
         if not self._projection_resolved:
-            self._projection = await database_sync_to_async_pool(person_property_projection_for)(
-                self.team_id, self.binding
+            self._projection = await aretry_on_db_connection_drop(
+                lambda: database_sync_to_async_pool(person_property_projection_for)(self.team_id, self.binding)
             )
             self._projection_resolved = True
         return self._projection

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.conf import settings
+from django.db import OperationalError
 
 import pyarrow as pa
 from parameterized import parameterized
@@ -51,6 +52,22 @@ async def test_should_run_reflects_projection():
     other = _sink()
     with patch(f"{_MODULE}.person_property_projection_for", return_value=[_projection("distinct_id", "plan")]):
         assert await other.should_run() is True
+
+
+@pytest.mark.asyncio
+async def test_should_run_retries_once_on_a_transient_db_connection_drop():
+    # A long-lived Temporal worker's pooled app-DB connection can go stale (pooler recycle,
+    # failover, deploy) between syncs. Without a retry, that one-off OperationalError would
+    # propagate and get treated as "no person-property mapping to sync" for the whole run instead
+    # of the transient blip it is.
+    sink = _sink()
+    projection = [_projection("distinct_id", "plan")]
+    resolver = MagicMock(side_effect=[OperationalError("server closed the connection unexpectedly"), projection])
+
+    with patch(f"{_MODULE}.person_property_projection_for", resolver):
+        assert await sink.should_run() is True
+
+    assert resolver.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Materializing a view can silently skip staging that run's person or account
properties, and files a fresh error-tracking issue, whenever the app
database's pooled connection is stale the moment `materialize_view.py`
resolves which sources map to the view.

`PersonPropertyRowSink._get_projection` (and its account-property sibling)
run a single ORM read to resolve which sources map to the view. A pooler
recycle, failover, or deploy between syncs can leave that read on a stale
connection, so it raises `OperationalError`/`InterfaceError` (a Postgres
connection reset). `materialize_view.py`'s catch-all reports that to error
tracking and returns "nothing to stage" for the run, with no retry.

## Changes

- Person-property and account-property projection lookups now retry once on
  a transient app-DB connection drop, reusing the existing
  `aretry_on_db_connection_drop` helper already used for this same failure
  class elsewhere in the pipeline.
- A one-off pooler blip now recovers on the retry instead of skipping that
  run's property sync and filing an error-tracking issue.
- Mechanical: a genuine, sustained DB outage still propagates and reports
  after the retry, same as before.

## How did you test this code?

- Added a case to `person_property_row_sink_test.py` and
  `account_property_row_sink_test.py`: `should_run` retries past one
  `OperationalError` and returns the resolved projection. Confirmed each
  fails on `master` (propagates on the first call) and passes with the fix.
- Ran both full test files, `ruff check`/`format`, `tach check
  --dependencies --interfaces`, and `mypy --cache-fine-grained` on both
  changed source files.
- Not run: an end-to-end Temporal activity test against a real dropped
  Postgres connection, which needs a live pooler restart to reproduce.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Code (Sonnet 5) investigated and wrote this, triaging a webhook-delivered
error tracking issue in the warehouse-sources data-import pipeline. Skills
invoked: `/investigating-error-issue`, `/writing-tests`,
`/writing-pr-descriptions`.

The fix reuses `posthog/temporal/common/utils.py`'s
`aretry_on_db_connection_drop`, the same helper already applied to comparable
stale-connection reads elsewhere in this pipeline (e.g.
`fanout_reuse_flag.py`), rather than widening `NonRetryableErrors` or only
suppressing the error-tracking report. The connection drop is exactly the
transient case that helper exists to self-heal, so retrying at the read
avoids the noise instead of hiding it after the fact.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
