### PR TITLE
test: stabilize bare ClickHouse tests against shard ordering

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -12,6 +12,7 @@ from posthog.test.base import (
     cleanup_materialized_columns,
     snapshot_clickhouse_queries,
 )
+from unittest.mock import patch
 
 from rest_framework.exceptions import ValidationError
 
@@ -1922,7 +1923,8 @@ def test_combine_group_properties():
     }
 
 
-def test_session_property_validation():
+@patch("posthog.models.event.new_events_schema.use_new_events_schema", return_value=False)
+def test_session_property_validation(_mock_use_new_events_schema):
     # Property key not valid for type session
     with pytest.raises(ValidationError):
         filter = Filter(

--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -3,6 +3,7 @@ import pytest
 from clickhouse_driver.errors import ServerException
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import default_client
 from posthog.errors import (
     CH_TRANSIENT_ERRORS,
     QueryErrorCategory,
@@ -224,10 +225,16 @@ def test_wrap_clickhouse_query_error(error, expected_type, expected_message, exp
 
 
 def test_per_query_memory_limit_phrasing_matches_real_clickhouse():
+    # The query reads only the built-in `numbers` table function, so it needs no tenant
+    # database. default_client connects to `system`, which always exists, so this bare
+    # test (no BaseTest, no django_db mark) does not depend on another test in the
+    # shard having created posthog_test first.
     with pytest.raises(ClickHouseQueryMemoryLimitExceeded) as ctx:
         sync_execute(
             "SELECT groupArray(number) FROM numbers(10000000)",
             settings={"max_memory_usage": 1_000_000},
+            sync_client=default_client(),
+            flush=False,
         )
     assert ctx.value.is_per_query_limit
     assert not isinstance(ctx.value, ClickHouseClusterMemoryLimitExceeded)

--- a/posthog/hogql_queries/ai/test/test_ai_table_resolver.py
+++ b/posthog/hogql_queries/ai/test/test_ai_table_resolver.py
@@ -84,8 +84,9 @@ class TestQueryAiEvents:
         assert mock_execute.call_count == 2
         assert mock_execute.call_args.kwargs["context"].use_new_events_schema is True
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=True)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_raises_expired_when_ai_events_empty_but_events_has_rows(self, mock_execute):
+    def test_raises_expired_when_ai_events_empty_but_events_has_rows(self, mock_execute, _mock_use_new_events_schema):
         # ai_events empty, events probe finds the row -> the data aged past the TTL.
         mock_execute.side_effect = [self._make_result([]), self._make_result([[1]])]
 
@@ -99,8 +100,9 @@ class TestQueryAiEvents:
             )
         assert mock_execute.call_count == 2
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=True)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_raises_not_found_when_empty_in_both_tables(self, mock_execute):
+    def test_raises_not_found_when_empty_in_both_tables(self, mock_execute, _mock_use_new_events_schema):
         mock_execute.side_effect = [self._make_result([]), self._make_result([])]
 
         team = Mock(id=1, organization_id="org")
@@ -132,8 +134,9 @@ class TestQueryAiEvents:
         assert isinstance(rewritten, ast.Field)
         assert rewritten.chain == ["trace_id"]
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=True)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_rewrites_placeholders_for_events_fallback(self, mock_execute):
+    def test_rewrites_placeholders_for_events_fallback(self, mock_execute, _mock_use_new_events_schema):
         mock_execute.side_effect = [self._make_result([]), self._make_result([["found"]])]
 
         team = Mock(id=1, organization_id="org")
@@ -153,8 +156,9 @@ class TestQueryAiEvents:
         assert isinstance(rewritten, ast.Field)
         assert rewritten.chain == ["properties", "$ai_trace_id"]
 
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.use_new_events_schema", return_value=True)
     @patch("posthog.hogql_queries.ai.ai_table_resolver.execute_hogql_query")
-    def test_rewrites_query_from_clause_for_events_fallback(self, mock_execute):
+    def test_rewrites_query_from_clause_for_events_fallback(self, mock_execute, _mock_use_new_events_schema):
         mock_execute.side_effect = [self._make_result([]), self._make_result([])]
 
         team = Mock(id=1, organization_id="org")


### PR DESCRIPTION
## Problem

Two bare pytest tests (no `django_db`) pass or fail depending on which tests ran before them in a ClickHouse shard, so unrelated PRs hit their failures.

- `test_per_query_memory_limit_phrasing_matches_real_clickhouse` queried through a client pinned to `posthog_test`, which exists only after a DB-backed test has run in the same shard.
- `test_session_property_validation` resolved the new-events-schema lookup from ambient state it does not control.

## Changes

- The memory-limit test now queries through `default_client()`, which connects to the `system` database, and disables flushing. The query reads only the `numbers` table function, so it needs no tenant database.
- `test_session_property_validation` pins `use_new_events_schema` to `False`.

No user-visible change; both edits are test-only.

## How did you test this code?

Split out of #87671, where these exact changes ran in CI ([Trunk: 0 failures at `76ac092`](https://app.trunk.io/posthog-inc/flaky-tests/pr/87671?repo=PostHog/posthog&commitHash=76ac092d5e72a561f44d44fd6860d822dbe41c9b)). Not re-run locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Cherry-picked out of #87671 (Claude Code session) so that PR carries only its feature. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. No session-private material is in the diff.
