### PR TITLE
fix(dashboards): convert legacy filters template tiles instead of minting blank insights

### DIFF
--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -516,6 +516,37 @@ def create_from_template(
         tile_type = template_tile.get("type")
         if tile_type == "INSIGHT":
             query = template_tile.get("query", None)
+            if not query and template_tile.get("filters"):
+                # Pre-query templates carry the tile definition in legacy `filters`, which
+                # _create_tile_for_insight never reads — convert instead of minting a blank insight.
+                from posthog.schema import (  # noqa: PLC0415 — keeps the heavy schema module off the django setup path
+                    InsightVizNode,
+                )
+
+                from posthog.hogql_queries.legacy_compatibility.filter_to_query import (  # noqa: PLC0415 — top-level import cycles through posthog.models.filters
+                    filter_to_query,
+                )
+
+                try:
+                    # allow_variables matches migration 0530 — template tiles may carry template variables
+                    query = InsightVizNode(
+                        source=filter_to_query(template_tile["filters"], allow_variables=True)
+                    ).model_dump(exclude_none=True)
+                except Exception:
+                    logger.exception(
+                        "dashboard_template_tile_filters_conversion_failed",
+                        template_id=str(template.id),
+                        team_id=dashboard.team_id,
+                    )
+            if not query:
+                # Template tiles aren't schema-validated, so a tile without a query would mint an
+                # insight with neither query nor filters — a permanently blank chart. Skip it.
+                logger.warning(
+                    "dashboard_template_insight_tile_without_query_skipped",
+                    template_id=str(template.id),
+                    team_id=dashboard.team_id,
+                )
+                continue
             _create_tile_for_insight(
                 dashboard,
                 name=template_tile.get("name"),

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -1783,3 +1783,26 @@ class TestCreateFromTemplate(BaseTest):
         assert insight.query["kind"] == "InsightVizNode"
         assert insight.query["source"]["kind"] == "TrendsQuery"
         assert insight.query["source"]["series"][0]["event"] == "$pageview"
+
+    def test_tile_with_unconvertible_legacy_filters_does_not_fail_the_dashboard(self):
+        template = DashboardTemplate.objects.create(
+            team=self.team,
+            template_name="one broken tile",
+            dashboard_filters={},
+            tiles=[
+                {"type": "INSIGHT", "name": "broken", "filters": {"insight": "NOT_AN_INSIGHT_TYPE"}, "layouts": {}},
+                {
+                    "type": "INSIGHT",
+                    "name": "fine",
+                    "query": {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}},
+                    "layouts": {},
+                },
+            ],
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="from broken template", filters={})
+
+        create_from_template(dashboard, template)
+
+        insights = Insight.objects.filter(team=self.team)
+        assert insights.count() == 1
+        assert insights.get().name == "fine"

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any, Optional
 
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, BaseTest
 from unittest.mock import MagicMock, patch
 
 from django.db.models import Q
@@ -11,6 +11,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.constants import AvailableFeature
+from posthog.helpers.dashboard_templates import create_from_template
 from posthog.models import User
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -20,7 +21,9 @@ from products.dashboards.backend.api.dashboard_templates import (
     MAX_DASHBOARD_TEMPLATES_PER_ORGANIZATION,
     organization_dashboard_template_limit_detail,
 )
+from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
+from products.product_analytics.backend.facade.models import Insight
 
 
 def assert_template_equals(received, expected):
@@ -1728,3 +1731,55 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
         )
         resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": str(tpl.id)}, format="json")
         assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestCreateFromTemplate(BaseTest):
+    def test_insight_tile_without_query_creates_no_empty_shell_insight(self):
+        template = DashboardTemplate.objects.create(
+            team=self.team,
+            template_name="mixed tiles",
+            dashboard_filters={},
+            tiles=[
+                {"type": "INSIGHT", "name": "queryless", "layouts": {}},
+                {
+                    "type": "INSIGHT",
+                    "name": "real",
+                    "query": {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}},
+                    "layouts": {},
+                },
+            ],
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="from template", filters={})
+
+        create_from_template(dashboard, template)
+
+        insights = Insight.objects.filter(team=self.team)
+        assert insights.count() == 1
+        assert insights.get().query is not None
+
+    def test_insight_tile_with_legacy_filters_converts_to_query(self):
+        template = DashboardTemplate.objects.create(
+            team=self.team,
+            template_name="legacy tiles",
+            dashboard_filters={},
+            tiles=[
+                {
+                    "type": "INSIGHT",
+                    "name": "DAUs",
+                    "filters": {
+                        "insight": "TRENDS",
+                        "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
+                    },
+                    "layouts": {},
+                },
+            ],
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="from legacy template", filters={})
+
+        create_from_template(dashboard, template)
+
+        insight = Insight.objects.get(team=self.team)
+        assert insight.query is not None
+        assert insight.query["kind"] == "InsightVizNode"
+        assert insight.query["source"]["kind"] == "TrendsQuery"
+        assert insight.query["source"]["series"][0]["event"] == "$pageview"


### PR DESCRIPTION
## Problem

Someone who creates a dashboard from certain templates gets charts that are permanently blank and cannot be repaired from the UI.

- Template `INSIGHT` tiles are not schema-validated, so a tile may carry its definition in legacy `filters`, or carry no definition at all.
- `create_from_template` reads only the tile's `query`. It passes neither key on, so the new insight has no `query` and no `filters`.
- Templates in this shape still mint such insights today, which is also why the legacy `filters` removal keeps finding fresh rows to convert.

## Changes

- A tile whose definition sits in legacy `filters` now produces a working chart instead of a blank one. `create_from_template` converts it with `filter_to_query(..., allow_variables=True)`, the same call and the same variable handling as migration 0530.
- A tile with no definition at all now produces no insight, instead of a blank one nobody can fix. The skip is logged with the template and team.
- A conversion failure logs and falls through to that skip, so one bad tile cannot fail the whole dashboard.
- Both imports stay function-local. `posthog.schema` costs about 1.5s on the `django.setup()` path and would breach the startup import budget, and a top-level `filter_to_query` import cycles through `posthog.models.filters`.
- Nothing changes for a template whose tiles already carry a `query`, which is every template shipped in the repo.

No screenshots: the change is a backend code path. The visible difference is a chart that renders rather than an empty one, which depends on the template.

## How did you test this code?

Three tests in `TestCreateFromTemplate`, in `products/dashboards/backend/api/test/test_dashboard_templates.py`:

- A queryless tile creates no insight. This catches the empty-shell path reopening.
- A legacy `filters` tile converts to a trends query carrying the tile's event. This catches the conversion branch being dropped or losing `allow_variables`.
- A tile whose `filters` name an insight type that does not exist is skipped, and the tile beside it still becomes an insight. This catches the `try`/`except` being removed, which would turn one bad tile into a failed dashboard creation. The tile uses real malformed input rather than a patched `filter_to_query`.

Ran locally against the dev stack: the whole `test_dashboard_templates.py` file, since `create_from_template` is shared with the existing template tests, and `posthog/test/repo_invariants` for the startup import budget and the model-crossing ratchet.

Not run locally: repo-wide mypy. CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by Thomas Obermüller.

- Split out of [#85132](https://github.com/PostHog/posthog/pull/85132), which mixed this fix with two one-off backfill commands. The commands stay there and will not merge.
- Authored in PostHog Desktop. Skills invoked: `/writing-pr-descriptions`.
- One deliberate change against the original: a `# noqa` comment on the deferred `posthog.schema` import used to read "off the django.setup() path". The parentheses in that comment broke the model-crossing scanner, which reads a file's imports with a regex whose parenthesized-import branch stops at the first `)`. The whole import table then failed to parse and the module dropped out of the scan, so `Insight.objects.create` in this file silently stopped being tracked and the ratchet asked for its baseline line to be deleted. Rewording the comment restores the scan and leaves `products/model_crossing_uses_baseline.txt` untouched.
- No session material is in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

