### PR TITLE
fix(tasks): keep scout runs out of the activity feed

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7955,13 +7955,24 @@ def project_completed_activity(task_run: "TaskRun") -> None:
     )
 
 
+# A scout runs headless on a schedule, under an acting user resolved from the scout skill's
+# author rather than from whoever asked for the run. Its task therefore carries a real person
+# as `created_by`, so every projected row lands in a feed that person never asked for. Scout
+# output belongs in the Signals inbox instead.
+ACTIVITY_FEED_EXCLUDED_ORIGIN_PRODUCTS = (Task.OriginProduct.SIGNALS_SCOUT,)
+
+
 def _task_activity_qs(team_id: int, user_id: int) -> QuerySet[TaskActivity]:
     """The requester's feed rows, gated to tasks they can still see.
 
     Rows outlive visibility changes (a task moving to a private channel, say), so the
     visibility gate belongs on read rather than being enforced when projecting.
     """
-    visible_tasks = _visible_task_qs(team_id, user_id).filter(internal=False, archived=False)
+    visible_tasks = (
+        _visible_task_qs(team_id, user_id)
+        .filter(internal=False, archived=False)
+        .exclude(origin_product__in=ACTIVITY_FEED_EXCLUDED_ORIGIN_PRODUCTS)
+    )
     return TaskActivity.objects.for_team(team_id).filter(user_id=user_id, task__in=visible_tasks)
 
 

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7962,22 +7962,26 @@ def project_completed_activity(task_run: "TaskRun") -> None:
 ACTIVITY_FEED_EXCLUDED_ORIGIN_PRODUCTS = (Task.OriginProduct.SIGNALS_SCOUT,)
 
 
+def _activity_visible_task_qs(team_id: int, user_id: int) -> QuerySet[Task]:
+    return (
+        _visible_task_qs(team_id, user_id)
+        .filter(internal=False, archived=False)
+        .exclude(origin_product__in=ACTIVITY_FEED_EXCLUDED_ORIGIN_PRODUCTS)
+    )
+
+
 def _task_activity_qs(team_id: int, user_id: int) -> QuerySet[TaskActivity]:
     """The requester's feed rows, gated to tasks they can still see.
 
     Rows outlive visibility changes (a task moving to a private channel, say), so the
     visibility gate belongs on read rather than being enforced when projecting.
     """
-    visible_tasks = (
-        _visible_task_qs(team_id, user_id)
-        .filter(internal=False, archived=False)
-        .exclude(origin_product__in=ACTIVITY_FEED_EXCLUDED_ORIGIN_PRODUCTS)
-    )
+    visible_tasks = _activity_visible_task_qs(team_id, user_id)
     return TaskActivity.objects.for_team(team_id).filter(user_id=user_id, task__in=visible_tasks)
 
 
 def _comment_activity_qs(team_id: int, user_id: int) -> QuerySet[TaskCommentActivity]:
-    visible_tasks = _visible_task_qs(team_id, user_id).filter(internal=False, archived=False)
+    visible_tasks = _activity_visible_task_qs(team_id, user_id)
     return TaskCommentActivity.objects.for_team(team_id).filter(
         user_id=user_id, task__in=visible_tasks, comment__deleted=False
     )

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -821,9 +821,10 @@ class TaskActivityAPITestCase(ChannelTaskAPITestCase):
         [
             ("internal", {"internal": True}),
             ("archived", {"archived": True}),
+            ("scout", {"origin_product": Task.OriginProduct.SIGNALS_SCOUT}),
         ]
     )
-    def test_hidden_tasks_are_excluded_from_activity(self, _name, task_updates):
+    def test_tasks_outside_the_feed_are_excluded_from_activity(self, _name, task_updates):
         Task.objects.filter(id=self.task.id).update(**task_updates)
         self._awaiting_input()
 

--- a/products/tasks/backend/tests/test_comment_activity.py
+++ b/products/tasks/backend/tests/test_comment_activity.py
@@ -175,12 +175,22 @@ class TestCommentActivity(CommentActivityTestCase):
 
         assert not TaskCommentActivity.objects.filter(team=self.team, user=self.author).exists()
 
-    def test_deleted_comments_are_hidden_from_activity(self):
+    @parameterized.expand(
+        [
+            ("deleted_comment", {}, {"deleted": True}),
+            ("scout_task", {"origin_product": Task.OriginProduct.SIGNALS_SCOUT}, {}),
+        ]
+    )
+    def test_comments_outside_the_feed_are_hidden_from_activity(
+        self, _name: str, task_updates: dict[str, object], comment_updates: dict[str, object]
+    ) -> None:
         unread_before = tasks_facade.count_unread_task_activity(self.team.id, self.author.id)
         comment = self._comment()
         self._record_activity(comment, [self.author.id])
-        comment.deleted = True
-        comment.save(update_fields=["deleted"])
+        if task_updates:
+            Task.objects.filter(id=self.task.id).update(**task_updates)
+        if comment_updates:
+            Comment.objects.filter(id=comment.id).update(**comment_updates)
 
         page = tasks_facade.list_task_activity(self.team.id, self.author.id)
 


### PR DESCRIPTION
## Problem

Anyone whose team runs Signals scouts finds the Activity feed in PostHog Desktop, and its unread badge, filled with scheduled scout runs instead of the sessions they work on.

- The feed is meant to hold tasks the viewer is involved in: created, mentioned in, or messaged in.
- A scout run is headless. It mints its task under an acting user resolved from the scout skill's author, so `Task.created_by` is a real person who never started the run.
- Every task creation projects an activity row for `created_by`, and the run's later messages and completion keep updating that row.

## Changes

- The Activity feed and its unread badge no longer list scout runs. Scout output stays in the Signals inbox.
- `_task_activity_qs` excludes the `signals_scout` origin from the tasks it gates on, so the feed page and the badge count drop the same rows.
- The exclusion reads at query time instead of skipping projection at write time. That clears feeds that are already noisy without a backfill, and covers all five activity kinds in one place rather than four projection call sites.
- Scout tasks stay reachable everywhere else, including the task feed's `origin:scout` filter and the Signals inbox.
- No frontend code changed. The feed page, the nav rail badge and the hover card all read `/api/projects/:id/task_activity/`, so one server-side filter covers all three.
- The test rename is mechanical. "Hidden" no longer describes every case in the parameterized set.

No screenshot: the visible change is scout rows no longer appearing, which needs a project with scheduled scout runs to reproduce.

## How did you test this code?

- Added a `scout` case to the parameterized exclusion test in `TaskActivityAPITestCase`. It catches a dropped filter putting a scheduled scout run back in the acting user's feed and unread count. The existing cases only covered `internal` and `archived`, so nothing guarded the origin.
- Ran the whole `TaskActivityAPITestCase` class locally against Postgres and ClickHouse from the dev stack. It passed.
- Not run: the desktop client, because no built desktop app was pointed at the local stack in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus) from a Slack thread reporting scout runs crowding the desktop activity feed. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/announcing-behavior-changes`, `/writing-pr-descriptions`.

`/announcing-behavior-changes` was checked and returned no notice: the rows that disappear are runs the reader never started, so noise stopping needs no in-app announcement.

The PR needs an assignee. The person who asked for this is identified in the linked Slack thread; their GitHub handle was not verified in this session, so no handle is guessed here.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787744267089959?thread_ts=1787744267.089959&cid=C09G8Q32R6F)*
