### PR TITLE
chore(tasks): bake protoc into the dev-stack image

### DIFF
--- a/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
+++ b/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
@@ -92,7 +92,7 @@ log "installing dev toolchain (brotli, phrocs, go, rust)"
 # process-manager resolution (phrocs), and the Go/Rust procs and rust/bin migrators
 # need their toolchains.
 apt-get update
-apt-get install -y --no-install-recommends brotli make
+apt-get install -y --no-install-recommends brotli make protobuf-compiler
 rm -rf /var/lib/apt/lists/*
 
 case "$(uname -m)" in


### PR DESCRIPTION
## Problem

On the prebaked `posthog-dev-stack` image, eight Rust services (`personhog-*`, `property-defs-rs`, `usage-ingestion`) never come up. `hogli start` restarts each one in a loop, and the box spends its CPU recompiling them.

- Their `build.rs` compiles protobuf definitions and needs the `protoc` binary.
- The bake installs the Rust toolchain but not `protobuf-compiler`, so every `cargo run` fails at the build script.

## Changes

- The Rust services start on dev-stack cloud runs: the bake installs `protobuf-compiler` next to `brotli` and `make`.
- Nothing changes for other images or for dev machines, where flox already provides `protoc`.
- Takes effect after the next image bake.

