### PR TITLE
fix(data-warehouse): resolve warehouse group types by project, not team

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
@@ -40,7 +40,7 @@ from posthog.kafka_client.routing import producer_scope
 from posthog.kafka_client.topics import KAFKA_WAREHOUSE_PERSON_PROPERTY_UPDATES
 from posthog.models import PropertyDefinition, Team
 from posthog.models.group.util import get_groups_by_identifiers
-from posthog.models.group_type_mapping import get_group_types_for_team
+from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.person.util import get_persons_mapped_by_distinct_id
 from posthog.sync import database_sync_to_async
 
@@ -349,9 +349,11 @@ def _filter_existing_ids(team_id: int, source: PersonPropertySyncSource, ids: li
     return existing
 
 
-def _group_type_name(team_id: int, group_type_index: int) -> str | None:
+def _group_type_name(project_id: int, group_type_index: int) -> str | None:
     # $groupidentify carries the group-type *name*; the config stores the index, so resolve it.
-    for group_type in get_group_types_for_team(team_id):
+    # Group types are project-scoped, and GroupTypeMapping stores the project's root team id, so a
+    # team that is a child environment has no rows of its own — resolve by project, not by team.
+    for group_type in get_group_types_for_project(project_id, caller_tag="warehouse_sources/person_property_sync"):
         if group_type.get("group_type_index") == group_type_index:
             return group_type.get("group_type")
     return None
@@ -442,6 +444,7 @@ def _stamp_provenance(
 async def _process_source_bundles(
     *,
     team_id: int,
+    project_id: int,
     binding: WarehouseBinding,
     team_api_token: str,
     team_uuid: str,
@@ -481,7 +484,7 @@ async def _process_source_bundles(
     group_type_name = None
     if source.target == _GROUP_TARGET and source.group_type_index is not None:
         group_type_name = await database_sync_to_async(_group_type_name, thread_sensitive=False)(
-            team_id, source.group_type_index
+            project_id, source.group_type_index
         )
         if group_type_name is None:
             # Without the group-type name the consumer can't build a valid $groupidentify and would
@@ -561,6 +564,7 @@ async def run_person_property_sync(*, team_id: int, binding: WarehouseBinding, j
         bundles = build_bundles(rows, source.key_column, source.column_property_map or {})
         ps = await _process_source_bundles(
             team_id=team_id,
+            project_id=team.project_id,
             binding=binding,
             team_api_token=team.api_token,
             team_uuid=str(team.uuid),
@@ -702,6 +706,7 @@ async def run_person_property_backfill(*, team_id: int, binding: WarehouseBindin
         bundles = list(accumulated[str(source.source_id)].items())
         ps = await _process_source_bundles(
             team_id=team_id,
+            project_id=team.project_id,
             binding=binding,
             team_api_token=team.api_token,
             team_uuid=str(team.uuid),

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync_test.py
@@ -429,6 +429,36 @@ class TestGroupTarget:
         write_snapshot.assert_not_awaited()
         assert result.produced == 0
 
+    @pytest.mark.asyncio
+    async def test_group_type_is_resolved_by_project_not_team(self):
+        # Group types are project-scoped, and GroupTypeMapping stores the project's root team id, so
+        # a child environment has no rows under its own team id. Resolving by team id found nothing
+        # there, which skipped every group source on that team and produced no intents at all.
+        team = MagicMock(api_token="tok", uuid="team-uuid", project_id=77)
+        rows = [{"group_key": "acme", "plan": "pro"}]
+        by_project = {77: [{"group_type_index": 0, "group_type": "organization"}]}
+        with (
+            patch(f"{_MODULE}.person_property_sync_sources_for", return_value=[self._group_source()]),
+            patch(f"{_MODULE}.Team") as team_cls,
+            patch(f"{_MODULE}._read_staged_rows", new=AsyncMock(return_value=rows)),
+            patch(f"{_MODULE}._read_snapshot_hashes", new=AsyncMock(return_value={})),
+            patch(f"{_MODULE}._filter_existing_ids", return_value={"acme"}),
+            patch(
+                f"{_MODULE}.get_group_types_for_project",
+                side_effect=lambda project_id, **_kwargs: by_project.get(project_id, []),
+            ) as lookup,
+            patch(f"{_MODULE}._produce_intents", return_value=1) as produce,
+            patch(f"{_MODULE}._write_snapshot_hashes", new=AsyncMock()),
+            patch(f"{_MODULE}._stamp_provenance"),
+            patch(f"{_MODULE}._clear_staged", new=AsyncMock()),
+        ):
+            team_cls.objects.get.return_value = team
+            result = await pps.run_person_property_sync(team_id=1, binding=_SCHEMA, job_id="job-1")
+
+        assert lookup.call_args.args[0] == 77  # the project, not team_id=1
+        assert produce.call_args.kwargs["group_type_name"] == "organization"
+        assert result.produced == 1
+
 
 class TestExistenceLookupChunking:
     """Both personhog helpers return whole models (properties included) and hold every one before


### PR DESCRIPTION
## Problem

On a team that is a **child environment** of its project, a warehouse property mapped onto a **group** silently writes nothing. The source reports a successful sync, the group profile page stays empty, and a manual backfill changes nothing either. Person-target properties on the same view keep working, so the feature looks half-broken rather than misconfigured. Group targets on a project's root team are unaffected, which is why this hides.

`GroupTypeMapping` is project-scoped. It is unique per `(project, group_type)`, and `RootTeamMixin.save()` rewrites the row's team to the project's root team. A child environment therefore has no mappings under its own team id.

The person-property sync resolved a group source's type name with `get_group_types_for_team`, so on such a team that lookup returned nothing and `_group_type_name` returned `None`. That branch skips the source before producing any `$groupidentify` intent, and it only logs a warning, so the run still reports success while writing no group properties. The scheduled sync and the manual backfill share this path, which is why neither works.

Refs #44002

## Changes

- A group-target warehouse property now reaches the group on teams that are child environments. Every such source was skipped before.
- `_group_type_name` resolves by project id instead of team id, matching `get_group_types_for_project` everywhere else, including the `trigger_group_identify` path this producer already mirrors.
- Mechanical: `_process_source_bundles` gains a project id, and both call sites pass `team.project_id` off the `Team` they already load.

> [!NOTE]
> The skip itself is left alone. A missing group-type name is still a real reason not to produce, since the consumer would DLQ a `$groupidentify` without one. Only the lookup feeding it was wrong.

## How did you test this code?

Added one regression test to `TestGroupTarget`. It runs a group source through `run_person_property_sync` on a team whose id and project id differ, then asserts the type resolves and the intent is produced. Reverting only the threaded id back to `team_id` fails it on `assert 1 == 77`. No existing test covered this: the nearest one mocks `_group_type_name` outright, so it never exercises the scope key.

Ran locally: the `person_property_sync_test.py` suite, and repo-wide `mypy` (clean).

Not run: the DB-backed and object-storage-backed cases in that file need Postgres and SeaweedFS, and error identically on an unmodified tree in this sandbox. There was no manual end-to-end run against a real warehouse source.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The documented behavior is what this restores.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in PostHog Desktop, found while triaging an unrelated report of group properties not being written.

- Skills invoked: the repo's `triaging-warehouse-sync-tickets`, plus `writing-tests` for the test value gate and `writing-pr-descriptions` for this body.
- This is a latent defect found by reading the code, not the cause of the report that prompted the work. Production data showed that reporter's team is its project's root team, so their group type resolved and their intents were produced. Their loss happens further downstream. This PR is deliberately scoped to the lookup defect alone and claims nothing about that report.
- An earlier pass had concluded the group write path was simply unimplemented, reading from the open tracking issue and a flag comment that names only persons. That was wrong: the group branch is complete and covered end to end.
- Public artifact: this PR describes the defect only. No reporting team, project, view, or column name appears in the diff, the test, or this description, and the test fixture values are invented.
