### PR TITLE
fix(ci): Re-use the cached schema dump on sandbox-image builds

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -81,6 +81,85 @@ jobs:
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # The schema cache key is computed from the merge base, which depth 1
+                  # cannot reach. Blob-less keeps the deeper clone cheap.
+                  fetch-depth: 1000
+                  filter: blob:none
+
+            - name: Fetch base branch for merge-base computation
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              # Scoped, blob-less, no-tags: without an explicit refspec, git fetch
+              # falls back to remote.origin.fetch and pulls every branch.
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+            - name: Compute schema cache keys
+              id: schema-key
+              # Restores the schema dump ci-backend saves on master pushes, so the
+              # migrate step below only tops up what is newer instead of replaying the
+              # full migration history. On a PR the migration-set key is the merge-base's;
+              # on a master push it is HEAD's. A cache miss falls through to a full
+              # migrate, so an absent or wrong key is never a correctness risk.
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  IS_PUSH: ${{ github.event_name != 'pull_request' }}
+                  # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
+                  # ci-backend.yml, which saves these caches on master pushes.
+                  SCHEMA_CACHE_EPOCH: v2
+              run: |
+                  if [ "$IS_PUSH" = "true" ]; then
+                      # Pushed commit is checked out directly: no merge commit, no base ref.
+                      # The per-SHA key would point at this same push's cache (saved
+                      # concurrently by ci-backend, so racy); rely on the stable
+                      # migration-set key below.
+                      REF=HEAD
+                  else
+                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                      MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                      if [ -z "$MERGE_BASE" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::merge-base not found (branch too stale?), so the schema cache is skipped"
+                          exit 0
+                      fi
+                      # Routing decides which app labels reach the dump, so an edited routing
+                      # config matches no master dump: drop both keys and migrate from scratch.
+                      DB_ROUTING_BASE=$(git ls-tree -r --format='%(objectname) %(path)' "$MERGE_BASE" -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                      DB_ROUTING_HEAD=$(git ls-tree -r --format='%(objectname) %(path)' HEAD -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                      if [ "$DB_ROUTING_BASE" != "$DB_ROUTING_HEAD" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::db routing config or router differs from the merge base, so the schema cache is skipped"
+                          exit 0
+                      fi
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                      REF="$MERGE_BASE"
+                  fi
+                  # Last-resort restore prefix: matches the newest saved dump when the exact
+                  # keys miss. Gated on checkout age because a re-run of an old commit could
+                  # restore a dump newer than its code, which forward-only migrate cannot repair.
+                  HEAD_AGE_SECONDS=$(( $(date +%s) - $(git show -s --format=%ct HEAD) ))
+                  if [ "$HEAD_AGE_SECONDS" -lt 86400 ]; then
+                      echo "prefix_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-" >> $GITHUB_OUTPUT
+                  fi
+                  # Must match ci-backend.yml's save-side computation byte for byte or the key never hits.
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$REF" \
+                      | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
+                      | grep -vE '/(clickhouse|async_migrations)/migrations/' \
+                      | LC_ALL=C sort) || true
+                  # Routing decides which app labels are in the dump, so these inputs belong in the key.
+                  DB_ROUTING=$(git ls-tree -r --format='%(objectname) %(path)' "$REF" -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                  PG_IMAGE=$(git show "${REF}:docker-compose.base.yml" 2>/dev/null \
+                      | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
+                  if [ -z "$MIG_FILES" ]; then
+                      echo "migrations_key=" >> $GITHUB_OUTPUT
+                      echo "::notice::no migration files matched, so restore falls back to the SHA schema key"
+                  else
+                      MIG_HASH=$(printf '%s\n%s\n%s' "$MIG_FILES" "$PG_IMAGE" "$DB_ROUTING" | sha256sum | cut -c1-40)
+                      echo "migrations_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-${MIG_HASH}" >> $GITHUB_OUTPUT
+                  fi
 
             - name: Start Docker services
               env:
@@ -123,6 +202,41 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
               run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              if: steps.schema-key.outputs.migrations_key != '' || steps.schema-key.outputs.key != ''
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  # Prefer the shared content key; fall back to the exact merge-base SHA
+                  # key, then to the newest dump of any migration set.
+                  key: ${{ steps.schema-key.outputs.migrations_key || steps.schema-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.schema-key.outputs.key }}
+                      ${{ steps.schema-key.outputs.prefix_key }}
+
+            - name: Prime posthog from cached schema
+              # db:restore-schema-fresh restores the dump and seeds the RunPython data a
+              # schema-only dump lacks; the migrate step below layers anything newer on
+              # top. On failure it leaves a fresh empty db, so migrate runs the full history.
+              env:
+                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+                  REDIS_URL: 'redis://localhost'
+                  OBJECT_STORAGE_ENABLED: 'False'
+                  TEST: 1
+                  DEBUG: 1
+                  TARGET_DB: posthog
+              run: |
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss, so the migrate step below runs the full history"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ! ./bin/hogli db:restore-schema-fresh; then
+                      echo "::warning::Schema restore failed (stale or incompatible cached dump?), so the migrate step below runs the full history"
+                  fi
 
             - name: Run migrations
               env:


### PR DESCRIPTION
## Problem

Anyone whose PR touches the sandbox paths gets a red `Sandbox Base Image Pass` check that no change to their branch can fix.

- The `build_skills` job replays the full Django migration history against an empty Postgres. That step reached 28 minutes on [this run](https://github.com/PostHog/posthog/actions/runs/32948514314/job/98114593288), against the job's 30-minute cap.
- 10 of the 16 recent runs that actually execute the job time out. Every failure lands between 30m15s and 30m20s.
- Three of those failures are pushes to master ([1](https://github.com/PostHog/posthog/actions/runs/32947688666), [2](https://github.com/PostHog/posthog/actions/runs/32908528852), [3](https://github.com/PostHog/posthog/actions/runs/32884850677)). A timeout there skips `Build and push Tasks Sandbox container image`, so the `:master` sandbox image never gets published.
- The workflow still looks healthy, because its paths filter matches rarely and most runs skip the job entirely.

| Outcome | Runs | Durations |
| --- | --- | --- |
| Success | 6 | 22m31s to 29m51s |
| Timeout | 10 | 30m15s to 30m20s |

The slowest success cleared the cap by nine seconds, so the job fails on runner speed rather than on anything in the diff under test.

## Changes

- The sandbox image publishes again on master pushes, because the migrate step now fits inside the job's budget.
- `build_skills` restores the schema dump that `ci-backend` saves on master pushes, then migrates on top of it. The three steps are ported from `ci-agent-skills.yml`.
- A cache miss falls through to the full migrate, so the restore never risks correctness.
- Checkout moves to `fetch-depth: 1000` with `filter: blob:none`. The cache key comes from the merge base, which depth 1 cannot reach.
- `workflow_dispatch` now takes the push path. The source workflow tests `event_name == 'push'`, which sends a dispatch into a merge-base lookup that cannot succeed.
- Nothing a product user sees changes. This is CI wiring only.

Raising `timeout-minutes` was the obvious alternative. It buys time against a step that grows with every migration merged, and `/authoring-ci-workflows` already requires the schema restore for any job that migrates a fresh Postgres.

Before:

```mermaid
flowchart TD
    A[Wait for Docker services] --> B[Run migrations: full history, 28 min]
    B --> C[Build skills]
    C --> D[Push sandbox image]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class B phRed;
    class A,C phGray;
    class D phYellow;
```

After:

```mermaid
flowchart TD
    A[Wait for Docker services] --> B[Restore schema cache from master]
    B --> C[Prime posthog from cached schema]
    C --> D[Run migrations: top-up only]
    D --> E[Build skills]
    E --> F[Push sandbox image]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class B,C phBlue;
    class A,D,E phGray;
    class F phYellow;
```

## How did you test this code?

- `hogli lint:workflows` passes: 8 checks across 128 workflows.
- `actionlint` reports the same 5 findings before and after this change. They are pre-existing, and they come from the local binary being older than the version CI pins.
- Not run: the workflow itself. A schema-cache hit only happens in CI, so this PR's own `Build agent skills from source` run is the test. Watch its migrate step drop from ~28 minutes to seconds.
- No new tests. The change adds no code paths that a unit test can reach.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, directed by @sinan-ku. Skills invoked: `/authoring-ci-workflows` and `/writing-pr-descriptions`.

The investigation started from one red check on an unrelated notebooks PR. Reading the job log ruled out that PR's own migration, which applied in 0.6 seconds, and a sweep of 120 workflow runs showed the same timeout on five other branches and on master.

The first plan was to raise `timeout-minutes` and port the schema cache behind it. `/authoring-ci-workflows` rules that out: it requires the schema restore for any job running `manage.py migrate` against a fresh Postgres, and cites this job's own timeout as the example. The timeout bump was dropped and only the restore shipped.

Public artifact: nothing here draws on anything outside this repository and its public CI runs.
