### PR TITLE
fix(devex): size test shards so a full PR run lands near 15 minutes

### DIFF
--- a/.github/scripts/turbo-discover-selection.test.js
+++ b/.github/scripts/turbo-discover-selection.test.js
@@ -114,7 +114,7 @@ test('a selected run hands each matrix leg its own file list', () => {
     assert.equal(decision.compat_files, 'posthog/clickhouse/test_b.py')
     assert.equal(decision.run_poe, true)
     assert.equal(decision.run_temporal, true)
-    assert.deepEqual(decision.segment_shards, { core: 9, poe: 1, temporal: 2 })
+    assert.deepEqual(decision.segment_shards, { core: 12, poe: 1, temporal: 2 })
 })
 
 test('a selection with no temporal file does not start the temporal leg', () => {
@@ -130,7 +130,7 @@ test('applies the full-matrix budget to the selected seconds of each segment', (
     // matrix: Core ceil(5000 / (900 - 295)) = 9, Temporal ceil(900 / (900 - 182)) = 2.
     // POE floors at 1 despite nothing selected.
     const selection = { durations: { selected_seconds_by_segment: { core: 5000, poe: 0, temporal: 900 } } }
-    assert.deepEqual(selectedShards(selection), { core: 9, poe: 1, temporal: 2 })
+    assert.deepEqual(selectedShards(selection), { core: 12, poe: 1, temporal: 2 })
 })
 
 test('shard counts floor at one, below the full-run minimum of three, and cap at the maximum', () => {

--- a/.github/scripts/turbo-discover-selection.test.js
+++ b/.github/scripts/turbo-discover-selection.test.js
@@ -127,7 +127,7 @@ test('a selection with no temporal file does not start the temporal leg', () => 
 
 test('applies the full-matrix budget to the selected seconds of each segment', () => {
     // Work budget per shard is (target wall - segment overhead), same as the full
-    // matrix: Core ceil(5000 / (900 - 295)) = 9, Temporal ceil(900 / (900 - 182)) = 2.
+    // matrix: Core ceil(5000 / (720 - 295)) = 12, Temporal ceil(900 / (720 - 182)) = 2.
     // POE floors at 1 despite nothing selected.
     const selection = { durations: { selected_seconds_by_segment: { core: 5000, poe: 0, temporal: 900 } } }
     assert.deepEqual(selectedShards(selection), { core: 12, poe: 1, temporal: 2 })

--- a/.github/scripts/turbo-discover-sizing.test.js
+++ b/.github/scripts/turbo-discover-sizing.test.js
@@ -7,7 +7,7 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 
-const { pruneDeadDurations, getSegmentDuration, calculateShards, resolveProductSizing, buildMatrix, PRODUCT_JOB_OVERHEAD_SECONDS, TARGET_WALL_SECONDS } = require('./turbo-discover.js')
+const { pruneDeadDurations, getSegmentDuration, calculateShards, resolveProductSizing, buildMatrix, PRODUCT_JOB_OVERHEAD_SECONDS, PRODUCT_SAFETY_FACTOR, TARGET_WALL_SECONDS } = require('./turbo-discover.js')
 
 // A path that exists in every checkout, so the existence check is deterministic.
 const LIVE_FILE = '.github/scripts/turbo-discover.js'
@@ -52,13 +52,13 @@ test('getSegmentDuration still applies the segment exclude rules under an allowl
 // Sizing to the shared flat wall target: every shard carries
 // (target - overhead) of work, so walls land near the target in every lane.
 test('calculateShards sizes shards to the flat wall target', () => {
-    // 100 min of work, 5 min overhead: each shard gets 10 min of tests,
-    // walls land at the 15 min target.
-    assert.equal(calculateShards(6000, 300, 1), 10)
+    // 105 min of work, 5 min overhead: each shard gets 7 min of tests,
+    // walls land at the 12 min target.
+    assert.equal(calculateShards(6300, 300, 1), 15)
 })
 
 test('calculateShards rounds up, so the target is a ceiling, not an average', () => {
-    assert.equal(calculateShards(6001, 300, 1), 11)
+    assert.equal(calculateShards(6301, 300, 1), 16)
 })
 
 test('calculateShards keeps the floor and ceiling', () => {
@@ -66,10 +66,10 @@ test('calculateShards keeps the floor and ceiling', () => {
     assert.equal(calculateShards(100000, 300, 1), 50)
 })
 
-test('calculateShards degrades to 50% efficiency when overhead reaches the target', () => {
+test('calculateShards floors the work budget at half the overhead', () => {
     // Overhead above the target makes it unreachable; the work budget floors at
-    // the overhead itself instead of going negative.
-    assert.equal(calculateShards(6000, TARGET_WALL_SECONDS + 100, 1), Math.ceil(6000 / (TARGET_WALL_SECONDS + 100)))
+    // half the overhead instead of going negative.
+    assert.equal(calculateShards(6000, TARGET_WALL_SECONDS + 100, 1), Math.ceil(6000 / ((TARGET_WALL_SECONDS + 100) / 2)))
 })
 
 // Product sizing: with the junit-scaled marker the union's product sums are
@@ -95,8 +95,8 @@ test('buildMatrix splits a product to the shared wall target', () => {
 
     const matrix = buildMatrix(['big-one'], union, true)
 
-    // 2000s of work over a (target - overhead) budget per shard.
-    assert.equal(matrix.length, Math.ceil(2000 / (TARGET_WALL_SECONDS - O)))
+    // 2000s of work, with the safety factor, over a (target - overhead) budget per shard.
+    assert.equal(matrix.length, Math.ceil((2000 * PRODUCT_SAFETY_FACTOR) / (TARGET_WALL_SECONDS - O)))
     assert.match(matrix[0].group, /^big-one \(1\/\d+\)$/)
 })
 

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -819,8 +819,8 @@ const DJANGO_FALLBACK_SHARDS = { Core: 38, CorePOE: 7, Temporal: 7 }
 // average.
 //
 // The floor on the work budget covers a pathological overhead at or above the
-// target: it degrades to the 50% efficiency rule (work budget = overhead)
-// instead of dividing by zero or a negative.
+// target: the budget stops at half the overhead instead of going to zero or
+// negative, so the shard count stays bounded.
 //
 // minShards: full runs keep the DJANGO_MIN_SHARDS floor, but a narrowed
 // (test-selection) run may legitimately fit one shard.

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -48,7 +48,10 @@ const { loadContractSurfaces } = require('./trunk-impacted-targets')
 // without knowing which segment it is. Sizing solves wall = overhead + work/n
 // for n, so the target is a promise about the PR lane (where the overheads below
 // are fitted); master pays extra overhead (full migration replay) on top.
-const TARGET_WALL_SECONDS = 15 * 60
+// A full run's wall is discovery plus the slowest of its shards, and with many
+// shards packed to one target the slowest lands a few minutes above it, so a
+// 12-minute shard target puts a full PR run near 15 minutes end to end.
+const TARGET_WALL_SECONDS = 12 * 60
 // Per-product cost within a runner: turbo dispatch, pytest collection, Django
 // init. First product pays ~45s, subsequent ~15s; use 60s as a conservative
 // average that also absorbs the amortized portion of runner startup.
@@ -822,7 +825,10 @@ const DJANGO_FALLBACK_SHARDS = { Core: 38, CorePOE: 7, Temporal: 7 }
 // minShards: full runs keep the DJANGO_MIN_SHARDS floor, but a narrowed
 // (test-selection) run may legitimately fit one shard.
 function calculateShards(totalWorkSeconds, overheadSeconds, minShards = DJANGO_MIN_SHARDS) {
-    const budget = Math.max(TARGET_WALL_SECONDS - overheadSeconds, overheadSeconds, 1)
+    // The floor stops an overhead near the target from exploding the shard
+    // count. It sits at half the overhead: a floor at the full overhead pinned
+    // split product shards at twice their overhead, above any target below it.
+    const budget = Math.max(TARGET_WALL_SECONDS - overheadSeconds, overheadSeconds / 2, 1)
     const shards = Math.ceil(totalWorkSeconds / budget)
     return Math.max(minShards, Math.min(DJANGO_MAX_SHARDS, shards))
 }
@@ -985,10 +991,10 @@ function buildMatrix(products, durations, productsScaled = false) {
     const packable = []
 
     // Split a product across multiple shards with the same rule Django uses:
-    // enough shards that each lands at the shared wall target. Don't apply the
-    // safety factor here — that inflation is for packing-capacity decisions
-    // (avoid stuffing a bucket beyond budget under variance), not for the
-    // "must we split?" check.
+    // enough shards that each lands at the shared wall target. The safety
+    // factor applies here as it does to packing: the products that split are
+    // the fixture-heavy suites whose recorded durations undercount the most,
+    // and a split sized on the bare sum lands its shards well past the target.
     for (const product of products) {
         const { work, staleUnionWork, staleness } = resolveProductSizing(product, durations, productsScaled)
         if (staleUnionWork !== null) {
@@ -1002,7 +1008,7 @@ function buildMatrix(products, durations, productsScaled = false) {
             )
         }
 
-        const shards = calculateShards(work, PRODUCT_JOB_OVERHEAD_SECONDS, 1)
+        const shards = calculateShards(work * PRODUCT_SAFETY_FACTOR, PRODUCT_JOB_OVERHEAD_SECONDS, 1)
         if (shards > 1) {
             console.error(`  ${product}: ${(work / 60).toFixed(1)} min work → split across ${shards} shards`)
             const filters = `--filter=@posthog/products-${product}`
@@ -1056,6 +1062,7 @@ module.exports = {
     resolveProductSizing,
     buildMatrix,
     PRODUCT_JOB_OVERHEAD_SECONDS,
+    PRODUCT_SAFETY_FACTOR,
     PRODUCTS_SCALED_MARKER,
     TARGET_WALL_SECONDS,
     DJANGO_OVERHEAD_SECONDS_BY_SEGMENT,


### PR DESCRIPTION
## Problem

- A full PR run of Backend CI takes about 24 minutes at the median and 28 at p95 since #87687 landed, up from 18 and 21. Measured on the per-job CI timing events, Aug 22 to 25 versus after the merge, runs where every shard passed.
- The 15-minute shard target was meant as the wall of a run. A run's wall is discovery plus the slowest of its shards, and the slowest of many shards packed to one target lands a few minutes above it.
- The long pole of a run moved. Before, one product bucket at ~14 minutes led. After, warehouse-sources shards lead at 19.5 minutes, Django Core at 17.5, experiments at 16.8.
- The split products overshoot because their recorded durations undercount fixture-heavy tests. A warehouse-sources shard estimated at 411 s ran 647 s; on master, without coverage, shard 3/8 estimated at 248 s ran 390 s while shard 8/8 estimated at 245 s ran 124 s. The split path did not apply the safety factor that packing applies.
- Below a 13-minute target the sizer could not follow: `calculateShards` floored the work budget at the full overhead, so a split product shard never estimated under twice its overhead.

## Changes

- A full PR run should land near 15 minutes end to end. The per-shard target drops from 15 to 12 minutes.
- Split products get the safety factor the packing step already uses, so their shards are sized on the same headroom.
- The work-budget floor moves from the full overhead to half of it, which lets split shards follow the target.
- Against master's `.test_durations` the sizer goes from about 50 to about 80 jobs for a full run and uses about a quarter more runner minutes. That is still well under the cost before #87687.
- Mechanical: the sizing and selection tests pin the new target and the new floor.

Not changed here: the bias in `.test_durations` itself, and coverage running on PR shards while timings are stored only on master runs. Both make the estimate low on PRs; the safety factor covers the gap for now.

## How did you test this code?

- `node --test` over the five turbo-discover suites, 54 pass.
- A local dry run of the sizer against master's `.test_durations` at 15, 13, 12, 11 and 10 minutes, with and without the two sizer fixes. Without them the estimated long pole stayed at 13 minutes for every target under 13, which is how the floor showed up.
- Not run: a real PR through the new matrix. The first legacy-diff PR after merge shows the real wall; the per-job timing events give the p50 and p95 after a day.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code in the session linked from the commit. Skills invoked: /authoring-ci-workflows, /writing-tests, /writing-code-comments, /writing-pr-descriptions.

Came out of measuring shard timings after #87687 and #87770 landed. #88961 fixes the separate master gate failure from the check-migrations timeout.
