### PR TITLE
fix(cdp): block reserved async functions in user-authored hog

### DIFF
--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -17,6 +17,7 @@ from posthog.cdp.validation import (
     RecordAliasRewriter,
     compile_hog,
     generate_template_bytecode,
+    reserved_functions_used,
 )
 from posthog.models.integration import Integration
 
@@ -1219,3 +1220,25 @@ class TestTaskInputTypeValidation(SimpleTestCase):
         else:
             with pytest.raises(ValidationError):
                 validate_inputs(schema, inputs)
+
+
+class TestReservedFunctionsUsed(SimpleTestCase):
+    # The worker's async function registry is global, so the save-time check is the only thing
+    # that stops user-authored hog from reaching a handler only PostHog's machinery should call.
+    @parameterized.expand(
+        [
+            ("direct_call", "let res := sendEmail(inputs.email)", {"sendEmail"}),
+            ("bare_reference", "let f := sendEmail", {"sendEmail"}),
+            ("inside_block", "if (true) { sendEmail(inputs.email) }", {"sendEmail"}),
+            ("inside_lambda", "let f := (to) -> sendEmail(to)", {"sendEmail"}),
+            ("as_argument", "print(sendEmail)", {"sendEmail"}),
+            ("two_names", "sendEmail(1)\nsendPushNotification(2)", {"sendEmail", "sendPushNotification"}),
+            ("supported_function", "let res := fetch('https://example.com', {})", set()),
+            ("similar_name", "let res := sendEmails(inputs.email)", set()),
+            ("property_of_same_name", "return inputs.sendEmail", set()),
+            ("string_only", "return f'sendEmail is not called here'", set()),
+            ("does_not_parse", "let res := sendEmail(", set()),
+        ]
+    )
+    def test_reserved_functions_used(self, _name, hog, expected):
+        assert reserved_functions_used(hog) == expected

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -1240,5 +1240,5 @@ class TestReservedFunctionsUsed(SimpleTestCase):
             ("does_not_parse", "let res := sendEmail(", set()),
         ]
     )
-    def test_reserved_functions_used(self, _name, hog, expected):
+    def test_reserved_functions_used(self, _name: str, hog: str, expected: set[str]) -> None:
         assert reserved_functions_used(hog) == expected

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -201,6 +201,27 @@ register_supported_function("postHogUpdateAccount")
 register_supported_function("postHogSetAccountProperties")
 
 
+# Async functions that the CDP worker registers for every hog program it runs. The registry is
+# global and is not scoped by function type, so a hand-written call reaches the real handler.
+# PostHog's own machinery is the only intended caller. Workflows dispatch the email and the push
+# step through hidden templates, and warehouse webhooks go through source functions. A call from
+# user-authored code skips the setup those paths do first, and the handler then fails in a way the
+# worker does not expect. A `sendEmail` call from a plain destination produces to a Kafka topic
+# that the destination's cluster does not have. The produce error terminates the worker process,
+# and the partition it owned stops draining.
+#
+# Keep this set in sync with registerAsyncFunction() under nodejs/src/cdp/async-functions/. A
+# registered name belongs here unless CORE_SUPPORTED_FUNCTIONS or register_supported_function()
+# above makes it available to user-authored code.
+RESERVED_ASYNC_FUNCTIONS = {
+    "sendEmail",
+    "sendPushNotification",
+    "produceToWarehouseWebhooks",
+    "postHogCreateTask",
+    "postHogCreateAccount",
+}
+
+
 # Globals that the realtime transformer actually populates at runtime.
 # Keep in sync with HogTransformerService.createInvocationGlobals
 # (nodejs/src/cdp/hog-transformations/hog-transformer.service.ts).
@@ -341,6 +362,42 @@ class HyphenatedPropertyDetector(TraversingVisitor):
         if left.end is not None and right.start is not None:
             return right.start - left.end == 1
         return True
+
+
+class ReservedFunctionDetector(TraversingVisitor):
+    names: set[str]
+
+    def __init__(self):
+        super().__init__()
+        self.names = set()
+
+    def visit_call(self, node: ast.Call):
+        super().visit_call(node)
+        if node.name in RESERVED_ASYNC_FUNCTIONS:
+            self.names.add(node.name)
+
+    def visit_field(self, node: ast.Field):
+        # A bare reference is caught as well as a direct call. `let f := sendEmail` followed by
+        # `f()` compiles to the same global dispatch, so the name alone is refused.
+        super().visit_field(node)
+        if len(node.chain) == 1 and str(node.chain[0]) in RESERVED_ASYNC_FUNCTIONS:
+            self.names.add(str(node.chain[0]))
+
+
+def reserved_functions_used(hog: str) -> set[str]:
+    """The reserved async functions that the given hog source names.
+
+    Source that does not parse gives an empty set. compile_hog reports the parse error with a
+    better message, so this must not raise before it runs.
+    """
+    try:
+        program = parse_program(hog)
+    except Exception:
+        return set()
+
+    detector = ReservedFunctionDetector()
+    detector.visit(program)
+    return detector.names
 
 
 class RecordAliasRewriter(TraversingVisitor):

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -369,16 +369,16 @@ class HyphenatedPropertyDetector(TraversingVisitor):
 class ReservedFunctionDetector(TraversingVisitor):
     names: set[str]
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.names = set()
 
-    def visit_call(self, node: ast.Call):
+    def visit_call(self, node: ast.Call) -> None:
         super().visit_call(node)
         if node.name in RESERVED_ASYNC_FUNCTIONS:
             self.names.add(node.name)
 
-    def visit_field(self, node: ast.Field):
+    def visit_field(self, node: ast.Field) -> None:
         # A bare reference is caught as well as a direct call. `let f := sendEmail` followed by
         # `f()` compiles to the same global dispatch, so the name alone is refused.
         super().visit_field(node)

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -201,24 +201,26 @@ register_supported_function("postHogUpdateAccount")
 register_supported_function("postHogSetAccountProperties")
 
 
-# Async functions that the CDP worker registers for every hog program it runs. The registry is
-# global and is not scoped by function type, so a hand-written call reaches the real handler.
-# PostHog's own machinery is the only intended caller. Workflows dispatch the email and the push
-# step through hidden templates, and warehouse webhooks go through source functions. A call from
-# user-authored code skips the setup those paths do first, and the handler then fails in a way the
-# worker does not expect. A `sendEmail` call from a plain destination produces to a Kafka topic
-# that the destination's cluster does not have. The produce error terminates the worker process,
-# and the partition it owned stops draining.
+# Async functions that put the invocation on a queue the running consumer cannot serve.
 #
-# Keep this set in sync with registerAsyncFunction() under nodejs/src/cdp/async-functions/. A
-# registered name belongs here unless CORE_SUPPORTED_FUNCTIONS or register_supported_function()
-# above makes it available to user-authored code.
+# The worker's async function registry is global and is not scoped by function type, so any hog
+# program that names one of these reaches the real handler. These two handlers set
+# `queueParameters` to a bespoke type ('email', 'sendPushNotification') instead of the ordinary
+# 'fetch'. Only the messaging consumers process those queues. When a plain destination stages one,
+# the cyclotron worker produces to a Kafka topic its cluster does not have. The produce error
+# terminates the worker process, and the partition it owned stops draining.
+#
+# Membership is decided by that failure mode, NOT by "the worker registers it". Most registered
+# async functions stage an ordinary 'fetch' (postHogCreateAccount, postHogCreateTask and the
+# postHogGet*/postHogUpdate* family), which is the same mechanism CORE_SUPPORTED_FUNCTIONS already
+# gives user code, so they are safe here and are deliberately absent. produceToWarehouseWebhooks is
+# also absent: it only appends to an in-memory list, and its callers are all
+# `warehouse_source_webhook` functions, which HogFunctionSerializer.validate_type refuses anyway.
+#
+# Before adding a name, check what its handler in nodejs/src/cdp/async-functions/ stages.
 RESERVED_ASYNC_FUNCTIONS = {
     "sendEmail",
     "sendPushNotification",
-    "produceToWarehouseWebhooks",
-    "postHogCreateTask",
-    "postHogCreateAccount",
 }
 
 

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -38,6 +38,7 @@ from posthog.cdp.validation import (
     compile_hog,
     generate_template_bytecode,
     masked_secret_input_keys,
+    reserved_functions_used,
 )
 from posthog.event_usage import AGENT_EVENT_SOURCES, get_event_source
 from posthog.exceptions_capture import capture_exception
@@ -463,6 +464,32 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                 }
             )
 
+    def _validate_no_reserved_functions(self, attrs: dict) -> None:
+        # The worker's async function registry is global, so `sendEmail` and its peers run from any
+        # function that names them, and a call from user-authored code kills the worker process.
+        # These functions are reached legitimately through a hidden template, so a template's own
+        # calls stay allowed. That keeps a function built from one editable, disableable and
+        # deletable, which is how such a function gets cleaned up.
+        used = reserved_functions_used(attrs["hog"])
+        if not used:
+            return
+
+        template_id = attrs.get("template_id") or (
+            self.instance.template_id if isinstance(self.instance, HogFunction) else None
+        )
+        template = HogFunctionTemplate.get_template(template_id) if template_id else None
+        allowed = reserved_functions_used(template.code) if template and template.code else set()
+
+        unexpected = used - allowed
+        if unexpected:
+            names = ", ".join(sorted(unexpected))
+            raise serializers.ValidationError(
+                {
+                    "hog": f"Reserved for PostHog's own use and not callable from a function's code: {names}. "
+                    "Use the matching workflow step or destination template instead."
+                }
+            )
+
     # NOTE: All pre-validation should be done here such as loading the template info etc.
     def to_internal_value(self, data):
         # Copy before filling in defaults below: `data` is `request.data` itself, and injecting
@@ -669,6 +696,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                     raise serializers.ValidationError({"hog": "Error in TypeScript code"})
                 attrs["bytecode"] = None
             else:
+                self._validate_no_reserved_functions(attrs)
                 attrs["bytecode"] = compile_hog(attrs["hog"], hog_type)
                 attrs["transpiled"] = None
 

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -377,6 +377,92 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         )
         assert response.status_code == expected, response.json()
 
+    def _create_email_template(self) -> None:
+        # Mirrors the real `template-email`: a hidden template whose code calls the reserved
+        # `sendEmail` async function.
+        HogFunctionTemplate.objects.create(
+            template_id="template-email-test",
+            sha="1.0.0",
+            name="Email",
+            description="Internal building block",
+            code="let res := sendEmail(inputs.email)\nif (not res.success) { throw Error('failed') }",
+            code_language="hog",
+            inputs_schema=[],
+            type="destination",
+            status="hidden",
+            category=["Other"],
+            free=True,
+        )
+
+    @parameterized.expand(
+        [
+            # The worker registers these async functions for every hog program it runs, so a call
+            # from user-authored code reaches the real handler and kills the worker process. Both a
+            # direct call and a bare reference are refused, because the bare name compiles to the
+            # same global dispatch once it is called.
+            ("send_email_call", "let res := sendEmail(inputs.email)\nreturn res"),
+            ("send_email_reference", "let f := sendEmail\nreturn f(inputs.email)"),
+            ("send_email_nested", "if (true) { for (let i := 0; i < 1; i := i + 1) { sendEmail(inputs.email) } }"),
+            ("send_push_notification", "return sendPushNotification(inputs.message)"),
+            ("produce_to_warehouse_webhooks", "return produceToWarehouseWebhooks(event)"),
+            ("post_hog_create_task", "return postHogCreateTask(inputs.task)"),
+            ("post_hog_create_account", "return postHogCreateAccount(inputs.account)"),
+        ]
+    )
+    def test_create_calling_reserved_function_is_blocked(self, _name, hog):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={"type": "destination", "name": "Sneaky", "hog": hog, "inputs": {}},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["attr"] == "hog"
+        assert "Reserved for PostHog's own use" in response.json()["detail"]
+        assert not HogFunction.objects.filter(team=self.team, name="Sneaky").exists()
+
+    def test_create_with_supported_function_is_allowed(self):
+        # Only the reserved names are refused. The ones destinations are meant to call still work.
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "type": "destination",
+                "name": "Fine",
+                "hog": "let res := fetch('https://example.com', {})\nreturn res",
+                "inputs": {},
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    @parameterized.expand(
+        [
+            # A function built from the template that legitimately calls the reserved function keeps
+            # the template's own calls, so it can still be disabled and deleted. Adding a call the
+            # template does not make is refused even on that function.
+            ("resave_template_code_allowed", "let res := sendEmail(inputs.email)", status.HTTP_200_OK),
+            (
+                "added_reserved_call_blocked",
+                "let res := sendEmail(inputs.email)\nsendPushNotification(inputs.message)",
+                status.HTTP_400_BAD_REQUEST,
+            ),
+        ]
+    )
+    def test_function_from_template_may_only_keep_the_templates_reserved_calls(self, _name, hog, expected):
+        self._create_email_template()
+        fn = HogFunction.objects.create(
+            team=self.team,
+            name="Workflow email step",
+            type="destination",
+            template_id="template-email-test",
+            enabled=False,
+            inputs_schema=[],
+            inputs={},
+            hog="let res := sendEmail(inputs.email)",
+        )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/{fn.id}/",
+            data={"hog": hog},
+        )
+        assert response.status_code == expected, response.json()
+
     @parameterized.expand(
         [
             # Filters that no longer compile (e.g. the team's test account filters gained a static

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -396,17 +396,14 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
     @parameterized.expand(
         [
-            # The worker registers these async functions for every hog program it runs, so a call
-            # from user-authored code reaches the real handler and kills the worker process. Both a
-            # direct call and a bare reference are refused, because the bare name compiles to the
-            # same global dispatch once it is called.
+            # These two handlers stage a queue only the messaging consumers serve, so a call from a
+            # plain destination makes the worker produce to a topic its cluster lacks and the
+            # process dies. Both a direct call and a bare reference are refused, because the bare
+            # name compiles to the same global dispatch once it is called.
             ("send_email_call", "let res := sendEmail(inputs.email)\nreturn res"),
             ("send_email_reference", "let f := sendEmail\nreturn f(inputs.email)"),
             ("send_email_nested", "if (true) { for (let i := 0; i < 1; i := i + 1) { sendEmail(inputs.email) } }"),
             ("send_push_notification", "return sendPushNotification(inputs.message)"),
-            ("produce_to_warehouse_webhooks", "return produceToWarehouseWebhooks(event)"),
-            ("post_hog_create_task", "return postHogCreateTask(inputs.task)"),
-            ("post_hog_create_account", "return postHogCreateAccount(inputs.account)"),
         ]
     )
     def test_create_calling_reserved_function_is_blocked(self, _name, hog):
@@ -419,16 +416,19 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert "Reserved for PostHog's own use" in response.json()["detail"]
         assert not HogFunction.objects.filter(team=self.team, name="Sneaky").exists()
 
-    def test_create_with_supported_function_is_allowed(self):
-        # Only the reserved names are refused. The ones destinations are meant to call still work.
+    @parameterized.expand(
+        [
+            # Only the two messaging functions are refused. Async functions that stage an ordinary
+            # 'fetch' carry no such risk, so the reserved set must not creep out to swallow the
+            # customer analytics family that destinations are meant to call.
+            ("fetch", "let res := fetch('https://example.com', {})\nreturn res"),
+            ("post_hog_update_account", "return postHogUpdateAccount({'external_id': '1', 'updates': {}})"),
+        ]
+    )
+    def test_create_with_supported_function_is_allowed(self, _name, hog):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
-            data={
-                "type": "destination",
-                "name": "Fine",
-                "hog": "let res := fetch('https://example.com', {})\nreturn res",
-                "inputs": {},
-            },
+            data={"type": "destination", "name": f"Fine {_name}", "hog": hog, "inputs": {}},
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
 

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -406,7 +406,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             ("send_push_notification", "return sendPushNotification(inputs.message)"),
         ]
     )
-    def test_create_calling_reserved_function_is_blocked(self, _name, hog):
+    def test_create_calling_reserved_function_is_blocked(self, _name: str, hog: str) -> None:
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
             data={"type": "destination", "name": "Sneaky", "hog": hog, "inputs": {}},
@@ -425,7 +425,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             ("post_hog_update_account", "return postHogUpdateAccount({'external_id': '1', 'updates': {}})"),
         ]
     )
-    def test_create_with_supported_function_is_allowed(self, _name, hog):
+    def test_create_with_supported_function_is_allowed(self, _name: str, hog: str) -> None:
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
             data={"type": "destination", "name": f"Fine {_name}", "hog": hog, "inputs": {}},
@@ -445,7 +445,9 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             ),
         ]
     )
-    def test_function_from_template_may_only_keep_the_templates_reserved_calls(self, _name, hog, expected):
+    def test_function_from_template_may_only_keep_the_templates_reserved_calls(
+        self, _name: str, hog: str, expected: int
+    ) -> None:
         self._create_email_template()
         fn = HogFunction.objects.create(
             team=self.team,
@@ -462,6 +464,37 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             data={"hog": hog},
         )
         assert response.status_code == expected, response.json()
+
+    @parameterized.expand(
+        [
+            # The template carve-out keeps the reserved call a hidden template makes, so a function
+            # built from one stays disableable and deletable. It must never yield a function that
+            # RUNS, because only a running one can wedge a worker. Two independent rules close that:
+            # the hidden-template rule refuses any save leaving it enabled, and an existing
+            # function's type is immutable, so it cannot be re-typed into a plain destination while
+            # keeping the call.
+            ("enable_blocked", {"enabled": True}, "enabled"),
+            ("retype_blocked", {"type": "transformation"}, "type"),
+        ]
+    )
+    def test_template_carve_out_cannot_yield_a_runnable_function(self, _name: str, patch: dict, attr: str) -> None:
+        self._create_email_template()
+        fn = HogFunction.objects.create(
+            team=self.team,
+            name="Workflow email step",
+            type="destination",
+            template_id="template-email-test",
+            enabled=False,
+            inputs_schema=[],
+            inputs={},
+            hog="let res := sendEmail(inputs.email)",
+        )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/{fn.id}/",
+            data={**patch, "hog": "let res := sendEmail(inputs.email)"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["attr"] == attr
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Anyone authoring a hog function through the UI, the API or MCP could call `sendEmail` directly from the function's code:

```
let res := sendEmail(inputs.email)
if (not res.success) { throw Error(f'Email failed to send: {res.error}') }
```

The CDP worker's async function registry is global and is not scoped by function type, so the call reaches the real handler. `sendEmail` sets the invocation's `queueParameters` to `type: 'email'` — a queue only the messaging consumers serve. From a plain destination the cyclotron worker then produces to a Kafka topic its cluster does not have. The produce error escapes as an unhandled promise rejection, the worker terminates its own process, and the partition it owned stops draining — one function wedges a shared queue partition for every team on it.

Creating a function from the internal email template was already blocked, but hand-written hog bypassed that gate: the compiler records an unknown-function call as a context error and then emits the call anyway, and `compile_hog` only raises on those errors for `transformation_log`.

`sendPushNotification` is the one other async function built the same way — `queueParameters` of `type: 'sendPushNotification'`, served only by the messaging consumers — so it can wedge a partition by the same route.

## Changes

- Saving a hog function whose code names `sendEmail` or `sendPushNotification` now fails with a 400 on `hog`, instead of saving and killing a worker at run time. The message points at the workflow step or destination template to use instead. In the destination editor it lands inline under the code:

  ![destination editor rejecting a hand-written sendEmail call](https://raw.githubusercontent.com/PostHog/pr-assets/4fc06cd0199322a3ddc1b61cc101cea90e3bac9e/2026/08/d6e20566-8eb2-4ca8-9f8e-2081349dfb70.png)

- Both spellings are refused: a direct `sendEmail(...)` call and a bare `sendEmail` reference that is called later. Both compile to the same global dispatch.
- A function built from a template that legitimately makes the call keeps that template's own calls. Such a function stays editable, disableable and deletable, which is how it gets cleaned up — the existing hidden-template rules still stop it from being left enabled.
- The check runs in the serializer, not in `compile_hog`, so template sync and the workflows email and push steps are untouched.

**Scope: the two messaging functions only.** The reserved set is defined by the failure mode above, not by "the worker registers it". Deliberately *not* reserved:

- `postHogCreateAccount`, `postHogCreateTask` and the `postHogGet*` / `postHogUpdate*` family stage an ordinary `type: 'fetch'` — the same mechanism `fetch` already gives user code, so they cannot wedge a partition this way. (`postHogCreateAccount`'s handler is the same shape as `postHogUpdateAccount`'s, which *is* in the supported-function allowlist; its absence from that list looks like an oversight rather than a policy, and this PR is not the place to settle it.)
- `produceToWarehouseWebhooks` only appends to an in-memory list that the DWH webhook consumer drains. Its ~26 callers are all `warehouse_source_webhook` templates, a type `validate_type` refuses outright, so it never reaches this check.

`RESERVED_ASYNC_FUNCTIONS` in `posthog/cdp/validation.py` carries that criterion as a comment, so the next person adding a name checks what the handler stages rather than assuming registration implies risk.

Not in this PR: a single failed produce should not terminate the worker. That unhandled rejection deserves its own fix so no future bad destination can wedge a partition.

## How did you test this code?

Added tests, run locally against a local Postgres and ClickHouse:

- `TestReservedFunctionsUsed` in `posthog/cdp/test/test_validation.py` — the detector over 11 hog shapes. Catches the spellings a name-substring check would miss in either direction: `sendEmails`, `inputs.sendEmail` and the name inside an f-string are not flagged; a bare reference, a call inside a block, inside a lambda, and a name passed as an argument are.
- `test_create_calling_reserved_function_is_blocked` — both reserved names plus a nested call, asserting a 400 on `hog` and that nothing is saved. No existing test covered creating from raw hog rather than from a `template_id`, which is exactly the bypass.
- `test_create_with_supported_function_is_allowed` — `fetch` and `postHogUpdateAccount` both still save, so the reserved set cannot creep out to swallow the fetch-based customer analytics family.
- `test_function_from_template_may_only_keep_the_templates_reserved_calls` — resaving the template's own call succeeds while adding a second reserved call is refused, covering the cleanup path for functions built from the internal templates.

Also run: the full `products/cdp/backend/api/test/test_hog_function.py` and `posthog/cdp/test/test_validation.py`, and `products/workflows/backend/api/test/test_hog_flow.py`, `test_hog_flow_action_email.py` and `products/cdp/backend/api/test/test_hog_function_templates.py` to confirm the workflows email path and template sync are unaffected. `ruff` and `mypy` clean on the changed files.

Also exercised by hand on a dev stack running this branch (Django + Vite), because the tests drive the serializer and not the screen:

- Pasting the snippet above into a custom destination's Hog and pressing **Save** is rejected inline, as in the screenshot — the `PATCH` returns 400 with `attr: "hog"`.
- A bare `let f := sendEmail` reference is refused the same way; a plain `fetch` destination still saves (201).
- On a function whose `template_id` is `template-email`: resaving the template's own `sendEmail` call returns 200, adding a `sendPushNotification` call returns 400, and deleting returns 200 — so an existing email function stays cleanable.

Not checked: the CDP worker itself. Its plugin-server would not build in that VM (an unrelated native-module failure), so what is verified here is the save path that blocks the function, not the worker behaviour that path protects. `sendPushNotification` is reserved by structural analogy to `sendEmail` — its handler stages the same kind of queue — not because a wedged partition was reproduced for it. No audit of already-saved functions calling either name either; existing rows are unaffected by this change and need a separate sweep.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread, after a CDP hog worker partition stopped draining and the crash was traced to a hand-written `sendEmail` call. No repo skills were invoked.

The first design put the check inside `compile_hog`, which was wrong: template sync compiles the internal email template's own code through the same function, so it would have failed at sync time. The check moved to `HogFunctionSerializer.validate`, which covers the create, update, draft and test-invocation paths while leaving internal compilation alone. The allowed set is derived from the source template's own calls rather than hardcoded, so a function built from an internal template does not become impossible to disable or delete.

The reserved set was initially five names — every async function the worker registers that is not already in the supported-function allowlist. Review pushed back on that, and reading each handler showed the reasoning was wrong: registration governs reachability, not blast radius. Only `sendEmail` and `sendPushNotification` stage a messaging-only queue; the rest stage an ordinary fetch or are unreachable through this serializer. The set was narrowed to two and the comment rewritten to state the real criterion.

The screenshot was captured on a throwaway local dev stack driven headlessly, not from any real project. The Hog in it is verbatim the public `template-email` code in this repo (`nodejs/src/cdp/templates/_destinations/email/email.template.ts`), so no customer data, identifiers or session material is present in the image, the diff or this description.
