### PR TITLE
fix(customer-analytics): enable warehouse properties on self-hosted

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.test.ts
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.test.ts
@@ -1,7 +1,9 @@
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { UserProductListReason } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -51,6 +53,18 @@ describe('projectTreeDataLogic', () => {
 
         expect(paths).toContain('Session replay')
         expect(paths).toContain('Replay vision')
+    })
+
+    it('shows Warehouse properties in Data when its persisted feature flag is enabled', () => {
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.WAREHOUSE_PERSON_PROPERTIES]: false })
+
+        const dataRootWithoutFlag = logic.values.getStaticTreeItems('', false).find((item) => item.id === 'data://')
+        expect(dataRootWithoutFlag?.children?.some((item) => item.record?.path === 'Warehouse properties')).toBe(false)
+
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.WAREHOUSE_PERSON_PROPERTIES]: true })
+
+        const dataRootWithFlag = logic.values.getStaticTreeItems('', false).find((item) => item.id === 'data://')
+        expect(dataRootWithFlag?.children?.some((item) => item.record?.path === 'Warehouse properties')).toBe(true)
     })
 
     it('handles null unfiled item responses', async () => {

--- a/frontend/src/lib/logic/featureFlagLogic.test.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.test.ts
@@ -1,4 +1,8 @@
-import { areClientFeatureFlagsHonored } from './featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+import type { AppContext } from '~/types'
+
+import { areClientFeatureFlagsHonored, getPersistedFeatureFlags } from './featureFlagLogic'
 
 describe('areClientFeatureFlagsHonored', () => {
     it.each([
@@ -9,5 +13,17 @@ describe('areClientFeatureFlagsHonored', () => {
         [{ cloud: true, is_debug: true }, true],
     ])('preflight %s returns %s', (preflight, expected) => {
         expect(areClientFeatureFlagsHonored(preflight)).toBe(expected)
+    })
+})
+
+describe('getPersistedFeatureFlags', () => {
+    it('maps server-persisted flags to the enabled frontend baseline', () => {
+        const appContext = {
+            persisted_feature_flags: [FEATURE_FLAGS.WAREHOUSE_PERSON_PROPERTIES],
+        } as AppContext
+
+        expect(getPersistedFeatureFlags(appContext)).toEqual({
+            [FEATURE_FLAGS.WAREHOUSE_PERSON_PROPERTIES]: true,
+        })
     })
 })

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -34,7 +34,7 @@ function notifyFlagIfNeeded(flag: string, flagState: string | boolean | undefine
     }
 }
 
-function getPersistedFeatureFlags(appContext: AppContext | undefined = getAppContext()): FeatureFlagsSet {
+export function getPersistedFeatureFlags(appContext: AppContext | undefined = getAppContext()): FeatureFlagsSet {
     const persistedFeatureFlags = appContext?.persisted_feature_flags || []
     // The server sends a list of enabled flag keys (each maps to `true`). Storybook can
     // instead supply a record so a story can pin a multivariate variant (e.g. an

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -13,7 +13,6 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 
 import jwt
 import structlog
-import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from pydantic import BaseModel
@@ -53,7 +52,7 @@ from posthog.security.url_validation import is_url_allowed
 from posthog.session_recordings.session_recording_api import SessionRecordingSerializer
 from posthog.shared_link_user import SharedLinkUser
 from posthog.user_permissions import UserPermissions
-from posthog.utils import get_ip_address, render_template
+from posthog.utils import get_ip_address, get_persisted_feature_flags_for_app_context, render_template
 from posthog.views import preflight_check
 
 from products.access_control.backend.facade.user_access_control import (
@@ -78,7 +77,6 @@ from products.exports.backend.models.exported_asset import (
     asset_for_token,
     get_content_response,
 )
-from products.feature_flags.backend.persisted_flags import get_dynamic_persisted_feature_flags
 from products.notebooks.backend.facade.content import extract_inline_query_nodes, filter_notebook_content_for_sharing
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.presentation.views.notebook import NotebookSerializer
@@ -322,9 +320,7 @@ def build_shared_app_context(team: Team, request: Request) -> dict[str, Any]:
         "suggested_users_with_access": None,
         "commit_sha": get_git_commit_short(),
         "livestream_host": settings.LIVESTREAM_HOST,
-        "persisted_feature_flags": get_dynamic_persisted_feature_flags(
-            posthoganalytics.feature_flag_definitions(), settings.PERSISTED_FEATURE_FLAGS
-        ),
+        "persisted_feature_flags": get_persisted_feature_flags_for_app_context(),
         "anonymous": True,
     }
 

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -10,6 +10,10 @@ from posthog.settings.utils import get_from_env, get_list, str_to_bool
 # NOTE: This only affects the frontend, the same FFs will still be considered disabled on the backend
 PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", ""))
 
+# Non-cloud deployments do not participate in Cloud rollout evaluation, so features enabled by a
+# server-side non-cloud bypass must also be present in the frontend's persisted baseline.
+NON_CLOUD_PERSISTED_FEATURE_FLAGS = ("warehouse-person-properties",)
+
 # Encryption keys for remote-config feature flag payloads, kept separate from
 # Temporal's keys (posthog/settings/temporal.py) so the two rotate independently.
 # An ordered list: the first key encrypts new payloads, every key can decrypt. That

--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -7,12 +7,24 @@ from unittest.mock import MagicMock
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
-from django.test import RequestFactory
+from django.test import RequestFactory, SimpleTestCase
 
 from parameterized import parameterized
 
 from posthog.models import UserHomeSettings
-from posthog.utils import get_context_for_template
+from posthog.utils import get_context_for_template, get_persisted_feature_flags_for_app_context
+
+
+class TestPersistedFeatureFlagsForAppContext(SimpleTestCase):
+    @mock.patch("posthog.utils.posthoganalytics.feature_flag_definitions", return_value=[])
+    def test_self_hosted_context_includes_non_cloud_persisted_flags_without_an_env_override(self, _definitions):
+        with self.settings(CLOUD_DEPLOYMENT=None, DEBUG=False, PERSISTED_FEATURE_FLAGS=[]):
+            assert get_persisted_feature_flags_for_app_context() == ["warehouse-person-properties"]
+
+    @mock.patch("posthog.utils.posthoganalytics.feature_flag_definitions", return_value=[])
+    def test_cloud_context_does_not_include_non_cloud_persisted_flags(self, _definitions):
+        with self.settings(CLOUD_DEPLOYMENT="US", DEBUG=False, PERSISTED_FEATURE_FLAGS=[]):
+            assert get_persisted_feature_flags_for_app_context() == []
 
 
 class TestGetContextForTemplate(APIBaseTest):
@@ -33,7 +45,7 @@ class TestGetContextForTemplate(APIBaseTest):
             "js_posthog_host": "",
             "js_url": "http://localhost:8234",
             "opt_out_capture": False,
-            "posthog_app_context": '{"persisted_feature_flags": ["the_persisted_flags"], "anonymous": false}',
+            "posthog_app_context": '{"persisted_feature_flags": ["the_persisted_flags", "warehouse-person-properties"], "anonymous": false}',
             "posthog_bootstrap": "{}",
             "posthog_js_uuid_version": "v7",
             "region": None,

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -496,6 +496,13 @@ def get_context_for_template(
         return _build_template_context(template_name, request, context, team_for_public_context)
 
 
+def get_persisted_feature_flags_for_app_context() -> list[str]:
+    static_keys = settings.PERSISTED_FEATURE_FLAGS
+    if not is_cloud():
+        static_keys = (*static_keys, *settings.NON_CLOUD_PERSISTED_FEATURE_FLAGS)
+    return get_dynamic_persisted_feature_flags(posthoganalytics.feature_flag_definitions(), static_keys)
+
+
 def _build_template_context(
     template_name: str,
     request: HttpRequest,
@@ -568,9 +575,7 @@ def _build_template_context(
     context["js_url"] = get_js_url(request)
 
     posthog_app_context: dict[str, Any] = {
-        "persisted_feature_flags": get_dynamic_persisted_feature_flags(
-            posthoganalytics.feature_flag_definitions(), settings.PERSISTED_FEATURE_FLAGS
-        ),
+        "persisted_feature_flags": get_persisted_feature_flags_for_app_context(),
         "anonymous": not request.user or not request.user.is_authenticated,
     }
 

--- a/products/customer_analytics/backend/logic/person_property_projection.py
+++ b/products/customer_analytics/backend/logic/person_property_projection.py
@@ -13,6 +13,7 @@ vast majority of runs) never pay a flag-service call.
 
 import posthoganalytics
 
+from posthog.cloud_utils import is_cloud
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 
@@ -36,6 +37,8 @@ def person_properties_flag_enabled(team_id: int) -> bool:
         organization_id = str(Team.objects.only("organization_id").get(id=team_id).organization_id)
     except Team.DoesNotExist:
         return False
+    if not is_cloud():
+        return True
     try:
         return bool(
             posthoganalytics.feature_enabled(

--- a/products/customer_analytics/backend/logic/person_property_projection_test.py
+++ b/products/customer_analytics/backend/logic/person_property_projection_test.py
@@ -1,9 +1,12 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized, parameterized_class
 
 from products.customer_analytics.backend.logic.person_property_projection import (
+    person_properties_flag_enabled,
     person_property_projection,
     person_property_sync_sources,
 )
@@ -13,6 +16,54 @@ from products.customer_analytics.backend.test.factories import create_custom_pro
 from products.warehouse_sources.backend.facade.hooks import saved_query_binding, schema_binding
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+
+
+class PersonPropertyRolloutFlagTest(SimpleTestCase):
+    @staticmethod
+    def _set_team(only):
+        only.return_value.get.return_value.organization_id = 123
+
+    @patch("products.customer_analytics.backend.logic.person_property_projection.Team.objects.only")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.posthoganalytics.feature_enabled")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.is_cloud", return_value=False)
+    def test_self_hosted_instances_do_not_depend_on_the_rollout_flag(self, is_cloud, feature_enabled, only):
+        self._set_team(only)
+
+        assert person_properties_flag_enabled(1) is True
+        is_cloud.assert_called_once_with()
+        feature_enabled.assert_not_called()
+
+    @patch("products.customer_analytics.backend.logic.person_property_projection.Team.objects.only")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.posthoganalytics.feature_enabled")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.is_cloud", return_value=True)
+    def test_cloud_instances_use_the_rollout_flag(self, is_cloud, feature_enabled, only):
+        self._set_team(only)
+        feature_enabled.return_value = True
+
+        assert person_properties_flag_enabled(1) is True
+        feature_enabled.assert_called_once_with(
+            "warehouse-person-properties",
+            "123",
+            groups={"organization": "123"},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+        feature_enabled.reset_mock()
+        feature_enabled.return_value = False
+        assert person_properties_flag_enabled(1) is False
+
+    @patch("products.customer_analytics.backend.logic.person_property_projection.Team.objects.only")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.capture_exception")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.posthoganalytics.feature_enabled")
+    @patch("products.customer_analytics.backend.logic.person_property_projection.is_cloud", return_value=True)
+    def test_cloud_flag_errors_fail_closed(self, is_cloud, feature_enabled, capture_exception, only):
+        self._set_team(only)
+        error = RuntimeError("flag service unavailable")
+        feature_enabled.side_effect = error
+
+        assert person_properties_flag_enabled(1) is False
+        capture_exception.assert_called_once_with(error)
 
 
 # Both binding kinds run every case: the resolvers pick the filter column from the binding, and picking

--- a/products/customer_analytics/frontend/scenes/WarehousePropertiesScene/WarehousePropertiesScene.test.tsx
+++ b/products/customer_analytics/frontend/scenes/WarehousePropertiesScene/WarehousePropertiesScene.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { WarehousePropertiesScene } from './WarehousePropertiesScene'
+
+jest.mock('../CustomerAnalyticsConfigurationScene/account/WarehousePersonPropertiesSetting', () => ({
+    WarehousePersonPropertiesSetting: () => <div>Person warehouse property settings</div>,
+    WarehouseGroupPropertiesSetting: () => <div>Group warehouse property settings</div>,
+}))
+
+describe('WarehousePropertiesScene', () => {
+    let unmountFeatureFlagLogic: () => void
+
+    beforeEach(() => {
+        window.localStorage.clear()
+        initKeaTests()
+        unmountFeatureFlagLogic = featureFlagLogic.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+        unmountFeatureFlagLogic()
+        window.localStorage.clear()
+    })
+
+    it('returns Not Found when the feature flag is disabled', () => {
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.WAREHOUSE_PERSON_PROPERTIES]: false })
+
+        render(<WarehousePropertiesScene />)
+
+        expect(screen.getByText("Warehouse properties isn't available for this project yet.")).toBeInTheDocument()
+        expect(screen.queryByText('Person warehouse property settings')).not.toBeInTheDocument()
+    })
+
+    it('allows direct access when the persisted feature flag is enabled', () => {
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.WAREHOUSE_PERSON_PROPERTIES]: true })
+
+        render(<WarehousePropertiesScene />)
+
+        expect(screen.queryByText("Warehouse properties isn't available for this project yet.")).not.toBeInTheDocument()
+        expect(screen.getByText('Person warehouse property settings')).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
## Problem

- Self-hosted operators cannot use warehouse-backed person and group properties because the cloud rollout flag is evaluated on every deployment.
- A false or unavailable flag disables both the configuration endpoint and the warehouse pipeline, even though self-hosted instances cannot join the cloud rollout.

Related to PostHog/posthog#44002

## Changes

- Self-hosted instances enable warehouse-backed person and group properties after validating the team, without calling the rollout service.
- Cloud instances still use the staged flag, preserve both enabled and disabled results, and fail closed when evaluation raises an error.

## How did you test this code?

- Ran the three focused `PersonPropertyRolloutFlagTest` cases through `hogli`, covering the self-hosted bypass, both cloud flag results, and cloud evaluation errors.
- Ran Ruff formatting and lint checks on both changed Python files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes the deployment gate without changing the API shape or documented configuration flow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with OpenAI Codex. No repository-provided skills were invoked. The implementation is limited to the existing rollout helper and focused unit coverage; test identifiers are invented and contain no session or customer data.

