### PR TITLE
fix(notebooks): stop the kernel poll when its kea store is replaced

### DIFF
--- a/.agents/skills/using-kea-disposables/SKILL.md
+++ b/.agents/skills/using-kea-disposables/SKILL.md
@@ -82,6 +82,15 @@ actions.connectionErrored(reason)
 This matters most in a `finally`.
 A request the unmount aborted rejects, and the `finally` then runs against a logic that no longer exists.
 
+One caveat on a logic that mounts again.
+The next mount puts a fresh manager on the cache, so a continuation left over from the previous life can reach `cache.disposables` and find a live one.
+`isDisposed` reads `false` there, and disposing a shared key tears down the new life's resource.
+Capture what the continuation needs while the logic is alive when that matters.
+
+Do not guard a timer callback with `isDisposed` alone if it reads `values`.
+The flag only moves on unmount, and replacing the kea context (which storybook does on every story mount) drops the logic from the store without unmounting it, so the cleanup never runs.
+Compare `getContext()` against the context the resource was set up in — see `frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts`.
+
 ## Examples in the codebase
 
 **Unnamed `setInterval` poller** — see the canonical example in [The pattern](#the-pattern) (`frontend/src/layout/navigation/noEventsBannerLogic.ts:14-21`).

--- a/frontend/src/kea-disposables.test.ts
+++ b/frontend/src/kea-disposables.test.ts
@@ -229,4 +229,23 @@ describe('disposablesPlugin', () => {
         expect(setupCalls).toBe(1)
         expect(cache.disposables.registry.has('k2')).toBe(false)
     })
+
+    it('mounting a built logic again replaces its disposed manager', () => {
+        // Remounting a retained built logic keeps its cache, the lifecycle
+        // scratchpadLogic.test.ts exercises. A manager left disposed there makes every add() in
+        // the next afterMount a no-op, so the logic loses its timers and listeners for good.
+        setHidden(false)
+        const remounted = kea<logicType>([path(['test', 'disposablesRemountTest'])]).build()
+        remounted.mount()
+        ;(remounted as any).cache.disposables.add(makeSetup(), 'k1')
+        remounted.unmount()
+        expect(cleanupCalls).toBe(1)
+        expect((remounted as any).cache.disposables.isDisposed).toBe(true)
+
+        remounted.mount()
+        ;(remounted as any).cache.disposables.add(makeSetup(), 'k1')
+        expect(setupCalls).toBe(2)
+        expect((remounted as any).cache.disposables.registry.has('k1')).toBe(true)
+        remounted.unmount()
+    })
 })

--- a/frontend/src/kea-disposables.ts
+++ b/frontend/src/kea-disposables.ts
@@ -25,6 +25,12 @@ export type DisposablesManager = {
      * `dispose` do nothing from that point on, which is what lets async work that outlives the
      * unmount call them unconditionally. Read it when the continuation itself must stop early,
      * for instance before reading `values` on a logic whose reducers are already detached.
+     *
+     * A disposed manager stays inert for the rest of its own life, but the next mount of the same
+     * logic puts a fresh manager on the cache. So a continuation that reaches `cache.disposables`
+     * late can find a live manager belonging to the logic's next life, and disposing a shared key
+     * from there tears down the new life's resource. Capture what the continuation needs while the
+     * logic is alive when that matters.
      */
     isDisposed: boolean
 }

--- a/frontend/src/kea-disposables.ts
+++ b/frontend/src/kea-disposables.ts
@@ -114,7 +114,10 @@ const detachGlobalVisibilityListener = (): void => {
 }
 
 const initializeDisposablesManager = (logic: LogicWithCache): void => {
-    if (logic.cache.disposables) {
+    // A logic that mounts again keeps the same cache, so the disposed manager from its previous
+    // life is still attached. Replace it, or every `add` in the new `afterMount` is a no-op and
+    // the logic silently loses its timers and listeners for the rest of the session.
+    if (logic.cache.disposables && !logic.cache.disposables.isDisposed) {
         return
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
@@ -49,4 +49,45 @@ describe('notebookKernelInfoLogic', () => {
             expect(kernelStatusSpy).not.toHaveBeenCalled()
         }
     })
+
+    test('stops the refresh loop when the kea store is replaced under it', async () => {
+        logic = notebookKernelInfoLogic({ shortId: 'store-reset-01890abc', mode: 'notebook' })
+        logic.mount()
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        const callsBeforeReset = kernelStatusSpy.mock.calls.length
+        expect(callsBeforeReset).toBeGreaterThan(1)
+
+        // Storybook resets the kea context on every story mount, which drops this logic's path
+        // from the store without unmounting it. A tick that reads `values` after that throws
+        // "[KEA] Can not find path", and in a story that surfaces as an unhandled error.
+        initKeaTests()
+        // The reset already dropped the logic, so leave the afterEach unmount nothing to do.
+        logic = undefined
+
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        expect(kernelStatusSpy).toHaveBeenCalledTimes(callsBeforeReset)
+    })
+
+    test('a logic replaced at the same path keeps its own refresh loop', async () => {
+        const shortId = 'remount-01890abc'
+        logic = notebookKernelInfoLogic({ shortId, mode: 'notebook' })
+        logic.mount()
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        const callsPerMount = kernelStatusSpy.mock.calls.length
+        expect(callsPerMount).toBeGreaterThan(1)
+
+        // A storybook remount resets the context and then mounts the same notebook again, so the
+        // replaced logic's loop finds a live logic sitting at its own path. Checking the path
+        // alone lets it keep polling, which doubles the request rate for the new logic.
+        initKeaTests()
+        kernelStatusSpy.mockClear()
+        logic = notebookKernelInfoLogic({ shortId, mode: 'notebook' })
+        logic.mount()
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        expect(kernelStatusSpy).toHaveBeenCalledTimes(callsPerMount)
+    })
 })

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
@@ -5,6 +5,11 @@ import { initKeaTests } from '~/test/init'
 import { notebookKernelInfoLogic } from './notebookKernelInfoLogic'
 import type { NotebookLogicMode } from './notebookLogic'
 
+const setHidden = (hidden: boolean): void => {
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+    document.dispatchEvent(new Event('visibilitychange'))
+}
+
 describe('notebookKernelInfoLogic', () => {
     let kernelStatusSpy: jest.SpyInstance
     let logic: ReturnType<typeof notebookKernelInfoLogic.build> | undefined
@@ -20,6 +25,7 @@ describe('notebookKernelInfoLogic', () => {
     afterEach(() => {
         logic?.unmount()
         logic = undefined
+        setHidden(false)
         jest.useRealTimers()
         kernelStatusSpy.mockRestore()
     })
@@ -109,5 +115,33 @@ describe('notebookKernelInfoLogic', () => {
 
         // One fewer than a full window, because the mount request itself is already counted out.
         expect(kernelStatusSpy).toHaveBeenCalledTimes(callsPerMount - 1)
+    })
+
+    test('stays stopped when the tab returns after the kea store was replaced', async () => {
+        logic = notebookKernelInfoLogic({ shortId: 'hidden-tab-01890abc', mode: 'notebook' })
+        logic.mount()
+        await jest.advanceTimersByTimeAsync(30_000)
+        expect(kernelStatusSpy.mock.calls.length).toBeGreaterThan(1)
+
+        initKeaTests()
+        // The reset already dropped the logic, so the afterEach unmount has nothing to do.
+        logic = undefined
+        kernelStatusSpy.mockClear()
+
+        // The plugin keeps every manager in a module-level set, so the reset leaves this one
+        // registered. Going hidden and back reruns its setup, which has to stay inert instead of
+        // reading `values` from a store without this logic's path. The plugin catches a throwing
+        // setup and logs it, so the log is what separates an inert rerun from a reading one.
+        const consoleErrorSpy = jest.spyOn(console, 'error')
+        try {
+            setHidden(true)
+            setHidden(false)
+            await jest.advanceTimersByTimeAsync(30_000)
+
+            expect(kernelStatusSpy).not.toHaveBeenCalled()
+            expect(consoleErrorSpy.mock.calls.flat().join(' ')).not.toContain('Disposable setup failed')
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
@@ -90,4 +90,24 @@ describe('notebookKernelInfoLogic', () => {
 
         expect(kernelStatusSpy).toHaveBeenCalledTimes(callsPerMount)
     })
+
+    test('re-arms the refresh loop when a remounted logic reuses its cache', async () => {
+        logic = notebookKernelInfoLogic({ shortId: 'reused-cache-01890abc', mode: 'notebook' })
+        logic.mount()
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        const callsPerMount = kernelStatusSpy.mock.calls.length
+        expect(callsPerMount).toBeGreaterThan(1)
+
+        // Remounting a retained built logic keeps its cache and its kea context, the lifecycle
+        // scratchpadLogic.test.ts exercises. The loop has to arm again instead of reading the
+        // reused cache as a sign that the logic went away.
+        logic.unmount()
+        logic.mount()
+        kernelStatusSpy.mockClear()
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        // One fewer than a full window, because the mount request itself is already counted out.
+        expect(kernelStatusSpy).toHaveBeenCalledTimes(callsPerMount - 1)
+    })
 })

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.test.ts
@@ -62,7 +62,7 @@ describe('notebookKernelInfoLogic', () => {
         // from the store without unmounting it. A tick that reads `values` after that throws
         // "[KEA] Can not find path", and in a story that surfaces as an unhandled error.
         initKeaTests()
-        // The reset already dropped the logic, so leave the afterEach unmount nothing to do.
+        // The reset already dropped the logic, so the afterEach unmount has nothing to do.
         logic = undefined
 
         await jest.advanceTimersByTimeAsync(30_000)

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
@@ -1,4 +1,16 @@
-import { MakeLogicType, actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import {
+    MakeLogicType,
+    actions,
+    afterMount,
+    getContext,
+    kea,
+    key,
+    listeners,
+    path,
+    props,
+    reducers,
+    selectors,
+} from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -548,12 +560,13 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
         }
         actions.loadKernelInfo()
         cache.disposables.add(() => {
-            // A replaced kea store drops this logic without unmounting it, so the disposable that
-            // owns this timer never runs its cleanup. Storybook does that on every story mount.
-            // The `cache` identity check finds the case a path check misses, which is a new logic
-            // mounted at the same path by the next story. Both call sites read `values`, which on
-            // a dropped logic either throws "Can not find path" or reads the wrong store.
-            const isLive = (): boolean => notebookKernelInfoLogic.findMounted(props.shortId)?.cache === cache
+            // Replacing the kea context drops this logic's path from the store without unmounting
+            // it, so the disposable never runs its cleanup and the timer survives. Storybook does
+            // that on every story mount. Reading `values` from a tick that outlived its context
+            // either throws "Can not find path" or, once the next story mounts a logic at the same
+            // path, reads a store this timer no longer belongs to.
+            const mountedIn = getContext()
+            const isLive = (): boolean => getContext() === mountedIn
             // Reschedules itself rather than using setInterval, because a starting kernel is
             // polled five times more often than a settled one.
             let timeoutId = 0
@@ -571,8 +584,8 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
                     values.isStarting ? 2000 : 10000
                 )
             }
-            // The plugin keeps every manager in a module-level set and reruns setup when the tab
-            // becomes visible, so this setup can also run after the store went away.
+            // The plugin holds every manager in a module-level set and reruns setup when the tab
+            // becomes visible, so this setup can also run after the context went away.
             if (isLive()) {
                 scheduleRefresh()
             }

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
@@ -548,20 +548,19 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
         }
         actions.loadKernelInfo()
         cache.disposables.add(() => {
+            // A replaced kea store drops this logic without unmounting it, so the disposable that
+            // owns this timer never runs its cleanup. Storybook does that on every story mount.
+            // The `cache` identity check finds the case a path check misses, which is a new logic
+            // mounted at the same path by the next story. Both call sites read `values`, which on
+            // a dropped logic either throws "Can not find path" or reads the wrong store.
+            const isLive = (): boolean => notebookKernelInfoLogic.findMounted(props.shortId)?.cache === cache
             // Reschedules itself rather than using setInterval, because a starting kernel is
             // polled five times more often than a settled one.
             let timeoutId = 0
             const scheduleRefresh = (): void => {
                 timeoutId = window.setTimeout(
                     () => {
-                        // A replaced kea store drops this logic without unmounting it, so the
-                        // disposable that owns this timer never runs its cleanup. Storybook does
-                        // that on every story mount. The `cache` identity check finds the case a
-                        // path check misses, which is a new logic mounted at the same path by the
-                        // next story. Without it, reading `values` here either throws "Can not
-                        // find path" or reads the wrong store, and both surface in the story as
-                        // an unhandled error.
-                        if (notebookKernelInfoLogic.findMounted(props.shortId)?.cache !== cache) {
+                        if (!isLive()) {
                             return
                         }
                         if (!values.actionInFlight.refresh) {
@@ -572,7 +571,11 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
                     values.isStarting ? 2000 : 10000
                 )
             }
-            scheduleRefresh()
+            // The plugin keeps every manager in a module-level set and reruns setup when the tab
+            // becomes visible, so this setup can also run after the store went away.
+            if (isLive()) {
+                scheduleRefresh()
+            }
             return () => clearTimeout(timeoutId)
         }, 'kernelInfoRefresh')
     }),

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
@@ -558,19 +558,25 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
         if (props.mode && props.mode !== 'notebook') {
             return
         }
+        // Replacing the kea context drops this logic's path from the store without unmounting it,
+        // so the disposable never runs its cleanup and the timer survives. Storybook does that on
+        // every story mount. Reading `values` after it either throws "Can not find path" or, once
+        // something else mounts at the same path, reads a store this loop no longer belongs to.
+        // Captured out here rather than inside the setup, because the plugin holds every manager
+        // in a module-level set and reruns setup when the tab becomes visible. A context read
+        // inside the setup would be the context of that rerun, which compares equal to itself and
+        // guards nothing.
+        const mountedIn = getContext()
+        const isLive = (): boolean => getContext() === mountedIn
         actions.loadKernelInfo()
         cache.disposables.add(() => {
-            // Replacing the kea context drops this logic's path from the store without unmounting
-            // it, so the disposable never runs its cleanup and the timer survives. Storybook does
-            // that on every story mount. Reading `values` from a tick that outlived its context
-            // either throws "Can not find path" or, once the next story mounts a logic at the same
-            // path, reads a store this timer no longer belongs to.
-            const mountedIn = getContext()
-            const isLive = (): boolean => getContext() === mountedIn
             // Reschedules itself rather than using setInterval, because a starting kernel is
             // polled five times more often than a settled one.
             let timeoutId = 0
             const scheduleRefresh = (): void => {
+                if (!isLive()) {
+                    return
+                }
                 timeoutId = window.setTimeout(
                     () => {
                         if (!isLive()) {
@@ -584,11 +590,7 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
                     values.isStarting ? 2000 : 10000
                 )
             }
-            // The plugin holds every manager in a module-level set and reruns setup when the tab
-            // becomes visible, so this setup can also run after the context went away.
-            if (isLive()) {
-                scheduleRefresh()
-            }
+            scheduleRefresh()
             return () => clearTimeout(timeoutId)
         }, 'kernelInfoRefresh')
     }),

--- a/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookKernelInfoLogic.ts
@@ -1,16 +1,4 @@
-import {
-    MakeLogicType,
-    actions,
-    afterMount,
-    beforeUnmount,
-    kea,
-    key,
-    listeners,
-    path,
-    props,
-    reducers,
-    selectors,
-} from 'kea'
+import { MakeLogicType, actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -558,21 +546,34 @@ export const notebookKernelInfoLogic = kea<notebookKernelInfoLogicType>([
         if (props.mode && props.mode !== 'notebook') {
             return
         }
-        const scheduleRefresh = (): void => {
-            const delayMs = values.isStarting ? 2000 : 10000
-            cache.kernelInfoRefresh = window.setTimeout(() => {
-                if (!values.actionInFlight.refresh) {
-                    actions.loadKernelInfo()
-                }
-                scheduleRefresh()
-            }, delayMs)
-        }
         actions.loadKernelInfo()
-        scheduleRefresh()
-    }),
-    beforeUnmount(({ cache }) => {
-        if (cache.kernelInfoRefresh) {
-            clearTimeout(cache.kernelInfoRefresh)
-        }
+        cache.disposables.add(() => {
+            // Reschedules itself rather than using setInterval, because a starting kernel is
+            // polled five times more often than a settled one.
+            let timeoutId = 0
+            const scheduleRefresh = (): void => {
+                timeoutId = window.setTimeout(
+                    () => {
+                        // A replaced kea store drops this logic without unmounting it, so the
+                        // disposable that owns this timer never runs its cleanup. Storybook does
+                        // that on every story mount. The `cache` identity check finds the case a
+                        // path check misses, which is a new logic mounted at the same path by the
+                        // next story. Without it, reading `values` here either throws "Can not
+                        // find path" or reads the wrong store, and both surface in the story as
+                        // an unhandled error.
+                        if (notebookKernelInfoLogic.findMounted(props.shortId)?.cache !== cache) {
+                            return
+                        }
+                        if (!values.actionInFlight.refresh) {
+                            actions.loadKernelInfo()
+                        }
+                        scheduleRefresh()
+                    },
+                    values.isStarting ? 2000 : 10000
+                )
+            }
+            scheduleRefresh()
+            return () => clearTimeout(timeoutId)
+        }, 'kernelInfoRefresh')
     }),
 ])


### PR DESCRIPTION
## Problem

Notebook storybook stories fail at random with `[KEA] Can not find path "scenes.notebooks.Notebook.notebookKernelInfoLogic.<short_id>" in the store`, and `Scenes-App/Notebooks/Widget views › WorkflowViews` has been red on master. The error is unrelated to what the story asserts, so it hides the real failure behind remount machinery.

- `notebookKernelInfoLogic` polls kernel status on a bare `setTimeout`, cleared from `beforeUnmount`.
- Replacing the kea context drops the logic's path from the store without unmounting it, so that cleanup never runs.
- Storybook's `withKea` decorator calls `initKea()` on every story mount, which is exactly that.
- The next tick reads `values.actionInFlight`, finds no path, and throws. Storybook reports it as `unhandledErrorsWhilePlaying`.

Moving the poll onto `cache.disposables` then exposed a second bug, in the plugin itself. A logic that mounts again keeps its cache, so the manager disposed by its previous unmount stays attached, and `add()` is a permanent no-op from that point. Any logic remounted from a retained reference silently loses its timers and listeners for the rest of the session. That reaches well past notebooks: 137 files register disposables, including the session recording player, dashboards, and live events.

## Changes

- Notebook stories no longer fail on a stray kernel poll. The loop stops itself instead of throwing.
- A remounted logic gets a working disposables manager again, so its polling and listeners resume rather than staying dead. `initializeDisposablesManager` replaces a disposed manager instead of returning early.
- The kernel poll moves to `cache.disposables`, the convention every other timer in the notebooks tree already uses, and now pauses on a hidden tab.
- Each tick and each setup checks that the kea context is still the one the logic mounted in, before it reads `values`.

The live check compares the kea context rather than looking the logic up through its wrapper. `findMounted` does not find a logic remounted from a retained reference, so a wrapper lookup reads a healthy remount as a dropped logic and never arms the poll. Comparing contexts also covers the case a path check misses, where the next story mounts a different logic at the same path.

Nothing user-visible changes in notebooks. The plugin change is one condition; the risk sits there rather than in the notebook logic, because every disposables consumer runs through it.

The rest is documentation: the `isDisposed` doc comment and the `using-kea-disposables` skill.

## How did you test this code?

Three new cases, each covering a regression no existing test caught. Every one of them fails on the commit before its fix.

- `kea-disposables.test.ts`: a built logic mounted again gets a live manager, so `add()` registers instead of no-oping.
- `notebookKernelInfoLogic.test.ts`: replacing the kea store under a mounted logic stops the loop. Without the fix this reproduces the production error verbatim, including the path.
- `notebookKernelInfoLogic.test.ts`: a remounted logic re-arms its loop, and a replacement logic at the same path polls at a single logic's rate.
- `notebookKernelInfoLogic.test.ts`: a tab going hidden and back after a store swap leaves the loop inert. The plugin swallows a throwing setup into a log line, so the test asserts on that log rather than on a crash.

The plugin change is global, so 19 suites covering the heaviest disposables consumers ran locally as well: dataNode, dashboard, experiment, session recording player, snapshot data, taxonomic filter, max thread, scratchpad, live events, and the notebook logics. 708 passed.

Not run: the storybook visual-regression suite. It needs a storybook build plus webkit, and the failure is a race, so a single green run would not confirm the fix. Also note `ci-storybook.yml` builds a chromium-only matrix for `pull_request`, so the webkit configuration the flake was recorded under first runs when this lands on master. The kea-level reproduction is deterministic instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`using-kea-disposables` and the `isDisposed` doc comment now record two traps this PR walked into: a remount puts a fresh manager on the cache, so a late continuation can dispose a key belonging to the logic's next life, and `isDisposed` alone does not guard a timer that reads `values`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Trunk flaky-test report for `WorkflowViews play-test`. Reading the code did not settle which async continuation escaped the unmount, so the mechanism came from a throwaway jest case that replaced the context under a mounted logic. That reproduced the exact error string, path, and source line, which pointed at `withKea` calling `initKea()` per story mount.

Codex raised two P2 findings across the session and both were real. The first, a setup-time `values` read on tab focus, is fixed by applying the live check at both call sites. The second, that disposables never re-arm after a same-instance remount, turned out to be two bugs at once: the plugin reused its disposed manager, and the live check itself used `findMounted`, which does not see a retained-reference remount. Both are fixed, and both halves are pinned by tests. Stamphog refused the earlier head over these, correctly.

The live check went through four shapes: `logic.isMounted()` (not on `MakeLogicType`), a `findMounted(...).cache` identity comparison (broke the remount path), a context comparison captured inside the disposable's setup, then the same comparison captured in `afterMount`. Stamphog caught the third: the plugin reruns setup on tab focus, so a context read inside it compared equal to itself and guarded nothing. Its verdicts drove two of the four shapes, and the wording it refused claimed a fix that was not there.

24 other logics still hold a timer in `cache` with a matching `beforeUnmount` rather than using disposables. Any that read `values` from the callback can fail the same way. Converting them is follow-up work.

Tools: Claude Opus 5 via the PostHog Slack app. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/merging-prs`, and the `using-kea-disposables` guidance.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1787727019895929?thread_ts=1787727019.895929&cid=C0AS64N6DJL)*


