### PR TITLE
fix(clerk): skip the domains table when the feature is off instead of failing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
@@ -75,7 +75,16 @@ CLERK_ENDPOINTS: dict[str, ClerkEndpointConfig] = {
         is_wrapped_response=True,
         gated_feature="Restrictions (the allow-list and block-list)",
     ),
-    "domains": ClerkEndpointConfig(name="domains", path="/domains", partition_key=None, is_wrapped_response=True),
+    "domains": ClerkEndpointConfig(
+        name="domains",
+        path="/domains",
+        partition_key=None,
+        is_wrapped_response=True,
+        # Clerk answers 404 resource_not_found for the domains list on instances that don't have the
+        # feature switched on — the same feature-off signal the OAuth applications and Restrictions
+        # endpoints give. Skip zero rows instead of failing the schema every run.
+        gated_feature="Satellite domains",
+    ),
     "saml_connections": ClerkEndpointConfig(
         name="saml_connections", path="/saml_connections", is_wrapped_response=True
     ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -522,6 +522,8 @@ class TestClerkFeatureGatedEndpoints:
             ("allowlist_identifiers", 404, {"errors": [{"code": "resource_not_found"}]}),
             # OAuth applications off: the list endpoint answers the same 404 resource_not_found.
             ("oauth_applications", 404, {"errors": [{"code": "resource_not_found"}]}),
+            # Domains feature off: the list endpoint answers the same 404 resource_not_found.
+            ("domains", 404, {"errors": [{"code": "resource_not_found"}]}),
         ],
     )
     def test_feature_not_enabled_syncs_no_rows_instead_of_failing(


### PR DESCRIPTION
## Problem

- Teams syncing the Clerk source's `domains` table see the table fail every run when their Clerk instance doesn't have the domains feature switched on.
- Clerk answers those instances with a 404 `resource_not_found` for the `/domains` list endpoint. The `domains` schema had no feature gate, so that 404 failed the whole schema, retried to the activity limit, and surfaced a raw HTTP error with the request URL.
- Clerk's OAuth applications and Restrictions endpoints already give the same 404 signal and are handled; `domains` was the one gated-list endpoint that still fell through.

## Changes

- The `domains` table now syncs zero rows and logs the feature name when Clerk reports the feature is off, instead of failing the schema and retrying. This is the visible fix.
- Mechanical: adds `gated_feature="Satellite domains"` to the `domains` endpoint config, routing it through the existing `_skip_when_feature_disabled` path that already recognizes a 404 `resource_not_found` on a gated endpoint.

## How did you test this code?

- Extended the parameterized `TestClerkFeatureGatedEndpoints.test_feature_not_enabled_syncs_no_rows_instead_of_failing` with a `domains` 404 `resource_not_found` case — it asserts the table skips (logs the feature name) rather than raising. The sibling `test_other_errors_still_fail_the_sync` cases keep an unrelated 404 code failing the sync, so the skip stays scoped to the feature-off signal.
- Ran `TestClerkFeatureGatedEndpoints` locally: 11 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code (Opus 4.8) while triaging a batch of data-warehouse sync failure classes.
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The `domains` failure was one class in that triage. The chosen fix mirrors the in-repo `oauth_applications` precedent (same 404 `resource_not_found` signal), rather than adding a non-retryable error mapping — gating makes the table degrade to zero rows without disabling the schema, which matches how Clerk reports an unprovisioned feature.
- Public artifact: no material from the session is embedded. The failing customer's values were not used; the test asserts on an invented 404 body shape already used by the sibling cases.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
