### PR TITLE
fix(devex): give the master migration replay room under its timeout

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1074,7 +1074,12 @@ jobs:
     check-migrations:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.migrations == 'true'
-        timeout-minutes: 20
+        # On master this job replays the full migration history from scratch to
+        # produce the schema dump every PR job restores. That replay grows with
+        # every merged migration and hits a fixed limit eventually, which cancels
+        # the job and fails the Django gate on master. Sized at about twice the
+        # replay so it stays a guard against a hang, not a ceiling on history.
+        timeout-minutes: 40
         name: Validate migrations
         runs-on: depot-ubuntu-24.04
         steps:

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1076,9 +1076,8 @@ jobs:
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.migrations == 'true'
         # On master this job replays the full migration history from scratch to
         # produce the schema dump every PR job restores. That replay grows with
-        # every merged migration and hits a fixed limit eventually, which cancels
-        # the job and fails the Django gate on master. Sized at about twice the
-        # replay so it stays a guard against a hang, not a ceiling on history.
+        # every merged migration, so the limit needs headroom over it: it is
+        # there to cancel a hang, not to cap how long the history takes.
         timeout-minutes: 40
         name: Validate migrations
         runs-on: depot-ubuntu-24.04

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1324,7 +1324,12 @@ jobs:
     check-migrations:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.migrations == 'true' || needs.changes.outputs.persons_sql == 'true'
-        timeout-minutes: 20
+        # On master this job replays the full migration history from scratch to
+        # produce the schema dump every PR job restores. That replay grows with
+        # every merged migration and hits a fixed limit eventually, which cancels
+        # the job and fails the Django gate on master. Sized at about twice the
+        # replay so it stays a guard against a hang, not a ceiling on history.
+        timeout-minutes: 40
         outputs:
             mig_schema_key: ${{ steps.mig-schema-key.outputs.key }}
         # The "Publish Migration risk check" step posts the check via the

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1326,9 +1326,8 @@ jobs:
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.migrations == 'true' || needs.changes.outputs.persons_sql == 'true'
         # On master this job replays the full migration history from scratch to
         # produce the schema dump every PR job restores. That replay grows with
-        # every merged migration and hits a fixed limit eventually, which cancels
-        # the job and fails the Django gate on master. Sized at about twice the
-        # replay so it stays a guard against a hang, not a ceiling on history.
+        # every merged migration, so the limit needs headroom over it: it is
+        # there to cancel a hang, not to cap how long the history takes.
         timeout-minutes: 40
         outputs:
             mig_schema_key: ${{ steps.mig-schema-key.outputs.key }}


### PR DESCRIPTION
## Problem

- Master shows a red Django gate on most pushes with nothing wrong in the code. This week 57% of master runs of `Validate migrations` ended as cancelled.
- The job hits its 20-minute `timeout-minutes` limit. GitHub reports a timed-out job as cancelled, and the gate fails closed on cancelled.
- On master the job replays the full migration history from scratch to produce the schema dump every PR job restores. That replay grew from about 11 minutes in June to about 20 minutes now, roughly one minute per week, until it crossed the limit.

## Changes

- `check-migrations` gets a 40-minute limit, about twice the current replay, in the canonical workflow and the Depot shadow. Nothing else changes; PR runs of the job take about 3 minutes and are unaffected.
- The growth is not fixed here. Every master job pays the same from-scratch replay, and the trend needs its own change.

## How did you test this code?

- `hogli ci:preflight` passes, including the shadow-drift check.
- Weekly p50 of the master job since June, from the per-job CI timing events in the DevEx project: 10.6, 11.0, 11.3, 12.0, 12.5, 13.0, 13.9, 14.6, 15.5, 17.0, 18.0, 19.3, 20.1 minutes. The cancelled share went from 0 to 0.57 over the same weeks.
- Not run: the job itself on master. The first master push after merge shows whether the gate goes green.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code in the session linked from the commit. Skills invoked: /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions.

Found while measuring shard timings after #87687 and #87770 landed: the master gate failed in 91% of runs after the merge versus 56% before, and most of that was this timeout, not the shard change.
