### PR TITLE
fix(replay): stop the late-snapshot banner cutting off its own text

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -359,6 +359,9 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
                                     {hasLateFullSnapshot && !hidePlayerElements ? (
                                         <LemonBanner
                                             type="warning"
+                                            // The player column over-commits its height, so a flexible banner gets
+                                            // squashed and its text spills out of the border in narrow players
+                                            className="shrink-0"
                                             dismissKey={`late-full-snapshot-${sessionRecordingId}`}
                                         >
                                             The first{' '}


### PR DESCRIPTION
## Problem

Anyone watching a session replay in a narrow container sees the "The first 2h…" warning banner break: the text no longer fits inside the border, so the last line sits on the edge and the "Learn more" link is not visible at all. It shows up in the support ticket side panel, where the replay sits in a fixed 500px-tall column at the panel's default width.

The player stacks its chrome in a column flex, and the player body asks for the full height of that column. The column is therefore over-committed, so every child shrinks. The banner shrank to its 3rem minimum while the text inside it kept the height three or four wrapped lines need, so the text ran past the banner box.

## Changes

- The banner now keeps the height its text needs, so the whole message and its link stay inside the border at any player width. Longer messages take space from the player frame instead of overflowing.
- One line: `shrink-0` on the banner, matching how eight other banners in the app already opt out of shrinking.

![Before and after, banner in a 360px-wide player column](https://raw.githubusercontent.com/PostHog/pr-assets/1edc143cefcd38ecfd84fe7aa789caf754fd01fd/2026/08/30fecf5c-2f3e-488e-8b54-0e77e05f4d27.png)

Both panels above are a Storybook reproduction of the player's column layout at 360px wide, not the support panel itself. Before, the message is cut at the border and "Learn more" is hidden behind the chrome below. After, the banner is 27px taller and holds all of it.

Fixing this in `LemonBanner` itself was the alternative. It was rejected: `flex-shrink` has no axis, so a global `flex-shrink: 0` would also stop banners narrowing inside row flex containers, and there are several of those.

## How did you test this code?

Measured in a headless Chromium against the Storybook story shown above, which reproduces the player's column layout (a banner, a fixed-height bar, a `height: 100%` body, a controller) at 360px wide and 420px tall. The story was scratch scaffolding and is not part of this PR.

- Before: banner box 79px, text 88px, text bottom 18px past the banner border.
- After: banner box 106px, text fully inside it.

No automated test added — this is a CSS-only layout fix, and the repo has no visual-regression story for the player with this banner showing.

Not checked: the running app. The environment has no dev stack, and the banner needs a recording whose first full snapshot arrived late.

Noted while measuring, not changed here: the same over-commitment already compresses the meta bar and the controller in short players (32px bar renders at 22px), independent of this banner. That predates this change and is left alone.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported in Slack and worked by the PostHog Slack app (Claude Code).

The first attempt made `LemonBanner` itself unshrinkable. A scan for banners inside row flex containers turned up enough of them that the blast radius wasn't worth it, so the fix moved to the call site.

Skills invoked: none.

Public artifact: the diff, this description, the uploaded image, and the commit message contain no material from the originating thread beyond the product symptom. The screenshot is a synthetic Storybook layout with product copy only.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787739490849219?thread_ts=1787739490.849219&cid=C0ACRAMJUAG)*
