### PR TITLE
fix(empty-states): keep product empty states readable on narrow scenes

### DIFF
--- a/.agents/skills/building-product-empty-states/SKILL.md
+++ b/.agents/skills/building-product-empty-states/SKILL.md
@@ -88,6 +88,7 @@ This is not a flat mock - the bar is "fun and involved", and the references set 
 - **Crossfade with the `preview-swap-hidden` / `preview-swap-visible` mixins** (`lib/components/ProductEmptyState/_previewMixins.scss`), never bare `opacity`. Opacity alone leaves the hidden half in the accessibility tree and the tab order, so a screen reader announces both states at once and a keyboard user can land on an invisible button. The mixins add `visibility` on a delay, which keeps the fade and costs no layout shift.
 - The hidden input stays keyboard-focusable, so the row it labels needs a `:focus-visible` outline (WCAG 2.4.7).
 - The preview must **never scroll**; guard all animation with `prefers-reduced-motion` and an `inStorybook()`-driven static class so visual-regression snapshots stay stable.
+- **It has to hold up from ~340px wide to the full scene.** The empty state keys its layout off its own width (a container query, not the viewport, because the sidebar and side panel eat into it): a wide scene puts the preview in a 40% column beside the copy, and a narrow one stacks it full width underneath. So every row wraps or truncates rather than clipping — `productEmptyStateStory(..., { containerWidth })` pins a narrow width for a snapshot.
 - Honor the `mode` prop: `waiting-for-data` should read as "listening" (e.g. a pinned spinner row).
 
 ### 4. Declare it on the scene

--- a/docs/internal/product-empty-state-layout.md
+++ b/docs/internal/product-empty-state-layout.md
@@ -8,3 +8,5 @@
 - Secondary links and replay vision preview filters wrap when space is limited.
 
 Use `containerWidth` in `productEmptyStateStory` to cover narrow scenes independently of the Storybook viewport. Cover both setup and waiting modes when the product supports them.
+
+The story wrapper defaults to the viewport width minus Storybook's padding. Keep an explicit width on this wrapper: the snapshot runner uses an inline-block root, which collapses around an unsized query container.

--- a/docs/internal/product-empty-state-layout.md
+++ b/docs/internal/product-empty-state-layout.md
@@ -1,0 +1,10 @@
+# Product empty-state layout
+
+`ProductEmptyState` responds to the width of its scene container, including the space left after the sidebar and side panel.
+
+- Below 64rem, the preview stacks below the setup copy and stays visible.
+- At 64rem and above, the preview occupies a separate column.
+- A `beside` hedgehog appears beside the copy when the copy container reaches 52rem. Below that, a smaller illustration appears above the product name.
+- Secondary links and replay vision preview filters wrap when space is limited.
+
+Use `containerWidth` in `productEmptyStateStory` to cover narrow scenes independently of the Storybook viewport. Cover both setup and waiting modes when the product supports them.

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1765,53 +1765,53 @@ snapshots:
     components-playerinspector-itemsessionchange--session-previous--light:
         hash: v1.k794b7964.33ce327f146d06d1412d431080ac84ae39558411b2073fe18a2ed98d834a2681.FDbDlC4-qfrH2RR1F_KpijnZNM9Ss_4s-p19Ee8fGtY
     components-product-empty-state--actions-needs-setup--dark:
-        hash: v1.k794b7964.10ab8bd219c3110809c99653076caeaf5088284a876c9ab1aadb8a06d881b210.EucMhcIMbn1Z41tBACbSV89kJkEYWgjTkwl7THDWL0c
+        hash: v1.k794b7964.bcb8a737d22c6d807eb524fca2acc9c36420609fa1dc3921cee64b73cfb5fdea.686y8Z8cYiKOvpy5d_0CEVwMkSP00WIznn1Cqd7lxEI
     components-product-empty-state--actions-needs-setup--light:
-        hash: v1.k794b7964.6c495049afd9798382f53acd004c500608181045e9c2bef81c66ab9feb535a6b.TbUx7yVN6P2hiijY7RK9j5a0vrRDkN1WQAKcOPhfUZk
+        hash: v1.k794b7964.b4701836fdf284e62ae9da03bf32a9cc09d898a9c0db0138ba4ee335432fa1f2.mqi38iKen75EKsuT_68i4Q5H8pbVALe94xLD597LNYY
     components-product-empty-state--ai-observability-needs-setup--dark:
-        hash: v1.k794b7964.f10735d00b8b7484f071fdcaebec654ef0042bf7894e374cbe077acb88d1de1f.DVP2UF6lwJvd5PyN12NBZIhS9EOv5z-N0T-aYKrAONw
+        hash: v1.k794b7964.2ce9ca22b2f0b974f0c2def5b3b658e03b836a1d07a45a22e2d3397460d56672.azUEh-Kn3S6S3k7gRjERwLxZwpu5aEGL3_bQNUS8QXE
     components-product-empty-state--ai-observability-needs-setup--light:
-        hash: v1.k794b7964.356081f2e978bf91130ebf0aa39fdc921a169780d2c3b9e289191d40dc73f6f1.nOlwt03p_7y2o0g2xV7835qBylZDe7uIdPxowxXI8mA
+        hash: v1.k794b7964.6c47a1a8d6063f0bb47b8372f500aa01c3313636b2eff91296780241d790f28a.DJbtjJcC7CdT49nsfqzNU4PIr_x4TbeYfbJgWWLHepc
     components-product-empty-state--alerts-needs-setup--dark:
-        hash: v1.k794b7964.c32ae94661df7717f1eb3d34a588fb448656034cdf8c311c9d57d0a7b252e1bb.bsy-jXMCqyPPSTw5BnWFt0b_KAsSFhzOkZmZYGKh6NI
+        hash: v1.k794b7964.740bb7aca5726c22ea0c0ce85195d40ed3dee9eda6359e8d107843dd2349e86d.OrPZVz03KkuENrzK3DeQwOZv8_6RTEf6rJKWWqGNYwA
     components-product-empty-state--alerts-needs-setup--light:
-        hash: v1.k794b7964.086690dbcdaadf39afe5fbccc09064b60772fc2773bbca51ff93dac49bb450b6.qT3UeCTW9_w2NIoSfASbExcPfCqJ4wRL1e3DkUajEQQ
+        hash: v1.k794b7964.0272366d36117687f05607764f8e536b62fd20df521d68bef5e4ab7e78416330.jahgs8RL5li9d5EUGml0QbzJEn9F7DYfoCfL1RgiYD4
     components-product-empty-state--annotations-needs-setup--dark:
-        hash: v1.k794b7964.375eb5c484baae36185d43a8b1ae04a6ec0915405be7f4f4a05887816dfde456.L2szPOMNE0IT-m3Dxbt1SKmvgfc9bT1pvlF13-L4doI
+        hash: v1.k794b7964.c3f5754bea8552c800c670cbdfcb24a53e7ca1369496cb831387cf43f3808ff7.pFJ-Rw3WTcosSfXAaTXqEjTj6tlVUrn2c7w6_oMLH70
     components-product-empty-state--annotations-needs-setup--light:
-        hash: v1.k794b7964.56dbdea2b6fb8aaf02bf4ff304ba2d4bff2df277d11255585ceb5c58453a9ceb.jmML3vhPE30ZAvN7k5Fr8gC0RDKY3GusMz-_osZ5o-I
+        hash: v1.k794b7964.bb01c5547c824c269806b08cd741762d41e0670d58d8083c73637cb02462b9d5.WASevvrN_mTi4y7SAV9euuc0gwXzvVMC9ogukxXkAj4
     components-product-empty-state--business-knowledge-needs-setup--dark:
         hash: v1.k794b7964.821fd6f4f4b44c031534220f8ea657b5d8cb4839b2c1a92384740ddcfcdbf609.ZS3c9kBrLeu0aclLNMZNBNaUk6KLbOKFgFkB4KrQQZc
     components-product-empty-state--business-knowledge-needs-setup--light:
         hash: v1.k794b7964.ae6f46310f1951eb56d74f61222e3f48586585170be86fd18cedb4ec6e53b431.rgzkhE0Nr-GJuwhQAcEg-Ydf24sR21A7Xa9D-WtvOkc
     components-product-empty-state--clusters-needs-setup--dark:
-        hash: v1.k794b7964.faa055314518c1586c7206158a3781a2fb1a4856a22f362319cf803d1f66a7aa.dMZbPs6mdTPaZb3k8eBWBWCb5IpQKzC6YRppnzZ1kxc
+        hash: v1.k794b7964.170fa1e2a0c94344278934b9b158cd07d8e3c585695e0791c3221f12a81b7d9a.BeVK0Tvo7z2gIsiLlKuju5DVLRWV0fMi4q7O7wu-AsM
     components-product-empty-state--clusters-needs-setup--light:
-        hash: v1.k794b7964.5b930dfde7322e8de0b7a2ef4dcbce4a0d5d235f26715a713e568cd199cd68e3.QFQtZlRiKsgrsrOPAS-Ku2FAxKEexsJRe6_mlZonrHI
+        hash: v1.k794b7964.369c74b21b3ff1219eb3d2e3d054bb35d944bf1b714601166b8e78b4b32e0ea5.Et4qBlU2asXj7y-xFHTRW0-ze9b0pimwjSLisUr2o24
     components-product-empty-state--clusters-waiting-for-data--dark:
-        hash: v1.k794b7964.f59a25bce82516d5ca71cab99ed1ec37df01973e3bae1973d4bb7ff2743f293c.0pGxZ3xX-nNDzww09MVlzglAtL2b63HxD0auDl8zIcY
+        hash: v1.k794b7964.31f281a9fc1bdc93a030ebb4d46e4c0ccaca792f97056deb0737f42702ce9a2c.tQUs-amee_6yZo8CLunvEST_lcrHjOeRgiEdrnGl9EQ
     components-product-empty-state--clusters-waiting-for-data--light:
-        hash: v1.k794b7964.9073ef14994645a0b8bad9bc18af76d0f542ada523b3c08e8cc16946b71ac50d.Bm86guaVb4P4Bvj1jR1TfhOD65cOdE9XvhJxGpBSWew
+        hash: v1.k794b7964.e431bf3cac3873ded2d5d82f14dd2625d8eb698d8d6380195f8bf2ed90700f3c.3vB3F3yx6XEVs1YseTitdfUPn2qRhTamYf7EdpTiJzo
     components-product-empty-state--cohorts-needs-setup--dark:
-        hash: v1.k794b7964.83b26d21c2c1d191e3c7f6aa34bd3d8d24e9d6002d3e1369bf5b6a049f757758.PhaOyvOdwWsqT3HArkFs-5X-Bcgx3hwAnlhBFYnJUQo
+        hash: v1.k794b7964.02aa27dcb18062c65248d0ee3f28f83d4660801bd64ccbf29732923ebd939ee1.XDBAzeXvKmMML6X8yNm9j8JH-h-5p8LD0rTmtnUFP10
     components-product-empty-state--cohorts-needs-setup--light:
-        hash: v1.k794b7964.b827ea6e4b03f02c32a32b12c618f75a69ad0b2b58f913fe7d5c334c0ae5cac9.fKm3ytRKGmpO82oUS7SSw9GbRTxgdtlygk9c3Cmcd60
+        hash: v1.k794b7964.a0774a7605fc2c4c7bc0ac33e22df2854b6b43859a88899c57c4ab974c63bfdd.Qx-pEutXy6rQrPCG0rb-5AS2bFEFZkLgQh7ByNb8rBQ
     components-product-empty-state--customer-analytics-needs-setup--dark:
-        hash: v1.k794b7964.019d4465129ae3debfa6287a1ed62c2521a7ec42adb10702d0df81e0a116f0df.YMvw7NwMw84MxuQDNkMkXP0whmcHalLe4DmiiQCYGN4
+        hash: v1.k794b7964.2a1c973ebac447324a9544d720ec5ce4a668c80715aae71b12681d8e3d10ad2e.khJQ3k9WQV7RIX1tbbfjcC1WSMu5PLOO2NttcUBSBlg
     components-product-empty-state--customer-analytics-needs-setup--light:
-        hash: v1.k794b7964.37874200d15c611b25896fca3b82ee1d073f66b2738f7d9007012a91ccfd6c2c.dJOr1_tfAOmuS3_T5eeBTS58lTIOztYjcSU01T4Knx4
+        hash: v1.k794b7964.fa61c54b7afafafc561cf63b356ede4240a59226e52bf264af60a9f995a8ba05.v0O5AftMBtOXo-0Lb40m7D6k34TSuqfaaELwittN64Q
     components-product-empty-state--dashboards-needs-setup--dark:
-        hash: v1.k794b7964.b3a148d96ca0b54ca8929084054b91f4e52ae02160039f3a47ee04db7aeb62cc.SH8xd4Ro7F3Zuetn_B_qgVFVbWtT__aDzaW2YOr-Eac
+        hash: v1.k794b7964.f0e8e8c822f664ec1421efff215c362f0ee4272da7b32aad4afac0c7be160f29.ID2ccq_RUpKaIIaY-cfiXXAezHAcizs1WHee0UCQI1E
     components-product-empty-state--dashboards-needs-setup--light:
-        hash: v1.k794b7964.2782384906e9b2efb6153b3bf4b8135fc541639245f74f0abd3456a35023e641.vaJwGqX3KJ-_XLxP_slQ1vIyHx0QZ4fCXnrMtPJHnjg
+        hash: v1.k794b7964.d295695549b8f4c4d8b034614d02cf277db135062f26d18aff8d04565f04c5d2.SKV0X6XXEr8ocRPim88dSlvhS3QJa2gv6BhWp6l7bfc
     components-product-empty-state--data-catalog-needs-setup--dark:
-        hash: v1.k794b7964.9ed4c29d6ca8589e87e45cd10ec459dab8a72d2daba5cae04d181ed6c0ae640c.pRHqmxDzmgJd4rkDZOPcDeN9Ye1aEvZYUD0p7FKCVuk
+        hash: v1.k794b7964.89143617da8fddca7be233da4e08e18b1ad690fb668a6d7383b3bc7fab8001a8.YMC16rnqLDMO7K6GaqMHnZlupfPoMcOTfa4wAWPX2DM
     components-product-empty-state--data-catalog-needs-setup--light:
-        hash: v1.k794b7964.097d8cc7ffaf531a26fb0e1bf2ff8af8b47df93ca3cfb74f2649d39a290dfd50.WcTdtzYAhQD28lIYtcl9_uIdSxwz3VJFcxTZT8Y7pTA
+        hash: v1.k794b7964.81809376f80d76be96e2647fca75af76d17d55bbfb43496ed9c85d1fe4810139.roVZ8kCloiAyUXFk9sZacVik-z8_q2rolJQySrvVE4M
     components-product-empty-state--data-warehouse-needs-setup--dark:
-        hash: v1.k794b7964.3d7df6ce8c56af7c0c5200d0a381d5f28c885ad380cb370ea0e250266882d608.vwwreN_qibegkh3R21znmwi-Sp9TfdStRZyRxa-g69A
+        hash: v1.k794b7964.06c82fe1313f4d0ba354ae3cd54d9b407a01acdf1f0c6cd9229d05caa1c2a3c2.JMqjYyVCeUE4YbPgyp0WllqSriWfjcv2oK08uMVYPiI
     components-product-empty-state--data-warehouse-needs-setup--light:
-        hash: v1.k794b7964.5bdb2d34c7084ea2351b074cd03275e3558be2b79d0e8a7769d57bdb38e87faa.xNdrkZ0mjoEiJ5DAwDJn1W2x8biEG3DKPcO9wAzRM8c
+        hash: v1.k794b7964.00719fec7ae732c14e138f5490b704dd4b43851f8b64ed4f0b520c405e036d61.cMX_6z3cOUjIzxBTb0s6zFxXtvMkSIc8bpg-WdgariU
     components-product-empty-state--datasets-needs-setup--dark:
         hash: v1.k794b7964.01f60a890684cbe8ce2e6710438881a14cea589f0329a0c7bb81e6ba3c7d705c.RDQRVZbNasaNJAmELuFQwrgwmPHFLSDnpqwMR65kwLc
     components-product-empty-state--datasets-needs-setup--light:
@@ -1821,9 +1821,9 @@ snapshots:
     components-product-empty-state--destinations-needs-setup--light:
         hash: v1.k794b7964.e215096b71a24d85fa746ec02cbbbf72715f8008381b65e645a34e0328585d71.eNKn5uPbgOhor19ppzPwUqXtogIXg4N0JePmDjq5dgw
     components-product-empty-state--early-access-features-needs-setup--dark:
-        hash: v1.k794b7964.ce612c03290780c1098886d9e2e0f9d920bfa899c591fadfecabf969b1897fe6.RlwNrGim39bhZH0hO39-bt6bWPUPJU-5XgIq2smDxSk
+        hash: v1.k794b7964.fe7a669fd495464bfe4b098b431f0982b3e411c572c052b05b796f3d0fd68c56.JPdT5nmRPnshWiWHdbbUdkwgRr1NR5TWYvjcfmo0ojg
     components-product-empty-state--early-access-features-needs-setup--light:
-        hash: v1.k794b7964.563633a4174e6b82faff11a7d2c874fb50a28882f4b4657fdcab70cdb88b479f.mEBCqNYE4cD9VvOJqQs8Z50S9eRIL1HOnu9MNHbIoPQ
+        hash: v1.k794b7964.fea7b233af76669aeceffabc7929d32232743e66ba6c20830f76fffa81697cfd.ySqyCAZFkR6vl82SzGu0Q2CJ3AAUpykO7UBy6boL-Is
     components-product-empty-state--empty-no-action--dark:
         hash: v1.k794b7964.6d07321d951e9c7bf3bf7de4b49b599f16a8584340cb77a78e270a5010218db0.bnlqCCe_LJ1XmziLkFnZ9-hsJTDknXFwdqF7_foBC7A
     components-product-empty-state--empty-no-action--light:
@@ -1833,37 +1833,41 @@ snapshots:
     components-product-empty-state--empty-with-action--light:
         hash: v1.k794b7964.80a94ce3b72b30fc78f17c3df97f60b02513da190f16b10b785ddc6410e29610.LI50ALV6r5CTuWZhpD9jAdNFn5t82tuAdtAuP0FZw7o
     components-product-empty-state--endpoints-needs-setup--dark:
-        hash: v1.k794b7964.de021a6d2a8c7ec6bc031fc7c9586a2d9f12e80804b9a92ec1a9f464c096314e.jqj7jfnrY7rf7IO2Uqrc784pV_YXfH52sTArLcXn8c0
+        hash: v1.k794b7964.3c5039cbcc774991bfb7e05d84438d5f1b9620c84a344712afc9b5c13c9ceea6.zm9S5unaKvH8yjtwEX4Yy_j65dpsk6ggEHqogRNH4i8
     components-product-empty-state--endpoints-needs-setup--light:
-        hash: v1.k794b7964.f704e98aa8d0102c164b7db7390449584c4b84f461cc5bbeac426e48a16dc200.S0QeUPtO_6LQsU5lZ09MyJMaf_Q_CPBBuYbvKzik1cU
+        hash: v1.k794b7964.469d0d5a9946460cfb61138bf4e7d188b8b1dfe4c3ef28464094c233776cafd8.mVmnTe1dNcZjfkGE_Hk_YqapXw603g_7v6ZgtmvQoM4
     components-product-empty-state--engineering-analytics-needs-setup--dark:
-        hash: v1.k794b7964.f7882e375c8b2730c69d683328d88541ef262da3287cfd29f169da8726a56ffc.03tjEZ1wDOe8_yDAZMUx1bTS8YVSLa5q_fhO3sz3oYE
+        hash: v1.k794b7964.f4701ace2d331f207653d041cbee247542a2fdcc8bd4b8ac6e1aee20bdf1fe21.me5Fb7zbwdX-93VdIfM8UE6Yv3pOH4FsbXCUxIlsYiU
     components-product-empty-state--engineering-analytics-needs-setup--light:
-        hash: v1.k794b7964.77d16ba7ab8cbf85db31ec8d482970fe3ad311978901ffea75688390a3894824.GTpSlL6ZixDiYCyrG1IhtXxM1_i25Hk2pW_PYVPs4X8
+        hash: v1.k794b7964.a0f37bcd45673319a2e07436c1f13227c081532748d17a14112d9f4e2e315342.qo2rkKYRoyOjriLqMdVMdahc5DIlqag-01WXrTUEBO0
     components-product-empty-state--error-tracking-needs-setup--dark:
-        hash: v1.k794b7964.a3fcfa83eb816f90ccc0a031486d1d493e3893df6d9b23ab8138efbbfe833374.AIGP2LVUdagSan_3zq5NEx5QT3To4HN4BwQv06ML7Nw
+        hash: v1.k794b7964.c0cd3727394a11388389774d7880c2a28aeb059a308d75feeb1341b13673a104.SetdbHN--yP6YcrM12BpBzA0_aqJVqwxQM3Uc2Wchmg
     components-product-empty-state--error-tracking-needs-setup--light:
-        hash: v1.k794b7964.e14dd5aa0920ec0d2fe037a2bbe475dbe63aa94a8bb0d707d99bff904d03ceac.g1vL6Sreqh6sDhZZ73EXQfP24ijGmiecYFgz75lHR_c
+        hash: v1.k794b7964.7f40a4a9bc119d95d61ef68b1ed144de44a460d8015a7196100e9048c6b57ce5.cKeg20m9AJX9GmwJ0XKpX1qaZB5sopbADXCeE9ZsHL0
     components-product-empty-state--error-tracking-waiting-for-data--dark:
-        hash: v1.k794b7964.574cdf4564785073be5f6199e47f8818070a50b52fc03eefc96c56f40ae51f06.T9kHDbgsBiwQgDUbvF_6K4FP5S4Ku_OAPM1X901Xslk
+        hash: v1.k794b7964.80bdd04e414ed36e173f1dcac8e4ccf407375157fdd5b9497e7209bdb623564b.RbOoZt9BkTBAV3sXCR0IHWu0wvAh9JNPIdFcZJ7axOU
     components-product-empty-state--error-tracking-waiting-for-data--light:
-        hash: v1.k794b7964.eff072a6e6de72483eb81c9f78e1582f0f5765038832e15dde0437c579af8a6c.MxorCvxObSX63Sd1i7-cam8gtY401euSXUpUrYtC1ko
+        hash: v1.k794b7964.cb5b64ff05ca6ec20971e41ee0118074f9473ae1cb8859671c21b5d7fd8655bc.px_ONC8K1r-Vjznny_3zZIGWHxfw2diwOcUrFzKA6H4
     components-product-empty-state--evaluations-needs-setup--dark:
-        hash: v1.k794b7964.a8a278b2693519ebf1783f4062be3f6c1d6235bc9e2497b75c18cc94f82de6cf.Up4GSsLrtmP_2OaDnpbgyytBv3JZyzvehnNKGQkPsI8
+        hash: v1.k794b7964.d66a917dd9bbb71fe2c50f81b2c5a873af729170292973601909c77c6ed54304.X1ueW3Kooz45WUhf9edIjjWCpiT9MwXfZAuclmpxL_M
     components-product-empty-state--evaluations-needs-setup--light:
-        hash: v1.k794b7964.10a5bc122e1e17fbbd2f025f29624ad5eccac123560a54274966acf9e2971c51.HyJZax1MznN0JPYKMFadCn3l9qDQ2_JbxFgO9CXEotg
+        hash: v1.k794b7964.8f1c1a0f298854ab3d87e5d52a4531daf193a9a4415bfaefc2962d1403860d33.4vgyKRIRxjX1MkCE9LQv5yEOfh3jfs1SEMiFvIzAOSI
     components-product-empty-state--experiments-needs-setup--dark:
-        hash: v1.k794b7964.4963f41af44c16dbfdacc188339ff9c4f5ca4aada2f5848ad4f195b52c1cc81d.SiIn79B-XFAK4ZwxeLxdLgGNGPbtraECPD_tfCokLdg
+        hash: v1.k794b7964.2cdc47f158cecd85687618856c238c7ac65456dfa887db9e5e66baa9476cd145.mBKJtWHPn-vr4FCycrTMD2WE4K4a6cOT8SGg4p6MzbE
     components-product-empty-state--experiments-needs-setup--light:
-        hash: v1.k794b7964.8f49c9ae20266a0dcb99c84dc3db2b58b2b5e10047b885a53f738e1553e9a4f7.xopRCDiMsqJY5Sq6k0CIJM0ZTvXD7eN3xHbRN64Tpow
+        hash: v1.k794b7964.1614b7507d5208e7618539678833371202a80edcf596025d6ffb1a78fae2ffd6.C7XzWCNOgywXpWJLkH4Cme1mdsrScHp9B43vtOad-90
+    components-product-empty-state--feature-flags-narrow-scene--dark:
+        hash: v1.k794b7964.f48c3f84df86a402f58b02d70b195b7d28b8de9f035c64e71399d10b17df3c5f.nUKCJSZyG3d4NoQwCv9h1408eB5zvHASv4gXF1ESAa8
+    components-product-empty-state--feature-flags-narrow-scene--light:
+        hash: v1.k794b7964.169da878f977739abd310a7407dd82abcb52344c122878716573d4707bc63169.jABQeM7xAJ2HH_vNE3BxUHShCYIes23_03D2DPub2GQ
     components-product-empty-state--feature-flags-needs-setup--dark:
-        hash: v1.k794b7964.75f63a26a820ea1d1261897b278f1cbe04c46ba50431f7b0b087803000a73591.xzu_boakPi1km0kgLmyNk5EuD4YG0CdPl6LYEiJjp8I
+        hash: v1.k794b7964.81f385824e22ebb174c6584235c7adbb4d6ab75930b5a817b86dd1351db1cf4b.lJIaV0jAsPB2Xpb5Y1-ZwqkxcKfW-WehIM3gDkVId88
     components-product-empty-state--feature-flags-needs-setup--light:
-        hash: v1.k794b7964.34d494ddf930bbfa26d1233de53e3ecbb2abd594f02e6320efdc170b55bfb858.MdeFEd9dR9MxST9SByounoWeAdLp4nhfKm-sS3Xln7A
+        hash: v1.k794b7964.65dfcf916be1d901f3d5ef1748a5fad557d98fd8bf48335ad2f7580f80d25414.yuzIQVv29JIgxzhuy5KJJ_9CIc3WYE2iDRKMyb1UyUY
     components-product-empty-state--heatmaps-needs-setup--dark:
-        hash: v1.k794b7964.0f8d204fc21b6a4a4c4a44713855b69d2b6771869fdf56d6f3f0352f2c6099dd.OfNvsrwPP74BsmuHwheLT7PfzqvWozBGArKPtYQqiOE
+        hash: v1.k794b7964.c379154c72fafbd20c95d4e5aa67693656f388bf6d611b9795e566f97bfdec37.ZhN0r0aW88xYyYGBelE2y_s4OAgh42lPHimmWlNSdqs
     components-product-empty-state--heatmaps-needs-setup--light:
-        hash: v1.k794b7964.72acaab1bc71bf2486109cf133c3fb66f21039afac6b3a26a7806636371a73af.T6jgYO3dwmpgalMH-yLm7MyfozQQIdyhWhtzXPd0UGM
+        hash: v1.k794b7964.7cb5c40e18650ac749c6797f0ccb1208335ec63e326f1bfe1e7a11168162f118.su0faN78iQ9bJAonJY7ZIYgR64qNx-eT1lkaSQiDut4
     components-product-empty-state--hog-layout-responsive--dark:
         hash: v1.k794b7964.8c137beea63f1365924e6f66a2d70092161a78859f5de68c0f01fbaa8ece1cdb.Cc2QUvwJ0APGb2C7S5ETG1EfPK0rUmD5RiypJLrfX2c
     components-product-empty-state--hog-layout-responsive--light:
@@ -1873,117 +1877,121 @@ snapshots:
     components-product-empty-state--hog-layout-responsive-with-main-content-container-queries--light:
         hash: v1.k794b7964.21032c000615555ecc02b4546fc2425c677f06c451b6b8d10307c4ec89faf6a0.1ZPt3gD7fOiCI28QnBWuHfoBz6EhHsDtdHBWv04lQMg
     components-product-empty-state--links-needs-setup--dark:
-        hash: v1.k794b7964.3df0b39f119f7cee6e28da77d891d7655fca655d37661ab474b42fa24cef4aff.UE2nzteHycjHQatlhLj9NbarufB0DYf-rOuFf3J4DZ8
+        hash: v1.k794b7964.8aa4e78c2d391e5ff0e41f7572ce783b831fc77f2f2a4e225f19c15ff4177b06.v5Wc6LWOLnbCMYl-dJv14jNVWhwPoyKfEAstg5vtC_4
     components-product-empty-state--links-needs-setup--light:
-        hash: v1.k794b7964.b183161da12461f01783c1f14501d0a1c14a964d891e6380a8e002115e58f3e2.TPHWkv5zEqn4Fg-H2SUPRRJrHVyMlXLPtJrpdvfinuM
+        hash: v1.k794b7964.e116bb54c7dd63ae6a935c348fed6f953f772a82206318d068707168f104add1.XtBQZyftHzjEwpZGccncDuCsRVGeGNaefqvGCg4xkFw
     components-product-empty-state--llm-prompts-needs-setup--dark:
         hash: v1.k794b7964.fdd99f387e7d5885faca819190788b78c604be9c25d72a234daac5782d00eb73.YY1FKMtEKT0kYnSd-BFzETTo38_Iz3420mOMtMSpzWc
     components-product-empty-state--llm-prompts-needs-setup--light:
         hash: v1.k794b7964.c3e4634294bdb1582ce43c77c7d1075144d4410d551eb4d1bdd9b04846cba79b.54gmU9o9rPj8Skp924kc_djpXXXRW0MftHzY_4ZaDkk
     components-product-empty-state--logs-needs-setup--dark:
-        hash: v1.k794b7964.96e30395bc4290ad188a84e94f5d40d46f545a3223e4d13fe44737d322129e2f.kj5dwA7EuPOvu6YfDc2jc2s38u8BfXT1EcfPAMPztuM
+        hash: v1.k794b7964.b98c7582ea1b97dfde9a3e9d2aa5446e13de565874f920bd47ce86c78c58d79b.lh5Frbh5JXMlynlewVKbjTTY-cwWlIJDyclbAC5B7vw
     components-product-empty-state--logs-needs-setup--light:
-        hash: v1.k794b7964.e48c85227bbcc871026a1cdf096c1cf21ab5a0504983d138048258516841b153.p74Gybn8AxHmoKKMNcSfmx6gTus5K56ARAEhsPYcxDY
+        hash: v1.k794b7964.0e1d6d62c4809f1aa242f31070487e65c6d899fb9de135485ee899c5211139e3.uOL2D9eF3fDPIlFN-DgfccHR-AUy-vKjeT55XirfeJ0
     components-product-empty-state--marketing-analytics-needs-setup--dark:
-        hash: v1.k794b7964.ce0aac7a759743749623867c4cea9529ecb3738a6f43eec92e962b4f6c1f1564.EM_vzdZrvKmEbge1FryouAY6DqEN4P1sL_eBrOWTZcY
+        hash: v1.k794b7964.c30a033cfdc557c02c2e1231e3a39f9c4ab5b7fc6f58861b2b6488a5771679bc.CGcyNSruX__p-Pb-BgL3aLhk-y4gvWPnVWQ4WRt3QZ4
     components-product-empty-state--marketing-analytics-needs-setup--light:
-        hash: v1.k794b7964.0d1f0a6d68cc64cc406dbc57510707e9fcafd6a315193e6345e7168e9a38fe24.SeOl-kOg6cQqIgJKNCTRiXiSRvIv-2KHhg6y5hzhMe4
+        hash: v1.k794b7964.81468d19337f95e32e9d53d71ec649509f0be961a0bfa1e3fbcf44f28258cfd7.YfD9ppWZGbZ8BfGaZpaUJLLrkXeKv_ra2G6Qn0en1uM
     components-product-empty-state--mcp-analytics-needs-setup--dark:
-        hash: v1.k794b7964.96d4c2d4afe9d7834d3667aa266bafdcb7f8192e4c51927b7661824c9f982d97.leY0JcEWIDNFZQl9s4uuj96BWBHxb3cYGMaU3rJ0g0k
+        hash: v1.k794b7964.955d7799e78bc9c0ace10dabd2bce52b354eb11b56475b6744e02b3288b7f01c.ZF3v1WTUmhePhYs8qcP_C2jQ8ak1RVqBrRx_2WN-0cA
     components-product-empty-state--mcp-analytics-needs-setup--light:
-        hash: v1.k794b7964.bf4aef71690c12d5adbcb5f5b22857b7df77dbb42b523840afe2a3d6f091c094.mGZ8Dfga9ZS-41uGnaouR9US9DzOGQIfFQql0MWeOEg
+        hash: v1.k794b7964.2a07f9c4ad3cdc67496665fe087d96ef624b5416af4ea6f0a372f225bfbdf51a.nmYxmPP8M2WfgIfiO02FH1LRo3l2iHZNUAQeoIqxbyM
     components-product-empty-state--mcp-analytics-waiting-for-data--dark:
-        hash: v1.k794b7964.c3e7cbfd193c3aa86acc78887391f740f3bd85f6a6064d9240778fa4674cb311.h_hviVpuQkTB-z1lwox2PC5Mso02_ERNpm0orV4mJJw
+        hash: v1.k794b7964.381cc4b0a52b7be8e197807df0d452faa90f841070c0b7903db848d457379360.SF2yhvD2RC5dv2ArNdphtjCRRw8Q9QWAK5hbS_7nZgQ
     components-product-empty-state--mcp-analytics-waiting-for-data--light:
-        hash: v1.k794b7964.750368d2ae6fd45adb00bb8477873a11e3ad33398221dc86774f259aae28aceb.8GXJt80IxwzaybuskY7MKympWJ4X0SCjwLatW0QLHko
+        hash: v1.k794b7964.afc36da92cd8599bb37c555313e58ac2d9b8e0ad1d3507a3bcc2e0dd83bba0f8.4h24zMTfQcsLf2u0Y76RLDgWrzIILudjQofdU6wLJXI
     components-product-empty-state--mcp-analytics-without-wizard--dark:
-        hash: v1.k794b7964.4fa27c3231a20ff8e3d545a0979d1b86b1367e925d2db6ea67360941a9c10e23.bJBq_kK46OIZZXI05CslNdEuBIgjed2YSK3c5YAm4ww
+        hash: v1.k794b7964.1a86992164badf9773af819ff363afd2da5c58e60f684b4c012b8d3fec92da0a.mJKIdXOe0PObMF3hc0adlk72-bWNdZgTRAwn-QtCqbM
     components-product-empty-state--mcp-analytics-without-wizard--light:
-        hash: v1.k794b7964.8044fd4dc9bbf1559e453dd5a61a62c2aedc86a0d9e9cdbe32f29462a3c4096b.sAIpZsncmM_qxpuHF0Cq6PPIVJT412weeElI8Juz2XI
+        hash: v1.k794b7964.b90e900cd86f566f2ba8ca414dbadc30b47192fa3623c74d0877073e045fb10a.jzrhSBUDnD-A8Mb3pbz2kfVRItka5I2R3wBh-miWC1Q
     components-product-empty-state--metrics-needs-setup--dark:
-        hash: v1.k794b7964.f871f80c2e0437044742c14a0db2f29109168ec4dcb8ccec7e6fd814248bfc3f.GEM_Stq79cSU_62UY6840MfBQiGz-SJZ1u9dW5JG_pQ
+        hash: v1.k794b7964.75f2906aa996af4484df6752b48fbc306ceb5ab82beca50473c236506a0ba1ce.keyNXrAKRwr57hyLW_G-8QEAiiz_rhxkdxkCAMNpx9E
     components-product-empty-state--metrics-needs-setup--light:
-        hash: v1.k794b7964.508b62772da1dcd8700e677010732092b48e105cf837a8b074aa0bf5522abb9e.RySrCBS1xNDjeB8G8w7HObsdeP2ZssrvUNfm-We6Vpc
+        hash: v1.k794b7964.8f6e4b6fb198ded5f84135148245345df32d91e1282803bc953f16569a31eb57.FA87RDzZhrLHLiW6kI9IM4n_Zefees_qIIROyXZfcGE
     components-product-empty-state--notebooks-needs-setup--dark:
-        hash: v1.k794b7964.be9dec9126ce31f33d3c19f4cd94cbc7602c6d102365f841197dbbdc66dd6349.L9TQMe38uFWnpl9gSVpRkebTBH24Gpkxgug29h0eojo
+        hash: v1.k794b7964.50882b00196667fbcf87130d1e4b7ffa1b0ea2f8f3e079c12df2d04eb7d4b5a0.CbZfU54_ZWDE2cJscwNBtVPK0YbnpFr9yXLBO59i3Dg
     components-product-empty-state--notebooks-needs-setup--light:
-        hash: v1.k794b7964.8faed3905cb11fc08ac70fb3e958effbb7d0f06af399336ce3d7d1b43152dd60.S8d2m0fiT_yzW6FkMhJrj2jrWo3HxZa4fHMqVawEJbE
+        hash: v1.k794b7964.1560ac92b194b0c45fd0c30a84393d25d17b6cc0e7a36c5ccab235ed616f26fa.qDZHkloPN6qcVdgdMenLhEcNSLNHJtLVOVEF1RBLf_4
     components-product-empty-state--product-analytics-needs-setup--dark:
-        hash: v1.k794b7964.1ba74ff0bea7eef70d4faedf8160e9edd14b89ac74b23b98a1322f74f29c7188.eXqkpdeyPlzK4NAYg9xIMc73g54455Ng0wnqLkFqOCg
+        hash: v1.k794b7964.83c11ee197cc180e6dee91a015ca98c1ad715f8b94925b52b294ff6c197a3e11.vpN6edPSaROLOBloHi4RA9qZWTt6cRZrfPCYpUTLrqs
     components-product-empty-state--product-analytics-needs-setup--light:
-        hash: v1.k794b7964.e090c6d53b8aa01575575b5ffb99c69d884033dfbda577571c740ae424ba0edb.wX4jI_gpHjxLPca_EFTH1-f2YzmvnU1Rozi3zQVGtsk
+        hash: v1.k794b7964.c909f59d3208397356364866a33b49d652d70f9991bad02c2b5e7ec4046559bd.O9TVaP-m6ag9dEu_TjVAAKZEykF5-bB3e0LTl-4A4VI
     components-product-empty-state--product-introduction--dark:
         hash: v1.k794b7964.6fb2d5feff1fa62c3ed888268602b4eb017f75d33178538542ee4a6d28072fc3.tHRCmCQubhMPmffxXOGXE0jpd1kSvcnGMay-GOjl-J0
     components-product-empty-state--product-introduction--light:
         hash: v1.k794b7964.80a94ce3b72b30fc78f17c3df97f60b02513da190f16b10b785ddc6410e29610.4XhHHGq7prdUMyvvHE7cOA3EgP4Ia_lrdFQCDxvt470
     components-product-empty-state--product-tours-needs-setup--dark:
-        hash: v1.k794b7964.ba387f94bf7380934a79b9a58f19d27dbe5561163315728c3a2d813a747757f0.XpF43f3StaHvZq-5TpAo3Uw5ABra8ikrJrLcMaCFqlM
+        hash: v1.k794b7964.02fe8679003a9244b40ba91604dac96a35b92ff2bfcd9107876eb0979b360e3e.mu4_7tWLakBe6_SV2yoD1TdtKFWEu3LwiBfkcAxM0xU
     components-product-empty-state--product-tours-needs-setup--light:
-        hash: v1.k794b7964.bcb7662c9b7c8b359951611d5d8c707b752df3cf4b51d4b55db0031a895fbb1d.LLNYGfrenmzwrDMW0v_HX5rZG8y7Zh-H_GoHbWDymRU
+        hash: v1.k794b7964.d27489bf38ccef6ee9acf481525b75f8788461619de2f59cef2808ee7a129cc3.YNswH85tui0FuNDL0f3pq_HS_5yKBNXu-72kufRXM7o
     components-product-empty-state--pulse-needs-setup--dark:
         hash: v1.k794b7964.bd2d483068c315b50470af80852f8f62ce8555992ae68e1001202e8e81dcac78.Y9erf8kVRfgMPhVGKX_GzF_Z883Qbexj_oj0C3wum6I
     components-product-empty-state--pulse-needs-setup--light:
         hash: v1.k794b7964.a2c52e420aaa52404df68dfeddcbb967d4656c9c5f708944d9d5a4809190bc94.A4KCBgE0Es3MIwO9Ui8lr1Wy51GBY3weQ1qjJU5hnXc
+    components-product-empty-state--replay-vision-narrow-scene--dark:
+        hash: v1.k794b7964.9ae080adb1f578d1ddb5bc7bd7779af89b9cd180855f6018e0753ebd4cbfed6f.bvjL-dHufdxEsakI7DMaqUzi3Du6eXX73YTPGZs4OFU
+    components-product-empty-state--replay-vision-narrow-scene--light:
+        hash: v1.k794b7964.2d5d05fff44240db06c2b604b04f2ee87e7872a95d4b2f55b296e03faad98bbf.ZnRiEIIKJS-1f-elelPTjtxH2E6Vze2EmQ2M_iV7Bw8
     components-product-empty-state--replay-vision-needs-setup--dark:
-        hash: v1.k794b7964.78d06d6c9f11d54919ad81abffe6a5d409dd1b4e7ba08a822a17485f8503617f.owccqODY_2d4-T-mAhHHfXx-rjYgbeohS0xVOLc5FXQ
+        hash: v1.k794b7964.fccf1b8565b3f497ad0988865c45ebb18493175322c79f2444d9cf59a8e62257.YUmT9sUYgPtcKxD_V6BBO5MXOUAOKxpFWABTf9htzg4
     components-product-empty-state--replay-vision-needs-setup--light:
-        hash: v1.k794b7964.251eee6169c98d22d57c361fdcf9747e16187d832d3ce775d93ce9418b67466a.QZzU0myILKJWAjynyGeUQybg5UwVqniqT1Q1TuT-jkE
+        hash: v1.k794b7964.58be79b431334f414cd22bedded4510c8ccfc467ef2490ae85978ad163c0e13d.C2DBrAzrTRzDrwXCcaCrkh-jhymcP-l5FGEv_VfNjSQ
     components-product-empty-state--session-replay-needs-setup--dark:
-        hash: v1.k794b7964.df47e82b994f7ef3a3015ee0cc0c2744ae54badd8382b885549901d6935213a5.ZHU7jAayHU1qzdeAGgXqY9GLRexVyv7RQKamYEOzYZY
+        hash: v1.k794b7964.81fcac6cc23b229acfb5e5f49420ad3c57c5d4fef767f5a00aded64bb7fc2073.LQS6joNzhVNm5rYI5sBTOUPIWhQKU8KrgkIjGhDK55M
     components-product-empty-state--session-replay-needs-setup--light:
-        hash: v1.k794b7964.f4359d8ea9ba08eb83ebcd19655f1f0772474b505b9ed557851d6a90415232c3.87yxPfiw4wvAnIuGBIupYBTSTWkpLllKEl-bg4tzxMM
+        hash: v1.k794b7964.792ffe6451d0685960b3ba58966accc9f9496a9c248fa6953faeef47d4a02d96.HT9HY0wH0OHeBxfteGgCpqvdALtZz0MATWJEizNCn5Y
     components-product-empty-state--session-replay-waiting-for-data--dark:
-        hash: v1.k794b7964.cc8c1c17fa808feef5b537443040ff1f820bfacfd6c9a3875da35e6897747bf2.2etdmMjx52jxI4KVTTu5zVtIPwBXSuVwpgrjAu7OI14
+        hash: v1.k794b7964.6798a9a2195639cb30a50c15ecbb664006aec584a09306610c9670990bacae67.Uw2f53JiwLGhwqwgau9VB5SX6UCUt2f-wtdHX-D1k3w
     components-product-empty-state--session-replay-waiting-for-data--light:
-        hash: v1.k794b7964.16cc3b59102cec6204dd171dfaa10f539ee30670ffd3d9243dd0dde38f9b937d.dR77we_J-giW8Eg7VC7LLYHrSweLA-W83Ib8GVfBtNY
+        hash: v1.k794b7964.b4d9936e8f82c04da619ee3824ae1166511c035beb319f72ee42f42a215888fe.oTu26l3mTGGE0ZetaCcN1wltmhVrCuCV0bwAvXTgjaY
     components-product-empty-state--skills-needs-setup--dark:
-        hash: v1.k794b7964.7fb1bfe531cab39785cf3d98edc3fed01122cbe04f2fc10b23054648455ed423.VhFzyJUt9ckAydjv1P6BL83AKLhlKl3NRrb5fL1o2M8
+        hash: v1.k794b7964.1bda7cec871dc0768d1d1801eef8bd5c66e70e1e7d493439ed4dad5e35e40b33.14Yy7rk5Dg6cdRkP552n4lsaUugBN8umal6s2_bFo9E
     components-product-empty-state--skills-needs-setup--light:
-        hash: v1.k794b7964.6190af5d97300186be7d9edec9bb4139d2681ba6cfcb04961dca1f97d46181e2.puC3H-Nh82vaTwg0DxFehnS9abgqDzd_PW0XOv0QRGo
+        hash: v1.k794b7964.7f224f1c034e8fa826d6600a6ad8b55e50fc51e7ec3dd0ec2ae1de9e5ee6a7a9.-5vFdQrvzz4GzFGP-13eNBC69nLS2o6YKjSQEuwmZ2I
     components-product-empty-state--subscriptions-needs-setup--dark:
-        hash: v1.k794b7964.bc7bc4e1e0b0bf5194f2409493a69fd0d630ccb95c240bc218e5a337d1079af1.04db5sSfCI3tTZ5yYWQ-JsVmhekakdoCsgO5LGzsynM
+        hash: v1.k794b7964.afd844a74bd9b4ba5b03236f654be4f243ca4fab774d0ef2abacfc8d44833c63.1ZG-zNdVUfTwKM8eBhwgWuvgDoc-3Hz-AuyEkRhWghk
     components-product-empty-state--subscriptions-needs-setup--light:
-        hash: v1.k794b7964.a5432f63afad30c6582ec786f219ceb409e1c117eabb71f1067fad83319742c6.SPizGdnHCfeluzxbsLLxTRKyrfoMhs0PntrnZ6cmkI8
+        hash: v1.k794b7964.7e84be57fe7cb28cd2885e0a00858e43b3b3ce60aa9411c48b43353dff536491.l_CHC8TlZql7hih2oFJB54ZGj3AM-_PLpevII4bcPAY
     components-product-empty-state--support-needs-setup--dark:
-        hash: v1.k794b7964.5f6d75f3dccda00b4931407c41fc8a2a3d11bbe477f53b938862867f9d96baad.sdnyT_ZwGyHUuOxOrOCN4oWyqPKe1dZ-iJN8f42ulAs
+        hash: v1.k794b7964.298ee8cc0cbaa8aa5c703a85a3370365c022bff86f2a107d9c2db1aedd285bd1.7KIJ5WOFw41mHZgPoWwFL6mPn_aWwH-3Cwdc3b6QD_M
     components-product-empty-state--support-needs-setup--light:
-        hash: v1.k794b7964.0fc3c0efdc434d5d7f2b755a5952967363f9829e8cc443d665f783a712161bbf.BJ2PT-Ivzu8CtPgGaxVmj2ZdP7iZ4Ev2iipLIO_x9l4
+        hash: v1.k794b7964.8e13a18244cd8a58818c4d2e3a4665eaa50ce477df4ae12825ff4d7b19416ed2.0jk2RU-yG0JRLRx4-6pEOR3cM959NFxyEb3FVW57aHo
     components-product-empty-state--support-waiting-for-data--dark:
-        hash: v1.k794b7964.369d8902d1857ba89bc0995bbf90de39a2664d4c0ad9d7457b2c6c2972c65865.Q3OsOnoxbBawKNFS75yyCxSY3RTWKLXvDelOZhZQ6BE
+        hash: v1.k794b7964.8b7db5a93189ca9f5ab21487cfd183502d2cfb4fb0fe4d00bd6a9dde4db20e5d.xh_OfNBVKhUiTvy5I2_TY0pyw4qbAIwiYkGYiouZM-k
     components-product-empty-state--support-waiting-for-data--light:
-        hash: v1.k794b7964.81466638b2ad508f29fb15596fe41e493559cb42d140fc9a0631a5beb52a90af.eTpjSWKyf2FL3SoGdY-EGFLGwLo407-BlQiMsILXDkc
+        hash: v1.k794b7964.4b72d3b8f741ec0372f436a9fea4aed31dfa85f445426d3206866d9c818e17c7.fI50hCzet5th8fdw8-l5OrCJWICd8JG1jjdMnoyvvrQ
     components-product-empty-state--surveys-needs-setup--dark:
-        hash: v1.k794b7964.48e0b204f4d32e3f43354e173336cdfd6686f18df2c4b5fa180ea8a31a0235da.s_YKrWdUSThhx49a5WBAhgjGd4H-UB4Ok6nPC3lInE4
+        hash: v1.k794b7964.959b8e3842026374457af9aaa077e1665dfe57a51cd048b367882f6d1d7e2cba.FsE2PqOyUaM0W_QZd3OL9kQIbZzdHGdE7g1FytJlw3s
     components-product-empty-state--surveys-needs-setup--light:
-        hash: v1.k794b7964.605f8db038c8045d9b471fb9b6f9fcf8d00a08f76b83c8dac975fed59daa25d2.Khbj1vgQ8N6v8XHihiQfjF3d-TClZLLUf9hoY6VAPRE
+        hash: v1.k794b7964.996f4451c62d87a34121aeca5f87204586188f91960b4c5e1db65514b5e85095.71ClaVTix-yBEo66Pd-FsX2paPQ_jx1SHEJUdkJNsaQ
     components-product-empty-state--tracing-needs-setup--dark:
-        hash: v1.k794b7964.31166d2274ea22226bc3281a0fe2f39caef85292a870fa58b0339964bcb2cb6b.xl8D1Zuw7EzZn8ptdhasdeA8LNEskINpumcYVM619Jg
+        hash: v1.k794b7964.b509c25c4828f3147eb5e83fe0e60b5c7fd92c4eb97cdb6f2f1199163963d7fa.BL4xbLKbTR1DwxgebUirZz2N7dnZdG7K4a5PNPZqetc
     components-product-empty-state--tracing-needs-setup--light:
-        hash: v1.k794b7964.186a74ebee46c9341b2dffbc73c647d7be5f38bdbabbeaf4098237c96ca56c35.i2DjPIjhqrqsIkHPC5Kkd28o97GAL-z6XDcrnjfsE54
+        hash: v1.k794b7964.58a52808fdf381267e5dc776c528d7f7eb88d897d45e50e030c4d8489c81c6d4.AMaR5hj81GG6OFTeFEsxWhjc-yk-hmqZ-MKV-yvL0hk
     components-product-empty-state--transformations-needs-setup--dark:
-        hash: v1.k794b7964.a09118f4e9969306bb2ac6477d7ae051ab7eeeac59b6c87ce5e4f998ea5d8688.Jnuv05RYowSxts1UpR_VYN1SYieAk8Ok8COTLPhaiM4
+        hash: v1.k794b7964.48584f21d48763853573991689622b0af35fac432c0cadaef6a6a75d0f0c9212.6EHjBCMPD2ZHVQrc_tGG8hCLGL8HVk-YRmZDXj3GZHE
     components-product-empty-state--transformations-needs-setup--light:
-        hash: v1.k794b7964.9e5fe5cec95fd5a51beff5b88ee3f59161e745544d954447681cbe52100da410.fsdC2KYRbTnlRWfpzf5bWt3EmN9t1FPr7wz3-J577Gk
+        hash: v1.k794b7964.7dc310b2337e6ab0a748d155e418eef0e8cb898b0fd1508da33ca2dfbb9d23f9.jYRYFePNajfiGMNSMsg-iHtcS8Tn0rXmSVvNlPzjH-k
     components-product-empty-state--user-interviews-needs-setup--dark:
-        hash: v1.k794b7964.5834b5549690d205c2ec9d9b9765f392eeba757749a0cf243c810311f3733079.Ju4u90HdGqU4tcIDHMsmpInKHheBwMYRvpYnd8oGa30
+        hash: v1.k794b7964.d6755cd66e42f856d03984558b3199db8ffae489ba6724566d055d6ef62e73ca.3zwfUetLHLrs4BwJ5wg7vTTOIhCYTjgI-TKYTTjdFUI
     components-product-empty-state--user-interviews-needs-setup--light:
-        hash: v1.k794b7964.81ae25179c9ae9329dcea53365c7be8f78633d34b7979929cb0066586148a642.5Rr7HaxoZaoD8RyCEH0ysbldkUQ68Ws3HXBgXCNZMMQ
+        hash: v1.k794b7964.77cf80da4377ee0deae418cf8f1539ddeb989182c3e681b873a06bfa2acd52bd.IZPNE4KjQuQ6vL1375iXUtiz_5hLYGT_Ql2MrEh6374
     components-product-empty-state--web-scripts-needs-setup--dark:
-        hash: v1.k794b7964.bc46449177ab847f94c92990d63d818c36eee7c688fc4c694469bb4ffad13e99.YN8yq4k0SgUx8yRoP6iyXigFMsObNSJMRXij34vvvu0
+        hash: v1.k794b7964.b8df680b75a655d45a2371155e529b7a46417b8c9bee1c04ee2c9ff2debf7d80.oRFx2ui1Bf2MbcCJ396mUxfFdU4meehkiuB1ZmLb2W4
     components-product-empty-state--web-scripts-needs-setup--light:
-        hash: v1.k794b7964.d70b7bb0fd575b82e9fd19678205c7a6d54fbaf7301b7670494f07f198a46253.upjEetjILtgCy80wRPMBvXc8e2v_85QawiUUX_zQfWI
+        hash: v1.k794b7964.53ae8b817b628a5101666f63ba745219c5d831089dcd7e532556e639a3bf2238.Jmt0-_sydTWapTG886EmYwmxolgFCoeDO6fjCQqgl7o
     components-product-empty-state--web-vitals-needs-setup--dark:
-        hash: v1.k794b7964.a123b5fbeb5ec66e2b86029722bdb747f611edd6b3351d19aab595998f9a3e71.nq3NPk6-keGcErRmLOYzHUTNfhw9QZ-8yMF0CgMGhRA
+        hash: v1.k794b7964.b784295383b3d02b6816c036a31e20f01161089593b5e61900c745a69a088937.5qpqtCMo70LD8okFHA8c8VSwG_VhGjvQXPp-rWXNv3Q
     components-product-empty-state--web-vitals-needs-setup--light:
-        hash: v1.k794b7964.ae9aaec0dabe879db5d840061203cf13d750f0164c9a2fdf911f79af6e814604.YkoWUrhiyFPv1Z9FSvQXitElTzMRVX4iNq_UoxxQDRA
+        hash: v1.k794b7964.49a529ec7d92790937b44848d8530112575c9b1f8c560fb40690a7b0cf8d04b6.Fp3h_z0fEkQD0vt29L9i-xxRrCLKp6m9Kzw6Sf1XFs8
     components-product-empty-state--web-vitals-waiting-for-data--dark:
-        hash: v1.k794b7964.9f74f04645220e7f649d8086c82e822766320c8a29bcbfd3d5aa5345e9da964f.rzsACSxaLP53U_YzFwcDYxpVsCy4XN4Qg0U8-5SsCyk
+        hash: v1.k794b7964.9260f32f4917df15eba149ac8740825ac59bc581c8197377cfe916835ed68a6e.l1BAO1rzCVplug_xQNzdkF0ZVHRMtoUZtCeRLgJFTCc
     components-product-empty-state--web-vitals-waiting-for-data--light:
-        hash: v1.k794b7964.eaac20368e776886dceff3b45c056fb19f21b7a09a22e6d7e229e9dab7140512.55yNDBmaE14aOQD_JQRC28OIos3A7vEZatViEIlgLSs
+        hash: v1.k794b7964.68143ec0b4e11838e50d77e1153ace37ea97095a2744c7bb21056fc823ec8c61.k3H3_be9rW05TYUGjusSxRuP3-Hb0skCExHyumjxet0
     components-product-empty-state--workflows-needs-setup--dark:
-        hash: v1.k794b7964.63935ffbe9eb50a42da1299be2d30d74f63d40f8bd45f5c596b1bca660af45b5.5cSx0FK8vg7vXmIQR49wqJIEAv0ecNV3X8lHsQQaB3g
+        hash: v1.k794b7964.5715b2b6618e07bbfb8f79e9d5693ab827f784a258ee467db80efc020864e878.89v_z0AYjKYJJsLJOg_DNCSfkBAb_b8D7luHlZem-b0
     components-product-empty-state--workflows-needs-setup--light:
-        hash: v1.k794b7964.112e706a8e35787676a7c3023ce64ccfb8ac34ad710531d8f6276ed69cee375b.9kdpK9mKYvA75kyckBYxf6XDxVAMRr2bIRkFsPkWB1g
+        hash: v1.k794b7964.7224c6486a41259cae1f14e8c4681a4c724cfa55732bb73a8790e69e5ce0ff3b.FAgjbudwnM6xpKppdCytepsCZSZPI5FudRun6qm6Re8
     components-productsetup-productsetuppopover--default--dark:
         hash: v1.k794b7964.8577f1ec7bdb47266c031df353e220d017de2e86125924d5da8b0f052c6ce1a6.cA5-fWqyOm-PbSjy7Y8JZ4rQXAe7hn0soi6VkQ36dfc
     components-productsetup-productsetuppopover--default--light:
@@ -8865,9 +8873,9 @@ snapshots:
     scenes-app-replay-vision--scanners-list--light:
         hash: v1.k794b7964.5292ea9ec8e36367949fbad5f1f8302886c86c146a03a49e4726b74f7cc94eaf.IFMBSVVIVPnW39lyHcjNuWtl45Nn9ne4TYQL7MYYDHU
     scenes-app-replay-vision--scanners-list-empty--dark:
-        hash: v1.k794b7964.7885031209ed7ffeed4ef005e8713c1bc4d16b69c2e22ace83108c3bce2bf882.FFodN1fm17trx9UeixS2sxUnPU_yubgkaR-97mOCLbk
+        hash: v1.k794b7964.b0b8603eba135270184b6a52b522914520af970ad23350f1f071e350cc006fcb.dH-Ur8_uzo6d-zUXf8gdiwNY9zhZuHGzGqxy3CReTFc
     scenes-app-replay-vision--scanners-list-empty--light:
-        hash: v1.k794b7964.73ae7eb6a69efdfc1d7ccee798c452f608b209cd9abddfaa25fa72aa53abc6e8.XcekA1SUZ7lNVl302KAdsFT_iqAZbqt6PENT3IbqwLI
+        hash: v1.k794b7964.1305a1f13b1128ff600e6d485373b16577fac3ff319097d0c0eafeee9c44309e.CN7z37xkXH69--y9YK5mthNSSu8NdpUNBYMDmNyf9uM
     scenes-app-replay-vision--startup-program-cap--dark:
         hash: v1.k794b7964.c621d85ea79f9e749deed225cdbca1daa3e3eec5790456dc2a7c0a1fa4d6c692.FCURh_R9xcDFAq5LbaSPxHzkZMXFpB9woeecjM5MhPQ
     scenes-app-replay-vision--startup-program-cap--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -201,6 +201,17 @@ export const WebScriptsNeedsSetup: ProductEmptyStateStory = productEmptyStateSto
     }
 )
 
+// A scene narrowed by the side panel (or a small window): the preview stacks under the copy
+// instead of sharing the row, so neither is squeezed into a column too narrow to read.
+export const FeatureFlagsNarrowScene: ProductEmptyStateStory = productEmptyStateStory(
+    featureFlagsEmptyState,
+    'needs-setup',
+    {
+        containerWidth: 600,
+        mocks: { get: { '/api/projects/:team_id/feature_flags/': [200, emptyEntityList] } },
+    }
+)
+
 // AI observability detection is binary (no waiting-for-data middle state).
 export const AIObservabilityNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
     aiObservabilityEmptyState,
@@ -209,25 +220,34 @@ export const AIObservabilityNeedsSetup: ProductEmptyStateStory = productEmptySta
 
 // Replay vision detection is binary too (a scanner is the unit of setup); its
 // detection logic polls the scanner stats endpoint, so answer it with zeros.
+const replayVisionScannerStatsMocks: Mocks = {
+    get: {
+        '/api/projects/:team_id/vision/scanners/stats/': {
+            total: 0,
+            enabled: 0,
+            by_type: {
+                monitor: { enabled: 0, total: 0 },
+                classifier: { enabled: 0, total: 0 },
+                scorer: { enabled: 0, total: 0 },
+                summarizer: { enabled: 0, total: 0 },
+            },
+        },
+    },
+}
+
 export const ReplayVisionNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
     replayVisionEmptyState,
     'needs-setup',
-    {
-        mocks: {
-            get: {
-                '/api/projects/:team_id/vision/scanners/stats/': {
-                    total: 0,
-                    enabled: 0,
-                    by_type: {
-                        monitor: { enabled: 0, total: 0 },
-                        classifier: { enabled: 0, total: 0 },
-                        scorer: { enabled: 0, total: 0 },
-                        summarizer: { enabled: 0, total: 0 },
-                    },
-                },
-            },
-        },
-    }
+    { mocks: replayVisionScannerStatsMocks }
+)
+
+// Replay vision is the one product with `hedgehogPlacement: 'beside'`. Below the width the
+// wide illustration needs, it falls back to the small hedgehog above the product name, so
+// the pitch keeps a readable column instead of being squeezed next to the artwork.
+export const ReplayVisionNarrowScene: ProductEmptyStateStory = productEmptyStateStory(
+    replayVisionEmptyState,
+    'needs-setup',
+    { containerWidth: 1100, mocks: replayVisionScannerStatsMocks }
 )
 
 // Actions detection lists actions on mount - answer "none yet".

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
@@ -212,7 +212,9 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
                             <p className="text-secondary text-sm m-0">{text.lead}</p>
                         </div>
 
-                        {text.hint && callToAction ? <div className="text-xs text-tertiary mt-2">{text.hint}</div> : null}
+                        {text.hint && callToAction ? (
+                            <div className="text-xs text-tertiary mt-2">{text.hint}</div>
+                        ) : null}
 
                         {callToAction}
 

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
@@ -151,12 +151,14 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
     ) : null
 
     return (
+        // Breakpoints key off our own width, not the viewport: the sidebar, the side panel, and
+        // the scene padding all eat into it, so a viewport breakpoint fires long after the copy
+        // has already been squeezed. Two containers because the two decisions read different
+        // widths - the preview watches the whole surface, the hedgehog watches the copy column.
         <div
-            // Frozen selector. Playwright specs use it to detect the setup screen, because a
-            // scene behind this gate does not render until the product has data.
+            // Frozen selector used by Playwright to detect the setup screen.
             data-attr="product-empty-state"
-            // Fill the scene: viewport minus the app chrome and the product header above us.
-            className="grid w-full flex-1 grid-cols-1 items-stretch gap-10 md:grid-cols-[minmax(0,1fr)_40%] min-h-[calc(100vh-var(--breadcrumbs-height-full,0px)-var(--scene-padding,1rem)-4rem)]"
+            className="@container/product-empty-state flex w-full flex-1"
             style={
                 {
                     '--empty-state-accent': config.accentColor,
@@ -165,88 +167,116 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
             }
         >
             <div
-                className={cn(
-                    'mx-auto flex w-full min-w-0 justify-center gap-8 px-6',
-                    hedgehogBeside ? 'max-w-[56rem] items-center' : 'max-w-[36rem]'
-                )}
+                // Fill the scene: viewport minus the app chrome and the product header above us.
+                // Side by side needs 64rem for both halves to hold their content; below that the
+                // preview stacks under the copy, so a narrow scene keeps the pitch and the
+                // preview rather than squeezing both into columns too narrow to read.
+                className="grid w-full flex-1 grid-cols-1 items-stretch gap-10 @min-[64rem]/product-empty-state:grid-cols-[minmax(0,1fr)_40%] min-h-[calc(100vh-var(--breadcrumbs-height-full,0px)-var(--scene-padding,1rem)-4rem)]"
             >
-                {Hedgehog && hedgehogBeside ? <Hedgehog className="hidden w-72 shrink-0 xl:block" /> : null}
-                <div className="flex min-w-0 max-w-[36rem] flex-col justify-center gap-4">
-                    <div className="flex flex-col items-start gap-3">
-                        {Hedgehog && !hedgehogBeside ? <Hedgehog className="w-32 shrink-0" /> : null}
-                        <div className="inline-flex items-center gap-2.5 text-4xl font-bold [&_svg]:text-[2.25rem]">
-                            <span className={ACCENT_TEXT}>{config.icon}</span>
-                            <span>{config.productName}</span>
+                <div
+                    className={cn(
+                        '@container/product-empty-state-copy mx-auto flex w-full min-w-0 justify-center gap-8 px-6',
+                        // Widening the column to seat the illustration beside the copy is only
+                        // worth it once the preview is up in its own column, so it stays capped
+                        // while the two are stacked.
+                        hedgehogBeside
+                            ? 'max-w-[36rem] items-center @min-[64rem]/product-empty-state:max-w-[56rem]'
+                            : 'max-w-[36rem]'
+                    )}
+                >
+                    {Hedgehog && hedgehogBeside ? (
+                        // At this width the illustration still leaves the copy 32rem, about what
+                        // an `above` empty state gives it. Below it the column drops the wide
+                        // illustration and falls back to the small one above the product name.
+                        <Hedgehog className="hidden w-72 shrink-0 @min-[52rem]/product-empty-state-copy:block" />
+                    ) : null}
+                    <div className="flex min-w-0 max-w-[36rem] flex-col justify-center gap-4">
+                        <div className="flex flex-col items-start gap-3">
+                            {Hedgehog ? (
+                                <Hedgehog
+                                    className={cn(
+                                        'shrink-0',
+                                        // `beside` artwork is wide rather than square, so it needs
+                                        // more width than an `above` hedgehog to stay legible here.
+                                        hedgehogBeside ? 'w-48 @min-[52rem]/product-empty-state-copy:hidden' : 'w-32'
+                                    )}
+                                />
+                            ) : null}
+                            <div className="inline-flex items-center gap-2.5 text-4xl font-bold [&_svg]:text-[2.25rem]">
+                                <span className={ACCENT_TEXT}>{config.icon}</span>
+                                <span>{config.productName}</span>
+                            </div>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <h2 className="text-xl font-semibold m-0">{text.headline}</h2>
+                            <p className="text-secondary text-sm m-0">{text.lead}</p>
+                        </div>
+
+                        {text.hint && callToAction ? <div className="text-xs text-tertiary mt-2">{text.hint}</div> : null}
+
+                        {callToAction}
+
+                        {config.statusIndicator ? <div className="text-xs">{config.statusIndicator}</div> : null}
+
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                            {showWizard && !primaryActionButton && !config.PrimaryAction && manualUrl ? (
+                                <LemonButton
+                                    type="secondary"
+                                    icon={<IconGear />}
+                                    to={manualUrl}
+                                    targetBlank
+                                    onClick={() => captureClick('manual setup clicked')}
+                                    data-attr="product-empty-state-manual-setup"
+                                >
+                                    Configure manually
+                                </LemonButton>
+                            ) : null}
+                            {config.docsUrl ? (
+                                <LemonButton
+                                    size="xsmall"
+                                    type="tertiary"
+                                    icon={<IconBook />}
+                                    to={config.docsUrl}
+                                    targetBlank
+                                    onClick={() => captureClick('docs clicked')}
+                                    data-attr="product-empty-state-docs"
+                                >
+                                    Read the docs
+                                </LemonButton>
+                            ) : null}
+                            {config.skippable !== false ? (
+                                <LemonButton
+                                    size="xsmall"
+                                    type="tertiary"
+                                    onClick={skipEmptyState}
+                                    data-attr="product-empty-state-skip"
+                                >
+                                    Skip for now
+                                </LemonButton>
+                            ) : null}
                         </div>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <h2 className="text-xl font-semibold m-0">{text.headline}</h2>
-                        <p className="text-secondary text-sm m-0">{text.lead}</p>
-                    </div>
-
-                    {text.hint && callToAction ? <div className="text-xs text-tertiary mt-2">{text.hint}</div> : null}
-
-                    {callToAction}
-
-                    {config.statusIndicator ? <div className="text-xs">{config.statusIndicator}</div> : null}
-
-                    <div className="flex items-center gap-4">
-                        {showWizard && !primaryActionButton && !config.PrimaryAction && manualUrl ? (
-                            <LemonButton
-                                type="secondary"
-                                icon={<IconGear />}
-                                to={manualUrl}
-                                targetBlank
-                                onClick={() => captureClick('manual setup clicked')}
-                                data-attr="product-empty-state-manual-setup"
-                            >
-                                Configure manually
-                            </LemonButton>
-                        ) : null}
-                        {config.docsUrl ? (
-                            <LemonButton
-                                size="xsmall"
-                                type="tertiary"
-                                icon={<IconBook />}
-                                to={config.docsUrl}
-                                targetBlank
-                                onClick={() => captureClick('docs clicked')}
-                                data-attr="product-empty-state-docs"
-                            >
-                                Read the docs
-                            </LemonButton>
-                        ) : null}
-                        {config.skippable !== false ? (
-                            <LemonButton
-                                size="xsmall"
-                                type="tertiary"
-                                onClick={skipEmptyState}
-                                data-attr="product-empty-state-skip"
-                            >
-                                Skip for now
-                            </LemonButton>
-                        ) : null}
-                    </div>
                 </div>
-            </div>
 
-            <div
-                // Previews read `--empty-state-accent` only, so in dark mode point that at the dark
-                // token here rather than asking every preview to branch on the theme itself.
-                className="hidden min-w-0 flex-col justify-center gap-3 p-10 md:flex rounded-md border border-primary dark:[--empty-state-accent:var(--empty-state-accent-dark)]"
-                style={{
-                    backgroundImage:
-                        'linear-gradient(135deg, color-mix(in oklab, var(--empty-state-accent) 16%, transparent) 0%, color-mix(in oklab, var(--empty-state-accent) 5%, transparent) 45%, transparent 80%)',
-                }}
-            >
-                <div className="flex items-center gap-2 text-xs font-semibold text-secondary">
-                    <span
-                        className="size-2 rounded-full bg-[var(--empty-state-accent)] dark:bg-[var(--empty-state-accent-dark)] animate-pulse motion-reduce:animate-none"
-                        aria-hidden="true"
-                    />
-                    {config.previewLabel}
+                <div
+                    // Previews read `--empty-state-accent` only, so in dark mode point that at the dark
+                    // token here rather than asking every preview to branch on the theme itself.
+                    // Tighter padding while stacked, where the width goes to the preview itself.
+                    className="flex min-w-0 flex-col justify-center gap-3 p-6 @min-[64rem]/product-empty-state:p-10 rounded-md border border-primary dark:[--empty-state-accent:var(--empty-state-accent-dark)]"
+                    style={{
+                        backgroundImage:
+                            'linear-gradient(135deg, color-mix(in oklab, var(--empty-state-accent) 16%, transparent) 0%, color-mix(in oklab, var(--empty-state-accent) 5%, transparent) 45%, transparent 80%)',
+                    }}
+                >
+                    <div className="flex items-center gap-2 text-xs font-semibold text-secondary">
+                        <span
+                            className="size-2 rounded-full bg-[var(--empty-state-accent)] dark:bg-[var(--empty-state-accent-dark)] animate-pulse motion-reduce:animate-none"
+                            aria-hidden="true"
+                        />
+                        {config.previewLabel}
+                    </div>
+                    <Preview mode={mode} />
                 </div>
-                <Preview mode={mode} />
             </div>
         </div>
     )

--- a/frontend/src/lib/components/ProductEmptyState/storybookHelpers.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/storybookHelpers.tsx
@@ -13,6 +13,12 @@ export interface ProductEmptyStateStoryOptions {
     config?: Partial<ProductEmptyStateConfig>
     /** Extra msw handlers, merged over the defaults (same path wins), e.g. to drive the product's status indicator into a specific state */
     mocks?: Mocks
+    /**
+     * Render inside a fixed-width column instead of filling the canvas. The empty state's
+     * breakpoints read its own width, so this pins the layout a snapshot captures - use it
+     * to cover a narrow scene (side panel open, or a small window) at a stable size.
+     */
+    containerWidth?: number
 }
 
 /**
@@ -29,7 +35,7 @@ export interface ProductEmptyStateStoryOptions {
 export function productEmptyStateStory(
     emptyState: SceneProductEmptyState,
     mode: ProductEmptyStateMode,
-    { config, mocks }: ProductEmptyStateStoryOptions = {}
+    { config, mocks, containerWidth }: ProductEmptyStateStoryOptions = {}
 ): ProductEmptyStateStory {
     return {
         // Empty states show a persistent "listening for data" spinner (and animated preview)
@@ -37,6 +43,14 @@ export function productEmptyStateStory(
         parameters: { testOptions: { waitForLoadersToDisappear: false } },
         args: { config: { ...emptyState.config, ...config }, mode },
         decorators: [
+            (Story) =>
+                containerWidth ? (
+                    <div style={{ width: containerWidth }}>
+                        <Story />
+                    </div>
+                ) : (
+                    <Story />
+                ),
             mswDecorator({
                 ...mocks,
                 post: {

--- a/frontend/src/lib/components/ProductEmptyState/storybookHelpers.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/storybookHelpers.tsx
@@ -43,14 +43,13 @@ export function productEmptyStateStory(
         parameters: { testOptions: { waitForLoadersToDisappear: false } },
         args: { config: { ...emptyState.config, ...config }, mode },
         decorators: [
-            (Story) =>
-                containerWidth ? (
-                    <div style={{ width: containerWidth }}>
-                        <Story />
-                    </div>
-                ) : (
+            // The snapshot root is inline-block. Give the query container a width so
+            // inline-size containment cannot collapse that root to zero.
+            (Story) => (
+                <div style={{ width: containerWidth ?? 'calc(100vw - 2rem)' }}>
                     <Story />
-                ),
+                </div>
+            ),
             mswDecorator({
                 ...mocks,
                 post: {

--- a/frontend/src/lib/components/ProductEmptyState/types.ts
+++ b/frontend/src/lib/components/ProductEmptyState/types.ts
@@ -117,7 +117,8 @@ export interface ProductEmptyStateConfig {
     /**
      * Where the hedgehog sits: `above` (default) is a small illustration above the
      * product name; `beside` renders it large next to the text and install command,
-     * for wide scene-setting illustrations.
+     * for wide scene-setting illustrations. `beside` needs a wide scene to work in,
+     * so on a narrower one it falls back to `above` rather than squeezing the copy.
      */
     hedgehogPlacement?: 'above' | 'beside'
     text: ProductEmptyStateTextByMode

--- a/products/replay_vision/frontend/emptyState/ReplayVisionObservationPreview.scss
+++ b/products/replay_vision/frontend/emptyState/ReplayVisionObservationPreview.scss
@@ -30,6 +30,10 @@
 
     &__chips {
         display: flex;
+
+        // Five chips are more than the narrowest scene fits on one line, and the preview
+        // must not scroll - so let the row wrap instead.
+        flex-wrap: wrap;
         gap: 0.375rem;
         padding: 0.625rem 0.75rem;
     }


### PR DESCRIPTION
## Problem

Anyone opening a product scene that has not been set up yet, on anything narrower than a very wide monitor, reads the pitch in a column too tight for it.

- The empty state sized itself off the viewport, but the sidebar, the side panel and the scene padding all take width off what it actually gets.
- So a `md`/`xl` breakpoint fired long after the real space ran out. Replay Vision at 1280px put its wide hedgehog beside 340px of copy.
- The preview shared the row from 768px viewport up, where its own filter chips clipped.
- Reported for Replay Vision, but the geometry is shared, so every empty state built on the component has it.

| | Before | After |
| --- | --- | --- |
| Wide illustration beside the copy | ![before](https://raw.githubusercontent.com/PostHog/pr-assets/7284fcf206fdd5f89a5ddeddc2acffa9897ae7a8/2026/08/041a11a6-e4ba-445d-834c-0152ac8969c7.png) | ![after](https://raw.githubusercontent.com/PostHog/pr-assets/60ecfd24c852eb527e115a969d61460ceed82c96/2026/08/4cb7b43d-05f8-4a3b-ab1a-e84c7560ae9d.png) |

## Changes

- The wide `beside` hedgehog now gives way to the small above-the-name illustration once the copy column drops under 52rem. The pitch keeps a readable column at every width, and the artwork stays.
- A narrow scene keeps the preview: below 64rem it stacks under the copy at full width, instead of disappearing at `md` as it did before.
- Layout reads its own width through container queries, not the viewport, so opening the side panel or docking the sidebar changes it the same way resizing the window does.
- The secondary link row ("Configure manually", "Read the docs", "Skip for now") wraps instead of running past the column.
- Replay Vision's preview wraps its five filter chips, which clipped in a narrow scene.
- Mechanical: the copy column gains one wrapper element, so most of the diff in `ProductEmptyState.tsx` is re-indentation.

A narrow scene, stacked:

![narrow](https://raw.githubusercontent.com/PostHog/pr-assets/4ad08af1f138b8c8846113aab59e02510b24bb3e/2026/08/bcd2f163-1e08-4066-aad1-c4a3e5cbd2b4.png)

### Why stack the preview rather than drop it

Dropping it is what the old `md` breakpoint did, and it costs the narrow scene the one element that shows what the product looks like. Stacking keeps both halves and costs page scroll, which a narrow window has anyway.

## How did you test this code?

Verified in Storybook with headless Chromium, over all 17 empty-state stories at container widths from 420px to 1888px, in light and dark, with reduced motion.

- Measured the layout at each width: the copy column never drops below 420px, and the ladder is monotonic (stacked, then two columns, then two columns with the wide illustration).
- Swept every story for horizontal overflow. The remaining hits are pre-existing ellipsis truncation, present at 1600px too.
- Two stories added for the narrow rendering, at pinned container widths so they snapshot stably. Neither width was covered before, and both are where the squeeze happened.
- Not run: the app itself. The dev stack was not brought up, so this was verified against the real configs in Storybook rather than in a running PostHog.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The `building-product-empty-states` skill gains one line on the width range a preview has to hold up across.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread reporting the squeezed copy on Replay Vision. Skills invoked: `/building-product-empty-states`, `/writing-pr-descriptions`.

The first attempt kept the old "hide the illustration" behavior and only moved the breakpoint. Measuring the result showed the mid-range then had a bare column with no artwork and no preview, so the illustration falls back to the `above` placement instead, and the preview stacks rather than disappearing. Thresholds were picked from measured column widths at each step, not guessed: 64rem is where both halves hold their content, and 52rem of copy column is where the wide illustration still leaves the pitch 32rem, about what an `above` empty state gives it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787742840832139?thread_ts=1787742840.832139&cid=C0ACRAMJUAG)*
