### PR TITLE
feat(logs): stamp the masked pattern onto the log record

### DIFF
--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -1,6 +1,7 @@
 import type { Counter } from 'prom-client'
 
 import { DEFAULT_PATTERN_MAX_INPUT_CHARS } from './config'
+import { PATTERN_VERSION } from './log-pattern-mask'
 import {
     logsPatternBodyKindCounter,
     logsPatternInputCappedCounter,
@@ -40,7 +41,7 @@ describe('log-pattern-stage', () => {
         return Object.fromEntries(metric.values.map((v) => [Object.values(v.labels)[0] ?? '', v.value]))
     }
 
-    it('tallies body kinds, rule fires, and input caps across a batch without touching the records', async () => {
+    it('tallies body kinds, rule fires, and input caps across a batch without touching the body', async () => {
         const stage = makePatternMaskingStage(20, 1024)
         const records = [
             makeRecord(null),
@@ -60,6 +61,23 @@ describe('log-pattern-stage', () => {
         })
         expect(await counterValues(logsPatternRuleFiredCounter)).toEqual({ num: 1 })
         expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
+    })
+
+    it.each([
+        [
+            'the masked body, not the raw one',
+            'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 took 7141ms',
+            'request <UUID> took <N>ms',
+        ],
+        ['a plain body', 'retry 5', 'retry <N>'],
+        ['an empty body, which must still carry a version or it reads as written before masking', null, ''],
+    ])('stamps pattern and version onto the record: %s', async (_name, body, expected) => {
+        const stage = makePatternMaskingStage(1024, 1024)
+        const record = makeRecord(body)
+
+        await stage.run([record])
+
+        expect(record).toMatchObject({ pattern: expected, pattern_version: PATTERN_VERSION })
     })
 
     it('falls back to the default caps when a configured cap is not a positive integer', async () => {

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -2,7 +2,7 @@ import { performance } from 'node:perf_hooks'
 import { Counter, Histogram } from 'prom-client'
 
 import { DEFAULT_PATTERN_MAX_INPUT_CHARS, DEFAULT_PATTERN_MAX_OUTPUT_CHARS } from './config'
-import { MASK_RULES, computeLogPattern } from './log-pattern-mask'
+import { MASK_RULES, PATTERN_VERSION, computeLogPattern } from './log-pattern-mask'
 import type { LogRecord } from './log-record-avro'
 import type { PipelineStage } from './pipeline/log-processing-pipeline'
 
@@ -49,7 +49,7 @@ export const logsPatternForcedDecodeCounter = new Counter({
 
 export const logsPatternStageErrorCounter = new Counter({
     name: 'logs_ingestion_pattern_stage_error_total',
-    help: 'Batches where the pattern masking stage threw. The records survive; only these metrics are lost.',
+    help: 'Batches where the pattern masking stage threw. The records survive. Any record the throw came before keeps its stamp, and the rest stay unstamped, which reads as version 0.',
 })
 
 const positiveIntOr = (value: number, fallback: number): number =>
@@ -63,7 +63,7 @@ export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: n
         name: 'pattern_masking',
         run: (records) => {
             try {
-                measureBatch(records, inputCap, outputCap)
+                stampBatch(records, inputCap, outputCap)
             } catch {
                 logsPatternStageErrorCounter.inc()
             }
@@ -71,7 +71,7 @@ export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: n
     }
 }
 
-function measureBatch(records: LogRecord[], inputCap: number, outputCap: number): void {
+function stampBatch(records: LogRecord[], inputCap: number, outputCap: number): void {
     const kindCounts = new Map<string, number>()
     const ruleFires: number[] = new Array(MASK_RULES.length).fill(0)
     let inputCapped = 0
@@ -79,6 +79,8 @@ function measureBatch(records: LogRecord[], inputCap: number, outputCap: number)
     for (const record of records) {
         const start = performance.now()
         const result = computeLogPattern(record.body, inputCap, outputCap)
+        record.pattern = result.pattern
+        record.pattern_version = PATTERN_VERSION
         logsPatternMaskingDurationHistogram.observe((performance.now() - start) / 1000)
 
         logsPatternMaskedLengthHistogram.observe(result.maskedLength)

--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -53,6 +53,12 @@ export interface LogRecord {
     /** Per-row retention in days, stamped by the retention stage from team retention rules. Null/undefined
      * leaves ClickHouse to fall back to the batch `retention-days` header (the team default). */
     retention_days?: number | null
+    /** Masked body, stamped by the pattern masking stage. Identifiers become placeholders, so two
+     * lines differing only by a request id share one pattern. */
+    pattern?: string | null
+    /** Masking rule set that produced `pattern`. Null reads as 0 in ClickHouse, marking a row
+     * written before masking. */
+    pattern_version?: number | null
 }
 
 export async function decodeLogRecords(buffer: Buffer): Promise<[avro.Type | undefined, string, LogRecord[]]> {

--- a/rust/capture-logs/src/avro_schema.rs
+++ b/rust/capture-logs/src/avro_schema.rs
@@ -96,6 +96,18 @@ pub const AVRO_SCHEMA: &str = r#"
     "type": ["null", "int"],
     "default": null,
     "doc": "Per-row retention in days, stamped by the Node consumer from team retention rules. Null when unset — ClickHouse then falls back to the batch `retention-days` header. capture-logs always writes null; it does not evaluate team rules."
+    },
+    {
+    "name": "pattern",
+    "type": ["null", "string"],
+    "default": null,
+    "doc": "Masked log body, stamped by the Node consumer. Identifiers are replaced with placeholders, so two lines differing only by a request id share one pattern. capture-logs always writes null; it does not mask."
+    },
+    {
+    "name": "pattern_version",
+    "type": ["null", "int"],
+    "default": null,
+    "doc": "Masking rule set that produced `pattern`. A rule change re-masks every line, so the detector compares within a version and treats a change as a cold start. Null reads as version 0 in ClickHouse, marking a row written before masking. capture-logs always writes null."
     }
 ]
 }"#;

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -258,6 +258,8 @@ pub fn datadog_log_to_kafka_row(
         attributes,
         bytes_uncompressed: None,
         retention_days: None,
+        pattern: None,
+        pattern_version: None,
     }
     .with_computed_bytes();
     (row, was_overridden)

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -42,6 +42,11 @@ pub struct KafkaLogRow {
     // Per-row retention in days. capture-logs always writes None — the Node consumer stamps
     // this from team retention rules. Null lets ClickHouse fall back to the batch header.
     pub retention_days: Option<i32>,
+    // Masked body and the rule set that produced it. capture-logs always writes None — the Node
+    // consumer stamps both. The fields exist here so the schema carries them; a value the writer
+    // schema has no slot for is silently dropped at encode.
+    pub pattern: Option<String>,
+    pub pattern_version: Option<i32>,
 }
 
 /// Sum byte lengths of the row's string and map content. Fixed-width fields
@@ -179,6 +184,8 @@ impl KafkaLogRow {
             attributes,
             bytes_uncompressed: None,
             retention_days: None,
+            pattern: None,
+            pattern_version: None,
         }
         .with_computed_bytes();
         debug!("log: {:?}", log_row);
@@ -395,6 +402,8 @@ mod tests {
             attributes,
             bytes_uncompressed: None,
             retention_days: None,
+            pattern: None,
+            pattern_version: None,
         }
     }
 


### PR DESCRIPTION
## Problem

The logs consumer masks every log body, then throws the result away. Nothing downstream can use it, so pattern-anchored detection stays blocked.

The parent work needs an identity for a log line that ignores the parts which always change. A UUID becomes `<UUID>`, a number becomes `<N>`. Two lines differing only by a request id then share one pattern, and a pattern nobody has seen before is a new fault even at low volume. The masking already happens. This puts the answer on the wire.

Stacked on the migration that adds the columns.

## Changes

Nothing user-visible changes. No query reads the fields and no ClickHouse column consumes them yet.

- `capture-logs` declares `pattern` and `pattern_version` in its Avro schema, nullable with `default: null`, and always writes null for both.
- The masking stage assigns both onto each record. `measureBatch` becomes `stampBatch`, because it no longer only measures.
- An empty body stamps an empty pattern and a real version. An unset version reads as `0` in ClickHouse, which marks a row written before masking, so a record the stage handled must never leave it unset.

**Why the producer declares fields it never fills.** The consumer re-encodes each batch using the schema that arrived inside the message, so a field the producer never declared has no slot to write into. `retention_days` already works exactly this way and says so in its own schema doc.

This is not a theoretical concern. Encoding a record that carries an undeclared field does **not** throw — avro discards it silently. The consumer would report success and its metrics would show the stage ran, while nothing reached ClickHouse.

**The stage-error metric's help text was wrong** once the stage started mutating. It said the records survive and only the metrics are lost. A throw part-way through a batch now leaves earlier records stamped and later ones not, so the text says that instead.

## Deploy order

Three stages, and the middle one is inert on its own:

1. `capture-logs`, carrying the widened schema. Until this is fully rolled out, the consumer's stamps are silently dropped.
2. The logs consumer, stamping the fields.
3. A later migration declaring the column on the Kafka table.

Stage 2 before stage 1 is safe but does nothing. Stage 3 before stage 2 is an outage, because a declared column with no matching field is an error.

## How did you test this code?

Round-tripped a stamp through the **real** producer schema, read out of `rust/capture-logs/src/avro_schema.rs` rather than a fixture: the field arrives null, the stage stamps it, and it survives the re-encode with the body untouched. That is the claim the whole change rests on, and a hand-written fixture would not have tested it.

`cargo check` and `cargo test` pass for `capture-logs`. The Node logs suite passes.

Test changes are one parameterized case covering three bodies. It guards two regressions no existing test caught: stamping the raw body instead of the masked one, and skipping the version on an empty body so the row falsely reads as written before masking. The existing stage test asserts the body is *unchanged*, so nothing asserted the fields were *set*.

Not checked: no consumer has run against a real broker with the widened schema. The end-to-end proof here is an in-process encode and decode using the production schema, not a live pipeline.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, config, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The plan for this change said the Rust producer schema never changes. That was wrong, and following it would have shipped a silent no-op. Reading how `retention_days` reaches the wire is what surfaced it, and the avro drop behavior was then confirmed directly rather than assumed.
- The two stamping tests were first written as separate functions. On re-reading the repo's testing guidance the second was a variation of the first, so they were folded into one parameterized test.
- Public artifact: this diff is schema and consumer code only. Nothing from the authoring session appears in the code, tests, commit messages, or this description.
