### PR TITLE
fix(desktop): show restore sandbox conversation item in pi

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/buildAgentConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildAgentConversationItems.test.ts
@@ -265,6 +265,86 @@ describe("buildAgentConversationItems", () => {
     );
   });
 
+  it("appends setup progress when Pi restarts a completed sandbox", () => {
+    const result = buildAgentConversationItems(
+      [
+        {
+          type: "progress",
+          timestamp: 1,
+          step: "agent",
+          status: "completed",
+          label: "Started agent",
+          group: "setup:run-1",
+        },
+        {
+          type: "user_message",
+          id: "user-1",
+          timestamp: 2,
+          content: [{ type: "text", text: "First message" }],
+        },
+        {
+          type: "assistant_message_chunk",
+          timestamp: 3,
+          content: { type: "text", text: "Done" },
+        },
+        { type: "turn_completed", timestamp: 4 },
+        {
+          type: "user_message",
+          id: "user-2",
+          timestamp: 5,
+          content: [{ type: "text", text: "Continue" }],
+        },
+        {
+          type: "progress",
+          timestamp: 6,
+          step: "sandbox",
+          status: "in_progress",
+          label: "Restoring sandbox",
+          group: "setup:run-1",
+        },
+        {
+          type: "progress",
+          timestamp: 7,
+          step: "sandbox",
+          status: "completed",
+          label: "Restored sandbox",
+          group: "setup:run-1",
+        },
+        {
+          type: "progress",
+          timestamp: 8,
+          step: "agent",
+          status: "completed",
+          label: "Started agent",
+          group: "setup:run-1",
+        },
+      ],
+      true,
+    );
+
+    const itemOrder = result.items.flatMap((item) => {
+      if (item.type === "user_message") {
+        return [`user:${item.content}`];
+      }
+      if (
+        item.type === "session_update" &&
+        item.update.sessionUpdate === "progress_group"
+      ) {
+        return [
+          `progress:${item.update.steps.map((step) => step.key).join(",")}`,
+        ];
+      }
+      return [];
+    });
+
+    expect(itemOrder).toEqual([
+      "user:First message",
+      "progress:agent",
+      "user:Continue",
+      "progress:sandbox,agent",
+    ]);
+  });
+
   it("builds and completes a generic compaction status", () => {
     const result = buildAgentConversationItems(
       [

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -465,7 +465,10 @@ export function processAgentConversationEvent(
   }
 
   if (event.type === "progress") {
-    handleProgress(b, event, event.timestamp, false);
+    handleProgress(b, event, event.timestamp, {
+      waitForRunStarted: false,
+      appendOnSetupRestart: true,
+    });
     return;
   }
 
@@ -1010,7 +1013,10 @@ function handleProgress(
   b: ItemBuilder,
   rawParams: unknown,
   ts: number,
-  waitForRunStarted = true,
+  options?: {
+    waitForRunStarted?: boolean;
+    appendOnSetupRestart?: boolean;
+  },
 ) {
   const params = rawParams as
     | {
@@ -1024,6 +1030,18 @@ function handleProgress(
   if (!params?.step || !params.label || !params.group) return;
 
   const status = normalizeStepStatus(params.status);
+  const existingCard = b.progressCards.get(params.group);
+  const previousAgentStatus = existingCard?.steps.get("agent")?.status;
+  const startsNewSetup =
+    options?.appendOnSetupRestart === true &&
+    params.step === "sandbox" &&
+    status === "in_progress" &&
+    previousAgentStatus !== undefined &&
+    previousAgentStatus !== "in_progress";
+  if (startsNewSetup) {
+    b.progressCards.delete(params.group);
+  }
+
   const card = ensureProgressCardForGroup(b, params.group, ts);
   if (!card) return;
   if (card.itemIndex < b.lowestTouchedProgressIndex) {
@@ -1035,7 +1053,7 @@ function handleProgress(
     label: params.label,
     detail: params.detail,
   });
-  syncProgressCard(card, b, waitForRunStarted);
+  syncProgressCard(card, b, options?.waitForRunStarted);
 }
 
 function normalizeStepStatus(raw: string | undefined): StepStatus {


### PR DESCRIPTION
## Problem

<img width="688" height="240" alt="CleanShot 2026-08-26 at 15 06 44@2x" src="https://github.com/user-attachments/assets/6c0a4a10-5eca-4c1e-ad06-039585ccf476" />

This was not showing in Pi, but it was in claude/codex

## Solution

Now it is

## How did you test this code?

- Added a test for two Pi starts in the same chat.
- Ran the full UI test suite.
- Ran type checks, code checks, and CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This only fixes where the setup card appears.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The coding agent used file, shell, and edit tools.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The test uses made-up messages and IDs.
