### PR TITLE
feat(warehouse_sources): add Asana AI Studio usage tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -485,10 +485,12 @@ Note: Diffed against the upstream swagger spec (82 paths). PostHog's deployment_
 
 ## Asana — gaps
 
-Today (8): `custom_fields`, `projects`, `sections`, `tags`, `tasks`, `teams`, `users`, `workspaces`
+Today (10): `ai_studio_runs`, `ai_studio_seats`, `custom_fields`, `projects`, `sections`, `tags`, `tasks`, `teams`, `users`, `workspaces`
 
 Diffed against: <https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml>
 
+- [x] `workspaces/{workspace_gid}/ai_studio/runs` — one row per AI Studio run (rule execution) with the credits it consumed; from the AI Studio usage API (not in the OpenAPI spec above)
+- [x] `workspaces/{workspace_gid}/ai_studio/seats` — current snapshot of who holds an AI Studio seat, at what tier and state; from the AI Studio usage API (not in the OpenAPI spec above)
 - [ ] `tasks/{task_gid}/stories` — task activity + comment stream, the only source of state-transition history (assignee/section/due-date changes) (high)
 - [ ] `projects/{project_gid}/project_memberships` — who is on which project and in what role; joins users to projects we already sync (high)
 - [ ] `goals (+ goals/{gid}/parentGoals)` — Asana's headline OKR object with progress/status, entirely absent today (high)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/canonical_descriptions.py
@@ -132,4 +132,33 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             created_by="The user who created the custom field.",
         ),
     },
+    "ai_studio_runs": {
+        "description": "A single AI Studio run (rule execution), with the credits it consumed. Requires an AI Studio-licensed organization.",
+        "docs_url": "https://developers.asana.com/reference/ai-studio-usage-api",
+        "columns": _columns(
+            rule="The AI Studio smart rule that executed.",
+            rule_owner="The user who owns the rule that ran.",
+            triggered_by="The user whose action triggered the run.",
+            triggering_container="The project or portfolio the run was triggered from.",
+            division="The division the run is attributed to.",
+            run_started_at="Time at which the run was triggered.",
+            run_completed_at="Time at which the run finished.",
+            status="Outcome of the run (success, failed, cancelled).",
+            model="The AI model used for the run.",
+            credits_used="Number of AI Studio credits the run consumed.",
+            credit_source="Whether the consumed credits were paid or free.",
+        ),
+    },
+    "ai_studio_seats": {
+        "description": "A current snapshot of an AI Studio seat — who holds it, at what tier, and in what state. Only paid seats are returned.",
+        "docs_url": "https://developers.asana.com/reference/ai-studio-usage-api",
+        "columns": _columns(
+            user="The user who holds the seat.",
+            license="The AI Studio license tier of the seat (ai_studio_pro, ai_studio_plus, ai_studio_max).",
+            state="Current state of the seat (active, revoked, expired).",
+            assigned_at="Time at which the seat was granted.",
+            revoked_at="Time at which the seat was revoked or expired.",
+            assigned_by="The user who assigned the seat.",
+        ),
+    },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/settings.py
@@ -137,6 +137,46 @@ ASANA_ENDPOINTS: dict[str, AsanaEndpointConfig] = {
             "resource_type",
         ],
     ),
+    # AI Studio usage endpoints (organization fan-out — AI Studio is an org/division feature, so
+    # non-organization workspaces are skipped to avoid invalid requests). Both require the
+    # `admin.ai_studio_usage:read` scope on an AI Studio-licensed org; unlicensed orgs return 403.
+    "ai_studio_runs": AsanaEndpointConfig(
+        name="ai_studio_runs",
+        fan_out="organization",
+        path="/workspaces/{workspace_gid}/ai_studio/runs",
+        opt_fields=[
+            "rule.name",
+            "rule_owner.name",
+            "rule_owner.email",
+            "triggered_by.name",
+            "triggered_by.email",
+            "triggering_container.resource_type",
+            "division.name",
+            "run_started_at",
+            "run_completed_at",
+            "status",
+            "model",
+            "credits_used",
+            "credit_source",
+            "resource_type",
+        ],
+        partition_key="run_started_at",
+    ),
+    "ai_studio_seats": AsanaEndpointConfig(
+        name="ai_studio_seats",
+        fan_out="organization",
+        path="/workspaces/{workspace_gid}/ai_studio/seats",
+        opt_fields=[
+            "user.name",
+            "user.email",
+            "license",
+            "state",
+            "assigned_at",
+            "revoked_at",
+            "assigned_by.name",
+            "resource_type",
+        ],
+    ),
 }
 
 ENDPOINTS = tuple(ASANA_ENDPOINTS.keys())
@@ -147,4 +187,7 @@ ENDPOINTS = tuple(ASANA_ENDPOINTS.keys())
 # real server filter would make every "incremental" run cost the same as a full refresh.
 # Incremental tasks (via `modified_since`) and the Events API are tracked as follow-ups; they
 # need a live token to smoke-test the filter behaviour before we can rely on it.
+# `ai_studio/runs` does take a `start_at`/`end_at` window, but it filters by an internal metering
+# timestamp that the row shape does not expose — so no synced column maps cleanly onto the cursor,
+# and the arrival order can't be verified without a live token. It stays full-refresh with the rest.
 INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/source.py
@@ -64,6 +64,8 @@ Grant these read scopes so every table can sync:
 - `tags:read`
 - `teams:read`
 - `custom_fields:read`
+
+The AI Studio usage tables (`ai_studio_runs`, `ai_studio_seats`) additionally need the `admin.ai_studio_usage:read` scope on an AI Studio-licensed organization. Skip them if you don't use AI Studio.
 """,
             iconPath="/static/services/asana.png",
             docsUrl="https://posthog.com/docs/cdp/sources/asana",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/asana/tests/test_asana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/asana/tests/test_asana.py
@@ -254,9 +254,13 @@ class TestAsanaSourceResponse:
             assert response.partition_mode is None
             assert response.partition_keys is None
 
+    # Creation-time fields that never change after a row is written — safe to partition on.
+    # A mutable field (modified_at, lastSeen) would rewrite partitions on every sync.
+    STABLE_CREATION_FIELDS = {"created_at", "run_started_at"}
+
     @pytest.mark.parametrize("config", list(ASANA_ENDPOINTS.values()))
     def test_partition_keys_are_stable_creation_fields(self, config) -> None:
         if config.partition_key:
-            assert config.partition_key == "created_at"
+            assert config.partition_key in self.STABLE_CREATION_FIELDS
             # The partition field must be opted into the response, else partitioning fails.
             assert config.partition_key in config.opt_fields


### PR DESCRIPTION
## Problem

Someone connecting Asana to the PostHog Data warehouse cannot pull their AI Studio usage. Asana shipped an AI Studio usage API with two read-only endpoints, and the Asana source had no table for either — so credit spend and seat allocation stayed out of the warehouse.

## Changes

- Adds an `ai_studio_runs` table: one row per AI Studio run (rule execution), with the rule, its owner, who triggered it, the model, and the credits consumed.
- Adds an `ai_studio_seats` table: a current snapshot of who holds a paid AI Studio seat, at what tier, and in what state.
- Both endpoints fan out over organization workspaces only — AI Studio is an org/division feature, so non-organization workspaces are skipped to avoid invalid requests. This reuses the fan-out mode the source already applies to `teams`.
- Both reuse the source's existing `rest_source` wiring, `next_page` paginator, and Bearer auth; no transport code changed.
- `ai_studio_runs` partitions by `run_started_at` (a stable creation-time field); `ai_studio_seats` is a small snapshot and is not partitioned.
- Both ship full refresh. The runs endpoint takes a `start_at`/`end_at` window, but it filters by an internal metering timestamp that no synced column exposes, so there is no safe cursor to map — matching the full-refresh stance of the rest of the source.
- The connection form now notes the extra `admin.ai_studio_usage:read` scope these two tables need on an AI Studio-licensed org.
- Canonical column descriptions for both tables come from the official Asana API reference, so the docs "Supported tables" section and the AI agent get accurate metadata without an LLM pass.
- Mechanical: ticked the two endpoints in `COVERAGE_GAPS_APPENDIX.md`.

## Endpoints verified

Both endpoints were confirmed against Asana's official [AI Studio usage API reference](https://developers.asana.com/reference/ai-studio-usage-api) before building. Neither was skipped. No new API version — they live under the same Asana API 1.0 surface the source already targets.

## How did you test this code?

- Extended `test_partition_keys_are_stable_creation_fields` to accept `run_started_at` alongside `created_at`. It catches a partition key set to a mutable field (`modified_at`), which would rewrite partitions every sync — the new `run_started_at` key had to be admitted without weakening that guard.
- The existing parameterized transport and response tests (`test_asana.py`) already extend to the two new endpoints, covering the `SourceResponse` shape and partition metadata per endpoint. No endpoint-specific test was added, since asserting the path string back would only restate the settings declaration.
- Ran the Asana source tests and the source-wide category and version invariant suites locally; all passed. Not run: any live sync against a real Asana account — this environment has no AI Studio token, so the endpoints were verified against the vendor reference rather than by curl.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code). Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-pr-descriptions`.

The AI Studio usage API is not in Asana's public OpenAPI spec (the source used for the coverage appendix), so both endpoints were verified from the vendor's hosted reference. Incremental sync was considered for `ai_studio_runs` — it has a real `start_at` server filter and ascending order — but rejected: the filter keys off a metering timestamp the row shape does not expose, so no synced column maps onto the cursor and arrival order cannot be verified without a live token. Shipping full refresh avoids a watermark bug and matches the rest of the source.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
