### PR TITLE
chore(ci): install protoc for the MCP CI rust build

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -97,6 +97,7 @@ jobs:
                         - 'posthog/user_scripts/latest_user_defined_function.xml'
                         # Composite actions used by the workflow
                         - '.github/actions/commit-snapshots/**'
+                        - '.github/actions/setup-protoc/**'
                         # hogli db setup (db:restore-test-db). Scoped to the
                         # modules that command actually imports — framework,
                         # manifest, boot modules, db_schema — so unrelated hogli
@@ -423,6 +424,11 @@ jobs:
 
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
+
+            # feature-flags depends on usage-ingestion-proto, whose build script
+            # compiles .proto files and needs protoc on PATH.
+            - name: Install protoc
+              uses: ./.github/actions/setup-protoc
 
             - name: Build Rust flags service
               working-directory: rust


### PR DESCRIPTION
## Problem

Anyone whose PR touches MCP or the Python backend hits a red **MCP CI / Integration Tests** job that has nothing to do with their change. The job dies before any test runs, so there is no signal about whether their code works — and the same failure blocks the Trunk merge queue.

The job builds the Rust flags service to run the integration suite against it. `feature-flags` depends on `usage-ingestion-proto`, whose build script compiles `.proto` files and needs `protoc` on `PATH`. MCP CI never installed it:

```
error: failed to run custom build command for `usage-ingestion-proto v0.1.0`
Error: Could not find `protoc`. If `protoc` is installed, try setting the
`PROTOC` environment variable to the path of the `protoc` binary.
```

Every other workflow that builds this crate already installs `protoc` — `ci-rust.yml` via the `setup-protoc` composite action, `ci-rust-flags-integration.yml` via apt. MCP CI was the one that was missed when the proto dependency was added.

## Changes

- MCP CI's Integration Tests job now gets past the Rust build, so it reports on the tests instead of failing during setup. It installs `protoc` with the existing `.github/actions/setup-protoc` action, which is cached and pinned to 28.3.
- Mechanical: `.github/actions/setup-protoc/**` joins the workflow's paths filter, next to the composite action already listed there, so editing the action retriggers this workflow.

