### PR TITLE
feat(batch-exports): filter runs by status in the API

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -162,11 +162,58 @@ class BatchExportRunSerializer(serializers.ModelSerializer):
         read_only_fields = ["batch_export"]
 
 
+class BatchExportRunListQuerySerializer(serializers.Serializer):
+    """Query parameters accepted when listing the runs of a batch export."""
+
+    status = serializers.ListField(
+        required=False,
+        child=serializers.ChoiceField(choices=BatchExportRun.Status.choices),
+        help_text="Only return runs in these statuses. Repeat the parameter to pass more than one status.",
+    )
+    after = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Only return runs created at or after this point. "
+            "Accepts an ISO-8601 datetime or a relative value like `-7d`. Defaults to `-7d`. "
+            "Ignored when ordering by `data_interval_start`."
+        ),
+    )
+    before = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Only return runs created at or before this point. "
+            "Accepts an ISO-8601 datetime or a relative value like `-1d`. Defaults to now. "
+            "Ignored when ordering by `data_interval_start`."
+        ),
+    )
+    start = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Only return runs whose data interval starts at or after this point. "
+            "Accepts an ISO-8601 datetime or a relative value like `-7d`. Defaults to `-7d`. "
+            "Only applies when ordering by `data_interval_start`."
+        ),
+    )
+    end = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Only return runs whose data interval ends at or before this point. "
+            "Accepts an ISO-8601 datetime or a relative value like `-1d`. Defaults to now. "
+            "Only applies when ordering by `data_interval_start`."
+        ),
+    )
+
+
 class RunsCursorPagination(CursorPagination):
     page_size = 100
 
 
 @extend_schema(tags=["batch_exports"])
+@extend_schema_view(list=extend_schema(parameters=[BatchExportRunListQuerySerializer]))
 class BatchExportRunViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ReadOnlyModelViewSet):
     scope_object = "batch_export"
     queryset = BatchExportRun.objects.select_related("batch_export__destination").all()
@@ -182,10 +229,15 @@ class BatchExportRunViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.Read
         return cast(str, self.parents_query_dict["run_id"])
 
     def safely_get_queryset(self, queryset):
-        after = self.request.GET.get("after", None)
-        before = self.request.GET.get("before", None)
-        start = self.request.GET.get("start", None)
-        end = self.request.GET.get("end", None)
+        query = BatchExportRunListQuerySerializer(data=self.request.GET)
+        query.is_valid(raise_exception=True)
+        params = query.validated_data
+
+        after = params.get("after")
+        before = params.get("before")
+        start = params.get("start")
+        end = params.get("end")
+        # Read from the query string rather than the serializer, as OrderingFilter owns this parameter.
         ordering = self.request.GET.get("ordering", None)
 
         # If we're ordering by data_interval_start, we need to filter by that otherwise we're ordering by created_at
@@ -198,6 +250,9 @@ class BatchExportRunViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.Read
             before_datetime = relative_date_parse(before, self.team.timezone_info) if before else now()
             date_range = (after_datetime, before_datetime)
             queryset = queryset.filter(created_at__range=date_range)
+
+        if statuses := params.get("status"):
+            queryset = queryset.filter(status__in=statuses)
 
         queryset = queryset.filter(batch_export_id=self.kwargs["parent_lookup_batch_export_id"])
         return queryset

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -237,9 +237,9 @@ class BatchExportRunViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.Read
         before = params.get("before")
         start = params.get("start")
         end = params.get("end")
-        # Read from the query string rather than the serializer, as OrderingFilter owns this parameter.
-        ordering = self.request.GET.get("ordering", None)
 
+        # OrderingFilter applies the sort and declares this parameter, so it is not on the serializer.
+        ordering = self.request.GET.get("ordering", None)
         # If we're ordering by data_interval_start, we need to filter by that otherwise we're ordering by created_at
         if ordering == "data_interval_start" or ordering == "-data_interval_start":
             start_timestamp = relative_date_parse(start if start else "-7d", self.team.timezone_info)

--- a/products/batch_exports/backend/tests/api/operations.py
+++ b/products/batch_exports/backend/tests/api/operations.py
@@ -74,15 +74,17 @@ def get_batch_export_ok(client: TestClient, team_id: int, batch_export_id: UUIDT
     return response.json()
 
 
-def get_batch_export_runs(client: TestClient, team_id: int, batch_export_id: str):
+def get_batch_export_runs(client: TestClient, team_id: int, batch_export_id: str, **query_params):
     return client.get(
         f"/api/projects/{team_id}/batch_exports/{batch_export_id}/runs",
+        # List values are encoded as repeated parameters, matching how the API expects them.
+        data=query_params or None,
         content_type="application/json",
     )
 
 
-def get_batch_export_runs_ok(client: TestClient, team_id: int, batch_export_id: str):
-    response = get_batch_export_runs(client, team_id, batch_export_id)
+def get_batch_export_runs_ok(client: TestClient, team_id: int, batch_export_id: str, **query_params):
+    response = get_batch_export_runs(client, team_id, batch_export_id, **query_params)
     assert response.status_code == status.HTTP_200_OK, response.json()
     return response.json()
 

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -284,17 +284,10 @@ def test_get_batch_export_runs_date_filter_depends_on_ordering(client: HttpClien
     batch_export = create_batch_export(team, create_destination())
     now = dt.datetime.now(dt.UTC)
 
-    # Recent data interval, but created a month ago.
-    run_by_interval = create_run(
-        batch_export,
-        status=BatchExportRun.Status.COMPLETED,
-        data_interval_start=now - dt.timedelta(hours=1),
-        data_interval_end=now,
-    )
-    BatchExportRun.objects.filter(id=run_by_interval.id).update(created_at=now - dt.timedelta(days=30))
-
-    # Data interval from a month ago, but created just now.
-    run_by_created_at = create_run(
+    # A backfill run created today for a data interval from a month ago. This is the only way a
+    # run's created_at and data interval genuinely decouple: a run can be created long after the
+    # interval it covers, but never before that interval has occurred.
+    run = create_run(
         batch_export,
         status=BatchExportRun.Status.COMPLETED,
         data_interval_start=now - dt.timedelta(days=30, hours=1),
@@ -303,17 +296,22 @@ def test_get_batch_export_runs_date_filter_depends_on_ordering(client: HttpClien
 
     client.force_login(user)
 
-    # Default ordering filters by created_at. `start` is passed too and must have no effect:
-    # if it did, run_by_created_at's month-old interval would exclude it from the result.
+    # Default ordering filters by created_at (today). `start` is passed too and must have no
+    # effect: if it were also applied, the month-old interval would exclude the run.
     data = get_batch_export_runs_ok(client, team.pk, batch_export.id, after="-2d", start="-2d")
-    assert {run["id"] for run in data["results"]} == {str(run_by_created_at.id)}
+    assert {run["id"] for run in data["results"]} == {str(run.id)}
 
-    # Ordering by data_interval_start filters by the interval instead. `after` is passed too and
-    # must have no effect: if it did, run_by_interval's month-old created_at would exclude it.
+    # Ordering by data_interval_start filters the interval instead. `before` is passed too and
+    # must have no effect: the run was created today, which `before` alone would exclude.
     data = get_batch_export_runs_ok(
-        client, team.pk, batch_export.id, ordering="-data_interval_start", start="-2d", after="-2d"
+        client, team.pk, batch_export.id, ordering="-data_interval_start", start="-40d", before="-2d"
     )
-    assert {run["id"] for run in data["results"]} == {str(run_by_interval.id)}
+    assert {run["id"] for run in data["results"]} == {str(run.id)}
+
+    # And under that ordering, `start` genuinely filters the interval: narrowing it to exclude
+    # the month-old interval returns nothing.
+    data = get_batch_export_runs_ok(client, team.pk, batch_export.id, ordering="-data_interval_start", start="-2d")
+    assert data["results"] == []
 
 
 def test_cannot_cancel_completed_batch_export_run(client: HttpClient, team, user):

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -279,39 +279,55 @@ def test_get_batch_export_runs_rejects_unknown_status(client: HttpClient, team, 
 
 
 def test_get_batch_export_runs_date_filter_depends_on_ordering(client: HttpClient, team, user):
-    """`after`/`before` filter on `created_at` unless ordering by `data_interval_start`, in which
-    case `start`/`end` filter the data interval instead, and the other pair has no effect."""
     batch_export = create_batch_export(team, create_destination())
     now = dt.datetime.now(dt.UTC)
 
-    # A backfill run created today for a data interval from a month ago. This is the only way a
-    # run's created_at and data interval genuinely decouple: a run can be created long after the
-    # interval it covers, but never before that interval has occurred.
-    run = create_run(
+    def days_ago(days: float) -> dt.datetime:
+        return now - dt.timedelta(days=days)
+
+    # Backfilled today for a 40-day-old interval
+    run_old_interval = create_run(
         batch_export,
         status=BatchExportRun.Status.COMPLETED,
-        data_interval_start=now - dt.timedelta(days=30, hours=1),
-        data_interval_end=now - dt.timedelta(days=30),
+        data_interval_start=days_ago(40) - dt.timedelta(hours=1),
+        data_interval_end=days_ago(40),
     )
+
+    # Backfilled 10 days ago for a 20-day-old interval.
+    run_mid_interval = create_run(
+        batch_export,
+        status=BatchExportRun.Status.COMPLETED,
+        data_interval_start=days_ago(20) - dt.timedelta(hours=1),
+        data_interval_end=days_ago(20),
+    )
+    BatchExportRun.objects.filter(id=run_mid_interval.id).update(created_at=days_ago(10))
+
+    # A normal, on-schedule run: created right as its 5-day-old interval ended.
+    run_recent_interval = create_run(
+        batch_export,
+        status=BatchExportRun.Status.COMPLETED,
+        data_interval_start=days_ago(5) - dt.timedelta(hours=1),
+        data_interval_end=days_ago(5),
+    )
+    BatchExportRun.objects.filter(id=run_recent_interval.id).update(created_at=days_ago(5))
 
     client.force_login(user)
 
-    # Default ordering filters by created_at (today). `start` is passed too and must have no
-    # effect: if it were also applied, the month-old interval would exclude the run.
-    data = get_batch_export_runs_ok(client, team.pk, batch_export.id, after="-2d", start="-2d")
-    assert {run["id"] for run in data["results"]} == {str(run.id)}
+    # Default ordering sorts and filters by created_at: today (run_old_interval), then 5 days ago
+    # (run_recent_interval); 10 days ago (run_mid_interval) falls outside the 8-day window.
+    # `start` is passed too and must have no effect: applied, it would exclude run_old_interval's
+    # 40-day-old interval.
+    data = get_batch_export_runs_ok(client, team.pk, batch_export.id, after="-8d", start="-25d")
+    assert [run["id"] for run in data["results"]] == [str(run_old_interval.id), str(run_recent_interval.id)]
 
-    # Ordering by data_interval_start filters the interval instead. `before` is passed too and
-    # must have no effect: the run was created today, which `before` alone would exclude.
+    # Ordering by data_interval_start instead sorts and filters by the interval: 5 days ago
+    # (run_recent_interval), then 20 days ago (run_mid_interval); 40 days ago (run_old_interval)
+    # falls outside the 25-day window. `before` is passed too and must have no effect: applied, it
+    # would exclude run_recent_interval, which was created only 5 days ago.
     data = get_batch_export_runs_ok(
-        client, team.pk, batch_export.id, ordering="-data_interval_start", start="-40d", before="-2d"
+        client, team.pk, batch_export.id, ordering="-data_interval_start", start="-25d", before="-8d"
     )
-    assert {run["id"] for run in data["results"]} == {str(run.id)}
-
-    # And under that ordering, `start` genuinely filters the interval: narrowing it to exclude
-    # the month-old interval returns nothing.
-    data = get_batch_export_runs_ok(client, team.pk, batch_export.id, ordering="-data_interval_start", start="-2d")
-    assert data["results"] == []
+    assert [run["id"] for run in data["results"]] == [str(run_recent_interval.id), str(run_mid_interval.id)]
 
 
 def test_cannot_cancel_completed_batch_export_run(client: HttpClient, team, user):

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -251,6 +251,7 @@ def test_get_batch_export_runs_filtered_by_status(client: HttpClient, team, user
     client.force_login(user)
     query_params = {"ordering": ordering} if ordering else {}
 
+    # List runs filtered by failed statuses, asserting that only failed runs are returned
     data = get_batch_export_runs_ok(
         client,
         team.pk,
@@ -263,6 +264,7 @@ def test_get_batch_export_runs_filtered_by_status(client: HttpClient, team, user
         str(runs[BatchExportRun.Status.FAILED_RETRYABLE].id),
     }
 
+    # List all runs, without any status filter, asserting that all runs are returned
     data = get_batch_export_runs_ok(client, team.pk, batch_export.id, **query_params)
     assert {run["id"] for run in data["results"]} == {str(run.id) for run in runs.values()}
 

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -278,6 +278,44 @@ def test_get_batch_export_runs_rejects_unknown_status(client: HttpClient, team, 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
+def test_get_batch_export_runs_date_filter_depends_on_ordering(client: HttpClient, team, user):
+    """`after`/`before` filter on `created_at` unless ordering by `data_interval_start`, in which
+    case `start`/`end` filter the data interval instead, and the other pair has no effect."""
+    batch_export = create_batch_export(team, create_destination())
+    now = dt.datetime.now(dt.UTC)
+
+    # Recent data interval, but created a month ago.
+    run_by_interval = create_run(
+        batch_export,
+        status=BatchExportRun.Status.COMPLETED,
+        data_interval_start=now - dt.timedelta(hours=1),
+        data_interval_end=now,
+    )
+    BatchExportRun.objects.filter(id=run_by_interval.id).update(created_at=now - dt.timedelta(days=30))
+
+    # Data interval from a month ago, but created just now.
+    run_by_created_at = create_run(
+        batch_export,
+        status=BatchExportRun.Status.COMPLETED,
+        data_interval_start=now - dt.timedelta(days=30, hours=1),
+        data_interval_end=now - dt.timedelta(days=30),
+    )
+
+    client.force_login(user)
+
+    # Default ordering filters by created_at. `start` is passed too and must have no effect:
+    # if it did, run_by_created_at's month-old interval would exclude it from the result.
+    data = get_batch_export_runs_ok(client, team.pk, batch_export.id, after="-2d", start="-2d")
+    assert {run["id"] for run in data["results"]} == {str(run_by_created_at.id)}
+
+    # Ordering by data_interval_start filters by the interval instead. `after` is passed too and
+    # must have no effect: if it did, run_by_interval's month-old created_at would exclude it.
+    data = get_batch_export_runs_ok(
+        client, team.pk, batch_export.id, ordering="-data_interval_start", start="-2d", after="-2d"
+    )
+    assert {run["id"] for run in data["results"]} == {str(run_by_interval.id)}
+
+
 def test_cannot_cancel_completed_batch_export_run(client: HttpClient, team, user):
     destination = create_destination()
     batch_export = create_batch_export(team, destination)

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -227,6 +227,55 @@ def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organizatio
         assert run["status"] == "Cancelled"
 
 
+@pytest.mark.parametrize("ordering", [None, "-data_interval_start"])
+def test_get_batch_export_runs_filtered_by_status(client: HttpClient, team, user, ordering):
+    batch_export = create_batch_export(team, create_destination())
+    # Runs are only returned when their data interval falls inside the default window of the last 7 days.
+    interval_end = dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)
+    runs = {}
+    for hours, run_status in enumerate(
+        [
+            BatchExportRun.Status.COMPLETED,
+            BatchExportRun.Status.FAILED,
+            BatchExportRun.Status.FAILED_RETRYABLE,
+            BatchExportRun.Status.RUNNING,
+        ]
+    ):
+        runs[run_status] = create_run(
+            batch_export,
+            status=run_status,
+            data_interval_start=interval_end - dt.timedelta(hours=hours + 1),
+            data_interval_end=interval_end - dt.timedelta(hours=hours),
+        )
+
+    client.force_login(user)
+    query_params = {"ordering": ordering} if ordering else {}
+
+    data = get_batch_export_runs_ok(
+        client,
+        team.pk,
+        batch_export.id,
+        status=[BatchExportRun.Status.FAILED, BatchExportRun.Status.FAILED_RETRYABLE],
+        **query_params,
+    )
+    assert {run["id"] for run in data["results"]} == {
+        str(runs[BatchExportRun.Status.FAILED].id),
+        str(runs[BatchExportRun.Status.FAILED_RETRYABLE].id),
+    }
+
+    data = get_batch_export_runs_ok(client, team.pk, batch_export.id, **query_params)
+    assert {run["id"] for run in data["results"]} == {str(run.id) for run in runs.values()}
+
+
+def test_get_batch_export_runs_rejects_unknown_status(client: HttpClient, team, user):
+    batch_export = create_batch_export(team, create_destination())
+    client.force_login(user)
+
+    response = get_batch_export_runs(client, team.pk, batch_export.id, status=["NotAStatus"])
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+
+
 def test_cannot_cancel_completed_batch_export_run(client: HttpClient, team, user):
     destination = create_destination()
     batch_export = create_batch_export(team, destination)

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -1938,14 +1938,62 @@ export type BatchExportsBackfillsListParams = {
 
 export type BatchExportsRunsListParams = {
     /**
+     * Only return runs created at or after this point. Accepts an ISO-8601 datetime or a relative value like `-7d`. Defaults to `-7d`. Ignored when ordering by `data_interval_start`.
+     */
+    after?: string
+    /**
+     * Only return runs created at or before this point. Accepts an ISO-8601 datetime or a relative value like `-1d`. Defaults to now. Ignored when ordering by `data_interval_start`.
+     */
+    before?: string
+    /**
      * The pagination cursor value.
      */
     cursor?: string
     /**
+     * Only return runs whose data interval ends at or before this point. Accepts an ISO-8601 datetime or a relative value like `-1d`. Defaults to now. Only applies when ordering by `data_interval_start`.
+     */
+    end?: string
+    /**
      * Which field to use when ordering the results.
      */
     ordering?: string
+    /**
+     * Only return runs whose data interval starts at or after this point. Accepts an ISO-8601 datetime or a relative value like `-7d`. Defaults to `-7d`. Only applies when ordering by `data_interval_start`.
+     */
+    start?: string
+    /**
+     * Only return runs in these statuses. Repeat the parameter to pass more than one status.
+     */
+    status?: BatchExportsRunsListStatusItem[]
 }
+
+/**
+ * * `Cancelled` - Cancelled
+ * * `Completed` - Completed
+ * * `ContinuedAsNew` - Continued As New
+ * * `Failed` - Failed
+ * * `FailedRetryable` - Failed Retryable
+ * * `FailedBilling` - Failed Billing
+ * * `Terminated` - Terminated
+ * * `TimedOut` - Timedout
+ * * `Running` - Running
+ * * `Starting` - Starting
+ */
+export type BatchExportsRunsListStatusItem =
+    (typeof BatchExportsRunsListStatusItem)[keyof typeof BatchExportsRunsListStatusItem]
+
+export const BatchExportsRunsListStatusItem = {
+    Cancelled: 'Cancelled',
+    Completed: 'Completed',
+    ContinuedAsNew: 'ContinuedAsNew',
+    Failed: 'Failed',
+    FailedRetryable: 'FailedRetryable',
+    FailedBilling: 'FailedBilling',
+    Terminated: 'Terminated',
+    TimedOut: 'TimedOut',
+    Running: 'Running',
+    Starting: 'Starting',
+} as const
 
 export type BatchExportsRunsLogsRetrieveParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -88255,14 +88255,62 @@ export namespace Schemas {
 
     export type BatchExportsRunsListParams = {
     /**
+     * Only return runs created at or after this point. Accepts an ISO-8601 datetime or a relative value like `-7d`. Defaults to `-7d`. Ignored when ordering by `data_interval_start`.
+     */
+    after?: string;
+    /**
+     * Only return runs created at or before this point. Accepts an ISO-8601 datetime or a relative value like `-1d`. Defaults to now. Ignored when ordering by `data_interval_start`.
+     */
+    before?: string;
+    /**
      * The pagination cursor value.
      */
     cursor?: string;
     /**
+     * Only return runs whose data interval ends at or before this point. Accepts an ISO-8601 datetime or a relative value like `-1d`. Defaults to now. Only applies when ordering by `data_interval_start`.
+     */
+    end?: string;
+    /**
      * Which field to use when ordering the results.
      */
     ordering?: string;
+    /**
+     * Only return runs whose data interval starts at or after this point. Accepts an ISO-8601 datetime or a relative value like `-7d`. Defaults to `-7d`. Only applies when ordering by `data_interval_start`.
+     */
+    start?: string;
+    /**
+     * Only return runs in these statuses. Repeat the parameter to pass more than one status.
+     */
+    status?: BatchExportsRunsListStatusItem[];
     };
+
+    /**
+     * * `Cancelled` - Cancelled
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `FailedBilling` - Failed Billing
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting
+     */
+    export type BatchExportsRunsListStatusItem = typeof BatchExportsRunsListStatusItem[keyof typeof BatchExportsRunsListStatusItem];
+
+
+    export const BatchExportsRunsListStatusItem = {
+      Cancelled: 'Cancelled',
+      Completed: 'Completed',
+      ContinuedAsNew: 'ContinuedAsNew',
+      Failed: 'Failed',
+      FailedRetryable: 'FailedRetryable',
+      FailedBilling: 'FailedBilling',
+      Terminated: 'Terminated',
+      TimedOut: 'TimedOut',
+      Running: 'Running',
+      Starting: 'Starting',
+    } as const;
 
     export type BatchExportsRunsLogsRetrieveParams = {
     /**


### PR DESCRIPTION
## Problem

Someone debugging a batch export cannot ask the API for only its failed runs.
The runs endpoint returns every run in the window, 100 per page, and the caller has to page through and sort them out.

The frontend Runs tab has the same limitation, and this PR is the base layer that lets it filter server-side.
The UI sits on top in the next PR in the stack.

## Changes

- `GET /api/projects/:team_id/batch_exports/:id/runs` accepts a `status` parameter, repeatable, so `?status=Failed&status=FailedRetryable` returns only those runs.
- An unknown status returns 400 rather than being ignored, so a client bug surfaces instead of silently changing the result set.
- The `after`, `before`, `start` and `end` parameters now appear in the published schema. The endpoint always accepted them, but generated clients and MCP tools could not see them.
- Filtering happens on the queryset, before pagination, so the filter applies across every page rather than within the first one.
- Also added a `test_get_batch_export_runs_date_filter_depends_on_ordering` test to lock-in the filtering and ordering behaviour as it wasn't previously being tested

The parameter takes raw model statuses rather than friendly groupings, so its enum stays equal to `BatchExportRun.Status`.
Any grouping is a presentation choice and belongs in the client.

Nothing user-visible changes in this PR. The generated files under `products/batch_exports/frontend/generated/` and `services/mcp/src/api/generated.ts` are codegen output from `hogli build:openapi`.

## How did you test this code?

Three new tests in `products/batch_exports/backend/tests/api/test_runs.py`, which had no coverage of query parameters at all: 2 for the new behaviour and 1 to test the existing filtering and ordering by `created_at` vs `data_interval_start`

Both ran locally against the dev stack, along with the existing tests in that file.
Repo-wide mypy ran clean.
No manual API calls beyond the test client.

## Automatic notifications

- [ ] Publish to changelog? Maybe combine with the next PR in the stack

## Docs update

None. The parameter is generated into the API schema, which is what the public API reference reads from.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (PostHog Desktop), directed by @rossgray, who asked for a way to filter the runs list by status and then asked for the work to be split into a backend PR and a frontend PR.

Skills invoked: `/improving-drf-endpoints` for the serializer and schema annotation shape, `/writing-tests` for the test gate, `/writing-pr-descriptions` for this body.

Two decisions worth a reviewer's attention. Repeated parameters won over a comma-joined string because DRF's `ListField` reads a `QueryDict` natively and drf-spectacular emits a typed array, where a comma-joined `CharField` would generate a bare `string` and drop the enum. And the four date parameters were folded into the same serializer rather than left as raw `GET` reads, because they were accepted but undocumented, and one validation pass is cheaper than two code paths.

Nothing in this PR draws on material outside the repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
