### PR TITLE
fix(desktop): gate user spend limit requests

### DIFF
--- a/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.test.tsx
+++ b/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  enabled: false,
+  getUserSpendLimit: vi.fn(),
+  setUserSpendLimit: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => ({
+    getUserSpendLimit: mocks.getUserSpendLimit,
+    setUserSpendLimit: mocks.setUserSpendLimit,
+  }),
+}));
+
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: () => mocks.enabled,
+}));
+
+import { useSetUserSpendLimit, useUserSpendLimit } from "./useUserSpendLimit";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useUserSpendLimit", () => {
+  beforeEach(() => {
+    mocks.enabled = false;
+    mocks.getUserSpendLimit.mockReset();
+    mocks.setUserSpendLimit.mockReset();
+    mocks.getUserSpendLimit.mockResolvedValue({
+      available: true,
+      limitUsd: null,
+      windowSeconds: null,
+    });
+  });
+
+  it("does not call the endpoint while its rollout flag is off", () => {
+    renderHook(() => useUserSpendLimit(), { wrapper });
+
+    expect(mocks.getUserSpendLimit).not.toHaveBeenCalled();
+  });
+
+  it("calls the endpoint when its rollout flag is on", async () => {
+    mocks.enabled = true;
+
+    renderHook(() => useUserSpendLimit(), { wrapper });
+
+    await waitFor(() => expect(mocks.getUserSpendLimit).toHaveBeenCalledOnce());
+  });
+
+  it("does not write to the endpoint while its rollout flag is off", async () => {
+    const { result } = renderHook(() => useSetUserSpendLimit(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({ limitUsd: 10, windowSeconds: 60 }),
+    ).rejects.toThrow("Spend limits are not available yet");
+
+    expect(mocks.setUserSpendLimit).not.toHaveBeenCalled();
+  });
+});

--- a/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.test.tsx
+++ b/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.test.tsx
@@ -62,7 +62,11 @@ describe("useUserSpendLimit", () => {
 
     await expect(
       result.current.mutateAsync({ limitUsd: 10, windowSeconds: 60 }),
-    ).rejects.toThrow("Spend limits are not available yet");
+    ).resolves.toEqual({
+      available: false,
+      limitUsd: null,
+      windowSeconds: null,
+    });
 
     expect(mocks.setUserSpendLimit).not.toHaveBeenCalled();
   });

--- a/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.ts
+++ b/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.ts
@@ -1,7 +1,10 @@
 import type { UserSpendLimit } from "@posthog/api-client/spend-limit";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export const USER_SPEND_LIMIT_FLAG = "ai-gateway-user-spend-limit";
 
 export const USER_SPEND_LIMIT_QUERY_KEY = [
   "billing",
@@ -11,13 +14,16 @@ export const USER_SPEND_LIMIT_QUERY_KEY = [
 /** The stop line the gateway holds, which is what actually refuses spend. */
 export function useUserSpendLimit() {
   const client = useOptionalAuthenticatedClient();
+  const enabled = useFeatureFlag(USER_SPEND_LIMIT_FLAG);
   return useQuery({
     queryKey: USER_SPEND_LIMIT_QUERY_KEY,
     queryFn: () => {
       if (!client) throw new Error("Not authenticated");
       return client.getUserSpendLimit();
     },
-    enabled: client !== null,
+    // This endpoint can arrive independently of Desktop. Do not request it
+    // until its production deployment has been verified.
+    enabled: client !== null && enabled,
     staleTime: 60_000,
     retry: false,
     // The stop limit is per user: drop it on any auth transition so a new
@@ -33,6 +39,7 @@ export function useUserSpendLimit() {
  */
 export function useSetUserSpendLimit() {
   const client = useOptionalAuthenticatedClient();
+  const enabled = useFeatureFlag(USER_SPEND_LIMIT_FLAG);
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: {
@@ -40,6 +47,7 @@ export function useSetUserSpendLimit() {
       windowSeconds: number;
     }): Promise<UserSpendLimit> => {
       if (!client) throw new Error("Not authenticated");
+      if (!enabled) throw new Error("Spend limits are not available yet");
       return input.limitUsd === null
         ? client.clearUserSpendLimit()
         : client.setUserSpendLimit(input.limitUsd, input.windowSeconds);

--- a/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.ts
+++ b/products/desktop/packages/ui/src/features/billing/useUserSpendLimit.ts
@@ -47,7 +47,13 @@ export function useSetUserSpendLimit() {
       windowSeconds: number;
     }): Promise<UserSpendLimit> => {
       if (!client) throw new Error("Not authenticated");
-      if (!enabled) throw new Error("Spend limits are not available yet");
+      if (!enabled) {
+        return Promise.resolve({
+          available: false,
+          limitUsd: null,
+          windowSeconds: null,
+        });
+      }
       return input.limitUsd === null
         ? client.clearUserSpendLimit()
         : client.setUserSpendLimit(input.limitUsd, input.windowSeconds);

--- a/products/desktop/packages/ui/src/features/settings/sections/SpendLimitsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SpendLimitsSettings.tsx
@@ -11,10 +11,12 @@ import {
   useSpendTotals,
 } from "@posthog/ui/features/billing/useSpendTotals";
 import {
+  USER_SPEND_LIMIT_FLAG,
   USER_SPEND_LIMIT_QUERY_KEY,
   useSetUserSpendLimit,
   useUserSpendLimit,
 } from "@posthog/ui/features/billing/useUserSpendLimit";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SettingsSubsection } from "@posthog/ui/features/settings/components/SettingsSubsection";
 import { SpendLimitCard } from "@posthog/ui/features/settings/sections/SpendLimitCard";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
@@ -30,6 +32,7 @@ import { useEffect } from "react";
 const MONTH_WINDOW_SECONDS = 30 * 24 * 60 * 60;
 
 export function SpendLimitsSettings() {
+  const enabled = useFeatureFlag(USER_SPEND_LIMIT_FLAG);
   const spendLimits = useSettingsStore((state) => state.spendLimits);
   const setSpendLimits = useSettingsStore((state) => state.setSpendLimits);
   const totals = useSpendTotals();
@@ -80,6 +83,10 @@ export function SpendLimitsSettings() {
       },
     );
   };
+
+  if (!enabled) {
+    return null;
+  }
 
   return (
     <SpendLimitsSettingsView


### PR DESCRIPTION
## Problem

People using Desktop can encounter a failed spend-limit request before the supporting API is available.

**Why:** A controlled rollout keeps the setting usable without relying on backend deployment timing.

## Changes

- Gate spend-limit reads and writes behind the disabled-by-default rollout flag.
- Add regression coverage for enabled and disabled request behavior.

## How did you test this code?

- Ran the focused UI hook test and the UI package typecheck.
- Did not run the repository preflight helper because it is unavailable in this environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update: this is a temporary rollout guard.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with PostHog Desktop. Used the feature-flag instrumentation guidance. The change gates both reads and writes and adds regression coverage. No private incident or customer data is included.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*