### PR TITLE
perf(ci): skip static compression in e2e

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -738,14 +738,11 @@ jobs:
                   pnpm --filter=@posthog/frontend build:products
                   pnpm --filter=@posthog/frontend build
 
-            - name: Collect static files
+            - name: Collect static files without compression
               # The image-bitmap-data-url-worker-*.js.map files are already mirrored
               # into frontend/dist/ by copyRRWebWorkerFiles() in frontend/build.mjs
               # (see common/esbuilder/utils.mjs), which runs as part of the
               # `pnpm --filter=@posthog/frontend build` step above. No extra cp needed.
-              #
-              # Chromium fetches static over loopback here, so the pre-compressed .br
-              # and .gz variants are never read and only cost collectstatic time.
               env:
                   STATIC_PRECOMPRESS: '0'
               run: python manage.py collectstatic --noinput

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -743,6 +743,11 @@ jobs:
               # into frontend/dist/ by copyRRWebWorkerFiles() in frontend/build.mjs
               # (see common/esbuilder/utils.mjs), which runs as part of the
               # `pnpm --filter=@posthog/frontend build` step above. No extra cp needed.
+              #
+              # Chromium fetches static over loopback here, so the pre-compressed .br
+              # and .gz variants are never read and only cost collectstatic time.
+              env:
+                  STATIC_PRECOMPRESS: '0'
               run: python manage.py collectstatic --noinput
             - name: Create test database
               shell: bash

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -446,28 +446,20 @@ if DEBUG:
     # duplicate destinations for no gain.
     STATICFILES_DIRS.append(os.path.join(BASE_DIR, "frontend/public"))
 
-# CompressedManifest: collectstatic pre-generates .br and .gz (brotli is
-# already a dependency) so WhiteNoise serves compressed bytes from disk and
-# the envoy edge — which otherwise gzips static per request (Contour's
-# default compression filter) — skips recompression since Content-Encoding
-# is already set. Same Manifest base class: hashed names unchanged.
-#
-# STATIC_PRECOMPRESS gates only what collectstatic writes. WhiteNoise probes for
-# .br and .gz on disk per request, so clearing it on a serving process does nothing;
-# only the build that ran collectstatic decides whether they exist.
+# WhiteNoise serves precompressed files when present, so this only controls collectstatic output.
 if TEST:
-    _staticfiles_backend = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    _staticfiles_storage_backend = "django.contrib.staticfiles.storage.StaticFilesStorage"
 elif get_from_env("STATIC_PRECOMPRESS", True, type_cast=str_to_bool):
-    _staticfiles_backend = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    _staticfiles_storage_backend = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 else:
-    _staticfiles_backend = "whitenoise.storage.ManifestStaticFilesStorage"
+    _staticfiles_storage_backend = "whitenoise.storage.ManifestStaticFilesStorage"
 
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        "BACKEND": _staticfiles_backend,
+        "BACKEND": _staticfiles_storage_backend,
     },
 }
 # Never emit .map.gz/.map.br: the production image deletes *.map after the

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -445,21 +445,29 @@ if DEBUG:
     # a second source for 1300+ identical assets would make collectstatic warn about
     # duplicate destinations for no gain.
     STATICFILES_DIRS.append(os.path.join(BASE_DIR, "frontend/public"))
+
+# CompressedManifest: collectstatic pre-generates .br and .gz (brotli is
+# already a dependency) so WhiteNoise serves compressed bytes from disk and
+# the envoy edge — which otherwise gzips static per request (Contour's
+# default compression filter) — skips recompression since Content-Encoding
+# is already set. Same Manifest base class: hashed names unchanged.
+#
+# STATIC_PRECOMPRESS gates only what collectstatic writes. WhiteNoise probes for
+# .br and .gz on disk per request, so clearing it on a serving process does nothing;
+# only the build that ran collectstatic decides whether they exist.
+if TEST:
+    _staticfiles_backend = "django.contrib.staticfiles.storage.StaticFilesStorage"
+elif get_from_env("STATIC_PRECOMPRESS", True, type_cast=str_to_bool):
+    _staticfiles_backend = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+else:
+    _staticfiles_backend = "whitenoise.storage.ManifestStaticFilesStorage"
+
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        # CompressedManifest: collectstatic pre-generates .br and .gz (brotli is
-        # already a dependency) so WhiteNoise serves compressed bytes from disk and
-        # the envoy edge — which otherwise gzips static per request (Contour's
-        # default compression filter) — skips recompression since Content-Encoding
-        # is already set. Same Manifest base class: hashed names unchanged.
-        "BACKEND": (
-            "django.contrib.staticfiles.storage.StaticFilesStorage"
-            if TEST
-            else "whitenoise.storage.CompressedManifestStaticFilesStorage"
-        ),
+        "BACKEND": _staticfiles_backend,
     },
 }
 # Never emit .map.gz/.map.br: the production image deletes *.map after the


### PR DESCRIPTION
## Problem

- `Collect static files` in the E2E job jumped from 25s to 120s on 13 July, inside one commit: [`ea91c3a3`](https://github.com/PostHog/posthog/commit/ea91c3a3fc21) 24s, then [`53b905b7`](https://github.com/PostHog/posthog/commit/53b905b7e230) 195s.
- `53b905b7` is [pre-compress static files at collectstatic time](https://github.com/PostHog/posthog/pull/70422). It writes a brotli and a gzip copy of every static file.
- Right for production, where the edge serves those bytes. Useless in E2E, where Chromium fetches over loopback and never asks for them.
- It stayed hidden because schema caching cut migrations by ~500s in the same window.

## Changes

- A Playwright run finishes about 100 seconds sooner.
- `STATIC_PRECOMPRESS` gates the compressing backend and defaults to on, so production is unchanged.
- Off, `staticfiles` falls back to `ManifestStaticFilesStorage`, the pre-13-July backend. Hashed names unchanged.
- The Playwright workflow sets it to `0` on that one step.

| collectstatic | |
| --- | --- |
| before 13 Jul | 25s |
| master today, fast-tier runner | 131s |
| master today, slow-tier runner | 214s |
| **this branch, fast-tier runner** | **29s** |

## How did you test this code?

- Suite green on this branch: [run 32974733458](https://github.com/PostHog/posthog/actions/runs/32974733458), `138 passed, 3 skipped`. Post-processing fell from 18,891 to 7,026, exactly the copies no longer written.
- Settings resolve both ways against a real `django.setup()`:

<details>
<summary>Backend resolution</summary>

```
DJANGO_SETTINGS_MODULE=posthog.settings                      -> whitenoise.storage.CompressedManifestStaticFilesStorage
DJANGO_SETTINGS_MODULE=posthog.settings STATIC_PRECOMPRESS=0 -> whitenoise.storage.ManifestStaticFilesStorage
```

</details>

- Not verified: the saving on a slow-tier runner. This run landed on a fast machine.
- That run used the flag under its earlier name, before review renamed it to `STATIC_PRECOMPRESS`. The backend it selects is unchanged, and both resolution paths above were re-checked after the rename.

> [!NOTE]
> That run's job total is not comparable. A dispatched branch run misses the master schema cache, so migrations replayed in full (1103s). Unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Found by bisecting the `Collect static files` step timing across master runs day by day, down to a 25-minute window on 13 July, then reading the one commit inside it.

Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`, `/writing-code-comments`.
