### PR TITLE
fix(customer-analytics): emit sync metrics through SDK

### DIFF
--- a/products/customer_analytics/backend/metrics.py
+++ b/products/customer_analytics/backend/metrics.py
@@ -1,3 +1,4 @@
+import posthoganalytics
 from prometheus_client import Counter, Gauge, Histogram
 
 from posthog.otel_metrics import OtelInstrumentFactory
@@ -54,15 +55,19 @@ _ACCOUNT_PROPERTY_SYNC_PHASE_DURATION_SECONDS = Histogram(
 )
 
 _otel = OtelInstrumentFactory("customer-analytics-account-track-rules")
-_account_property_sync_otel = OtelInstrumentFactory("customer-analytics-account-property-sync")
 
 
 def record_account_property_sync_phase_duration(*, phase: str, segment: str, duration_seconds: float) -> None:
     labels = {"phase": phase, "segment": segment}
     _ACCOUNT_PROPERTY_SYNC_PHASE_DURATION_SECONDS.labels(**labels).observe(duration_seconds)
-    _account_property_sync_otel.record_histogram_twin(
-        _ACCOUNT_PROPERTY_SYNC_PHASE_DURATION_SECONDS, duration_seconds, labels
-    )
+    client = posthoganalytics.default_client
+    if client is not None:
+        client.metrics.histogram(
+            "customer_analytics_account_property_sync_phase_duration_seconds",
+            duration_seconds,
+            unit="s",
+            attributes=labels,
+        )
 
 
 def record_account_track_rule_run(

--- a/products/customer_analytics/backend/metrics.py
+++ b/products/customer_analytics/backend/metrics.py
@@ -62,12 +62,15 @@ def record_account_property_sync_phase_duration(*, phase: str, segment: str, dur
     _ACCOUNT_PROPERTY_SYNC_PHASE_DURATION_SECONDS.labels(**labels).observe(duration_seconds)
     client = posthoganalytics.default_client
     if client is not None:
-        client.metrics.histogram(
-            "customer_analytics_account_property_sync_phase_duration_seconds",
-            duration_seconds,
-            unit="s",
-            attributes=labels,
-        )
+        try:
+            client.metrics.histogram(
+                "customer_analytics_account_property_sync_phase_duration_seconds",
+                duration_seconds,
+                unit="s",
+                attributes=labels,
+            )
+        except Exception:
+            pass
 
 
 def record_account_track_rule_run(

--- a/products/customer_analytics/backend/metrics_test.py
+++ b/products/customer_analytics/backend/metrics_test.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock, patch
+
+from products.customer_analytics.backend.metrics import record_account_property_sync_phase_duration
+
+
+def test_account_property_sync_phase_duration_records_posthog_metric() -> None:
+    client = MagicMock()
+
+    with patch("products.customer_analytics.backend.metrics.posthoganalytics.default_client", client):
+        record_account_property_sync_phase_duration(
+            phase="apply_values",
+            segment="tracked",
+            duration_seconds=1.25,
+        )
+
+    client.metrics.histogram.assert_called_once_with(
+        "customer_analytics_account_property_sync_phase_duration_seconds",
+        1.25,
+        unit="s",
+        attributes={"phase": "apply_values", "segment": "tracked"},
+    )

--- a/products/customer_analytics/backend/metrics_test.py
+++ b/products/customer_analytics/backend/metrics_test.py
@@ -19,3 +19,15 @@ def test_account_property_sync_phase_duration_records_posthog_metric() -> None:
         unit="s",
         attributes={"phase": "apply_values", "segment": "tracked"},
     )
+
+
+def test_account_property_sync_phase_duration_ignores_metric_failures() -> None:
+    client = MagicMock()
+    client.metrics.histogram.side_effect = RuntimeError()
+
+    with patch("products.customer_analytics.backend.metrics.posthoganalytics.default_client", client):
+        record_account_property_sync_phase_duration(
+            phase="apply_values",
+            segment="tracked",
+            duration_seconds=1.25,
+        )


### PR DESCRIPTION
## Problem

- Account-property sync phase durations reach Logs, but the Metrics product cannot show them.
- The OTLP export path can be disabled in the worker that runs account property syncs.

## Changes

- The configured PostHog SDK now sends each sync phase duration to the Metrics product.
- The existing Prometheus histogram remains unchanged.

## How did you test this code?

- `uv run pytest products/customer_analytics/backend/metrics_test.py` verifies the SDK histogram name, unit, and attributes.
- `uv run ruff check` and `uv run ruff format --check` passed for the changed files.
- The account property sync suite could not run because this environment has no PostgreSQL server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This internal telemetry transport change does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the missing metric with PostHog Logs and Metrics. It changed the phase metric transport from the optional OTLP twin to the configured SDK. Skills invoked: `/instrumenting-first-party-metrics`, `/querying-posthog-data`, `/writing-tests`, and `/writing-pr-descriptions`.