### PR TITLE
feat(deletions): let deletes_job sweep a table on another cluster

### DIFF
--- a/docs/internal/clickhouse-deletion-coverage.md
+++ b/docs/internal/clickhouse-deletion-coverage.md
@@ -54,12 +54,27 @@ Sweeps that iterate placements dispatch each target over `placement.cluster.shar
 
 - `delete_person_events_op`
 - `execute_event_deletion`, immediate mode
+- `deletes_job` → `delete_events`, which also has to put its dictionaries on the second cluster; see below
 
 The rest are bound to a single handle and refuse rather than skip when a target has moved off it (`dispatchable_here`, `UnreachableTargetError`):
 
 - Property removal. Its staging table is host-local and its fan-out is one op per shard of one cluster.
 - The deferred queue fill. Both halves of its `INSERT` are host-local: the source table it reads and the `adhoc_events_deletion` queue it writes.
-- `deletes_job`. Its mutation predicate joins a pending-deletes dictionary that would have to be bootstrapped on the second cluster first — created, populated from Postgres, replicated, loaded and checksum-verified.
+
+### Getting the dictionaries onto the second cluster
+
+`delete_events` does not name the rows it removes. Its predicate joins two dictionaries, `pending_deletes_<timestamp>_dictionary` and `adhoc_events_deletion_dictionary`, so a mutation cannot run anywhere those are absent.
+
+Both reach every host of one cluster because their source table is replicated, and replication is exactly what a cluster boundary stops: a cluster with its own Keeper can never join that replica set.
+`adhoc_events_deletion` compounds it, being migration-managed and present only on the main cluster.
+
+So the rows are staged instead. One Parquet object per dictionary per run, written by the cluster itself with `INSERT INTO FUNCTION s3(...)`, and every host on the other cluster loads it through `SOURCE(CLICKHOUSE(QUERY 'SELECT ... FROM s3(...)'))`.
+ClickHouse has no S3 dictionary source, but that source runs its query locally, and the query can read anything the server can.
+
+- Nothing changes on a deployment where every target sits on the cluster the job connects to. The handle in hand is probed first, and no object is written.
+- The source tables stay where they are. `pending_deletes_<timestamp>` also carries the Postgres `AsyncDeletion` row ids that `mark_deletions_verified` reads back, and those never enter a dictionary.
+- `load_and_verify_deletes_dictionary` loads on every host of every cluster and fails the run unless all of them checksum alike. That is what catches a stale or missing object: without it the mutation there joins an empty dictionary, deletes nothing, and reports success.
+- Retention belongs to the bucket lifecycle policy, set through `DELETES_DICTIONARY_S3_*`. Nothing deletes the objects.
 
 ## Covered tables
 

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -28,7 +28,7 @@ from posthog.clickhouse.plugin_log_entries import PLUGIN_LOG_ENTRIES_TABLE
 from posthog.dags.common import JobOwners
 from posthog.dags.person_overrides import squash_person_overrides
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-from posthog.models.deletion_targets import personal_data_tables
+from posthog.models.deletion_targets import resolve_placements, sweep_clusters
 from posthog.models.event.deletion import events_data_tables
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.group.sql import GROUPS_TABLE
@@ -106,6 +106,10 @@ class MonthlyCleanupConfig(dagster.Config):
 
 
 ShardMutations = dict[int, MutationWaiters]
+# Shard numbers are per cluster, so a sweep spanning two of them cannot key its waiters by shard
+# alone. Keyed by cluster name rather than by handle: the handle is recovered with
+# ClickhouseCluster.sibling, which is memoized, and a name survives the op boundary.
+ClusterShardMutations = dict[str, ShardMutations]
 
 
 @dataclass
@@ -226,6 +230,57 @@ class AdhocEventDeletesTable(Table):
         client.execute(f"OPTIMIZE TABLE {self.qualified_name} FINAL")
 
 
+def _dictionary_s3_args(key: str, structure: str) -> str:
+    """Argument list for a ClickHouse ``s3(...)`` call over a staged dictionary payload.
+
+    Credentials are emitted only where an endpoint is configured, which is local, dev and test
+    object storage. On prod the endpoint is empty and the cluster reaches the bucket through its
+    attached IAM role, so no secret is ever interpolated into SQL.
+    """
+    path = f"{settings.DELETES_DICTIONARY_S3_PREFIX}/{key}"
+    endpoint = settings.DELETES_DICTIONARY_S3_ENDPOINT
+    if endpoint:
+        url = f"{endpoint}/{settings.DELETES_DICTIONARY_S3_BUCKET}/{path}"
+        creds = f"'{settings.OBJECT_STORAGE_ACCESS_KEY_ID}', '{settings.OBJECT_STORAGE_SECRET_ACCESS_KEY}', "
+    else:
+        bucket = settings.DELETES_DICTIONARY_S3_BUCKET
+        url = f"https://{bucket}.s3.{settings.DELETES_DICTIONARY_S3_REGION}.amazonaws.com/{path}"
+        creds = ""
+    # The structure sits inside a single-quoted SQL literal, so escape the quotes in a type like
+    # DateTime64(6, 'UTC') or they terminate the literal early.
+    escaped = " ".join(structure.split()).replace("'", "\\'")
+    return f"'{url}', {creds}'Parquet', '{escaped}'"
+
+
+@dataclass(frozen=True, kw_only=True)
+class StagedDictionary:
+    """A dictionary's rows copied to one Parquet object, for clusters that share no Keeper.
+
+    A dictionary's source table reaches every host of one cluster by replication, and replication
+    is exactly what a cluster boundary stops: a cluster with its own Keeper can never join that
+    replica set. An object each host reads for itself crosses the boundary instead, and both sides
+    load identical bytes, which is what makes comparing their checksums meaningful.
+    """
+
+    key: str
+    columns: str
+    structure: str
+
+    @property
+    def __args(self) -> str:
+        return _dictionary_s3_args(self.key, self.structure)
+
+    @property
+    def query(self) -> str:
+        """The dictionary SOURCE query, for hosts that cannot see the source table."""
+        return f"SELECT {self.columns} FROM s3({self.__args})"
+
+    def export(self, client: Client, source_query: str) -> None:
+        # Truncate rather than append: a retried run has to leave the object holding this run's
+        # rows alone, or the two clusters load different data and the checksum gate fails.
+        client.execute(f"INSERT INTO FUNCTION s3({self.__args}) {source_query} SETTINGS s3_truncate_on_insert=1")
+
+
 @dataclass
 class Dictionary(abc.ABC):
     source: Table
@@ -244,7 +299,20 @@ class Dictionary(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
+    def create(
+        self,
+        client: Client,
+        shards: int,
+        max_execution_time: int,
+        max_memory_usage: int,
+        query: str | None = None,
+    ) -> None:
+        """``query`` overrides the SOURCE query, for a host that cannot see the source table."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def staged(self, run_key: str) -> StagedDictionary:
+        """Where this dictionary's rows go so another cluster can load them; see StagedDictionary."""
         raise NotImplementedError()
 
     def exists(self, client: Client) -> bool:
@@ -300,7 +368,21 @@ class PendingDeletesDictionary(Dictionary):
     def query(self) -> str:
         return f"SELECT team_id, deletion_type, key, created_at FROM {self.source.qualified_name}"
 
-    def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
+    def staged(self, run_key: str) -> StagedDictionary:
+        return StagedDictionary(
+            key=f"{run_key}/pending_deletes.parquet",
+            columns="team_id, deletion_type, key, created_at",
+            structure="team_id Int64, deletion_type UInt8, key String, created_at DateTime",
+        )
+
+    def create(
+        self,
+        client: Client,
+        shards: int,
+        max_execution_time: int,
+        max_memory_usage: int,
+        query: str | None = None,
+    ) -> None:
         client.execute(
             f"""
             CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} (
@@ -319,7 +401,7 @@ class PendingDeletesDictionary(Dictionary):
                 "database": settings.CLICKHOUSE_DATABASE,
                 "user": settings.CLICKHOUSE_USER,
                 "password": settings.CLICKHOUSE_PASSWORD,
-                "query": self.query,
+                "query": query or self.query,
             },
         )
 
@@ -342,7 +424,21 @@ class AdhocEventDeletesDictionary(Dictionary):
     def query(self) -> str:
         return f"SELECT team_id, uuid, created_at FROM {self.source.qualified_name} WHERE (team_id, uuid) not in (SELECT team_id, uuid FROM {self.source.qualified_name} WHERE is_deleted = 1)"
 
-    def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
+    def staged(self, run_key: str) -> StagedDictionary:
+        return StagedDictionary(
+            key=f"{run_key}/adhoc_event_deletes.parquet",
+            columns="team_id, uuid, created_at",
+            structure="team_id Int64, uuid UUID, created_at DateTime64(6, 'UTC')",
+        )
+
+    def create(
+        self,
+        client: Client,
+        shards: int,
+        max_execution_time: int,
+        max_memory_usage: int,
+        query: str | None = None,
+    ) -> None:
         client.execute(
             f"""
             CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} (
@@ -360,7 +456,7 @@ class AdhocEventDeletesDictionary(Dictionary):
                 "database": settings.CLICKHOUSE_DATABASE,
                 "user": settings.CLICKHOUSE_USER,
                 "password": settings.CLICKHOUSE_PASSWORD,
-                "query": self.query,
+                "query": query or self.query,
             },
         )
 
@@ -457,8 +553,61 @@ def load_pending_deletions(
     return create_pending_deletions_table
 
 
+def _create_dictionary_everywhere(
+    context: dagster.OpExecutionContext,
+    cluster: ClickhouseCluster,
+    config: DeleteConfig,
+    dictionary: Dictionary,
+) -> None:
+    """Create ``dictionary`` on every cluster the delete mutations will run on.
+
+    The handle in hand reads its own replicated source table. A cluster that shares no Keeper with
+    it cannot see that table at all, so the rows are staged to S3 first and every host there loads
+    the object for itself.
+    """
+    create = partial(
+        dictionary.create,
+        shards=config.shards,
+        max_execution_time=config.max_execution_time,
+        max_memory_usage=config.max_memory_usage,
+    )
+    cluster.map_all_hosts(create).result()
+
+    siblings = [handle for handle in sweep_clusters(cluster) if handle is not cluster]
+    if not siblings:
+        return
+
+    staged = dictionary.staged(context.run_id)
+    cluster.any_host_by_role(partial(staged.export, source_query=dictionary.query), NodeRole.DATA).result()
+    for sibling in siblings:
+        sibling.map_all_hosts(partial(create, query=staged.query)).result()
+
+    context.log.info(
+        f"Staged {dictionary.name} to {staged.key} for {[sibling.data_cluster_name for sibling in siblings]}"
+    )
+
+
+def _load_and_verify_everywhere(cluster: ClickhouseCluster, dictionary: Dictionary) -> None:
+    """Load ``dictionary`` on every host of every cluster, and prove they all hold the same rows.
+
+    Comparing checksums across clusters is what catches a stale or missing staged object. Without
+    it the mutation there runs against an empty dictionary, deletes nothing, and reports success.
+    """
+    by_cluster: dict[str, set[int]] = {}
+    for handle in sweep_clusters(cluster):
+        results = handle.map_all_hosts(dictionary.load, concurrency=1).result()
+        by_cluster[handle.data_cluster_name] = set(results.values())
+
+    if len({checksum for checksums in by_cluster.values() for checksum in checksums}) != 1:
+        raise dagster.Failure(
+            description=f"{dictionary.name} does not hold the same rows on every host: "
+            + ", ".join(f"{name}={sorted(checksums)}" for name, checksums in by_cluster.items())
+        )
+
+
 @dagster.op
 def create_deletes_dict(
+    context: dagster.OpExecutionContext,
     load_pending_deletions: PendingDeletesTable,
     config: DeleteConfig,
     cluster: dagster.ResourceParam[ClickhouseCluster],
@@ -475,14 +624,7 @@ def create_deletes_dict(
         source=load_pending_deletions,
     )
 
-    cluster.map_all_hosts(
-        partial(
-            del_dict.create,
-            shards=config.shards,
-            max_execution_time=config.max_execution_time,
-            max_memory_usage=config.max_memory_usage,
-        )
-    ).result()
+    _create_dictionary_everywhere(context, cluster, config, del_dict)
     return del_dict
 
 
@@ -506,14 +648,7 @@ def create_adhoc_event_deletes_dict(
         source=adhoc_event_deletions,
     )
 
-    cluster.map_all_hosts(
-        partial(
-            del_dict.create,
-            shards=config.shards,
-            max_execution_time=config.max_execution_time,
-            max_memory_usage=config.max_memory_usage,
-        )
-    ).result()
+    _create_dictionary_everywhere(context, cluster, config, del_dict)
 
     # The dictionary holds identical data on every host, so count the loaded ids on a single
     # data node (verifying replica identity is the job of load_and_verify_adhoc_event_deletes_dictionary).
@@ -538,9 +673,8 @@ def load_and_verify_deletes_dictionary(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     dictionary: PendingDeletesDictionary,
 ) -> PendingDeletesDictionary:
-    """Load the dictionary data on all hosts in the cluster, and ensure all hosts have identical data."""
-    checksums = cluster.map_all_hosts(dictionary.load, concurrency=1).result()
-    assert len(set(checksums.values())) == 1
+    """Load the dictionary on every host of every cluster the mutations run on, and verify it."""
+    _load_and_verify_everywhere(cluster, dictionary)
     return dictionary
 
 
@@ -549,9 +683,8 @@ def load_and_verify_adhoc_event_deletes_dictionary(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     dictionary: AdhocEventDeletesDictionary,
 ) -> AdhocEventDeletesDictionary:
-    """Load the dictionary data on all hosts in the cluster, and ensure all hosts have identical data."""
-    checksums = cluster.map_all_hosts(dictionary.load, concurrency=1).result()
-    assert len(set(checksums.values())) == 1
+    """Load the dictionary on every host of every cluster the mutations run on, and verify it."""
+    _load_and_verify_everywhere(cluster, dictionary)
     return dictionary
 
 
@@ -561,8 +694,8 @@ def delete_events(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     load_and_verify_deletes_dictionary: PendingDeletesDictionary,
     load_and_verify_adhoc_event_deletes_dictionary: AdhocEventDeletesDictionary,
-) -> tuple[PendingDeletesDictionary, ShardMutations]:
-    """Delete events from sharded_events table for pending deletions."""
+) -> tuple[PendingDeletesDictionary, ClusterShardMutations]:
+    """Delete events from every personal-data table, on whichever cluster stores each one."""
 
     def count_pending_deletes(client: Client) -> int:
         result = client.execute(
@@ -605,35 +738,44 @@ def delete_events(
     # Every registered target must get this delete, or rows survive on the table that got skipped.
     # The predicate below reads only team_id, person_id, timestamp and uuid, which every target
     # declares, so it applies unchanged to all of them.
+    placements = resolve_placements(cluster)
     delete_mutation_runners = [
-        LightweightDeleteMutationRunner(
-            table=table,
-            predicate="""or(
+        (
+            placement,
+            LightweightDeleteMutationRunner(
+                table=placement.target.data_table,
+                predicate="""or(
             (dictHas(%(pending_deletes_dictionary)s, (team_id, %(person_deletion_type)s, person_id)) AND timestamp <= dictGet(%(pending_deletes_dictionary)s, 'created_at', (team_id, %(person_deletion_type)s, person_id))),
             (dictHas(%(pending_deletes_dictionary)s, (team_id, %(team_deletion_type)s, team_id))),
             (dictHas(%(adhoc_event_deletes_dictionary)s, (team_id, uuid)))
         )
         """,
-            parameters={
-                "pending_deletes_dictionary": load_and_verify_deletes_dictionary.qualified_name,
-                "person_deletion_type": DeletionType.Person,
-                "team_deletion_type": DeletionType.Team,
-                "adhoc_event_deletes_dictionary": load_and_verify_adhoc_event_deletes_dictionary.qualified_name,
-            },
+                parameters={
+                    "pending_deletes_dictionary": load_and_verify_deletes_dictionary.qualified_name,
+                    "person_deletion_type": DeletionType.Person,
+                    "team_deletion_type": DeletionType.Team,
+                    "adhoc_event_deletes_dictionary": load_and_verify_adhoc_event_deletes_dictionary.qualified_name,
+                },
+            ),
         )
-        for table in personal_data_tables(cluster)
+        for placement in placements
     ]
 
-    shard_waiters: dict[int, list[MutationWaiter]] = {}
-    for delete_mutation_runner in delete_mutation_runners:
-        for host, mutation in cluster.map_one_host_per_shard(delete_mutation_runner).result().items():
+    waiters: dict[str, dict[int, list[MutationWaiter]]] = {}
+    for placement, delete_mutation_runner in delete_mutation_runners:
+        # placement.cluster, not the job's handle: the dictionary the predicate joins was created
+        # on every cluster here, but the storage table only exists on this one.
+        for host, mutation in placement.cluster.map_one_host_per_shard(delete_mutation_runner).result().items():
             if host.shard_num is not None:
-                shard_waiters.setdefault(host.shard_num, []).append(mutation)
-    shard_mutations: ShardMutations = {
-        shard_num: MutationWaiters(waiters=waiters) for shard_num, waiters in shard_waiters.items()
+                by_shard = waiters.setdefault(placement.cluster.data_cluster_name, {})
+                by_shard.setdefault(host.shard_num, []).append(mutation)
+
+    cluster_mutations: ClusterShardMutations = {
+        name: {shard_num: MutationWaiters(waiters=shard_waiters) for shard_num, shard_waiters in by_shard.items()}
+        for name, by_shard in waiters.items()
     }
 
-    return (load_and_verify_deletes_dictionary, shard_mutations)
+    return (load_and_verify_deletes_dictionary, cluster_mutations)
 
 
 def delete_team_data(
@@ -713,11 +855,13 @@ def delete_team_data_from(
 def wait_for_delete_mutations_in_shards(
     context: dagster.OpExecutionContext,
     cluster: dagster.ResourceParam[ClickhouseCluster],
-    delete_mutations: tuple[PendingDeletesDictionary, ShardMutations],
+    delete_mutations: tuple[PendingDeletesDictionary, ClusterShardMutations],
 ) -> PendingDeletesDictionary:
-    pending_deletes_dict, shard_mutations = delete_mutations
+    pending_deletes_dict, cluster_mutations = delete_mutations
 
-    cluster.map_all_hosts_in_shards({shard: mutation.wait for shard, mutation in shard_mutations.items()}).result()
+    for cluster_name, shard_mutations in cluster_mutations.items():
+        handle = cluster.sibling(cluster_name)
+        handle.map_all_hosts_in_shards({shard: mutation.wait for shard, mutation in shard_mutations.items()}).result()
 
     return pending_deletes_dict
 
@@ -783,11 +927,13 @@ def cleanup_delete_assets(
         dagster.get_dagster_logger().info("Skipping cleanup as cleanup is disabled")
         return True
 
-    # Must drop dict first
-    cluster.map_all_hosts(resources.pending_deletions_dictionary.drop).result()
-    cluster.map_all_hosts(resources.pending_deletions_dictionary.source.drop).result()
+    # Must drop dict first. Every cluster the mutations ran on carries a copy of each dictionary;
+    # only the job's own cluster carries the source table the staged object was exported from.
+    for handle in sweep_clusters(cluster):
+        handle.map_all_hosts(resources.pending_deletions_dictionary.drop).result()
+        handle.map_all_hosts(resources.adhoc_event_deletes_dictionary.drop).result()
 
-    cluster.map_all_hosts(resources.adhoc_event_deletes_dictionary.drop).result()
+    cluster.map_all_hosts(resources.pending_deletions_dictionary.source.drop).result()
     cluster.any_host_by_role(
         resources.adhoc_event_deletes_dictionary.source.optimize, NodeRole.DATA, Workload.ONLINE
     ).result()

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -27,6 +27,7 @@ from posthog.clickhouse.cluster import (
 from posthog.clickhouse.plugin_log_entries import PLUGIN_LOG_ENTRIES_TABLE
 from posthog.dags.common import JobOwners
 from posthog.dags.person_overrides import squash_person_overrides
+from posthog.dataclasses import frozen
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.deletion_targets import resolve_placements, sweep_clusters
 from posthog.models.event.deletion import events_data_tables
@@ -281,7 +282,7 @@ class StagedDictionary:
         client.execute(f"INSERT INTO FUNCTION s3({self.__args}) {source_query} SETTINGS s3_truncate_on_insert=1")
 
 
-@dataclass
+@frozen
 class Dictionary(abc.ABC):
     source: Table
 
@@ -382,7 +383,7 @@ class Dictionary(abc.ABC):
         raise NotImplementedError()
 
 
-@dataclass
+@frozen
 class PendingDeletesDictionary(Dictionary):
     source: PendingDeletesTable
 
@@ -438,7 +439,7 @@ class PendingDeletesDictionary(Dictionary):
         return checksum
 
 
-@dataclass
+@frozen
 class AdhocEventDeletesDictionary(Dictionary):
     source: AdhocEventDeletesTable
 

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -311,9 +311,31 @@ class Dictionary(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def staged(self, run_key: str) -> StagedDictionary:
-        """Where this dictionary's rows go so another cluster can load them; see StagedDictionary."""
+    def staged(self) -> StagedDictionary:
+        """Where this dictionary's rows go so another cluster can load them; see StagedDictionary.
+
+        Keyed by the dictionary's own name, never by anything per-run. A dictionary outlives the
+        run that created it, and CREATE ... IF NOT EXISTS keys on that same name, so a per-run key
+        would leave the earlier definition pointing at an object no later run writes.
+        """
         raise NotImplementedError()
+
+    def recreate(
+        self,
+        client: Client,
+        shards: int,
+        max_execution_time: int,
+        max_memory_usage: int,
+        query: str | None = None,
+    ) -> None:
+        """Replace the dictionary, so no definition an earlier run left behind can survive.
+
+        CREATE ... IF NOT EXISTS keeps the existing source, which is right where that source is the
+        replicated table and wrong where it is a staged object whose query can change between
+        deploys.
+        """
+        self.drop(client)
+        self.create(client, shards, max_execution_time, max_memory_usage, query)
 
     def exists(self, client: Client) -> bool:
         results = client.execute(
@@ -368,9 +390,9 @@ class PendingDeletesDictionary(Dictionary):
     def query(self) -> str:
         return f"SELECT team_id, deletion_type, key, created_at FROM {self.source.qualified_name}"
 
-    def staged(self, run_key: str) -> StagedDictionary:
+    def staged(self) -> StagedDictionary:
         return StagedDictionary(
-            key=f"{run_key}/pending_deletes.parquet",
+            key=f"{self.name}.parquet",
             columns="team_id, deletion_type, key, created_at",
             structure="team_id Int64, deletion_type UInt8, key String, created_at DateTime",
         )
@@ -424,9 +446,9 @@ class AdhocEventDeletesDictionary(Dictionary):
     def query(self) -> str:
         return f"SELECT team_id, uuid, created_at FROM {self.source.qualified_name} WHERE (team_id, uuid) not in (SELECT team_id, uuid FROM {self.source.qualified_name} WHERE is_deleted = 1)"
 
-    def staged(self, run_key: str) -> StagedDictionary:
+    def staged(self) -> StagedDictionary:
         return StagedDictionary(
-            key=f"{run_key}/adhoc_event_deletes.parquet",
+            key=f"{self.name}.parquet",
             columns="team_id, uuid, created_at",
             structure="team_id Int64, uuid UUID, created_at DateTime64(6, 'UTC')",
         )
@@ -577,10 +599,17 @@ def _create_dictionary_everywhere(
     if not siblings:
         return
 
-    staged = dictionary.staged(context.run_id)
+    staged = dictionary.staged()
     cluster.any_host_by_role(partial(staged.export, source_query=dictionary.query), NodeRole.DATA).result()
+    recreate = partial(
+        dictionary.recreate,
+        shards=config.shards,
+        max_execution_time=config.max_execution_time,
+        max_memory_usage=config.max_memory_usage,
+        query=staged.query,
+    )
     for sibling in siblings:
-        sibling.map_all_hosts(partial(create, query=staged.query)).result()
+        sibling.map_all_hosts(recreate).result()
 
     context.log.info(
         f"Staged {dictionary.name} to {staged.key} for {[sibling.data_cluster_name for sibling in siblings]}"

--- a/posthog/dags/tests/test_deletes.py
+++ b/posthog/dags/tests/test_deletes.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from functools import partial
 from typing import cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from freezegun import freeze_time
@@ -15,6 +15,7 @@ from posthog.dags.deletes import (
     MonthlyCleanupConfig,
     PendingDeletesDictionary,
     PendingDeletesTable,
+    StagedDictionary,
     cleanup_old_events_by_partition,
     deletes_job,
     find_partitions_to_cleanup,
@@ -675,3 +676,62 @@ def test_monthly_old_events_cleanup_job(cluster: ClickhouseCluster):
 
     events_after = cluster.any_host(count_all_events).result()
     assert events_after == len(recent_events)
+
+
+def _insert_pending_deletes(table: PendingDeletesTable, client: Client) -> None:
+    client.execute(
+        table.populate_query,
+        [
+            {
+                "id": i,
+                "deletion_type": int(DeletionType.Person),
+                "key": str(UUID(int=i)),
+                "group_type_index": None,
+                "created_at": datetime(2026, 8, 26, 10, 11, 12),
+                "delete_verified_at": None,
+                "created_by_id": None,
+                "team_id": 99999,
+            }
+            for i in range(5)
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_a_staged_dictionary_holds_the_same_rows_as_the_source_table(cluster: ClickhouseCluster):
+    # A cluster with its own Keeper can never join the source table's replica set, so it loads the
+    # dictionary from a staged object instead, and the run is gated on both sides checksumming
+    # alike. That gate only means something if the staged copy round-trips every column exactly:
+    # a type Parquet does not preserve would make two correct clusters look like they disagree.
+    table = PendingDeletesTable(timestamp=datetime(2026, 8, 26, 10, 11, 12))
+    dictionary = PendingDeletesDictionary(source=table)
+    create = partial(dictionary.create, shards=1, max_execution_time=0, max_memory_usage=0)
+
+    try:
+        cluster.any_host(table.create).result()
+        cluster.any_host(partial(_insert_pending_deletes, table)).result()
+
+        cluster.any_host(create).result()
+        from_source_table = cluster.any_host(dictionary.load).result()
+
+        staged = dictionary.staged(f"test_{uuid4()}")
+        cluster.any_host(partial(staged.export, source_query=dictionary.query)).result()
+        cluster.any_host(dictionary.drop).result()
+        cluster.any_host(partial(create, query=staged.query)).result()
+        from_staged_object = cluster.any_host(dictionary.load).result()
+
+        assert from_staged_object == from_source_table
+    finally:
+        cluster.any_host(dictionary.drop).result()
+        cluster.any_host(table.drop).result()
+
+
+def test_staged_dictionary_escapes_quotes_inside_a_column_type() -> None:
+    # DateTime64(6, 'UTC') carries single quotes, and the structure is itself a quoted SQL literal,
+    # so an unescaped copy terminates the literal early and the s3() call fails to parse.
+    staged = StagedDictionary(
+        key="run/adhoc.parquet",
+        columns="team_id, uuid, created_at",
+        structure="team_id Int64, uuid UUID, created_at DateTime64(6, 'UTC')",
+    )
+    assert "DateTime64(6, \\'UTC\\')" in staged.query

--- a/posthog/dags/tests/test_deletes.py
+++ b/posthog/dags/tests/test_deletes.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from functools import partial
 from typing import cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
@@ -678,7 +678,7 @@ def test_monthly_old_events_cleanup_job(cluster: ClickhouseCluster):
     assert events_after == len(recent_events)
 
 
-def _insert_pending_deletes(table: PendingDeletesTable, client: Client) -> None:
+def _insert_pending_deletes(table: PendingDeletesTable, client: Client, count: int = 5, first_id: int = 0) -> None:
     client.execute(
         table.populate_query,
         [
@@ -692,7 +692,7 @@ def _insert_pending_deletes(table: PendingDeletesTable, client: Client) -> None:
                 "created_by_id": None,
                 "team_id": 99999,
             }
-            for i in range(5)
+            for i in range(first_id, first_id + count)
         ],
     )
 
@@ -706,6 +706,7 @@ def test_a_staged_dictionary_holds_the_same_rows_as_the_source_table(cluster: Cl
     table = PendingDeletesTable(timestamp=datetime(2026, 8, 26, 10, 11, 12))
     dictionary = PendingDeletesDictionary(source=table)
     create = partial(dictionary.create, shards=1, max_execution_time=0, max_memory_usage=0)
+    recreate = partial(dictionary.recreate, shards=1, max_execution_time=0, max_memory_usage=0)
 
     try:
         cluster.any_host(table.create).result()
@@ -714,10 +715,9 @@ def test_a_staged_dictionary_holds_the_same_rows_as_the_source_table(cluster: Cl
         cluster.any_host(create).result()
         from_source_table = cluster.any_host(dictionary.load).result()
 
-        staged = dictionary.staged(f"test_{uuid4()}")
+        staged = dictionary.staged()
         cluster.any_host(partial(staged.export, source_query=dictionary.query)).result()
-        cluster.any_host(dictionary.drop).result()
-        cluster.any_host(partial(create, query=staged.query)).result()
+        cluster.any_host(partial(recreate, query=staged.query)).result()
         from_staged_object = cluster.any_host(dictionary.load).result()
 
         assert from_staged_object == from_source_table
@@ -735,3 +735,49 @@ def test_staged_dictionary_escapes_quotes_inside_a_column_type() -> None:
         structure="team_id Int64, uuid UUID, created_at DateTime64(6, 'UTC')",
     )
     assert "DateTime64(6, \\'UTC\\')" in staged.query
+
+
+@pytest.mark.parametrize(
+    "dictionary",
+    [
+        PendingDeletesDictionary(source=PendingDeletesTable(timestamp=datetime(2026, 8, 26, 10, 11, 12))),
+        AdhocEventDeletesDictionary(source=AdhocEventDeletesTable()),
+    ],
+    ids=["pending_deletes", "adhoc_event_deletes"],
+)
+def test_a_staged_dictionary_is_keyed_by_the_dictionary_name(dictionary) -> None:
+    # CREATE ... IF NOT EXISTS keys on the dictionary name, and a dictionary outlives the run that
+    # created it. Keying the object per run instead leaves that definition naming an object no
+    # later run writes, so a cluster loading from S3 serves the first run's rows for ever.
+    assert dictionary.staged().key == f"{dictionary.name}.parquet"
+
+
+@pytest.mark.django_db
+def test_a_rerun_stages_over_the_previous_runs_object(cluster: ClickhouseCluster):
+    # Every run writes the same key, so the export has to replace the object rather than add to it.
+    # An append leaves both runs' rows behind, and the cluster loading from S3 then holds rows the
+    # cluster reading the source table does not.
+    table = PendingDeletesTable(timestamp=datetime(2026, 8, 26, 10, 11, 13))
+    dictionary = PendingDeletesDictionary(source=table)
+    recreate = partial(dictionary.recreate, shards=1, max_execution_time=0, max_memory_usage=0)
+    staged = dictionary.staged()
+
+    try:
+        cluster.any_host(table.create).result()
+        cluster.any_host(partial(_insert_pending_deletes, table, count=5)).result()
+        cluster.any_host(partial(staged.export, source_query=dictionary.query)).result()
+
+        cluster.any_host(table.truncate).result()
+        cluster.any_host(partial(_insert_pending_deletes, table, count=2, first_id=100)).result()
+        cluster.any_host(partial(staged.export, source_query=dictionary.query)).result()
+
+        cluster.any_host(partial(recreate, query=staged.query)).result()
+        from_staged_object = cluster.any_host(dictionary.load).result()
+
+        cluster.any_host(partial(recreate)).result()
+        from_source_table = cluster.any_host(dictionary.load).result()
+
+        assert from_staged_object == from_source_table
+    finally:
+        cluster.any_host(dictionary.drop).result()
+        cluster.any_host(table.drop).result()

--- a/posthog/models/deletion_targets.py
+++ b/posthog/models/deletion_targets.py
@@ -310,6 +310,22 @@ def resolve_placements(
     return [placement for placement in placements if placement is not None]
 
 
+def sweep_clusters(
+    cluster: ClickhouseCluster, targets: Sequence[DeletionTarget] = PERSONAL_DATA_TARGETS
+) -> list[ClickhouseCluster]:
+    """Every distinct cluster a sweep over ``targets`` dispatches to, the handle in hand first.
+
+    A mutation predicate that joins a dictionary needs that dictionary present on every cluster the
+    mutation runs on, which is what this enumerates. The handle in hand is always included: sweeps
+    over the replicated, non-sharded tables run there whatever the targets resolve to.
+    """
+    clusters = [cluster]
+    for placement in resolve_placements(cluster, targets):
+        if not any(placement.cluster is known for known in clusters):
+            clusters.append(placement.cluster)
+    return clusters
+
+
 def resolve_targets_here(
     cluster: ClickhouseCluster, targets: Sequence[DeletionTarget] = PERSONAL_DATA_TARGETS
 ) -> list[DeletionTarget]:

--- a/posthog/models/test/test_deletion_targets.py
+++ b/posthog/models/test/test_deletion_targets.py
@@ -7,7 +7,13 @@ from unittest.mock import Mock, patch
 from django.test import override_settings
 
 from posthog.clickhouse.cluster import ClickhouseCluster, HostInfo
-from posthog.models.deletion_targets import DeletionTarget, UnreachableTargetError, dispatchable_here, placement_for
+from posthog.models.deletion_targets import (
+    DeletionTarget,
+    UnreachableTargetError,
+    dispatchable_here,
+    placement_for,
+    sweep_clusters,
+)
 
 # One data node each, so a table present on one cluster and absent from the other is the only
 # difference between them. That is the topology the placement resolution exists for and the one no
@@ -78,3 +84,22 @@ def test_dispatchable_here_refuses_a_target_another_cluster_carries() -> None:
     with _cluster_with({"data1": set(), "events1": {"sharded_events_json"}}) as cluster:
         with pytest.raises(UnreachableTargetError):
             dispatchable_here(cluster, _OFF_CLUSTER_TARGET)
+
+
+@override_settings(CLICKHOUSE_EVENTS_CLUSTER="events")
+def test_sweep_clusters_lists_every_cluster_a_mutation_runs_on() -> None:
+    # The delete predicate joins a dictionary, so the dictionary has to exist on each cluster this
+    # returns. Missing one there means the mutation runs against nothing and reports success.
+    with _cluster_with({"data1": set(), "events1": {"sharded_events_json"}}) as cluster:
+        clusters = sweep_clusters(cluster, [_OFF_CLUSTER_TARGET])
+
+        assert [handle.data_cluster_name for handle in clusters] == ["posthog", "events"]
+        assert clusters[0] is cluster
+
+
+@override_settings(CLICKHOUSE_EVENTS_CLUSTER="events")
+def test_sweep_clusters_does_not_repeat_the_handle_in_hand() -> None:
+    # Building the dictionary twice on one cluster is wasted work, and every sweep keyed off this
+    # list would run its mutations twice.
+    with _cluster_with({"data1": {"sharded_events_json"}, "events1": {"sharded_events_json"}}) as cluster:
+        assert sweep_clusters(cluster, [_OFF_CLUSTER_TARGET]) == [cluster]

--- a/posthog/settings/object_storage.py
+++ b/posthog/settings/object_storage.py
@@ -134,3 +134,24 @@ if TEST or DEBUG:
     )
 else:
     IDENTITY_MATCHING_S3_ENDPOINT = os.getenv("IDENTITY_MATCHING_S3_ENDPOINT", "") or None
+
+# Deletion dictionary staging (posthog/dags/deletes.py). The pending-deletion and queued-uuid
+# dictionaries reach every host of the main cluster because their source table is replicated, and
+# replication is exactly what stops at a cluster boundary: a cluster with its own Keeper can never
+# join that replica set. So when a deletion target's storage lives on another cluster, deletes_job
+# stages the dictionary rows here as Parquet and each host there loads the same object for itself.
+# Written and read by the ClickHouse cluster via `INSERT INTO FUNCTION s3(...)` / `s3(...)`, so
+# only the cluster needs bucket access; the Dagster process never touches boto3. Nothing deletes
+# these objects, so infra must expire the prefix through the bucket lifecycle policy. They hold
+# team ids and the person uuids already recorded on the Postgres AsyncDeletion rows.
+DELETES_DICTIONARY_S3_BUCKET = os.getenv("DELETES_DICTIONARY_S3_BUCKET") or OBJECT_STORAGE_BUCKET
+DELETES_DICTIONARY_S3_PREFIX = os.getenv("DELETES_DICTIONARY_S3_PREFIX", "deletes_dictionaries")
+DELETES_DICTIONARY_S3_REGION = os.getenv("DELETES_DICTIONARY_S3_REGION") or OBJECT_STORAGE_REGION
+# Must be an endpoint the ClickHouse cluster can reach, which is not always OBJECT_STORAGE_ENDPOINT;
+# see the IDENTITY_MATCHING_S3_ENDPOINT note above for why localhost breaks under TEST.
+if TEST or DEBUG:
+    DELETES_DICTIONARY_S3_ENDPOINT: Optional[str] = (
+        os.getenv("DELETES_DICTIONARY_S3_ENDPOINT", "http://objectstorage:19000") or None
+    )
+else:
+    DELETES_DICTIONARY_S3_ENDPOINT = os.getenv("DELETES_DICTIONARY_S3_ENDPOINT", "") or None

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
+                  ([e__person.properties___fish] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,6 +44,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -111,7 +121,17 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -168,8 +188,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -178,6 +198,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -294,7 +324,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -326,7 +373,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([e__person.properties___fish] AS value) AS prop_basic,
+                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,16 +44,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -121,17 +111,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -188,8 +168,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -198,16 +178,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -324,24 +294,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -373,24 +326,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)


### PR DESCRIPTION
## Problem

`deletes_job` runs weekly and sweeps every personal-data table. It cannot sweep one stored on another cluster, and the reason is not dispatch.

- `delete_events` never names the rows it removes. Its predicate joins two dictionaries.
- A dictionary's source table reaches every host of one cluster because it is replicated.
- Replication is exactly what a cluster boundary stops. The `events` cluster has its own Keeper, so it can never join that replica set.
- `adhoc_events_deletion` compounds it. It is migration-managed and exists only on the main cluster.

So a mutation on the `events` cluster has no dictionary to join, and the sweep cannot run there at all.

## Changes

The rows are staged instead. One Parquet object per dictionary, written by the cluster itself.

```mermaid
flowchart LR
    PG[(Postgres AsyncDeletion)] --> T[pending_deletes_ts]
    T -- replication --> D1[dictionary on posthog]
    T -- INSERT INTO FUNCTION s3 --> O[(Parquet object)]
    O -- SOURCE CLICKHOUSE QUERY s3 --> D2[dictionary on events]
    D1 --> M1[mutate sharded_events]
    D2 --> M2[mutate sharded_events_json]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class PG phYellow;
    class D1,D2 phBlue;
    class T,O,M1,M2 phGray;
```

- ClickHouse has no S3 dictionary source. `SOURCE(CLICKHOUSE(...))` runs its query on the local host, and that query can read anything the server can, including `s3(...)`.
- The object is keyed by the dictionary's own name, which is what `CREATE ... IF NOT EXISTS` keys on. A dictionary outlives the run that created it, so a per-run key would strand a sibling on an object no later run writes.
- A sibling gets its definition replaced rather than preserved, so a source query that changes between deploys cannot survive.
- A deployment whose targets all sit on the job's own cluster probes that handle first and writes no object. Nothing changes there.
- The source tables stay where they are. `pending_deletes_<ts>` also carries the Postgres row ids `mark_deletions_verified` reads back, and those never enter a dictionary.
- `delete_events` dispatches per placement. Waiters are keyed by cluster name then shard, because shard numbers are per cluster.
- `cleanup_delete_assets` drops the dictionaries on every cluster, and the source table on the job's own.

> [!WARNING]
> Nothing deletes the staged objects. Infra must expire `DELETES_DICTIONARY_S3_PREFIX` through the bucket lifecycle policy. The objects hold team ids and the person uuids already recorded on the Postgres `AsyncDeletion` rows.

### The gate

`load_and_verify_*` now loads on every host of every cluster and fails the run unless all of them checksum alike.

That is what catches a stale or missing object. Without it the mutation on the second cluster joins an empty dictionary, deletes nothing, and reports success, which is the exact failure this whole line of work exists to remove.

## How did you test this code?

Three facts the design rests on, checked against a local ClickHouse rather than assumed:

<details>
<summary>Probe results</summary>

- A dictionary with `SOURCE(CLICKHOUSE(QUERY '… FROM s3(…)'))` reaches `status = LOADED` and answers `dictHas`.
- clickhouse-driver's parameter escaping handles the nested query, so the s3 quotes need no manual doubling.
- `uuid UUID` and `created_at DateTime64(6, 'UTC')` survive Parquet with an identical `cityHash64(*)`: both sides checksum `805333203889117097`.

</details>

- `test_a_staged_dictionary_holds_the_same_rows_as_the_source_table` builds the dictionary from the local table, then rebuilds it from the staged object, and compares checksums. It fails if a column stops round-tripping, or if the staged columns drift from the dictionary's declaration.
- `test_staged_dictionary_escapes_quotes_inside_a_column_type` fails if the quotes in `DateTime64(6, 'UTC')` stop being escaped, which terminates the structure literal early and breaks the `s3()` call.
- `test_a_staged_dictionary_is_keyed_by_the_dictionary_name` fails if the key regains a per-run component, which strands a sibling on an earlier run's object.
- `test_a_rerun_stages_over_the_previous_runs_object` fails if the export appends instead of replacing, leaving both runs' rows behind.
- `test_sweep_clusters_lists_every_cluster_a_mutation_runs_on` fails if a cluster the mutation runs on stops getting a dictionary.
- `test_sweep_clusters_does_not_repeat_the_handle_in_hand` fails if a single-cluster deployment starts building the dictionary twice and mutating twice.
- The existing `deletes_job` suite passes unchanged, which is the single-cluster regression check.
- No test runs against a real second ClickHouse cluster. The multinode stack defines no `events` cluster, so the second-cluster path is covered by fake host discovery and by the staged round-trip, not end to end.
- `mypy --cache-fine-grained .` reports nothing in the files this PR touches.
- Patch coverage flags 14 changed lines and I added no tests for them. They are one-line delegations whose behavior is tested where it lives, a defensive re-raise for a non-701 server error, and the prod-only branch of the endpoint setting.

## Automatic notifications

- [ ] Publish to changelog?

Internal deletion machinery with no user-visible behavior, so no changelog entry.

## Docs update

`docs/internal/clickhouse-deletion-coverage.md` gains "Getting the dictionaries onto the second cluster", and moves `deletes_job` from the list of sweeps that refuse to the list that dispatch.
