### PR TITLE
fix(metrics): match service names exactly in the picker scope

### DIFF
--- a/products/metrics/backend/presentation/api.py
+++ b/products/metrics/backend/presentation/api.py
@@ -410,11 +410,16 @@ class _MetricValuesParamsSerializer(serializers.Serializer):
         allow_blank=True,
         default=None,
         max_length=1024,
+        # CharField trims by default, which would strip the padding off a service whose
+        # name carries it and quietly scope the picker to a name that reports nothing.
+        trim_whitespace=False,
         help_text=(
             "Comma-separated services to narrow the list to, e.g. `service=web,worker`. "
-            "Omit for every service. Send it empty to select only series whose sender "
-            "did not set `service.name`. A service name containing a comma cannot be "
-            "selected."
+            "Omit for every service. Send it empty, and only empty, to select the series "
+            "whose sender did not set `service.name`. Names are matched exactly, so they "
+            "are neither trimmed nor unescaped: a service whose name contains a comma "
+            "cannot be selected, and one padded with spaces must be sent padded. Empty "
+            "entries are dropped, so a trailing or repeated comma is ignored."
         ),
     )
 
@@ -424,7 +429,17 @@ class _MetricValuesParamsSerializer(serializers.Serializer):
         # sending it empty scopes to the senders that set no service name.
         if value is None:
             return []
-        return [service.strip() for service in value.split(",")]
+        if value == "":
+            return [""]
+        # Empty entries are dropped rather than passed through, so `web,` scopes to
+        # `web` instead of silently widening to the unnamed senders as well. The cost
+        # is that the unnamed group can only be selected alone — an inherent limit of
+        # comma-joining values that may themselves be empty.
+        #
+        # Entries are used verbatim: `service.name` is arbitrary user data, so trimming
+        # would make a name padded with spaces impossible to select while the filter bar
+        # still shows it, which is a silently-empty picker rather than a visibly wrong one.
+        return [service for service in value.split(",") if service]
 
 
 class _MetricNameSerializer(serializers.Serializer):

--- a/products/metrics/backend/tests/test_metric_names_query_runner.py
+++ b/products/metrics/backend/tests/test_metric_names_query_runner.py
@@ -256,15 +256,27 @@ class TestMetricsValuesAPI(ClickhouseTestMixin, APIBaseTest):
         [
             # Omitting the param and sending it empty mean different things, and the
             # only thing carrying that difference over the wire is the query string.
-            ("omitted", "", {"http.duration", "jobs.processed", "orphan.metric"}),
+            ("omitted", "", {"http.duration", "jobs.processed", "orphan.metric", "padded.metric"}),
             ("one service", "&service=web", {"http.duration"}),
             ("several services", "&service=web,worker", {"http.duration", "jobs.processed"}),
             ("empty, the unnamed sender group", "&service=", {"orphan.metric"}),
+            # An empty entry must not widen the scope to the unnamed senders, which is
+            # what a trailing or repeated comma would otherwise smuggle in.
+            ("a trailing comma", "&service=web,", {"http.duration"}),
+            ("a repeated comma", "&service=web,,worker", {"http.duration", "jobs.processed"}),
+            # Service names are arbitrary user data, so trimming an entry would make a
+            # padded name unselectable while the filter bar still offers it.
+            ("a padded name, sent padded", "&service=%20padded%20", {"padded.metric"}),
         ]
     )
     def test_values_service_param(self, _name: str, query: str, expected: set[str]):
         anchor = timezone.now().replace(microsecond=0) - dt.timedelta(minutes=5)
-        for service, metric_name in (("web", "http.duration"), ("worker", "jobs.processed"), ("", "orphan.metric")):
+        for service, metric_name in (
+            ("web", "http.duration"),
+            ("worker", "jobs.processed"),
+            ("", "orphan.metric"),
+            (" padded ", "padded.metric"),
+        ):
             seed_metric(
                 team_id=self.team.id,
                 metric_name=metric_name,

--- a/products/metrics/frontend/generated/api.schemas.ts
+++ b/products/metrics/frontend/generated/api.schemas.ts
@@ -815,7 +815,7 @@ export type MetricsValuesRetrieveParams = {
      */
     limit?: number
     /**
-     * Comma-separated services to narrow the list to, e.g. `service=web,worker`. Omit for every service. Send it empty to select only series whose sender did not set `service.name`. A service name containing a comma cannot be selected.
+     * Comma-separated services to narrow the list to, e.g. `service=web,worker`. Omit for every service. Send it empty, and only empty, to select the series whose sender did not set `service.name`. Names are matched exactly, so they are neither trimmed nor unescaped: a service whose name contains a comma cannot be selected, and one padded with spaces must be sent padded. Empty entries are dropped, so a trailing or repeated comma is ignored.
      * @maxLength 1024
      */
     service?: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -94315,7 +94315,7 @@ export namespace Schemas {
      */
     limit?: number;
     /**
-     * Comma-separated services to narrow the list to, e.g. `service=web,worker`. Omit for every service. Send it empty to select only series whose sender did not set `service.name`. A service name containing a comma cannot be selected.
+     * Comma-separated services to narrow the list to, e.g. `service=web,worker`. Omit for every service. Send it empty, and only empty, to select the series whose sender did not set `service.name`. Names are matched exactly, so they are neither trimmed nor unescaped: a service whose name contains a comma cannot be selected, and one padded with spaces must be sent padded. Empty entries are dropped, so a trailing or repeated comma is ignored.
      * @maxLength 1024
      */
     service?: string;

--- a/services/mcp/src/generated/metrics/api.ts
+++ b/services/mcp/src/generated/metrics/api.ts
@@ -414,7 +414,7 @@ export const MetricsValuesRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .max(metricsValuesRetrieveQueryServiceMax)
         .optional()
         .describe(
-            'Comma-separated services to narrow the list to, e.g. `service=web,worker`. Omit for every service. Send it empty to select only series whose sender did not set `service.name`. A service name containing a comma cannot be selected.'
+            'Comma-separated services to narrow the list to, e.g. `service=web,worker`. Omit for every service. Send it empty, and only empty, to select the series whose sender did not set `service.name`. Names are matched exactly, so they are neither trimmed nor unescaped: a service whose name contains a comma cannot be selected, and one padded with spaces must be sent padded. Empty entries are dropped, so a trailing or repeated comma is ignored.'
         ),
     value: zod
         .string()


### PR DESCRIPTION
## Problem

A service whose name carries leading or trailing spaces cannot be selected in the metric picker. The overview lists it, clicking it sets a filter chip with the exact name, and the picker comes back empty with no way to recover.

The `service` parameter trims the value twice over: once in `validate_service`, and once by DRF's `CharField`, which sets `trim_whitespace=True` by default.

A second shape is wrong on the API surface: `service=web,` splits to `["web", ""]`, so a trailing or repeated comma silently widens the picker to include senders that set no `service.name`. PostHog's own UI never sends that shape, so this one is reachable only by calling the endpoint directly.

Follow-up to [#88834](https://github.com/PostHog/posthog/pull/88834), which added the parameter. Both shapes were reported by the review bots there, but the comments arrived after the PR was already submitted to the merge queue, so it landed unfixed.

## Changes

- A padded service name now selects the metrics it reports. Entries are used verbatim, so a padded name must be sent padded, and `trim_whitespace=False` stops the field from undoing that.
- A trailing or repeated comma no longer widens the scope. Empty entries are dropped, so `service=web,` scopes to `web`.
- The parameter documents both, plus the consequence: the unnamed-sender group can now only be selected alone, never alongside a named service. That is inherent to comma-joining values that may themselves be empty.

Mechanical: the `generated/` and `services/mcp/` changes are `hogli build:openapi` output for the new help text.

Why not a repeated `?service=a&service=b` parameter, which has neither problem: the shared generated API client stringifies params, so a `string[]` goes out as one comma-joined value regardless. The wire format is comma-separated because that is what the client can actually send.

## How did you test this code?

- Three cases added to the existing `test_values_service_param`, one per shape: trailing comma, repeated comma, and a service seeded as `" padded "` requested as `?service=%20padded%20`.
- The padded case is what found the `CharField` default. Dropping the explicit `.strip()` alone left it failing with `Items in the second set but not the first: 'padded.metric'`, because the value was already trimmed before `validate_service` ran.
- `pytest products/metrics/backend/tests/test_metric_names_query_runner.py` — 29 passed.
- `uv run mypy --cache-fine-grained .` passes repo-wide.
- Metrics Jest suites pass, unchanged at 103. The only frontend change is a doc comment in a generated type.
- **Not done: no manual browser check.** The behavior is covered above, but nobody has watched a padded service name resolve in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The parameter's own help text carries the contract, and no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Desktop). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.
- The two bot findings on #88834 suggested fixes that contradict each other: keeping the `.strip()` preserves the trailing-comma bug, and `return value.split(",")` restores the empty-entry bug. This takes both findings and neither patch.
- Neither suggestion would have been sufficient on its own. `return value.split(",")` still leaves a padded name unselectable, because `CharField` trims before the validator runs. The field-level default is the actual root cause.
- This is a separate PR rather than a push to #88834 because that PR had already merged by the time the fixes were ready.
- No customer data or internal material appears in this PR. The test fixtures are invented service and metric names.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
