### PR TITLE
chore(devex): run repo checks on crossings baseline and turbo.json edits

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -334,9 +334,13 @@ jobs:
                         - 'tools/hogli-commands/hogli_commands/hints.py'
                         - 'tools/hogli-commands/hogli_commands/product/**'
                         - 'tools/hogli-commands/hogli_commands/product_structure.yaml'
-                        # product:lint --all checks this generated file against the tree,
-                        # so a baseline-only edit must run it too
+                        # product:lint --all checks these generated files against the tree,
+                        # so a baseline-only edit must run it too. The crossings baseline is
+                        # also what product:lint reads to let a wiring location leave a
+                        # product's turbo.json inputs, so both edits must run the checks.
                         - products/isolation_baseline.txt
+                        - products/model_crossing_uses_baseline.txt
+                        - 'products/*/turbo.json'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .depot/workflows/ci-backend.yml
                         - .github/clickhouse-versions.json

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -212,9 +212,13 @@ jobs:
                         - 'tools/hogli-commands/hogli_commands/hints.py'
                         - 'tools/hogli-commands/hogli_commands/product/**'
                         - 'tools/hogli-commands/hogli_commands/product_structure.yaml'
-                        # product:lint --all checks this generated file against the tree,
-                        # so a baseline-only edit must run it too
+                        # product:lint --all checks these generated files against the tree,
+                        # so a baseline-only edit must run it too. The crossings baseline is
+                        # also what product:lint reads to let a wiring location leave a
+                        # product's turbo.json inputs, so both edits must run the checks.
                         - products/isolation_baseline.txt
+                        - products/model_crossing_uses_baseline.txt
+                        - 'products/*/turbo.json'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .github/workflows/ci-backend.yml
                         - .github/clickhouse-versions.json


### PR DESCRIPTION
## Problem

- A PR that edits only `products/model_crossing_uses_baseline.txt` or a product's `turbo.json` runs no backend checks. The backend change filter lists `products/isolation_baseline.txt` but not those two files.
- Such a PR can delete a baseline line, or drop a contract-check input, without the strict-equality invariant test or `product:lint` running.
- #89147 makes `product:lint` read the crossings baseline to decide whether `backend/hogql_queries/` may leave a product's inputs, so the gap becomes a way past that check.

## Changes

- Both copies of `ci-backend.yml` add the two paths to the `backend` filter, next to the isolation baseline they already list.
- Nothing user-facing changes. A PR touching only those files now runs `repo-checks` like any backend PR.

## How did you test this code?

- `bin/hogli lint:workflows` and `actionlint` pass locally. The filter change is a two-entry list addition; the workflow runs on this PR itself.

## Changelog

- [ ] Changelog: this PR contains user-facing changes and needs a changelog entry

## 🤖 Agent context

- Written by Claude Code in a session driven by @webjunkie, from a Codex finding on #89147.
- Skills invoked: authoring-ci-workflows, writing-pr-descriptions.
