### PR TITLE
fix(mcp): keep the claude exec schema under the registry size cap

### DIFF
--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -28,6 +28,13 @@ export const MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
 // fit, and the tool-domain index absorbs whatever budget the fixed sections leave.
 export const MCP_INSTRUCTIONS_CHAR_BUDGET = 2048
 
+// claude.ai's registry silently drops a tool whose serialized `inputSchema` crosses ~16,384
+// chars. The exec command reference lands in that schema's `command.description`; this budget
+// caps the reference itself, leaving room for the schema's fixed structure, the exec tool
+// description, and the injected `context` property. The tool-domain index absorbs the
+// overflow by collapsing sub-families, so adding a tool cannot push the schema past the cap.
+export const CLAUDE_EXEC_COMMAND_REFERENCE_CHAR_BUDGET = 15_200
+
 // Gates the semantic layer (governed-metrics catalog) — no tool declares it, so it must be
 // joined into the evaluated flag set explicitly; instructions content branches on it.
 export const PRODUCT_DATA_CATALOG_FLAG = 'product-data-catalog'

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -1,5 +1,5 @@
 import type { GroupType } from '@/api/client'
-import { MCP_INSTRUCTIONS_CHAR_BUDGET } from '@/lib/constants'
+import { CLAUDE_EXEC_COMMAND_REFERENCE_CHAR_BUDGET, MCP_INSTRUCTIONS_CHAR_BUDGET } from '@/lib/constants'
 import {
     buildAvailableToolsBlock,
     buildDefinedGroupsBlock,
@@ -202,26 +202,36 @@ export class InstructionsFormatter {
             tools: ctx.tools,
         }
 
-        return this.compose(
-            [
-                CLI_SYNTAX,
-                helpSection,
-                ...(ctx.dataCatalogEnabled ? [METRIC_DISCOVERY_COMPACT] : []),
-                CLI_SCHEMA_DRILLDOWN,
-                CLI_DATA_DISCOVERY,
-                CLI_EXAMPLES_CLAUDE,
-                CLI_ERROR_HANDLING,
-                BASIC_FUNCTIONALITY,
-                TOOL_SEARCH,
-                ENV_CONTEXT,
-            ],
-            renderCtx,
-            {
-                compact: false,
-                compactToolDomains: true,
-                extraCommands: LEARN_COMMAND_LINE,
-            }
-        )
+        const sections = [
+            CLI_SYNTAX,
+            helpSection,
+            ...(ctx.dataCatalogEnabled ? [METRIC_DISCOVERY_COMPACT] : []),
+            CLI_SCHEMA_DRILLDOWN,
+            CLI_DATA_DISCOVERY,
+            CLI_EXAMPLES_CLAUDE,
+            CLI_ERROR_HANDLING,
+            BASIC_FUNCTIONALITY,
+            TOOL_SEARCH,
+            ENV_CONTEXT,
+        ]
+        const opts = {
+            compact: false,
+            compactToolDomains: true,
+            extraCommands: LEARN_COMMAND_LINE,
+        }
+
+        // Same overflow mechanism as buildExecInstructions: when the reference outgrows
+        // its budget, only the tool-domain index shrinks, by exactly the overflow.
+        const rendered = this.compose(sections, renderCtx, opts)
+        const overflow = rendered.length - CLAUDE_EXEC_COMMAND_REFERENCE_CHAR_BUDGET
+        if (overflow <= 0) {
+            return rendered
+        }
+        const domains = buildToolDomainsCompact(renderCtx.tools ?? [])
+        return this.compose(sections, renderCtx, {
+            ...opts,
+            toolDomainsMaxChars: domains.length - overflow,
+        })
     }
 
     /** Build the `command` parameter description for the exec tool. When


### PR DESCRIPTION
## Problem

claude.ai silently hides any tool whose serialized schema is longer than about 16,384 characters. Our exec tool's schema embeds a directory of all tool families, so it grows a little with every tool we enable. It recently sat 5 characters under the limit: enabling one more tool would have made the exec tool disappear for every claude.ai user, with no error anywhere. Recent trims (moving URL rules behind exec learn) bought some room back, but the wall returns as the catalog grows.

## Changes

- The exec command reference gets a size budget (15,200 characters). Under the budget, the output is unchanged, byte for byte. That is the case today: all prompt snapshots pass without changes.
- Over the budget, only the tool family directory shrinks: sub-entries fold into their family, for example the 24 experiment-* entries would become one "experiment" entry.
- This is the same shrink-on-overflow mechanism `buildExecInstructions` already uses for the Claude Code instructions payload, applied to the claude.ai schema path too.

This is a preparatory PR for #86946, which enables a new experiments tool. The two are independent: the tool currently fits, this just makes sure the next tools keep fitting.

## How did you test this code?

- Full MCP unit suite passes (2740 tests) with no snapshot updates, which proves the output is unchanged today.
- The worst-case budget test in instructions-formatter-snapshot.test.ts covers the cap; with this change the overflow path keeps it under the limit no matter how many tools are enabled.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session directed by @jurajmajerik. Extracted from #86946 after stamphog flagged the cross-cutting change for platform review. The budget value (15,200) leaves about 1,200 characters for the schema's fixed structure, the exec tool description, and the injected context property.
