### PR TITLE
fix(data-warehouse): restore Shipmail docs link

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/source.py
@@ -49,6 +49,7 @@ class ShipmailSource(ResumableSource[ShipmailSourceConfig, ShipmailResumeConfig]
 
 Grant the key the read scopes for the tables you want to sync: `messages:read`, `mailboxes:read`, `domains:read`, and `suppressions:read`.""",
             iconPath="/static/services/shipmail.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/shipmail",
             fields=cast(
                 list[FieldType],
                 [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/tests/test_shipmail_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/tests/test_shipmail_source.py
@@ -20,6 +20,7 @@ class TestShipmailSource:
         assert self.source.source_type == ExternalDataSourceType.SHIPMAIL
         assert self.source.lists_tables_without_credentials is True
         assert self.source.get_source_config.releaseStatus == ReleaseStatus.ALPHA
+        assert self.source.get_source_config.docsUrl == "https://posthog.com/docs/cdp/sources/shipmail"
 
     def test_static_schemas_include_keys_and_incremental_support(self) -> None:
         schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, team_id=1)}


### PR DESCRIPTION
## Problem

Shipmail users cannot open setup documentation from the source configuration, even though the page is now live.

## Changes

- Restore the in-app documentation link to the published Shipmail source page.
- Extend the existing metadata test to guard the URL and slug.

## How did you test this code?

- `OPT_OUT_CAPTURE=1 bin/hogli test products/warehouse_sources/backend/temporal/data_imports/sources/shipmail/tests/test_shipmail_source.py`
- `OPT_OUT_CAPTURE=1 bin/hogli ci:preflight --strict`
- Not run: manual UI verification or screenshot capture.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The [Shipmail source page](https://posthog.com/docs/cdp/sources/shipmail) is live from PostHog/posthog.com#19086.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this user-directed follow-up. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, authenticated GitHub CLI, git workflow, and git commit.
