### PR TITLE
feat(messaging): suppress recipients who report an email as spam

### DIFF
--- a/nodejs/src/cdp/services/messaging/email-suppression.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-suppression.service.test.ts
@@ -46,6 +46,16 @@ describe('EmailSuppressionService', () => {
         return res.rows[0]
     }
 
+    const readReason = async (email: string): Promise<string | undefined> => {
+        const res = await hub.postgres.query<{ reason: string }>(
+            PostgresUse.COMMON_READ,
+            `SELECT reason FROM posthog_messagesuppression WHERE team_id = $1 AND identifier = $2`,
+            [team.id, email],
+            'test-read-reason'
+        )
+        return res.rows[0]?.reason
+    }
+
     describe('recordTransientBounces (threshold=3)', () => {
         beforeEach(() => {
             // Threshold=3 gives a clean boundary: 2 bounces must not flip, 3 must.
@@ -201,6 +211,95 @@ describe('EmailSuppressionService', () => {
                 'test-read-reason'
             )
             expect(detail.rows[0].reason).toBe('Manually added')
+        })
+    })
+
+    describe('recordComplaints', () => {
+        it('suppresses immediately with source=COMPLAINT and the feedback type in the reason', async () => {
+            const svc = new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv())
+            const email = 'reported-us@example.com'
+            await svc.recordComplaints(team.id, [email], 'abuse')
+
+            expect(await readRow(email)).toMatchObject({
+                identifier: email,
+                source: 'COMPLAINT',
+                suppressed: true,
+                deleted: false,
+            })
+            expect(await readReason(email)).toBe('Auto-suppressed after a spam complaint (abuse)')
+        })
+
+        it('drops an unrecognized feedback type rather than storing it in the reason', async () => {
+            const svc = new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv())
+            const email = 'odd-feedback@example.com'
+            await svc.recordComplaints(team.id, [email], 'Reason: [Action:evil] injected')
+
+            expect(await readReason(email)).toBe('Auto-suppressed after a spam complaint')
+        })
+
+        it('escalates a bounce-counter row to COMPLAINT without disturbing the bounce counter', async () => {
+            const svc = new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv())
+            const email = 'bounced-then-complained@example.com'
+            await svc.recordTransientBounces(team.id, [email], 'temp')
+            expect(await readRow(email)).toMatchObject({ suppressed: false, transient_bounce_count: 1 })
+
+            await svc.recordComplaints(team.id, [email], 'abuse')
+            expect(await readRow(email)).toMatchObject({
+                source: 'COMPLAINT',
+                suppressed: true,
+                // A complaint is not a deliverability failure, so bounce history is left as-is.
+                transient_bounce_count: 1,
+            })
+        })
+
+        it('does not override a MANUAL entry (user-managed rows are authoritative)', async () => {
+            const email = 'user-managed-complaint@example.com'
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `INSERT INTO posthog_messagesuppression
+                    (id, team_id, identifier, source, reason, transient_bounce_count,
+                     suppressed, suppressed_at, deleted, created_at, updated_at)
+                 VALUES (gen_random_uuid(), $1, $2, 'MANUAL', 'Manually added', 0,
+                     false, NULL, true, NOW(), NOW())`,
+                [team.id, email],
+                'test-insert-manual'
+            )
+
+            const svc = new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv())
+            await svc.recordComplaints(team.id, [email], 'abuse')
+
+            // A user who deliberately removed the address keeps it removed.
+            expect(await readRow(email)).toMatchObject({
+                source: 'MANUAL',
+                suppressed: false,
+                deleted: true,
+            })
+            expect(await readReason(email)).toBe('Manually added')
+        })
+
+        it('re-suppresses an auto row a user had removed, since the address complained again', async () => {
+            const svc = new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv())
+            const email = 'removed-then-complained@example.com'
+            await svc.recordComplaints(team.id, [email], 'abuse')
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `UPDATE posthog_messagesuppression SET suppressed = false, deleted = true
+                 WHERE team_id = $1 AND identifier = $2`,
+                [team.id, email],
+                'test-soft-delete'
+            )
+
+            await svc.recordComplaints(team.id, [email], 'abuse')
+            expect(await readRow(email)).toMatchObject({ suppressed: true, deleted: false })
+        })
+
+        it('blocks the address from the next send', async () => {
+            const svc = new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv())
+            const email = 'blocked-after-complaint@example.com'
+            expect(await svc.isSuppressed(team.id, email)).toBe(false)
+
+            await svc.recordComplaints(team.id, [email], 'abuse')
+            expect(await svc.isSuppressed(team.id, email)).toBe(true)
         })
     })
 

--- a/nodejs/src/cdp/services/messaging/email-suppression.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-suppression.service.ts
@@ -6,11 +6,16 @@ import { logger } from '~/common/utils/logger'
 
 const cdpEmailSuppressionTotal = new Counter({
     name: 'cdp_email_suppression_total',
-    help: 'Email suppression-list outcomes. `suppressed_hit` = a send skipped because the recipient is on the list; `transient_bounce` = a soft-bounce counter increment; `hard_bounce` = an address suppressed immediately after a permanent bounce.',
+    help: 'Email suppression-list outcomes. `suppressed_hit` = a send skipped because the recipient is on the list; `transient_bounce` = a soft-bounce counter increment; `hard_bounce` = an address suppressed immediately after a permanent bounce; `complaint` = an address suppressed immediately after a spam complaint.',
     labelNames: ['result'],
 })
 
 const DIAGNOSTIC_MAX_LENGTH = 1000
+
+// RFC 5965 feedback types a provider may report on a complaint. `not-spam` is absent on purpose:
+// it means the recipient moved the message *out* of their spam folder, so it must never suppress
+// (see COMPLAINT_SUPPRESSING_FEEDBACK_TYPES in the SES webhook handler).
+const COMPLAINT_FEEDBACK_TYPES = new Set(['abuse', 'auth-failure', 'fraud', 'other', 'virus'])
 
 const normalizeIdentifier = (email: string): string => email.trim().toLowerCase()
 
@@ -218,6 +223,80 @@ export class EmailSuppressionService {
             this.lazyLoader.markForRefresh(identifiers.map((identifier) => toKey(teamId, identifier)))
         } catch (error) {
             logger.error('[EmailSuppression] Failed to record hard bounces', { teamId, error })
+        }
+    }
+
+    /**
+     * Record one or more spam complaints. Suppresses each address immediately — no threshold, no
+     * counter — because the recipient has explicitly said they don't want our mail, and every
+     * further send to them pushes the account-level complaint rate toward the level at which the
+     * provider throttles or pauses sending for every team on the account.
+     *
+     * `feedbackType` is the RFC 5965 feedback type the provider reported. It only reaches the
+     * stored reason, and callers are expected to have already dropped `not-spam` reports (see the
+     * SES webhook handler) — those mean the recipient rescued the message from their spam folder,
+     * which is the opposite of a complaint.
+     *
+     * Bounce bookkeeping (`transient_bounce_count`, `last_bounce_at`, `last_bounce_diagnostic`) is
+     * deliberately left untouched: a complaint is not a deliverability failure, and the address may
+     * still be accepting mail perfectly well. Manual entries are never overridden.
+     */
+    public async recordComplaints(teamId: number, emails: string[], feedbackType?: string): Promise<void> {
+        const identifiers = Array.from(new Set(emails.map(normalizeIdentifier).filter(Boolean)))
+        if (identifiers.length === 0) {
+            return
+        }
+
+        // The provider-reported feedback type is attacker-influenceable in principle, so only a
+        // known RFC 5965 token reaches the stored reason; anything else degrades to no suffix.
+        const suffix = feedbackType && COMPLAINT_FEEDBACK_TYPES.has(feedbackType) ? ` (${feedbackType})` : ''
+        const reason = `Auto-suppressed after a spam complaint${suffix}`
+
+        // Params: teamId, reason, then one identifier per row.
+        const valueClauses: string[] = []
+        const params: (number | string)[] = [teamId, reason]
+        identifiers.forEach((identifier, i) => {
+            const p = params.length + 1 + i
+            valueClauses.push(`(gen_random_uuid(), $1, $${p}, 'COMPLAINT', $2, 0, true, NOW(), false, NOW(), NOW())`)
+        })
+        params.push(...identifiers)
+
+        const query = `
+            INSERT INTO posthog_messagesuppression
+                (id, team_id, identifier, source, reason, transient_bounce_count,
+                 suppressed, suppressed_at, deleted, created_at, updated_at)
+            VALUES ${valueClauses.join(', ')}
+            ON CONFLICT (team_id, identifier) DO UPDATE SET
+                -- Manual entries are authoritative; never override them.
+                suppressed = CASE
+                    WHEN posthog_messagesuppression.source = 'MANUAL' THEN posthog_messagesuppression.suppressed
+                    ELSE true END,
+                suppressed_at = CASE
+                    WHEN posthog_messagesuppression.source = 'MANUAL' THEN posthog_messagesuppression.suppressed_at
+                    WHEN posthog_messagesuppression.suppressed = false THEN NOW()
+                    ELSE posthog_messagesuppression.suppressed_at END,
+                -- A complaint outranks a bounce counter as the reason the address is suppressed,
+                -- so escalate the row's source and reason to reflect why it's really blocked.
+                source = CASE
+                    WHEN posthog_messagesuppression.source = 'MANUAL' THEN posthog_messagesuppression.source
+                    ELSE 'COMPLAINT' END,
+                reason = CASE
+                    WHEN posthog_messagesuppression.source = 'MANUAL' THEN posthog_messagesuppression.reason
+                    ELSE EXCLUDED.reason END,
+                -- A complaining address coming back un-deletes itself: it must stay blocked.
+                deleted = CASE
+                    WHEN posthog_messagesuppression.source = 'MANUAL' THEN posthog_messagesuppression.deleted
+                    ELSE false END,
+                updated_at = NOW()
+        `
+
+        try {
+            await this.postgres.query(PostgresUse.COMMON_WRITE, query, params, 'recordComplaints')
+            cdpEmailSuppressionTotal.inc({ result: 'complaint' }, identifiers.length)
+            // Only invalidate the keys we touched — cross-team entries stay warm.
+            this.lazyLoader.markForRefresh(identifiers.map((identifier) => toKey(teamId, identifier)))
+        } catch (error) {
+            logger.error('[EmailSuppression] Failed to record complaints', { teamId, error })
         }
     }
 

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -566,6 +566,75 @@ describe('EmailTrackingService', () => {
                 .send(JSON.stringify(envelope))
         }
 
+        const postComplaint = async (
+            functionId: string,
+            emailAddress: string,
+            complaintFeedbackType?: string
+        ): Promise<supertest.Response> => {
+            const trackingCode = signer.generate({ functionId, id: 'invocation-id', teamId: team.id })
+            const sesRecord = {
+                eventType: 'Complaint',
+                mail: {
+                    timestamp: '2024-01-01T00:00:00.000Z',
+                    source: 'sender@posthog.com',
+                    messageId: 'ses-message-id',
+                    destination: [emailAddress],
+                    headers: [{ name: TRACKING_CODE_HEADER_NAME, value: trackingCode }],
+                },
+                complaint: {
+                    complainedRecipients: [{ emailAddress }],
+                    timestamp: '2024-01-01T00:00:00.000Z',
+                    ...(complaintFeedbackType ? { complaintFeedbackType } : {}),
+                },
+            }
+            const envelope = {
+                Type: 'Notification',
+                MessageId: 'sns-message-id',
+                TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-events',
+                Message: JSON.stringify(sesRecord),
+                Timestamp: '2024-01-01T00:00:00.000Z',
+                SignatureVersion: '1',
+                Signature: 'stubbed',
+                SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
+            }
+            return await supertest(app)
+                .post('/public/m/ses_webhook')
+                .set('Content-Type', 'text/plain')
+                .send(JSON.stringify(envelope))
+        }
+
+        it('inserts a suppressed row for a Complaint webhook, so we stop mailing a complainer', async () => {
+            const hogFlow = await insertHogFlow(hub.postgres, new FixtureHogFlowBuilder().withTeamId(team.id).build())
+            const email = 'complainer@example.com'
+
+            const res = await postComplaint(hogFlow.id, email, 'abuse')
+            expect(res.status).toBe(200)
+
+            const result = await hub.postgres.query<{
+                identifier: string
+                source: string
+                suppressed: boolean
+                reason: string
+                deleted: boolean
+            }>(
+                PostgresUse.COMMON_READ,
+                `SELECT identifier, source, suppressed, reason, deleted
+                 FROM posthog_messagesuppression
+                 WHERE team_id = $1 AND identifier = $2`,
+                [team.id, email],
+                'test-read-complaint-suppression'
+            )
+            expect(result.rows).toEqual([
+                {
+                    identifier: email,
+                    source: 'COMPLAINT',
+                    suppressed: true,
+                    reason: 'Auto-suppressed after a spam complaint (abuse)',
+                    deleted: false,
+                },
+            ])
+        })
+
         it('inserts a suppression row and marks it suppressed after a Transient bounce webhook', async () => {
             const hogFlow = await insertHogFlow(hub.postgres, new FixtureHogFlowBuilder().withTeamId(team.id).build())
             const email = 'transient-bouncer@example.com'

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -391,6 +391,7 @@ export class EmailTrackingService {
                 transientBounceRecipients,
                 hardBounceRecipients,
                 deliveredRecipients,
+                complainedRecipients,
             } = await this.sesWebhookHandler.handleWebhook({
                 body: parseJSON(req.body),
                 headers: req.headers,
@@ -436,10 +437,11 @@ export class EmailTrackingService {
                 emailTrackingErrorsCounter.inc({ error_type: 'track_logs_failed', source: 'ses' })
             }
 
-            // Feed bounces and successful deliveries into the suppression list. Wrapped so a
-            // failure here never affects the webhook's 200 response to SNS. Deliveries are processed
-            // first so a delivery + bounce in the same batch nets out conservatively (count resets,
-            // then the fresh bounce re-counts from a clean slate).
+            // Feed bounces, complaints and successful deliveries into the suppression list. Wrapped
+            // so a failure here never affects the webhook's 200 response to SNS. Deliveries are
+            // processed first so a delivery + bounce in the same batch nets out conservatively
+            // (count resets, then the fresh bounce re-counts from a clean slate). Complaints go last
+            // because they suppress outright, so they must win over any counter reset in the batch.
             try {
                 for (const { teamId, emailAddresses, timestamp } of deliveredRecipients || []) {
                     const parsedTeamId = teamId ? parseInt(teamId, 10) : NaN
@@ -461,6 +463,12 @@ export class EmailTrackingService {
                     const parsedTeamId = teamId ? parseInt(teamId, 10) : NaN
                     if (parsedTeamId && !isNaN(parsedTeamId)) {
                         await this.emailSuppressionService.recordHardBounces(parsedTeamId, emailAddresses, diagnostic)
+                    }
+                }
+                for (const { teamId, emailAddresses, feedbackType } of complainedRecipients || []) {
+                    const parsedTeamId = teamId ? parseInt(teamId, 10) : NaN
+                    if (parsedTeamId && !isNaN(parsedTeamId)) {
+                        await this.emailSuppressionService.recordComplaints(parsedTeamId, emailAddresses, feedbackType)
                     }
                 }
             } catch (error) {

--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -555,21 +555,37 @@ describe('SesWebhookHandler', () => {
         expect(result.hardBounceRecipients).toBeUndefined()
     })
 
-    it('parses a raw Complaint event', async () => {
-        const body = [
-            {
-                eventType: 'Complaint',
-                mail: baseMail,
-                complaint: {
-                    complainedRecipients: [{ emailAddress: 'to@example.com' }],
-                    timestamp: '2025-10-03T12:05:00Z',
-                },
+    const buildComplaintBody = (complaintFeedbackType?: string): Record<string, any>[] => [
+        {
+            eventType: 'Complaint',
+            mail: baseMail,
+            complaint: {
+                complainedRecipients: [{ emailAddress: 'to@example.com' }],
+                timestamp: '2025-10-03T12:05:00Z',
+                ...(complaintFeedbackType ? { complaintFeedbackType } : {}),
             },
-        ]
-        const result = await handler.handleWebhook({ body, headers: {} })
+        },
+    ]
+
+    // A `not-spam` report means the recipient moved the message out of their spam folder. SES
+    // relays it as a Complaint, so suppressing on it would block the people who want the mail.
+    // The metric assertion pins today's behavior rather than endorsing it: every complaint,
+    // not-spam included, lands in email_blocked, which the UI shows as "Marked as spam".
+    // Splitting that out changes what the reputation complaint rate counts, so it belongs with
+    // the metric path, not here.
+    it.each([
+        ['abuse', ['to@example.com']],
+        // SES may omit the feedback type entirely; a complaint is still a complaint.
+        [undefined, ['to@example.com']],
+        ['not-spam', []],
+    ] as const)('a %s complaint surfaces %j for suppression', async (feedbackType, expectedEmails) => {
+        const result = await handler.handleWebhook({ body: buildComplaintBody(feedbackType), headers: {} })
         expect(result.status).toBe(200)
         expect(result.metrics?.[0].metricName).toBe('email_blocked')
         expect(result.metrics?.[0].distinctId).toBe('user-123')
+        expect(result.complainedRecipients).toEqual(
+            expectedEmails.length ? [{ teamId: '1', emailAddresses: expectedEmails, feedbackType }] : []
+        )
     })
 
     it('returns 200 and no metrics if tracking code is missing from both carriers', async () => {
@@ -1016,12 +1032,22 @@ describe('SesWebhookHandler', () => {
                     mail: unsignedMail,
                     delivery: { timestamp: '2025-10-03T12:05:00Z', recipients: ['delivered@example.com'] },
                 },
+                {
+                    eventType: 'Complaint',
+                    mail: unsignedMail,
+                    complaint: {
+                        complainedRecipients: [{ emailAddress: 'complained@example.com' }],
+                        timestamp: '2025-10-03T12:06:00Z',
+                        complaintFeedbackType: 'abuse',
+                    },
+                },
             ]
             const result = await handler.handleWebhook({ body, headers: {} })
             expect(result.status).toBe(200)
             expect(result.transientBounceRecipients).toEqual([])
             expect(result.hardBounceRecipients).toEqual([])
             expect(result.deliveredRecipients).toEqual([])
+            expect(result.complainedRecipients).toEqual([])
             // Metrics are unaffected — engagement signal is still emitted for the parsed events.
             expect(result.metrics?.length).toBeGreaterThan(0)
         })

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -178,6 +178,11 @@ const EVENT_TYPE_TO_METRIC_NAME: Partial<Record<SesEventRecord['eventType'], Min
     Reject: 'email_failed',
 }
 
+// RFC 5965 feedback types that count as a real complaint and so suppress the address. `not-spam`
+// is excluded on purpose — SES relays it through the same Complaint event, but it means the
+// recipient moved the message out of their spam folder.
+const COMPLAINT_SUPPRESSING_FEEDBACK_TYPES = new Set(['abuse', 'auth-failure', 'fraud', 'other', 'virus'])
+
 export type SesEventLogLine = {
     level: 'warn' | 'error'
     message: string
@@ -567,6 +572,14 @@ export class SesWebhookHandler {
             emailAddresses: string[]
             timestamp?: string
         }[]
+        // Spam complaints — suppressed immediately, since the recipient has said they don't want our
+        // mail and the provider measures the complaint rate across the whole sending account.
+        // Excludes `not-spam` reports, which SES relays as complaints but mean the opposite.
+        complainedRecipients?: {
+            teamId?: string
+            emailAddresses: string[]
+            feedbackType?: string
+        }[]
     }> {
         logger.info('[SesWebhookHandler] handleWebhook', { body: opts.body, headers: opts.headers })
         const parsed = this.parseIncomingBody(opts.body)
@@ -659,6 +672,11 @@ export class SesWebhookHandler {
             teamId?: string
             emailAddresses: string[]
             timestamp?: string
+        }[] = []
+        const complainedRecipients: {
+            teamId?: string
+            emailAddresses: string[]
+            feedbackType?: string
         }[] = []
 
         for (const rec of records) {
@@ -813,6 +831,29 @@ export class SesWebhookHandler {
                 transientBounceRecipients.push({ teamId, emailAddresses: emails, diagnostic })
             }
 
+            // A complaint is the recipient telling us they don't want our mail, so suppress the
+            // address immediately. This also protects every other team on the account: AWS measures
+            // the complaint rate at account level and throttles or pauses sending once it climbs too
+            // high, so repeat sends to a complainer are a shared cost, not just this team's.
+            if (
+                suppressionAllowed &&
+                rec.eventType === 'Complaint' &&
+                // A `not-spam` report means the recipient rescued the message from their spam
+                // folder. SES relays it through the same Complaint event, so suppressing on it
+                // would block exactly the people who said they *do* want the mail.
+                (!rec.complaint.complaintFeedbackType ||
+                    COMPLAINT_SUPPRESSING_FEEDBACK_TYPES.has(rec.complaint.complaintFeedbackType))
+            ) {
+                const emails = rec.complaint.complainedRecipients.map((r) => r.emailAddress)
+                if (emails.length > 0) {
+                    complainedRecipients.push({
+                        teamId,
+                        emailAddresses: emails,
+                        feedbackType: rec.complaint.complaintFeedbackType,
+                    })
+                }
+            }
+
             // Successful delivery resets an address's soft-bounce counter — but only if newer than the
             // last-recorded bounce (checked at the SQL layer), so an out-of-order delivery from an
             // older send can't erase a fresh bounce.
@@ -832,6 +873,7 @@ export class SesWebhookHandler {
             transientBounceRecipients,
             hardBounceRecipients,
             deliveredRecipients,
+            complainedRecipients,
         }
     }
 }

--- a/products/messaging/backend/api/message_suppression.py
+++ b/products/messaging/backend/api/message_suppression.py
@@ -48,7 +48,7 @@ class MessageSuppressionSerializer(serializers.ModelSerializer):
                 "help_text": "Normalized recipient email address. Suppression is keyed on this value, per team."
             },
             "source": {
-                "help_text": "How the entry landed on the list: `BOUNCE` for automatic (bounce-driven), `MANUAL` for user-added via the UI/API."
+                "help_text": "How the entry landed on the list: `BOUNCE` for automatic (bounce-driven), `COMPLAINT` when the recipient reported a message as spam, `MANUAL` for user-added via the UI/API."
             },
             "reason": {
                 "help_text": "Human-readable reason for the suppression (e.g. 'Auto-suppressed after 5 consecutive soft bounces')."

--- a/products/messaging/backend/migrations/0004_suppression_source_complaint.py
+++ b/products/messaging/backend/migrations/0004_suppression_source_complaint.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("messaging", "0003_message_suppression"),
+    ]
+
+    operations = [
+        # Choices-only change, so the schema editor emits no SQL — `choices` is in Django's
+        # `Field.non_db_attrs`. It exists to keep migration state in step with the model.
+        # "COMPLAINT" is 9 characters, well inside the column's existing varchar(16).
+        migrations.AlterField(
+            model_name="messagesuppression",
+            name="source",
+            field=models.CharField(
+                choices=[("BOUNCE", "Bounce"), ("COMPLAINT", "Complaint"), ("MANUAL", "Manual")],
+                default="BOUNCE",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/products/messaging/backend/migrations/max_migration.txt
+++ b/products/messaging/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_message_suppression
+0004_suppression_source_complaint

--- a/products/messaging/backend/models/message_suppression.py
+++ b/products/messaging/backend/models/message_suppression.py
@@ -9,6 +9,9 @@ class SuppressionSource(models.TextChoices):
     # Added automatically after an address repeatedly soft-bounced (see the transient
     # bounce handling in the SES webhook path).
     BOUNCE = "BOUNCE"
+    # Added automatically after the recipient reported a message as spam, relayed to us
+    # through the provider's feedback loop (see the SES Complaint handling).
+    COMPLAINT = "COMPLAINT"
     # Added by a user via the Suppression list tab / API.
     MANUAL = "MANUAL"
 
@@ -22,6 +25,10 @@ class MessageSuppression(TeamScopedRootMixin, UUIDModel):
       sends without a successful delivery in between. A single soft bounce is not enough — the
       recipient server may just be briefly down — so we count and only suppress once the count
       crosses a configurable threshold. Any successful delivery resets the count.
+    - Automatically and immediately, when the recipient reports a message as spam. Unlike a soft
+      bounce this needs no threshold: the recipient has explicitly said they don't want our mail,
+      and continuing to send drives the account-level complaint rate toward the level at which the
+      provider throttles or pauses sending for every team.
     - Manually, when a user adds it in the Suppression list UI.
 
     The pre-send path consults this list (see the Node `EmailSuppressionService`) and skips

--- a/products/messaging/frontend/generated/api.schemas.ts
+++ b/products/messaging/frontend/generated/api.schemas.ts
@@ -171,6 +171,7 @@ export interface AddSuppressionRequestApi {
 
 /**
  * * `BOUNCE` - Bounce
+ * * `COMPLAINT` - Complaint
  * * `MANUAL` - Manual
  */
 export type MessageSuppressionSourceEnumApi =
@@ -178,6 +179,7 @@ export type MessageSuppressionSourceEnumApi =
 
 export const MessageSuppressionSourceEnumApi = {
     Bounce: 'BOUNCE',
+    Complaint: 'COMPLAINT',
     Manual: 'MANUAL',
 } as const
 
@@ -186,9 +188,10 @@ export interface MessageSuppressionApi {
     readonly id: string
     /** Normalized recipient email address. Suppression is keyed on this value, per team. */
     readonly identifier: string
-    /** How the entry landed on the list: `BOUNCE` for automatic (bounce-driven), `MANUAL` for user-added via the UI/API.
+    /** How the entry landed on the list: `BOUNCE` for automatic (bounce-driven), `COMPLAINT` when the recipient reported a message as spam, `MANUAL` for user-added via the UI/API.
      *
      * * `BOUNCE` - Bounce
+     * * `COMPLAINT` - Complaint
      * * `MANUAL` - Manual */
     readonly source: MessageSuppressionSourceEnumApi
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -49454,6 +49454,7 @@ export namespace Schemas {
 
     /**
      * * `BOUNCE` - Bounce
+     * * `COMPLAINT` - Complaint
      * * `MANUAL` - Manual
      */
     export type MessageSuppressionSourceEnum = typeof MessageSuppressionSourceEnum[keyof typeof MessageSuppressionSourceEnum];
@@ -49461,6 +49462,7 @@ export namespace Schemas {
 
     export const MessageSuppressionSourceEnum = {
       Bounce: 'BOUNCE',
+      Complaint: 'COMPLAINT',
       Manual: 'MANUAL',
     } as const;
 
@@ -49469,9 +49471,10 @@ export namespace Schemas {
       readonly id: string;
       /** Normalized recipient email address. Suppression is keyed on this value, per team. */
       readonly identifier: string;
-      /** How the entry landed on the list: `BOUNCE` for automatic (bounce-driven), `MANUAL` for user-added via the UI/API.
+      /** How the entry landed on the list: `BOUNCE` for automatic (bounce-driven), `COMPLAINT` when the recipient reported a message as spam, `MANUAL` for user-added via the UI/API.
        *
        * * `BOUNCE` - Bounce
+       * * `COMPLAINT` - Complaint
        * * `MANUAL` - Manual */
       readonly source: MessageSuppressionSourceEnum;
       /**


### PR DESCRIPTION
## Problem

A person who reports one of our emails as spam keeps receiving them. Nothing stops the next send.

- SES relays the report through its feedback loop, and the webhook records an `email_blocked` metric plus a WARN log line.
- The address never reaches the suppression list, so the pre-send check still lets it through.
- Every further send to that person raises the complaint rate AWS measures across the whole sending account, which is shared by every team.

Hard bounces have had immediate suppression since the list shipped. Complaints were the gap.

## Changes

- A spam complaint now suppresses the recipient for that team, so later sends skip them. The Suppression list shows the row with source `COMPLAINT` and the reason `Auto-suppressed after a spam complaint (abuse)`.
- `not-spam` feedback does not suppress. SES relays it as a Complaint, but it means the recipient moved the message out of their spam folder, so suppressing would block the people who want the mail.
- A complaint on an address that already has a soft-bounce counter escalates the row to `COMPLAINT` and leaves `transient_bounce_count`, `last_bounce_at`, and `last_bounce_diagnostic` alone. A complaint is not a deliverability failure, so bounce history stays accurate.
- A `MANUAL` row is never overridden, matching the hard-bounce path. A user who removed an address keeps it removed.
- The stored reason takes the provider feedback type only when it is a known RFC 5965 token. The provider controls that string, so anything else is dropped.

Mechanical: the `COMPLAINT` choice on `SuppressionSource`, its migration, the `source` field help text, and the regenerated frontend and MCP types.

> [!NOTE]
> This changes who receives email. Addresses that complain stop getting mail from that team, including transactional mail, because a suppression is a deliverability signal rather than a messaging preference.

The migration emits no SQL. `choices` sits in Django's `Field.non_db_attrs`, and `COMPLAINT` fits the existing `varchar(16)`. It exists to keep migration state in step with the model.

Not in this PR: the `email_blocked` metric still counts `not-spam` reports, and the UI labels that metric "Marked as spam". Splitting them changes what the reputation complaint rate counts, so it belongs with the metric path.

## How did you test this code?

Automated tests only. No manual testing in the app, and no send through real SES.

New coverage, and the regression each group catches:

- `email-suppression.service.test.ts`, 6 cases on `recordComplaints`: the row is inserted and suppressed; an unknown feedback type stays out of the reason; a bounce-counter row escalates without losing its counter; a `MANUAL` row survives; an auto row a user removed is re-suppressed on a repeat complaint; `isSuppressed` returns true straight after the write, which fails if the write forgets to invalidate the `LazyLoader` cache.
- `helpers/ses.test.ts`, one `it.each` over the feedback type: `abuse` and a missing type surface the recipient, `not-spam` surfaces nothing. Replaces the old single-assertion complaint test. One assertion added to the unsigned-tracking-code test, so an unsigned code cannot drive a complaint suppression.
- `email-tracking.service.test.ts`, one end-to-end case: a signed SNS Complaint envelope posted to `/public/m/ses_webhook` leaves a suppressed row in Postgres. This is the wiring guard, and the only new test above the unit rung. The feedback-type matrix stays at the handler level.

Also run locally: `tsc --noEmit` over `nodejs/`, `makemigrations --check` (no drift), `sqlmigrate messaging 0004` (reports `-- (no-op)`), `migrate messaging` (applies), `migrate --check` (passes), `find_enum_collisions` (none), `ruff`, and `hogli build:openapi`.

Not checked: `migrate_clickhouse --check` and `run_async_migrations --check` fail in this sandbox because its local ClickHouse was never migrated. This diff touches no ClickHouse migration. The Python suite for `products/messaging` did not run, because building its test database in this sandbox conflicted with the hand-built schema the Jest suites needed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude) from a [Slack thread](https://posthog.slack.com/archives/C07CR2K1H6G/p1787710864321359?thread_ts=1787710864.321359&cid=C07CR2K1H6G) investigating an SES complaint-rate alert.

Skills invoked: `/django-migrations`, `/writing-tests`, `/improving-drf-endpoints`, `/writing-pr-descriptions`.

Two decisions worth flagging for review. The thread started from the premise that no complaint metric existed, and asked for a new `email_complained` metric. Reading the code showed SES `Complaint` already maps to `email_blocked` and already feeds `complaint_rate`, so a new name would have been a second empty metric and would have split the reputation math. The metric is near-empty in practice, which is a separate and still-open question; the missing suppression write is the part with a clear fix, so this PR does that instead. Separately, `/writing-tests` cut two additions from an earlier draft: three near-identical handler tests became one `it.each`, and an end-to-end `not-spam` case was dropped because the handler tests already cover that gate a rung cheaper.

The investigation behind this used a production project's data. No part of this PR carries it: the diff has no counts, addresses, workflow names, or thread contents, and every address in the tests is an invented `example.com` one.
