### PR TITLE
fix(devex): stop flooring test durations and check the map against the clock

### DIFF
--- a/.depot/workflows/ci-backend-update-test-timing.yml
+++ b/.depot/workflows/ci-backend-update-test-timing.yml
@@ -96,10 +96,19 @@ jobs:
                   # A products slice whose shape drifted from the JUnit clock must not
                   # reach the cache; a missing slice is worse (the merge takes product
                   # entries only from this file), so keep the previous slice instead.
-                  if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
-                      --segment Products --junit-dir junit_artifacts --fail-on-drift; then
-                      echo "::warning::Products durations drifted from the JUnit clock; keeping the previous products slice"
-                      jq 'with_entries(select(.key | startswith("products/")))' /tmp/previous_durations > /tmp/products_durations
+                  set +e
+                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
+                      --segment Products --junit-dir junit_artifacts --fail-on-drift
+                  products_status=$?
+                  set -e
+                  if [ "$products_status" -ne 0 ]; then
+                      echo "::warning::Products durations refresh exited $products_status; keeping the previous products slice. Drift or an incomplete JUnit set are the expected causes, see the log above."
+                      # Only entries the fresh slices do not carry: the outlier merge would
+                      # otherwise let a stale value here beat a fresh one for the same test.
+                      jq -s 'add' $(ls /tmp/core_durations /tmp/temporal_durations 2>/dev/null) > /tmp/fresh_durations
+                      jq --slurpfile fresh /tmp/fresh_durations \
+                          'with_entries(select((.key | startswith("products/")) and ($fresh[0][.key] == null)))' \
+                          /tmp/previous_durations > /tmp/products_durations
                   fi
                   uv run .github/scripts/optimize_test_durations.py .test_durations \
                       --merge-files /tmp/core_durations /tmp/temporal_durations /tmp/products_durations \

--- a/.depot/workflows/ci-backend-update-test-timing.yml
+++ b/.depot/workflows/ci-backend-update-test-timing.yml
@@ -52,6 +52,25 @@ jobs:
                   fi
                   echo "run_id=$primary" >> "$GITHUB_OUTPUT"
 
+            - name: Restore the previous map for the drift fallback
+              # The merge below takes product entries only from the products file
+              # (--replace-prefix), so a Products slice that fails the drift check
+              # needs a stand-in or every product loses its durations. The last
+              # cached map is that stand-in. A miss leaves the checked-out file.
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              continue-on-error: true
+              with:
+                  path: .test_durations
+                  # run_id never matches — forces the prefix restore-key to the newest entry.
+                  key: posthog-test-durations-${{ github.run_id }}
+                  restore-keys: |
+                      posthog-test-durations-
+
+            - name: Set the previous map aside
+              run: |
+                  cp .test_durations /tmp/previous_durations
+                  git checkout -- .test_durations
+
             - name: Download timing artifacts
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -74,8 +93,14 @@ jobs:
                       --segment Core --junit-dir junit_artifacts
                   uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/temporal_durations \
                       --segment Temporal --junit-dir junit_artifacts
-                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
-                      --segment Products --junit-dir junit_artifacts
+                  # A products slice whose shape drifted from the JUnit clock must not
+                  # reach the cache; a missing slice is worse (the merge takes product
+                  # entries only from this file), so keep the previous slice instead.
+                  if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
+                      --segment Products --junit-dir junit_artifacts --fail-on-drift; then
+                      echo "::warning::Products durations drifted from the JUnit clock; keeping the previous products slice"
+                      jq 'with_entries(select(.key | startswith("products/")))' /tmp/previous_durations > /tmp/products_durations
+                  fi
                   uv run .github/scripts/optimize_test_durations.py .test_durations \
                       --merge-files /tmp/core_durations /tmp/temporal_durations /tmp/products_durations \
                       --replace-prefix products/

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -943,6 +943,13 @@ def main():
         ratios = shard_map_clock_ratios(durations, junit_shards)
         for name, ratio in sorted(ratios.items()):
             logger.info("  map/clock %s: %.2f", name, ratio)
+        # A shard with no ratio shares no keys with the map, or only zero times.
+        # Neither is a pass: it means the clock and the map do not describe the
+        # same tests, which is exactly what strict mode is there to catch.
+        unrated = [shard.name for shard in junit_shards if shard.name not in ratios]
+        if unrated and args.fail_on_drift:
+            logger.error("Map/clock ratio missing for %d shards (no overlapping tests): %s", len(unrated), unrated)
+            sys.exit(1)
         drift = drifting_shards(ratios)
         if drift:
             level = logger.error if args.fail_on_drift else logger.warning

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -927,6 +927,18 @@ def main():
 
     logger.info("  Total tests: %d", len(durations))
 
+    if args.fail_on_drift:
+        # The check is only as good as its clock. A missing, partial, or
+        # truncated JUnit set would pass vacuously and let an unchecked slice
+        # through, so a strict run needs one readable JUnit per timing shard.
+        unreadable = [shard.name for shard in junit_shards or [] if shard.unreadable or not shard.call_times]
+        if not junit_shards or unreadable or not shard_sets_match(shards, junit_shards):
+            logger.error(
+                "--fail-on-drift needs a readable JUnit artifact for every timing shard; missing or unreadable: %s",
+                unreadable or "all",
+            )
+            sys.exit(1)
+
     if junit_shards:
         ratios = shard_map_clock_ratios(durations, junit_shards)
         for name, ratio in sorted(ratios.items()):

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -58,6 +58,12 @@ MIN_DURATION = 0.001
 # the wrong total. Per-shard sums cover hundreds of tests, so run-to-run noise
 # stays well inside it.
 SHARD_DRIFT_TOLERANCE = 1.5
+# Share of a JUnit shard's time that must have a map entry before strict mode
+# trusts its ratio. The ratio only sees tests both sides hold, so a partial
+# timing artifact or an id that fails conversion would drop out of both sums
+# and leave the ratio at 1.0. A complete run covers 100%; the margin is for a
+# handful of unconvertible ids.
+SHARD_CLOCK_COVERAGE_MIN = 0.9
 # Tests with recorded duration above this threshold in a single shard
 # are candidates for migration carriers (real tests rarely exceed this)
 CARRIER_THRESHOLD_SECONDS = 200.0
@@ -516,6 +522,17 @@ def shard_map_clock_ratios(durations: dict[str, float], junit_shards: list["JUni
     return ratios
 
 
+def shard_clock_coverage(durations: dict[str, float], junit_shards: list["JUnitShard"]) -> dict[str, float]:
+    """Per JUnit shard: share of its JUnit time whose test has a map entry."""
+    coverage: dict[str, float] = {}
+    for shard in junit_shards:
+        total = sum(shard.call_times.values())
+        covered = sum(seconds for test_id, seconds in shard.call_times.items() if test_id in durations)
+        if total > 0:
+            coverage[shard.name] = covered / total
+    return coverage
+
+
 def drifting_shards(ratios: dict[str, float], tolerance: float = SHARD_DRIFT_TOLERANCE) -> dict[str, float]:
     return {name: ratio for name, ratio in ratios.items() if ratio > tolerance or ratio < 1 / tolerance}
 
@@ -949,6 +966,19 @@ def main():
         unrated = [shard.name for shard in junit_shards if shard.name not in ratios]
         if unrated and args.fail_on_drift:
             logger.error("Map/clock ratio missing for %d shards (no overlapping tests): %s", len(unrated), unrated)
+            sys.exit(1)
+        uncovered = {
+            name: share
+            for name, share in shard_clock_coverage(durations, junit_shards).items()
+            if share < SHARD_CLOCK_COVERAGE_MIN
+        }
+        if uncovered and args.fail_on_drift:
+            logger.error(
+                "Map covers less than %.0f%% of the JUnit time on %d shards: %s",
+                SHARD_CLOCK_COVERAGE_MIN * 100,
+                len(uncovered),
+                ", ".join(f"{name}={share:.2f}" for name, share in sorted(uncovered.items())),
+            )
             sys.exit(1)
         drift = drifting_shards(ratios)
         if drift:

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -21,6 +21,16 @@ and skewing pytest-split.
 This script merges the per-shard artifacts, floors any test recorded far
 above its JUnit call time (or sitting at a flat-default placeholder) back
 to that call time, and outputs clean durations for balanced distribution.
+There is no global minimum: a 1 ms test is written as 1 ms. A floor there
+gave tens of thousands of tiny parametrized tests ten times their real
+weight, so a contiguous shard of them planned at twice its real length
+while the fixture-heavy shard next to it ran past its budget.
+
+The map-versus-clock report at the end compares, per JUnit shard, the sum of
+the finished durations for the tests that shard ran against the sum of the
+shard's JUnit times. Both are per-test measurements of the same run, so a
+correct file lands near 1.0 on every shard; a ratio far from 1.0 means a
+processing step changed the shape of the data, not just its total.
 """
 
 import re
@@ -40,7 +50,14 @@ from defusedxml.ElementTree import ParseError
 
 logger = logging.getLogger(__name__)
 
-MIN_DURATION = 0.01
+# Lower bound for a duration the corrections below rewrite: a corrected value
+# must stay positive so pytest-split still counts the test. Not a floor for
+# measured values; those are written as recorded.
+MIN_DURATION = 0.001
+# A shard whose map/clock ratio leaves this band has the wrong shape, not just
+# the wrong total. Per-shard sums cover hundreds of tests, so run-to-run noise
+# stays well inside it.
+SHARD_DRIFT_TOLERANCE = 1.5
 # Tests with recorded duration above this threshold in a single shard
 # are candidates for migration carriers (real tests rarely exceed this)
 CARRIER_THRESHOLD_SECONDS = 200.0
@@ -479,9 +496,28 @@ def _junit_to_pytest_id(classname: str, testname: str) -> str | None:
     return f"{module_path}::{testname}"
 
 
-def ensure_minimum_duration(durations: dict[str, float]) -> dict[str, float]:
-    """Ensure all durations have a minimum value for pytest-split."""
-    return {test: max(MIN_DURATION, dur) for test, dur in durations.items()}
+def shard_map_clock_ratios(durations: dict[str, float], junit_shards: list["JUnitShard"]) -> dict[str, float]:
+    """Per JUnit shard: sum of finished durations / sum of JUnit times, over the tests both hold.
+
+    The map is what pytest-split plans from; the clock is what the same run
+    measured. A shard far from 1.0 is one the plan will cut wrong.
+    """
+    ratios: dict[str, float] = {}
+    for shard in junit_shards:
+        clock = 0.0
+        mapped = 0.0
+        for test_id, seconds in shard.call_times.items():
+            if test_id not in durations:
+                continue
+            clock += seconds
+            mapped += durations[test_id]
+        if clock > 0:
+            ratios[shard.name] = mapped / clock
+    return ratios
+
+
+def drifting_shards(ratios: dict[str, float], tolerance: float = SHARD_DRIFT_TOLERANCE) -> dict[str, float]:
+    return {name: ratio for name, ratio in ratios.items() if ratio > tolerance or ratio < 1 / tolerance}
 
 
 def shard_sets_match(timing_shards: list[ShardTimings], junit_shards: list[JUnitShard]) -> bool:
@@ -717,6 +753,15 @@ def main():
         help="Filter to only tests that exist in the codebase (runs pytest --collect-only)",
     )
     parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help=(
+            "Exit non-zero when a JUnit shard's finished durations sum to more than "
+            f"{SHARD_DRIFT_TOLERANCE}x (or less than 1/{SHARD_DRIFT_TOLERANCE}x) of its JUnit times "
+            "(requires --junit-dir). Without it the drift is only logged."
+        ),
+    )
+    parser.add_argument(
         "--scope-to-junit",
         action="store_true",
         help=(
@@ -881,12 +926,28 @@ def main():
         logger.info("  Filtered to %d tests (removed %d stale)", len(durations), before_count - len(durations))
 
     logger.info("  Total tests: %d", len(durations))
-    processed = ensure_minimum_duration(durations)
+
+    if junit_shards:
+        ratios = shard_map_clock_ratios(durations, junit_shards)
+        for name, ratio in sorted(ratios.items()):
+            logger.info("  map/clock %s: %.2f", name, ratio)
+        drift = drifting_shards(ratios)
+        if drift:
+            level = logger.error if args.fail_on_drift else logger.warning
+            level(
+                "Map/clock drift outside %.2fx on %d of %d shards: %s",
+                SHARD_DRIFT_TOLERANCE,
+                len(drift),
+                len(ratios),
+                ", ".join(f"{name}={ratio:.2f}" for name, ratio in sorted(drift.items())),
+            )
+            if args.fail_on_drift:
+                sys.exit(1)
 
     with open(args.output_file, "w") as f:
-        json.dump(processed, f, indent=4, sort_keys=True)
+        json.dump(durations, f, indent=4, sort_keys=True)
         f.write("\n")
-    logger.info("Saved %d tests to %s", len(processed), args.output_file)
+    logger.info("Saved %d tests to %s", len(durations), args.output_file)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -949,10 +949,19 @@ def main():
         # truncated JUnit set would pass vacuously and let an unchecked slice
         # through, so a strict run needs one readable JUnit per timing shard.
         unreadable = [shard.name for shard in junit_shards or [] if shard.unreadable or not shard.call_times]
-        if not junit_shards or unreadable or not shard_sets_match(shards, junit_shards):
+        if not junit_shards:
+            logger.error("--fail-on-drift needs JUnit artifacts and none loaded")
+            sys.exit(1)
+        if unreadable:
             logger.error(
-                "--fail-on-drift needs a readable JUnit artifact for every timing shard; missing or unreadable: %s",
-                unreadable or "all",
+                "--fail-on-drift needs a readable JUnit artifact for every timing shard; unreadable: %s", unreadable
+            )
+            sys.exit(1)
+        if not shard_sets_match(shards, junit_shards):
+            logger.error(
+                "--fail-on-drift needs the same shard set on both sides: %d timing shards, %d JUnit shards",
+                len(shards),
+                len(junit_shards),
             )
             sys.exit(1)
 

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -15,12 +15,14 @@ from optimize_test_durations import (
     ShardTimings,
     _pick_outlier,
     average_durations,
+    drifting_shards,
     main,
     outlier_merge_durations,
     run_average_files,
     run_merge_files,
     scale_products_to_junit,
     scope_products_to_junit,
+    shard_map_clock_ratios,
     shard_sets_match,
 )
 
@@ -450,6 +452,62 @@ def test_scale_products_to_junit_matches_sums_to_measured_work(tmp_path: Path) -
     assert scaled["products/big_one/backend/test_a.py::TestA::test_b"] == pytest.approx(200.0)
     assert scaled["posthog/test/test_x.py::test_x"] == 5.0
     assert scaled["products/.junit-scaled"] == 1.0
+
+
+def test_main_writes_sub_ten_millisecond_durations_as_recorded(tmp_path: Path, monkeypatch) -> None:
+    # A global floor once rewrote every fast test as 10 ms. Tens of thousands of
+    # parametrized tests really take 1 ms, so a shard of them planned at twice
+    # its real length.
+    shard_dir = tmp_path / "timing_artifacts" / "timing_data-Core-1"
+    shard_dir.mkdir(parents=True)
+    (shard_dir / ".test_durations").write_text(
+        json.dumps({"posthog/test_foo.py::TestThing::test_one": 0.5, "posthog/test_foo.py::TestThing::test_two": 0.001})
+    )
+    junit_dir = tmp_path / "junit_artifacts" / "junit-results-backend-core-1"
+    junit_dir.mkdir(parents=True)
+    (junit_dir / "junit.xml").write_bytes(
+        b'<?xml version="1.0"?><testsuite name="pytest">'
+        b'<testcase classname="posthog.test_foo.TestThing" name="test_one" time="0.5"/>'
+        b'<testcase classname="posthog.test_foo.TestThing" name="test_two" time="0.001"/></testsuite>'
+    )
+    out = tmp_path / "core_durations"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "optimize_test_durations.py",
+            str(tmp_path / "timing_artifacts"),
+            str(out),
+            "--segment",
+            "Core",
+            "--junit-dir",
+            str(tmp_path / "junit_artifacts"),
+            "--fail-on-drift",
+        ],
+    )
+
+    main()
+
+    assert json.loads(out.read_text())["posthog/test_foo.py::TestThing::test_two"] == 0.001
+
+
+@pytest.mark.parametrize(
+    "mapped_seconds, drifts",
+    [
+        (110.0, False),  # a tenth over: run-to-run noise
+        (250.0, True),  # the shape is wrong: tiny tests carrying phantom weight
+        (40.0, True),  # the other direction: heavy tests under-counted
+    ],
+)
+def test_shard_map_clock_ratio_flags_shape_drift(mapped_seconds: float, drifts: bool) -> None:
+    shard = JUnitShard(name="product-junit-results-3", call_times={"products/p/backend/test_a.py::test_a": 100.0})
+    durations = {"products/p/backend/test_a.py::test_a": mapped_seconds, "products/p/backend/test_b.py::test_b": 5.0}
+
+    ratios = shard_map_clock_ratios(durations, [shard])
+
+    # test_b never ran in this shard, so it does not count against the shard.
+    assert ratios == {"product-junit-results-3": pytest.approx(mapped_seconds / 100.0)}
+    assert bool(drifting_shards(ratios)) is drifts
 
 
 def test_scale_products_to_junit_leaves_products_without_junit_alone(tmp_path: Path) -> None:

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -491,6 +491,42 @@ def test_main_writes_sub_ten_millisecond_durations_as_recorded(tmp_path: Path, m
     assert json.loads(out.read_text())["posthog/test_foo.py::TestThing::test_two"] == 0.001
 
 
+@pytest.mark.parametrize("junit_shards_present", [(), ("1",)])
+def test_fail_on_drift_refuses_an_incomplete_junit_set(tmp_path: Path, monkeypatch, junit_shards_present) -> None:
+    # No JUnit, or JUnit for only one of two shards, would let the drift check
+    # pass on nothing; a strict run must refuse so the workflow keeps the
+    # previous slice instead of caching an unchecked one.
+    artifacts = tmp_path / "timing_artifacts"
+    for shard in ("1", "2"):
+        shard_dir = artifacts / f"timing_data-Core-{shard}"
+        shard_dir.mkdir(parents=True)
+        (shard_dir / ".test_durations").write_text(json.dumps({f"posthog/test_{shard}.py::test_{shard}": 1.0}))
+    junit_dir = tmp_path / "junit_artifacts"
+    junit_dir.mkdir()
+    for shard in junit_shards_present:
+        (junit_dir / f"junit-results-backend-core-{shard}").mkdir()
+        (junit_dir / f"junit-results-backend-core-{shard}" / "junit.xml").write_bytes(_MIN_JUNIT_XML)
+    out = tmp_path / "core_durations"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "optimize_test_durations.py",
+            str(artifacts),
+            str(out),
+            "--segment",
+            "Core",
+            "--junit-dir",
+            str(junit_dir),
+            "--fail-on-drift",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+    assert not out.exists()
+
+
 @pytest.mark.parametrize(
     "mapped_seconds, drifts",
     [

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -491,11 +491,13 @@ def test_main_writes_sub_ten_millisecond_durations_as_recorded(tmp_path: Path, m
     assert json.loads(out.read_text())["posthog/test_foo.py::TestThing::test_two"] == 0.001
 
 
-@pytest.mark.parametrize("junit_shards_present", [(), ("1",)])
+@pytest.mark.parametrize("junit_shards_present", [(), ("1",), ("1", "2")])
 def test_fail_on_drift_refuses_an_incomplete_junit_set(tmp_path: Path, monkeypatch, junit_shards_present) -> None:
-    # No JUnit, or JUnit for only one of two shards, would let the drift check
-    # pass on nothing; a strict run must refuse so the workflow keeps the
-    # previous slice instead of caching an unchecked one.
+    # No JUnit, JUnit for only one of two shards, or JUnit that shares no test
+    # with the timing data (the XML here names test_foo, the timings test_1 and
+    # test_2) would let the drift check pass on nothing; a strict run must
+    # refuse so the workflow keeps the previous slice instead of caching an
+    # unchecked one.
     artifacts = tmp_path / "timing_artifacts"
     for shard in ("1", "2"):
         shard_dir = artifacts / f"timing_data-Core-{shard}"

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -22,6 +22,7 @@ from optimize_test_durations import (
     run_merge_files,
     scale_products_to_junit,
     scope_products_to_junit,
+    shard_clock_coverage,
     shard_map_clock_ratios,
     shard_sets_match,
 )
@@ -546,6 +547,19 @@ def test_shard_map_clock_ratio_flags_shape_drift(mapped_seconds: float, drifts: 
     # test_b never ran in this shard, so it does not count against the shard.
     assert ratios == {"product-junit-results-3": pytest.approx(mapped_seconds / 100.0)}
     assert bool(drifting_shards(ratios)) is drifts
+
+
+def test_shard_clock_coverage_counts_only_tests_the_map_holds() -> None:
+    # A test missing from the map drops out of the ratio on both sides, so the
+    # ratio alone cannot see a partial artifact; coverage can.
+    shard = JUnitShard(
+        name="product-junit-results-3",
+        call_times={"products/p/backend/test_a.py::test_a": 30.0, "products/p/backend/test_b.py::test_b": 70.0},
+    )
+
+    assert shard_clock_coverage({"products/p/backend/test_a.py::test_a": 31.0}, [shard]) == {
+        "product-junit-results-3": pytest.approx(0.3)
+    }
 
 
 def test_scale_products_to_junit_leaves_products_without_junit_alone(tmp_path: Path) -> None:

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -244,8 +244,10 @@ jobs:
                   fi
                   # Products has its own guarded scoping inside the script (only scopes when the
                   # JUnit shard set is complete), so no flag here.
+                  # Products has no unscoped retry: a map whose shape drifted from the
+                  # clock must not reach the cache, so this one fails the refresh.
                   uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
-                      --segment Products --junit-dir junit_artifacts
+                      --segment Products --junit-dir junit_artifacts --fail-on-drift
 
                   # Process Dagster segment if available
                   if [ -n "$DAGSTER_RUN_ID" ]; then

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -269,10 +269,19 @@ jobs:
                   # the clock must not reach the cache, and a missing slice is worse
                   # (the merge takes product entries only from this file), so keep
                   # the previous slice and still refresh Core and Temporal.
-                  if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
-                      --segment Products --junit-dir junit_artifacts --fail-on-drift; then
-                      echo "::warning::Products durations drifted from the JUnit clock; keeping the previous products slice"
-                      jq 'with_entries(select(.key | startswith("products/")))' /tmp/previous_durations > /tmp/products_durations
+                  set +e
+                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
+                      --segment Products --junit-dir junit_artifacts --fail-on-drift
+                  products_status=$?
+                  set -e
+                  if [ "$products_status" -ne 0 ]; then
+                      echo "::warning::Products durations refresh exited $products_status; keeping the previous products slice. Drift or an incomplete JUnit set are the expected causes, see the log above."
+                      # Only entries the fresh slices do not carry: the outlier merge would
+                      # otherwise let a stale value here beat a fresh one for the same test.
+                      jq -s 'add' $(ls /tmp/core_durations /tmp/temporal_durations /tmp/dagster_durations 2>/dev/null) > /tmp/fresh_durations
+                      jq --slurpfile fresh /tmp/fresh_durations \
+                          'with_entries(select((.key | startswith("products/")) and ($fresh[0][.key] == null)))' \
+                          /tmp/previous_durations > /tmp/products_durations
                   fi
 
                   # Process Dagster segment if available

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -162,6 +162,27 @@ jobs:
                       echo "Found Dagster CI run: $run_id"
                   fi
 
+            - name: Restore the previous map for the drift fallback
+              # The merge below takes product entries only from the products file
+              # (--replace-prefix), so a Products slice that fails the drift check
+              # needs a stand-in or every product loses its durations. The last
+              # cached map is that stand-in. A miss leaves the checked-out file.
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              continue-on-error: true
+              with:
+                  path: .test_durations
+                  # run_id never matches — forces the prefix restore-key to the newest entry.
+                  key: posthog-test-durations-${{ github.run_id }}
+                  restore-keys: |
+                      posthog-test-durations-
+
+            - name: Set the previous map aside
+              # The restore lands on the tracked file; keep the copy elsewhere and put
+              # the committed file back so the change check below diffs a clean tree.
+              run: |
+                  cp .test_durations /tmp/previous_durations
+                  git checkout -- .test_durations
+
             - name: Download timing artifacts
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -244,10 +265,15 @@ jobs:
                   fi
                   # Products has its own guarded scoping inside the script (only scopes when the
                   # JUnit shard set is complete), so no flag here.
-                  # Products has no unscoped retry: a map whose shape drifted from the
-                  # clock must not reach the cache, so this one fails the refresh.
-                  uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
-                      --segment Products --junit-dir junit_artifacts --fail-on-drift
+                  # Products has no unscoped retry. A slice whose shape drifted from
+                  # the clock must not reach the cache, and a missing slice is worse
+                  # (the merge takes product entries only from this file), so keep
+                  # the previous slice and still refresh Core and Temporal.
+                  if ! uv run .github/scripts/optimize_test_durations.py timing_artifacts /tmp/products_durations \
+                      --segment Products --junit-dir junit_artifacts --fail-on-drift; then
+                      echo "::warning::Products durations drifted from the JUnit clock; keeping the previous products slice"
+                      jq 'with_entries(select(.key | startswith("products/")))' /tmp/previous_durations > /tmp/products_durations
+                  fi
 
                   # Process Dagster segment if available
                   if [ -n "$DAGSTER_RUN_ID" ]; then


### PR DESCRIPTION
## Problem

- Product test shards in Backend CI are cut unevenly: in one master run a warehouse-sources shard of 20k tests planned at 245 s ran in 124 s, while the shard next to it planned at 248 s ran in 390 s. The slowest of those shards is the long pole of most full PR runs.
- The map pytest-split cuts from, `.test_durations`, has the wrong shape. The collector rewrites every test faster than 10 ms as 10 ms (`ensure_minimum_duration`, since #42610). warehouse-sources has 49k parametrized tests that really take about 1 ms; on the map they weigh 10 ms.
- The raw measurements are right. For the same run, pytest-split's store and junit agree per test (median ratio 1.00). The floor is applied after that.
- Later fixes corrected each product's total (#83138, #87687) and left the shape alone, so the sizer counts the right amount of work and cuts it in the wrong places. Today 92,765 of the 172,261 entries in the committed file sit at the floor.
- Nothing compared the finished file with the clock. Every earlier check measured how evenly shards split the map.

## Changes

- Fast tests are written as recorded. The global floor is gone; `MIN_DURATION` stays at 1 ms only as a positive lower bound for the values the tax and placeholder corrections rewrite.
- The collector reports map versus clock per JUnit shard: the sum of finished durations for the tests a shard ran, over the sum of that shard's junit times. A correct file lands near 1.0 on every shard.
- A Products slice that leaves 1.5x either way does not reach the cache (`--fail-on-drift`). The refresh keeps the last cached products slice instead, still refreshes Core and Temporal, and warns in the run. Without the stand-in the merge would drop every product entry, since it takes them only from the products file. Core and Temporal log the ratios only; their unscoped retry would write the drifted map anyway.
- Nothing changes in CI until the next timing refresh (every 6 h) writes a floor-free map to the cache PR jobs restore. The committed file is not regenerated here; it is the fallback, and the monthly commit picks up the new shape.

The scaling step stays. On real data it now lands near 1.0 and covers the few fixture-first tests whose shared setup junit charges to one test.

## How did you test this code?

- New test: the collector writes a 1 ms test as 1 ms through `main()`. It fails on the previous code.
- New parameterized test for the drift check: a tenth over passes, 2.5x and 0.4x are flagged, and a test the shard did not run does not count against it.
- The patched collector ran on five real product artifacts from a master run ([32858794150](https://github.com/PostHog/posthog/actions/runs/32858794150)). The 20k-test shard goes from 493 s on the map to 75 s, against 74 s on the clock; all five shards land between 0.96 and 1.01.
- Held-out check: the map built from that run's artifacts was cut with the fork's `optimal_chunks` and each shard scored against the junit clock of two other master runs ([32946810563](https://github.com/PostHog/posthog/actions/runs/32946810563), [32944421329](https://github.com/PostHog/posthog/actions/runs/32944421329)). Spread is the slowest shard over the mean, test time only.

| Product, shards | Old map | New map |
| --- | ---: | ---: |
| warehouse-sources, 5 | 44% / 25% | 12% / 12% |
| warehouse-sources, 8 | 54% / 34% | 27% / 25% |
| batch-exports, 4 | 11% / 11% | 3% / 4% |
| tasks, 2 | 16% / 21% | 2% / 9% |
| experiments, 2 | 3% / 2% | 1% / 3% |

- On the run the map came from, every product lands at 0 to 3%: the algorithm is optimal when the map is right. What remains on held-out runs is run-to-run variance of the heavy tests and tests that run in one master run and skip in another (tasks' Modal suite), which the floor never touched.
- Not run: the timing workflow itself. Its first run after merge shows the ratios in the log.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code in the session linked from the commit. Skills invoked: /authoring-ci-workflows, /writing-tests, /writing-code-comments, /writing-pr-descriptions.

Third PR from measuring shard timings after #87687 and #87770: #88961 fixes the master gate timeout, #88968 lowers the shard target. With this one in place the safety factor #88968 applies to split products becomes headroom rather than a correction.
