### PR TITLE
feat(desktop): copy a link to one message in a thread

### DIFF
--- a/frontend/src/scenes/code-canvas/CodeTaskLink.test.ts
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.test.ts
@@ -14,14 +14,17 @@ describe('CodeTaskLink', () => {
         jest.clearAllMocks()
     })
 
-    it('forwards the comment target from the browser URL to PostHog Desktop', () => {
+    it('forwards the comment target and the message anchor from the browser URL to PostHog Desktop', () => {
         expect(
             taskDeepLink('task/1', {
                 comment: 'comment/1',
                 scope: 'task_artifact',
                 item: 'artifact/1',
+                message: 'turn-1/user',
             })
-        ).toBe('posthog-code://task/task%2F1?comment=comment%2F1&scope=task_artifact&item=artifact%2F1')
+        ).toBe(
+            'posthog-code://task/task%2F1?comment=comment%2F1&scope=task_artifact&item=artifact%2F1&message=turn-1%2Fuser'
+        )
     })
 
     it('reads the comment target from the active URL when rendering the bridge', () => {

--- a/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
@@ -32,6 +32,9 @@ export function taskDeepLink(taskId: string, searchParams: Record<string, unknow
     if (typeof searchParams.item === 'string') {
         params.set('item', searchParams.item)
     }
+    if (typeof searchParams.message === 'string') {
+        params.set('message', searchParams.message)
+    }
     const query = params.toString()
     return `${DESKTOP_SCHEME}://task/${encodeURIComponent(taskId)}${query ? `?${query}` : ''}`
 }

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -78,12 +78,13 @@ The link is rejected if `url` is missing, is not a `github.com` URL, or does not
 
 ### `posthog-code://task/<taskId>[/run/<taskRunId>]`
 
-Open an existing task. Optionally jump to a specific run, or focus a comment thread inside the task.
+Open an existing task. Optionally jump to a specific run, scroll to one message in the transcript, or focus a comment thread inside the task.
 
 | Segment / Parameter | Required | Description |
 |---|---|---|
 | `<taskId>` | Yes | Task ID |
 | `run/<taskRunId>` | No | Specific run to open |
+| `message` | No | Conversation item id to scroll the transcript to after the task opens. This is the link the thread's own copy-link affordances produce (the message minimap and the per-turn footer). |
 | `comment` | No | Comment thread (root comment id) to focus after the task opens |
 | `scope` | No | Comment target scope when the thread lives on a sub-resource: `desktop_canvas` or `task_artifact`. Defaults to the task itself. |
 | `item` | No | Row id of the canvas/artifact the thread lives on; required alongside `scope` |
@@ -91,10 +92,13 @@ Open an existing task. Optionally jump to a specific run, or focus a comment thr
 ```
 posthog-code://task/abc123
 posthog-code://task/abc123/run/xyz789
+posthog-code://task/abc123?message=turn-1730000000000-user
 posthog-code://task/abc123?comment=thread-1&scope=desktop_canvas&item=canvas-9
 ```
 
-An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme — forwarding the `comment`, `scope`, and `item` params — or offers the desktop-app download.
+The request is retried for a few seconds while the transcript loads, then dropped. So a message the transcript never renders — an id from a transcript that has since changed, or one far enough back that its page of history has not been loaded — leaves the task open at its usual position rather than scrolling.
+
+An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme — forwarding the `message`, `comment`, `scope`, and `item` params — or offers the desktop-app download.
 
 ### `posthog-code://inbox[/<reportId>]`
 

--- a/products/desktop/packages/core/src/links/task-link.test.ts
+++ b/products/desktop/packages/core/src/links/task-link.test.ts
@@ -133,6 +133,20 @@ describe("TaskLinkService", () => {
       },
     );
 
+    it("parses a message anchor from the query params", () => {
+      const listener = vi.fn();
+      service.on(TaskLinkEvent.OpenTask, listener);
+
+      mockDeepLink._invoke("task", "task-123", "message=turn-1-user");
+
+      expect(listener).toHaveBeenCalledWith({
+        taskId: "task-123",
+        taskRunId: undefined,
+        comment: undefined,
+        messageId: "turn-1-user",
+      });
+    });
+
     it("ignores a second path segment that is not 'run'", () => {
       const listener = vi.fn();
       service.on(TaskLinkEvent.OpenTask, listener);

--- a/products/desktop/packages/core/src/links/task-link.ts
+++ b/products/desktop/packages/core/src/links/task-link.ts
@@ -25,6 +25,8 @@ export interface TaskLinkPayload {
   taskId: string;
   taskRunId?: string;
   comment?: TaskLinkCommentAnchor;
+  /** Conversation item id the transcript scrolls to once the task is open. */
+  messageId?: string;
 }
 
 export interface TaskLinkEvents {
@@ -72,7 +74,8 @@ export class TaskLinkService extends TypedEventEmitter<TaskLinkEvents> {
           itemId: searchParams.get("item") ?? undefined,
         }
       : undefined;
-    return this.openTask({ taskId, taskRunId, comment });
+    const messageId = searchParams.get("message") ?? undefined;
+    return this.openTask({ taskId, taskRunId, comment, messageId });
   }
 
   /** Routes the main window to a task, queueing until the renderer is ready. */

--- a/products/desktop/packages/ui/src/features/deep-links/useHandleOpenTask.ts
+++ b/products/desktop/packages/ui/src/features/deep-links/useHandleOpenTask.ts
@@ -1,5 +1,8 @@
 import type { CommentTarget } from "@posthog/core/comments/anchors";
-import type { TaskLinkCommentAnchor } from "@posthog/core/links/task-link";
+import type {
+  TaskLinkCommentAnchor,
+  TaskLinkPayload,
+} from "@posthog/core/links/task-link";
 import {
   TASK_SERVICE,
   type TaskService,
@@ -9,6 +12,7 @@ import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
+import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { toast } from "@posthog/ui/primitives/toast";
@@ -40,9 +44,7 @@ function commentTargetFromAnchor(
 }
 
 export function useHandleOpenTask(): (
-  taskId: string,
-  taskRunId?: string,
-  comment?: TaskLinkCommentAnchor,
+  payload: TaskLinkPayload,
 ) => Promise<void> {
   const taskService = useService<TaskService>(TASK_SERVICE);
   const { markAsViewed } = useTaskViewed();
@@ -54,11 +56,7 @@ export function useHandleOpenTask(): (
   );
 
   return useCallback(
-    async (
-      taskId: string,
-      taskRunId?: string,
-      comment?: TaskLinkCommentAnchor,
-    ) => {
+    async ({ taskId, taskRunId, comment, messageId }: TaskLinkPayload) => {
       log.info(
         `Opening task from deep link: ${taskId}${taskRunId ? `, run: ${taskRunId}` : ""}`,
       );
@@ -102,6 +100,13 @@ export function useHandleOpenTask(): (
               commentTargetFromAnchor(taskId, comment),
               comment.threadId,
             );
+        }
+        // The transcript mounts after this, and the request is durable until served, so it does
+        // not matter that nothing is listening yet — the retry loop starts when it mounts.
+        if (messageId) {
+          useThreadNavigationStore
+            .getState()
+            .requestScrollToMessage(taskId, messageId);
         }
         log.info(`Opened task from deep link: ${taskId}`);
       } catch (error) {

--- a/products/desktop/packages/ui/src/features/deep-links/useOpenTargetDeepLink.ts
+++ b/products/desktop/packages/ui/src/features/deep-links/useOpenTargetDeepLink.ts
@@ -24,7 +24,10 @@ export function useOpenTargetDeepLink() {
       log.info("Opening notification target", { kind: target.kind });
       switch (target.kind) {
         case "task":
-          handleOpenTask(target.taskId, target.taskRunId);
+          handleOpenTask({
+            taskId: target.taskId,
+            taskRunId: target.taskRunId,
+          });
           break;
         case "canvas":
           navigateToChannelDashboard(target.channelId, target.dashboardId);

--- a/products/desktop/packages/ui/src/features/deep-links/useTaskDeepLink.ts
+++ b/products/desktop/packages/ui/src/features/deep-links/useTaskDeepLink.ts
@@ -31,7 +31,7 @@ export function useTaskDeepLink() {
           log.info(
             `Found pending deep link: taskId=${pending.taskId}, taskRunId=${pending.taskRunId ?? "none"}`,
           );
-          handleOpenTask(pending.taskId, pending.taskRunId, pending.comment);
+          handleOpenTask(pending);
         }
       } catch (error) {
         log.error("Failed to check for pending deep link:", error);
@@ -49,7 +49,7 @@ export function useTaskDeepLink() {
           `Received deep link event: taskId=${data.taskId}, taskRunId=${data.taskRunId ?? "none"}`,
         );
         if (!data?.taskId) return;
-        handleOpenTask(data.taskId, data.taskRunId, data.comment);
+        handleOpenTask(data);
       },
     });
     return () => subscription.unsubscribe();

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -3,6 +3,7 @@ import {
   Check,
   Copy,
   FileText,
+  LinkIcon,
   Robot,
   Scroll,
   ThumbsDown,
@@ -85,6 +86,7 @@ import {
   type TurnRow,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
 import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { useCopyMessageLink } from "@posthog/ui/features/sessions/components/chat-thread/useCopyMessageLink";
 import { usePromptRecallSource } from "@posthog/ui/features/sessions/components/chat-thread/usePromptRecallSource";
 import { VirtualThreadScrollBody } from "@posthog/ui/features/sessions/components/chat-thread/VirtualThreadScrollBody";
 import {
@@ -372,6 +374,7 @@ function TurnFooter({
         {formatTimestamp(timestamp)}
       </span>
       {copyText && <CopyButton value={copyText} label="Copy turn" />}
+      <CopyLinkButton messageId={turnId} label="Copy link to turn" />
       <TurnFeedback turnId={turnId} sentiment={sentiment} />
     </ChatMessageFooter>
   );
@@ -483,6 +486,36 @@ function CopyButton({ value, label }: { value: string; label: string }) {
 }
 
 /**
+ * Copies a link straight back to this spot in the transcript, so a turn or a message can be handed
+ * to someone else — or to yourself later — without asking them to scroll for it. Renders nothing
+ * when the thread has no task to link to (see {@link useCopyMessageLink}).
+ */
+function CopyLinkButton({
+  messageId,
+  label,
+}: {
+  messageId: string;
+  label: string;
+}) {
+  const { copied, copyLink } = useCopyMessageLink(messageId);
+  const [hovered, setHovered] = useState(false);
+  if (!copyLink) return null;
+  return (
+    // Same held-open confirmation as {@link CopyButton}: the click can move the pointer off the
+    // button, and the tooltip is the only thing that says the write happened.
+    <FooterIconButton
+      label={label}
+      tooltip={copied ? "Link copied!" : label}
+      open={copied || hovered}
+      onOpenChange={setHovered}
+      onClick={copyLink}
+    >
+      {copied ? <Check size={12} /> : <LinkIcon size={12} />}
+    </FooterIconButton>
+  );
+}
+
+/**
  * End-aligned user bubble. The text is clamped to five lines (`max-height: 5lh` + `overflow-hidden`,
  * which — unlike `-webkit-line-clamp` — reliably clamps markdown's block `<p>` children); a "Show
  * more" toggle appears only when the content actually exceeds the clamp, so short messages never
@@ -497,11 +530,13 @@ function CopyButton({ value, label }: { value: string; label: string }) {
  * The send timestamp sits in a `ChatMessageFooter` revealed on hover.
  */
 function UserBubble({
+  messageId,
   content,
   timestamp,
   attachments = [],
   keyboardFocused = false,
 }: {
+  messageId: string;
   content: string;
   timestamp?: number;
   attachments?: UserMessageAttachment[];
@@ -692,6 +727,10 @@ function UserBubble({
             <ChatMessageFooter className="items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
               {formatTimestamp(timestamp)}
               <CopyButton value={displayContent} label="Copy message" />
+              <CopyLinkButton
+                messageId={messageId}
+                label="Copy link to message"
+              />
             </ChatMessageFooter>
           )}
         </ChatMessageContent>
@@ -823,6 +862,7 @@ function ThreadItemBody({
   if (item.type === "user_message") {
     return (
       <UserBubble
+        messageId={item.id}
         content={item.content}
         timestamp={item.timestamp}
         attachments={item.attachments}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/MessageMinimap.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/MessageMinimap.stories.tsx
@@ -1,0 +1,54 @@
+import { ChatMessageScrollerProvider } from "@posthog/quill";
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { MessageMinimap } from "@posthog/ui/features/sessions/components/chat-thread/MessageMinimap";
+import { SessionTaskIdProvider } from "@posthog/ui/features/sessions/useSessionTaskId";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/** Fixed timestamps keep the rail's tick widths and the row order stable across runs. */
+function userMessage(index: number, content: string): ConversationItem {
+  return {
+    type: "user_message",
+    id: `turn-${1700000000000 + index * 60000}-user`,
+    content,
+    timestamp: 1700000000000 + index * 60000,
+  };
+}
+
+const ITEMS: ConversationItem[] = [
+  userMessage(0, "Why is the minimap popover so wide?"),
+  userMessage(
+    1,
+    "In our minimap of user messages, drop the send time on the right and give the row a link affordance instead — the reader is picking a message here, and what they want from one is a way to send it to someone.",
+  ),
+  userMessage(2, "Ship it"),
+  userMessage(
+    3,
+    "One more: the same icon should sit under each turn, next to copy.",
+  ),
+];
+
+const meta = {
+  title: "Sessions/MessageMinimap",
+  component: MessageMinimap,
+  // The minimap parks itself in the scroller's top-right corner, so it needs a positioned box to
+  // hug and the scroller context it reads its anchor from.
+  decorators: [
+    (Story) => (
+      <SessionTaskIdProvider taskId="task-1">
+        <ChatMessageScrollerProvider>
+          <div className="relative h-72 w-[560px] rounded-md border border-(--gray-5) bg-(--color-background)">
+            <Story />
+          </div>
+        </ChatMessageScrollerProvider>
+      </SessionTaskIdProvider>
+    ),
+  ],
+} satisfies Meta<typeof MessageMinimap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The collapsed rail — one tick per user message, width scaled by message length. */
+export const Rail: Story = {
+  args: { items: ITEMS, anchorId: ITEMS[1].id },
+};

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/MessageMinimap.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/MessageMinimap.tsx
@@ -1,3 +1,4 @@
+import { Check, LinkIcon } from "@phosphor-icons/react";
 import {
   cn,
   DropdownMenu,
@@ -8,6 +9,7 @@ import {
   useChatMessageScrollerVisibility,
 } from "@posthog/quill";
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { useCopyMessageLink } from "@posthog/ui/features/sessions/components/chat-thread/useCopyMessageLink";
 import {
   OverflowTickerText,
   useOverflowTickerReveal,
@@ -26,7 +28,6 @@ const MIN_TICK_WIDTH_PCT = 34;
 interface MinimapEntry {
   id: string;
   label: string;
-  timestamp: number;
   /** 34–100%: longer messages draw longer ticks, so the rail reads like a document minimap. */
   widthPct: number;
 }
@@ -37,18 +38,14 @@ function truncate(text: string, maxLength: number): string {
   return `${singleLine.slice(0, maxLength)}…`;
 }
 
-function formatTime(ts: number): string {
-  return new Date(ts).toLocaleString([], {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
 /**
  * One row of the expanded list. The message text is never statically clipped: it fades at the right
  * edge while idle and ticker-scrolls to its end on hover or keyboard focus, matching sidebar items.
+ *
+ * The row's trailing slot is a link affordance rather than the send time: what a reader wants from a
+ * message they cannot scroll to together is a way to send it. It is a sibling of the menu item, not
+ * a child, because the item itself renders a button and buttons do not nest — so it is laid over the
+ * item's trailing padding, and a click on it never reaches the row's jump.
  */
 function MinimapMenuItem({
   entry,
@@ -62,26 +59,43 @@ function MinimapMenuItem({
   onSelect: (id: string) => void;
 }) {
   const { reveal, hoverProps, focusProps } = useOverflowTickerReveal();
+  const { copied, copyLink } = useCopyMessageLink(entry.id);
 
   return (
-    <DropdownMenuItem
-      ref={itemRef}
-      // The list is a navigation surface, not a one-shot command: clicking scrolls the thread and
-      // leaves the menu up so the reader can keep hopping between turns.
-      closeOnClick={false}
-      onClick={() => onSelect(entry.id)}
-      {...hoverProps}
-      {...focusProps}
-      data-selected={isCurrent || undefined}
-      className="group/entry h-auto! min-h-7 items-center gap-2 py-1.5 text-left data-selected:bg-fill-selected data-selected:text-gray-12"
-    >
-      <OverflowTickerText reveal={reveal} className="flex-1 text-[13px]">
-        {entry.label}
-      </OverflowTickerText>
-      <span className="shrink-0 text-(--gray-10) text-[11px] tabular-nums opacity-0 transition-opacity group-hover/entry:opacity-100 motion-reduce:transition-none">
-        {formatTime(entry.timestamp)}
-      </span>
-    </DropdownMenuItem>
+    <div className="group/entry relative flex items-center">
+      <DropdownMenuItem
+        ref={itemRef}
+        // The list is a navigation surface, not a one-shot command: clicking scrolls the thread and
+        // leaves the menu up so the reader can keep hopping between turns.
+        closeOnClick={false}
+        onClick={() => onSelect(entry.id)}
+        {...hoverProps}
+        {...focusProps}
+        data-selected={isCurrent || undefined}
+        className={cn(
+          "h-auto! min-h-7 flex-1 items-center py-1.5 text-left data-selected:bg-fill-selected data-selected:text-gray-12",
+          copyLink && "pr-7",
+        )}
+      >
+        <OverflowTickerText reveal={reveal} className="flex-1 text-[13px]">
+          {entry.label}
+        </OverflowTickerText>
+      </DropdownMenuItem>
+      {copyLink && (
+        // Out of the tab order: Tab closes the menu, so the row stays the keyboard target and
+        // copying is a pointer convenience.
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label="Copy link to this message"
+          title={copied ? "Link copied" : "Copy link to this message"}
+          onClick={copyLink}
+          className="absolute right-1.5 flex items-center rounded p-0.5 text-(--gray-10) opacity-60 transition-opacity hover:opacity-100 group-hover/entry:opacity-100 motion-reduce:transition-none"
+        >
+          {copied ? <Check size={12} /> : <LinkIcon size={12} />}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -131,7 +145,6 @@ export function MessageMinimap({
       result.push({
         id: item.id,
         label: truncate(fullText, MAX_LABEL_LENGTH),
-        timestamp: item.timestamp,
         widthPct: MIN_TICK_WIDTH_PCT + (100 - MIN_TICK_WIDTH_PCT) * ratio,
       });
     }

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/useCopyMessageLink.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/useCopyMessageLink.ts
@@ -1,0 +1,35 @@
+import { useSessionTaskId } from "@posthog/ui/features/sessions/useSessionTaskId";
+import { toast } from "@posthog/ui/primitives/toast";
+import { useCopy } from "@posthog/ui/primitives/useCopy";
+import { taskShareUrl } from "@posthog/ui/utils/posthogLinks";
+import { useCallback } from "react";
+
+/**
+ * Copies the shareable link that reopens this transcript scrolled to one message. Backs both link
+ * affordances in the thread — the minimap's per-message icon and the turn footer's — so they copy
+ * the same url and report the same state.
+ *
+ * `copyLink` is null when the thread has no task behind it (the live-agent preview), because there
+ * is nothing for a link to reopen. Callers render nothing in that case rather than a button that
+ * cannot work.
+ */
+export function useCopyMessageLink(messageId: string): {
+  copied: boolean;
+  copyLink: (() => void) | null;
+} {
+  const taskId = useSessionTaskId();
+  const { copied, copy } = useCopy();
+
+  const copyLink = useCallback(() => {
+    const url = taskId ? taskShareUrl(taskId, messageId) : null;
+    if (!url) {
+      // No signed-in region to build an instance url against. Say so — a silent no-op would
+      // leave the reader pasting whatever the clipboard already held.
+      toast.error("Couldn't build a link to this message");
+      return;
+    }
+    copy(url);
+  }, [copy, messageId, taskId]);
+
+  return { copied, copyLink: taskId ? copyLink : null };
+}

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  JUMP_ATTEMPT_FRAMES,
   useThreadNavigationStore,
   useThreadScrollRequest,
 } from "./threadNavigationStore";
@@ -101,7 +102,7 @@ describe("useThreadScrollRequest", () => {
         .getState()
         .requestScrollToMessage("task-1", "no-such-row");
     });
-    runFrames(120);
+    runFrames(JUMP_ATTEMPT_FRAMES + 2);
 
     expect(useThreadNavigationStore.getState().scrollRequests["task-1"]).toBe(
       null,

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
@@ -59,8 +59,13 @@ export const useThreadNavigationStore = create<ThreadNavigationStore>()(
 );
 
 /** The target row may not be registered yet, and the tab holding the transcript may only
- *  just have been activated, so the first frame after a request is routinely too early. */
-const JUMP_ATTEMPT_FRAMES = 60;
+ *  just have been activated, so the first frame after a request is routinely too early.
+ *
+ *  Budgeted for the slowest caller rather than the common one: a deep link opens the task and
+ *  then requests the jump, so the transcript mounts empty and streams its rows in afterwards —
+ *  a request made from a pane that is already showing the transcript lands in a frame or two.
+ *  A target that never arrives costs a Map lookup per frame until this runs out. */
+export const JUMP_ATTEMPT_FRAMES = 240;
 
 /** Rows above the target measure late (diffs, highlighted code, images), which moves it out
  *  from under an offset already committed, so a landed jump is re-issued for a few frames. */

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/ImageDetailPage.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/ImageDetailPage.tsx
@@ -86,7 +86,8 @@ export function ImageDetailPage({
   const openBuilder = async () => {
     try {
       const updated = await builderTaskMutation.mutateAsync(current.id);
-      if (updated.builder_task_id) void handleOpenTask(updated.builder_task_id);
+      if (updated.builder_task_id)
+        void handleOpenTask({ taskId: updated.builder_task_id });
     } catch {
       // The mutation's onError toast already explains the failure.
     }

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentSetupFlow.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentSetupFlow.tsx
@@ -153,7 +153,7 @@ function LoadedSetupFlow({
     }
     onDone(null);
     if (result.created?.builder_task_id) {
-      void handleOpenTask(result.created.builder_task_id);
+      void handleOpenTask({ taskId: result.created.builder_task_id });
     }
   };
 

--- a/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.test.ts
@@ -2,6 +2,7 @@ import {
   canvasShareUrl,
   errorTrackingIssueUrl,
   parseShareLink,
+  taskShareUrl,
 } from "@posthog/ui/utils/posthogLinks";
 import { describe, expect, it, vi } from "vitest";
 
@@ -13,6 +14,19 @@ describe("canvasShareUrl", () => {
   it("builds an https /code/canvas link with encoded ids", () => {
     expect(canvasShareUrl("chan/1", "dash 2", "us")).toBe(
       "https://us.posthog.com/code/canvas/chan%2F1/dash%202",
+    );
+  });
+});
+
+// The `message` param name is a contract with `TaskLinkService` (which reads it) and the web
+// interstitial (which forwards it), so it is pinned here rather than left to the callers.
+describe("taskShareUrl", () => {
+  it("builds an https /code/task link, with the message as an encoded query param", () => {
+    expect(taskShareUrl("task 1")).toBe(
+      "https://us.posthog.com/code/task/task%201",
+    );
+    expect(taskShareUrl("task1", "turn-1/user")).toBe(
+      "https://us.posthog.com/code/task/task1?message=turn-1%2Fuser",
     );
   });
 });

--- a/products/desktop/packages/ui/src/utils/posthogLinks.ts
+++ b/products/desktop/packages/ui/src/utils/posthogLinks.ts
@@ -122,6 +122,24 @@ export function channelShareUrl(
 }
 
 /**
+ * The shareable https link for a task — or, with `messageId`, for one message in
+ * its transcript: `<instance>/code/task/<taskId>[?message=<messageId>]`. Opening
+ * it in a browser hits the same web interstitial the channel links use, which
+ * deep-links into the desktop app or offers the download. The inbound desktop
+ * side lives in `TaskLinkService` / `useTaskDeepLink`, which hands the message
+ * to the transcript's own scroll-to-message request.
+ */
+export function taskShareUrl(
+  taskId: string,
+  messageId?: string,
+): string | null {
+  const base = `/code/task/${encodeURIComponent(taskId)}`;
+  return getPostHogUrl(
+    messageId ? `${base}?message=${encodeURIComponent(messageId)}` : base,
+  );
+}
+
+/**
  * Parse a URL, rejecting anything that isn't https. The gate every surface that
  * renders a backend-supplied link goes through before fetching from it or
  * handing it to the host's external-link opener.


### PR DESCRIPTION
## Problem

Someone reading a task thread cannot point a colleague at one message in it — nothing in the thread produces a link to a single turn.

The minimap's message list also spends part of every row on a send time. The time only appears on hover, but it holds its space always, so every label clips early.

## Changes

- Each minimap row carries a chain-link icon that copies a link to that message. The send time is gone and the label takes the width back.
- The footer under each agent turn carries the same icon, next to "Copy turn".
- A user message's own footer carries it too, so the affordance sits on the message as well as in the list.
- Opening a copied link reopens the task and scrolls its transcript to that message.
- `taskShareUrl` builds `<instance>/code/task/<id>?message=<item id>` — the same https bridge the channel links use, so the link also opens for someone without the app installed.
- The copy control is a sibling of the menu item rather than a child, because the item renders a real button and buttons do not nest. A click on it never reaches the row's jump.
- A scroll request now retries for about 4 seconds rather than 1. A deep link asks for the jump before the transcript has rows, and 1 second was not always enough for it to land.
- Mechanical: `useHandleOpenTask` takes a payload object instead of three positional arguments.

The minimap list, hovering the second row. Before:

![minimap-before](https://raw.githubusercontent.com/PostHog/pr-assets/4c75524c3d71526ccf8585982e07cad3dff58e65/2026/08/aa931e1e-229c-4c70-bdb4-e175e5ca7a49.png)

After:

![minimap-after](https://raw.githubusercontent.com/PostHog/pr-assets/4c75524c3d71526ccf8585982e07cad3dff58e65/2026/08/48731565-3c25-42bb-944f-29eb51c3228c.png)

The two footer icons have no screenshot: they need a signed-in app with a completed turn, which this sandbox cannot run.

## How did you test this code?

Rendered the minimap in Storybook through a headless Chromium, in a new `MessageMinimap.stories.tsx`. That confirmed the layout above, and that arrow-key navigation still moves between rows now that each row sits in a wrapper element.

New automated coverage, and the regression each case catches:

- `taskShareUrl` in `posthogLinks.test.ts` — pins the `message` param name and the encoding. Three places have to agree on that name, and nothing else fails if one drifts.
- `TaskLinkService` in `task-link.test.ts` — catches the parser dropping or renaming the param, which would silently open the task without scrolling.
- `taskDeepLink` in `CodeTaskLink.test.ts` — extends the existing forwarding case, so the web interstitial cannot stop passing the param through.

Not verified: the whole round trip. Each leg is covered on its own, but no test or manual run copies a link, opens it, and watches the transcript scroll — that needs a running app signed in to an instance.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/DEEP-LINKS.md` documents the `message` param, and what happens when the transcript never renders the target.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a request in Slack. Skills invoked: `/writing-tests`, `/storybook-stories`, `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. The copy control started inside the menu item as a `span` with `role="button"`; Biome's a11y rules rejected it, and moving it out to a sibling made it a real button and removed the nested-interactive problem at the same time. The retry-budget change came later, after tracing when a deep link actually requests the jump relative to the transcript mounting — the feature looked correct without it but would have failed intermittently on a cold open.

The inbound side reuses `useThreadNavigationStore`, which the Activity timeline already uses to ask the transcript to scroll. No new navigation channel.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787744548293539?thread_ts=1787744548.293539&cid=C09G8Q32R6F)*
