### PR TITLE
fix(data-warehouse): treat read-only-transaction blips as transient in repartition

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -17,9 +17,10 @@ import datetime as dt
 import dataclasses
 from typing import Any
 
-from django.db import InterfaceError, OperationalError, close_old_connections
+from django.db import InterfaceError, InternalError, OperationalError, close_old_connections
 from django.utils import timezone
 
+import psycopg.errors
 from asgiref.sync import async_to_sync
 from structlog.contextvars import bind_contextvars
 from structlog.types import FilteringBoundLogger
@@ -134,6 +135,14 @@ def _rewrite_deadline(activity_started: float) -> float | None:
 
 def _is_transient_infra_error(error: Exception) -> bool:
     if isinstance(error, OperationalError | InterfaceError):
+        return True
+    # A primary-DB failover briefly routes one of the rewrite's own writes (checkpoint, swap marker,
+    # scheme persist) onto a connection that has become a read-only standby: Postgres raises
+    # ReadOnlySqlTransaction (SQLSTATE 25006), which psycopg classifies under InternalError rather than
+    # OperationalError, so it needs its own check. Matched on the cause, not a bare InternalError
+    # isinstance, so real corruption errors sharing the base class are still reported. Mirrors the same
+    # classification in delta.errors.is_transient_maintenance_error.
+    if isinstance(error, InternalError) and isinstance(error.__cause__, psycopg.errors.ReadOnlySqlTransaction):
         return True
     message = str(error).lower()
     return any(snippet in message for snippet in _TRANSIENT_ERROR_SNIPPETS)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -5,8 +5,9 @@ import contextvars
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from django.db import InterfaceError, OperationalError
+from django.db import InterfaceError, InternalError, OperationalError
 
+import psycopg.errors
 from parameterized import parameterized
 
 from posthog.exceptions_capture import ambient_exception_properties
@@ -43,6 +44,14 @@ PENDING_TARGET = {
     "trigger_reason": "proactive_threshold",
     "attempts": 0,
 }
+
+
+def _read_only_transaction_error() -> InternalError:
+    # Mirrors how Django's DatabaseErrorWrapper re-raises a psycopg error: the driver exception
+    # (carrying SQLSTATE 25006) becomes __cause__.
+    error = InternalError("cannot execute UPDATE in a read-only transaction")
+    error.__cause__ = psycopg.errors.ReadOnlySqlTransaction("cannot execute UPDATE in a read-only transaction")
+    return error
 
 
 def _schema(
@@ -544,6 +553,10 @@ class TestTransientObjectStoreFailure:
                 ),
             ),
             ("interface_error", InterfaceError("connection already closed")),
+            # A primary-DB failover routes a rewrite write onto a read-only standby mid-run: psycopg
+            # raises ReadOnlySqlTransaction (25006), wrapped by Django as InternalError. It clears on
+            # the next sync, so it must stand down like the other infra blips, not burn an attempt.
+            ("read_only_transaction_failover", _read_only_transaction_error()),
         ]
     )
     @patch(f"{MODULE}.capture_exception")


### PR DESCRIPTION
## Problem

A data-warehouse table's automatic repartition can be abandoned by a routine database failover. When the primary DB fails over, one of the rewrite's own writes (a checkpoint, the swap marker, or the final scheme persist) briefly lands on a read-only standby. Postgres raises `ReadOnlySqlTransaction` (SQLSTATE 25006, "cannot execute UPDATE in a read-only transaction"), which psycopg wraps under `InternalError`.

The repartition activity classifies infra blips (connection drops, S3 throttling) as transient and retries them on the next sync without penalty. But `_is_transient_infra_error` only matched `OperationalError`/`InterfaceError`, so this `InternalError` fell through and was treated as a genuine repartition bug: it emitted `warehouse_repartition_failed`, opened an error-tracking issue, and consumed one of the table's finite repartition attempts. Enough of these in a row exhausts the attempt cap and leaves the table un-repartitioned.

## Changes

- A repartition attempt hit by a read-only-transaction failover now stands down quietly and retries on the next sync, instead of failing.
- `_is_transient_infra_error` recognizes a Django `InternalError` whose cause is psycopg's `ReadOnlySqlTransaction`, matching the check already in `delta.errors.is_transient_maintenance_error`. Matched on the cause, not a bare `InternalError`, so real corruption errors sharing the base class are still reported.
- No change to sync semantics, partition sizing, or the retry cap. Only this one error's classification moves.

## How did you test this code?

- Added a parameterized case to `test_db_connection_drop_stands_down_without_reporting_to_error_tracking` that raises the wrapped `ReadOnlySqlTransaction`. It catches the regression that no existing case did: an `InternalError` reaching `_handle_failure` instead of the transient stand-down. The case fails on `master` (calls `capture_exception`, emits `warehouse_repartition_failed`) and passes with the fix.
- Ran the transient-path repartition tests locally; the read-only case and the existing connection-drop/object-store cases pass.
- Not run: the full database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal error-classification change with no user-facing behavior or documented workflow affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a batch of `warehouse_repartition_failed` events grouped by error type. This PR addresses the `InternalError: cannot execute UPDATE in a read-only transaction` mode. Traced the emit site in `repartition_table.py`, found the sibling `delta.errors.is_transient_maintenance_error` already handled this exact error, and mirrored its check in `_is_transient_infra_error`.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

The `RepartitionBudgetExceededError` events in the same batch were assessed and left alone: they are the checkpoint/resume convergence mechanism working as designed on very large, actively-syncing tables, with the terminal give-up acting as the intended backstop against an endless rewrite loop. The remedy there is operational (the import-hold rollout flag, or a larger activity budget), not a code change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
