### PR TITLE
chore(insights): stop agents rendering %% on SQL insight axes

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2208,12 +2208,12 @@
                     "type": "string"
                 },
                 "style": {
-                    "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                    "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                     "enum": ["none", "number", "short", "percent"],
                     "type": "string"
                 },
                 "suffix": {
-                    "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                    "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                     "type": "string"
                 }
             },

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -1828,14 +1828,14 @@ export interface AssistantDataVisualizationAxisDisplaySettings {
 export interface AssistantDataVisualizationAxisFormatting {
     /** Text prepended to each value (e.g. `$`). */
     prefix?: string
-    /** Text appended to each value (e.g. `%` or ` ms`). */
+    /** Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign. */
     suffix?: string
     /**
      * Number formatting style.
      * - `none` — no formatting.
      * - `number` — thousands separators (e.g. `1,234`).
      * - `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).
-     * - `percent` — render the value as a percentage.
+     * - `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.
      */
     style?: 'none' | 'number' | 'short' | 'percent'
     /** Number of decimal places to display. */

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -491,11 +491,18 @@ class AssistantDataVisualizationAxisFormatting(BaseModel):
         description=(
             "Number formatting style.\n- `none` — no formatting.\n- `number` —"
             " thousands separators (e.g. `1,234`).\n- `short` — abbreviated large"
-            " numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a"
-            " percentage."
+            " numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100"
+            " and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a /"
+            " b`). Never pair it with a `%` suffix, which renders `47.3%%`."
         ),
     )
-    suffix: str | None = Field(default=None, description="Text appended to each value (e.g. `%` or ` ms`).")
+    suffix: str | None = Field(
+        default=None,
+        description=(
+            "Text appended to each value (e.g. ` ms`). Leave unset when `style` is"
+            " `percent`, which already appends the `%` sign."
+        ),
+    )
 
 
 class AssistantDataVisualizationAxisSettings(BaseModel):

--- a/products/product_analytics/skills/formatting-insight-axes/SKILL.md
+++ b/products/product_analytics/skills/formatting-insight-axes/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: formatting-insight-axes
 description: >
-  Pick the right y-axis unit when creating or updating a TrendsQuery insight
-  via `posthog:insight-create` or `posthog:insight-update`. Use when the agent
-  is about to add a `formula` purely to convert units (e.g. dividing seconds
-  by 60 to display minutes), when a `math_property` is a duration, currency,
-  ratio, or large count, or whenever the user mentions "format the y-axis",
-  "duration", "seconds", "minutes", "hours", "milliseconds", "ms",
-  "percentage", "currency", "decimals", "axis label", or "axis unit" in the
-  context of a graph insight.
+  Pick the right y-axis unit when creating or updating an insight via
+  `posthog:insight-create` or `posthog:insight-update` — both TrendsQuery
+  (`trendsFilter.aggregationAxisFormat`) and SQL insights
+  (`DataVisualizationNode`, `chartSettings.yAxis[].settings.formatting`).
+  Use when the agent is about to add a `formula` purely to convert units
+  (e.g. dividing seconds by 60 to display minutes), when a `math_property`
+  or SQL column is a duration, currency, ratio, or large count, when a SQL
+  query returns a percentage or rate column, or whenever the user mentions
+  "format the y-axis", "duration", "seconds", "minutes", "hours",
+  "milliseconds", "ms", "percentage", "%%", "double percent", "currency",
+  "decimals", "axis label", or "axis unit" in the context of a graph insight.
 ---
 
 # Formatting insight axes
 
-PostHog renders TrendsQuery insights with a built-in axis formatter. Use it
-instead of contorting `formula` or `aggregationAxisPostfix` to fake units.
+PostHog renders insights with a built-in axis formatter. Use it instead of
+contorting the query or a literal prefix/postfix to fake units.
+
+The two insight kinds configure it in different places:
+
+- **TrendsQuery** — `trendsFilter.aggregationAxisFormat` (this page, below)
+- **SQL insights** (`DataVisualizationNode`) — per-column
+  `settings.formatting` (see [SQL insights](#sql-insights-datavisualizationnode))
 
 ## The anti-pattern
 
@@ -172,11 +181,61 @@ and move on.
 }
 ```
 
+## SQL insights (DataVisualizationNode)
+
+SQL insights have no `trendsFilter`.
+Formatting is per column, on `chartSettings.yAxis[].settings.formatting` for a chart and `chartSettings.tableSettings.columns[].settings.formatting` for a table.
+
+```json
+{
+  "kind": "DataVisualizationNode",
+  "source": { "kind": "HogQLQuery", "query": "SELECT week, conversion_rate FROM ..." },
+  "display": "ActionsLineGraph",
+  "chartSettings": {
+    "xAxis": { "column": "week" },
+    "yAxis": [
+      {
+        "column": "conversion_rate",
+        "settings": { "formatting": { "style": "percent", "decimalPlaces": 1 } }
+      }
+    ]
+  }
+}
+```
+
+`style` is one of `none`, `number`, `short`, `percent` — there is no `duration` or `currency` here.
+Express those with `prefix` / `suffix`, or format them in the SQL itself.
+
+### `percent` owns both the sign and the scale
+
+Two rules, and mixing either one with hand-rolled formatting is the most common way a SQL insight ships broken:
+
+1. **It appends the `%` itself.**
+   Adding `suffix: "%"` on top renders `47.3%%`.
+   Leave `suffix` off entirely when `style` is `percent`.
+2. **It multiplies the value by 100.**
+   `percent` is the SQL equivalent of the trends `percentage_scaled` format, and there is no unscaled variant.
+   Feed it a 0-1 ratio.
+   If the SQL already returns 0-100, the chart reads `4730%`.
+
+So pick one of the two consistent shapes, never a mix of both:
+
+| SQL returns                       | `formatting`                                             | Renders |
+| --------------------------------- | -------------------------------------------------------- | ------- |
+| a 0-1 ratio (`a / b`)             | `{"style": "percent", "decimalPlaces": 1}`               | `47.3%` |
+| 0-100 (`round(100.0 * a / b, 1)`) | `{"style": "number", "suffix": "%", "decimalPlaces": 1}` | `47.3%` |
+
+Prefer the first: keep the `100.0 *` out of the query and let the formatter own the unit, the same way `aggregationAxisFormat` does for trends.
+The stored column then stays a plain ratio for anything else that reads it.
+
+An axis or series label may of course still say "%" — `leftYAxisSettings.label`, `xAxisLabel`, and `settings.display.label` are free text and are not part of the value formatting.
+
 ## Updating an existing insight
 
-If you are updating an insight and notice it already uses the
-`formula`/`postfix` anti-pattern, fix it in the same `posthog:insight-update`
-call — drop the divide-by-N, drop the `aggregationAxisPostfix`, and set the
-matching `aggregationAxisFormat`. The series values stay the same, only the
-labels change. Do not go scanning unrelated insights for this pattern —
-fix only the ones you are already touching.
+If you are updating an insight and notice it already uses one of these
+anti-patterns — a trends `formula`/`postfix` pair, or a SQL column with both
+`style: "percent"` and a `"%"` suffix — fix it in the same
+`posthog:insight-update` call: drop the divide-by-N or the `100.0 *`, drop the
+literal `%`, and let the format own the unit. The underlying values stay the
+same, only the labels change. Do not go scanning unrelated insights for this
+pattern — fix only the ones you are already touching.

--- a/products/product_analytics/skills/formatting-insight-axes/SKILL.md
+++ b/products/product_analytics/skills/formatting-insight-axes/SKILL.md
@@ -183,7 +183,7 @@ and move on.
 ## SQL insights (DataVisualizationNode)
 
 SQL insights have no `trendsFilter`.
-Formatting is per column, on `chartSettings.yAxis[].settings.formatting` for a chart and `chartSettings.tableSettings.columns[].settings.formatting` for a table.
+Formatting is per column, on `chartSettings.yAxis[].settings.formatting` for a chart and top-level `tableSettings.columns[].settings.formatting` for a table.
 
 ```json
 {

--- a/products/product_analytics/skills/formatting-insight-axes/SKILL.md
+++ b/products/product_analytics/skills/formatting-insight-axes/SKILL.md
@@ -7,11 +7,10 @@ description: >
   (`DataVisualizationNode`, `chartSettings.yAxis[].settings.formatting`).
   Use when the agent is about to add a `formula` purely to convert units
   (e.g. dividing seconds by 60 to display minutes), when a `math_property`
-  or SQL column is a duration, currency, ratio, or large count, when a SQL
-  query returns a percentage or rate column, or whenever the user mentions
-  "format the y-axis", "duration", "seconds", "minutes", "hours",
-  "milliseconds", "ms", "percentage", "%%", "double percent", "currency",
-  "decimals", "axis label", or "axis unit" in the context of a graph insight.
+  or SQL column is a duration, currency, ratio, or large count, or whenever
+  the user mentions "format the y-axis", "duration", "seconds", "minutes",
+  "hours", "milliseconds", "ms", "percentage", "%%", "currency", "decimals",
+  "axis label", or "axis unit" in the context of a graph insight.
 ---
 
 # Formatting insight axes
@@ -203,39 +202,25 @@ Formatting is per column, on `chartSettings.yAxis[].settings.formatting` for a c
 }
 ```
 
-`style` is one of `none`, `number`, `short`, `percent` — there is no `duration` or `currency` here.
-Express those with `prefix` / `suffix`, or format them in the SQL itself.
+`style` is `none`, `number`, `short`, or `percent` — no `duration` or `currency`.
+Express those with `prefix` / `suffix`, or in the SQL itself.
 
-### `percent` owns both the sign and the scale
-
-Two rules, and mixing either one with hand-rolled formatting is the most common way a SQL insight ships broken:
-
-1. **It appends the `%` itself.**
-   Adding `suffix: "%"` on top renders `47.3%%`.
-   Leave `suffix` off entirely when `style` is `percent`.
-2. **It multiplies the value by 100.**
-   `percent` is the SQL equivalent of the trends `percentage_scaled` format, and there is no unscaled variant.
-   Feed it a 0-1 ratio.
-   If the SQL already returns 0-100, the chart reads `4730%`.
-
-So pick one of the two consistent shapes, never a mix of both:
+`percent` both appends the `%` sign and multiplies the value by 100 (like the trends `percentage_scaled` format; there is no unscaled variant).
+So feed it a 0-1 ratio and leave `suffix` unset — pick one shape, never a mix:
 
 | SQL returns                       | `formatting`                                             | Renders |
 | --------------------------------- | -------------------------------------------------------- | ------- |
 | a 0-1 ratio (`a / b`)             | `{"style": "percent", "decimalPlaces": 1}`               | `47.3%` |
 | 0-100 (`round(100.0 * a / b, 1)`) | `{"style": "number", "suffix": "%", "decimalPlaces": 1}` | `47.3%` |
 
-Prefer the first: keep the `100.0 *` out of the query and let the formatter own the unit, the same way `aggregationAxisFormat` does for trends.
-The stored column then stays a plain ratio for anything else that reads it.
-
-An axis or series label may of course still say "%" — `leftYAxisSettings.label`, `xAxisLabel`, and `settings.display.label` are free text and are not part of the value formatting.
+A mix renders broken: `style: "percent"` plus a `"%"` suffix gives `47.3%%`, and `percent` on an already-scaled 0-100 column gives `4730%`.
+Prefer the ratio form — it keeps the `100.0 *` out of the query, so the stored column stays a plain ratio for anything else that reads it.
 
 ## Updating an existing insight
 
-If you are updating an insight and notice it already uses one of these
-anti-patterns — a trends `formula`/`postfix` pair, or a SQL column with both
-`style: "percent"` and a `"%"` suffix — fix it in the same
-`posthog:insight-update` call: drop the divide-by-N or the `100.0 *`, drop the
-literal `%`, and let the format own the unit. The underlying values stay the
-same, only the labels change. Do not go scanning unrelated insights for this
-pattern — fix only the ones you are already touching.
+If an insight you are already editing uses one of these anti-patterns — a
+trends `formula`/`postfix` pair, or a SQL column with both `style: "percent"`
+and a `"%"` suffix — fix it in the same `posthog:insight-update` call: drop the
+divide-by-N or `100.0 *` and the literal `%`, and let the format own the unit.
+Values stay the same, only labels change. Do not scan unrelated insights — fix
+only the ones you are already touching.

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -70,10 +70,10 @@ const AssistantDataVisualizationAxisFormatting = z.object({
     style: z
         .enum(['none', 'number', 'short', 'percent'])
         .describe(
-            'Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.'
+            'Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.'
         )
         .optional(),
-    suffix: z.string().describe('Text appended to each value (e.g. `%` or ` ms`).').optional(),
+    suffix: z.string().describe('Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.').optional(),
 })
 
 const AssistantDataVisualizationAxisSettings = z.object({

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -73,7 +73,12 @@ const AssistantDataVisualizationAxisFormatting = z.object({
             'Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.'
         )
         .optional(),
-    suffix: z.string().describe('Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.').optional(),
+    suffix: z
+        .string()
+        .describe(
+            'Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.'
+        )
+        .optional(),
 })
 
 const AssistantDataVisualizationAxisSettings = z.object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
@@ -213,12 +213,12 @@
                                                             "type": "string"
                                                         },
                                                         "style": {
-                                                            "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                                                            "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                                                             "enum": ["none", "number", "short", "percent"],
                                                             "type": "string"
                                                         },
                                                         "suffix": {
-                                                            "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                                                            "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                                                             "type": "string"
                                                         }
                                                     },
@@ -286,12 +286,12 @@
                                                                 "type": "string"
                                                             },
                                                             "style": {
-                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                                                                 "enum": ["none", "number", "short", "percent"],
                                                                 "type": "string"
                                                             },
                                                             "suffix": {
-                                                                "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                                                                "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                                                                 "type": "string"
                                                             }
                                                         },
@@ -391,12 +391,12 @@
                                                                 "type": "string"
                                                             },
                                                             "style": {
-                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                                                                 "enum": ["none", "number", "short", "percent"],
                                                                 "type": "string"
                                                             },
                                                             "suffix": {
-                                                                "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                                                                "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                                                                 "type": "string"
                                                             }
                                                         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
@@ -224,12 +224,12 @@
                                                             "type": "string"
                                                         },
                                                         "style": {
-                                                            "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                                                            "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                                                             "enum": ["none", "number", "short", "percent"],
                                                             "type": "string"
                                                         },
                                                         "suffix": {
-                                                            "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                                                            "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                                                             "type": "string"
                                                         }
                                                     },
@@ -297,12 +297,12 @@
                                                                 "type": "string"
                                                             },
                                                             "style": {
-                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                                                                 "enum": ["none", "number", "short", "percent"],
                                                                 "type": "string"
                                                             },
                                                             "suffix": {
-                                                                "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                                                                "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                                                                 "type": "string"
                                                             }
                                                         },
@@ -402,12 +402,12 @@
                                                                 "type": "string"
                                                             },
                                                             "style": {
-                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — render the value as a percentage.",
+                                                                "description": "Number formatting style.\n- `none` — no formatting.\n- `number` — thousands separators (e.g. `1,234`).\n- `short` — abbreviated large numbers (e.g. `1.2k`, `3.4M`).\n- `percent` — multiply the value by 100 and append a `%` sign, so pass a 0-1 ratio (`a / b`, not `100.0 * a / b`). Never pair it with a `%` suffix, which renders `47.3%%`.",
                                                                 "enum": ["none", "number", "short", "percent"],
                                                                 "type": "string"
                                                             },
                                                             "suffix": {
-                                                                "description": "Text appended to each value (e.g. `%` or ` ms`).",
+                                                                "description": "Text appended to each value (e.g. ` ms`). Leave unset when `style` is `percent`, which already appends the `%` sign.",
                                                                 "type": "string"
                                                             }
                                                         },


### PR DESCRIPTION
## Problem

Agents that build SQL insights format percentage columns wrong, and users see the result on the chart: a y-axis reading `47.3%%`, or values 100x too high.

`style: "percent"` on a `DataVisualizationNode` column does two things nothing told the agent about — it appends the `%` sign itself, and it multiplies the value by 100 before rendering. Its schema description said only "render the value as a percentage", and the `formatting-insight-axes` skill covered only `trendsFilter.aggregationAxisFormat` on trends insights. So an agent reasonably adds a literal `"%"` suffix on top, and feeds it a column its SQL already scaled with `100.0 *`.

Reported for a SQL insight in a PostHog Slack thread; the same pattern sits on other saved SQL insights.

## Changes

- Agents writing a SQL insight now read what `percent` actually does at the point they choose it: the `style` description states the `%` sign and the ×100 scaling and names the `47.3%%` failure, and `suffix` says to leave it unset for percent columns.
- The `formatting-insight-axes` skill now covers SQL insights — where per-column formatting lives (`chartSettings.yAxis[].settings.formatting`, and the table equivalent), a worked `DataVisualizationNode` example, and the two consistent shapes for a percentage column so an agent picks one instead of mixing them.
- The skill's frontmatter description names SQL insights and `DataVisualizationNode`, so it fires on that work rather than only on trends work.
- Its "updating an existing insight" rule now covers the SQL variant of the anti-pattern.
- Mechanical: `schema.json`, `posthog/schema.py`, the generated MCP tool schemas, and their snapshots are rebuilt from the source JSDoc. No behavior change — the formatter itself is untouched.

## How did you test this code?

No new tests. The change is documentation plus the generated artifacts that carry it; the runtime is unchanged.

The documented behavior was read off the implementation rather than assumed: `formatDataWithSettings` in `frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts` appends `%` for `style: 'percent'` and applies `suffix` after it, and the same file multiplies percent-styled values by 100 on the way in (chart series, table cells, and breakdown series).

`bin/build-schema-python.sh` was run to regenerate `posthog/schema.py`, so that file is generator output rather than hand-edited. The frontend and MCP artifacts were edited to match the source string exactly; `hogli build:schema` and `hogli lint:skills` were not run, since hogli is unavailable in this environment. CI's drift checks are the authority on both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app after a colleague reported a SQL insight rendering `%%` on its y-axis. The ×100 behavior turned up while reading the formatter to confirm the `%%` cause, and it is the more damaging half of the problem, so both are documented together.

The fix is deliberately in two places rather than one. The skill is what a coding agent loads when it decides how to build the insight; the schema description is what an agent reading the raw MCP tool schema sees at the moment it picks a `style`, which is where the earlier trends-only guidance failed to reach. Scope stayed inside the existing skill rather than a new one, per the "new trigger → new skill, more detail → existing skill" rule in `/writing-skills`.

Skills invoked: `/writing-skills`, `/writing-pr-descriptions` (repo guidance read directly), plus the repo PR template.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787740914126469?thread_ts=1787740914.126469&cid=C0ACRAMJUAG)*
