### PR TITLE
feat(logs): add the host mask rule to log pattern masking

### DIFF
--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -150,7 +150,7 @@ describe('log-pattern-mask', () => {
                 .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
-            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 2, digest: 'd4700d63dd52ba57' })
+            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 2, digest: 'cf5d13fd81dbf547' })
         })
     })
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -25,6 +25,15 @@ describe('log-pattern-mask', () => {
             ['timestamp is not shredded by num', '2026-08-24T10:20:45Z', '<TIMESTAMP>'],
             ['ip octets are not eaten by num', 'peer 192.168.0.1:8080 up', 'peer <IP>:<N> up'],
             ['email starting with digits is not mangled by num', '99bottles@example.com sent', '<EMAIL> sent'],
+            ['email domain is not claimed by host', 'user@example.com sent', '<EMAIL> sent'],
+            ['hex-looking labels are claimed by host, not hex', 'from deadbeefdeadbeef.com now', 'from <HOST> now'],
+            ['dotted quad stays an ip, not a host', 'from 10.0.0.1 now', 'from <IP> now'],
+            ['host in a url masks whole', 'GET https://api.example.io/v2/users', 'GET https://<HOST>/v2/users'],
+            [
+                'multi-label internal host masks whole',
+                'dial capture.posthog.svc.cluster.local failed',
+                'dial <HOST> failed',
+            ],
         ])('ordering: %s', (_name, input, expected) => {
             expect(maskString(input).masked).toEqual(expected)
         })
@@ -38,9 +47,9 @@ describe('log-pattern-mask', () => {
         })
 
         it('counts fires per rule', () => {
-            const { ruleFires } = maskString('a@example.com b@example.com from 10.0.0.1 in 12ms')
+            const { ruleFires } = maskString('a@example.com b@example.com via api.example.net from 10.0.0.1 in 12ms')
             const byName = Object.fromEntries(MASK_RULES.map((rule, i) => [rule.name, ruleFires[i]]))
-            expect(byName).toEqual({ timestamp: 0, uuid: 0, email: 2, hex0x: 0, hex: 0, ipv4: 1, num: 1 })
+            expect(byName).toEqual({ timestamp: 0, uuid: 0, email: 2, host: 1, hex0x: 0, hex: 0, ipv4: 1, num: 1 })
         })
     })
 
@@ -141,7 +150,7 @@ describe('log-pattern-mask', () => {
                 .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
-            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 1, digest: 'd8b059c25a24983d' })
+            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 2, digest: 'd4700d63dd52ba57' })
         })
     })
 

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -27,7 +27,7 @@ export const MASK_RULES: readonly MaskRule[] = [
     {
         name: 'host',
         pattern:
-            '\\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.){1,8}(?:ai|app|bot|cloud|co|com|de|dev|eu|fr|gg|internal|io|jp|local|me|net|nl|org|sh|so|tv|uk|us|xyz)\\b',
+            '\\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.){1,8}(?:ai|app|aws|bot|cloud|co|com|de|dev|eu|fr|gg|internal|io|jp|local|me|net|nl|org|sh|so|tv|uk|us|xyz)\\b',
         replacement: '<HOST>',
     },
     { name: 'hex0x', pattern: '\\b0x[0-9a-fA-F]+\\b', replacement: '<HEX>' },

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -2,9 +2,9 @@ import { createTrackedRE2 } from '~/common/utils/tracked-re2'
 
 import { parseLogBodyForIngestion } from './log-body-parse'
 
-export const PATTERN_VERSION = 1
+export const PATTERN_VERSION = 2
 
-export type MaskRuleName = 'timestamp' | 'uuid' | 'email' | 'hex0x' | 'hex' | 'ipv4' | 'num'
+export type MaskRuleName = 'timestamp' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
 export type MaskRule = {
     name: MaskRuleName
@@ -24,6 +24,12 @@ export const MASK_RULES: readonly MaskRule[] = [
         replacement: '<UUID>',
     },
     { name: 'email', pattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}', replacement: '<EMAIL>' },
+    {
+        name: 'host',
+        pattern:
+            '\\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\.){1,8}(?:ai|app|bot|cloud|co|com|de|dev|eu|fr|gg|internal|io|jp|local|me|net|nl|org|sh|so|tv|uk|us|xyz)\\b',
+        replacement: '<HOST>',
+    },
     { name: 'hex0x', pattern: '\\b0x[0-9a-fA-F]+\\b', replacement: '<HEX>' },
     { name: 'hex', pattern: '\\b[0-9a-fA-F]{16,}\\b', replacement: '<HEX>' },
     { name: 'ipv4', pattern: '\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b', replacement: '<IP>' },


### PR DESCRIPTION
## Problem

Hostnames are the largest unmasked variance in log patterns: sampling recent fleet bodies via ClickHouse found hostnames in a substantial minority of maskable rows in both regions. Every pod name, region, and domain mints a distinct pattern today, splitting templates that are otherwise identical.

The query-time Drain3 masker (`products/logs/backend/log_patterns.py`) already carries a `host` rule; the ingestion ruleset launched without it.

## Changes

- New `host` mask rule: up to eight dotted labels ending in a known suffix mask to `<HOST>` (`capture.posthog.svc.cluster.local` becomes `<HOST>`). The label pattern and suffix list are ported from the query-time Drain3 masker.
- Placement is load-bearing: after `email` so an address's domain stays inside `<EMAIL>`, before `hex` so a hex-looking label is claimed as a host. A dotted quad has no alphabetic suffix, so `ipv4` keeps it.
- The suffix list is the query-time one plus `aws` (it appeared throughout the sampled bodies, every occurrence a real domain).
- The label repeat is capped at eight, which bounds the compiled automaton rather than enforcing a DNS limit. A hostname with more labels masks its tail and leaks its head, so the cap degrades rather than breaks. Sampling both regions found no hostname that exceeds the cap, and raising the cap would grow the automaton while removing it would make a long dotted run retry the suffix alternation at every label boundary.
- The list stays short on purpose. A full TLD list would mask file names, because `py`, `md`, `zip`, and `one` are all real TLDs. Sampling the endings this rule does not cover returned mostly file names (`wrr.go`, `daemon.json`, `x.parquet`), gRPC service paths (`ingester.v1.IngesterService`), and structured attribute keys (`grpc.method`, `peer.address`) - none of them hosts.
- `PATTERN_VERSION` bumps to 2. Measure-only stores nothing, so the re-key is free now and will not be once patterns land on logs34.
- The rule is RE2-safe with no capture groups; the existing ratchet and node/ClickHouse agreement corpus cover it unchanged.
- The `rule` label on `logs_ingestion_pattern_rule_fired_total` gains a `host` value; the dashboard legend follows automatically.

Not included: the `klogtime` rule (next in line, needs capture-and-restore replacement support) and the `version` rule (negligible reach in the sampled bodies - not worth the surface).

## How did you test this code?

- New ordering cases pin the three interactions above (email domain, hex-looking label, dotted quad) plus URL and multi-label host masking.
- The fires-per-rule case and the version ratchet updated with the new rule set and digest.
- Rule reach and the suffix list were measured on sampled production log bodies via ClickHouse `match()` and `extractAll()`, which run the same RE2 engine as `replaceRegexpAll`.
- Not run locally: the consumer suite (needs the persons test database). Mask and stage suites pass (64 tests).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal ruleset.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/debugging-ci-failures` earlier in session.
- Rule selection came from a fleet measurement: `host` and `klogtime` showed real reach, `version` and ip-guards did not. `klogtime` follows separately.
- May conflict trivially with #88637 (label rename) in the same files; whichever lands second rebases.



