### PR TITLE
fix(data-warehouse): mark the source webhook step as optional

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/WebhookSetupForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/WebhookSetupForm.tsx
@@ -114,6 +114,10 @@ export function WebhookSetupForm({
                 <LemonButton type="primary" onClick={onCreateWebhook}>
                     {manualOnly ? 'Generate webhook URL' : 'Create webhook'}
                 </LemonButton>
+                <p className="text-sm text-muted mb-0">
+                    This step is optional. Your source is already connected, so you can continue without a webhook and
+                    set one up later in the source settings.
+                </p>
             </WebhookSetupCard>
         )
     }


### PR DESCRIPTION
## Problem

Someone connecting a data warehouse source that supports webhook sync reaches a "Set up webhook" step near the end of the new-source wizard. At that point the source is already connected, so the webhook is optional and can be added later. The step only showed a "Create webhook" primary button and gave no sign you could move on without it, so some people stalled on it and left the wizard without finishing.

## Changes

- The webhook step now says it is optional, that your source is already connected, and that you can set up a webhook later in the source settings — so the wizard's Next action reads as a clear way forward instead of a dead end.
- No behavior change: the step was always skippable and the webhook was always configurable later from the source's webhook settings tab.

## How did you test this code?

Copy-only change to an existing render branch of `WebhookSetupForm`. Formatted with oxfmt. No automated tests were added — the change adds a static line of helper text and touches no logic. Not manually run in-app by the agent.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Opened from a review of anonymized new-source onboarding session summaries, which showed a user reaching the webhook step and stalling there without advancing. Traced the wizard flow (`sourceWizardLogic`) to confirm the source is created before the webhook step and that the step is skippable via the footer Next, with the webhook also configurable later from the source settings tab — so the added copy states only what is already true. Skill invoked: `/writing-user-facing-copy` conventions (sentence case, second person, no exclamation). No customer data, names, or session content appear in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
