### PR TITLE
feat(warehouse_sources): add Ashby referrals and sequences tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -506,10 +506,12 @@ Note: Diffed against Asana's official OpenAPI spec (3 MB, ~120 GET paths). Also 
 
 ## Ashby — gaps
 
-Today (16): `applications`, `archive_reasons`, `candidate_tags`, `candidates`, `custom_fields`, `departments`, `interview_schedules`, `interviews`, `job_postings`, `jobs`, `locations`, `offers`, `openings`, `projects`, `sources`, `users`
+Today (18): `applications`, `archive_reasons`, `candidate_tags`, `candidates`, `custom_fields`, `departments`, `interview_schedules`, `interviews`, `job_postings`, `jobs`, `locations`, `offers`, `openings`, `projects`, `referrals`, `sequences`, `sources`, `users`
 
 Diffed against: <https://developers.ashbyhq.com/reference/introduction>
 
+- [x] `referral.list` — candidate referrals tying a referrer to an application/job, a sourcing-attribution table (medium)
+- [x] `sequence.list` — candidate enrollments in outreach sequences, with per-stage scheduling (medium)
 - [ ] `applicationFeedback.list` — interview scorecards and ratings, the core quality signal for hiring analytics (high)
 - [ ] `application.listHistory` — stage-transition history; without it you cannot compute time-in-stage or funnel conversion (high)
 - [ ] `interviewStage.list` — lookup resolving the currentInterviewStage ID carried on every synced application (high)
@@ -524,6 +526,8 @@ Diffed against: <https://developers.ashbyhq.com/reference/introduction>
 - [ ] `sourceTrackingLink.list` — resolves attribution links behind the sources table already synced (low)
 
 Note: Ashby's readme.io OpenAPI JSON is not publicly downloadable (404), so the resource list was read from the full reference navigation on the introduction page, filtering on \*.list endpoints. Other list endpoints deliberately excluded as config: communicationTemplate, emailSender, sequenceTemplate, jobBoard, jobTemplate, brand, apiKey, webhook.
+
+Excluded as not table-shaped: `notetakerTranscript.info` is a single-object getter keyed by a `notetakerTranscriptId` (not enumerable, and it returns a transient pre-signed download URL); `candidate.getRecentEmailMessages` is a per-candidate fetch with no durable row id (`recordId` is documented as non-durable) and a silent 200-message snapshot cap, so it does not map to a stable, complete table.
 
 ## Asknicely — gaps
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/canonical_descriptions.py
@@ -190,4 +190,32 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             authorId="ID of the user who created the project.",
         ),
     },
+    "referrals": {
+        "description": "A referral of a candidate for a job in Ashby.",
+        "docs_url": "https://developers.ashbyhq.com/reference/referrallist",
+        "columns": _columns(
+            candidateId="ID of the referred candidate.",
+            applicationId="ID of the application created from the referral.",
+            jobId="ID of the job the candidate was referred for.",
+            referralType="How the referral was made (e.g. Direct).",
+            referrer="The user who submitted the referral.",
+            sourceFormDefinitionId="ID of the referral form definition used.",
+            formDefinition="The referral form's sections and fields.",
+            submittedValues="The values submitted on the referral form.",
+        ),
+    },
+    "sequences": {
+        "description": "A candidate's enrollment in an outreach sequence in Ashby.",
+        # sequence.list objects carry no updatedAt, so this entry omits the shared column.
+        "docs_url": "https://developers.ashbyhq.com/reference/sequencelist",
+        "columns": {
+            "id": _COMMON_COLUMNS["id"],
+            "createdAt": _COMMON_COLUMNS["createdAt"],
+            "candidateId": "ID of the candidate enrolled in the sequence.",
+            "applicationId": "ID of the application the enrollment is associated with.",
+            "sequenceTemplateId": "ID of the sequence template this enrollment is based on.",
+            "status": "Status of the enrollment (Running, Paused, Completed, Cancelled, Unsubscribed).",
+            "stages": "The sequence's stages and their scheduling details.",
+        },
+    },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ashby/settings.py
@@ -47,6 +47,12 @@ ASHBY_ENDPOINTS: dict[str, AshbyEndpointConfig] = {
     "custom_fields": AshbyEndpointConfig(name="custom_fields", path="customField.list", primary_key=["id"]),
     "openings": AshbyEndpointConfig(name="openings", path="opening.list", primary_key=["id"]),
     "projects": AshbyEndpointConfig(name="projects", path="project.list", primary_key=["id"]),
+    "referrals": AshbyEndpointConfig(
+        name="referrals", path="referral.list", primary_key=["id"], partition_key="createdAt"
+    ),
+    "sequences": AshbyEndpointConfig(
+        name="sequences", path="sequence.list", primary_key=["id"], partition_key="createdAt"
+    ),
 }
 
 ENDPOINTS = tuple(ASHBY_ENDPOINTS.keys())


### PR DESCRIPTION
## Problem

A team syncing Ashby into the PostHog Data warehouse cannot get referral or sequence data. Ashby shipped two list endpoints (`referral.list`, `sequence.list`) that this source had no table for, so sourcing-attribution and outreach-sequence records were unreachable for analysis.

## Changes

- Ashby users can now sync two new tables: `referrals` (candidate referrals tying a referrer to an application and job) and `sequences` (a candidate's enrollment in an outreach sequence, with per-stage scheduling).
- Both endpoints are top-level POST list endpoints, so they reuse the existing cursor paginator, full-refresh config, and `id` primary key, partitioned by the stable `createdAt` field.
- Canonical column descriptions for both tables are added from the official API reference so the AI agent gets curated metadata instead of LLM-derived guesses.
- `sequence.list` objects carry no `updatedAt`, so its description entry omits the shared column.

Two announced endpoints were verified against the official API reference and skipped as not table-shaped:

- `notetakerTranscript.info` is a single-object getter keyed by a `notetakerTranscriptId`. It is not enumerable and returns a transient pre-signed download URL, so it cannot back a stable table.
- `candidate.getRecentEmailMessages` is a per-candidate fetch with no durable row id (`recordId` is documented as non-durable) and a silent 200-message snapshot cap (`snapshotTruncated`). It does not fit this source's top-level-list wiring and would be lossy as a table.

## How did you test this code?

The source's existing tests parametrize over the endpoint catalog, so the two new endpoints are exercised by the current suite without new cases: `test_all_endpoints_buildable` builds a `SourceResponse` for each, and `test_get_schemas_covers_all_endpoints_as_full_refresh` asserts every schema is full refresh. Adding endpoint-specific partition tests would only restate the `settings.py` declarations.

Ran `products/warehouse_sources/backend/temporal/data_imports/sources/ashby/tests/` locally: all pass. Not run: the wider warehouse-sources suites and any live Ashby API calls (no credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The `<SourceTables />` docs section is fed by `get_documented_tables()`, which lists the endpoint catalog plus canonical descriptions, so both new tables appear once this ships. No doc file change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude Code) from an automated changelog-coverage task. Skills invoked: `/implementing-warehouse-sources`, `/writing-pr-descriptions`, `/writing-tests`.

Each announced endpoint was checked against the Ashby API reference before building. The two `.list` endpoints matched the source's existing wiring and were added; the two non-list endpoints were skipped for the reasons in Changes. No new tests were added because the source's parametrized tests already cover new catalog entries.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
