### PR TITLE
refactor(access-control): derive queryset block/allow sets from the object row decision

### DIFF
--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -1110,7 +1110,7 @@ class UserAccessControl:
         filters = self._access_controls_filters_for_queryset(resource)
         access_controls = self._get_access_controls(filters)
 
-        decision = self._blocked_and_allowed_object_ids(access_controls)
+        decision = self._blocked_and_allowed_object_ids(resource, access_controls)
 
         # Apply filtering logic based on resource-level access
         if not self.has_resource_access(resource) and decision.allowed_ids:
@@ -1129,48 +1129,35 @@ class UserAccessControl:
 
         return queryset
 
-    def _blocked_and_allowed_object_ids(self, access_controls: list[_AccessControl]) -> ObjectAccessDecision:
+    def _blocked_and_allowed_object_ids(
+        self, resource: APIScopeObject, access_controls: list[_AccessControl]
+    ) -> ObjectAccessDecision:
         """Canonical object-level decision over a pool of object access controls (rows with
         `resource_id` set), returning an ObjectAccessDecision of blocked and allowed ids.
 
-        Explicit-wins: if a resource_id has any explicit (role/member) rule, the object is
-        allowed when any explicit rule grants non-"none", otherwise blocked. With no explicit
-        rule, the object is blocked only when every default rule is "none".
+        Each object's rows resolve through `_object_rows_decision`, the same step the object
+        walk uses. An object is blocked when its rows decide "none". It is allowed when an
+        explicit (member or role) row decides with a level above "none" — the allowlist for
+        users with no resource-level access. An object whose default rows decide a level above
+        "none" is neither: the resource-level outcome applies to it.
 
         Reads the `role_id` / `organization_member_id` columns rather than the `.role` /
         `.organization_member` FK accessors — equivalent result (id is None iff the relation is
         None) without firing a query per row.
         """
-        resource_id_access_levels: dict[str, list[str]] = {}
+        rows_by_object_id: dict[str, list[_AccessControl]] = defaultdict(list)
         for access_control in access_controls:
-            resource_id_access_levels.setdefault(access_control.resource_id, []).append(access_control.access_level)
+            rows_by_object_id[access_control.resource_id].append(access_control)
 
         blocked_resource_ids: set[str] = set()
         allowed_resource_ids: set[str] = set()
 
-        for resource_id, access_levels in resource_id_access_levels.items():
-            # Get the access controls for this specific resource_id to check role/member
-            resource_access_controls = [ac for ac in access_controls if ac.resource_id == resource_id]
-
-            # Only consider access controls that have explicit role or member (not defaults)
-            explicit_access_controls = [
-                ac for ac in resource_access_controls if ac.role_id is not None or ac.organization_member_id is not None
-            ]
-
-            if not explicit_access_controls:
-                if all(access_level == NO_ACCESS_LEVEL for access_level in access_levels):
-                    blocked_resource_ids.add(resource_id)
-                # No explicit controls for this object - don't block it
-                continue
-
-            # Check if user has any non-"none" access to this specific object
-            has_specific_access = any(ac.access_level != NO_ACCESS_LEVEL for ac in explicit_access_controls)
-
-            if has_specific_access:
-                allowed_resource_ids.add(resource_id)
-            else:
-                # All explicit access levels are "none" - block this object
+        for resource_id, rows in rows_by_object_id.items():
+            row = self._object_rows_decision(resource, rows)
+            if row.access_level == NO_ACCESS_LEVEL:
                 blocked_resource_ids.add(resource_id)
+            elif self._row_subject(row) != "default":
+                allowed_resource_ids.add(resource_id)
 
         return ObjectAccessDecision(
             blocked_ids=frozenset(blocked_resource_ids), allowed_ids=frozenset(allowed_resource_ids)
@@ -1199,7 +1186,7 @@ class UserAccessControl:
 
         result: dict[APIScopeObject, frozenset[str]] = {}
         for resource, acs in object_rows_by_resource.items():
-            blocked = self._blocked_and_allowed_object_ids(acs).blocked_ids
+            blocked = self._blocked_and_allowed_object_ids(resource, acs).blocked_ids
             if blocked:
                 result[resource] = blocked
         return result
@@ -1231,7 +1218,7 @@ class UserAccessControl:
 
         result: dict[APIScopeObject, frozenset[str]] = {}
         for resource, acs in object_rows_by_resource.items():
-            allowed = self._blocked_and_allowed_object_ids(acs).allowed_ids
+            allowed = self._blocked_and_allowed_object_ids(resource, acs).allowed_ids
             if allowed and not self.has_resource_access(resource):
                 result[resource] = allowed
         return result
@@ -1464,6 +1451,18 @@ class UserAccessControl:
             return "role"
         return "default"
 
+    @staticmethod
+    def _object_rows_decision(resource: APIScopeObject, rows: list[_AccessControl]) -> _AccessControl:
+        """The decision an object's own rows give, before any resource-level fallback.
+
+        Explicit (member or role) rows decide first, at the highest level across both. Only when
+        the object has no explicit rows do its default rows decide. `rows` must be non-empty.
+        Shared by the object walk and `_blocked_and_allowed_object_ids` so the per-object checks
+        and the queryset filters cannot drift.
+        """
+        explicit_rows = [ac for ac in rows if ac.role_id is not None or ac.organization_member_id is not None]
+        return UserAccessControl._highest_access_from_rows(resource, explicit_rows or rows)
+
     def _object_access_level_from_rows(
         self,
         resource: APIScopeObject,
@@ -1482,7 +1481,7 @@ class UserAccessControl:
             ac for ac in object_access_controls if ac.role_id is not None or ac.organization_member_id is not None
         ]
         if explicit_rows:
-            row = self._highest_access_from_rows(resource, explicit_rows)
+            row = self._object_rows_decision(resource, object_access_controls)
             return ResolvedAccess(
                 access_level=row.access_level,
                 source="object",
@@ -1516,7 +1515,7 @@ class UserAccessControl:
                 return replace(access_for_parent, source="parent_resource")
 
         if object_access_controls:
-            row = self._highest_access_from_rows(resource, object_access_controls)
+            row = self._object_rows_decision(resource, object_access_controls)
             return ResolvedAccess(
                 access_level=row.access_level,
                 source="object",


### PR DESCRIPTION
## Problem

Two places decide what an object's own access rows mean, with two different implementations. The object walk (`_object_access_level_from_rows`) picks the highest explicit row, else the highest default row. `_blocked_and_allowed_object_ids` re-states the same rule as a set heuristic ("any explicit non-none row allows, all-none blocks") for list filtering, HogQL schema visibility, and the query cache fingerprint.

A planned resolution-mode change has to branch in every place that resolves rows. With two implementations, one of them gets missed and lists show objects the detail endpoint rejects. This PR does not change the mode — it removes the duplicate so a later branch has one place to live.

## Changes

Nothing user-visible changes; the refactor is behavior-preserving.

- New helper `_object_rows_decision`: the decision an object's own rows give (explicit rows first, else default rows), as one deterministic row pick.
- The object walk's two row steps now call the helper instead of inlining the pick.
- `_blocked_and_allowed_object_ids` now groups rows per object and derives blocked/allowed from the helper's decision: blocked when it resolves "none", allowed when an explicit row resolves above "none". This replaces the set heuristic with the same rule the per-object checks use. Equivalence holds because "none" is the lowest level, so "highest row is none" equals "every row is none".
- `_blocked_and_allowed_object_ids` takes the resource explicitly; its three callers already hold it. Mechanical.

## How did you test this code?

- `products/access_control/backend/tests/test_user_access_control.py` and `test_user_access_control_pbt.py` (152 passed) — the property-based suite checks the block/allow sets against an independent oracle across arbitrary row configurations, which is the equivalence proof for this rewrite.
- `products/access_control/backend/tests/test_access_control.py` (147 passed) — exercises the queryset filtering through the API.
- No new tests: the change is behavior-preserving and the oracle already covers the rewritten method.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — `posthog/hogql/ACCESS_CONTROL.md` describes behavior, which is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: /writing-pr-descriptions.
- Groundwork for an access-resolution mode switch; kept separate from the resolution preview stack (#87363, #88704) so it can land independently.
