### PR TITLE
fix(warehouse): support property mapping updates

### DIFF
--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -1706,7 +1706,9 @@ def _validate_column_property_map(column_property_map: Any) -> dict[str, str]:
     return column_property_map
 
 
-def _validate_column_descriptions(column_descriptions: Any, mapped_columns: set[str]) -> dict[str, str]:
+def _validate_column_descriptions(
+    column_descriptions: Any, mapped_columns: set[str], *, reject_unmapped: bool = False
+) -> dict[str, str]:
     """Optional {warehouse_column: description} for a person source. Descriptions are keyed by the
     same warehouse columns the source maps; unknown columns and blank descriptions are dropped."""
     if column_descriptions is None:
@@ -1716,6 +1718,10 @@ def _validate_column_descriptions(column_descriptions: Any, mapped_columns: set[
     cleaned: dict[str, str] = {}
     for column, description in column_descriptions.items():
         if column not in mapped_columns:
+            if reject_unmapped:
+                raise CustomPropertySourceValidationError(
+                    "column_descriptions keys must be present in column_property_map."
+                )
             continue
         if description is None or (isinstance(description, str) and not description.strip()):
             continue
@@ -2150,27 +2156,49 @@ def create_custom_property_source(
     return _to_custom_property_source_view(source, user_access_control)
 
 
+@transaction.atomic
 def update_custom_property_source(
     *, team_id: int, source_id: str, fields: dict[str, Any], user_access_control: "UserAccessControl | None" = None
 ) -> contracts.CustomPropertySourceView | None:
-    """Apply ``fields`` (source_column / key_column / is_enabled) to a team-scoped source. Re-enabling
-    (is_enabled False→True) resets the failure streak and clears the last error. Returns None (→ 404)
-    when no source matches."""
-    source = CustomPropertySource.objects.for_team(team_id).select_related("definition").filter(id=source_id).first()
+    """Apply writable fields to a team-scoped source. Re-enabling (is_enabled False→True) resets the
+    failure streak and clears the last error. Returns None (→ 404) when no source matches."""
+    source = (
+        CustomPropertySource.objects.for_team(team_id)
+        .select_for_update(of=("self",))
+        .select_related("definition")
+        .filter(id=source_id)
+        .first()
+    )
     if source is None:
         return None
+    fields = dict(fields)
+    profile_mapping_fields = {"column_property_map", "column_descriptions"}.intersection(fields)
+    if profile_mapping_fields:
+        if source.definition.target_type not in _WAREHOUSE_PROFILE_TARGETS:
+            raise CustomPropertySourceValidationError(
+                "An account property source uses saved_query + source_column, not external_data_schema."
+            )
+        validated_map = _validate_column_property_map(fields.get("column_property_map", source.column_property_map))
+        if "column_property_map" in fields:
+            fields["column_property_map"] = validated_map
+        if "column_descriptions" in fields:
+            fields["column_descriptions"] = _validate_column_descriptions(
+                fields["column_descriptions"], set(validated_map), reject_unmapped=True
+            )
+        elif "column_property_map" in fields:
+            fields["column_descriptions"] = _validate_column_descriptions(
+                source.column_descriptions, set(validated_map)
+            )
     reenabling = fields.get("is_enabled") is True and not source.is_enabled
     columns_changed = any(
-        attr in fields and fields[attr] != getattr(source, attr) for attr in ("source_column", "key_column")
+        attr in fields and fields[attr] != getattr(source, attr)
+        for attr in ("source_column", "key_column", "column_property_map")
     )
-    # A profile source's backfill drives a real warehouse run, so any change that will trigger one —
-    # re-enabling, or changing the mapped columns while it stays enabled — requires the caller's editor
-    # access on the warehouse object, not account-scope editor alone (matching create). Both routes reach
-    # _start_person_backfill_if_enabled below via ``reenabling or columns_changed``; ``is_enabled`` here is
-    # the post-update state that decides whether that helper actually starts a backfill.
+    # Profile mapping fields always require editor access to the bound warehouse object, including while
+    # disabled. Existing re-enable/column changes require it when they will trigger a backfill.
     will_be_enabled = fields.get("is_enabled", source.is_enabled) is True
     binding = _profile_binding(source)
-    if binding is not None and will_be_enabled and (reenabling or columns_changed):
+    if binding is not None and (profile_mapping_fields or (will_be_enabled and (reenabling or columns_changed))):
         _assert_warehouse_editor(team_id, binding, user_access_control)
     for attr, value in fields.items():
         setattr(source, attr, value)

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -2209,7 +2209,8 @@ def update_custom_property_source(
     # Only re-sync on a change that affects what gets written — not on every (possibly no-op) PATCH.
     if reenabling or columns_changed:
         _enqueue_sync_if_enabled(source)
-        _start_person_backfill_if_enabled(source)
+        if will_be_enabled:
+            _start_person_backfill_if_enabled(source)
     return _to_custom_property_source_view(source, user_access_control)
 
 

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -1744,8 +1744,13 @@ def _enqueue_custom_property_sync(team_id: int, saved_query_id: str) -> None:
 
 def _enqueue_sync_if_enabled(source: CustomPropertySource) -> None:
     """Run an initial sync after the source is saved so its values populate immediately rather than
-    waiting for the next materialization. Skips disabled sources and ones whose view was deleted."""
-    if not source.is_enabled or source.saved_query_id is None:
+    waiting for the next materialization. This Celery path owns account sources only; person/group
+    sources use their warehouse binding workflow even when that binding is a saved query."""
+    if (
+        not source.is_enabled
+        or source.saved_query_id is None
+        or source.definition.target_type in _WAREHOUSE_PROFILE_TARGETS
+    ):
         return
     team_id, saved_query_id = source.team_id, str(source.saved_query_id)
     transaction.on_commit(lambda: _enqueue_custom_property_sync(team_id, saved_query_id))

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -1883,6 +1883,31 @@ def _start_person_backfill_if_enabled(source: CustomPropertySource) -> None:
     transaction.on_commit(lambda: _start_backfill(team_id, binding, "backfill"))
 
 
+def _stamp_profile_source_provenance(source: CustomPropertySource, binding: "WarehouseBinding") -> None:
+    """Apply the source's current mapping metadata without waiting for a value-hash change."""
+    from products.warehouse_sources.backend.facade.person_property_provenance import (  # noqa: PLC0415
+        stamp_person_property_provenance,
+    )
+
+    column_property_map = source.column_property_map or {}
+    column_descriptions = source.column_descriptions or {}
+    property_descriptions = {
+        column_property_map[column]: description
+        for column, description in column_descriptions.items()
+        if column in column_property_map and description
+    }
+    stamp_person_property_provenance(
+        team_id=source.team_id,
+        binding=binding,
+        source_id=str(source.id),
+        definition_id=str(source.definition_id),
+        target=source.definition.target_type,
+        group_type_index=source.definition.group_type_index,
+        property_names=column_property_map.values(),
+        property_descriptions=property_descriptions,
+    )
+
+
 def _triggerable_profile_binding(team_id: int, source_id: str) -> "WarehouseBinding | None":
     """The warehouse object to act on for a person/group-property trigger, or None when the source isn't
     a valid, flag-enabled warehouse-profile source (→ the view returns 400)."""
@@ -2192,10 +2217,14 @@ def update_custom_property_source(
                 source.column_descriptions, set(validated_map)
             )
     reenabling = fields.get("is_enabled") is True and not source.is_enabled
-    columns_changed = any(
-        attr in fields and fields[attr] != getattr(source, attr)
-        for attr in ("source_column", "key_column", "column_property_map")
+    mapping_changed = "column_property_map" in fields and fields["column_property_map"] != source.column_property_map
+    descriptions_changed = (
+        "column_descriptions" in fields and fields["column_descriptions"] != source.column_descriptions
     )
+    columns_changed = any(
+        attr in fields and fields[attr] != getattr(source, attr) for attr in ("source_column", "key_column")
+    )
+    columns_changed = columns_changed or mapping_changed
     # Profile mapping fields always require editor access to the bound warehouse object, including while
     # disabled. Existing re-enable/column changes require it when they will trigger a backfill.
     will_be_enabled = fields.get("is_enabled", source.is_enabled) is True
@@ -2208,6 +2237,8 @@ def update_custom_property_source(
         source.consecutive_failures = 0
         source.last_sync_error = None
     source.save()
+    if binding is not None and (mapping_changed or descriptions_changed):
+        _stamp_profile_source_provenance(source, binding)
     # Only re-sync on a change that affects what gets written — not on every (possibly no-op) PATCH.
     if reenabling or columns_changed:
         _enqueue_sync_if_enabled(source)

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -1706,9 +1706,7 @@ def _validate_column_property_map(column_property_map: Any) -> dict[str, str]:
     return column_property_map
 
 
-def _validate_column_descriptions(
-    column_descriptions: Any, mapped_columns: set[str], *, reject_unmapped: bool = False
-) -> dict[str, str]:
+def _validate_column_descriptions(column_descriptions: Any, mapped_columns: set[str]) -> dict[str, str]:
     """Optional {warehouse_column: description} for a person source. Descriptions are keyed by the
     same warehouse columns the source maps; unknown columns and blank descriptions are dropped."""
     if column_descriptions is None:
@@ -1718,10 +1716,6 @@ def _validate_column_descriptions(
     cleaned: dict[str, str] = {}
     for column, description in column_descriptions.items():
         if column not in mapped_columns:
-            if reject_unmapped:
-                raise CustomPropertySourceValidationError(
-                    "column_descriptions keys must be present in column_property_map."
-                )
             continue
         if description is None or (isinstance(description, str) and not description.strip()):
             continue
@@ -2207,20 +2201,27 @@ def update_custom_property_source(
     profile_mapping_fields = {"column_property_map", "column_descriptions"}.intersection(fields)
     if profile_mapping_fields:
         if source.definition.target_type not in _WAREHOUSE_PROFILE_TARGETS:
-            raise CustomPropertySourceValidationError(
-                "An account property source uses saved_query + source_column, not external_data_schema."
-            )
-        validated_map = _validate_column_property_map(fields.get("column_property_map", source.column_property_map))
-        if "column_property_map" in fields:
-            fields["column_property_map"] = validated_map
-        if "column_descriptions" in fields:
-            fields["column_descriptions"] = _validate_column_descriptions(
-                fields["column_descriptions"], set(validated_map), reject_unmapped=True
-            )
-        elif "column_property_map" in fields:
-            fields["column_descriptions"] = _validate_column_descriptions(
-                source.column_descriptions, set(validated_map)
-            )
+            if any(fields[field] is not None for field in profile_mapping_fields):
+                raise CustomPropertySourceValidationError(
+                    "An account property source uses saved_query + source_column, not external_data_schema."
+                )
+            # Account GET responses include these profile-only fields as null. Treating those nulls as
+            # absent keeps the writable representation compatible with a GET/PATCH round trip.
+            for field in profile_mapping_fields:
+                fields.pop(field)
+            profile_mapping_fields.clear()
+        else:
+            validated_map = _validate_column_property_map(fields.get("column_property_map", source.column_property_map))
+            if "column_property_map" in fields:
+                fields["column_property_map"] = validated_map
+            if "column_descriptions" in fields:
+                fields["column_descriptions"] = _validate_column_descriptions(
+                    fields["column_descriptions"], set(validated_map)
+                )
+            elif "column_property_map" in fields:
+                fields["column_descriptions"] = _validate_column_descriptions(
+                    source.column_descriptions, set(validated_map)
+                )
     reenabling = fields.get("is_enabled") is True and not source.is_enabled
     mapping_changed = "column_property_map" in fields and fields["column_property_map"] != source.column_property_map
     descriptions_changed = (

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -1790,10 +1790,10 @@ def _expire_stale_running_runs(team_id: int, runs: "Iterable[CustomPropertySyncR
 def _create_running_runs(team_id: int, binding: "WarehouseBinding", trigger: str) -> list[Any]:
     """Insert a 'running' run for each enabled person/group source on the binding that isn't already
     running. The UI shows these as in-progress and disables the trigger while they exist; the sync and
-    backfill activities reconcile them to their terminal state (see record_sync_run). Skipping sources
-    that already have a running run makes this a no-op when a run for the table is already in flight
-    (coalesced). Returns the source ids a placeholder was created for, so the caller can reconcile them
-    to FAILED if the workflow start never happens (see ``_fail_created_runs``)."""
+    backfill activities reconcile them to their terminal state (see record_sync_run). An existing row
+    suppresses only a duplicate placeholder; the binding workflow still receives a signal and opens a
+    new row when its follow-up starts. Returns the source ids a placeholder was created for, so the
+    caller can reconcile them to FAILED if the workflow start never happens (see ``_fail_created_runs``)."""
     # A source and a run name the same binding through different columns: a source's schema binding is
     # the `external_data_schema` FK, a run's is the plain `schema_id`.
     source_field = "saved_query_id" if binding.is_saved_query else "external_data_schema_id"
@@ -1875,7 +1875,7 @@ def _start_backfill(team_id: int, binding: "WarehouseBinding", trigger: str) -> 
 def _start_person_backfill_if_enabled(source: CustomPropertySource) -> None:
     """Auto-start a backfill after a person/group source is created/enabled so historical rows populate
     immediately rather than waiting for the next warehouse run. Profile sources only (an account source
-    has its own Celery sync); deduped per table by the workflow id."""
+    has its own Celery sync); serialized per table by the workflow id."""
     binding = _profile_binding(source)
     if not source.is_enabled or binding is None:
         return
@@ -1989,22 +1989,24 @@ def trigger_person_property_sync(
 def trigger_person_property_backfill(
     *, team_id: int, source_id: str, trigger: str = "manual", user_access_control: "UserAccessControl | None" = None
 ) -> bool | None:
-    """Start a backfill for a profile source's table. Returns True (started), False (already running →
-    coalesced), or None for an invalid source (→ 400). Requires editor access to the warehouse object
-    (→ 403)."""
+    """Request a backfill for a profile source's table. Returns True when a new visible run starts,
+    False when an existing run receives a guaranteed latest-state follow-up, or None for an invalid
+    source (→ 400). Requires editor access to the warehouse object (→ 403)."""
     binding = _triggerable_profile_binding(team_id, source_id)
     if binding is None:
         return None
     _assert_warehouse_editor(team_id, binding, user_access_control)
     # Placeholder rows before starting, so the activity always finds a running row to reconcile.
     created_source_ids = _create_running_runs(team_id, binding, trigger)
+    started_new_run = bool(created_source_ids)
     from products.warehouse_sources.backend.facade.temporal import (  # noqa: PLC0415
         WarehouseBindingMissingError,
         start_person_property_backfill,
     )
 
     try:
-        return start_person_property_backfill(team_id=team_id, binding=binding, trigger=trigger)
+        start_person_property_backfill(team_id=team_id, binding=binding, trigger=trigger)
+        return started_new_run
     except WarehouseBindingMissingError:
         # The warehouse table or view was deleted after the placeholders were created; reconcile them
         # so the source isn't stuck 'running', and report an invalid source (→ 400) rather than a

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -206,6 +206,158 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
                 user_access_control=self._uac(allowed=False),
             )
 
+    @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
+    def test_update_person_mapping_round_trips_on_the_same_source_and_starts_one_backfill(self, start_backfill):
+        source = self._create(user_access_control=self._uac(allowed=True))
+        start_backfill.reset_mock()
+        CustomPropertySource.objects.filter(id=source.id).update(
+            consecutive_failures=3, last_sync_error="previous sync failure"
+        )
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={
+                "column_property_map": {"plan": "plan_tier", "seats": "seat_count"},
+                "column_descriptions": {"seats": " Seat count "},
+            },
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is not None and view.id == source.id
+        assert view.column_property_map == {"plan": "plan_tier", "seats": "seat_count"}
+        assert view.column_descriptions == {"seats": "Seat count"}
+        assert view.consecutive_failures == 3 and view.last_sync_error == "previous sync failure"
+        start_backfill.assert_called_once()
+
+    @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
+    def test_update_person_mapping_noop_does_not_start_a_backfill(self, start_backfill):
+        source = self._create(user_access_control=self._uac(allowed=True))
+        start_backfill.reset_mock()
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_property_map": {"plan": "plan_tier"}},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is not None and view.id == source.id
+        start_backfill.assert_not_called()
+
+    @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
+    def test_update_person_descriptions_does_not_start_a_backfill(self, start_backfill):
+        source = self._create(user_access_control=self._uac(allowed=True))
+        start_backfill.reset_mock()
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_descriptions": {"plan": " Plan tier "}},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is not None and view.column_descriptions == {"plan": "Plan tier"}
+        start_backfill.assert_not_called()
+
+    @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
+    def test_update_disabled_person_mapping_requires_editor_without_starting_a_backfill(self, start_backfill):
+        source = self._create(is_enabled=False, user_access_control=self._uac(allowed=True))
+        start_backfill.reset_mock()
+
+        with self.assertRaises(api.ResourceForbiddenError):
+            api.update_custom_property_source(
+                team_id=self.team.id,
+                source_id=source.id,
+                fields={"column_property_map": {"plan": "plan_tier", "seats": "seat_count"}},
+                user_access_control=self._uac(allowed=False),
+            )
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_property_map": {"plan": "plan_tier", "seats": "seat_count"}},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is not None and view.column_property_map["seats"] == "seat_count"
+        start_backfill.assert_not_called()
+
+    def test_update_person_mapping_replacement_drops_descriptions_for_removed_columns(self):
+        source = self._create(
+            column_property_map={"plan": "plan_tier", "seats": "seat_count"},
+            column_descriptions={"plan": "Plan tier", "seats": "Seat count"},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_property_map": {"plan": "plan_tier"}},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is not None and view.column_descriptions == {"plan": "Plan tier"}
+
+    @parameterized.expand(
+        [
+            ("empty_map", {"column_property_map": {}}, "non-empty object"),
+            ("null_map", {"column_property_map": None}, "non-empty object"),
+            ("blank_property", {"column_property_map": {"plan": ""}}, "non-empty property names"),
+            (
+                "description_outside_map",
+                {"column_descriptions": {"unmapped": "Unknown column"}},
+                "present in column_property_map",
+            ),
+        ]
+    )
+    @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
+    def test_update_person_mapping_rejects_invalid_input_before_persistence_or_backfill(
+        self, _name, fields, expected_message, start_backfill
+    ):
+        source = self._create(user_access_control=self._uac(allowed=True))
+        start_backfill.reset_mock()
+
+        with self.assertRaisesMessage(api.CustomPropertySourceValidationError, expected_message):
+            api.update_custom_property_source(team_id=self.team.id, source_id=source.id, fields=fields)
+
+        row = CustomPropertySource.objects.unscoped().get(id=source.id)
+        assert row.column_property_map == {"plan": "plan_tier"}
+        start_backfill.assert_not_called()
+
+    @parameterized.expand(["column_property_map", "column_descriptions"])
+    def test_update_account_source_rejects_profile_mapping_fields(self, field):
+        source = self._create(
+            definition_id=self.account_def.id,
+            external_data_schema_id=None,
+            saved_query_id=self.saved_query.id,
+            source_column="mrr",
+            column_property_map=None,
+        )
+
+        value = {"mrr": "account_mrr"} if field == "column_property_map" else {"mrr": "Account MRR"}
+        with self.assertRaisesMessage(api.CustomPropertySourceValidationError, "not external_data_schema"):
+            api.update_custom_property_source(
+                team_id=self.team.id,
+                source_id=source.id,
+                fields={field: value},
+            )
+
+    def test_update_person_mapping_is_team_scoped(self):
+        source = self._create(user_access_control=self._uac(allowed=True))
+        other_team = self.organization.teams.create(name="other")
+
+        view = api.update_custom_property_source(
+            team_id=other_team.id,
+            source_id=source.id,
+            fields={"column_property_map": {"plan": "other_plan"}},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is None
+        source.refresh_from_db()
+        assert source.column_property_map == {"plan": "plan_tier"}
+
     def test_delete_person_source_requires_warehouse_source_editor(self):
         # Deleting a person source permanently stops its billable warehouse-driven updates, so it needs
         # external_data_source editor access, not account-scope editor alone.

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -624,6 +624,24 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
         with self.assertRaises(api.ResourceForbiddenError):
             self._create_view_source(user_access_control=self._uac(allowed=False))
 
+    @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
+    @patch("products.customer_analytics.backend.facade.api._enqueue_custom_property_sync")
+    def test_view_backed_person_source_never_queues_account_sync(self, enqueue_account_sync, _start_backfill):
+        with self.captureOnCommitCallbacks(execute=True):
+            source = self._create_view_source(user_access_control=self._uac(allowed=True))
+
+        enqueue_account_sync.assert_not_called()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            api.update_custom_property_source(
+                team_id=self.team.id,
+                source_id=source.id,
+                fields={"column_property_map": {"plan": "plan_tier", "seats": "seat_count"}},
+                user_access_control=self._uac(allowed=True),
+            )
+
+        enqueue_account_sync.assert_not_called()
+
     @patch("products.customer_analytics.backend.facade.api.person_properties_flag_enabled", return_value=True)
     def test_sync_now_materializes_the_view_and_opens_a_running_run(self, _flag):
         source = self._create_view_source(user_access_control=self._uac(allowed=True))

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -330,11 +330,6 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
             ("empty_map", {"column_property_map": {}}, "non-empty object"),
             ("null_map", {"column_property_map": None}, "non-empty object"),
             ("blank_property", {"column_property_map": {"plan": ""}}, "non-empty property names"),
-            (
-                "description_outside_map",
-                {"column_descriptions": {"unmapped": "Unknown column"}},
-                "present in column_property_map",
-            ),
         ]
     )
     @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
@@ -350,6 +345,18 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
         row = CustomPropertySource.objects.unscoped().get(id=source.id)
         assert row.column_property_map == {"plan": "plan_tier"}
         start_backfill.assert_not_called()
+
+    def test_update_person_source_drops_unmapped_descriptions_like_create(self):
+        source = self._create(user_access_control=self._uac(allowed=True))
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_descriptions": {"plan": " Plan tier ", "unmapped": "ignored"}},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert view is not None and view.column_descriptions == {"plan": "Plan tier"}
 
     @parameterized.expand(["column_property_map", "column_descriptions"])
     def test_update_account_source_rejects_profile_mapping_fields(self, field):
@@ -368,6 +375,24 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
                 source_id=source.id,
                 fields={field: value},
             )
+
+    def test_update_account_source_ignores_null_profile_mapping_fields(self):
+        source = self._create(
+            definition_id=self.account_def.id,
+            external_data_schema_id=None,
+            saved_query_id=self.saved_query.id,
+            source_column="mrr",
+            column_property_map=None,
+        )
+
+        view = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_property_map": None, "column_descriptions": None},
+        )
+
+        assert view is not None
+        assert view.column_property_map is None and view.column_descriptions is None
 
     def test_update_person_mapping_is_team_scoped(self):
         source = self._create(user_access_control=self._uac(allowed=True))

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -8,6 +8,8 @@ from django.utils import timezone
 
 from parameterized import parameterized
 
+from posthog.models import PropertyDefinition
+
 from products.customer_analytics.backend.facade import api
 from products.customer_analytics.backend.models import CustomPropertySource, CustomPropertySyncRun, TargetType
 from products.customer_analytics.backend.models.team_scoped_test_base import TeamScopedTestMixin
@@ -246,9 +248,17 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
         start_backfill.assert_not_called()
 
     @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")
-    def test_update_person_descriptions_does_not_start_a_backfill(self, start_backfill):
-        source = self._create(user_access_control=self._uac(allowed=True))
+    def test_update_person_descriptions_stamps_and_clears_provenance_without_a_backfill(self, start_backfill):
+        source = self._create(
+            column_descriptions={"plan": "Old description"}, user_access_control=self._uac(allowed=True)
+        )
         start_backfill.reset_mock()
+        definition = PropertyDefinition.objects.create(
+            team=self.team,
+            name="plan_tier",
+            type=PropertyDefinition.Type.PERSON,
+            warehouse_origin={"description": "Old description"},
+        )
 
         view = api.update_custom_property_source(
             team_id=self.team.id,
@@ -258,6 +268,22 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
         )
 
         assert view is not None and view.column_descriptions == {"plan": "Plan tier"}
+        definition.refresh_from_db()
+        assert definition.warehouse_origin is not None
+        assert definition.warehouse_origin["custom_property_source_id"] == str(source.id)
+        assert definition.warehouse_origin["description"] == "Plan tier"
+
+        cleared = api.update_custom_property_source(
+            team_id=self.team.id,
+            source_id=source.id,
+            fields={"column_descriptions": None},
+            user_access_control=self._uac(allowed=True),
+        )
+
+        assert cleared is not None and cleared.column_descriptions == {}
+        definition.refresh_from_db()
+        assert definition.warehouse_origin is not None
+        assert "description" not in definition.warehouse_origin
         start_backfill.assert_not_called()
 
     @patch("products.customer_analytics.backend.facade.api._start_person_backfill_if_enabled")

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -406,8 +406,8 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
         )
 
         assert view is None
-        source.refresh_from_db()
-        assert source.column_property_map == {"plan": "plan_tier"}
+        row = CustomPropertySource.objects.unscoped().get(id=source.id)
+        assert row.column_property_map == {"plan": "plan_tier"}
 
     def test_delete_person_source_requires_warehouse_source_editor(self):
         # Deleting a person source permanently stops its billable warehouse-driven updates, so it needs

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -306,7 +306,7 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
             user_access_control=self._uac(allowed=True),
         )
 
-        assert view is not None and view.column_property_map["seats"] == "seat_count"
+        assert view is not None and view.column_property_map == {"plan": "plan_tier", "seats": "seat_count"}
         start_backfill.assert_not_called()
 
     def test_update_person_mapping_replacement_drops_descriptions_for_removed_columns(self):

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -1539,7 +1539,7 @@ class CustomPropertySourceSerializer(DataclassSerializer):
         help_text=(
             "Person and group sources only: {warehouse_column: description} giving each mapped column a "
             "human-facing description, seeded from the warehouse column's information_schema "
-            "description. Optional per column. Create-only."
+            "description. Optional per column."
         ),
     )
     key_column = serializers.CharField(
@@ -1788,14 +1788,29 @@ class CustomPropertyDefinitionSerializer(DataclassSerializer):
 
 
 class CustomPropertySourceUpdateSerializer(serializers.Serializer):
-    """Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
-    they are intentionally absent — only these reach the facade's update."""
+    """Writable fields for updating a source. Binding and definition fields are create-only, so they
+    are intentionally absent — only these reach the facade's update."""
 
     source_column = serializers.CharField(
         max_length=400, required=False, help_text="Column in the view whose value is written to the property."
     )
     key_column = serializers.CharField(
         max_length=400, required=False, help_text="Column in the view whose value matches an account's external_id."
+    )
+    column_property_map = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Person and group sources only: {warehouse_column: property_name} mapping the columns this "
+            "source writes onto the person or group."
+        ),
+    )
+    column_descriptions = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column."
+        ),
     )
     is_enabled = serializers.BooleanField(
         required=False, help_text="Whether the source syncs; re-enabling it resets the failure count."

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -1428,12 +1428,12 @@ class CustomPropertySyncTriggerResponseSerializer(serializers.Serializer):
         choices=[("triggered", "triggered"), ("started", "started"), ("already_running", "already_running")],
         help_text=(
             "'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or "
-            "'already_running' (a backfill for this table was already in flight, so this was a no-op)."
+            "'already_running' (a backfill was in flight and a latest-state follow-up was queued)."
         ),
     )
     already_running = serializers.BooleanField(
         required=False,
-        help_text="Backfill only: true when a backfill for this table was already running and this call coalesced.",
+        help_text="Backfill only: true when a run was already in flight and this call queued its follow-up.",
     )
 
 

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -1249,6 +1249,8 @@ class CustomPropertySourceViewSet(
                 fields=write.validated_data,
                 user_access_control=_warehouse_scoped_uac(self),
             )
+        except api.CustomPropertySourceValidationError as e:
+            raise ValidationError(str(e))
         except api.ResourceForbiddenError:
             raise PermissionDenied()
         if source is None:

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -1315,8 +1315,8 @@ class CustomPropertySourceViewSet(
     @action(methods=["POST"], detail=True)
     def backfill(self, request: Request, *args, **kwargs) -> Response:
         """Person and group sources only: start a backfill that reads the whole warehouse table and
-        populates person or group properties for historical rows. Coalesces if one is already running
-        for the table."""
+        populates person or group properties for historical rows. If one is already running for the
+        table, queue a follow-up that observes the latest mapping."""
         self._guard_group_source(request, self.kwargs["pk"])
         try:
             started = api.trigger_person_property_backfill(

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -2053,6 +2053,30 @@ class TestCustomPropertySourceViewSet(APIBaseTest):
         assert body["column_property_map"] == {"plan": "plan_tier"}
         assert body["saved_query"] is None
 
+    def test_patch_person_source_mapping_round_trip_and_validation(self):
+        source_id = self._create_person_source()
+
+        patched = self.client.patch(
+            f"{self.endpoint}{source_id}/",
+            {
+                "column_property_map": {"plan": "plan_tier", "seats": "seat_count"},
+                "column_descriptions": {"seats": " Seat count "},
+            },
+            format="json",
+        )
+
+        assert patched.status_code == status.HTTP_200_OK, patched.content
+        assert patched.json()["id"] == source_id
+        assert patched.json()["column_property_map"] == {"plan": "plan_tier", "seats": "seat_count"}
+        assert patched.json()["column_descriptions"] == {"seats": "Seat count"}
+
+        invalid = self.client.patch(f"{self.endpoint}{source_id}/", {"column_property_map": {}}, format="json")
+        assert invalid.status_code == status.HTTP_400_BAD_REQUEST, invalid.content
+
+        cleared = self.client.patch(f"{self.endpoint}{source_id}/", {"column_descriptions": None}, format="json")
+        assert cleared.status_code == status.HTTP_200_OK, cleared.content
+        assert cleared.json()["column_descriptions"] == {}
+
     @patch("products.customer_analytics.backend.presentation.views.views.report_user_action")
     def test_mapping_lifecycle_emits_usage_events(self, report_user_action):
         definition, schema = self._person_definition_and_schema()
@@ -2175,6 +2199,15 @@ class TestCustomPropertySourceViewSet(APIBaseTest):
         )
         assert created.status_code == status.HTTP_201_CREATED, created.content
         assert created.json()["external_data_schema"] == str(schema.id)
+
+        patched = self.client.patch(
+            f"{self.endpoint}{created.json()['id']}/",
+            {"column_property_map": {"plan": "group_plan_tier"}},
+            format="json",
+        )
+        assert patched.status_code == status.HTTP_200_OK, patched.content
+        assert patched.json()["id"] == created.json()["id"]
+        assert patched.json()["column_property_map"] == {"plan": "group_plan_tier"}
 
     @parameterized.expand(
         [

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -2019,7 +2019,16 @@ class TestCustomPropertySourceViewSet(APIBaseTest):
         assert listed.status_code == status.HTTP_200_OK
         assert [s["id"] for s in listed.json()["results"]] == [source_id]
 
-        toggled = self.client.patch(f"{self.endpoint}{source_id}/", {"is_enabled": False}, format="json")
+        detail_endpoint = f"{self.endpoint}{source_id}/"
+        retrieved = self.client.get(detail_endpoint)
+        assert retrieved.status_code == status.HTTP_200_OK
+        assert retrieved.json()["column_property_map"] is None
+        assert retrieved.json()["column_descriptions"] is None
+
+        round_tripped = self.client.patch(detail_endpoint, retrieved.json(), format="json")
+        assert round_tripped.status_code == status.HTTP_200_OK, round_tripped.content
+
+        toggled = self.client.patch(detail_endpoint, {"is_enabled": False}, format="json")
         assert toggled.status_code == status.HTTP_200_OK
         assert toggled.json()["is_enabled"] is False
 

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -2162,7 +2162,7 @@ class TestCustomPropertySourceViewSet(APIBaseTest):
     @patch("posthoganalytics.feature_enabled", return_value=True)
     def test_person_source_actions_when_enabled(self, _flag, mock_trigger_sync, mock_start_backfill):
         # Wiring guard: the actions route through the facade to the temporal seam, return the typed
-        # response, and the backfill pre-creates a running run the runs feed then surfaces.
+        # response, and an in-flight sync still sends the manual latest-revision follow-up.
         source_id = self._create_person_source()
 
         synced = self.client.post(f"{self.endpoint}{source_id}/sync/")
@@ -2172,7 +2172,7 @@ class TestCustomPropertySourceViewSet(APIBaseTest):
 
         backfilled = self.client.post(f"{self.endpoint}{source_id}/backfill/")
         assert backfilled.status_code == status.HTTP_202_ACCEPTED, backfilled.content
-        assert backfilled.json() == {"status": "started", "already_running": False}
+        assert backfilled.json() == {"status": "already_running", "already_running": True}
         mock_start_backfill.assert_called_once()
 
         runs = self.client.get(f"{self.endpoint}{source_id}/runs/")

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -1244,7 +1244,7 @@ export interface CustomPropertySourceApi {
     source_column?: string | null
     /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
     column_property_map?: unknown
-    /** Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column. Create-only. */
+    /** Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column. */
     column_descriptions?: unknown
     /**
      * Column whose value identifies the target: an account's external_id for account sources, the person's distinct_id for person sources, or the group key for group sources.
@@ -1477,8 +1477,8 @@ export interface PaginatedCustomPropertySourceListApi {
 }
 
 /**
- * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
- * they are intentionally absent — only these reach the facade's update.
+ * Writable fields for updating a source. Binding and definition fields are create-only, so they
+ * are intentionally absent — only these reach the facade's update.
  */
 export interface CustomPropertySourceUpdateApi {
     /**
@@ -1491,13 +1491,17 @@ export interface CustomPropertySourceUpdateApi {
      * @maxLength 400
      */
     key_column?: string
+    /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
+    column_property_map?: unknown
+    /** Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column. */
+    column_descriptions?: unknown
     /** Whether the source syncs; re-enabling it resets the failure count. */
     is_enabled?: boolean
 }
 
 /**
- * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
- * they are intentionally absent — only these reach the facade's update.
+ * Writable fields for updating a source. Binding and definition fields are create-only, so they
+ * are intentionally absent — only these reach the facade's update.
  */
 export interface PatchedCustomPropertySourceUpdateApi {
     /**
@@ -1510,6 +1514,10 @@ export interface PatchedCustomPropertySourceUpdateApi {
      * @maxLength 400
      */
     key_column?: string
+    /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
+    column_property_map?: unknown
+    /** Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column. */
+    column_descriptions?: unknown
     /** Whether the source syncs; re-enabling it resets the failure count. */
     is_enabled?: boolean
 }
@@ -1532,13 +1540,13 @@ export const CustomPropertySyncTriggerResponseStatusEnumApi = {
  * Response of the person/group-property sync/backfill trigger actions.
  */
 export interface CustomPropertySyncTriggerResponseApi {
-    /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill for this table was already in flight, so this was a no-op).
+    /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill was in flight and a latest-state follow-up was queued).
      *
      * * `triggered` - triggered
      * * `started` - started
      * * `already_running` - already_running */
     status: CustomPropertySyncTriggerResponseStatusEnumApi
-    /** Backfill only: true when a backfill for this table was already running and this call coalesced. */
+    /** Backfill only: true when a run was already in flight and this call queued its follow-up. */
     already_running?: boolean
 }
 

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -1225,8 +1225,8 @@ export const getCustomPropertySourcesBackfillUrl = (projectId: string, id: strin
 
 /**
  * Person and group sources only: start a backfill that reads the whole warehouse table and
- * populates person or group properties for historical rows. Coalesces if one is already running
- * for the table.
+ * populates person or group properties for historical rows. If one is already running for the
+ * table, queue a follow-up that observes the latest mapping.
  */
 export const customPropertySourcesBackfill = async (
     projectId: string,

--- a/products/customer_analytics/frontend/generated/api.zod.ts
+++ b/products/customer_analytics/frontend/generated/api.zod.ts
@@ -732,7 +732,7 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             .unknown()
             .optional()
             .describe(
-                "Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column. Create-only."
+                "Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column."
             ),
         key_column: zod
             .string()
@@ -767,13 +767,25 @@ export const CustomPropertySourcesUpdateBody = /* @__PURE__ */ zod
             .max(customPropertySourcesUpdateBodyKeyColumnMax)
             .optional()
             .describe("Column in the view whose value matches an account's external_id."),
+        column_property_map: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group.'
+            ),
+        column_descriptions: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column.'
+            ),
         is_enabled: zod
             .boolean()
             .optional()
             .describe('Whether the source syncs; re-enabling it resets the failure count.'),
     })
     .describe(
-        "Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so\nthey are intentionally absent — only these reach the facade's update."
+        "Writable fields for updating a source. Binding and definition fields are create-only, so they\nare intentionally absent — only these reach the facade's update."
     )
 
 export const customPropertySourcesPartialUpdateBodySourceColumnMax = 400
@@ -792,13 +804,25 @@ export const CustomPropertySourcesPartialUpdateBody = /* @__PURE__ */ zod
             .max(customPropertySourcesPartialUpdateBodyKeyColumnMax)
             .optional()
             .describe("Column in the view whose value matches an account's external_id."),
+        column_property_map: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group.'
+            ),
+        column_descriptions: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column.'
+            ),
         is_enabled: zod
             .boolean()
             .optional()
             .describe('Whether the source syncs; re-enabling it resets the failure count.'),
     })
     .describe(
-        "Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so\nthey are intentionally absent — only these reach the facade's update."
+        "Writable fields for updating a source. Binding and definition fields are create-only, so they\nare intentionally absent — only these reach the facade's update."
     )
 
 export const customerJourneysCreateBodyNameMax = 400

--- a/products/warehouse_sources/backend/facade/person_property_provenance.py
+++ b/products/warehouse_sources/backend/facade/person_property_provenance.py
@@ -1,0 +1,45 @@
+from collections.abc import Iterable
+
+from posthog.models import PropertyDefinition
+
+from products.warehouse_sources.backend.facade.hooks import WarehouseBinding
+
+_GROUP_TARGET = "group"
+
+
+def stamp_person_property_provenance(
+    *,
+    team_id: int,
+    binding: WarehouseBinding,
+    source_id: str,
+    definition_id: str,
+    target: str,
+    group_type_index: int | None,
+    property_names: Iterable[str],
+    property_descriptions: dict[str, str],
+) -> None:
+    """Update existing person/group property definitions with their warehouse mapping provenance."""
+    origin: dict[str, str] = {
+        "source_id": definition_id,
+        "custom_property_source_id": source_id,
+        "binding_kind": binding.kind,
+        "binding_id": binding.id,
+    }
+    # Rows stamped before materialized-view bindings existed carry this compatibility key.
+    if not binding.is_saved_query:
+        origin["schema_id"] = binding.id
+
+    query = PropertyDefinition.objects.filter(team_id=team_id)
+    if target == _GROUP_TARGET:
+        query = query.filter(type=PropertyDefinition.Type.GROUP, group_type_index=group_type_index)
+    else:
+        query = query.filter(type=PropertyDefinition.Type.PERSON)
+
+    names = list(dict.fromkeys(property_names))
+    described = {name: property_descriptions[name] for name in names if property_descriptions.get(name)}
+    plain = [name for name in names if name not in described]
+    if plain:
+        # Replacing the whole origin deliberately clears a previously configured description.
+        query.filter(name__in=plain).update(warehouse_origin=origin)
+    for name, description in described.items():
+        query.filter(name=name).update(warehouse_origin={**origin, "description": description})

--- a/products/warehouse_sources/backend/temporal/data_imports/external_product_hooks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_product_hooks.py
@@ -305,6 +305,9 @@ class PersonPropertyBackfillActivityInputs:
     # "backfill" (auto on create/enable) or "manual" (a user asked to re-run). Recorded on the run.
     trigger: str
     saved_query_id: uuid.UUID | None = None
+    # Signal-with-start uses an empty workflow seed, then supplies the real activity input via its
+    # start signal. The default preserves replay for executions started before that trigger existed.
+    skip_initial_run: bool = False
 
     @property
     def binding(self) -> WarehouseBinding:

--- a/products/warehouse_sources/backend/temporal/data_imports/person_property_backfill_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/person_property_backfill_job.py
@@ -7,10 +7,11 @@ source on it, so mapping several properties from one table runs a single backfil
 an imported schema's or a materialized view's — the read is the same either way.
 
 Started from the customer_analytics facade (auto on mapping create/enable, or a manual "backfill"
-button) with a per-``{team, binding}`` workflow id so concurrent triggers for the same table coalesce.
-Runs on the DATA_WAREHOUSE_METADATA_TASK_QUEUE alongside the incremental sync so post-sync processing
-never competes with the sync workers. The snapshot diff still skips unchanged values, so a re-run is
-cheap and idempotent.
+button) with a per-``{team, binding}`` workflow id. Concurrent triggers replace one pending request,
+so an in-flight run is followed by a run that observes the latest committed mapping. Runs on the
+DATA_WAREHOUSE_METADATA_TASK_QUEUE alongside the incremental sync so post-sync processing never
+competes with the sync workers. The snapshot diff still skips unchanged values, so a re-run is cheap
+and idempotent.
 """
 
 import json
@@ -34,6 +35,7 @@ from products.warehouse_sources.backend.temporal.data_imports.external_product_h
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.person_property_sync import (
     record_completed_runs,
     record_failed_runs,
+    record_started_runs,
     run_person_property_backfill,
 )
 
@@ -68,6 +70,13 @@ async def backfill_warehouse_person_properties_activity(inputs: PersonPropertyBa
     start = time.monotonic()
     started_at = datetime.now(UTC).isoformat()
     binding = inputs.binding
+    await record_started_runs(
+        team_id=inputs.team_id,
+        binding=binding,
+        job_id=None,
+        trigger=inputs.trigger,
+        started_at=started_at,
+    )
     try:
         async with Heartbeater():
             result = await run_person_property_backfill(team_id=inputs.team_id, binding=binding, trigger=inputs.trigger)
@@ -121,6 +130,19 @@ async def backfill_warehouse_person_properties_activity(inputs: PersonPropertyBa
 
 @workflow.defn(name="backfill-warehouse-person-properties")
 class BackfillWarehousePersonPropertiesWorkflow(PostHogWorkflow):
+    @workflow.init
+    def __init__(self, inputs: PersonPropertyBackfillActivityInputs) -> None:
+        # Old executions were started directly with their activity input. Keeping that as the default
+        # initial request makes their histories replay unchanged after signal-with-start is deployed.
+        self._pending_inputs: PersonPropertyBackfillActivityInputs | None = None if inputs.skip_initial_run else inputs
+
+    @workflow.signal
+    async def request_backfill(self, inputs: PersonPropertyBackfillActivityInputs) -> None:
+        # A binding backfill always resolves source mappings from the database when its activity runs.
+        # Only the latest pending request is needed; replacing it coalesces bursts without losing the
+        # revision that must run after the current activity.
+        self._pending_inputs = dataclasses.replace(inputs, skip_initial_run=False)
+
     @staticmethod
     def parse_inputs(inputs: list[str]) -> PersonPropertyBackfillActivityInputs:
         loaded = json.loads(inputs[0])
@@ -128,14 +150,25 @@ class BackfillWarehousePersonPropertiesWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, inputs: PersonPropertyBackfillActivityInputs) -> None:
-        await workflow.execute_activity(
-            backfill_warehouse_person_properties_activity,
-            inputs,
-            start_to_close_timeout=timedelta(hours=6),
-            heartbeat_timeout=timedelta(minutes=5),
-            # A one-off full-table read: don't silently re-scan the whole table on a transient error.
-            retry_policy=RetryPolicy(maximum_attempts=1),
-        )
+        while True:
+            await workflow.wait_condition(lambda: self._pending_inputs is not None)
+            activity_inputs = self._pending_inputs
+            self._pending_inputs = None
+            assert activity_inputs is not None
+            await workflow.execute_activity(
+                backfill_warehouse_person_properties_activity,
+                activity_inputs,
+                start_to_close_timeout=timedelta(hours=6),
+                heartbeat_timeout=timedelta(minutes=5),
+                # A one-off full-table read: don't silently re-scan the whole table on a transient error.
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+
+            # Drain signal handlers and re-check before completing. A signal racing the completion
+            # command makes Temporal replay this task; a signal after completion starts a fresh run.
+            await workflow.wait_condition(workflow.all_handlers_finished)
+            if self._pending_inputs is None:
+                return
 
 
 PERSON_PROPERTY_BACKFILL_WORKFLOWS = [BackfillWarehousePersonPropertiesWorkflow]

--- a/products/warehouse_sources/backend/temporal/data_imports/person_property_backfill_job_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/person_property_backfill_job_test.py
@@ -1,4 +1,6 @@
 import uuid
+import asyncio
+import dataclasses
 
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -31,6 +33,7 @@ class TestBackfillWarehousePersonPropertiesActivity:
         result = SyncResult(sources=1, rows_read=5, changed=3, existing=0, produced=3, skipped_missing_person=1)
         with (
             patch.object(bj, "run_person_property_backfill", AsyncMock(return_value=result)),
+            patch.object(bj, "record_started_runs", AsyncMock()) as mock_started,
             patch.object(bj, "record_completed_runs", AsyncMock()) as mock_record,
         ):
             returned = await ActivityEnvironment().run(
@@ -46,6 +49,7 @@ class TestBackfillWarehousePersonPropertiesActivity:
             "skipped_missing_person": 1,
             "per_source": [],
         }
+        mock_started.assert_awaited_once()
         mock_record.assert_awaited_once()
 
         def stage_value(stage: str) -> float:
@@ -78,3 +82,36 @@ class TestBackfillWarehousePersonPropertiesActivity:
         assert stage_value("existing") == 10
         assert stage_value("changed") == 0
         assert stage_value("produced") == 0
+
+
+@pytest.mark.asyncio
+async def test_in_flight_backfill_runs_one_follow_up_with_the_latest_request() -> None:
+    first = _inputs(900003)
+    middle = dataclasses.replace(first, schema_name="users-v2")
+    latest = dataclasses.replace(first, schema_name="users-v3")
+    seed = dataclasses.replace(first, skip_initial_run=True)
+    runner = bj.BackfillWarehousePersonPropertiesWorkflow(seed)
+    await runner.request_backfill(first)
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    observed: list[PersonPropertyBackfillActivityInputs] = []
+
+    async def execute_activity(_activity, inputs, **_kwargs):
+        observed.append(inputs)
+        if len(observed) == 1:
+            first_started.set()
+            await release_first.wait()
+
+    with (
+        patch.object(bj.workflow, "execute_activity", AsyncMock(side_effect=execute_activity)),
+        patch.object(bj.workflow, "wait_condition", AsyncMock()),
+    ):
+        running = asyncio.create_task(runner.run(seed))
+        await first_started.wait()
+        await runner.request_backfill(middle)
+        await runner.request_backfill(latest)
+        release_first.set()
+        await running
+
+    assert observed == [first, latest]

--- a/products/warehouse_sources/backend/temporal/data_imports/person_property_triggers.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/person_property_triggers.py
@@ -9,6 +9,7 @@ Every entry point opens a Temporal client, so this module must stay off the ``dj
 it's reached only from the facade on a request, never from an AppConfig or model.
 """
 
+import dataclasses
 from uuid import UUID
 
 from django.conf import settings
@@ -16,8 +17,7 @@ from django.conf import settings
 import structlog
 from asgiref.sync import async_to_sync
 from temporalio.client import Client
-from temporalio.common import WorkflowIDReusePolicy
-from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.client import async_connect, sync_connect
@@ -33,6 +33,7 @@ from products.warehouse_sources.backend.temporal.data_imports.external_product_h
 logger = structlog.get_logger(__name__)
 
 BACKFILL_WORKFLOW_NAME = "backfill-warehouse-person-properties"
+BACKFILL_SIGNAL_NAME = "request_backfill"
 
 # The canonical warehouse schema reload/resync endpoints reject a manual sync with this message when
 # the team's syncing is paused (monthly limit reached); reused so person-property "sync now" matches.
@@ -89,19 +90,17 @@ def trigger_schema_sync(*, team_id: int, schema_id: str) -> None:
     log.info("Triggered warehouse schema sync for person-property sync-now")
 
 
-def start_person_property_backfill(*, team_id: int, binding: WarehouseBinding, trigger: str) -> bool:
-    """Start the per-table backfill workflow. One workflow per ``{team, binding}`` (id-keyed), so
-    concurrent triggers for the same table coalesce: returns False (does not raise) when one is
-    already running. Raises ``WarehouseBindingMissingError`` when the warehouse object no longer
-    exists, kept distinct from the coalesced False so the caller can fail the run rows it created
-    rather than reporting a coalesced run for a table that is gone."""
+def start_person_property_backfill(*, team_id: int, binding: WarehouseBinding, trigger: str) -> None:
+    """Request a per-table backfill. One workflow per ``{team, binding}`` serializes runs; a request
+    received while its activity is in flight replaces the pending request and guarantees a latest-state
+    follow-up. Raises ``WarehouseBindingMissingError`` when the warehouse object no longer exists."""
     log = logger.bind(team_id=team_id, binding_kind=binding.kind, binding_id=binding.id, trigger=trigger)
     inputs = _backfill_inputs(team_id, binding, trigger)
     if inputs is None:
         log.warning("person-property backfill not started: warehouse object no longer exists")
         raise WarehouseBindingMissingError
     workflow_id = f"{BACKFILL_WORKFLOW_NAME}-{team_id}-{binding.id}"
-    return _start_backfill_workflow(inputs, workflow_id)
+    _start_backfill_workflow(inputs, workflow_id)
 
 
 def _backfill_inputs(
@@ -177,25 +176,23 @@ def trigger_saved_query_materialization(*, team_id: int, saved_query_id: str) ->
 
 
 @async_to_sync
-async def _start_backfill_workflow(inputs: PersonPropertyBackfillActivityInputs, workflow_id: str) -> bool:
+async def _start_backfill_workflow(inputs: PersonPropertyBackfillActivityInputs, workflow_id: str) -> None:
     log = logger.bind(workflow_id=workflow_id, **inputs.properties_to_log)
     try:
         client: Client = await async_connect()
-        # ALLOW_DUPLICATE so a manual re-backfill is allowed after a prior run closes; a run currently
-        # in flight for the same id raises WorkflowAlreadyStartedError, which we swallow to coalesce.
+        # Atomic signal-with-start: route to the binding's current execution, or start a fresh one after
+        # the prior execution closes. The empty seed avoids running the same request twice on a new run.
         await client.start_workflow(
             BACKFILL_WORKFLOW_NAME,
-            inputs,
+            dataclasses.replace(inputs, skip_initial_run=True),
             id=workflow_id,
             task_queue=settings.DATA_WAREHOUSE_METADATA_TASK_QUEUE,
+            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
             id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            start_signal=BACKFILL_SIGNAL_NAME,
+            start_signal_args=[inputs],
         )
-        log.info("Started person-property backfill workflow")
-        return True
-    except WorkflowAlreadyStartedError:
-        # Expected: a backfill for this table is already in flight, so this trigger coalesces into it.
-        log.info("person-property backfill already running for binding, coalescing")
-        return False
+        log.info("Requested person-property backfill workflow")
     except Exception as e:
         # A real failure to reach Temporal — capture it; the caller (facade) treats a raise as
         # "start failed" and the placeholder running row is reconciled to failed by the next run.

--- a/products/warehouse_sources/backend/temporal/data_imports/person_property_triggers_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/person_property_triggers_test.py
@@ -1,5 +1,9 @@
+import dataclasses
+
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
 from products.warehouse_sources.backend.temporal.data_imports import person_property_triggers
 from products.warehouse_sources.backend.temporal.data_imports.person_property_triggers import (
@@ -27,3 +31,30 @@ def test_trigger_schema_sync_blocked_when_paused(_paused, mock_connect):
 def test_trigger_schema_sync_triggers_when_not_paused(_paused, _connect, mock_trigger_schedule):
     trigger_schema_sync(team_id=1, schema_id="abc")
     mock_trigger_schedule.assert_called_once()
+
+
+def test_backfill_request_uses_signal_with_start_for_the_binding_workflow():
+    inputs = person_property_triggers.PersonPropertyBackfillActivityInputs(
+        team_id=1,
+        schema_id=None,
+        saved_query_id=None,
+        source_type="Stripe",
+        schema_name="users",
+        trigger="backfill",
+    )
+    client = MagicMock()
+    client.start_workflow = AsyncMock()
+
+    with patch.object(person_property_triggers, "async_connect", AsyncMock(return_value=client)):
+        person_property_triggers._start_backfill_workflow(inputs, "backfill-1-schema")
+
+    client.start_workflow.assert_awaited_once_with(
+        person_property_triggers.BACKFILL_WORKFLOW_NAME,
+        dataclasses.replace(inputs, skip_initial_run=True),
+        id="backfill-1-schema",
+        task_queue=person_property_triggers.settings.DATA_WAREHOUSE_METADATA_TASK_QUEUE,
+        id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+        start_signal=person_property_triggers.BACKFILL_SIGNAL_NAME,
+        start_signal_args=[inputs],
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_sync.py
@@ -38,13 +38,14 @@ import pyarrow.parquet as pq
 from posthog.exceptions_capture import capture_exception
 from posthog.kafka_client.routing import producer_scope
 from posthog.kafka_client.topics import KAFKA_WAREHOUSE_PERSON_PROPERTY_UPDATES
-from posthog.models import PropertyDefinition, Team
+from posthog.models import Team
 from posthog.models.group.util import get_groups_by_identifiers
 from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.person.util import get_persons_mapped_by_distinct_id
 from posthog.sync import database_sync_to_async
 
 from products.data_warehouse.backend.facade.api import aget_s3_client
+from products.warehouse_sources.backend.facade.person_property_provenance import stamp_person_property_provenance
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.external_product_hooks import (
     PersonPropertySyncRunRecord,
@@ -408,34 +409,18 @@ def _stamp_provenance(
     team_id: int, binding: WarehouseBinding, source: PersonPropertySyncSource, property_names: list[str]
 ) -> None:
     # UPDATE-only on purpose: definitions are created by ingestion's propdef upsert when the $set /
-    # $groupidentify lands, so a brand-new property may not have a row yet on the first sync — the next
-    # sync's stamp catches it. Never inserting means this can't race that upsert.
-    origin: dict[str, str] = {
-        "source_id": str(source.definition_id),
-        "custom_property_source_id": str(source.source_id),
-        "binding_kind": binding.kind,
-        "binding_id": binding.id,
-    }
-    # Kept for schema bindings: rows stamped before views were supported carry this key, so dropping
-    # it would leave two stamps of the same schema describing it differently.
-    if not binding.is_saved_query:
-        origin["schema_id"] = binding.id
-    query = PropertyDefinition.objects.filter(team_id=team_id)
-    if source.target == _GROUP_TARGET:
-        # Group propdefs are keyed per group type, so the index predicate is mandatory.
-        query = query.filter(type=PropertyDefinition.Type.GROUP, group_type_index=source.group_type_index)
-    else:
-        query = query.filter(type=PropertyDefinition.Type.PERSON)
-
-    # Properties given a description carry it inside their provenance, so stamp those one at a time;
-    # the rest share the base origin and go in a single bulk update.
-    descriptions = source.property_descriptions or {}
-    described = [name for name in property_names if descriptions.get(name)]
-    plain = [name for name in property_names if not descriptions.get(name)]
-    if plain:
-        query.filter(name__in=plain).update(warehouse_origin=origin)
-    for name in described:
-        query.filter(name=name).update(warehouse_origin={**origin, "description": descriptions[name]})
+    # $groupidentify lands, so a brand-new property may not have a row yet on the first sync. Keeping
+    # the write in the warehouse facade also lets a description-only API update reuse the same owner.
+    stamp_person_property_provenance(
+        team_id=team_id,
+        binding=binding,
+        source_id=str(source.source_id),
+        definition_id=str(source.definition_id),
+        target=source.target,
+        group_type_index=source.group_type_index,
+        property_names=property_names,
+        property_descriptions=source.property_descriptions or {},
+    )
 
 
 # --- orchestration -----------------------------------------------------------------------

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19908,7 +19908,7 @@ export namespace Schemas {
       source_column?: string | null;
       /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
       column_property_map?: unknown;
-      /** Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column. Create-only. */
+      /** Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column. */
       column_descriptions?: unknown;
       /**
          * Column whose value identifies the target: an account's external_id for account sources, the person's distinct_id for person sources, or the group key for group sources.
@@ -20040,8 +20040,8 @@ export namespace Schemas {
     }
 
     /**
-     * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
-     * they are intentionally absent — only these reach the facade's update.
+     * Writable fields for updating a source. Binding and definition fields are create-only, so they
+     * are intentionally absent — only these reach the facade's update.
      */
     export interface CustomPropertySourceUpdate {
       /**
@@ -20054,6 +20054,10 @@ export namespace Schemas {
          * @maxLength 400
          */
       key_column?: string;
+      /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
+      column_property_map?: unknown;
+      /** Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column. */
+      column_descriptions?: unknown;
       /** Whether the source syncs; re-enabling it resets the failure count. */
       is_enabled?: boolean;
     }
@@ -20076,13 +20080,13 @@ export namespace Schemas {
      * Response of the person/group-property sync/backfill trigger actions.
      */
     export interface CustomPropertySyncTriggerResponse {
-      /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill for this table was already in flight, so this was a no-op).
+      /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill was in flight and a latest-state follow-up was queued).
        *
        * * `triggered` - triggered
        * * `started` - started
        * * `already_running` - already_running */
       status: CustomPropertySyncTriggerResponseStatusEnum;
-      /** Backfill only: true when a backfill for this table was already running and this call coalesced. */
+      /** Backfill only: true when a run was already in flight and this call queued its follow-up. */
       already_running?: boolean;
     }
 
@@ -58856,8 +58860,8 @@ export namespace Schemas {
     }
 
     /**
-     * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
-     * they are intentionally absent — only these reach the facade's update.
+     * Writable fields for updating a source. Binding and definition fields are create-only, so they
+     * are intentionally absent — only these reach the facade's update.
      */
     export interface PatchedCustomPropertySourceUpdate {
       /**
@@ -58870,6 +58874,10 @@ export namespace Schemas {
          * @maxLength 400
          */
       key_column?: string;
+      /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
+      column_property_map?: unknown;
+      /** Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column. */
+      column_descriptions?: unknown;
       /** Whether the source syncs; re-enabling it resets the failure count. */
       is_enabled?: boolean;
     }

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -783,7 +783,7 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             .unknown()
             .optional()
             .describe(
-                "Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column. Create-only."
+                "Person and group sources only: {warehouse_column: description} giving each mapped column a human-facing description, seeded from the warehouse column's information_schema description. Optional per column."
             ),
         key_column: zod
             .string()
@@ -836,13 +836,25 @@ export const CustomPropertySourcesPartialUpdateBody = /* @__PURE__ */ zod
             .max(customPropertySourcesPartialUpdateBodyKeyColumnMax)
             .optional()
             .describe("Column in the view whose value matches an account's external_id."),
+        column_property_map: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group.'
+            ),
+        column_descriptions: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person and group sources only: {warehouse_column: description} for mapped columns. Optional per column.'
+            ),
         is_enabled: zod
             .boolean()
             .optional()
             .describe('Whether the source syncs; re-enabling it resets the failure count.'),
     })
     .describe(
-        "Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so\nthey are intentionally absent — only these reach the facade's update."
+        "Writable fields for updating a source. Binding and definition fields are create-only, so they\nare intentionally absent — only these reach the facade's update."
     )
 
 export const CustomPropertySourcesDestroyParams = /* @__PURE__ */ zod.object({
@@ -856,8 +868,8 @@ export const CustomPropertySourcesDestroyParams = /* @__PURE__ */ zod.object({
 
 /**
  * Person and group sources only: start a backfill that reads the whole warehouse table and
- * populates person or group properties for historical rows. Coalesces if one is already running
- * for the table.
+ * populates person or group properties for historical rows. If one is already running for the
+ * table, queue a follow-up that observes the latest mapping.
  */
 export const CustomPropertySourcesBackfillParams = /* @__PURE__ */ zod.object({
     id: zod.string(),

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -974,6 +974,12 @@ const customPropertySourcesPartialUpdate = (): ToolBase<
         if (params.key_column !== undefined) {
             body['key_column'] = params.key_column
         }
+        if (params.column_property_map !== undefined) {
+            body['column_property_map'] = params.column_property_map
+        }
+        if (params.column_descriptions !== undefined) {
+            body['column_descriptions'] = params.column_descriptions
+        }
         if (params.is_enabled !== undefined) {
             body['is_enabled'] = params.is_enabled
         }


### PR DESCRIPTION
## Problem

Warehouse-backed person and group property sources accept `column_property_map` and `column_descriptions` on create, but the update API does not accept those fields. Correcting a mapping therefore requires deleting and recreating the source and changes its identity.

Close PostHog/posthog#88751

## Changes

- `PATCH` accepts `column_property_map` and `column_descriptions` for existing person and group property sources, with the same validation and normalization as create
- Mapping updates preserve source identity and save under the existing row lock
- An enabled source requests the existing binding-level backfill through signal-with-start when its effective mapping changes
- Description-only updates, including explicit clearing, update existing `PropertyDefinition` warehouse provenance without a value backfill
- Profile sources stay on the warehouse path and account sources stay on the account path
- Account-source `GET`/`PATCH` round trips accept null profile-only fields and continue to reject non-null profile mapping values
- Effective no-op updates do not schedule unnecessary work
- Generated frontend and MCP API clients expose the mutable request fields and the existing backfill response

## How did you test this code?

- Customer Analytics facade tests: `51 passed`
- Custom property source HTTP viewset tests: `10 passed`
- Person-property backfill workflow/trigger tests: `6 passed`
- Shared provenance tests: `4 passed`
- Ruff lint and format passed for all 12 changed Python files
- Targeted mypy passed for all 12 changed Python files; repo-wide mypy reached all 19,188 files and reported only three pre-existing errors outside this PR
- Repo-wide `ty check` passed
- `hogli ci:preflight --strict --against upstream/master` passed
- OpenAPI and generated client regeneration completed; MCP and full frontend `tsgo --noEmit` checks passed
- `git diff --check` passed, and the current branch merge-tree against upstream/master is conflict-free

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No separate docs update. Serializer help text and generated API clients describe both mapping fields as mutable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change in [the agent session](https://chatgpt.com/codex/tasks/01a03b61-1361-79f1-89de-8cf9b92aa688). No repository-provided skill was invoked.

The change uses the existing facade and binding-level backfill workflow. It does not define cross-workflow ordering, retries after activity failure, property-definition creation, provenance ownership, UI editing, or MCP instructions.
