### PR TITLE
fix(insights): convert legacy insights whose breakdowns list is empty

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -415,7 +415,9 @@ def _breakdown_filter(_filter: dict):
     if breakdownFilter["breakdown_type"] == "events":
         breakdownFilter["breakdown_type"] = "event"
 
-    if _filter.get("breakdowns") is not None:
+    # An empty `breakdowns` carries no breakdown at all. The trends branch below already ignores it,
+    # and the single-breakdown branch would otherwise read it as a multi-breakdown and refuse to convert.
+    if _filter.get("breakdowns"):
         if _insight_type(_filter) == "TRENDS":
             # Trends support multiple breakdowns
             breakdowns = []

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -3,6 +3,8 @@ from typing import Any, cast
 import pytest
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActionsNode,
     AggregationAxisFormat,
@@ -1677,43 +1679,30 @@ class TestFilterToQuery(BaseTest):
             ),
         )
 
-    def test_funnels_multiple_breakdowns(self):
-        filter: dict[str, Any] = {
-            "insight": "FUNNELS",
-            "breakdowns": [
-                {"type": "session", "property": "$session_duration"},
-            ],
-        }
+    @parameterized.expand(
+        [
+            (
+                "single",
+                [{"type": "session", "property": "$session_duration"}],
+                BreakdownFilter(breakdown="$session_duration", breakdown_type=BreakdownType.SESSION),
+            ),
+            (
+                "no_breakdown_type",
+                [{"property": "prop"}],
+                BreakdownFilter(breakdown="prop", breakdown_type=BreakdownType.EVENT),
+            ),
+            # An empty list used to raise "found more than one breakdown", so the insight never
+            # converted. It now lands where an absent `breakdowns` key lands: no breakdown property.
+            ("empty", [], BreakdownFilter(breakdown_type=BreakdownType.EVENT)),
+        ]
+    )
+    def test_funnels_breakdowns(self, _name, breakdowns, expected):
+        filter: dict[str, Any] = {"insight": "FUNNELS", "breakdowns": breakdowns}
 
         query = filter_to_query(filter)
 
         assert isinstance(query, FunnelsQuery)
-        self.assertEqual(
-            query.breakdownFilter,
-            BreakdownFilter(
-                breakdown="$session_duration",
-                breakdown_type=BreakdownType.SESSION,
-            ),
-        )
-
-    def test_funnels_multiple_breakdowns_no_breakdown_type(self):
-        filter: dict[str, Any] = {
-            "insight": "FUNNELS",
-            "breakdowns": [
-                {"property": "prop"},
-            ],
-        }
-
-        query = filter_to_query(filter)
-
-        assert isinstance(query, FunnelsQuery)
-        self.assertEqual(
-            query.breakdownFilter,
-            BreakdownFilter(
-                breakdown="prop",
-                breakdown_type=BreakdownType.EVENT,
-            ),
-        )
+        self.assertEqual(query.breakdownFilter, expected)
 
     def test_funnels_use_first_time_for_user_math(self):
         filter: dict[str, Any] = {


### PR DESCRIPTION
## Problem

A handful of older funnel and retention insights show an empty chart and cannot be repaired from the UI. Refreshing one, or an alert or export that reads it, errors.

- The insight stores its definition in legacy `filters` with `"breakdowns": []`.
- `_breakdown_filter` sends any non-trends `breakdowns` value through a guard that accepts exactly one entry and raises `Exception("found more than one breakdown")` on everything else. An empty list takes that path.
- The conversion then fails for the whole insight, not just its breakdown. `Insight.query_from_filters` swallows the error and returns `None`, so the chart renders blank; `conversion_to_query_based` re-raises, so every calculation path errors.
- The trends branch never had this problem. It collects breakdowns into a list and only sets them `if len(breakdowns) > 0`.

## Changes

- An affected insight now renders its chart instead of an empty one, and refresh, alerts and exports stop erroring on it.
- `_breakdown_filter` treats a falsy `breakdowns` as absent, so an empty list lands exactly where a missing `breakdowns` key already lands: a breakdown filter with no breakdown property. Verified both inputs produce the same `BreakdownFilter`.
- A genuine multi-breakdown on a non-trends insight still raises. That conversion is lossy and the error is accurate.
- Test change is mechanical: `test_funnels_multiple_breakdowns` and `test_funnels_multiple_breakdowns_no_breakdown_type` had identical bodies, so they became one parameterized test with the empty case added as a third row.

No screenshots. The visible difference is a chart that renders rather than an empty one, and it depends on the affected insight's own definition.

## How did you test this code?

One added case in `test_funnels_breakdowns`: a funnel with `"breakdowns": []` converts, and its breakdown filter matches the no-breakdowns outcome. It catches the guard regressing to reject an empty list, which is the bug being fixed.

The two folded cases keep their previous assertions verbatim, so single-breakdown conversion stays covered.

Ran `posthog/hogql_queries/legacy_compatibility/` locally: 101 tests pass.

Not run locally: repo-wide mypy, and the suites that read insights end to end. CI covers both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by Thomas Obermüller.

- Found while backfilling `query` from legacy `filters` as part of the legacy insight removal. A dry run over every insight without a `query` failed on 823 rows across six exception types; this bare `Exception` was the only bucket caused by the converter rather than by malformed stored data.
- The other 822 rows store values the schema rejects, and they fail the same conversion at read time today. They are out of scope here.
- Scope was deliberately held to the empty-list case. Several of the remaining failures look normalizable (`math: "unique_users"` for `dau`, and similar old spellings), but mapping legacy enum values is a separate change with its own risk.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- No session material is in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
