### PR TITLE
fix(frontend): keep esbuild dev watchers out of node_modules symlinks

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -617,8 +617,9 @@ export async function buildOrWatch(config) {
                     path.resolve(absWorkingDir, '../products/*/frontend/**/*'),
                 ],
                 {
-                    ignored: /.*(Type|\.test\.stories)\.[tj]sx?$/,
+                    ignored: [/.*(Type|\.test\.stories)\.[tj]sx?$/, /(^|[\/\\])node_modules([\/\\]|$)/],
                     ignoreInitial: true,
+                    followSymlinks: false,
                 }
             )
             .on('all', async (event, filePath) => {


### PR DESCRIPTION
## Problem

On Linux, the Vite dev server dies every few minutes and every open tab reload-loops with "Loading failed for the module" or `504 Outdated Optimize Dep`.

- The toolbar and workers watchers in `common/esbuilder` use chokidar with `followSymlinks` on by default.
- pnpm symlinks whole workspace packages into `common/*/node_modules` (storybook links the entire frontend package), so the watchers follow them into ~37k directories.
- Linux inotify watches on that tree exhaust the Node heap; the watcher process dies, `concurrently --kill-others-on-fail` takes Vite with it, and the process manager restarts the frontend with a new dep hash.
- macOS uses fsevents and never hits this, which is why it stayed hidden on dev machines. It shows up on every Linux dev stack, including cloud task sandboxes.

## Changes

- Vite stays up on Linux: the watchers no longer follow symlinks and ignore any `node_modules` path.
- Nothing user-visible changes on macOS. The watchers already only rebuild on source edits under `frontend/` and `products/*/frontend/`, which contain no symlinked packages.
