### PR TITLE
feat(insights): flag-gated performed event filter on insight series

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.scss
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.scss
@@ -35,3 +35,27 @@
         }
     }
 }
+
+// Frames each filter's controls the way a filter group frames its contents, so a multi-line
+// condition reads as one unit. The horizontal bleed keeps the controls' own width unchanged,
+// so framing them makes nothing wrap earlier.
+.PropertyFilters--framed-rows {
+    // The trailing add-filter row holds a button, not a condition, so it takes no frame
+    .TaxonomicPropertyFilter__row:not(.TaxonomicPropertyFilter__row--empty) {
+        .TaxonomicPropertyFilter__row-items {
+            padding: 0.375rem;
+            margin: 0 -0.375rem;
+            background-color: var(--color-bg-primary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius);
+        }
+
+        // A group already paints the surrounding grey, so its rows invert to stay visible
+        .property-group &,
+        .property-group--framed & {
+            .TaxonomicPropertyFilter__row-items {
+                background-color: var(--color-bg-surface-primary);
+            }
+        }
+    }
+}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.scss
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.scss
@@ -35,27 +35,3 @@
         }
     }
 }
-
-// Frames each filter's controls the way a filter group frames its contents, so a multi-line
-// condition reads as one unit. The horizontal bleed keeps the controls' own width unchanged,
-// so framing them makes nothing wrap earlier.
-.PropertyFilters--framed-rows {
-    // The trailing add-filter row holds a button, not a condition, so it takes no frame
-    .TaxonomicPropertyFilter__row:not(.TaxonomicPropertyFilter__row--empty) {
-        .TaxonomicPropertyFilter__row-items {
-            padding: 0.375rem;
-            margin: 0 -0.375rem;
-            background-color: var(--color-bg-primary);
-            border: 1px solid var(--color-border-primary);
-            border-radius: var(--radius);
-        }
-
-        // A group already paints the surrounding grey, so its rows invert to stay visible
-        .property-group &,
-        .property-group--framed & {
-            .TaxonomicPropertyFilter__row-items {
-                background-color: var(--color-bg-surface-primary);
-            }
-        }
-    }
-}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -1,9 +1,11 @@
 import './PropertyFilters.scss'
 
+import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import React, { useState } from 'react'
 
 import { BehavioralPropertyFilterRow } from 'lib/components/PropertyFilters/components/BehavioralPropertyFilterRow'
+import { PropertyFilterRowOperator } from 'lib/components/PropertyFilters/components/PropertyFilterRowOperator'
 import { TaxonomicPropertyFilter } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
 import { isBehavioralPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import {
@@ -80,6 +82,8 @@ export interface PropertyFiltersProps {
      * logic, so the caller doesn't have to rebuild the list from possibly-stale props. */
     addFilterSuffix?: ((addFilter: (property: AnyPropertyFilter) => void) => JSX.Element) | null
     addFilterDivider?: boolean
+    /** Frames each row's controls on a tinted panel, so a filter spanning several lines reads as one unit. */
+    framedRows?: boolean
 }
 
 export function PropertyFilters({
@@ -126,6 +130,7 @@ export function PropertyFilters({
     showRemoveButton = true,
     addFilterSuffix,
     addFilterDivider = false,
+    framedRows = false,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
     const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
@@ -140,7 +145,7 @@ export function PropertyFilters({
     useOnMountEffect(() => setAllowOpenOnInsert(true))
 
     return (
-        <div className="PropertyFilters">
+        <div className={clsx('PropertyFilters', framedRows && 'PropertyFilters--framed-rows')}>
             {showNestedArrow && !disablePopover && (
                 <div className="PropertyFilters__prefix">
                     <>&#8627;</>
@@ -177,12 +182,27 @@ export function PropertyFilters({
                                     editable={editable}
                                     filterComponent={(onComplete) =>
                                         isBehavioralPropertyFilter(item) ? (
-                                            <BehavioralPropertyFilterRow
-                                                filter={item}
-                                                onChange={(filter) => setFilter(index, filter)}
-                                                editable={editable}
-                                                size={buttonSize}
-                                            />
+                                            // Same row scaffolding as a taxonomic filter, so both kinds share
+                                            // one gutter and line up. w-full/min-w-0 stands in for the
+                                            // .TaxonomicPropertyFilter wrapper the other branch gets.
+                                            <div className="TaxonomicPropertyFilter__row w-full min-w-0">
+                                                {hasRowOperator && (
+                                                    <PropertyFilterRowOperator
+                                                        index={index}
+                                                        orFiltering={orFiltering}
+                                                        propertyGroupType={propertyGroupType}
+                                                        hasKey={!!item.key}
+                                                    />
+                                                )}
+                                                <div className="TaxonomicPropertyFilter__row-items">
+                                                    <BehavioralPropertyFilterRow
+                                                        filter={item}
+                                                        onChange={(filter) => setFilter(index, filter)}
+                                                        editable={editable}
+                                                        size={buttonSize}
+                                                    />
+                                                </div>
+                                            </div>
                                         ) : (
                                             <TaxonomicPropertyFilter
                                                 pageKey={pageKey}

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -5,6 +5,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import React, { useState } from 'react'
 
 import { BehavioralPropertyFilterRow } from 'lib/components/PropertyFilters/components/BehavioralPropertyFilterRow'
+import { FILTER_ROW_FRAME_CLASSES } from 'lib/components/PropertyFilters/components/filterRowFrame'
 import { PropertyFilterRowOperator } from 'lib/components/PropertyFilters/components/PropertyFilterRowOperator'
 import { TaxonomicPropertyFilter } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
 import { isBehavioralPropertyFilter } from 'lib/components/PropertyFilters/utils'
@@ -82,7 +83,6 @@ export interface PropertyFiltersProps {
      * logic, so the caller doesn't have to rebuild the list from possibly-stale props. */
     addFilterSuffix?: ((addFilter: (property: AnyPropertyFilter) => void) => JSX.Element) | null
     addFilterDivider?: boolean
-    /** Frames each row's controls on a tinted panel, so a filter spanning several lines reads as one unit. */
     framedRows?: boolean
 }
 
@@ -145,7 +145,7 @@ export function PropertyFilters({
     useOnMountEffect(() => setAllowOpenOnInsert(true))
 
     return (
-        <div className={clsx('PropertyFilters', framedRows && 'PropertyFilters--framed-rows')}>
+        <div className="PropertyFilters">
             {showNestedArrow && !disablePopover && (
                 <div className="PropertyFilters__prefix">
                     <>&#8627;</>
@@ -182,9 +182,6 @@ export function PropertyFilters({
                                     editable={editable}
                                     filterComponent={(onComplete) =>
                                         isBehavioralPropertyFilter(item) ? (
-                                            // Same row scaffolding as a taxonomic filter, so both kinds share
-                                            // one gutter and line up. w-full/min-w-0 stands in for the
-                                            // .TaxonomicPropertyFilter wrapper the other branch gets.
                                             <div className="TaxonomicPropertyFilter__row w-full min-w-0">
                                                 {hasRowOperator && (
                                                     <PropertyFilterRowOperator
@@ -194,7 +191,12 @@ export function PropertyFilters({
                                                         hasKey={!!item.key}
                                                     />
                                                 )}
-                                                <div className="TaxonomicPropertyFilter__row-items">
+                                                <div
+                                                    className={clsx(
+                                                        'TaxonomicPropertyFilter__row-items',
+                                                        framedRows && FILTER_ROW_FRAME_CLASSES
+                                                    )}
+                                                >
                                                     <BehavioralPropertyFilterRow
                                                         filter={item}
                                                         onChange={(filter) => setFilter(index, filter)}
@@ -237,6 +239,7 @@ export function PropertyFilters({
                                                 propertyDefinitionsOverride={propertyDefinitionsOverride}
                                                 propertyKeyEditable={propertyKeyEditable}
                                                 singleLine={singleLine}
+                                                framedRows={framedRows}
                                             />
                                         )
                                     }

--- a/frontend/src/lib/components/PropertyFilters/components/AddBehavioralFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/AddBehavioralFilterButton.tsx
@@ -11,8 +11,6 @@ export interface AddBehavioralFilterButtonProps {
     'data-attr': string
 }
 
-/** Entry point for a "performed event" filter. The button is the event picker itself, so — as with
- * "Add filter" — no row appears until the user has chosen what it targets. */
 export function AddBehavioralFilterButton({
     onAdd,
     'data-attr': dataAttr,
@@ -31,7 +29,6 @@ export function AddBehavioralFilterButton({
                 )
             }
             placeholder="Performed"
-            // The trigger never holds a value, so it should read as a button, not an empty field
             placeholderClass=""
             icon={<IconPlusSmall />}
             sideIcon={null}

--- a/frontend/src/lib/components/PropertyFilters/components/AddBehavioralFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/AddBehavioralFilterButton.tsx
@@ -1,0 +1,41 @@
+import { IconPlusSmall } from '@posthog/icons'
+
+import { newBehavioralFilter } from 'lib/components/PropertyFilters/utils'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+
+import { BehavioralPropertyFilter } from '~/types'
+
+export interface AddBehavioralFilterButtonProps {
+    onAdd: (filter: BehavioralPropertyFilter) => void
+    'data-attr': string
+}
+
+/** Entry point for a "performed event" filter. The button is the event picker itself, so — as with
+ * "Add filter" — no row appears until the user has chosen what it targets. */
+export function AddBehavioralFilterButton({
+    onAdd,
+    'data-attr': dataAttr,
+}: AddBehavioralFilterButtonProps): JSX.Element {
+    return (
+        <TaxonomicPopover
+            groupType={TaxonomicFilterGroupType.Events}
+            groupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]}
+            value={null}
+            onChange={(value, groupType) =>
+                onAdd(
+                    newBehavioralFilter(
+                        String(value),
+                        groupType === TaxonomicFilterGroupType.Actions ? 'actions' : 'events'
+                    )
+                )
+            }
+            placeholder="Performed"
+            // The trigger never holds a value, so it should read as a button, not an empty field
+            placeholderClass=""
+            icon={<IconPlusSmall />}
+            sideIcon={null}
+            data-attr={dataAttr}
+        />
+    )
+}

--- a/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.tsx
@@ -128,7 +128,7 @@ export function BehavioralPropertyFilterRow({
                     </div>
                 </div>
                 {!filter.negation && (
-                    <div className="flex items-center gap-2">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
                         <LemonSelect
                             size={size}
                             value={countOperator}
@@ -148,7 +148,7 @@ export function BehavioralPropertyFilterRow({
                         <span className="whitespace-nowrap">{countValue === 1 ? 'time' : 'times'}</span>
                     </div>
                 )}
-                <div className="flex items-center gap-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
                     <span className="whitespace-nowrap">in the last</span>
                     <LemonInput
                         type="number"

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -73,7 +73,11 @@ export const FilterRow = React.memo(function FilterRow({
     return (
         <>
             <div
-                className={clsx('property-filter-row flex items-center flex-nowrap deprecated-space-x-2 max-w-full', {
+                className={clsx('property-filter-row flex items-center max-w-full', {
+                    // A suffix puts two buttons on this row, which have to wrap rather than
+                    // overflow once the panel is narrow. space-x can't wrap; gap can.
+                    'flex-wrap gap-2': !!suffix,
+                    'flex-nowrap deprecated-space-x-2': !suffix,
                     'grow sm:grow-0': isValid,
                     'grow-0': !isValid,
                     'wrap-filters': !disablePopover,

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -74,8 +74,6 @@ export const FilterRow = React.memo(function FilterRow({
         <>
             <div
                 className={clsx('property-filter-row flex items-center max-w-full', {
-                    // A suffix puts two buttons on this row, which have to wrap rather than
-                    // overflow once the panel is narrow. space-x can't wrap; gap can.
                     'flex-wrap gap-2': !!suffix,
                     'flex-nowrap deprecated-space-x-2': !suffix,
                     'grow sm:grow-0': isValid,

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterRowOperator.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterRowOperator.tsx
@@ -8,12 +8,9 @@ export interface PropertyFilterRowOperatorProps {
     index: number
     orFiltering?: boolean
     propertyGroupType?: FilterLogicalOperator | null
-    /** Or-filtering leaves the gutter empty until the row has a key. */
     hasKey?: boolean
 }
 
-/** The fixed-width left gutter every filter row shares, holding "where" or the AND/OR tag.
- * Reserving it for each row is what keeps the rows' controls in one column. */
 export function PropertyFilterRowOperator({
     index,
     orFiltering,
@@ -33,9 +30,6 @@ export function PropertyFilterRowOperator({
         <OperandTag operand="and" />
     ) : null
 
-    // Still occupies the gutter when empty, so every row's controls stay in one column. The
-    // modifier lets the narrow layout drop it instead, where it would otherwise take a whole
-    // wrapped line and push the row's own controls down.
     return (
         <div
             className={clsx(

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterRowOperator.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterRowOperator.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx'
+
+import { FilterLogicalOperator } from '~/types'
+
+import { OperandTag } from './OperandTag'
+
+export interface PropertyFilterRowOperatorProps {
+    index: number
+    orFiltering?: boolean
+    propertyGroupType?: FilterLogicalOperator | null
+    /** Or-filtering leaves the gutter empty until the row has a key. */
+    hasKey?: boolean
+}
+
+/** The fixed-width left gutter every filter row shares, holding "where" or the AND/OR tag.
+ * Reserving it for each row is what keeps the rows' controls in one column. */
+export function PropertyFilterRowOperator({
+    index,
+    orFiltering,
+    propertyGroupType,
+    hasKey,
+}: PropertyFilterRowOperatorProps): JSX.Element {
+    const content = orFiltering ? (
+        propertyGroupType && index !== 0 && hasKey ? (
+            <OperandTag operand={propertyGroupType === FilterLogicalOperator.And ? 'and' : 'or'} />
+        ) : null
+    ) : index === 0 ? (
+        <>
+            <span className="TaxonomicPropertyFilter__row-arrow">&#8627;</span>
+            <span>where</span>
+        </>
+    ) : hasKey ? (
+        <OperandTag operand="and" />
+    ) : null
+
+    // Still occupies the gutter when empty, so every row's controls stay in one column. The
+    // modifier lets the narrow layout drop it instead, where it would otherwise take a whole
+    // wrapped line and push the row's own controls down.
+    return (
+        <div
+            className={clsx(
+                'TaxonomicPropertyFilter__row-operator',
+                !content && 'TaxonomicPropertyFilter__row-operator--empty'
+            )}
+        >
+            {content ? <div className="flex items-center gap-1">{content}</div> : null}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -40,6 +40,7 @@ import { AnyPropertyFilter, GroupTypeIndex, PropertyDefinitionType, PropertyFilt
 
 import { joinsLogic } from 'products/data_warehouse/frontend/shared/logics/joinsLogic'
 
+import { FILTER_ROW_FRAME_CLASSES } from './filterRowFrame'
 import { PropertyFilterRowOperator } from './PropertyFilterRowOperator'
 import { taxonomicPropertyFilterLogic } from './taxonomicPropertyFilterLogic'
 
@@ -89,6 +90,7 @@ export function TaxonomicPropertyFilter({
     propertyDefinitionsOverride,
     propertyKeyEditable = true,
     singleLine,
+    framedRows,
 }: PropertyFilterInternalProps): JSX.Element {
     const generatedKey = useId()
     const pageKey = pageKeyInput || `filter-${generatedKey}`
@@ -363,7 +365,6 @@ export function TaxonomicPropertyFilter({
                         'TaxonomicPropertyFilter__row--or-filtering': orFiltering,
                         'TaxonomicPropertyFilter__row--showing-operators': showOperatorValueSelect,
                         'TaxonomicPropertyFilter__row--editable': editable,
-                        'TaxonomicPropertyFilter__row--empty': !filter?.key,
                     })}
                 >
                     {hasRowOperator && (
@@ -375,9 +376,11 @@ export function TaxonomicPropertyFilter({
                         />
                     )}
                     <div
-                        className={clsx('TaxonomicPropertyFilter__row-items', {
-                            'TaxonomicPropertyFilter__row-items--single-line': singleLine,
-                        })}
+                        className={clsx(
+                            'TaxonomicPropertyFilter__row-items',
+                            { 'TaxonomicPropertyFilter__row-items--single-line': singleLine },
+                            framedRows && filter?.key && FILTER_ROW_FRAME_CLASSES
+                        )}
                     >
                         {showOperatorValueSelect && placeOperatorValueSelectOnLeft && operatorValueSelect}
                         {editable && propertyKeyEditable ? editablePicker : filterContent}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -36,17 +36,11 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import {
-    AnyPropertyFilter,
-    FilterLogicalOperator,
-    GroupTypeIndex,
-    PropertyDefinitionType,
-    PropertyFilterType,
-} from '~/types'
+import { AnyPropertyFilter, GroupTypeIndex, PropertyDefinitionType, PropertyFilterType } from '~/types'
 
 import { joinsLogic } from 'products/data_warehouse/frontend/shared/logics/joinsLogic'
 
-import { OperandTag } from './OperandTag'
+import { PropertyFilterRowOperator } from './PropertyFilterRowOperator'
 import { taxonomicPropertyFilterLogic } from './taxonomicPropertyFilterLogic'
 
 export const DEFAULT_TAXONOMIC_GROUP_TYPES = [
@@ -369,35 +363,16 @@ export function TaxonomicPropertyFilter({
                         'TaxonomicPropertyFilter__row--or-filtering': orFiltering,
                         'TaxonomicPropertyFilter__row--showing-operators': showOperatorValueSelect,
                         'TaxonomicPropertyFilter__row--editable': editable,
+                        'TaxonomicPropertyFilter__row--empty': !filter?.key,
                     })}
                 >
                     {hasRowOperator && (
-                        <div className="TaxonomicPropertyFilter__row-operator">
-                            {orFiltering ? (
-                                <>
-                                    {propertyGroupType && index !== 0 && filter?.key && (
-                                        <div className="flex items-center">
-                                            {propertyGroupType === FilterLogicalOperator.And ? (
-                                                <OperandTag operand="and" />
-                                            ) : (
-                                                <OperandTag operand="or" />
-                                            )}
-                                        </div>
-                                    )}
-                                </>
-                            ) : (
-                                <div className="flex items-center gap-1">
-                                    {index === 0 ? (
-                                        <>
-                                            <span className="TaxonomicPropertyFilter__row-arrow">&#8627;</span>
-                                            <span>where</span>
-                                        </>
-                                    ) : (
-                                        <OperandTag operand="and" />
-                                    )}
-                                </div>
-                            )}
-                        </div>
+                        <PropertyFilterRowOperator
+                            index={index}
+                            orFiltering={orFiltering}
+                            propertyGroupType={propertyGroupType}
+                            hasKey={!!filter?.key}
+                        />
                     )}
                     <div
                         className={clsx('TaxonomicPropertyFilter__row-items', {

--- a/frontend/src/lib/components/PropertyFilters/components/filterRowFrame.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/filterRowFrame.ts
@@ -1,0 +1,4 @@
+/** Frames a filter row's controls like a filter group. Inside a group the fill inverts, since the
+ * group already paints that grey. */
+export const FILTER_ROW_FRAME_CLASSES =
+    '-mx-1.5 rounded border border-primary bg-primary p-1.5 [.property-group_&]:bg-surface-primary [.property-group--framed_&]:bg-surface-primary'

--- a/frontend/src/lib/components/PropertyFilters/components/filterRowFrame.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/filterRowFrame.ts
@@ -1,4 +1,2 @@
-/** Frames a filter row's controls like a filter group. Inside a group the fill inverts, since the
- * group already paints that grey. */
-export const FILTER_ROW_FRAME_CLASSES =
-    '-mx-1.5 rounded border border-primary bg-primary p-1.5 [.property-group_&]:bg-surface-primary [.property-group--framed_&]:bg-surface-primary'
+/** Frames a filter row's controls like a filter group. */
+export const FILTER_ROW_FRAME_CLASSES = '-mx-1.5 rounded border border-primary bg-primary p-1.5'

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -87,4 +87,6 @@ export interface PropertyFilterInternalProps {
     propertyKeyEditable?: boolean
     /** Keep key, operator, and value controls on one row when the host has enough width. */
     singleLine?: boolean
+    /** Frame each row's controls like a filter group, so a multi-line condition reads as one unit. */
+    framedRows?: boolean
 }

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -250,6 +250,17 @@ export function isBehavioralPropertyFilter(filter?: AnyFilterLike | null): filte
     return filter?.type === PropertyFilterType.Behavioral
 }
 
+export function newBehavioralFilter(): BehavioralPropertyFilter {
+    return {
+        type: PropertyFilterType.Behavioral,
+        value: BehavioralEventType.PerformEvent,
+        key: '$pageview',
+        event_type: 'events',
+        time_value: 30,
+        time_interval: TimeUnitType.Day,
+    }
+}
+
 export const BEHAVIORAL_COUNT_OPERATOR_LABELS: Partial<Record<PropertyOperator, string>> = {
     [PropertyOperator.GreaterThanOrEqual]: 'at least',
     [PropertyOperator.LessThanOrEqual]: 'at most',

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -250,12 +250,12 @@ export function isBehavioralPropertyFilter(filter?: AnyFilterLike | null): filte
     return filter?.type === PropertyFilterType.Behavioral
 }
 
-export function newBehavioralFilter(): BehavioralPropertyFilter {
+export function newBehavioralFilter(key: string, eventType: 'events' | 'actions'): BehavioralPropertyFilter {
     return {
         type: PropertyFilterType.Behavioral,
         value: BehavioralEventType.PerformEvent,
-        key: '$pageview',
-        event_type: 'events',
+        key,
+        event_type: eventType,
         time_value: 30,
         time_interval: TimeUnitType.Day,
     }

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -67,6 +67,32 @@
                         flex-basis: 100%;
                     }
                 }
+
+                // Series rows hold their "where" gutter alongside the controls for longer than
+                // the denser inline-events list, collapsing only once the remaining column is
+                // too narrow to fit two controls side by side.
+                @container editor-panel (max-width: 400px) {
+                    .ActionFilterRow-filters .TaxonomicPropertyFilter__row {
+                        flex-wrap: wrap;
+                    }
+
+                    .ActionFilterRow-filters .TaxonomicPropertyFilter__row-items {
+                        flex-basis: 100%;
+                    }
+
+                    // On its own line the gutter has nothing to align to, so drop its fixed
+                    // width and row height and let the label sit flush with the controls
+                    .ActionFilterRow-filters .TaxonomicPropertyFilter__row-operator {
+                        justify-content: flex-start;
+                        width: auto;
+                        height: auto;
+                    }
+
+                    // An empty gutter here would still take a wrapped line, offsetting the row
+                    .ActionFilterRow-filters .TaxonomicPropertyFilter__row-operator--empty {
+                        display: none;
+                    }
+                }
             }
 
             &:not(.EditorFiltersWrapper--panels) {

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -68,9 +68,6 @@
                     }
                 }
 
-                // Series rows hold their "where" gutter alongside the controls for longer than
-                // the denser inline-events list, collapsing only once the remaining column is
-                // too narrow to fit two controls side by side.
                 @container editor-panel (max-width: 400px) {
                     .ActionFilterRow-filters .TaxonomicPropertyFilter__row {
                         flex-wrap: wrap;
@@ -80,15 +77,12 @@
                         flex-basis: 100%;
                     }
 
-                    // On its own line the gutter has nothing to align to, so drop its fixed
-                    // width and row height and let the label sit flush with the controls
                     .ActionFilterRow-filters .TaxonomicPropertyFilter__row-operator {
                         justify-content: flex-start;
                         width: auto;
                         height: auto;
                     }
 
-                    // An empty gutter here would still take a wrapped line, offsetting the row
                     .ActionFilterRow-filters .TaxonomicPropertyFilter__row-operator--empty {
                         display: none;
                     }

--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -8,37 +8,18 @@ import { IconCopy, IconPlusSmall, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { isPropertyGroupFilterLike } from 'lib/components/PropertyFilters/utils'
+import { isPropertyGroupFilterLike, newBehavioralFilter } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
 import { InsightQueryNode, ProductAnalyticsInsightQueryNode } from '~/queries/schema/schema-general'
-import {
-    AnyPropertyFilter,
-    BehavioralEventType,
-    BehavioralPropertyFilter,
-    InsightLogicProps,
-    PropertyFilterType,
-    PropertyGroupFilterValue,
-    TimeUnitType,
-} from '~/types'
+import { AnyPropertyFilter, InsightLogicProps, PropertyGroupFilterValue } from '~/types'
 
 import { InsightTestAccountFilter } from '../filters/InsightTestAccountFilter'
 import { AndOrFilterSelect } from './AndOrFilterSelect'
 import { propertyGroupFilterLogic } from './propertyGroupFilterLogic'
-
-function newBehavioralFilter(): BehavioralPropertyFilter {
-    return {
-        type: PropertyFilterType.Behavioral,
-        value: BehavioralEventType.PerformEvent,
-        key: '$pageview',
-        event_type: 'events',
-        time_value: 30,
-        time_interval: TimeUnitType.Day,
-    }
-}
 
 type PropertyGroupFiltersProps = {
     insightProps: InsightLogicProps

--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -176,7 +176,6 @@ export function PropertyGroupFilters({
                                                         logicalRowDivider={behavioralFiltersEnabled}
                                                         hasRowOperator={!behavioralFiltersEnabled}
                                                         addFilterDivider={behavioralFiltersEnabled}
-                                                        framedRows={behavioralFiltersEnabled}
                                                         addFilterSuffix={
                                                             behavioralFiltersEnabled
                                                                 ? (addFilter) => (

--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -7,8 +7,9 @@ import React from 'react'
 import { IconCopy, IconPlusSmall, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
+import { AddBehavioralFilterButton } from 'lib/components/PropertyFilters/components/AddBehavioralFilterButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { isPropertyGroupFilterLike, newBehavioralFilter } from 'lib/components/PropertyFilters/utils'
+import { isPropertyGroupFilterLike } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -175,20 +176,14 @@ export function PropertyGroupFilters({
                                                         logicalRowDivider={behavioralFiltersEnabled}
                                                         hasRowOperator={!behavioralFiltersEnabled}
                                                         addFilterDivider={behavioralFiltersEnabled}
+                                                        framedRows={behavioralFiltersEnabled}
                                                         addFilterSuffix={
                                                             behavioralFiltersEnabled
                                                                 ? (addFilter) => (
-                                                                      <LemonButton
+                                                                      <AddBehavioralFilterButton
                                                                           data-attr={`${pageKey}-add-behavioral-filter`}
-                                                                          type="secondary"
-                                                                          icon={<IconPlusSmall />}
-                                                                          sideIcon={null}
-                                                                          onClick={() =>
-                                                                              addFilter(newBehavioralFilter())
-                                                                          }
-                                                                      >
-                                                                          Performed
-                                                                      </LemonButton>
+                                                                          onAdd={addFilter}
+                                                                      />
                                                                   )
                                                                 : null
                                                         }

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
@@ -87,6 +87,7 @@ export function TrendsSeries(): JSX.Element | null {
         <>
             {isLifecycle && <LifecycleSeriesHeader />}
             <ActionFilter
+                allowBehavioralPropertyFilter
                 filters={filters}
                 setFilters={(payload: Partial<FilterType>): void => {
                     if (isLifecycle) {

--- a/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
@@ -52,6 +52,7 @@ export function FunnelsQuerySteps({ insightProps }: EditorFilterProps): JSX.Elem
         <>
             <div className="FunnelsQuerySteps">
                 <ActionFilter
+                    allowBehavioralPropertyFilter
                     bordered={false}
                     filters={actionFilters}
                     setFilters={setActionFilters}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -65,6 +65,9 @@ export interface ActionFilterProps {
     hideDuplicate?: boolean
     /** Whether to show the nested PropertyFilters in popover mode or not */
     propertyFiltersPopover?: boolean
+    /** Opt in the flag-gated "Performed event" behavioral filter on each series. Only insight
+     * query contexts should enable it — realtime contexts (CDP, workflows) reject behavioral filters. */
+    allowBehavioralPropertyFilter?: boolean
     /** A limit of entities (series or funnel steps) beyond which more can't be added */
     entitiesLimit?: number
     /** Custom suffix element to show in each ActionFilterRow */
@@ -131,6 +134,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         hideRename = false,
         hideDuplicate = false,
         propertyFiltersPopover,
+        allowBehavioralPropertyFilter,
         customRowSuffix,
         entitiesLimit,
         showNestedArrow = false,
@@ -203,6 +207,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         actionsTaxonomicGroupTypes,
         propertiesTaxonomicGroupTypes,
         propertyFiltersPopover,
+        allowBehavioralPropertyFilter,
         disabled,
         readOnly,
         renderRow,

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.test.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.test.tsx
@@ -7,6 +7,8 @@ import userEvent from '@testing-library/user-event'
 import { Provider } from 'kea'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { entityFilterLogic } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 
@@ -379,6 +381,22 @@ describe('ActionFilterRow', () => {
                 const { logic } = setup()
                 renderRow(logic)
                 expect(document.querySelector('.ActionFilterRow-filters')).not.toBeInTheDocument()
+            })
+
+            it.each([
+                [true, true],
+                [false, false],
+            ])('behavioral filter enabled=%s → "Performed" entry point shown=%s', (enabled, shown) => {
+                featureFlagLogic.mount()
+                featureFlagLogic.actions.setFeatureFlags(
+                    enabled ? [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER] : [],
+                    enabled ? { [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER]: true } : {}
+                )
+                const { logic } = setup()
+                logic.actions.setEntityFilterVisibility(0, true)
+                renderRow(logic)
+                const button = screen.queryByText('Performed')
+                expect(!!button).toBe(shown)
             })
         })
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.test.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.test.tsx
@@ -383,20 +383,20 @@ describe('ActionFilterRow', () => {
                 expect(document.querySelector('.ActionFilterRow-filters')).not.toBeInTheDocument()
             })
 
-            it.each([
-                [true, true],
-                [false, false],
-            ])('behavioral filter enabled=%s → "Performed" entry point shown=%s', (enabled, shown) => {
+            it.each<{ flags: string[]; variants: Record<string, string | boolean>; shown: boolean }>([
+                {
+                    flags: [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER],
+                    variants: { [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER]: true },
+                    shown: true,
+                },
+                { flags: [], variants: {}, shown: false },
+            ])('behavioral "Performed" entry point shown=$shown when flag present', ({ flags, variants, shown }) => {
                 featureFlagLogic.mount()
-                featureFlagLogic.actions.setFeatureFlags(
-                    enabled ? [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER] : [],
-                    enabled ? { [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER]: true } : {}
-                )
+                featureFlagLogic.actions.setFeatureFlags(flags, variants)
                 const { logic } = setup()
                 logic.actions.setEntityFilterVisibility(0, true)
-                renderRow(logic)
-                const button = screen.queryByText('Performed')
-                expect(!!button).toBe(shown)
+                renderRow(logic, { allowBehavioralPropertyFilter: true })
+                expect(!!screen.queryByText('Performed')).toBe(shown)
             })
         })
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -97,6 +97,7 @@ export function ActionFilterRow({
     hideDeleteBtn = false,
     showCombine = false,
     insightType,
+    allowBehavioralPropertyFilter = false,
     propertyFiltersPopover = false,
     onRenameClick = () => {},
     showSeriesIndicator,
@@ -360,7 +361,10 @@ export function ActionFilterRow({
 
     const isDataWarehouseFilter = filter.type === EntityTypes.DATA_WAREHOUSE
     // A behavioral filter compiles to a person_id subquery over the events table, which a warehouse series has no key for
-    const behavioralFiltersEnabled = !!featureFlags[FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER] && !isDataWarehouseFilter
+    const behavioralFiltersEnabled =
+        allowBehavioralPropertyFilter &&
+        !!featureFlags[FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER] &&
+        !isDataWarehouseFilter
     // CDP destination/workflow filters restrict the picker to the one warehouse table family their
     // trigger fires on, so each family gets its own typeKey.
     const dataWarehouseGroupType =

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -8,10 +8,11 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useCallback } from 'react'
 
-import { IconCopy, IconFilter, IconGroupIntersect, IconPencil, IconTrash } from '@posthog/icons'
+import { IconCopy, IconFilter, IconGroupIntersect, IconPencil, IconPlusSmall, IconTrash } from '@posthog/icons'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { newBehavioralFilter } from 'lib/components/PropertyFilters/utils'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
 import { defaultDataWarehousePopoverFields } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import {
@@ -21,8 +22,10 @@ import {
     quickFilterToPropertyFilters,
 } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover, TaxonomicPopoverProps } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { IconWithCount, SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getEventNamesForAction } from 'lib/utils/events'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -142,6 +145,7 @@ export function ActionFilterRow({
     const { actions } = useValues(actionsModel)
     const { mathDefinitions } = useValues(mathsLogic)
     const { dataWarehouseTablesMap } = useValues(databaseTableListLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const mountedInsightDataLogic = insightDataLogic.findMounted({ dashboardItemId: typeKey })
     const query = mountedInsightDataLogic?.values?.query
@@ -355,6 +359,8 @@ export function ActionFilterRow({
         )
 
     const isDataWarehouseFilter = filter.type === EntityTypes.DATA_WAREHOUSE
+    // A behavioral filter compiles to a person_id subquery over the events table, which a warehouse series has no key for
+    const behavioralFiltersEnabled = !!featureFlags[FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER] && !isDataWarehouseFilter
     // CDP destination/workflow filters restrict the picker to the one warehouse table family their
     // trigger fires on, so each family gets its own typeKey.
     const dataWarehouseGroupType =
@@ -734,6 +740,22 @@ export function ActionFilterRow({
                         hogQLGlobals={hogQLGlobals}
                         operatorAllowlist={operatorAllowlist}
                         triggerVariant="input"
+                        addFilterSuffix={
+                            behavioralFiltersEnabled
+                                ? (addFilter) => (
+                                      <LemonButton
+                                          data-attr={`${index}-${value}-${typeKey}-add-behavioral-filter`}
+                                          type="secondary"
+                                          size="small"
+                                          icon={<IconPlusSmall />}
+                                          sideIcon={null}
+                                          onClick={() => addFilter(newBehavioralFilter())}
+                                      >
+                                          Performed
+                                      </LemonButton>
+                                  )
+                                : null
+                        }
                     />
                     <SaveAsActionBanner filter={filter} />
                 </div>

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -745,7 +745,6 @@ export function ActionFilterRow({
                         operatorAllowlist={operatorAllowlist}
                         triggerVariant="input"
                         framedRows={behavioralFiltersEnabled}
-                        // Shortened to sit beside "Performed" as a matching pair
                         addText={behavioralFiltersEnabled ? 'Filter' : undefined}
                         addFilterSuffix={
                             behavioralFiltersEnabled

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -8,11 +8,11 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useCallback } from 'react'
 
-import { IconCopy, IconFilter, IconGroupIntersect, IconPencil, IconPlusSmall, IconTrash } from '@posthog/icons'
+import { IconCopy, IconFilter, IconGroupIntersect, IconPencil, IconTrash } from '@posthog/icons'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
+import { AddBehavioralFilterButton } from 'lib/components/PropertyFilters/components/AddBehavioralFilterButton'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { newBehavioralFilter } from 'lib/components/PropertyFilters/utils'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
 import { defaultDataWarehousePopoverFields } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import {
@@ -744,19 +744,16 @@ export function ActionFilterRow({
                         hogQLGlobals={hogQLGlobals}
                         operatorAllowlist={operatorAllowlist}
                         triggerVariant="input"
+                        framedRows={behavioralFiltersEnabled}
+                        // Shortened to sit beside "Performed" as a matching pair
+                        addText={behavioralFiltersEnabled ? 'Filter' : undefined}
                         addFilterSuffix={
                             behavioralFiltersEnabled
                                 ? (addFilter) => (
-                                      <LemonButton
+                                      <AddBehavioralFilterButton
                                           data-attr={`${index}-${value}-${typeKey}-add-behavioral-filter`}
-                                          type="secondary"
-                                          size="small"
-                                          icon={<IconPlusSmall />}
-                                          sideIcon={null}
-                                          onClick={() => addFilter(newBehavioralFilter())}
-                                      >
-                                          Performed
-                                      </LemonButton>
+                                          onAdd={addFilter}
+                                      />
                                   )
                                 : null
                         }

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/types.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/types.ts
@@ -40,6 +40,9 @@ export interface ActionFilterRowProps {
     hideDeleteBtn?: boolean // Choose to hide delete btn. You can use the onClose function passed into customRow{Pre|Suf}fix to render the delete btn anywhere
     showCombine?: boolean // Show the combine inline events option
     insightType?: InsightType // The type of insight (trends, funnels, etc.)
+    // Opt in the flag-gated "Performed event" behavioral filter. Off by default because behavioral
+    // filters compile to a person_id subquery, which realtime contexts (CDP, workflows) reject.
+    allowBehavioralPropertyFilter?: boolean
     propertyFiltersPopover?: boolean
     onRenameClick?: () => void // Used to open rename modal
     showSeriesIndicator?: boolean // Show series badge


### PR DESCRIPTION
## Problem

People building an insight can add a "performed event" filter to a whole filter group, but not to a single series. This PR lets them attach one to an individual series, so a series can be scoped to people who did (or did not) perform some event in a time window.

It builds directly on [#83740](https://github.com/PostHog/posthog/pull/83740), which added the same filter to insight filter groups. Same feature flag, same inline editor, one series row lower.

## Why

Follow-up to the merged filter-group work: the next step was applying the filter per series rather than per group.

## Changes
<img width="561" height="516" alt="Screenshot 2026-08-27 at 10 08 54" src="https://github.com/user-attachments/assets/4777de8a-72a0-43fd-a0c7-9b261106bd67" />

- Each insight series' property filters now show a "Performed" button next to "Add filter", behind the `behavioral-property-filter` flag (off by default). Clicking it inserts the inline behavioral row: performed / did not perform, event or action, count, and a time window.
- The button is hidden for data warehouse series, because a behavioral filter compiles to a `person_id` subquery over the events table that a warehouse series has no key to join on.
- The editor, label formatting, chip icon, and backend compilation are unchanged from #83740 and reused as-is. Per-series property filters flow through the same `PropertyFilters` component, so wiring the entry point was the only frontend change needed.
- Mechanical: `newBehavioralFilter` moved from `PropertyGroupFilters` into `PropertyFilters/utils` so both surfaces share one factory instead of duplicating it.

No screenshot: the sandbox cannot boot the app or Storybook. The row itself is unchanged from #83740, which carries its story.

## How did you test this code?

- Added a parameterized case to `ActionFilterRow.test.tsx`: the "Performed" entry point renders on a series only when the flag is on. Catches the feature silently vanishing, or leaking to all projects unflagged.
- Ran `ActionFilterRow.test.tsx` (72 pass) and the existing behavioral tests in `PropertyFilters` (60 pass) locally.
- Not run: manual UI verification (no bootable app in the sandbox) and the full frontend typecheck (the sandbox's `@posthog/quill` workspace is unbuilt, so the whole-repo `tsgo` run reports only pre-existing module-resolution errors; none in the changed files). CI covers the typecheck.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Deferred until the flag GAs, same as #83740.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Desktop task). Skills invoked: /writing-tests, /writing-pr-descriptions. The key decision was to reuse the generic behavioral machinery #83740 landed in `PropertyFilters` rather than rebuild it: per-series filters already render through that component, so the change reduced to passing the same `addFilterSuffix` button and gating it behind the flag, plus sharing the filter factory.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
