### PR TITLE
chore(devex): drop the get_model recipe for core test fixtures

### DIFF
--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -154,10 +154,11 @@ helpers, which no facade re-export naturally covers:
   product. Either way the cross-boundary test import disappears.
 - _Fixtures that need product rows_ — a core test seeds a product model
   (`InsightViewed`, `Account`) to set up its scenario. Seed through a
-  facade write function, or through a product-owned testing module the
-  product exposes in its tach interface for that purpose, with a normal
-  import. If neither exists yet, add the facade function; that is the
-  same move a production caller makes. Never
+  facade write function, with a normal import. If none exists yet, add
+  one; that is the same move a production caller makes. A helper that
+  only fixtures need goes in a `facade/testing.py` submodule: the tach
+  interface already exposes `backend.facade.*`, and any other exposed
+  module counts as a legacy leak and blocks the isolated tests. Never
   `apps.get_model("<label>", "<Model>")` at module scope: it is the same
   dependency with the import edge removed.
   tach, mypy, and LSP stop seeing it, and snob (the PR test selector) does

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -153,11 +153,13 @@ helpers, which no facade re-export naturally covers:
   really exercising the **product's** behavior, relocate the test into the
   product. Either way the cross-boundary test import disappears.
 - _Fixtures that need product rows_ — a core test seeds a product model
-  (`InsightViewed`, `Account`) to set up its scenario. Seed through the
-  facade's write function (`record_insight_views`) or a product-owned
-  testing door (`backend/testing.py`, exposed through the tach interface),
-  with a normal import. Never `apps.get_model("<label>", "<Model>")` at
-  module scope: it is the same dependency with the import edge removed.
+  (`InsightViewed`, `Account`) to set up its scenario. Seed through a
+  facade write function, or through a product-owned testing module the
+  product exposes in its tach interface for that purpose, with a normal
+  import. If neither exists yet, add the facade function; that is the
+  same move a production caller makes. Never
+  `apps.get_model("<label>", "<Model>")` at module scope: it is the same
+  dependency with the import edge removed.
   tach, mypy, and LSP stop seeing it, and snob (the PR test selector) does
   not select the test when the model changes, so the break lands on master.
   A `TYPE_CHECKING` import next to it does not restore the edge; tach

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -152,6 +152,16 @@ helpers, which no facade re-export naturally covers:
   it down into core and have both sides import it downward; if the core test is
   really exercising the **product's** behavior, relocate the test into the
   product. Either way the cross-boundary test import disappears.
+- _Fixtures that need product rows_ — a core test seeds a product model
+  (`InsightViewed`, `Account`) to set up its scenario. Seed through the
+  facade's write function (`record_insight_views`) or a product-owned
+  testing door (`backend/testing.py`, exposed through the tach interface),
+  with a normal import. Never `apps.get_model("<label>", "<Model>")` at
+  module scope: it is the same dependency with the import edge removed.
+  tach, mypy, and LSP stop seeing it, and snob (the PR test selector) does
+  not select the test when the model changes, so the break lands on master.
+  A `TYPE_CHECKING` import next to it does not restore the edge; tach
+  ignores type-only imports, and so does snob.
 
 **Surfaces outside `backend/`.** A product can expose non-Django surfaces at its
 root — Dagster assets under `products/<name>/dags/`, for instance — that core
@@ -206,9 +216,11 @@ says nothing about what the consumer does with it. Two rules cover that:
 
 `apps.get_model('label', 'Class')` is counted too, and for **every** product model,
 not only the allowance ones. It leaves no import edge, so tach cannot refuse it.
-Test modules stay out of scope, so the fixture escape hatch this skill recommends
-for core tests still works. Migrations stay out too: the historical registry is the
-only way a migration can reach a model. Production code may not add a call.
+Test modules stay out of the scan, which is a blind spot, not permission: a core
+test fixture that reaches a model this way is uncounted and unselected (see
+"Test-infrastructure coupling" above). Migrations stay out too: the historical
+registry is the only way a migration can reach a model. Production code may not
+add a call.
 
 `hogli product:crossings <product>` lists a product's crossing classes with every
 consumer use bucketed by kind, disallowed first. Disallowed uses are frozen in
@@ -259,10 +271,9 @@ records the decrease. See `products/architecture.md` § Wiring couplings.
    - The rewrite is mechanical (import swap + call mapping) and fully checked by the
      verification chain; batching it only stretches the window in which master drifts
      under the branch.
-   - Core test fixtures that need product models: use `apps.get_model("<app_label>",
-"Model")` at runtime plus a `TYPE_CHECKING` import for annotations — tach ignores
-     type-only imports. Fixtures only: the same call in production code is a
-     ratcheted `get_model` crossing (see above).
+   - Core test fixtures that need product rows go through the facade's write
+     function or a product testing door, with a normal import — not
+     `apps.get_model` (see "Test-infrastructure coupling" above for why).
    - Compatibility shims exist to bridge between serial PRs — the one-pass shape rarely
      needs them. If one is unavoidable, it dies in the final cleanup PR, not "later".
    - Exception: callers with subtle behavior (transaction boundaries, write-path

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -150,7 +150,9 @@ The consumer keeps the orchestration and the ids.
 `apps.get_model('label', 'Class')` reaches a model through the Django app registry.
 It leaves no import edge, so tach and import-linter cannot see it.
 The scan therefore does not stop at the watched-models allowance on this channel: a reference from outside the owning product to any class on any product's model surface is counted as the disallowed kind `get_model`.
-Test modules stay out of scope, which is a blind spot, not permission: a core test fixture that reaches a model this way is not counted here and, with no import edge, not selected by snob when the model changes. Seed product rows through the facade's write function or a product testing door instead.
+Test modules stay out of scope, which is a blind spot, not permission.
+A core test fixture that reaches a model this way is not counted here and, with no import edge, not selected by snob when the model changes.
+Seed product rows through a facade write function or a product-owned testing module instead.
 Migrations stay out of scope too: a migration reaches a model through the historical registry, and that is the only way a migration can.
 Production code may not add one.
 

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -150,7 +150,7 @@ The consumer keeps the orchestration and the ids.
 `apps.get_model('label', 'Class')` reaches a model through the Django app registry.
 It leaves no import edge, so tach and import-linter cannot see it.
 The scan therefore does not stop at the watched-models allowance on this channel: a reference from outside the owning product to any class on any product's model surface is counted as the disallowed kind `get_model`.
-Test modules stay out of scope, so a core test fixture may keep using the pattern.
+Test modules stay out of scope, which is a blind spot, not permission: a core test fixture that reaches a model this way is not counted here and, with no import edge, not selected by snob when the model changes. Seed product rows through the facade's write function or a product testing door instead.
 Migrations stay out of scope too: a migration reaches a model through the historical registry, and that is the only way a migration can.
 Production code may not add one.
 

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -152,7 +152,7 @@ It leaves no import edge, so tach and import-linter cannot see it.
 The scan therefore does not stop at the watched-models allowance on this channel: a reference from outside the owning product to any class on any product's model surface is counted as the disallowed kind `get_model`.
 Test modules stay out of scope, which is a blind spot, not permission.
 A core test fixture that reaches a model this way is not counted here and, with no import edge, not selected by snob when the model changes.
-Seed product rows through a facade write function or a product-owned testing module instead.
+Seed product rows through a facade write function, or through a `facade/testing.py` helper for fixture-only needs, instead; any other exposed module is a legacy interface leak.
 Migrations stay out of scope too: a migration reaches a model through the historical registry, and that is the only way a migration can.
 Production code may not add one.
 

--- a/tools/hogli-commands/hogli_commands/product/crossings.py
+++ b/tools/hogli-commands/hogli_commands/product/crossings.py
@@ -19,8 +19,8 @@ from anywhere. That scan therefore runs over every model class a product registe
 reference is counted as the disallowed kind `get_model`.
 
 Tests are out of scope. A test reaches concrete classes through testing doors on purpose, so counting
-its fixtures would measure the fixture, not the coupling. `apps.get_model` is the escape hatch core
-test fixtures are told to use, and keeping tests out is what leaves that advice intact.
+its fixtures would measure the fixture, not the coupling. That leaves `apps.get_model` in a test
+fixture uncounted; it is still a dependency with the import edge removed, not a sanctioned door.
 """
 
 from __future__ import annotations

--- a/tools/hogli-commands/hogli_commands/product/isolate.py
+++ b/tools/hogli-commands/hogli_commands/product/isolate.py
@@ -41,7 +41,7 @@ KIND_GUIDANCE = {
     "query-runner": "expose a builder plus a class re-export (facade/queries.py) — registry consumers dispatch on class identity",
     "celery-task": "re-export the task object (facade/tasks.py); core beat schedules import it",
     "temporal-wiring": "re-export workflows/activities/metrics/constants (facade/temporal.py)",
-    "test-fixture": "use apps.get_model(...) plus a TYPE_CHECKING import, or the facade accessor",
+    "test-fixture": "seed through a facade write function (add one, or a facade/testing.py helper); not apps.get_model",
     "string-reference": "dotted path in a string (mock @patch path, config) — must be rewritten when modules move",
     "other-internal": "route through a facade function or re-export",
 }

--- a/tools/hogli-commands/hogli_commands/product/isolate.py
+++ b/tools/hogli-commands/hogli_commands/product/isolate.py
@@ -41,7 +41,7 @@ KIND_GUIDANCE = {
     "query-runner": "expose a builder plus a class re-export (facade/queries.py) — registry consumers dispatch on class identity",
     "celery-task": "re-export the task object (facade/tasks.py); core beat schedules import it",
     "temporal-wiring": "re-export workflows/activities/metrics/constants (facade/temporal.py)",
-    "test-fixture": "seed through a facade write function (add one, or a facade/testing.py helper); not apps.get_model",
+    "test-fixture": "a test import: model rows go through a facade write function (or a facade/testing.py helper), anything else through the matching facade re-export; not apps.get_model",
     "string-reference": "dotted path in a string (mock @patch path, config) — must be rewritten when modules move",
     "other-internal": "route through a facade function or re-export",
 }


### PR DESCRIPTION
## Problem

- An agent or engineer following the isolation skill writes core test fixtures that reach a product model with `apps.get_model` at module scope, plus a `TYPE_CHECKING` import. Two such fixtures exist today (`InsightViewed`, `Account`).
- That is the same dependency with the import edge removed. tach, mypy and LSP stop seeing it.
- snob selects PR tests from the import graph. A fixture with no edge to the model's module is not selected when the model changes, so the break lands on master.
- The crossings scanner skips test modules. `architecture.md` and the scanner docstring read that as permission for the pattern.

## Changes

- The skill's "Test-infrastructure coupling" section gains the rule: seed product rows through the facade's write function or a product testing door, with a normal import, never `apps.get_model` at module scope. The step 4 recipe points there.
- `architecture.md` and the `crossings.py` docstring call the test exclusion a blind spot rather than a sanctioned door.
- `hogli product:isolate:scan` gives the same advice for a test fixture it finds; it used to recommend the `apps.get_model` recipe.
- Docs, one docstring, and one guidance string; no behavior change.

## How did you test this code?

- Docs only. The existing `InsightViewed` fixtures move to `record_insight_views` in #87061; the `Account` one in `ee/hogai/context/entity_search/test/test_context.py` is not touched here.
- Not done: a check that fails on a module-scope `apps.get_model` in a test. The natural home is the crossings ratchet (count the `get_model` kind in tests too), which is a follow-up decision.

## Changelog

- [ ] Changelog: this PR contains user-facing changes and needs a changelog entry

## 🤖 Agent context

- Written by Claude Code in a background session driven by @webjunkie, after review of the pattern in #87061.
- Skills invoked: writing-pr-descriptions, writing-code-comments.
