### PR TITLE
chore(desktop): rename review feed hint to PostHog Review

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/feedQuerySuggestions.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/feedQuerySuggestions.tsx
@@ -146,7 +146,7 @@ const ORIGIN_VALUES: { value: string; fallbackHint: string }[] = [
   { value: "session_summaries", fallbackHint: "Session summary" },
   { value: "loop", fallbackHint: "Loops" },
   { value: "automation", fallbackHint: "Automation" },
-  { value: "review_hog", fallbackHint: "ReviewHog" },
+  { value: "review_hog", fallbackHint: "PostHog Review" },
   { value: "support_queue", fallbackHint: "Support" },
   { value: "support_reply", fallbackHint: "Support reply" },
   { value: "eval_clusters", fallbackHint: "Evals" },


### PR DESCRIPTION
## Problem

- The desktop feed's origin hint for automated code review items still reads "ReviewHog". [#88626](https://github.com/PostHog/posthog/pull/88626) renames the product to "PostHog Review" on every other surface.
- The desktop backend coupling check keeps `products/desktop` changes out of backend PRs, so the desktop line ships here.

## Changes

- The feed's origin hint for code review items now reads "PostHog Review" (the `review_hog` origin's `fallbackHint`).
- Independent of [#88626](https://github.com/PostHog/posthog/pull/88626): a display string, safe to land in either order.
- No screenshot: rendering the hint needs a running desktop app with review feed data, which this sandbox does not have.

## How did you test this code?

- The identical line passed the desktop quality, typecheck, build, and test jobs on [#88626's CI run](https://github.com/PostHog/posthog/actions/runs/32960181778) before it moved here.
- Not run locally: the desktop Biome and typecheck suites; this sandbox has no desktop node_modules.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of [#88626](https://github.com/PostHog/posthog/pull/88626) by PostHog Desktop after the "Desktop backend coupling" check refused the combined PR; that PR drops the desktop line and this one carries it. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
