### PR TITLE
feat(autoresearch): validate predictions online once horizons mature (12/22)

### DIFF
--- a/products/autoresearch/backend/evaluation/AGENTS.md
+++ b/products/autoresearch/backend/evaluation/AGENTS.md
@@ -1,0 +1,64 @@
+# Evaluation
+
+Did the predictions actually come true?
+
+Training measures a model against a holdout slice of history. This package measures it against reality: once a prediction's horizon has elapsed, it joins the emitted `autoresearch_prediction` events back to what the person actually did and computes realized performance.
+
+It is the only honest number in the product. A holdout AUC of 0.93 says the model separates history well; the realized AUC says whether it predicted the future.
+
+This package landed ahead of its callers. `../presentation/` and `../temporal/` arrive in later pieces of the split tracked in [#88464](https://github.com/PostHog/posthog/pull/88464), so the references to them below describe where they will sit.
+
+## What lives here
+
+- `online_validation.py`
+  `run_online_validation_for_pipeline()` is the entry point, called by the Temporal validation activity and by the `autoresearch_validate_online` command.
+
+  Per matured prediction date, per model, it computes:
+  - **realized AUC** — ranking quality against actual outcomes
+  - **Brier score** — squared error of the probabilities
+  - **expected calibration error** (`_expected_calibration_error`, 10 bins) — whether "0.8" really means 80%
+  - **lift@k** (`_lift_at_k`) — how much better than random the top slice is
+
+  Champions and challengers are both scored, which is what makes challenger promotion decidable on evidence rather than on holdout alone.
+  Results land on `AutoresearchModel.realized_score` / `.calibration_error` / `.metrics` via `_update_model_realized_metrics()`, and each validated date records an `AutoresearchRun`.
+
+## Mental model
+
+```text
+predictions emitted on day D
+        │
+        │  ... wait horizon_days ...
+        │
+ D + horizon <= today  →  the label is now knowable
+        │
+ _find_mature_unvalidated_dates  →  dates with predictions but no validation run
+        │
+ _fetch_predictions_by_model  ×  _fetch_realized_labels  →  metrics per model
+```
+
+`_find_mature_unvalidated_dates()` is what keeps this idempotent: it only picks up dates whose horizon has passed _and_ which have not already been validated, so the workflow can run daily without recomputing history.
+
+All the heavy work — the HogQL queries and the sklearn metrics — happens inside a single Temporal activity. Nothing large crosses a workflow boundary, which is deliberate: activity payloads are capped, and prediction sets are big.
+
+## Things that bite
+
+- **Nothing to validate on day one.** Predictions written today mature in `horizon_days`. A fresh pipeline returns zero validated dates and that is correct, not a bug.
+  To get a populated view locally, backdate: `autoresearch_score --prediction-date <past>` or `--backfill-days N` emits already-matured predictions.
+- **Backdated events are silently dropped when the team sets `drop_events_older_than_seconds`.** Ingestion discards them as too old, so validation finds nothing and nothing errors anywhere.
+- **A contiguous gap in prediction dates means the backfill lost a chunk**, not that validation skipped it — a large backfill can overwhelm the local ingestion consumer.
+
+## Where the rest of the system meets this package
+
+- **Scheduled by** — `AutoresearchValidationWorkflow` / `activity_run_validation` in `../temporal/workflows.py`.
+- **Run headlessly by** — `autoresearch_validate_online` (see `../management/AGENTS.md`), which supports `--dry-run`.
+- **Reads** — `autoresearch_prediction` events emitted by `../inference/`, and the target condition from `../dataset/labeling.py` (`build_target_condition`) so "did it happen?" is defined identically to how it was labeled at training time.
+- **Writes** — realized metrics onto `AutoresearchModel`, plus an `AutoresearchRun` per validated date.
+- **Not to be confused with** `../dataset/validation.py`, which is pre-flight target viability. Same word, opposite ends of the lifecycle.
+
+## When editing this flow
+
+- **Reuse `build_target_condition()` from `../dataset/labeling.py`.** If realized outcomes were defined differently from training labels, every realized metric would be measuring a different question than the model was trained on.
+- Keep `_find_mature_unvalidated_dates()` the only date selector, so validation stays idempotent and safe to run on a schedule.
+- Keep the heavy work inside one activity. Returning prediction sets through the workflow would hit the Temporal payload limit as soon as a pipeline scores a real population.
+- Score challengers as well as the champion — challenger realized performance is the evidence promotion should eventually rest on.
+- **If you add a metric or change the maturity rule, update this file to match.**

--- a/products/autoresearch/backend/evaluation/AGENTS.md
+++ b/products/autoresearch/backend/evaluation/AGENTS.md
@@ -31,7 +31,7 @@ completed inference run for day D  (metrics: prediction_date, horizon_days, rows
         │
  D + horizon 00:00 UTC + grace <= now  →  the outcome window has closed and its last events have landed
         │
- find_pending_validation_dates  →  matured dates with no completed validation and no live claim
+ find_pending_validation_dates  →  matured (date, horizon) groups whose validation does not match their inference runs
         │
  _claim_date (RUNNING run, under the pipeline row lock)
         │
@@ -40,9 +40,9 @@ completed inference run for day D  (metrics: prediction_date, horizon_days, rows
 
 Candidate dates come from Postgres, not from a scan of the events table: the inference runs record the prediction date and the horizon they scored against, so a daily pass costs nothing for the dates it does not validate, and the horizon used is the one the predictions were made under.
 
-`find_pending_validation_dates()` is what keeps this idempotent: it skips dates with a `COMPLETED` validation run, dates with a `RUNNING` one younger than `STALE_CLAIM_AFTER`, and dates an inference run is still scoring, so the workflow can run daily without recomputing history. A `FAILED` run does not count, so its date is retried. Maturity waits `OUTCOME_INGESTION_GRACE` past the window end so the last outcome events have reached ClickHouse.
+`find_pending_validation_dates()` is what keeps this idempotent. A group is done once a `COMPLETED` validation run holds the same per-model counts as the group's inference runs, so the workflow can run daily without recomputing history, and a later rescore or a new model on the date makes the group pending again and replaces its evidence. A `FAILED` run does not count, so its group is retried. A `RUNNING` validation claim, and a `RUNNING` inference run, hold the group only while younger than `STALE_RUN_AFTER`, so a worker killed mid-run cannot block it forever. Models scored on one date under different horizons are separate groups with their own outcome windows. Maturity waits `OUTCOME_INGESTION_GRACE` past the window end so the last outcome events have reached ClickHouse.
 
-Both ClickHouse queries are bounded by what the inference runs say was emitted. The prediction fetch must return exactly `rows_scored` persons per model; fewer means ingestion has not caught up with a backfill, more means events the run did not emit, and either fails the date so it is retried instead of completing with wrong numbers. The realized-label scan is restricted to the predicted persons, and its window is the UTC one scoring bound the run to (`[D 00:00, D + horizon 00:00)`). Before the date is marked complete, the completed inference runs are read again inside the transaction: a run that finished while the queries ran changes the expected counts and fails the date, so the model it scored is not left unvalidated behind a completed date. The model rows are locked for the write, so two validators on different dates cannot race the newest-date guard.
+Both ClickHouse queries are bounded by what the inference runs say was emitted. The prediction fetch must return exactly `rows_scored` persons per model; fewer means ingestion has not caught up with a backfill, more means events the run did not emit, and either fails the date so it is retried instead of completing with wrong numbers. The realized-label scan is restricted to the predicted persons, and its window is the UTC one scoring bound the run to (`[D 00:00, D + horizon 00:00)`). Before the group is marked complete, its inference runs are read again inside the transaction: a run that finished or started while the queries ran fails the group, and a run that slips in after that check changes the counts and makes the group pending again on the next pass. The model rows are locked for the write, so two validators on different dates cannot race the newest-date guard.
 
 All the heavy work — the HogQL queries and the sklearn metrics — happens inside a single Temporal activity. Nothing large crosses a workflow boundary, which is deliberate: activity payloads are capped, and prediction sets are big.
 
@@ -67,7 +67,7 @@ All the heavy work — the HogQL queries and the sklearn metrics — happens ins
 ## When editing this flow
 
 - **Reuse `build_target_condition()` from `../dataset/labeling.py`.** If realized outcomes were defined differently from training labels, every realized metric would be measuring a different question than the model was trained on.
-- Keep `find_pending_validation_dates()` the only date selector, and keep the claim under the pipeline row lock, so validation stays idempotent and safe to run from the schedule and the command at once.
+- Keep `find_pending_validation_dates()` the only date selector, and keep the claim under the pipeline row lock, so validation stays idempotent and safe to run from the schedule and the command at once. A validation run's `per_model` entry carries each model's `n_scored`, which is what marks a group validated; keep writing it.
 - Keep every query bounded by the inference runs' counts. A bare HogQL SELECT is capped at 100 rows without an error.
 - Keep the model updates and the run write in one transaction, so a failure part-way leaves no model with a score its run does not record.
 - Keep the heavy work inside one activity. Returning prediction sets through the workflow would hit the Temporal payload limit as soon as a pipeline scores a real population.

--- a/products/autoresearch/backend/evaluation/AGENTS.md
+++ b/products/autoresearch/backend/evaluation/AGENTS.md
@@ -11,32 +11,38 @@ This package landed ahead of its callers. `../presentation/` and `../temporal/` 
 ## What lives here
 
 - `online_validation.py`
-  `run_online_validation_for_pipeline()` is the entry point, called by the Temporal validation activity and by the `autoresearch_validate_online` command.
+  `run_online_validation_for_pipeline()` is the entry point, called by the Temporal validation activity and by the `autoresearch_validate_online` command. It takes the acting `user` HogQL applies access control for, defaulting to the pipeline's creator.
 
-  Per matured prediction date, per model, it computes:
-  - **realized AUC** — ranking quality against actual outcomes
+  Per matured prediction date, per model that emitted predictions, it computes:
+  - **realized AUC** — ranking quality against actual outcomes (needs both classes; a single-class date records `single_class_no_auc` instead)
   - **Brier score** — squared error of the probabilities
   - **expected calibration error** (`_expected_calibration_error`, 10 bins) — whether "0.8" really means 80%
-  - **lift@k** (`_lift_at_k`) — how much better than random the top slice is
+  - **lift@k** (`_lift_at_k`) — how much better than random the top slice is; ties at the boundary score are split fractionally so the number does not depend on row order
 
-  Champions and challengers are both scored, which is what makes challenger promotion decidable on evidence rather than on holdout alone.
-  Results land on `AutoresearchModel.realized_score` / `.calibration_error` / `.metrics` via `_update_model_realized_metrics()`, and each validated date records an `AutoresearchRun`.
+  Every model that emitted predictions on the date is scored, whatever its role now. Inference emits the champion only today; when challenger shadow scoring ships, their realized numbers land here without a change, which is what makes challenger promotion decidable on evidence rather than on holdout alone.
+  Results land on `AutoresearchModel.realized_score` / `.calibration_error` / `.metrics["realized"]` via `_update_model_realized_metrics()`, and each validated date records an `AutoresearchRun` whose `metrics["per_model"]` keeps the emitted role next to the current one.
 
 ## Mental model
 
 ```text
-predictions emitted on day D
+completed inference run for day D  (metrics: prediction_date, horizon_days, rows_scored)
         │
         │  ... wait horizon_days ...
         │
- D + horizon <= today  →  the label is now knowable
+ D + horizon <= today (UTC)  →  the outcome window has closed
         │
- _find_mature_unvalidated_dates  →  dates with predictions but no validation run
+ find_pending_validation_dates  →  matured dates with no completed validation and no live claim
         │
- _fetch_predictions_by_model  ×  _fetch_realized_labels  →  metrics per model
+ _claim_date (RUNNING run, under the pipeline row lock)
+        │
+ _fetch_predictions  ×  _fetch_realized_labels  →  metrics per model  →  one transaction
 ```
 
-`_find_mature_unvalidated_dates()` is what keeps this idempotent: it only picks up dates whose horizon has passed _and_ which have not already been validated, so the workflow can run daily without recomputing history.
+Candidate dates come from Postgres, not from a scan of the events table: the inference runs record the prediction date and the horizon they scored against, so a daily pass costs nothing for the dates it does not validate, and the horizon used is the one the predictions were made under.
+
+`find_pending_validation_dates()` is what keeps this idempotent: it skips dates with a `COMPLETED` validation run and dates with a `RUNNING` one younger than `STALE_CLAIM_AFTER`, so the workflow can run daily without recomputing history. A `FAILED` run does not count, so its date is retried.
+
+Both ClickHouse queries are bounded by what the inference runs say was emitted. The prediction fetch must return exactly `rows_scored` persons per model; fewer means ingestion has not caught up with a backfill, more means events the run did not emit, and either fails the date so it is retried instead of completing with wrong numbers. The realized-label scan is restricted to the predicted persons, and its window is the UTC one scoring bound the run to (`[D 00:00, D + horizon 00:00)`).
 
 All the heavy work — the HogQL queries and the sklearn metrics — happens inside a single Temporal activity. Nothing large crosses a workflow boundary, which is deliberate: activity payloads are capped, and prediction sets are big.
 
@@ -44,21 +50,24 @@ All the heavy work — the HogQL queries and the sklearn metrics — happens ins
 
 - **Nothing to validate on day one.** Predictions written today mature in `horizon_days`. A fresh pipeline returns zero validated dates and that is correct, not a bug.
   To get a populated view locally, backdate: `autoresearch_score --prediction-date <past>` or `--backfill-days N` emits already-matured predictions.
-- **Backdated events are silently dropped when the team sets `drop_events_older_than_seconds`.** Ingestion discards them as too old, so validation finds nothing and nothing errors anywhere.
-- **A contiguous gap in prediction dates means the backfill lost a chunk**, not that validation skipped it — a large backfill can overwhelm the local ingestion consumer.
+- **A backfill's date fails validation until its events are all in ClickHouse.** The fetch compares against the run's `rows_scored`, so a pass that runs seconds after a backfill records a `FAILED` run and the next pass picks the date up.
+- **Backdated events are refused by scoring when the team sets `drop_events_older_than_seconds`**, so no inference run is recorded and validation has nothing to look for.
+- **A deleted model takes its evidence with it.** Its inference runs lose their model and drop out of the candidates, and its prediction events are not fetched. A model deleted mid-validation is recorded in the run's `per_model` as `deleted` and skipped for the model update.
+- **Only the AUC needs both classes.** An all-negative day still records Brier, calibration error, and lift, which is where calibration matters for a rare target.
 
 ## Where the rest of the system meets this package
 
 - **Scheduled by** — `AutoresearchValidationWorkflow` / `activity_run_validation` in `../temporal/workflows.py`.
-- **Run headlessly by** — `autoresearch_validate_online` (see `../management/AGENTS.md`), which supports `--dry-run`.
-- **Reads** — `autoresearch_prediction` events emitted by `../inference/`, and the target condition from `../dataset/labeling.py` (`build_target_condition`) so "did it happen?" is defined identically to how it was labeled at training time.
+- **Run headlessly by** — `autoresearch_validate_online` (see `../management/AGENTS.md`), which supports `--dry-run` and `--user-id`, and exits non-zero when a date fails.
+- **Reads** — `autoresearch_prediction` events emitted by `../inference/`, the `prediction_date` / `horizon_days` keys `scoring.py` records on each inference run, and the target condition from `../dataset/labeling.py` (`build_target_condition`) so "did it happen?" is defined identically to how it was labeled at training time. The product's own prediction event is excluded from the outcome scan, as it is from the labeler's.
 - **Writes** — realized metrics onto `AutoresearchModel`, plus an `AutoresearchRun` per validated date.
 - **Not to be confused with** `../dataset/validation.py`, which is pre-flight target viability. Same word, opposite ends of the lifecycle.
 
 ## When editing this flow
 
 - **Reuse `build_target_condition()` from `../dataset/labeling.py`.** If realized outcomes were defined differently from training labels, every realized metric would be measuring a different question than the model was trained on.
-- Keep `_find_mature_unvalidated_dates()` the only date selector, so validation stays idempotent and safe to run on a schedule.
+- Keep `find_pending_validation_dates()` the only date selector, and keep the claim under the pipeline row lock, so validation stays idempotent and safe to run from the schedule and the command at once.
+- Keep every query bounded by the inference runs' counts. A bare HogQL SELECT is capped at 100 rows without an error.
+- Keep the model updates and the run write in one transaction, so a failure part-way leaves no model with a score its run does not record.
 - Keep the heavy work inside one activity. Returning prediction sets through the workflow would hit the Temporal payload limit as soon as a pipeline scores a real population.
-- Score challengers as well as the champion — challenger realized performance is the evidence promotion should eventually rest on.
 - **If you add a metric or change the maturity rule, update this file to match.**

--- a/products/autoresearch/backend/evaluation/AGENTS.md
+++ b/products/autoresearch/backend/evaluation/AGENTS.md
@@ -52,7 +52,7 @@ All the heavy work — the HogQL queries and the sklearn metrics — happens ins
   To get a populated view locally, backdate: `autoresearch_score --prediction-date <past>` or `--backfill-days N` emits already-matured predictions.
 - **A backfill's date fails validation until its events are all in ClickHouse.** The fetch compares against the run's `rows_scored`, so a pass that runs seconds after a backfill records a `FAILED` run and the next pass picks the date up.
 - **Backdated events are refused by scoring when the team sets `drop_events_older_than_seconds`**, so no inference run is recorded and validation has nothing to look for.
-- **A deleted model takes its evidence with it.** Its inference runs lose their model and drop out of the candidates, and its prediction events are not fetched. A model deleted mid-validation is recorded in the run's `per_model` as `deleted` and skipped for the model update.
+- **A deleted model takes its evidence with it.** Its inference runs lose their model and drop out of the candidates, and its prediction events are not fetched. A model deleted mid-validation is recorded in the run's `per_model` as `deleted` and skipped for the model update, and its absence does not reopen the group.
 - **A completed date is never revisited.** An outcome event that reaches ClickHouse more than `OUTCOME_INGESTION_GRACE` after the window closed (an offline SDK buffer flushed days late) reads as a negative in the stored metrics.
 - **Only the AUC needs both classes.** An all-negative day still records Brier, calibration error, and lift, which is where calibration matters for a rare target.
 

--- a/products/autoresearch/backend/evaluation/AGENTS.md
+++ b/products/autoresearch/backend/evaluation/AGENTS.md
@@ -29,7 +29,7 @@ completed inference run for day D  (metrics: prediction_date, horizon_days, rows
         │
         │  ... wait horizon_days ...
         │
- D + horizon <= today (UTC)  →  the outcome window has closed
+ D + horizon 00:00 UTC + grace <= now  →  the outcome window has closed and its last events have landed
         │
  find_pending_validation_dates  →  matured dates with no completed validation and no live claim
         │
@@ -40,9 +40,9 @@ completed inference run for day D  (metrics: prediction_date, horizon_days, rows
 
 Candidate dates come from Postgres, not from a scan of the events table: the inference runs record the prediction date and the horizon they scored against, so a daily pass costs nothing for the dates it does not validate, and the horizon used is the one the predictions were made under.
 
-`find_pending_validation_dates()` is what keeps this idempotent: it skips dates with a `COMPLETED` validation run and dates with a `RUNNING` one younger than `STALE_CLAIM_AFTER`, so the workflow can run daily without recomputing history. A `FAILED` run does not count, so its date is retried.
+`find_pending_validation_dates()` is what keeps this idempotent: it skips dates with a `COMPLETED` validation run, dates with a `RUNNING` one younger than `STALE_CLAIM_AFTER`, and dates an inference run is still scoring, so the workflow can run daily without recomputing history. A `FAILED` run does not count, so its date is retried. Maturity waits `OUTCOME_INGESTION_GRACE` past the window end so the last outcome events have reached ClickHouse.
 
-Both ClickHouse queries are bounded by what the inference runs say was emitted. The prediction fetch must return exactly `rows_scored` persons per model; fewer means ingestion has not caught up with a backfill, more means events the run did not emit, and either fails the date so it is retried instead of completing with wrong numbers. The realized-label scan is restricted to the predicted persons, and its window is the UTC one scoring bound the run to (`[D 00:00, D + horizon 00:00)`).
+Both ClickHouse queries are bounded by what the inference runs say was emitted. The prediction fetch must return exactly `rows_scored` persons per model; fewer means ingestion has not caught up with a backfill, more means events the run did not emit, and either fails the date so it is retried instead of completing with wrong numbers. The realized-label scan is restricted to the predicted persons, and its window is the UTC one scoring bound the run to (`[D 00:00, D + horizon 00:00)`). Before the date is marked complete, the completed inference runs are read again inside the transaction: a run that finished while the queries ran changes the expected counts and fails the date, so the model it scored is not left unvalidated behind a completed date. The model rows are locked for the write, so two validators on different dates cannot race the newest-date guard.
 
 All the heavy work — the HogQL queries and the sklearn metrics — happens inside a single Temporal activity. Nothing large crosses a workflow boundary, which is deliberate: activity payloads are capped, and prediction sets are big.
 
@@ -53,6 +53,7 @@ All the heavy work — the HogQL queries and the sklearn metrics — happens ins
 - **A backfill's date fails validation until its events are all in ClickHouse.** The fetch compares against the run's `rows_scored`, so a pass that runs seconds after a backfill records a `FAILED` run and the next pass picks the date up.
 - **Backdated events are refused by scoring when the team sets `drop_events_older_than_seconds`**, so no inference run is recorded and validation has nothing to look for.
 - **A deleted model takes its evidence with it.** Its inference runs lose their model and drop out of the candidates, and its prediction events are not fetched. A model deleted mid-validation is recorded in the run's `per_model` as `deleted` and skipped for the model update.
+- **A completed date is never revisited.** An outcome event that reaches ClickHouse more than `OUTCOME_INGESTION_GRACE` after the window closed (an offline SDK buffer flushed days late) reads as a negative in the stored metrics.
 - **Only the AUC needs both classes.** An all-negative day still records Brier, calibration error, and lift, which is where calibration matters for a rare target.
 
 ## Where the rest of the system meets this package

--- a/products/autoresearch/backend/evaluation/CLAUDE.md
+++ b/products/autoresearch/backend/evaluation/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/products/autoresearch/backend/evaluation/online_validation.py
+++ b/products/autoresearch/backend/evaluation/online_validation.py
@@ -1,0 +1,442 @@
+"""
+Online validation: join autoresearch_prediction events to realized target outcomes
+after the prediction horizon has elapsed.
+
+Computes per-model: realized AUC, Brier score, expected calibration error (ECE),
+and lift@k for both champion and challengers.
+
+Architecture:
+- Pure activity functions called by AutoresearchValidationWorkflow (Temporal)
+  and the autoresearch_validate_online management command.
+- All heavy work (HogQL queries + sklearn metrics) happens inside a single activity;
+  nothing large passes through Temporal payloads.
+"""
+
+import math
+from datetime import date, timedelta
+from typing import Any
+
+from django.utils import timezone as django_timezone
+
+import numpy as np
+import structlog
+
+from posthog.schema import HogQLQuery
+
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.models.team.team import Team
+
+from products.autoresearch.backend.dataset.labeling import build_target_condition
+from products.autoresearch.backend.models import AutoresearchModel, AutoresearchPipeline, AutoresearchRun
+from products.autoresearch.backend.query import run_hogql_rows
+
+logger = structlog.get_logger(__name__)
+
+PREDICTION_EVENT_NAME = "autoresearch_prediction"
+VALIDATION_QUERY_LIMIT = 50_000
+
+
+class ValidationDataTruncatedError(Exception):
+    """The predictions query hit VALIDATION_QUERY_LIMIT, so the fetched set may be incomplete."""
+
+
+def run_online_validation_for_pipeline(pipeline: AutoresearchPipeline) -> list[AutoresearchRun]:
+    """
+    Find all matured, unvalidated prediction dates and validate each one.
+
+    A prediction date is "matured" when today >= prediction_date + horizon_days —
+    meaning the outcome window has closed and realized labels can be fetched.
+
+    Returns one AutoresearchRun per prediction_date processed and updates
+    realized_score / calibration_error on each AutoresearchModel.
+    """
+    team = pipeline.team
+    mature_dates = _find_mature_unvalidated_dates(team, pipeline)
+
+    if not mature_dates:
+        logger.info("autoresearch_validation_no_mature_dates", pipeline_id=str(pipeline.pk))
+        return []
+
+    results = []
+    for prediction_date in sorted(mature_dates):
+        run = _validate_one_date(team, pipeline, prediction_date)
+        results.append(run)
+    return results
+
+
+def _find_mature_unvalidated_dates(team: Team, pipeline: AutoresearchPipeline) -> list[date]:
+    """
+    Return prediction dates that have matured but haven't been successfully validated.
+    Already-validated dates are tracked as COMPLETED validation AutoresearchRuns with
+    metrics['prediction_date'] set.
+    """
+    matured = _fetch_matured_prediction_dates(team, pipeline)
+    if not matured:
+        return []
+
+    already_validated = {
+        r.metrics.get("prediction_date")
+        for r in AutoresearchRun.objects.filter(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.COMPLETED,
+        )
+        if r.metrics.get("prediction_date")
+    }
+
+    return [d for d in matured if d.isoformat() not in already_validated]
+
+
+def _fetch_matured_prediction_dates(team: Team, pipeline: AutoresearchPipeline) -> list[date]:
+    """
+    Query ClickHouse for distinct prediction dates where the horizon has elapsed:
+    prediction_date + horizon_days <= today.
+    """
+    sql = (
+        "SELECT DISTINCT toDate(properties['$autoresearch_prediction_date']) AS prediction_date"
+        " FROM events"
+        " WHERE event = {event_name}"
+        " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
+        " AND addDays(toDate(properties['$autoresearch_prediction_date']), {horizon_days}) <= today()"
+        " ORDER BY prediction_date ASC"
+    )
+    values: dict[str, Any] = {
+        "event_name": PREDICTION_EVENT_NAME,
+        "pipeline_id": str(pipeline.pk),
+        "horizon_days": pipeline.horizon_days,
+    }
+
+    try:
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
+        return [date.fromisoformat(str(row[0])) for row in rows if row[0]]
+    except Exception:
+        logger.exception("autoresearch_matured_dates_query_failed", pipeline_id=str(pipeline.pk))
+        return []
+
+
+def _validate_one_date(
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+) -> AutoresearchRun:
+    """
+    Validate predictions made on prediction_date for all models (champion + challengers).
+    Creates an AutoresearchRun record, computes metrics, and updates model records.
+
+    On any error the run is returned as FAILED (no metrics written), leaving the
+    date eligible for the next pass and other dates in the same pass unaffected.
+    """
+    now = django_timezone.now()
+    run = AutoresearchRun.objects.create(
+        pipeline=pipeline,
+        run_type=AutoresearchRun.RunType.VALIDATION,
+        status=AutoresearchRun.Status.RUNNING,
+        started_at=now,
+        metrics={"prediction_date": prediction_date.isoformat()},
+    )
+
+    try:
+        model_predictions = _fetch_predictions_by_model(team, pipeline, prediction_date)
+        realized_labels = _fetch_realized_labels(team, pipeline, prediction_date)
+
+        if not model_predictions:
+            logger.warning(
+                "autoresearch_validation_no_predictions",
+                pipeline_id=str(pipeline.pk),
+                prediction_date=prediction_date.isoformat(),
+            )
+            run.status = AutoresearchRun.Status.COMPLETED
+            run.rows_scored = 0
+            run.completed_at = django_timezone.now()
+            run.metrics["warning"] = "no_predictions_found"
+            run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
+            return run
+
+        per_model_metrics: dict[str, Any] = {}
+        total_rows = 0
+
+        for model_id, predictions in model_predictions.items():
+            model = AutoresearchModel.objects.filter(pk=model_id, pipeline=pipeline).first()
+            if not model:
+                continue
+
+            metrics = _compute_validation_metrics(predictions, realized_labels)
+            per_model_metrics[model_id] = {
+                "model_role": model.role,
+                "n_scored": len(predictions),
+                **metrics,
+            }
+            total_rows += len(predictions)
+            _update_model_realized_metrics(model, metrics)
+
+        run.status = AutoresearchRun.Status.COMPLETED
+        run.rows_scored = total_rows
+        run.completed_at = django_timezone.now()
+        run.metrics.update(
+            {
+                "prediction_date": prediction_date.isoformat(),
+                "realized_labels_count": len(realized_labels),
+                "per_model": per_model_metrics,
+            }
+        )
+        run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
+
+        logger.info(
+            "autoresearch_validation_complete",
+            pipeline_id=str(pipeline.pk),
+            prediction_date=prediction_date.isoformat(),
+            models_validated=len(per_model_metrics),
+            total_rows=total_rows,
+        )
+        return run
+
+    except Exception as exc:
+        # A FAILED run is not counted by _find_mature_unvalidated_dates, so the date
+        # stays eligible and the next validation pass retries it.
+        run.status = AutoresearchRun.Status.FAILED
+        run.completed_at = django_timezone.now()
+        run.metrics["error"] = str(exc)
+        run.save(update_fields=["status", "completed_at", "metrics"])
+        logger.exception(
+            "autoresearch_validation_failed",
+            pipeline_id=str(pipeline.pk),
+            prediction_date=prediction_date.isoformat(),
+        )
+        return run
+
+
+def _fetch_predictions_by_model(
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+) -> dict[str, dict[str, float]]:
+    """
+    Return {model_id: {person_id: p_y}} for all predictions emitted on prediction_date.
+
+    Keyed on person_id to match realized labels (also keyed on person_id). Predictions
+    carry it as the $autoresearch_person_id property; we fall back to distinct_id for
+    events emitted before that property existed (when distinct_id was str(person_id)).
+
+    Raises ValidationDataTruncatedError when the row count hits VALIDATION_QUERY_LIMIT:
+    an arbitrary subset would bias every realized metric, and the COMPLETED run would
+    permanently exclude the date from revalidation.
+    """
+    # argMax picks the latest emission per (model, person), so a manual re-score of an
+    # already-scored date is validated deterministically instead of in ClickHouse
+    # return order. Backfills stamp every event of a date at the same instant, so the
+    # event UUID breaks those ties rather than leaving them to merge order.
+    sql = (
+        "SELECT"
+        " coalesce(nullIf(properties['$autoresearch_person_id'], ''), distinct_id) AS person_id,"
+        " properties['$autoresearch_model_id'] AS model_id,"
+        " argMax(toFloat(properties['$autoresearch_p_y']), (timestamp, uuid)) AS p_y"
+        " FROM events"
+        " WHERE event = {event_name}"
+        " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
+        " AND properties['$autoresearch_prediction_date'] = {prediction_date}"
+        " GROUP BY person_id, model_id"
+        " LIMIT {limit}"
+    )
+    values: dict[str, Any] = {
+        "event_name": PREDICTION_EVENT_NAME,
+        "pipeline_id": str(pipeline.pk),
+        "prediction_date": prediction_date.isoformat(),
+        "limit": VALIDATION_QUERY_LIMIT,
+    }
+
+    try:
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
+        if not rows:
+            return {}
+    except Exception:
+        logger.exception(
+            "autoresearch_predictions_query_failed",
+            pipeline_id=str(pipeline.pk),
+            prediction_date=prediction_date.isoformat(),
+        )
+        # A swallowed failure would complete the run as no_predictions_found, and the
+        # maturity selector would then never revisit the date. Fail so it retries.
+        raise
+
+    if len(rows) >= VALIDATION_QUERY_LIMIT:
+        raise ValidationDataTruncatedError(
+            f"Predictions for {prediction_date.isoformat()} hit the {VALIDATION_QUERY_LIMIT} row limit; "
+            "refusing to compute metrics from a truncated subset"
+        )
+
+    model_predictions: dict[str, dict[str, float]] = {}
+    for row in rows:
+        person_id, model_id, p_y = row[0], row[1], row[2]
+        if not person_id or not model_id or p_y is None:
+            continue
+        mid = str(model_id)
+        if mid not in model_predictions:
+            model_predictions[mid] = {}
+        model_predictions[mid][str(person_id)] = float(p_y)
+
+    return model_predictions
+
+
+def _fetch_realized_labels(
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+) -> frozenset[str]:
+    """
+    Return person_ids that performed the pipeline's target (event or action) in the
+    window [prediction_date, prediction_date + horizon_days).
+
+    Keyed on person_id (not distinct_id) to match the prediction events, which
+    are emitted with distinct_id = str(person_id) — the feature/score SQL keys
+    every scored row on person_id (see labeling.py, sandbox_inference.py).
+    Joining on the raw event distinct_id would compare two disjoint key spaces
+    and yield all-negative labels (AUC ≈ 0.5 / single-class).
+    """
+    end_date = prediction_date + timedelta(days=pipeline.horizon_days)
+    target_cond, target_values = build_target_condition(
+        target_event=pipeline.target_event, target_definition=pipeline.target_definition, team=team
+    )
+    sql = (
+        "SELECT DISTINCT person_id"
+        " FROM events"
+        f" WHERE {target_cond}"
+        " AND toDate(timestamp) >= {start_date}"
+        " AND toDate(timestamp) < {end_date}"
+    )
+    values: dict[str, Any] = {
+        "start_date": prediction_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        **target_values,
+    }
+
+    # A query failure must propagate: returning an empty set here would make every
+    # prediction look negative, and the resulting COMPLETED run would permanently
+    # exclude this date from revalidation.
+    tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+    rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
+    return frozenset(str(row[0]) for row in rows if row[0])
+
+
+def _compute_validation_metrics(
+    predictions: dict[str, float],
+    realized_labels: frozenset[str],
+) -> dict[str, Any]:
+    """
+    Compute AUC, Brier score, ECE, and lift@k from scored predictions vs realized labels.
+
+    predictions: {distinct_id: p_y}
+    realized_labels: distinct_ids that performed the target event in the horizon window
+    """
+    distinct_ids = list(predictions.keys())
+    y_score = np.array([predictions[did] for did in distinct_ids], dtype=np.float64)
+    y_true = np.array([1 if did in realized_labels else 0 for did in distinct_ids], dtype=np.int32)
+
+    n = len(y_true)
+    n_pos = int(y_true.sum())
+    n_neg = n - n_pos
+    base_rate = n_pos / n if n > 0 else 0.0
+
+    metrics: dict[str, Any] = {
+        "n_scored": n,
+        "n_positive": n_pos,
+        "n_negative": n_neg,
+        "base_rate": round(base_rate, 4),
+    }
+
+    if n_pos == 0 or n_neg == 0:
+        metrics["warning"] = "single_class_no_auc"
+        return metrics
+
+    # Deferred to keep the heavy dependency off the import path.
+    from sklearn.metrics import brier_score_loss, roc_auc_score  # noqa: PLC0415
+
+    metrics["realized_auc"] = round(float(roc_auc_score(y_true, y_score)), 4)
+    metrics["brier_score"] = round(float(brier_score_loss(y_true, y_score)), 4)
+    metrics["calibration_error"] = round(_expected_calibration_error(y_true, y_score), 4)
+    metrics["lift_at_10"] = round(_lift_at_k(y_true, y_score, k=0.10), 4)
+    metrics["lift_at_20"] = round(_lift_at_k(y_true, y_score, k=0.20), 4)
+
+    return metrics
+
+
+def _expected_calibration_error(y_true: np.ndarray, y_score: np.ndarray, n_bins: int = 10) -> float:
+    """
+    Expected Calibration Error (ECE): fraction-weighted mean absolute difference
+    between mean predicted probability and actual positive rate within each decile bin.
+    """
+    n = len(y_true)
+    bin_boundaries = np.linspace(0.0, 1.0, n_bins + 1)
+    ece = 0.0
+    for i in range(n_bins):
+        lo, hi = bin_boundaries[i], bin_boundaries[i + 1]
+        mask = (y_score >= lo) & (y_score <= hi) if i == n_bins - 1 else (y_score >= lo) & (y_score < hi)
+        if not mask.any():
+            continue
+        bin_n = int(mask.sum())
+        avg_pred = float(y_score[mask].mean())
+        actual_rate = float(y_true[mask].mean())
+        ece += (bin_n / n) * abs(avg_pred - actual_rate)
+    return ece
+
+
+def _lift_at_k(y_true: np.ndarray, y_score: np.ndarray, k: float) -> float:
+    """
+    Lift@k: ratio of positives captured in the top-k% of scored users vs random.
+
+    lift@k = (positives in top k%) / (k × total positives)
+
+    A lift of 2.0 at k=10% means the top 10% by score contains 2× as many positives
+    as a random 10% sample would.
+    """
+    n_pos_total = int(y_true.sum())
+    if n_pos_total == 0 or k <= 0:
+        return 0.0
+    n = len(y_true)
+    cutoff = max(1, math.ceil(n * k))
+    top_k_idx = np.argsort(y_score)[::-1][:cutoff]
+    positives_captured = int(y_true[top_k_idx].sum())
+    # Normalize by the fraction actually selected, not the requested k — rounding up to
+    # a whole user would otherwise overstate lift on small validation sets.
+    random_expected = (cutoff / n) * n_pos_total
+    return positives_captured / random_expected
+
+
+def _update_model_realized_metrics(model: AutoresearchModel, metrics: dict[str, Any]) -> None:
+    """
+    Persist validation metrics to the model record.
+
+    On first realized validation (is_preliminary=True), clears the preliminary flag
+    and sets realized_score. Subsequent validations update realized_score to the latest.
+    """
+    auc = metrics.get("realized_auc")
+    cal_error = metrics.get("calibration_error")
+
+    existing = model.metrics or {}
+    existing["realized"] = metrics
+
+    update_fields = ["metrics", "updated_at"]
+
+    if auc is not None:
+        model.realized_score = auc
+        update_fields.append("realized_score")
+        if model.is_preliminary:
+            model.is_preliminary = False
+            update_fields.append("is_preliminary")
+
+    if cal_error is not None:
+        model.calibration_error = cal_error
+        update_fields.append("calibration_error")
+
+    model.metrics = existing
+    model.save(update_fields=update_fields)
+
+    logger.info(
+        "autoresearch_model_realized_metrics_updated",
+        model_id=str(model.pk),
+        role=model.role,
+        realized_auc=auc,
+        calibration_error=cal_error,
+        is_preliminary=model.is_preliminary,
+    )

--- a/products/autoresearch/backend/evaluation/online_validation.py
+++ b/products/autoresearch/backend/evaluation/online_validation.py
@@ -20,7 +20,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from django.db import transaction
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from django.utils import timezone as django_timezone
 
 import numpy as np
@@ -46,9 +46,10 @@ from products.autoresearch.backend.query import HogQLResult, run_hogql
 
 logger = structlog.get_logger(__name__)
 
-# A validation run does two bounded queries, so a RUNNING row older than this belongs to
-# a worker that died mid-run. It must not keep the date claimed forever.
-STALE_CLAIM_AFTER = timedelta(hours=6)
+# A validation run does two bounded queries and a scoring run is bounded by its sandbox
+# timeouts, so a RUNNING row older than this belongs to a worker that died mid-run and the
+# exception handler never ran. Neither kind may hold a date forever.
+STALE_RUN_AFTER = timedelta(hours=6)
 
 # An outcome event timestamped just before the window closes can still be in the ingestion
 # queue when the window closes. Maturity waits this long past the window end so it lands
@@ -93,6 +94,10 @@ class PendingValidationDate:
     @property
     def expected_rows(self) -> int:
         return sum(self.expected_rows_by_model.values())
+
+    @property
+    def key(self) -> tuple[date, int]:
+        return (self.prediction_date, self.horizon_days)
 
 
 @frozen
@@ -149,25 +154,29 @@ def _acting_user(*, team: Team, pipeline: AutoresearchPipeline, user: User | Non
 
 def find_pending_validation_dates(pipeline: AutoresearchPipeline) -> list[PendingValidationDate]:
     """
-    Matured prediction dates with no COMPLETED validation run and no live claim, oldest first.
+    Matured (date, horizon) groups whose validation does not match their inference runs, oldest first.
 
-    Candidates come from the completed inference runs, which record the prediction date
-    and the horizon they scored against. A date waits while an inference run for it is
-    still scoring, and for ``OUTCOME_INGESTION_GRACE`` after its window closes. A FAILED
-    validation run does not count, so its date is retried; a RUNNING one counts only while
-    it is younger than ``STALE_CLAIM_AFTER``.
+    Candidates come from the completed inference runs, which record the prediction date and
+    the horizon they scored against; models scored on one date under different horizons form
+    separate groups with their own outcome windows. A group waits while an inference run for
+    it is still scoring, and for ``OUTCOME_INGESTION_GRACE`` after its window closes. It is
+    done once a COMPLETED validation run holds the same per-model counts as its inference
+    runs, so a later rescore or a new model on the date makes it pending again. A FAILED
+    validation run does not count; a RUNNING one, like a RUNNING inference run, counts only
+    while it is younger than ``STALE_RUN_AFTER``.
     """
     now = django_timezone.now()
-    blocked = _blocked_dates(pipeline, now=now) | _dates_still_scoring(pipeline)
+    scoring = _groups_still_scoring(pipeline, now=now)
+    state = _validation_state(pipeline, now=now)
     return [
         item
-        for item in _dates_scored(pipeline)
-        if item.prediction_date not in blocked and item.window_end + OUTCOME_INGESTION_GRACE <= now
+        for item in _scored_groups(pipeline)
+        if item.key not in scoring and not _is_blocked(item, state) and item.window_end + OUTCOME_INGESTION_GRACE <= now
     ]
 
 
-def _dates_scored(pipeline: AutoresearchPipeline) -> list[PendingValidationDate]:
-    """Every date with a completed inference run, oldest first, with the rows each model's latest run emitted."""
+def _scored_groups(pipeline: AutoresearchPipeline) -> list[PendingValidationDate]:
+    """Every (date, horizon) with a completed inference run, oldest first, with the rows each model's latest run emitted."""
     runs = (
         AutoresearchRun.objects.filter(
             pipeline=pipeline,
@@ -176,73 +185,89 @@ def _dates_scored(pipeline: AutoresearchPipeline) -> list[PendingValidationDate]
             model__isnull=False,
             rows_scored__gt=0,
         )
-        # Ascending, so the latest run for a (date, model) is the one whose counts survive.
+        # Ascending, so the latest run for a (group, model) is the one whose counts survive.
         .order_by("completed_at", "created_at")
         .values_list("model_id", "rows_scored", "metrics")
     )
-    horizon_by_date: dict[date, int] = {}
-    expected_by_date: dict[date, dict[str, int]] = {}
+    expected_by_group: dict[tuple[date, int], dict[str, int]] = {}
     for model_id, rows_scored, metrics in runs:
-        stamp = metrics.get("prediction_date")
-        horizon_days = metrics.get("horizon_days")
-        if rows_scored is None or not isinstance(stamp, str) or not isinstance(horizon_days, int):
+        key = _group_key(metrics)
+        if key is None or rows_scored is None:
             continue
-        prediction_date = date.fromisoformat(stamp)
-        horizon_by_date[prediction_date] = horizon_days
-        expected_by_date.setdefault(prediction_date, {})[str(model_id)] = int(rows_scored)
-
+        expected_by_group.setdefault(key, {})[str(model_id)] = int(rows_scored)
     return [
         PendingValidationDate(
-            prediction_date=prediction_date,
-            horizon_days=horizon_by_date[prediction_date],
-            expected_rows_by_model=expected,
+            prediction_date=prediction_date, horizon_days=horizon_days, expected_rows_by_model=expected
         )
-        for prediction_date, expected in sorted(expected_by_date.items())
+        for (prediction_date, horizon_days), expected in sorted(expected_by_group.items())
     ]
 
 
-def _dates_still_scoring(pipeline: AutoresearchPipeline) -> set[date]:
+def _group_key(metrics: dict[str, Any]) -> tuple[date, int] | None:
+    stamp = metrics.get("prediction_date")
+    horizon_days = metrics.get("horizon_days")
+    if not isinstance(stamp, str) or not isinstance(horizon_days, int):
+        return None
+    return (date.fromisoformat(stamp), horizon_days)
+
+
+def _groups_still_scoring(pipeline: AutoresearchPipeline, *, now: datetime) -> set[tuple[date, int]]:
     in_flight = AutoresearchRun.objects.filter(
         pipeline=pipeline,
         run_type=AutoresearchRun.RunType.INFERENCE,
         status__in=(AutoresearchRun.Status.PENDING, AutoresearchRun.Status.RUNNING),
+        created_at__gte=now - STALE_RUN_AFTER,
     ).values_list("metrics", flat=True)
-    return {date.fromisoformat(m["prediction_date"]) for m in in_flight if isinstance(m.get("prediction_date"), str)}
+    return {key for key in (_group_key(m) for m in in_flight) if key is not None}
 
 
-def _blocking_validation_runs(pipeline: AutoresearchPipeline, *, now: datetime) -> QuerySet[AutoresearchRun]:
-    return AutoresearchRun.objects.filter(pipeline=pipeline, run_type=AutoresearchRun.RunType.VALIDATION).filter(
-        Q(status=AutoresearchRun.Status.COMPLETED)
-        | Q(status=AutoresearchRun.Status.RUNNING, started_at__gte=now - STALE_CLAIM_AFTER)
+def _validation_state(
+    pipeline: AutoresearchPipeline, *, now: datetime
+) -> dict[tuple[date, int], list[dict[str, int] | None]]:
+    """Per group: the per-model counts each COMPLETED validation run scored, and None for each live claim."""
+    runs = (
+        AutoresearchRun.objects.filter(pipeline=pipeline, run_type=AutoresearchRun.RunType.VALIDATION)
+        .filter(
+            Q(status=AutoresearchRun.Status.COMPLETED)
+            | Q(status=AutoresearchRun.Status.RUNNING, started_at__gte=now - STALE_RUN_AFTER)
+        )
+        .values_list("status", "metrics")
     )
+    state: dict[tuple[date, int], list[dict[str, int] | None]] = {}
+    for status, metrics in runs:
+        key = _group_key(metrics)
+        if key is None:
+            continue
+        if status == AutoresearchRun.Status.RUNNING:
+            state.setdefault(key, []).append(None)
+            continue
+        per_model = metrics.get("per_model") or {}
+        state.setdefault(key, []).append(
+            {
+                model_id: int(m["n_scored"])
+                for model_id, m in per_model.items()
+                if isinstance(m, dict) and "n_scored" in m
+            }
+        )
+    return state
 
 
-def _blocked_dates(pipeline: AutoresearchPipeline, *, now: datetime) -> set[date]:
-    blocked: set[date] = set()
-    for metrics in _blocking_validation_runs(pipeline, now=now).values_list("metrics", flat=True):
-        stamp = metrics.get("prediction_date")
-        if isinstance(stamp, str):
-            blocked.add(date.fromisoformat(stamp))
-    return blocked
+def _is_blocked(item: PendingValidationDate, state: dict[tuple[date, int], list[dict[str, int] | None]]) -> bool:
+    return any(counts is None or counts == item.expected_rows_by_model for counts in state.get(item.key, []))
 
 
 def _claim_date(pipeline: AutoresearchPipeline, pending: PendingValidationDate) -> AutoresearchRun | None:
     """
-    Record a RUNNING validation run for the date, or return None when another validator
-    already holds it. The check and the insert happen under the pipeline row's lock, so
-    the scheduled activity and a manual command cannot both score the same date. FOR NO
-    KEY UPDATE leaves the KEY SHARE locks an inference run's insert takes on the same row
-    unblocked.
+    Record a RUNNING validation run for the group, or return None when another validator
+    already holds it or has validated these exact runs. The check and the insert happen
+    under the pipeline row's lock, so the scheduled activity and a manual command cannot
+    both score the same group. FOR NO KEY UPDATE leaves the KEY SHARE locks an inference
+    run's insert takes on the same row unblocked.
     """
     now = django_timezone.now()
     with transaction.atomic():
         AutoresearchPipeline.objects.select_for_update(no_key=True).get(pk=pipeline.pk, team_id=pipeline.team_id)
-        already_claimed = (
-            _blocking_validation_runs(pipeline, now=now)
-            .filter(metrics__prediction_date=pending.prediction_date.isoformat())
-            .exists()
-        )
-        if already_claimed:
+        if _is_blocked(pending, _validation_state(pipeline, now=now)):
             return None
         return AutoresearchRun.objects.create(
             pipeline=pipeline,
@@ -318,10 +343,13 @@ def _persist_completed(
     run_metrics: dict[str, Any] = {}
     total_rows = 0
     with transaction.atomic():
-        # A run that completed for this date while the queries ran is missing from the counts
-        # the fetch was checked against; completing now would leave its model unvalidated.
-        current = {item.prediction_date: item.expected_rows_by_model for item in _dates_scored(pipeline)}
-        if current.get(pending.prediction_date) != pending.expected_rows_by_model:
+        # A run that completed or started for this group while the queries ran is missing from
+        # the counts the fetch was checked against.
+        now = django_timezone.now()
+        current = {item.key: item.expected_rows_by_model for item in _scored_groups(pipeline)}
+        if current.get(pending.key) != pending.expected_rows_by_model or pending.key in _groups_still_scoring(
+            pipeline, now=now
+        ):
             raise OnlineValidationError(
                 f"The inference runs for {pending.prediction_date.isoformat()} changed while it was being validated; "
                 "retrying on the next pass"

--- a/products/autoresearch/backend/evaluation/online_validation.py
+++ b/products/autoresearch/backend/evaluation/online_validation.py
@@ -50,6 +50,12 @@ logger = structlog.get_logger(__name__)
 # a worker that died mid-run. It must not keep the date claimed forever.
 STALE_CLAIM_AFTER = timedelta(hours=6)
 
+# An outcome event timestamped just before the window closes can still be in the ingestion
+# queue when the window closes. Maturity waits this long past the window end so it lands
+# first; a completed date is never revisited, so a positive that arrives later than this
+# reads as a negative.
+OUTCOME_INGESTION_GRACE = timedelta(hours=1)
+
 # A live run stamps its events at emission time, which can cross midnight UTC before the
 # batch goes out; a backfill stamps noon UTC of the date. Both fall within this many days
 # of the start of the prediction date, so the fetch can bound `timestamp` for pruning.
@@ -146,15 +152,22 @@ def find_pending_validation_dates(pipeline: AutoresearchPipeline) -> list[Pendin
     Matured prediction dates with no COMPLETED validation run and no live claim, oldest first.
 
     Candidates come from the completed inference runs, which record the prediction date
-    and the horizon they scored against. A FAILED validation run does not count, so its
-    date is retried; a RUNNING one counts only while it is younger than ``STALE_CLAIM_AFTER``.
+    and the horizon they scored against. A date waits while an inference run for it is
+    still scoring, and for ``OUTCOME_INGESTION_GRACE`` after its window closes. A FAILED
+    validation run does not count, so its date is retried; a RUNNING one counts only while
+    it is younger than ``STALE_CLAIM_AFTER``.
     """
     now = django_timezone.now()
-    blocked = _blocked_dates(pipeline, now=now)
-    return [item for item in _matured_dates(pipeline, now=now) if item.prediction_date not in blocked]
+    blocked = _blocked_dates(pipeline, now=now) | _dates_still_scoring(pipeline)
+    return [
+        item
+        for item in _dates_scored(pipeline)
+        if item.prediction_date not in blocked and item.window_end + OUTCOME_INGESTION_GRACE <= now
+    ]
 
 
-def _matured_dates(pipeline: AutoresearchPipeline, *, now: datetime) -> list[PendingValidationDate]:
+def _dates_scored(pipeline: AutoresearchPipeline) -> list[PendingValidationDate]:
+    """Every date with a completed inference run, oldest first, with the rows each model's latest run emitted."""
     runs = (
         AutoresearchRun.objects.filter(
             pipeline=pipeline,
@@ -178,7 +191,6 @@ def _matured_dates(pipeline: AutoresearchPipeline, *, now: datetime) -> list[Pen
         horizon_by_date[prediction_date] = horizon_days
         expected_by_date.setdefault(prediction_date, {})[str(model_id)] = int(rows_scored)
 
-    today_utc = now.astimezone(UTC).date()
     return [
         PendingValidationDate(
             prediction_date=prediction_date,
@@ -186,8 +198,16 @@ def _matured_dates(pipeline: AutoresearchPipeline, *, now: datetime) -> list[Pen
             expected_rows_by_model=expected,
         )
         for prediction_date, expected in sorted(expected_by_date.items())
-        if prediction_date + timedelta(days=horizon_by_date[prediction_date]) <= today_utc
     ]
+
+
+def _dates_still_scoring(pipeline: AutoresearchPipeline) -> set[date]:
+    in_flight = AutoresearchRun.objects.filter(
+        pipeline=pipeline,
+        run_type=AutoresearchRun.RunType.INFERENCE,
+        status__in=(AutoresearchRun.Status.PENDING, AutoresearchRun.Status.RUNNING),
+    ).values_list("metrics", flat=True)
+    return {date.fromisoformat(m["prediction_date"]) for m in in_flight if isinstance(m.get("prediction_date"), str)}
 
 
 def _blocking_validation_runs(pipeline: AutoresearchPipeline, *, now: datetime) -> QuerySet[AutoresearchRun]:
@@ -298,8 +318,21 @@ def _persist_completed(
     run_metrics: dict[str, Any] = {}
     total_rows = 0
     with transaction.atomic():
+        # A run that completed for this date while the queries ran is missing from the counts
+        # the fetch was checked against; completing now would leave its model unvalidated.
+        current = {item.prediction_date: item.expected_rows_by_model for item in _dates_scored(pipeline)}
+        if current.get(pending.prediction_date) != pending.expected_rows_by_model:
+            raise OnlineValidationError(
+                f"The inference runs for {pending.prediction_date.isoformat()} changed while it was being validated; "
+                "retrying on the next pass"
+            )
         for model_id, validation in per_model.items():
-            model = AutoresearchModel.objects.filter(pk=model_id, pipeline=pipeline, team_id=pipeline.team_id).first()
+            # Locked so two validators on different dates cannot race the newest-date guard.
+            model = (
+                AutoresearchModel.objects.select_for_update()
+                .filter(pk=model_id, pipeline=pipeline, team_id=pipeline.team_id)
+                .first()
+            )
             if model is not None:
                 _update_model_realized_metrics(model, validation.metrics, prediction_date=pending.prediction_date)
             run_metrics[model_id] = {

--- a/products/autoresearch/backend/evaluation/online_validation.py
+++ b/products/autoresearch/backend/evaluation/online_validation.py
@@ -2,20 +2,25 @@
 Online validation: join autoresearch_prediction events to realized target outcomes
 after the prediction horizon has elapsed.
 
-Computes per-model: realized AUC, Brier score, expected calibration error (ECE),
-and lift@k for both champion and challengers.
+Computes per model: realized AUC, Brier score, expected calibration error (ECE),
+and lift@k, for every model that emitted predictions on a date.
 
 Architecture:
 - Pure activity functions called by AutoresearchValidationWorkflow (Temporal)
   and the autoresearch_validate_online management command.
 - All heavy work (HogQL queries + sklearn metrics) happens inside a single activity;
   nothing large passes through Temporal payloads.
+- Candidate dates come from the completed inference runs in Postgres, never from a
+  scan of the events table, and every ClickHouse query is bounded by what those runs
+  say was emitted.
 """
 
 import math
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
+from django.db import transaction
+from django.db.models import Q, QuerySet
 from django.utils import timezone as django_timezone
 
 import numpy as np
@@ -24,299 +29,449 @@ import structlog
 from posthog.schema import HogQLQuery
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.dataclasses import frozen
+from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models.team.team import Team
+from posthog.models.user import User
 
-from products.autoresearch.backend.dataset.labeling import build_target_condition
+from products.autoresearch.backend.dataset.labeling import (
+    LABELER_QUERY_MODIFIERS,
+    PREDICTION_EVENT_NAME,
+    _own_events_excluded_clause,
+    build_target_condition,
+)
+from products.autoresearch.backend.inference.sandbox import SandboxInferenceError, _resolve_acting_user
 from products.autoresearch.backend.models import AutoresearchModel, AutoresearchPipeline, AutoresearchRun
-from products.autoresearch.backend.query import run_hogql_rows
+from products.autoresearch.backend.query import HogQLResult, run_hogql
 
 logger = structlog.get_logger(__name__)
 
-PREDICTION_EVENT_NAME = "autoresearch_prediction"
-VALIDATION_QUERY_LIMIT = 50_000
+# A validation run does two bounded queries, so a RUNNING row older than this belongs to
+# a worker that died mid-run. It must not keep the date claimed forever.
+STALE_CLAIM_AFTER = timedelta(hours=6)
+
+# A live run stamps its events at emission time, which can cross midnight UTC before the
+# batch goes out; a backfill stamps noon UTC of the date. Both fall within this many days
+# of the start of the prediction date, so the fetch can bound `timestamp` for pruning.
+_EMISSION_WINDOW_DAYS = 2
 
 
-class ValidationDataTruncatedError(Exception):
-    """The predictions query hit VALIDATION_QUERY_LIMIT, so the fetched set may be incomplete."""
+class OnlineValidationError(Exception):
+    """The date must fail, and be retried on a later pass, instead of completing with metrics from bad data."""
 
 
-def run_online_validation_for_pipeline(pipeline: AutoresearchPipeline) -> list[AutoresearchRun]:
+@frozen
+class PendingValidationDate:
+    """A matured prediction date with no completed validation, and what its inference runs emitted."""
+
+    prediction_date: date
+    horizon_days: int
+    # rows_scored of the latest completed inference run per model id. The prediction
+    # events for the date must match these counts exactly before metrics are trusted.
+    expected_rows_by_model: dict[str, int]
+
+    @property
+    def window_start(self) -> datetime:
+        # Scoring binds every run to the start of its prediction date in UTC, so the
+        # outcome window opens at the same instant whatever the project's timezone.
+        return datetime(self.prediction_date.year, self.prediction_date.month, self.prediction_date.day, tzinfo=UTC)
+
+    @property
+    def window_end(self) -> datetime:
+        return self.window_start + timedelta(days=self.horizon_days)
+
+    @property
+    def emitted_before(self) -> datetime:
+        return self.window_start + timedelta(days=_EMISSION_WINDOW_DAYS)
+
+    @property
+    def expected_rows(self) -> int:
+        return sum(self.expected_rows_by_model.values())
+
+
+@frozen
+class _ModelPredictions:
+    emitted_role: str
+    p_y_by_person: dict[str, float]
+
+
+@frozen
+class _ModelValidation:
+    emitted_role: str
+    metrics: dict[str, Any]
+
+
+def run_online_validation_for_pipeline(
+    pipeline: AutoresearchPipeline, *, user: User | None = None
+) -> list[AutoresearchRun]:
     """
-    Find all matured, unvalidated prediction dates and validate each one.
+    Validate every matured prediction date that has no completed validation yet.
 
-    A prediction date is "matured" when today >= prediction_date + horizon_days —
-    meaning the outcome window has closed and realized labels can be fetched.
+    A date is matured when its outcome window, ``[prediction_date, prediction_date +
+    horizon_days)`` in UTC, has closed. Each date is claimed with an ``AutoresearchRun``
+    before any query runs, so two validators cannot score the same date. Returns one run
+    per date processed, COMPLETED or FAILED, and updates ``realized_score`` and
+    ``calibration_error`` on each model that emitted predictions.
 
-    Returns one AutoresearchRun per prediction_date processed and updates
-    realized_score / calibration_error on each AutoresearchModel.
+    ``user`` is who HogQL applies access control for; it defaults to the pipeline's creator.
     """
     team = pipeline.team
-    mature_dates = _find_mature_unvalidated_dates(team, pipeline)
-
-    if not mature_dates:
+    acting_user = _acting_user(team=team, pipeline=pipeline, user=user)
+    pending = find_pending_validation_dates(pipeline)
+    if not pending:
         logger.info("autoresearch_validation_no_mature_dates", pipeline_id=str(pipeline.pk))
         return []
 
-    results = []
-    for prediction_date in sorted(mature_dates):
-        run = _validate_one_date(team, pipeline, prediction_date)
-        results.append(run)
+    results: list[AutoresearchRun] = []
+    for item in pending:
+        run = _claim_date(pipeline, item)
+        if run is None:
+            continue
+        results.append(_validate_claimed_date(team=team, pipeline=pipeline, run=run, pending=item, user=acting_user))
     return results
 
 
-def _find_mature_unvalidated_dates(team: Team, pipeline: AutoresearchPipeline) -> list[date]:
-    """
-    Return prediction dates that have matured but haven't been successfully validated.
-    Already-validated dates are tracked as COMPLETED validation AutoresearchRuns with
-    metrics['prediction_date'] set.
-    """
-    matured = _fetch_matured_prediction_dates(team, pipeline)
-    if not matured:
-        return []
-
-    already_validated = {
-        r.metrics.get("prediction_date")
-        for r in AutoresearchRun.objects.filter(
-            pipeline=pipeline,
-            run_type=AutoresearchRun.RunType.VALIDATION,
-            status=AutoresearchRun.Status.COMPLETED,
-        )
-        if r.metrics.get("prediction_date")
-    }
-
-    return [d for d in matured if d.isoformat() not in already_validated]
-
-
-def _fetch_matured_prediction_dates(team: Team, pipeline: AutoresearchPipeline) -> list[date]:
-    """
-    Query ClickHouse for distinct prediction dates where the horizon has elapsed:
-    prediction_date + horizon_days <= today.
-    """
-    sql = (
-        "SELECT DISTINCT toDate(properties['$autoresearch_prediction_date']) AS prediction_date"
-        " FROM events"
-        " WHERE event = {event_name}"
-        " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
-        " AND addDays(toDate(properties['$autoresearch_prediction_date']), {horizon_days}) <= today()"
-        " ORDER BY prediction_date ASC"
-    )
-    values: dict[str, Any] = {
-        "event_name": PREDICTION_EVENT_NAME,
-        "pipeline_id": str(pipeline.pk),
-        "horizon_days": pipeline.horizon_days,
-    }
-
+def _acting_user(*, team: Team, pipeline: AutoresearchPipeline, user: User | None) -> User:
     try:
-        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
-        rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
-        return [date.fromisoformat(str(row[0])) for row in rows if row[0]]
-    except Exception:
-        logger.exception("autoresearch_matured_dates_query_failed", pipeline_id=str(pipeline.pk))
-        return []
+        return _resolve_acting_user(team=team, pipeline=pipeline, user=user)
+    except SandboxInferenceError as exc:
+        raise OnlineValidationError(str(exc)) from exc
 
 
-def _validate_one_date(
-    team: Team,
-    pipeline: AutoresearchPipeline,
-    prediction_date: date,
-) -> AutoresearchRun:
+# ── Date selection and claiming ───────────────────────────────────────────────────
+
+
+def find_pending_validation_dates(pipeline: AutoresearchPipeline) -> list[PendingValidationDate]:
     """
-    Validate predictions made on prediction_date for all models (champion + challengers).
-    Creates an AutoresearchRun record, computes metrics, and updates model records.
+    Matured prediction dates with no COMPLETED validation run and no live claim, oldest first.
 
-    On any error the run is returned as FAILED (no metrics written), leaving the
-    date eligible for the next pass and other dates in the same pass unaffected.
+    Candidates come from the completed inference runs, which record the prediction date
+    and the horizon they scored against. A FAILED validation run does not count, so its
+    date is retried; a RUNNING one counts only while it is younger than ``STALE_CLAIM_AFTER``.
     """
     now = django_timezone.now()
-    run = AutoresearchRun.objects.create(
-        pipeline=pipeline,
-        run_type=AutoresearchRun.RunType.VALIDATION,
-        status=AutoresearchRun.Status.RUNNING,
-        started_at=now,
-        metrics={"prediction_date": prediction_date.isoformat()},
+    blocked = _blocked_dates(pipeline, now=now)
+    return [item for item in _matured_dates(pipeline, now=now) if item.prediction_date not in blocked]
+
+
+def _matured_dates(pipeline: AutoresearchPipeline, *, now: datetime) -> list[PendingValidationDate]:
+    runs = (
+        AutoresearchRun.objects.filter(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.INFERENCE,
+            status=AutoresearchRun.Status.COMPLETED,
+            model__isnull=False,
+            rows_scored__gt=0,
+        )
+        # Ascending, so the latest run for a (date, model) is the one whose counts survive.
+        .order_by("completed_at", "created_at")
+        .values_list("model_id", "rows_scored", "metrics")
+    )
+    horizon_by_date: dict[date, int] = {}
+    expected_by_date: dict[date, dict[str, int]] = {}
+    for model_id, rows_scored, metrics in runs:
+        stamp = metrics.get("prediction_date")
+        horizon_days = metrics.get("horizon_days")
+        if rows_scored is None or not isinstance(stamp, str) or not isinstance(horizon_days, int):
+            continue
+        prediction_date = date.fromisoformat(stamp)
+        horizon_by_date[prediction_date] = horizon_days
+        expected_by_date.setdefault(prediction_date, {})[str(model_id)] = int(rows_scored)
+
+    today_utc = now.astimezone(UTC).date()
+    return [
+        PendingValidationDate(
+            prediction_date=prediction_date,
+            horizon_days=horizon_by_date[prediction_date],
+            expected_rows_by_model=expected,
+        )
+        for prediction_date, expected in sorted(expected_by_date.items())
+        if prediction_date + timedelta(days=horizon_by_date[prediction_date]) <= today_utc
+    ]
+
+
+def _blocking_validation_runs(pipeline: AutoresearchPipeline, *, now: datetime) -> QuerySet[AutoresearchRun]:
+    return AutoresearchRun.objects.filter(pipeline=pipeline, run_type=AutoresearchRun.RunType.VALIDATION).filter(
+        Q(status=AutoresearchRun.Status.COMPLETED)
+        | Q(status=AutoresearchRun.Status.RUNNING, started_at__gte=now - STALE_CLAIM_AFTER)
     )
 
-    try:
-        model_predictions = _fetch_predictions_by_model(team, pipeline, prediction_date)
-        realized_labels = _fetch_realized_labels(team, pipeline, prediction_date)
 
-        if not model_predictions:
-            logger.warning(
-                "autoresearch_validation_no_predictions",
-                pipeline_id=str(pipeline.pk),
-                prediction_date=prediction_date.isoformat(),
-            )
-            run.status = AutoresearchRun.Status.COMPLETED
-            run.rows_scored = 0
-            run.completed_at = django_timezone.now()
-            run.metrics["warning"] = "no_predictions_found"
-            run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
-            return run
+def _blocked_dates(pipeline: AutoresearchPipeline, *, now: datetime) -> set[date]:
+    blocked: set[date] = set()
+    for metrics in _blocking_validation_runs(pipeline, now=now).values_list("metrics", flat=True):
+        stamp = metrics.get("prediction_date")
+        if isinstance(stamp, str):
+            blocked.add(date.fromisoformat(stamp))
+    return blocked
 
-        per_model_metrics: dict[str, Any] = {}
-        total_rows = 0
 
-        for model_id, predictions in model_predictions.items():
-            model = AutoresearchModel.objects.filter(pk=model_id, pipeline=pipeline).first()
-            if not model:
-                continue
-
-            metrics = _compute_validation_metrics(predictions, realized_labels)
-            per_model_metrics[model_id] = {
-                "model_role": model.role,
-                "n_scored": len(predictions),
-                **metrics,
-            }
-            total_rows += len(predictions)
-            _update_model_realized_metrics(model, metrics)
-
-        run.status = AutoresearchRun.Status.COMPLETED
-        run.rows_scored = total_rows
-        run.completed_at = django_timezone.now()
-        run.metrics.update(
-            {
-                "prediction_date": prediction_date.isoformat(),
-                "realized_labels_count": len(realized_labels),
-                "per_model": per_model_metrics,
-            }
+def _claim_date(pipeline: AutoresearchPipeline, pending: PendingValidationDate) -> AutoresearchRun | None:
+    """
+    Record a RUNNING validation run for the date, or return None when another validator
+    already holds it. The check and the insert happen under the pipeline row's lock, so
+    the scheduled activity and a manual command cannot both score the same date. FOR NO
+    KEY UPDATE leaves the KEY SHARE locks an inference run's insert takes on the same row
+    unblocked.
+    """
+    now = django_timezone.now()
+    with transaction.atomic():
+        AutoresearchPipeline.objects.select_for_update(no_key=True).get(pk=pipeline.pk, team_id=pipeline.team_id)
+        already_claimed = (
+            _blocking_validation_runs(pipeline, now=now)
+            .filter(metrics__prediction_date=pending.prediction_date.isoformat())
+            .exists()
         )
-        run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
+        if already_claimed:
+            return None
+        return AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.RUNNING,
+            started_at=now,
+            metrics={"prediction_date": pending.prediction_date.isoformat(), "horizon_days": pending.horizon_days},
+        )
 
+
+# ── Validating one date ───────────────────────────────────────────────────────────
+
+
+def _validate_claimed_date(
+    *,
+    team: Team,
+    pipeline: AutoresearchPipeline,
+    run: AutoresearchRun,
+    pending: PendingValidationDate,
+    user: User,
+) -> AutoresearchRun:
+    """
+    Compute realized metrics for every model that emitted predictions on the date, then
+    persist the model updates and the run in one transaction.
+
+    Any failure marks the run FAILED with nothing written to the models, so the date stays
+    eligible for the next pass and the other dates in this pass are unaffected.
+    """
+    try:
+        predictions = _fetch_predictions(team=team, pipeline=pipeline, pending=pending, user=user)
+        n_predicted = sum(len(model.p_y_by_person) for model in predictions.values())
+        realized = _fetch_realized_labels(
+            team=team, pipeline=pipeline, pending=pending, n_predicted=n_predicted, user=user
+        )
+        per_model = {
+            model_id: _ModelValidation(
+                emitted_role=model.emitted_role,
+                metrics=_compute_validation_metrics(model.p_y_by_person, realized),
+            )
+            for model_id, model in predictions.items()
+        }
+        _persist_completed(
+            pipeline=pipeline, run=run, pending=pending, per_model=per_model, realized_count=len(realized)
+        )
         logger.info(
             "autoresearch_validation_complete",
             pipeline_id=str(pipeline.pk),
-            prediction_date=prediction_date.isoformat(),
-            models_validated=len(per_model_metrics),
-            total_rows=total_rows,
+            prediction_date=pending.prediction_date.isoformat(),
+            models_validated=len(per_model),
+            total_rows=n_predicted,
         )
-        return run
-
     except Exception as exc:
-        # A FAILED run is not counted by _find_mature_unvalidated_dates, so the date
-        # stays eligible and the next validation pass retries it.
         run.status = AutoresearchRun.Status.FAILED
+        run.error = str(exc)[:2000]
         run.completed_at = django_timezone.now()
-        run.metrics["error"] = str(exc)
-        run.save(update_fields=["status", "completed_at", "metrics"])
+        run.save(update_fields=["status", "error", "completed_at"])
         logger.exception(
             "autoresearch_validation_failed",
             pipeline_id=str(pipeline.pk),
-            prediction_date=prediction_date.isoformat(),
+            prediction_date=pending.prediction_date.isoformat(),
         )
-        return run
+    return run
 
 
-def _fetch_predictions_by_model(
-    team: Team,
+def _persist_completed(
+    *,
     pipeline: AutoresearchPipeline,
-    prediction_date: date,
-) -> dict[str, dict[str, float]]:
-    """
-    Return {model_id: {person_id: p_y}} for all predictions emitted on prediction_date.
+    run: AutoresearchRun,
+    pending: PendingValidationDate,
+    per_model: dict[str, _ModelValidation],
+    realized_count: int,
+) -> None:
+    run_metrics: dict[str, Any] = {}
+    total_rows = 0
+    with transaction.atomic():
+        for model_id, validation in per_model.items():
+            model = AutoresearchModel.objects.filter(pk=model_id, pipeline=pipeline, team_id=pipeline.team_id).first()
+            if model is not None:
+                _update_model_realized_metrics(model, validation.metrics, prediction_date=pending.prediction_date)
+            run_metrics[model_id] = {
+                # Promotion can change the role before the horizon closes, so both are kept.
+                "emitted_role": validation.emitted_role,
+                "model_role": model.role if model is not None else "deleted",
+                **validation.metrics,
+            }
+            total_rows += int(validation.metrics["n_scored"])
+        run.status = AutoresearchRun.Status.COMPLETED
+        run.rows_scored = total_rows
+        run.completed_at = django_timezone.now()
+        run.metrics.update({"realized_labels_count": realized_count, "per_model": run_metrics})
+        run.save(update_fields=["status", "rows_scored", "completed_at", "metrics"])
 
-    Keyed on person_id to match realized labels (also keyed on person_id). Predictions
-    carry it as the $autoresearch_person_id property; we fall back to distinct_id for
-    events emitted before that property existed (when distinct_id was str(person_id)).
 
-    Raises ValidationDataTruncatedError when the row count hits VALIDATION_QUERY_LIMIT:
-    an arbitrary subset would bias every realized metric, and the COMPLETED run would
-    permanently exclude the date from revalidation.
-    """
-    # argMax picks the latest emission per (model, person), so a manual re-score of an
-    # already-scored date is validated deterministically instead of in ClickHouse
-    # return order. Backfills stamp every event of a date at the same instant, so the
-    # event UUID breaks those ties rather than leaving them to merge order.
-    sql = (
-        "SELECT"
-        " coalesce(nullIf(properties['$autoresearch_person_id'], ''), distinct_id) AS person_id,"
-        " properties['$autoresearch_model_id'] AS model_id,"
-        " argMax(toFloat(properties['$autoresearch_p_y']), (timestamp, uuid)) AS p_y"
-        " FROM events"
-        " WHERE event = {event_name}"
+# ── Queries ────────────────────────────────────────────────────────────────────────
+
+
+def _prediction_filter() -> str:
+    return (
+        " event = {event_name}"
         " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
         " AND properties['$autoresearch_prediction_date'] = {prediction_date}"
-        " GROUP BY person_id, model_id"
-        " LIMIT {limit}"
+        " AND properties['$autoresearch_model_id'] IN {model_ids}"
+        " AND properties['$autoresearch_person_id'] != ''"
+        " AND timestamp >= {emitted_from} AND timestamp < {emitted_before}"
     )
-    values: dict[str, Any] = {
+
+
+def _prediction_values(pipeline: AutoresearchPipeline, pending: PendingValidationDate) -> dict[str, Any]:
+    return {
         "event_name": PREDICTION_EVENT_NAME,
         "pipeline_id": str(pipeline.pk),
-        "prediction_date": prediction_date.isoformat(),
-        "limit": VALIDATION_QUERY_LIMIT,
+        "prediction_date": pending.prediction_date.isoformat(),
+        "model_ids": tuple(pending.expected_rows_by_model),
+        "emitted_from": pending.window_start,
+        "emitted_before": pending.emitted_before,
     }
 
-    try:
-        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
-        rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
-        if not rows:
-            return {}
-    except Exception:
-        logger.exception(
-            "autoresearch_predictions_query_failed",
-            pipeline_id=str(pipeline.pk),
-            prediction_date=prediction_date.isoformat(),
-        )
-        # A swallowed failure would complete the run as no_predictions_found, and the
-        # maturity selector would then never revisit the date. Fail so it retries.
-        raise
 
-    if len(rows) >= VALIDATION_QUERY_LIMIT:
-        raise ValidationDataTruncatedError(
-            f"Predictions for {prediction_date.isoformat()} hit the {VALIDATION_QUERY_LIMIT} row limit; "
-            "refusing to compute metrics from a truncated subset"
-        )
+def _fetch_predictions(
+    *, team: Team, pipeline: AutoresearchPipeline, pending: PendingValidationDate, user: User
+) -> dict[str, _ModelPredictions]:
+    """
+    ``{model_id: predictions}`` for every model the inference runs say scored the date.
 
-    model_predictions: dict[str, dict[str, float]] = {}
-    for row in rows:
-        person_id, model_id, p_y = row[0], row[1], row[2]
-        if not person_id or not model_id or p_y is None:
-            continue
-        mid = str(model_id)
-        if mid not in model_predictions:
-            model_predictions[mid] = {}
-        model_predictions[mid][str(person_id)] = float(p_y)
+    Keyed on ``$autoresearch_person_id``, the person key every scored row carries, so the
+    join to realized labels compares the same key space. Only models with a completed
+    inference run are fetched, and each model's row count must equal that run's
+    ``rows_scored``: fewer means ingestion has not caught up with a backfill yet, more
+    means events the run did not emit. Either way the metrics would be wrong, so the date
+    fails and is retried.
+    """
+    # argMax picks the latest emission per (model, person). Backfills stamp every event of
+    # a date at the same instant, so the event UUID breaks those ties rather than leaving
+    # them to merge order.
+    sql = (
+        "SELECT"
+        " properties['$autoresearch_model_id'] AS model_id,"
+        " properties['$autoresearch_person_id'] AS person_id,"
+        " argMax(toFloatOrNull(properties['$autoresearch_p_y']), (timestamp, uuid)) AS p_y,"
+        " any(properties['$autoresearch_model_role']) AS emitted_role"
+        " FROM events"
+        f" WHERE{_prediction_filter()}"
+        " GROUP BY model_id, person_id"
+    )
+    result = _query(
+        team=team,
+        sql=sql,
+        values=_prediction_values(pipeline, pending),
+        user=user,
+        limit=pending.expected_rows + 1,
+        what="Predictions",
+    )
 
-    return model_predictions
+    roles: dict[str, str] = {}
+    scores: dict[str, dict[str, float]] = {}
+    for model_id, person_id, p_y, emitted_role in result.rows:
+        if p_y is None:
+            raise OnlineValidationError(
+                f"Prediction for person {person_id} of model {model_id} carries a non-numeric $autoresearch_p_y; "
+                "refusing to compute metrics from it"
+            )
+        scores.setdefault(str(model_id), {})[str(person_id)] = float(p_y)
+        roles.setdefault(str(model_id), str(emitted_role or ""))
+
+    for model_id, expected in pending.expected_rows_by_model.items():
+        found = len(scores.get(model_id, {}))
+        if found < expected:
+            raise OnlineValidationError(
+                f"Found {found} of the {expected} predictions model {model_id} emitted for "
+                f"{pending.prediction_date.isoformat()}; ingestion may not have caught up, retrying on the next pass"
+            )
+        if found > expected:
+            raise OnlineValidationError(
+                f"Found {found} predictions for model {model_id} on {pending.prediction_date.isoformat()} but its "
+                f"inference run emitted {expected}; refusing to compute metrics from events the run did not emit"
+            )
+    return {
+        model_id: _ModelPredictions(emitted_role=roles[model_id], p_y_by_person=p_y_by_person)
+        for model_id, p_y_by_person in scores.items()
+    }
 
 
 def _fetch_realized_labels(
-    team: Team,
-    pipeline: AutoresearchPipeline,
-    prediction_date: date,
+    *, team: Team, pipeline: AutoresearchPipeline, pending: PendingValidationDate, n_predicted: int, user: User
 ) -> frozenset[str]:
     """
-    Return person_ids that performed the pipeline's target (event or action) in the
-    window [prediction_date, prediction_date + horizon_days).
+    The predicted persons who performed the pipeline's target inside the outcome window.
 
-    Keyed on person_id (not distinct_id) to match the prediction events, which
-    are emitted with distinct_id = str(person_id) — the feature/score SQL keys
-    every scored row on person_id (see labeling.py, sandbox_inference.py).
-    Joining on the raw event distinct_id would compare two disjoint key spaces
-    and yield all-negative labels (AUC ≈ 0.5 / single-class).
+    The target predicate is ``build_target_condition``, the same one that labeled the
+    training data, and the window is the UTC one scoring bound the run to. The scan is
+    restricted to the persons the prediction events name, so its size is bounded by the
+    predictions and not by how many people on the team performed the target. The
+    product's own prediction event is excluded, so a target that matches it does not turn
+    every scored person into a positive.
     """
-    end_date = prediction_date + timedelta(days=pipeline.horizon_days)
     target_cond, target_values = build_target_condition(
         target_event=pipeline.target_event, target_definition=pipeline.target_definition, team=team
     )
     sql = (
-        "SELECT DISTINCT person_id"
+        "SELECT DISTINCT toString(person_id) AS person_id"
         " FROM events"
-        f" WHERE {target_cond}"
-        " AND toDate(timestamp) >= {start_date}"
-        " AND toDate(timestamp) < {end_date}"
+        f" WHERE {target_cond}{_own_events_excluded_clause()}"
+        " AND timestamp >= {window_start} AND timestamp < {window_end}"
+        " AND toString(person_id) IN ("
+        "SELECT DISTINCT properties['$autoresearch_person_id'] FROM events"
+        f" WHERE{_prediction_filter()}"
+        ")"
     )
     values: dict[str, Any] = {
-        "start_date": prediction_date.isoformat(),
-        "end_date": end_date.isoformat(),
+        **_prediction_values(pipeline, pending),
         **target_values,
+        "window_start": pending.window_start,
+        "window_end": pending.window_end,
     }
+    result = _query(team=team, sql=sql, values=values, user=user, limit=n_predicted + 1, what="Realized labels")
+    return frozenset(str(row[0]) for row in result.rows if row[0])
 
-    # A query failure must propagate: returning an empty set here would make every
-    # prediction look negative, and the resulting COMPLETED run would permanently
-    # exclude this date from revalidation.
-    tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
-    rows = run_hogql_rows(team=team, query=HogQLQuery(query=sql, values=values))
-    return frozenset(str(row[0]) for row in rows if row[0])
+
+def _query(*, team: Team, sql: str, values: dict[str, Any], user: User, limit: int, what: str) -> HogQLResult:
+    """
+    Run a query as the acting user, fresh, with an explicit bound.
+
+    HogQL caps a bare SELECT at 100 rows without an error, so every query here carries a
+    LIMIT one above the rows the caller can account for, and a result that reaches it is
+    refused. The persons-on-events modifiers keep ``person_id`` resolving the way the
+    labeler's queries do, and the always-calculate mode stops a retry reading a cached
+    result from before ingestion caught up.
+    """
+    bounded_sql = sql.rstrip().rstrip(";") + "\nLIMIT {limit}"
+    try:
+        tag_queries(product=Product.AUTORESEARCH, feature=Feature.QUERY)
+        result = run_hogql(
+            team=team,
+            query=HogQLQuery(query=bounded_sql, values={**values, "limit": limit}, modifiers=LABELER_QUERY_MODIFIERS),
+            user=user,
+            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+        )
+    except Exception as exc:
+        logger.exception("autoresearch_validation_query_failed", team_id=team.pk, what=what)
+        raise OnlineValidationError(f"{what} query failed; failing the date so it is retried") from exc
+    if result.has_more or len(result.rows) >= limit:
+        raise OnlineValidationError(
+            f"{what} query returned more rows than the inference runs account for ({limit - 1}); "
+            "refusing to compute metrics from them"
+        )
+    return result
+
+
+# ── Metrics ────────────────────────────────────────────────────────────────────────
 
 
 def _compute_validation_metrics(
@@ -324,40 +479,40 @@ def _compute_validation_metrics(
     realized_labels: frozenset[str],
 ) -> dict[str, Any]:
     """
-    Compute AUC, Brier score, ECE, and lift@k from scored predictions vs realized labels.
+    AUC, Brier score, ECE, and lift@k from scored predictions against realized labels.
 
-    predictions: {distinct_id: p_y}
-    realized_labels: distinct_ids that performed the target event in the horizon window
+    Only the AUC needs both classes. The other metrics are computed for a single-class
+    date too, because an all-negative day is exactly where calibration matters for a rare
+    target.
     """
-    distinct_ids = list(predictions.keys())
-    y_score = np.array([predictions[did] for did in distinct_ids], dtype=np.float64)
-    y_true = np.array([1 if did in realized_labels else 0 for did in distinct_ids], dtype=np.int32)
+    person_ids = list(predictions.keys())
+    y_score = np.array([predictions[pid] for pid in person_ids], dtype=np.float64)
+    y_true = np.array([1 if pid in realized_labels else 0 for pid in person_ids], dtype=np.int32)
 
     n = len(y_true)
     n_pos = int(y_true.sum())
     n_neg = n - n_pos
-    base_rate = n_pos / n if n > 0 else 0.0
 
     metrics: dict[str, Any] = {
         "n_scored": n,
         "n_positive": n_pos,
         "n_negative": n_neg,
-        "base_rate": round(base_rate, 4),
+        "base_rate": round(n_pos / n, 4) if n > 0 else 0.0,
     }
-
-    if n_pos == 0 or n_neg == 0:
-        metrics["warning"] = "single_class_no_auc"
+    if n == 0:
         return metrics
 
     # Deferred to keep the heavy dependency off the import path.
     from sklearn.metrics import brier_score_loss, roc_auc_score  # noqa: PLC0415
 
-    metrics["realized_auc"] = round(float(roc_auc_score(y_true, y_score)), 4)
+    if n_pos == 0 or n_neg == 0:
+        metrics["warning"] = "single_class_no_auc"
+    else:
+        metrics["realized_auc"] = round(float(roc_auc_score(y_true, y_score)), 4)
     metrics["brier_score"] = round(float(brier_score_loss(y_true, y_score)), 4)
     metrics["calibration_error"] = round(_expected_calibration_error(y_true, y_score), 4)
     metrics["lift_at_10"] = round(_lift_at_k(y_true, y_score, k=0.10), 4)
     metrics["lift_at_20"] = round(_lift_at_k(y_true, y_score, k=0.20), 4)
-
     return metrics
 
 
@@ -383,39 +538,51 @@ def _expected_calibration_error(y_true: np.ndarray, y_score: np.ndarray, n_bins:
 
 def _lift_at_k(y_true: np.ndarray, y_score: np.ndarray, k: float) -> float:
     """
-    Lift@k: ratio of positives captured in the top-k% of scored users vs random.
+    Lift@k: positives captured in the top-k fraction of scored users, relative to random.
 
-    lift@k = (positives in top k%) / (k × total positives)
-
-    A lift of 2.0 at k=10% means the top 10% by score contains 2× as many positives
-    as a random 10% sample would.
+    A lift of 2.0 at k=10% means the top 10% by score contains twice the positives a
+    random 10% sample would. Rows tied at the boundary score are counted fractionally,
+    so the number does not depend on the order ClickHouse returned the tied persons in.
     """
     n_pos_total = int(y_true.sum())
-    if n_pos_total == 0 or k <= 0:
-        return 0.0
     n = len(y_true)
+    if n == 0 or n_pos_total == 0 or k <= 0:
+        return 0.0
     cutoff = max(1, math.ceil(n * k))
-    top_k_idx = np.argsort(y_score)[::-1][:cutoff]
-    positives_captured = int(y_true[top_k_idx].sum())
-    # Normalize by the fraction actually selected, not the requested k — rounding up to
-    # a whole user would otherwise overstate lift on small validation sets.
+    boundary = float(np.sort(y_score)[::-1][cutoff - 1])
+    above = y_score > boundary
+    tied = y_score == boundary
+    tie_share = (cutoff - int(above.sum())) / int(tied.sum())
+    positives_captured = float(y_true[above].sum()) + tie_share * float(y_true[tied].sum())
+    # Normalize by the fraction actually selected, not the requested k: rounding up to a
+    # whole user would otherwise overstate lift on small validation sets.
     random_expected = (cutoff / n) * n_pos_total
     return positives_captured / random_expected
 
 
-def _update_model_realized_metrics(model: AutoresearchModel, metrics: dict[str, Any]) -> None:
+def _update_model_realized_metrics(model: AutoresearchModel, metrics: dict[str, Any], *, prediction_date: date) -> None:
     """
-    Persist validation metrics to the model record.
+    Persist a date's realized metrics onto the model row.
 
-    On first realized validation (is_preliminary=True), clears the preliminary flag
-    and sets realized_score. Subsequent validations update realized_score to the latest.
+    The first realized AUC clears ``is_preliminary``. Later dates replace the model-level
+    numbers only when they are newer than what is stored: a retry of an older date that
+    failed earlier must not overwrite the evidence a newer date already left.
     """
+    existing = dict(model.metrics or {})
+    stored_date = (existing.get("realized") or {}).get("prediction_date")
+    if isinstance(stored_date, str) and stored_date > prediction_date.isoformat():
+        logger.info(
+            "autoresearch_model_realized_metrics_kept_newer",
+            model_id=str(model.pk),
+            stored_prediction_date=stored_date,
+            prediction_date=prediction_date.isoformat(),
+        )
+        return
+
     auc = metrics.get("realized_auc")
     cal_error = metrics.get("calibration_error")
-
-    existing = model.metrics or {}
-    existing["realized"] = metrics
-
+    existing["realized"] = {**metrics, "prediction_date": prediction_date.isoformat()}
+    model.metrics = existing
     update_fields = ["metrics", "updated_at"]
 
     if auc is not None:
@@ -429,7 +596,6 @@ def _update_model_realized_metrics(model: AutoresearchModel, metrics: dict[str, 
         model.calibration_error = cal_error
         update_fields.append("calibration_error")
 
-    model.metrics = existing
     model.save(update_fields=update_fields)
 
     logger.info(

--- a/products/autoresearch/backend/evaluation/online_validation.py
+++ b/products/autoresearch/backend/evaluation/online_validation.py
@@ -253,7 +253,12 @@ def _validation_state(
 
 
 def _is_blocked(item: PendingValidationDate, state: dict[tuple[date, int], list[dict[str, int] | None]]) -> bool:
-    return any(counts is None or counts == item.expected_rows_by_model for counts in state.get(item.key, []))
+    # A completed validation may hold counts for a model deleted since; a deleted model never
+    # returns, so only a model the validation has not seen at these counts reopens the group.
+    return any(
+        counts is None or all(counts.get(model_id) == n for model_id, n in item.expected_rows_by_model.items())
+        for counts in state.get(item.key, [])
+    )
 
 
 def _claim_date(pipeline: AutoresearchPipeline, pending: PendingValidationDate) -> AutoresearchRun | None:
@@ -344,12 +349,18 @@ def _persist_completed(
     total_rows = 0
     with transaction.atomic():
         # A run that completed or started for this group while the queries ran is missing from
-        # the counts the fetch was checked against.
+        # the counts the fetch was checked against. A model deleted meanwhile takes its run out
+        # of the group; its evidence is still written below, so that alone does not fail it.
         now = django_timezone.now()
-        current = {item.key: item.expected_rows_by_model for item in _scored_groups(pipeline)}
-        if current.get(pending.key) != pending.expected_rows_by_model or pending.key in _groups_still_scoring(
-            pipeline, now=now
-        ):
+        current = {item.key: item.expected_rows_by_model for item in _scored_groups(pipeline)}.get(pending.key, {})
+        changed = any(pending.expected_rows_by_model.get(model_id) != n for model_id, n in current.items())
+        vanished = set(pending.expected_rows_by_model) - set(current)
+        vanished_but_present = (
+            AutoresearchModel.objects.filter(pk__in=vanished, pipeline=pipeline, team_id=pipeline.team_id).exists()
+            if vanished
+            else False
+        )
+        if changed or vanished_but_present or pending.key in _groups_still_scoring(pipeline, now=now):
             raise OnlineValidationError(
                 f"The inference runs for {pending.prediction_date.isoformat()} changed while it was being validated; "
                 "retrying on the next pass"
@@ -386,6 +397,7 @@ def _prediction_filter() -> str:
         " AND properties['$autoresearch_pipeline_id'] = {pipeline_id}"
         " AND properties['$autoresearch_prediction_date'] = {prediction_date}"
         " AND properties['$autoresearch_model_id'] IN {model_ids}"
+        " AND properties['$autoresearch_horizon_days'] = {horizon_days}"
         " AND properties['$autoresearch_person_id'] != ''"
         " AND timestamp >= {emitted_from} AND timestamp < {emitted_before}"
     )
@@ -397,6 +409,8 @@ def _prediction_values(pipeline: AutoresearchPipeline, pending: PendingValidatio
         "pipeline_id": str(pipeline.pk),
         "prediction_date": pending.prediction_date.isoformat(),
         "model_ids": tuple(pending.expected_rows_by_model),
+        # Property values read back as strings, whatever type scoring emitted.
+        "horizon_days": str(pending.horizon_days),
         "emitted_from": pending.window_start,
         "emitted_before": pending.emitted_before,
     }

--- a/products/autoresearch/backend/evaluation/test_online_validation.py
+++ b/products/autoresearch/backend/evaluation/test_online_validation.py
@@ -1,0 +1,374 @@
+from datetime import date, timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+import numpy as np
+from parameterized import parameterized
+
+from products.autoresearch.backend.evaluation.online_validation import (
+    ValidationDataTruncatedError,
+    _compute_validation_metrics,
+    _expected_calibration_error,
+    _fetch_predictions_by_model,
+    _find_mature_unvalidated_dates,
+    _lift_at_k,
+    _update_model_realized_metrics,
+    run_online_validation_for_pipeline,
+)
+from products.autoresearch.backend.models import AutoresearchModel, AutoresearchPipeline, AutoresearchRun
+from products.autoresearch.backend.testing import TeamScopedTestMixin
+
+
+class TestComputeValidationMetrics(TeamScopedTestMixin, BaseTest):
+    def _predictions(self) -> dict[str, float]:
+        return {
+            "user-1": 0.9,
+            "user-2": 0.8,
+            "user-3": 0.4,
+            "user-4": 0.3,
+            "user-5": 0.1,
+        }
+
+    def test_returns_base_counts(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["n_scored"] == 5
+        assert metrics["n_positive"] == 2
+        assert metrics["n_negative"] == 3
+        assert metrics["base_rate"] == 0.4
+
+    def test_computes_auc_and_brier(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert "realized_auc" in metrics
+        assert "brier_score" in metrics
+        assert 0.0 <= metrics["realized_auc"] <= 1.0
+        assert 0.0 <= metrics["brier_score"] <= 1.0
+
+    def test_perfect_separation_gives_high_auc(self):
+        preds = {"high-1": 0.95, "high-2": 0.90, "low-1": 0.05, "low-2": 0.10}
+        labels = frozenset(["high-1", "high-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["realized_auc"] == 1.0
+
+    def test_reversed_scores_give_low_auc(self):
+        preds = {"high-1": 0.05, "high-2": 0.10, "low-1": 0.95, "low-2": 0.90}
+        labels = frozenset(["high-1", "high-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["realized_auc"] == 0.0
+
+    def test_no_positives_returns_warning(self):
+        preds = {"user-1": 0.5, "user-2": 0.6}
+        metrics = _compute_validation_metrics(preds, frozenset())
+        assert metrics.get("warning") == "single_class_no_auc"
+        assert "realized_auc" not in metrics
+
+    def test_no_negatives_returns_warning(self):
+        preds = {"user-1": 0.5, "user-2": 0.6}
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics.get("warning") == "single_class_no_auc"
+
+    def test_lift_at_k(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert metrics["lift_at_10"] > 0.0
+        assert metrics["lift_at_20"] > 0.0
+
+    def test_calibration_error_range(self):
+        preds = self._predictions()
+        labels = frozenset(["user-1", "user-2"])
+        metrics = _compute_validation_metrics(preds, labels)
+        assert 0.0 <= metrics["calibration_error"] <= 1.0
+
+
+class TestExpectedCalibrationError(TeamScopedTestMixin, BaseTest):
+    def test_perfect_calibration_zero_ece(self):
+        # One bin where predicted = actual rate
+        y_true = np.array([1, 0, 1, 0])
+        y_score = np.array([0.5, 0.5, 0.5, 0.5])
+        ece = _expected_calibration_error(y_true, y_score)
+        assert abs(ece) < 1e-6
+
+    def test_overconfident_model_high_ece(self):
+        y_true = np.array([0, 0, 0, 0])
+        y_score = np.array([0.9, 0.9, 0.9, 0.9])
+        ece = _expected_calibration_error(y_true, y_score)
+        assert ece > 0.5
+
+
+class TestLiftAtK(TeamScopedTestMixin, BaseTest):
+    def test_perfect_ranking_lift_at_50_is_2(self):
+        y_true = np.array([1, 1, 0, 0])
+        y_score = np.array([0.9, 0.8, 0.2, 0.1])
+        lift = _lift_at_k(y_true, y_score, k=0.5)
+        assert abs(lift - 2.0) < 1e-6
+
+    def test_no_positives_returns_zero(self):
+        y_true = np.array([0, 0, 0])
+        y_score = np.array([0.9, 0.5, 0.1])
+        assert _lift_at_k(y_true, y_score, k=0.5) == 0.0
+
+    def test_lift_normalizes_by_the_rows_actually_selected(self):
+        # 11 users at k=0.1 selects 2 rows (ceil), so the random baseline is 2/11 of the
+        # positives, not 1.1 — normalizing by the requested k overstates lift.
+        y_true = np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        y_score = np.array([0.99, 0.98, 0.5, 0.4, 0.3, 0.2, 0.1, 0.09, 0.08, 0.07, 0.06])
+        lift = _lift_at_k(y_true, y_score, k=0.1)
+        assert abs(lift - 5.5) < 1e-6
+
+    def test_random_ranking_lift_near_one(self):
+        rng = np.random.default_rng(42)
+        n = 1000
+        y_true = rng.integers(0, 2, n)
+        y_score = rng.uniform(0, 1, n)
+        lift = _lift_at_k(y_true, y_score, k=0.5)
+        assert 0.8 <= lift <= 1.2
+
+
+class TestUpdateModelRealizedMetrics(TeamScopedTestMixin, BaseTest):
+    def _make_model(self) -> AutoresearchModel:
+        pipeline = AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+        return AutoresearchModel.objects.create(
+            pipeline=pipeline,
+            role=AutoresearchModel.Role.CHAMPION,
+            model_recipe={"stub": True},
+            recipe_hash="abc123",
+            holdout_score=0.75,
+        )
+
+    def test_clears_preliminary_on_first_validation(self):
+        model = self._make_model()
+        assert model.is_preliminary is True
+        _update_model_realized_metrics(model, {"realized_auc": 0.82, "calibration_error": 0.05})
+        updated = AutoresearchModel.objects.get(pk=model.pk)
+        assert updated.is_preliminary is False
+        assert updated.realized_score == 0.82
+        assert updated.calibration_error == 0.05
+
+    def test_updates_realized_score_on_subsequent_validation(self):
+        model = self._make_model()
+        _update_model_realized_metrics(model, {"realized_auc": 0.80})
+        _update_model_realized_metrics(model, {"realized_auc": 0.85})
+        model.refresh_from_db()
+        assert model.realized_score == 0.85
+        assert model.is_preliminary is False
+
+    def test_no_auc_leaves_preliminary_unchanged(self):
+        model = self._make_model()
+        _update_model_realized_metrics(model, {"warning": "single_class_no_auc"})
+        model.refresh_from_db()
+        assert model.is_preliminary is True
+        assert model.realized_score is None
+
+
+class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
+    def _make_pipeline(self) -> AutoresearchPipeline:
+        return AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test pipeline",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+
+    def _make_champion(self, pipeline: AutoresearchPipeline) -> AutoresearchModel:
+        return AutoresearchModel.objects.create(
+            pipeline=pipeline,
+            role=AutoresearchModel.Role.CHAMPION,
+            model_recipe={"stub": True},
+            recipe_hash="abc123",
+            holdout_score=0.75,
+        )
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_no_mature_dates_returns_empty(self, mock_dates):
+        mock_dates.return_value = []
+        pipeline = self._make_pipeline()
+        runs = run_online_validation_for_pipeline(pipeline)
+        assert runs == []
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_validates_one_mature_date(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        champion = self._make_champion(pipeline)
+        prediction_date = date.today() - timedelta(days=10)
+
+        mock_dates.return_value = [prediction_date]
+        mock_preds.return_value = {
+            str(champion.pk): {
+                "user-a": 0.9,
+                "user-b": 0.8,
+                "user-c": 0.2,
+                "user-d": 0.1,
+            }
+        }
+        mock_labels.return_value = frozenset(["user-a", "user-b"])
+
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.status == AutoresearchRun.Status.COMPLETED
+        assert run.run_type == AutoresearchRun.RunType.VALIDATION
+        assert run.metrics["prediction_date"] == prediction_date.isoformat()
+        assert run.metrics["realized_labels_count"] == 2
+        assert str(champion.pk) in run.metrics["per_model"]
+
+        champion.refresh_from_db()
+        assert champion.realized_score is not None
+        assert champion.is_preliminary is False
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_skips_already_validated_dates(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        self._make_champion(pipeline)
+        prediction_date = date.today() - timedelta(days=10)
+
+        # Pre-create a completed validation run for that date
+        AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.COMPLETED,
+            metrics={"prediction_date": prediction_date.isoformat()},
+        )
+
+        mock_dates.return_value = [prediction_date]
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert runs == []
+        mock_preds.assert_not_called()
+        mock_labels.assert_not_called()
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_empty_predictions_marks_run_completed_with_warning(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        prediction_date = date.today() - timedelta(days=10)
+
+        mock_dates.return_value = [prediction_date]
+        mock_preds.return_value = {}  # no predictions found
+        mock_labels.return_value = frozenset(["user-a"])
+
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert len(runs) == 1
+        assert runs[0].status == AutoresearchRun.Status.COMPLETED
+        assert runs[0].rows_scored == 0
+        assert runs[0].metrics.get("warning") == "no_predictions_found"
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_label_fetch_failure_marks_run_failed_and_continues(self, mock_dates, mock_preds, mock_labels):
+        pipeline = self._make_pipeline()
+        champion = self._make_champion(pipeline)
+        d1 = date.today() - timedelta(days=11)
+        d2 = date.today() - timedelta(days=10)
+
+        mock_dates.return_value = [d1, d2]
+        mock_preds.return_value = {str(champion.pk): {"user-a": 0.9, "user-b": 0.2}}
+        mock_labels.side_effect = [RuntimeError("clickhouse unavailable"), frozenset(["user-a"])]
+
+        runs = run_online_validation_for_pipeline(pipeline)
+
+        assert [r.status for r in runs] == [AutoresearchRun.Status.FAILED, AutoresearchRun.Status.COMPLETED]
+        failed_run = runs[0]
+        assert failed_run.metrics["prediction_date"] == d1.isoformat()
+        assert "per_model" not in failed_run.metrics
+        assert "clickhouse unavailable" in failed_run.metrics["error"]
+
+
+class TestFetchPredictionsByModel(TeamScopedTestMixin, BaseTest):
+    def _make_pipeline(self) -> AutoresearchPipeline:
+        return AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+
+    @parameterized.expand(
+        [
+            ("at_limit_raises", 3, True),
+            ("under_limit_returns", 2, False),
+        ]
+    )
+    @patch("products.autoresearch.backend.evaluation.online_validation.VALIDATION_QUERY_LIMIT", 3)
+    @patch("products.autoresearch.backend.evaluation.online_validation.run_hogql_rows")
+    def test_truncation_guard(self, _name, n_rows, expect_raise, mock_rows):
+        pipeline = self._make_pipeline()
+        mock_rows.return_value = [[f"user-{i}", "model-1", 0.5] for i in range(n_rows)]
+
+        if expect_raise:
+            with self.assertRaises(ValidationDataTruncatedError):
+                _fetch_predictions_by_model(self.team, pipeline, date(2026, 5, 1))
+        else:
+            predictions = _fetch_predictions_by_model(self.team, pipeline, date(2026, 5, 1))
+            assert predictions == {"model-1": {f"user-{i}": 0.5 for i in range(n_rows)}}
+
+
+class TestFindMatureUnvalidatedDates(TeamScopedTestMixin, BaseTest):
+    def _make_pipeline(self) -> AutoresearchPipeline:
+        return AutoresearchPipeline.objects.create(
+            team=self.team,
+            name="Test",
+            target_event="$pageview",
+            horizon_days=7,
+            iteration_budget=50,
+            iteration_budget_remaining=50,
+        )
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_excludes_already_validated(self, mock_dates):
+        pipeline = self._make_pipeline()
+        d1 = date(2026, 5, 1)
+        d2 = date(2026, 5, 2)
+        mock_dates.return_value = [d1, d2]
+
+        # d1 already validated
+        AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.COMPLETED,
+            metrics={"prediction_date": d1.isoformat()},
+        )
+
+        unvalidated = _find_mature_unvalidated_dates(team=self.team, pipeline=pipeline)
+        assert unvalidated == [d2]
+
+    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
+    def test_failed_validation_run_is_retried(self, mock_dates):
+        pipeline = self._make_pipeline()
+        d1 = date(2026, 5, 1)
+        mock_dates.return_value = [d1]
+
+        # FAILED run does not count as validated
+        AutoresearchRun.objects.create(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.FAILED,
+            metrics={"prediction_date": d1.isoformat()},
+        )
+
+        unvalidated = _find_mature_unvalidated_dates(team=self.team, pipeline=pipeline)
+        assert d1 in unvalidated

--- a/products/autoresearch/backend/evaluation/test_online_validation.py
+++ b/products/autoresearch/backend/evaluation/test_online_validation.py
@@ -1,374 +1,345 @@
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 
+import time_machine
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone as django_timezone
 
 import numpy as np
 from parameterized import parameterized
 
+from posthog.models.user import User
+
+from products.autoresearch.backend.evaluation import online_validation
 from products.autoresearch.backend.evaluation.online_validation import (
-    ValidationDataTruncatedError,
+    STALE_CLAIM_AFTER,
+    OnlineValidationError,
     _compute_validation_metrics,
     _expected_calibration_error,
-    _fetch_predictions_by_model,
-    _find_mature_unvalidated_dates,
     _lift_at_k,
     _update_model_realized_metrics,
+    find_pending_validation_dates,
     run_online_validation_for_pipeline,
 )
 from products.autoresearch.backend.models import AutoresearchModel, AutoresearchPipeline, AutoresearchRun
+from products.autoresearch.backend.query import HogQLResult
 from products.autoresearch.backend.testing import TeamScopedTestMixin
 
+FROZEN_NOW = "2026-09-11T12:00:00Z"
 
-class TestComputeValidationMetrics(TeamScopedTestMixin, BaseTest):
+
+class TestComputeValidationMetrics(SimpleTestCase):
     def _predictions(self) -> dict[str, float]:
-        return {
-            "user-1": 0.9,
-            "user-2": 0.8,
-            "user-3": 0.4,
-            "user-4": 0.3,
-            "user-5": 0.1,
-        }
+        return {"user-1": 0.9, "user-2": 0.8, "user-3": 0.4, "user-4": 0.3, "user-5": 0.1}
 
     def test_returns_base_counts(self):
-        preds = self._predictions()
-        labels = frozenset(["user-1", "user-2"])
-        metrics = _compute_validation_metrics(preds, labels)
+        metrics = _compute_validation_metrics(self._predictions(), frozenset(["user-1", "user-2"]))
         assert metrics["n_scored"] == 5
         assert metrics["n_positive"] == 2
         assert metrics["n_negative"] == 3
         assert metrics["base_rate"] == 0.4
-
-    def test_computes_auc_and_brier(self):
-        preds = self._predictions()
-        labels = frozenset(["user-1", "user-2"])
-        metrics = _compute_validation_metrics(preds, labels)
-        assert "realized_auc" in metrics
-        assert "brier_score" in metrics
-        assert 0.0 <= metrics["realized_auc"] <= 1.0
         assert 0.0 <= metrics["brier_score"] <= 1.0
-
-    def test_perfect_separation_gives_high_auc(self):
-        preds = {"high-1": 0.95, "high-2": 0.90, "low-1": 0.05, "low-2": 0.10}
-        labels = frozenset(["high-1", "high-2"])
-        metrics = _compute_validation_metrics(preds, labels)
-        assert metrics["realized_auc"] == 1.0
-
-    def test_reversed_scores_give_low_auc(self):
-        preds = {"high-1": 0.05, "high-2": 0.10, "low-1": 0.95, "low-2": 0.90}
-        labels = frozenset(["high-1", "high-2"])
-        metrics = _compute_validation_metrics(preds, labels)
-        assert metrics["realized_auc"] == 0.0
-
-    def test_no_positives_returns_warning(self):
-        preds = {"user-1": 0.5, "user-2": 0.6}
-        metrics = _compute_validation_metrics(preds, frozenset())
-        assert metrics.get("warning") == "single_class_no_auc"
-        assert "realized_auc" not in metrics
-
-    def test_no_negatives_returns_warning(self):
-        preds = {"user-1": 0.5, "user-2": 0.6}
-        labels = frozenset(["user-1", "user-2"])
-        metrics = _compute_validation_metrics(preds, labels)
-        assert metrics.get("warning") == "single_class_no_auc"
-
-    def test_lift_at_k(self):
-        preds = self._predictions()
-        labels = frozenset(["user-1", "user-2"])
-        metrics = _compute_validation_metrics(preds, labels)
-        assert metrics["lift_at_10"] > 0.0
-        assert metrics["lift_at_20"] > 0.0
-
-    def test_calibration_error_range(self):
-        preds = self._predictions()
-        labels = frozenset(["user-1", "user-2"])
-        metrics = _compute_validation_metrics(preds, labels)
         assert 0.0 <= metrics["calibration_error"] <= 1.0
-
-
-class TestExpectedCalibrationError(TeamScopedTestMixin, BaseTest):
-    def test_perfect_calibration_zero_ece(self):
-        # One bin where predicted = actual rate
-        y_true = np.array([1, 0, 1, 0])
-        y_score = np.array([0.5, 0.5, 0.5, 0.5])
-        ece = _expected_calibration_error(y_true, y_score)
-        assert abs(ece) < 1e-6
-
-    def test_overconfident_model_high_ece(self):
-        y_true = np.array([0, 0, 0, 0])
-        y_score = np.array([0.9, 0.9, 0.9, 0.9])
-        ece = _expected_calibration_error(y_true, y_score)
-        assert ece > 0.5
-
-
-class TestLiftAtK(TeamScopedTestMixin, BaseTest):
-    def test_perfect_ranking_lift_at_50_is_2(self):
-        y_true = np.array([1, 1, 0, 0])
-        y_score = np.array([0.9, 0.8, 0.2, 0.1])
-        lift = _lift_at_k(y_true, y_score, k=0.5)
-        assert abs(lift - 2.0) < 1e-6
-
-    def test_no_positives_returns_zero(self):
-        y_true = np.array([0, 0, 0])
-        y_score = np.array([0.9, 0.5, 0.1])
-        assert _lift_at_k(y_true, y_score, k=0.5) == 0.0
-
-    def test_lift_normalizes_by_the_rows_actually_selected(self):
-        # 11 users at k=0.1 selects 2 rows (ceil), so the random baseline is 2/11 of the
-        # positives, not 1.1 — normalizing by the requested k overstates lift.
-        y_true = np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        y_score = np.array([0.99, 0.98, 0.5, 0.4, 0.3, 0.2, 0.1, 0.09, 0.08, 0.07, 0.06])
-        lift = _lift_at_k(y_true, y_score, k=0.1)
-        assert abs(lift - 5.5) < 1e-6
-
-    def test_random_ranking_lift_near_one(self):
-        rng = np.random.default_rng(42)
-        n = 1000
-        y_true = rng.integers(0, 2, n)
-        y_score = rng.uniform(0, 1, n)
-        lift = _lift_at_k(y_true, y_score, k=0.5)
-        assert 0.8 <= lift <= 1.2
-
-
-class TestUpdateModelRealizedMetrics(TeamScopedTestMixin, BaseTest):
-    def _make_model(self) -> AutoresearchModel:
-        pipeline = AutoresearchPipeline.objects.create(
-            team=self.team,
-            name="Test",
-            target_event="$pageview",
-            horizon_days=7,
-            iteration_budget=50,
-            iteration_budget_remaining=50,
-        )
-        return AutoresearchModel.objects.create(
-            pipeline=pipeline,
-            role=AutoresearchModel.Role.CHAMPION,
-            model_recipe={"stub": True},
-            recipe_hash="abc123",
-            holdout_score=0.75,
-        )
-
-    def test_clears_preliminary_on_first_validation(self):
-        model = self._make_model()
-        assert model.is_preliminary is True
-        _update_model_realized_metrics(model, {"realized_auc": 0.82, "calibration_error": 0.05})
-        updated = AutoresearchModel.objects.get(pk=model.pk)
-        assert updated.is_preliminary is False
-        assert updated.realized_score == 0.82
-        assert updated.calibration_error == 0.05
-
-    def test_updates_realized_score_on_subsequent_validation(self):
-        model = self._make_model()
-        _update_model_realized_metrics(model, {"realized_auc": 0.80})
-        _update_model_realized_metrics(model, {"realized_auc": 0.85})
-        model.refresh_from_db()
-        assert model.realized_score == 0.85
-        assert model.is_preliminary is False
-
-    def test_no_auc_leaves_preliminary_unchanged(self):
-        model = self._make_model()
-        _update_model_realized_metrics(model, {"warning": "single_class_no_auc"})
-        model.refresh_from_db()
-        assert model.is_preliminary is True
-        assert model.realized_score is None
-
-
-class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
-    def _make_pipeline(self) -> AutoresearchPipeline:
-        return AutoresearchPipeline.objects.create(
-            team=self.team,
-            name="Test pipeline",
-            target_event="$pageview",
-            horizon_days=7,
-            iteration_budget=50,
-            iteration_budget_remaining=50,
-        )
-
-    def _make_champion(self, pipeline: AutoresearchPipeline) -> AutoresearchModel:
-        return AutoresearchModel.objects.create(
-            pipeline=pipeline,
-            role=AutoresearchModel.Role.CHAMPION,
-            model_recipe={"stub": True},
-            recipe_hash="abc123",
-            holdout_score=0.75,
-        )
-
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_no_mature_dates_returns_empty(self, mock_dates):
-        mock_dates.return_value = []
-        pipeline = self._make_pipeline()
-        runs = run_online_validation_for_pipeline(pipeline)
-        assert runs == []
-
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_validates_one_mature_date(self, mock_dates, mock_preds, mock_labels):
-        pipeline = self._make_pipeline()
-        champion = self._make_champion(pipeline)
-        prediction_date = date.today() - timedelta(days=10)
-
-        mock_dates.return_value = [prediction_date]
-        mock_preds.return_value = {
-            str(champion.pk): {
-                "user-a": 0.9,
-                "user-b": 0.8,
-                "user-c": 0.2,
-                "user-d": 0.1,
-            }
-        }
-        mock_labels.return_value = frozenset(["user-a", "user-b"])
-
-        runs = run_online_validation_for_pipeline(pipeline)
-
-        assert len(runs) == 1
-        run = runs[0]
-        assert run.status == AutoresearchRun.Status.COMPLETED
-        assert run.run_type == AutoresearchRun.RunType.VALIDATION
-        assert run.metrics["prediction_date"] == prediction_date.isoformat()
-        assert run.metrics["realized_labels_count"] == 2
-        assert str(champion.pk) in run.metrics["per_model"]
-
-        champion.refresh_from_db()
-        assert champion.realized_score is not None
-        assert champion.is_preliminary is False
-
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_skips_already_validated_dates(self, mock_dates, mock_preds, mock_labels):
-        pipeline = self._make_pipeline()
-        self._make_champion(pipeline)
-        prediction_date = date.today() - timedelta(days=10)
-
-        # Pre-create a completed validation run for that date
-        AutoresearchRun.objects.create(
-            pipeline=pipeline,
-            run_type=AutoresearchRun.RunType.VALIDATION,
-            status=AutoresearchRun.Status.COMPLETED,
-            metrics={"prediction_date": prediction_date.isoformat()},
-        )
-
-        mock_dates.return_value = [prediction_date]
-        runs = run_online_validation_for_pipeline(pipeline)
-
-        assert runs == []
-        mock_preds.assert_not_called()
-        mock_labels.assert_not_called()
-
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_empty_predictions_marks_run_completed_with_warning(self, mock_dates, mock_preds, mock_labels):
-        pipeline = self._make_pipeline()
-        prediction_date = date.today() - timedelta(days=10)
-
-        mock_dates.return_value = [prediction_date]
-        mock_preds.return_value = {}  # no predictions found
-        mock_labels.return_value = frozenset(["user-a"])
-
-        runs = run_online_validation_for_pipeline(pipeline)
-
-        assert len(runs) == 1
-        assert runs[0].status == AutoresearchRun.Status.COMPLETED
-        assert runs[0].rows_scored == 0
-        assert runs[0].metrics.get("warning") == "no_predictions_found"
-
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_realized_labels")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_predictions_by_model")
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_label_fetch_failure_marks_run_failed_and_continues(self, mock_dates, mock_preds, mock_labels):
-        pipeline = self._make_pipeline()
-        champion = self._make_champion(pipeline)
-        d1 = date.today() - timedelta(days=11)
-        d2 = date.today() - timedelta(days=10)
-
-        mock_dates.return_value = [d1, d2]
-        mock_preds.return_value = {str(champion.pk): {"user-a": 0.9, "user-b": 0.2}}
-        mock_labels.side_effect = [RuntimeError("clickhouse unavailable"), frozenset(["user-a"])]
-
-        runs = run_online_validation_for_pipeline(pipeline)
-
-        assert [r.status for r in runs] == [AutoresearchRun.Status.FAILED, AutoresearchRun.Status.COMPLETED]
-        failed_run = runs[0]
-        assert failed_run.metrics["prediction_date"] == d1.isoformat()
-        assert "per_model" not in failed_run.metrics
-        assert "clickhouse unavailable" in failed_run.metrics["error"]
-
-
-class TestFetchPredictionsByModel(TeamScopedTestMixin, BaseTest):
-    def _make_pipeline(self) -> AutoresearchPipeline:
-        return AutoresearchPipeline.objects.create(
-            team=self.team,
-            name="Test",
-            target_event="$pageview",
-            horizon_days=7,
-            iteration_budget=50,
-            iteration_budget_remaining=50,
-        )
+        assert metrics["lift_at_10"] > 0.0
 
     @parameterized.expand(
         [
-            ("at_limit_raises", 3, True),
-            ("under_limit_returns", 2, False),
+            ("perfect_separation", {"high-1": 0.95, "high-2": 0.90, "low-1": 0.05, "low-2": 0.10}, 1.0),
+            ("reversed_scores", {"high-1": 0.05, "high-2": 0.10, "low-1": 0.95, "low-2": 0.90}, 0.0),
         ]
     )
-    @patch("products.autoresearch.backend.evaluation.online_validation.VALIDATION_QUERY_LIMIT", 3)
-    @patch("products.autoresearch.backend.evaluation.online_validation.run_hogql_rows")
-    def test_truncation_guard(self, _name, n_rows, expect_raise, mock_rows):
-        pipeline = self._make_pipeline()
-        mock_rows.return_value = [[f"user-{i}", "model-1", 0.5] for i in range(n_rows)]
+    def test_realized_auc(self, _name, preds, expected_auc):
+        metrics = _compute_validation_metrics(preds, frozenset(["high-1", "high-2"]))
+        assert metrics["realized_auc"] == expected_auc
 
-        if expect_raise:
-            with self.assertRaises(ValidationDataTruncatedError):
-                _fetch_predictions_by_model(self.team, pipeline, date(2026, 5, 1))
-        else:
-            predictions = _fetch_predictions_by_model(self.team, pipeline, date(2026, 5, 1))
-            assert predictions == {"model-1": {f"user-{i}": 0.5 for i in range(n_rows)}}
+    @parameterized.expand(
+        [
+            ("no_positives", frozenset()),
+            ("no_negatives", frozenset(["user-1", "user-2"])),
+        ]
+    )
+    def test_single_class_skips_only_the_auc(self, _name, labels):
+        metrics = _compute_validation_metrics({"user-1": 0.5, "user-2": 0.6}, labels)
+        assert metrics["warning"] == "single_class_no_auc"
+        assert "realized_auc" not in metrics
+        assert 0.0 <= metrics["brier_score"] <= 1.0
+        assert 0.0 <= metrics["calibration_error"] <= 1.0
+        assert "lift_at_10" in metrics
 
 
-class TestFindMatureUnvalidatedDates(TeamScopedTestMixin, BaseTest):
-    def _make_pipeline(self) -> AutoresearchPipeline:
-        return AutoresearchPipeline.objects.create(
-            team=self.team,
-            name="Test",
-            target_event="$pageview",
-            horizon_days=7,
-            iteration_budget=50,
-            iteration_budget_remaining=50,
+class TestExpectedCalibrationError(SimpleTestCase):
+    def test_perfect_calibration_zero_ece(self):
+        ece = _expected_calibration_error(np.array([1, 0, 1, 0]), np.array([0.5, 0.5, 0.5, 0.5]))
+        assert abs(ece) < 1e-6
+
+    def test_overconfident_model_high_ece(self):
+        ece = _expected_calibration_error(np.array([0, 0, 0, 0]), np.array([0.9, 0.9, 0.9, 0.9]))
+        assert ece > 0.5
+
+
+class TestLiftAtK(SimpleTestCase):
+    def test_perfect_ranking_lift_at_50_is_2(self):
+        lift = _lift_at_k(np.array([1, 1, 0, 0]), np.array([0.9, 0.8, 0.2, 0.1]), k=0.5)
+        assert abs(lift - 2.0) < 1e-6
+
+    def test_no_positives_returns_zero(self):
+        assert _lift_at_k(np.array([0, 0, 0]), np.array([0.9, 0.5, 0.1]), k=0.5) == 0.0
+
+    def test_lift_normalizes_by_the_rows_actually_selected(self):
+        # 11 users at k=0.1 selects 2 rows (ceil), so the random baseline is 2/11 of the
+        # positives, not 1.1.
+        y_true = np.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        y_score = np.array([0.99, 0.98, 0.5, 0.4, 0.3, 0.2, 0.1, 0.09, 0.08, 0.07, 0.06])
+        assert abs(_lift_at_k(y_true, y_score, k=0.1) - 5.5) < 1e-6
+
+    def test_ties_at_the_boundary_are_split_fractionally_whatever_the_row_order(self):
+        y_true = np.array([1, 0, 0, 0, 1, 0])
+        y_score = np.full(6, 0.5)
+        assert abs(_lift_at_k(y_true, y_score, k=0.5) - 1.0) < 1e-6
+        assert abs(_lift_at_k(y_true[::-1], y_score, k=0.5) - 1.0) < 1e-6
+
+
+def _make_pipeline(team, user: User | None, horizon_days: int = 7) -> AutoresearchPipeline:
+    return AutoresearchPipeline.objects.create(
+        team=team,
+        created_by=user,
+        name="Test pipeline",
+        target_event="$pageview",
+        horizon_days=horizon_days,
+        iteration_budget=50,
+        iteration_budget_remaining=50,
+    )
+
+
+def _make_model(pipeline: AutoresearchPipeline) -> AutoresearchModel:
+    return AutoresearchModel.objects.create(
+        pipeline=pipeline,
+        role=AutoresearchModel.Role.CHAMPION,
+        model_recipe={"stub": True},
+        recipe_hash="abc123",
+        holdout_score=0.75,
+    )
+
+
+def _inference_run(
+    pipeline: AutoresearchPipeline,
+    model: AutoresearchModel | None,
+    prediction_date: date,
+    rows_scored: int,
+    *,
+    horizon_days: int = 7,
+) -> AutoresearchRun:
+    return AutoresearchRun.objects.create(
+        pipeline=pipeline,
+        model=model,
+        run_type=AutoresearchRun.RunType.INFERENCE,
+        status=AutoresearchRun.Status.COMPLETED,
+        rows_scored=rows_scored,
+        completed_at=django_timezone.now(),
+        metrics={"prediction_date": prediction_date.isoformat(), "horizon_days": horizon_days},
+    )
+
+
+def _validation_run(
+    pipeline: AutoresearchPipeline, prediction_date: date, status: str, *, started_at: datetime | None = None
+) -> AutoresearchRun:
+    return AutoresearchRun.objects.create(
+        pipeline=pipeline,
+        run_type=AutoresearchRun.RunType.VALIDATION,
+        status=status,
+        started_at=started_at or django_timezone.now(),
+        metrics={"prediction_date": prediction_date.isoformat()},
+    )
+
+
+class TestUpdateModelRealizedMetrics(TeamScopedTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.model = _make_model(_make_pipeline(self.team, self.user))
+
+    def test_clears_preliminary_on_first_validation(self):
+        assert self.model.is_preliminary is True
+        _update_model_realized_metrics(
+            self.model, {"realized_auc": 0.82, "calibration_error": 0.05}, prediction_date=date(2026, 9, 1)
         )
+        updated = AutoresearchModel.objects.get(pk=self.model.pk)
+        assert updated.is_preliminary is False
+        assert updated.realized_score == 0.82
+        assert updated.calibration_error == 0.05
+        assert updated.metrics["realized"]["prediction_date"] == "2026-09-01"
 
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_excludes_already_validated(self, mock_dates):
-        pipeline = self._make_pipeline()
-        d1 = date(2026, 5, 1)
-        d2 = date(2026, 5, 2)
-        mock_dates.return_value = [d1, d2]
+    @parameterized.expand(
+        [
+            ("newer_date_replaces", date(2026, 9, 2), 0.85),
+            ("older_retry_keeps_the_newer_evidence", date(2026, 8, 30), 0.80),
+        ]
+    )
+    def test_model_level_score_follows_the_newest_date(self, _name, second_date, expected_score):
+        _update_model_realized_metrics(self.model, {"realized_auc": 0.80}, prediction_date=date(2026, 9, 1))
+        _update_model_realized_metrics(self.model, {"realized_auc": 0.85}, prediction_date=second_date)
+        self.model.refresh_from_db()
+        assert self.model.realized_score == expected_score
+        assert self.model.is_preliminary is False
 
-        # d1 already validated
-        AutoresearchRun.objects.create(
-            pipeline=pipeline,
-            run_type=AutoresearchRun.RunType.VALIDATION,
-            status=AutoresearchRun.Status.COMPLETED,
-            metrics={"prediction_date": d1.isoformat()},
-        )
+    def test_no_auc_leaves_preliminary_unchanged(self):
+        _update_model_realized_metrics(self.model, {"warning": "single_class_no_auc"}, prediction_date=date(2026, 9, 1))
+        self.model.refresh_from_db()
+        assert self.model.is_preliminary is True
+        assert self.model.realized_score is None
 
-        unvalidated = _find_mature_unvalidated_dates(team=self.team, pipeline=pipeline)
-        assert unvalidated == [d2]
 
-    @patch("products.autoresearch.backend.evaluation.online_validation._fetch_matured_prediction_dates")
-    def test_failed_validation_run_is_retried(self, mock_dates):
-        pipeline = self._make_pipeline()
-        d1 = date(2026, 5, 1)
-        mock_dates.return_value = [d1]
+@time_machine.travel(FROZEN_NOW, tick=False)
+class TestFindPendingValidationDates(TeamScopedTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.pipeline = _make_pipeline(self.team, self.user)
+        self.model = _make_model(self.pipeline)
 
-        # FAILED run does not count as validated
-        AutoresearchRun.objects.create(
-            pipeline=pipeline,
-            run_type=AutoresearchRun.RunType.VALIDATION,
-            status=AutoresearchRun.Status.FAILED,
-            metrics={"prediction_date": d1.isoformat()},
-        )
+    def test_matured_dates_come_from_the_inference_runs(self):
+        matured = date(2026, 9, 1)
+        _inference_run(self.pipeline, self.model, matured, rows_scored=5)
+        _inference_run(self.pipeline, self.model, matured, rows_scored=8)
+        # Not matured: 2026-09-05 + 7 days is after the frozen 2026-09-11.
+        _inference_run(self.pipeline, self.model, date(2026, 9, 5), rows_scored=3)
+        # Matured under the horizon the run recorded, not the pipeline's current 7 days.
+        _inference_run(self.pipeline, self.model, date(2026, 9, 6), rows_scored=2, horizon_days=3)
+        # Nothing emitted, and a run whose model was deleted: neither can be validated.
+        _inference_run(self.pipeline, self.model, date(2026, 8, 20), rows_scored=0)
+        _inference_run(self.pipeline, None, date(2026, 8, 21), rows_scored=4)
 
-        unvalidated = _find_mature_unvalidated_dates(team=self.team, pipeline=pipeline)
-        assert d1 in unvalidated
+        pending = find_pending_validation_dates(self.pipeline)
+
+        assert [(p.prediction_date, p.horizon_days, p.expected_rows_by_model) for p in pending] == [
+            (matured, 7, {str(self.model.pk): 8}),
+            (date(2026, 9, 6), 3, {str(self.model.pk): 2}),
+        ]
+        assert pending[0].window_start == datetime(2026, 9, 1, tzinfo=UTC)
+        assert pending[0].window_end == datetime(2026, 9, 8, tzinfo=UTC)
+
+    @parameterized.expand(
+        [
+            ("completed_blocks", AutoresearchRun.Status.COMPLETED, timedelta(0), False),
+            ("failed_is_retried", AutoresearchRun.Status.FAILED, timedelta(0), True),
+            ("fresh_claim_blocks", AutoresearchRun.Status.RUNNING, timedelta(hours=1), False),
+            ("stale_claim_is_retried", AutoresearchRun.Status.RUNNING, STALE_CLAIM_AFTER + timedelta(minutes=1), True),
+        ]
+    )
+    def test_existing_validation_runs(self, _name, status, age, expect_pending):
+        matured = date(2026, 9, 1)
+        _inference_run(self.pipeline, self.model, matured, rows_scored=5)
+        _validation_run(self.pipeline, matured, status, started_at=django_timezone.now() - age)
+
+        pending = find_pending_validation_dates(self.pipeline)
+
+        assert [p.prediction_date for p in pending] == ([matured] if expect_pending else [])
+
+
+def _fake_hogql(
+    *,
+    predictions: list[list[object]],
+    labels: list[list[object]],
+    fail_labels_once: bool = False,
+) -> MagicMock:
+    """Answer the prediction query with ``predictions`` and the label query with ``labels``, recording each call."""
+    state = {"labels_failed": False}
+
+    def side_effect(*, team, query, user, execution_mode):
+        if "argMax" in query.query:
+            return HogQLResult(columns=["model_id", "person_id", "p_y", "emitted_role"], rows=predictions)
+        if fail_labels_once and not state["labels_failed"]:
+            state["labels_failed"] = True
+            raise RuntimeError("clickhouse unavailable")
+        return HogQLResult(columns=["person_id"], rows=labels)
+
+    return MagicMock(side_effect=side_effect)
+
+
+@time_machine.travel(FROZEN_NOW, tick=False)
+class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.pipeline = _make_pipeline(self.team, self.user)
+        self.champion = _make_model(self.pipeline)
+        self.prediction_date = date(2026, 9, 1)
+        _inference_run(self.pipeline, self.champion, self.prediction_date, rows_scored=4)
+
+    def _prediction_rows(self, n: int) -> list[list[object]]:
+        scores = [0.9, 0.8, 0.2, 0.1, 0.5]
+        return [[str(self.champion.pk), f"user-{i}", scores[i], "champion"] for i in range(n)]
+
+    def test_validates_a_matured_date_and_records_the_evidence(self):
+        hogql = _fake_hogql(predictions=self._prediction_rows(4), labels=[["user-0"], ["user-1"]])
+
+        with patch.object(online_validation, "run_hogql", hogql):
+            runs = run_online_validation_for_pipeline(self.pipeline)
+
+        assert [r.status for r in runs] == [AutoresearchRun.Status.COMPLETED]
+        run = runs[0]
+        assert run.rows_scored == 4
+        assert run.metrics["prediction_date"] == "2026-09-01"
+        assert run.metrics["realized_labels_count"] == 2
+        per_model = run.metrics["per_model"][str(self.champion.pk)]
+        assert per_model["emitted_role"] == "champion"
+        assert per_model["model_role"] == "champion"
+        assert per_model["realized_auc"] == 1.0
+        self.champion.refresh_from_db()
+        assert self.champion.realized_score == 1.0
+        assert self.champion.is_preliminary is False
+        assert self.champion.metrics["realized"]["prediction_date"] == "2026-09-01"
+        assert find_pending_validation_dates(self.pipeline) == []
+
+        prediction_call, label_call = hogql.call_args_list
+        assert prediction_call.kwargs["user"] == self.user
+        assert prediction_call.kwargs["query"].values["limit"] == 5
+        assert prediction_call.kwargs["query"].values["model_ids"] == (str(self.champion.pk),)
+        assert prediction_call.kwargs["query"].values["emitted_from"] == datetime(2026, 9, 1, tzinfo=UTC)
+        assert label_call.kwargs["query"].values["window_start"] == datetime(2026, 9, 1, tzinfo=UTC)
+        assert label_call.kwargs["query"].values["window_end"] == datetime(2026, 9, 8, tzinfo=UTC)
+        assert label_call.kwargs["query"].values["limit"] == 5
+        assert "LIMIT {limit}" in label_call.kwargs["query"].query
+
+    @parameterized.expand(
+        [
+            ("fewer_rows_than_emitted", 3, "Found 3 of the 4 predictions"),
+            ("more_rows_than_emitted", 5, "more rows than the inference runs account for (4)"),
+        ]
+    )
+    def test_a_count_mismatch_fails_the_date_and_keeps_it_pending(self, _name, n_rows, error_fragment):
+        hogql = _fake_hogql(predictions=self._prediction_rows(n_rows), labels=[["user-0"]])
+
+        with patch.object(online_validation, "run_hogql", hogql):
+            runs = run_online_validation_for_pipeline(self.pipeline)
+
+        assert [r.status for r in runs] == [AutoresearchRun.Status.FAILED]
+        assert error_fragment in runs[0].error
+        assert "per_model" not in runs[0].metrics
+        self.champion.refresh_from_db()
+        assert self.champion.realized_score is None
+        assert [p.prediction_date for p in find_pending_validation_dates(self.pipeline)] == [self.prediction_date]
+
+    def test_a_query_failure_fails_that_date_and_continues_to_the_next(self):
+        second_date = date(2026, 9, 2)
+        _inference_run(self.pipeline, self.champion, second_date, rows_scored=4)
+        hogql = _fake_hogql(predictions=self._prediction_rows(4), labels=[["user-0"]], fail_labels_once=True)
+
+        with patch.object(online_validation, "run_hogql", hogql):
+            runs = run_online_validation_for_pipeline(self.pipeline)
+
+        assert [(r.metrics["prediction_date"], r.status) for r in runs] == [
+            ("2026-09-01", AutoresearchRun.Status.FAILED),
+            ("2026-09-02", AutoresearchRun.Status.COMPLETED),
+        ]
+        assert "Realized labels query failed" in runs[0].error
+
+    def test_a_pipeline_without_a_creator_fails_before_any_query(self):
+        self.pipeline.created_by = None
+        self.pipeline.save(update_fields=["created_by"])
+        hogql = _fake_hogql(predictions=[], labels=[])
+
+        with patch.object(online_validation, "run_hogql", hogql), self.assertRaises(OnlineValidationError):
+            run_online_validation_for_pipeline(self.pipeline)
+
+        hogql.assert_not_called()
+        assert not AutoresearchRun.objects.filter(run_type=AutoresearchRun.RunType.VALIDATION).exists()

--- a/products/autoresearch/backend/evaluation/test_online_validation.py
+++ b/products/autoresearch/backend/evaluation/test_online_validation.py
@@ -14,6 +14,7 @@ from posthog.models.user import User
 
 from products.autoresearch.backend.evaluation import online_validation
 from products.autoresearch.backend.evaluation.online_validation import (
+    OUTCOME_INGESTION_GRACE,
     STALE_CLAIM_AFTER,
     OnlineValidationError,
     _compute_validation_metrics,
@@ -130,12 +131,13 @@ def _inference_run(
     rows_scored: int,
     *,
     horizon_days: int = 7,
+    status: str = AutoresearchRun.Status.COMPLETED,
 ) -> AutoresearchRun:
     return AutoresearchRun.objects.create(
         pipeline=pipeline,
         model=model,
         run_type=AutoresearchRun.RunType.INFERENCE,
-        status=AutoresearchRun.Status.COMPLETED,
+        status=status,
         rows_scored=rows_scored,
         completed_at=django_timezone.now(),
         metrics={"prediction_date": prediction_date.isoformat(), "horizon_days": horizon_days},
@@ -217,6 +219,21 @@ class TestFindPendingValidationDates(TeamScopedTestMixin, BaseTest):
         ]
         assert pending[0].window_start == datetime(2026, 9, 1, tzinfo=UTC)
         assert pending[0].window_end == datetime(2026, 9, 8, tzinfo=UTC)
+
+    def test_maturity_waits_for_the_ingestion_grace(self):
+        _inference_run(self.pipeline, self.model, date(2026, 9, 4), rows_scored=5)
+        window_end = datetime(2026, 9, 11, tzinfo=UTC)
+        with time_machine.travel(window_end + OUTCOME_INGESTION_GRACE - timedelta(minutes=1), tick=False):
+            assert find_pending_validation_dates(self.pipeline) == []
+        with time_machine.travel(window_end + OUTCOME_INGESTION_GRACE, tick=False):
+            assert [p.prediction_date for p in find_pending_validation_dates(self.pipeline)] == [date(2026, 9, 4)]
+
+    def test_a_date_still_being_scored_waits(self):
+        matured = date(2026, 9, 1)
+        _inference_run(self.pipeline, self.model, matured, rows_scored=5)
+        _inference_run(self.pipeline, self.model, matured, rows_scored=0, status=AutoresearchRun.Status.RUNNING)
+
+        assert find_pending_validation_dates(self.pipeline) == []
 
     @parameterized.expand(
         [
@@ -332,6 +349,31 @@ class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
             ("2026-09-02", AutoresearchRun.Status.COMPLETED),
         ]
         assert "Realized labels query failed" in runs[0].error
+
+    def test_an_inference_run_completing_mid_validation_fails_the_date(self):
+        challenger = AutoresearchModel.objects.create(
+            pipeline=self.pipeline,
+            role=AutoresearchModel.Role.CHALLENGER,
+            model_recipe={"stub": True},
+            recipe_hash="def",
+        )
+        hogql = _fake_hogql(predictions=self._prediction_rows(4), labels=[["user-0"]])
+        inner = hogql.side_effect
+
+        def complete_a_rescore_then_answer(**kwargs):
+            if "argMax" not in kwargs["query"].query:
+                _inference_run(self.pipeline, challenger, self.prediction_date, rows_scored=4)
+            return inner(**kwargs)
+
+        with patch.object(online_validation, "run_hogql", MagicMock(side_effect=complete_a_rescore_then_answer)):
+            runs = run_online_validation_for_pipeline(self.pipeline)
+
+        assert [r.status for r in runs] == [AutoresearchRun.Status.FAILED]
+        assert "changed while it was being validated" in runs[0].error
+        self.champion.refresh_from_db()
+        assert self.champion.realized_score is None
+        pending = find_pending_validation_dates(self.pipeline)
+        assert [set(p.expected_rows_by_model) for p in pending] == [{str(self.champion.pk), str(challenger.pk)}]
 
     def test_a_pipeline_without_a_creator_fails_before_any_query(self):
         self.pipeline.created_by = None

--- a/products/autoresearch/backend/evaluation/test_online_validation.py
+++ b/products/autoresearch/backend/evaluation/test_online_validation.py
@@ -268,6 +268,21 @@ class TestFindPendingValidationDates(TeamScopedTestMixin, BaseTest):
 
         assert [(p.horizon_days, p.expected_rows_by_model) for p in pending] == [(7, {str(self.model.pk): 5})]
 
+    def test_a_deleted_model_does_not_reopen_a_validated_date(self):
+        matured = date(2026, 9, 1)
+        other = AutoresearchModel.objects.create(
+            pipeline=self.pipeline, role=AutoresearchModel.Role.CHALLENGER, model_recipe={"stub": True}, recipe_hash="x"
+        )
+        _inference_run(self.pipeline, self.model, matured, rows_scored=5)
+        _inference_run(self.pipeline, other, matured, rows_scored=3)
+        _validation_run(
+            self.pipeline, matured, AutoresearchRun.Status.COMPLETED, counts={str(self.model.pk): 5, str(other.pk): 3}
+        )
+
+        other.delete()
+
+        assert find_pending_validation_dates(self.pipeline) == []
+
     def test_a_validated_date_becomes_pending_again_when_its_inference_runs_change(self):
         matured = date(2026, 9, 1)
         _inference_run(self.pipeline, self.model, matured, rows_scored=5)
@@ -358,6 +373,8 @@ class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
         assert prediction_call.kwargs["user"] == self.user
         assert prediction_call.kwargs["query"].values["limit"] == 5
         assert prediction_call.kwargs["query"].values["model_ids"] == (str(self.champion.pk),)
+        assert prediction_call.kwargs["query"].values["horizon_days"] == "7"
+        assert "$autoresearch_horizon_days'] = {horizon_days}" in prediction_call.kwargs["query"].query
         assert prediction_call.kwargs["query"].values["emitted_from"] == datetime(2026, 9, 1, tzinfo=UTC)
         assert label_call.kwargs["query"].values["window_start"] == datetime(2026, 9, 1, tzinfo=UTC)
         assert label_call.kwargs["query"].values["window_end"] == datetime(2026, 9, 8, tzinfo=UTC)
@@ -428,6 +445,24 @@ class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
         if status == AutoresearchRun.Status.COMPLETED:
             pending = find_pending_validation_dates(self.pipeline)
             assert [set(p.expected_rows_by_model) for p in pending] == [{str(self.champion.pk), str(challenger.pk)}]
+
+    def test_a_model_deleted_mid_validation_keeps_its_evidence_on_the_run(self):
+        hogql = _fake_hogql(predictions=self._prediction_rows(4), labels=[["user-0"], ["user-1"]])
+        inner = hogql.side_effect
+
+        def delete_the_model_then_answer(**kwargs):
+            if "argMax" not in kwargs["query"].query:
+                AutoresearchModel.objects.filter(pk=self.champion.pk).delete()
+            return inner(**kwargs)
+
+        with patch.object(online_validation, "run_hogql", MagicMock(side_effect=delete_the_model_then_answer)):
+            runs = run_online_validation_for_pipeline(self.pipeline)
+
+        assert [r.status for r in runs] == [AutoresearchRun.Status.COMPLETED]
+        per_model = runs[0].metrics["per_model"][str(self.champion.pk)]
+        assert per_model["model_role"] == "deleted"
+        assert per_model["realized_auc"] == 1.0
+        assert find_pending_validation_dates(self.pipeline) == []
 
     def test_a_pipeline_without_a_creator_fails_before_any_query(self):
         self.pipeline.created_by = None

--- a/products/autoresearch/backend/evaluation/test_online_validation.py
+++ b/products/autoresearch/backend/evaluation/test_online_validation.py
@@ -15,7 +15,7 @@ from posthog.models.user import User
 from products.autoresearch.backend.evaluation import online_validation
 from products.autoresearch.backend.evaluation.online_validation import (
     OUTCOME_INGESTION_GRACE,
-    STALE_CLAIM_AFTER,
+    STALE_RUN_AFTER,
     OnlineValidationError,
     _compute_validation_metrics,
     _expected_calibration_error,
@@ -145,14 +145,23 @@ def _inference_run(
 
 
 def _validation_run(
-    pipeline: AutoresearchPipeline, prediction_date: date, status: str, *, started_at: datetime | None = None
+    pipeline: AutoresearchPipeline,
+    prediction_date: date,
+    status: str,
+    *,
+    started_at: datetime | None = None,
+    horizon_days: int = 7,
+    counts: dict[str, int] | None = None,
 ) -> AutoresearchRun:
+    metrics: dict = {"prediction_date": prediction_date.isoformat(), "horizon_days": horizon_days}
+    if counts is not None:
+        metrics["per_model"] = {model_id: {"n_scored": n} for model_id, n in counts.items()}
     return AutoresearchRun.objects.create(
         pipeline=pipeline,
         run_type=AutoresearchRun.RunType.VALIDATION,
         status=status,
         started_at=started_at or django_timezone.now(),
-        metrics={"prediction_date": prediction_date.isoformat()},
+        metrics=metrics,
     )
 
 
@@ -228,25 +237,63 @@ class TestFindPendingValidationDates(TeamScopedTestMixin, BaseTest):
         with time_machine.travel(window_end + OUTCOME_INGESTION_GRACE, tick=False):
             assert [p.prediction_date for p in find_pending_validation_dates(self.pipeline)] == [date(2026, 9, 4)]
 
-    def test_a_date_still_being_scored_waits(self):
+    @parameterized.expand(
+        [
+            ("fresh_run_waits", timedelta(hours=1), False),
+            ("abandoned_run_is_ignored", STALE_RUN_AFTER + timedelta(minutes=1), True),
+        ]
+    )
+    def test_a_date_still_being_scored_waits(self, _name, age, expect_pending):
         matured = date(2026, 9, 1)
         _inference_run(self.pipeline, self.model, matured, rows_scored=5)
-        _inference_run(self.pipeline, self.model, matured, rows_scored=0, status=AutoresearchRun.Status.RUNNING)
+        in_flight = _inference_run(
+            self.pipeline, self.model, matured, rows_scored=0, status=AutoresearchRun.Status.RUNNING
+        )
+        AutoresearchRun.objects.filter(pk=in_flight.pk).update(created_at=django_timezone.now() - age)
 
+        assert [p.prediction_date for p in find_pending_validation_dates(self.pipeline)] == (
+            [matured] if expect_pending else []
+        )
+
+    def test_models_scored_under_different_horizons_validate_as_separate_groups(self):
+        # A 14-day replacement scored the same date as the 7-day champion: only the 7-day
+        # window has closed by the frozen 2026-09-11, and each group carries its own models.
+        other = AutoresearchModel.objects.create(
+            pipeline=self.pipeline, role=AutoresearchModel.Role.CHALLENGER, model_recipe={"stub": True}, recipe_hash="x"
+        )
+        _inference_run(self.pipeline, self.model, date(2026, 9, 1), rows_scored=5, horizon_days=7)
+        _inference_run(self.pipeline, other, date(2026, 9, 1), rows_scored=3, horizon_days=14)
+
+        pending = find_pending_validation_dates(self.pipeline)
+
+        assert [(p.horizon_days, p.expected_rows_by_model) for p in pending] == [(7, {str(self.model.pk): 5})]
+
+    def test_a_validated_date_becomes_pending_again_when_its_inference_runs_change(self):
+        matured = date(2026, 9, 1)
+        _inference_run(self.pipeline, self.model, matured, rows_scored=5)
+        _validation_run(self.pipeline, matured, AutoresearchRun.Status.COMPLETED, counts={str(self.model.pk): 5})
         assert find_pending_validation_dates(self.pipeline) == []
+
+        _inference_run(self.pipeline, self.model, matured, rows_scored=6)
+
+        assert [p.expected_rows_by_model for p in find_pending_validation_dates(self.pipeline)] == [
+            {str(self.model.pk): 6}
+        ]
 
     @parameterized.expand(
         [
             ("completed_blocks", AutoresearchRun.Status.COMPLETED, timedelta(0), False),
             ("failed_is_retried", AutoresearchRun.Status.FAILED, timedelta(0), True),
             ("fresh_claim_blocks", AutoresearchRun.Status.RUNNING, timedelta(hours=1), False),
-            ("stale_claim_is_retried", AutoresearchRun.Status.RUNNING, STALE_CLAIM_AFTER + timedelta(minutes=1), True),
+            ("stale_claim_is_retried", AutoresearchRun.Status.RUNNING, STALE_RUN_AFTER + timedelta(minutes=1), True),
         ]
     )
     def test_existing_validation_runs(self, _name, status, age, expect_pending):
         matured = date(2026, 9, 1)
         _inference_run(self.pipeline, self.model, matured, rows_scored=5)
-        _validation_run(self.pipeline, matured, status, started_at=django_timezone.now() - age)
+        _validation_run(
+            self.pipeline, matured, status, started_at=django_timezone.now() - age, counts={str(self.model.pk): 5}
+        )
 
         pending = find_pending_validation_dates(self.pipeline)
 
@@ -350,7 +397,13 @@ class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
         ]
         assert "Realized labels query failed" in runs[0].error
 
-    def test_an_inference_run_completing_mid_validation_fails_the_date(self):
+    @parameterized.expand(
+        [
+            ("completed", AutoresearchRun.Status.COMPLETED),
+            ("still_running", AutoresearchRun.Status.RUNNING),
+        ]
+    )
+    def test_an_inference_run_appearing_mid_validation_fails_the_date(self, _name, status):
         challenger = AutoresearchModel.objects.create(
             pipeline=self.pipeline,
             role=AutoresearchModel.Role.CHALLENGER,
@@ -362,7 +415,7 @@ class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
 
         def complete_a_rescore_then_answer(**kwargs):
             if "argMax" not in kwargs["query"].query:
-                _inference_run(self.pipeline, challenger, self.prediction_date, rows_scored=4)
+                _inference_run(self.pipeline, challenger, self.prediction_date, rows_scored=4, status=status)
             return inner(**kwargs)
 
         with patch.object(online_validation, "run_hogql", MagicMock(side_effect=complete_a_rescore_then_answer)):
@@ -372,8 +425,9 @@ class TestRunOnlineValidationForPipeline(TeamScopedTestMixin, BaseTest):
         assert "changed while it was being validated" in runs[0].error
         self.champion.refresh_from_db()
         assert self.champion.realized_score is None
-        pending = find_pending_validation_dates(self.pipeline)
-        assert [set(p.expected_rows_by_model) for p in pending] == [{str(self.champion.pk), str(challenger.pk)}]
+        if status == AutoresearchRun.Status.COMPLETED:
+            pending = find_pending_validation_dates(self.pipeline)
+            assert [set(p.expected_rows_by_model) for p in pending] == [{str(self.champion.pk), str(challenger.pk)}]
 
     def test_a_pipeline_without_a_creator_fails_before_any_query(self):
         self.pipeline.created_by = None

--- a/products/autoresearch/backend/inference/scoring.py
+++ b/products/autoresearch/backend/inference/scoring.py
@@ -207,6 +207,11 @@ def run_inference_for_pipeline(
             "stub": bool((model.model_recipe or {}).get("stub", False)),
             "sandbox": bool(model.artifact_prefix),
             "holdout_auc": scored.holdout_auc,
+            # Online validation discovers matured dates from these two keys instead of
+            # scanning the events table, and validates against the horizon scored here
+            # rather than the pipeline's current one.
+            "prediction_date": window.prediction_date.isoformat(),
+            "horizon_days": pipeline.horizon_days,
         }
         run.completed_at = django_timezone.now()
         run.save(update_fields=["status", "rows_scored", "metrics", "completed_at"])

--- a/products/autoresearch/backend/inference/scoring.py
+++ b/products/autoresearch/backend/inference/scoring.py
@@ -190,6 +190,10 @@ def run_inference_for_pipeline(
         run_type=AutoresearchRun.RunType.INFERENCE,
         status=AutoresearchRun.Status.RUNNING,
         started_at=django_timezone.now(),
+        # Online validation discovers matured dates from these two keys instead of scanning
+        # the events table, validates against the horizon scored here rather than the
+        # pipeline's current one, and waits for a run that is still scoring the date.
+        metrics={"prediction_date": window.prediction_date.isoformat(), "horizon_days": pipeline.horizon_days},
     )
 
     try:
@@ -202,17 +206,14 @@ def run_inference_for_pipeline(
 
         run.status = AutoresearchRun.Status.COMPLETED
         run.rows_scored = emitted.rows_emitted
-        run.metrics = {
-            "score_distribution": emitted.score_distribution,
-            "stub": bool((model.model_recipe or {}).get("stub", False)),
-            "sandbox": bool(model.artifact_prefix),
-            "holdout_auc": scored.holdout_auc,
-            # Online validation discovers matured dates from these two keys instead of
-            # scanning the events table, and validates against the horizon scored here
-            # rather than the pipeline's current one.
-            "prediction_date": window.prediction_date.isoformat(),
-            "horizon_days": pipeline.horizon_days,
-        }
+        run.metrics.update(
+            {
+                "score_distribution": emitted.score_distribution,
+                "stub": bool((model.model_recipe or {}).get("stub", False)),
+                "sandbox": bool(model.artifact_prefix),
+                "holdout_auc": scored.holdout_auc,
+            }
+        )
         run.completed_at = django_timezone.now()
         run.save(update_fields=["status", "rows_scored", "metrics", "completed_at"])
 

--- a/products/autoresearch/backend/inference/test_inference.py
+++ b/products/autoresearch/backend/inference/test_inference.py
@@ -94,6 +94,7 @@ class TestScoreRows(SimpleTestCase):
         assert _score_rows([]) == []
 
 
+@time_machine.travel("2026-09-11T12:00:00Z", tick=False)
 class TestRunInferencePipeline(TeamScopedTestMixin, BaseTest):
     def _make_pipeline_and_model(self, **pipeline_kwargs) -> tuple[AutoresearchPipeline, AutoresearchModel]:
         pipeline = AutoresearchPipeline.objects.create(
@@ -131,6 +132,8 @@ class TestRunInferencePipeline(TeamScopedTestMixin, BaseTest):
         assert run.status == AutoresearchRun.Status.COMPLETED
         assert run.rows_scored == 2
         assert run.metrics["holdout_auc"] == 0.7
+        assert run.metrics["prediction_date"] == "2026-09-11"
+        assert run.metrics["horizon_days"] == 7
         assert capture.call_count == 1
         kwargs = capture.call_args.kwargs
         events = kwargs["events"]

--- a/products/autoresearch/backend/inference/test_inference.py
+++ b/products/autoresearch/backend/inference/test_inference.py
@@ -259,6 +259,7 @@ class TestPredictionDateGuards(TeamScopedTestMixin, BaseTest):
         score.assert_not_called()
         run = AutoresearchRun.objects.filter(pipeline=pipeline).latest("created_at")
         assert run.status == AutoresearchRun.Status.FAILED
+        assert run.metrics["prediction_date"] == prediction_date.isoformat()
 
     def test_future_prediction_date_is_refused(self):
         # A future date reads as live: today's features under a future label.

--- a/products/autoresearch/backend/management/AGENTS.md
+++ b/products/autoresearch/backend/management/AGENTS.md
@@ -2,7 +2,7 @@
 
 The headless entrypoints. Four commands cover the whole product lifecycle, and together they are how autoresearch is exercised end to end locally without a browser.
 
-This package landed with `autoresearch_validate` and `autoresearch_score` only. `autoresearch_train` and `autoresearch_validate_online` arrive in later pieces of the split tracked in [#88464](https://github.com/PostHog/posthog/pull/88464), so the references to them below describe where they will sit.
+This package landed with `autoresearch_validate`, `autoresearch_score`, and `autoresearch_validate_online`. `autoresearch_train` arrives in a later piece of the split tracked in [#88464](https://github.com/PostHog/posthog/pull/88464), so the references to them below describe where they will sit.
 
 Every command calls the same functions the API and the Temporal activities call. They are thin wrappers, not a parallel implementation, and they should stay that way.
 

--- a/products/autoresearch/backend/management/AGENTS.md
+++ b/products/autoresearch/backend/management/AGENTS.md
@@ -22,7 +22,8 @@ Every command calls the same functions the API and the Temporal activities call.
   `--team-id --target --horizon --user-id`
   `--user-id` is the person HogQL applies access control for; without it the counts run fail-closed. Note there is no `--mode` flag. Note also that `autoresearch_train` does **not** call this, so a target that fails here still trains.
 - `autoresearch_validate_online` — realized performance for predictions whose horizon has elapsed.
-  `--pipeline-id --dry-run`
+  `--pipeline-id --user-id --dry-run`
+  `--dry-run` lists the matured dates waiting for validation and what each inference run emitted. `--user-id` is the person HogQL applies access control for; without it the queries run as the pipeline's creator. The command exits non-zero when any date fails, and the failed date is retried on the next pass.
 
 ## Running them locally
 

--- a/products/autoresearch/backend/management/commands/autoresearch_validate_online.py
+++ b/products/autoresearch/backend/management/commands/autoresearch_validate_online.py
@@ -1,0 +1,100 @@
+"""
+Run online validation for an autoresearch pipeline.
+
+Finds all matured, unvalidated prediction dates (today >= prediction_date + horizon_days),
+joins them to realized target outcomes, and computes realized AUC / Brier / ECE / lift@k
+per model. Updates AutoresearchModel.realized_score and calibration_error in Postgres.
+
+Usage:
+    python manage.py autoresearch_validate_online --pipeline-id <uuid>
+    python manage.py autoresearch_validate_online --pipeline-id <uuid> --dry-run
+
+Requires:
+    - PostHog running locally (./bin/start or hogli start)
+    - autoresearch_prediction events in ClickHouse (run autoresearch_score first)
+    - Enough time elapsed for the horizon to close (horizon_days must have passed)
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+
+from posthog.models.scoping import team_scope
+
+from products.autoresearch.backend.evaluation.online_validation import (
+    _fetch_matured_prediction_dates,
+    _find_mature_unvalidated_dates,
+    run_online_validation_for_pipeline,
+)
+from products.autoresearch.backend.management.scoping import resolve_pipeline
+from products.autoresearch.backend.models import AutoresearchPipeline
+
+
+class Command(BaseCommand):
+    help = "Run online validation for a pipeline: join predictions to realized labels and update model metrics."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--pipeline-id", type=str, required=True, help="UUID of the pipeline to validate.")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show matured dates and skip DB writes.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        pipeline = resolve_pipeline(options["pipeline_id"])
+        with team_scope(pipeline.team_id):
+            self._run(pipeline, options)
+
+    def _run(self, pipeline: AutoresearchPipeline, options: dict[str, Any]) -> None:
+        self.stdout.write(f"\nPipeline  : {pipeline.name} ({pipeline.pk})")
+        self.stdout.write(f"Target    : {pipeline.target_event}")
+        self.stdout.write(f"Horizon   : {pipeline.horizon_days} days")
+        self.stdout.write("")
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry-run mode: showing matured dates but not running validation.\n"))
+            all_matured = _fetch_matured_prediction_dates(team=pipeline.team, pipeline=pipeline)
+            unvalidated = _find_mature_unvalidated_dates(team=pipeline.team, pipeline=pipeline)
+            validated = [d for d in all_matured if d not in unvalidated]
+            self.stdout.write(f"Matured dates     : {len(all_matured)}")
+            self.stdout.write(f"Already validated : {len(validated)}")
+            self.stdout.write(f"Pending           : {len(unvalidated)}")
+            if unvalidated:
+                for d in sorted(unvalidated):
+                    self.stdout.write(f"  {d.isoformat()}")
+            return
+
+        runs = run_online_validation_for_pipeline(pipeline=pipeline)
+
+        if not runs:
+            self.stdout.write(self.style.WARNING("No matured, unvalidated prediction dates found."))
+            self.stdout.write("Either no predictions have been scored yet, or all mature dates are already validated.")
+            return
+
+        self.stdout.write(f"Validated {len(runs)} prediction date(s):\n")
+        for run in runs:
+            prediction_date = run.metrics.get("prediction_date", "?")
+            status = run.status
+            n_labels = run.metrics.get("realized_labels_count", "?")
+            self.stdout.write(
+                f"  {prediction_date}  status={status}  rows_scored={run.rows_scored}  realized_labels={n_labels}"
+            )
+
+            per_model = run.metrics.get("per_model", {})
+            for model_id, m in per_model.items():
+                auc = m.get("realized_auc")
+                brier = m.get("brier_score")
+                ece = m.get("calibration_error")
+                lift10 = m.get("lift_at_10")
+                role = m.get("model_role", "?")
+                self.stdout.write(
+                    f"    Model {model_id[:8]}…  role={role}  AUC={auc}  Brier={brier}  ECE={ece}  lift@10={lift10}"
+                )
+
+        completed = [r for r in runs if r.status == "completed"]
+        if completed:
+            self.stdout.write(self.style.SUCCESS(f"\n✓ Completed validation for {len(completed)} date(s)."))
+        failed = [r for r in runs if r.status == "failed"]
+        if failed:
+            self.stdout.write(self.style.ERROR(f"✗ {len(failed)} validation run(s) failed."))

--- a/products/autoresearch/backend/management/commands/autoresearch_validate_online.py
+++ b/products/autoresearch/backend/management/commands/autoresearch_validate_online.py
@@ -1,8 +1,8 @@
 """
 Run online validation for an autoresearch pipeline.
 
-Finds all matured, unvalidated prediction dates (today >= prediction_date + horizon_days),
-joins them to realized target outcomes, and computes realized AUC / Brier / ECE / lift@k
+Finds the matured prediction dates that have no completed validation, joins their
+predictions to realized target outcomes, and computes realized AUC / Brier / ECE / lift@k
 per model. Updates AutoresearchModel.realized_score and calibration_error in Postgres.
 
 Usage:
@@ -11,23 +11,23 @@ Usage:
 
 Requires:
     - PostHog running locally (./bin/start or hogli start)
-    - autoresearch_prediction events in ClickHouse (run autoresearch_score first)
+    - completed inference runs whose predictions are in ClickHouse (run autoresearch_score first)
     - Enough time elapsed for the horizon to close (horizon_days must have passed)
 """
 
 from typing import Any
 
-from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from posthog.models.scoping import team_scope
+from posthog.models.user import User
 
 from products.autoresearch.backend.evaluation.online_validation import (
-    _fetch_matured_prediction_dates,
-    _find_mature_unvalidated_dates,
+    find_pending_validation_dates,
     run_online_validation_for_pipeline,
 )
 from products.autoresearch.backend.management.scoping import resolve_pipeline
-from products.autoresearch.backend.models import AutoresearchPipeline
+from products.autoresearch.backend.models import AutoresearchPipeline, AutoresearchRun
 
 
 class Command(BaseCommand):
@@ -36,50 +36,67 @@ class Command(BaseCommand):
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("--pipeline-id", type=str, required=True, help="UUID of the pipeline to validate.")
         parser.add_argument(
+            "--user-id",
+            type=int,
+            default=None,
+            help="Run the queries as this user. Defaults to the pipeline's creator.",
+        )
+        parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Show matured dates and skip DB writes.",
+            help="Show the matured dates waiting for validation and skip DB writes.",
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
         pipeline = resolve_pipeline(options["pipeline_id"])
+        user = self._resolve_user(options["user_id"])
         with team_scope(pipeline.team_id):
-            self._run(pipeline, options)
+            self._run(pipeline, user, options)
 
-    def _run(self, pipeline: AutoresearchPipeline, options: dict[str, Any]) -> None:
+    @staticmethod
+    def _resolve_user(user_id: int | None) -> User | None:
+        if user_id is None:
+            return None
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            raise CommandError(f"User {user_id} not found.")
+
+    def _run(self, pipeline: AutoresearchPipeline, user: User | None, options: dict[str, Any]) -> None:
         self.stdout.write(f"\nPipeline  : {pipeline.name} ({pipeline.pk})")
         self.stdout.write(f"Target    : {pipeline.target_event}")
         self.stdout.write(f"Horizon   : {pipeline.horizon_days} days")
         self.stdout.write("")
 
         if options["dry_run"]:
-            self.stdout.write(self.style.WARNING("Dry-run mode: showing matured dates but not running validation.\n"))
-            all_matured = _fetch_matured_prediction_dates(team=pipeline.team, pipeline=pipeline)
-            unvalidated = _find_mature_unvalidated_dates(team=pipeline.team, pipeline=pipeline)
-            validated = [d for d in all_matured if d not in unvalidated]
-            self.stdout.write(f"Matured dates     : {len(all_matured)}")
-            self.stdout.write(f"Already validated : {len(validated)}")
-            self.stdout.write(f"Pending           : {len(unvalidated)}")
-            if unvalidated:
-                for d in sorted(unvalidated):
-                    self.stdout.write(f"  {d.isoformat()}")
+            self.stdout.write(self.style.WARNING("Dry-run mode: showing the pending dates but not validating them.\n"))
+            pending = find_pending_validation_dates(pipeline)
+            self.stdout.write(f"Pending dates : {len(pending)}")
+            for item in pending:
+                models = ", ".join(
+                    f"{model_id[:8]}… ({rows} rows)" for model_id, rows in item.expected_rows_by_model.items()
+                )
+                self.stdout.write(f"  {item.prediction_date.isoformat()}  horizon={item.horizon_days}d  {models}")
             return
 
-        runs = run_online_validation_for_pipeline(pipeline=pipeline)
+        runs = run_online_validation_for_pipeline(pipeline, user=user)
 
         if not runs:
-            self.stdout.write(self.style.WARNING("No matured, unvalidated prediction dates found."))
-            self.stdout.write("Either no predictions have been scored yet, or all mature dates are already validated.")
+            self.stdout.write(self.style.WARNING("No matured prediction dates are waiting for validation."))
+            self.stdout.write(
+                "Either no completed scoring run has passed its horizon yet, or every matured date is already validated."
+            )
             return
 
         self.stdout.write(f"Validated {len(runs)} prediction date(s):\n")
         for run in runs:
             prediction_date = run.metrics.get("prediction_date", "?")
-            status = run.status
             n_labels = run.metrics.get("realized_labels_count", "?")
             self.stdout.write(
-                f"  {prediction_date}  status={status}  rows_scored={run.rows_scored}  realized_labels={n_labels}"
+                f"  {prediction_date}  status={run.status}  rows_scored={run.rows_scored}  realized_labels={n_labels}"
             )
+            if run.error:
+                self.stdout.write(f"    error: {run.error}")
 
             per_model = run.metrics.get("per_model", {})
             for model_id, m in per_model.items():
@@ -92,9 +109,12 @@ class Command(BaseCommand):
                     f"    Model {model_id[:8]}…  role={role}  AUC={auc}  Brier={brier}  ECE={ece}  lift@10={lift10}"
                 )
 
-        completed = [r for r in runs if r.status == "completed"]
+        completed = [r for r in runs if r.status == AutoresearchRun.Status.COMPLETED]
         if completed:
             self.stdout.write(self.style.SUCCESS(f"\n✓ Completed validation for {len(completed)} date(s)."))
-        failed = [r for r in runs if r.status == "failed"]
+        failed = [r for r in runs if r.status == AutoresearchRun.Status.FAILED]
         if failed:
-            self.stdout.write(self.style.ERROR(f"✗ {len(failed)} validation run(s) failed."))
+            raise CommandError(
+                f"{len(failed)} validation run(s) failed. Each failed date is retried on the next pass; "
+                "the run's error field says why."
+            )

--- a/products/autoresearch/backend/management/test_autoresearch_validate_online.py
+++ b/products/autoresearch/backend/management/test_autoresearch_validate_online.py
@@ -1,0 +1,29 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from products.autoresearch.backend.management.commands import autoresearch_validate_online
+from products.autoresearch.backend.models import AutoresearchPipeline, AutoresearchRun
+from products.autoresearch.backend.testing import TeamScopedTestMixin
+
+
+class TestValidateOnlineCommand(TeamScopedTestMixin, BaseTest):
+    def test_a_failed_date_exits_non_zero(self):
+        pipeline = AutoresearchPipeline.objects.create(
+            team=self.team, created_by=self.user, name="Test", target_event="$pageview", horizon_days=7
+        )
+        failed = AutoresearchRun(
+            pipeline=pipeline,
+            run_type=AutoresearchRun.RunType.VALIDATION,
+            status=AutoresearchRun.Status.FAILED,
+            error="clickhouse unavailable",
+            metrics={"prediction_date": "2026-09-01"},
+        )
+
+        with (
+            patch.object(autoresearch_validate_online, "run_online_validation_for_pipeline", return_value=[failed]),
+            self.assertRaises(CommandError),
+        ):
+            call_command("autoresearch_validate_online", "--pipeline-id", str(pipeline.pk))


### PR DESCRIPTION
## Problem

A holdout AUC says how well a model separates history. Nothing says whether it predicted the future. Layer 13 of 31 in the split of [#88464](https://github.com/PostHog/posthog/pull/88464), on top of the merged scoring layer ([#89141](https://github.com/PostHog/posthog/pull/89141)). This layer joins emitted predictions back to what each person actually did once the horizon has elapsed, and records the realized performance. `autoresearch_validate_online` is the only entry point until the schedule (layer 14) and the API action (layer 17).

## Changes

- `run_online_validation_for_pipeline()` computes realized AUC, Brier score, expected calibration error (10 bins), and lift@k per matured prediction date, for every model that emitted predictions. Only the AUC needs both classes; a single-class date keeps the other three.
- Matured dates come from the completed inference runs, which now record `prediction_date` and `horizon_days` (a small change in `scoring.py`). Validation never scans the events table to find work. Models scored on one date under different horizons validate as separate groups, each with its own outcome window.
- Each date is claimed with a `RUNNING` run under the pipeline row lock before any query runs, so the schedule and a manual command cannot both score it. A claim older than six hours expires, and so does an abandoned `RUNNING` inference run. A `FAILED` run is retried on the next pass. A date matures one hour after its outcome window closes, so the last outcome events have landed, and a date an inference run is still scoring waits. A date counts as validated only while its validation run holds the same per-model counts as its inference runs, so a rescore or a new model makes it pending again and replaces the evidence.
- Both ClickHouse queries carry an explicit bound. The prediction fetch must return exactly the rows each inference run emitted: fewer means a backfill is still being ingested, more means events the run did not emit, and either fails the date so it retries instead of completing on wrong data. Before the date is marked complete, the inference runs are read again inside the transaction, and a run that finished or started mid-validation fails the date too.
- Realized outcomes use `build_target_condition()`, restricted to the predicted persons, inside the UTC window scoring bound the run to (`[D 00:00, D + horizon 00:00)` compared on bare `timestamp`, so partitions prune). The product's own prediction event is excluded from the scan.
- Results land on `AutoresearchModel.realized_score`, `.calibration_error` and `.metrics["realized"]` in one transaction with the run, with the model rows locked. An older date retried after a newer one does not overwrite the newer evidence. The run keeps the emitted role beside the current one, and a failure lands in its `error` field.
- Lift@k splits ties at the boundary fractionally, so a non-discriminating model reads 1.0 whatever order the rows arrive in.
- `autoresearch_validate_online --pipeline-id [--user-id] [--dry-run]` exits non-zero when a date fails.
- Mechanical: `backend/evaluation/AGENTS.md`, the `--user-id` line in the management `AGENTS.md`, and the landed-ahead paragraph there is trimmed.

Review threads: 25 are fixed in `efe7c8bae3f` and resolved. Four stay open on purpose with backlog ids: A26 (forged prediction events), A27 (person merges during the horizon), D2 (the pipeline contract, target, horizon and population, staying mutable after dates are scored; two threads). Codex's eighth round, posted as a PR comment against that head, is answered in `9adcce0db71`: three findings fixed, one (migrating pre-existing inference runs) has no data behind it because nothing has scored anywhere yet. Its ninth round (three inline threads on `9adcce0db71`) is fixed and resolved in `b06966996b9`. Its tenth (two threads on `b06966996b9`) is answered in `4ee3594887a`: the deleted-model thread is fixed, the rescore-after-a-population-change thread is half fixed (the fetch filters on the horizon) and otherwise joins D2, so four threads stay open with ids.

## How did you test this code?

No manual testing.

`test_online_validation.py` catches: a single-class date dropping Brier and calibration error; lift depending on the order of tied rows; the date selector reading the events table, ignoring the horizon a run recorded, retrying a fresh claim, or blocking on a stale one; a row-count mismatch completing the date; an older date's retry overwriting a newer date's model score; the outcome window drifting off UTC midnight; a query going out without a bound; a pipeline with no creator running a query; a date maturing before the ingestion grace; a date an inference run is still scoring being picked up; an inference run completing or still running mid-validation being left behind a completed date; an abandoned inference run blocking a date forever; two horizons on one date sharing a window; a validated date staying validated after its inference runs changed; a deleted model failing or reopening its group; two horizons mixing in one fetch. `test_autoresearch_validate_online.py` catches the command exiting 0 on a failed date. The scoring tests now assert the inference run records its prediction date and horizon, on a completed run and on a refused one.

Every guard was reverted once and its test went red. Both HogQL queries were compiled to ClickHouse SQL through the HogQL printer with one and two model ids, confirming bare `timestamp` bounds, a tuple `IN`, and a null-safe float cast.

Ran on this head: the product's tests, the repo invariants, tach, import-linter, repo-wide mypy, `hogli product:lint --all`, `hogli build:openapi` (no-op), and `hogli ci:preflight --strict`.

Not run: validation against matured predictions on a dev stack. Semgrep runs only in CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`backend/evaluation/AGENTS.md` documents the package. Everything stays behind the `autoresearch` flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) cut this layer from `autoresearch-integration` by path per the skill's `stack-split-plan.md`, cascaded it onto master after layer 11 merged, and answered seven review rounds in one fix commit. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`, `/writing-dataclasses`, `/writing-user-facing-copy`, `/phs autoresearch`. The CodeRabbit local pass is paused, so the PR stands without one.

Decision across the session: the ClickHouse date selector was replaced by a Postgres one over the inference runs after three threads found it unbounded and unprunable. That made an exact row match against each run possible, which answers the backfill-ingestion and per-model-limit threads at once.

Public artifact: no session material reached the diff.
