### PR TITLE
fix(insights): reject empty series saves

### DIFF
--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import EntityType, FunnelsQuery, LifecycleQuery, RetentionQuery, StickinessQuery, TrendsQuery
@@ -14,11 +16,28 @@ class RequireAtLeastOneSeries:
     code = "insight_requires_at_least_one_series"
 
     def validate(self, context: QueryValidationContext[TrendsQuery | StickinessQuery | LifecycleQuery]) -> None:
-        if not context.query.series:
-            raise ValidationError(
-                f"{get_query_insight_name(context.query)} require at least one series.",
-                code=self.code,
-            )
+        self.validate_query(context.query)
+
+    def validate_query(self, query: TrendsQuery | StickinessQuery | LifecycleQuery) -> None:
+        self._validate_series(get_query_insight_name(query), query.series)
+
+    def validate_serialized_query(self, query: dict[str, Any] | None) -> None:
+        if query is None:
+            return
+
+        source = query.get("source") if query.get("kind") == "InsightVizNode" else query
+        if not isinstance(source, dict):
+            return
+
+        query_kind = source.get("kind")
+        if query_kind not in {"TrendsQuery", "StickinessQuery", "LifecycleQuery"}:
+            return
+
+        self._validate_series(f"{query_kind.removesuffix('Query')} insights", source.get("series"))
+
+    def _validate_series(self, insight_name: str, series: object) -> None:
+        if not isinstance(series, list) or not series:
+            raise ValidationError(f"{insight_name} require at least one series.", code=self.code)
 
 
 class DisallowUnsupportedDataWarehouseSettings:

--- a/posthog/hogql_queries/validation/test_rules.py
+++ b/posthog/hogql_queries/validation/test_rules.py
@@ -36,6 +36,20 @@ class TestRequireAtLeastOneSeries(BaseTest):
 
         RequireAtLeastOneSeries().validate(self._context(query))
 
+    @parameterized.expand(
+        [
+            ("empty_series", {"kind": "TrendsQuery", "series": []}),
+            ("missing_series", {"kind": "StickinessQuery"}),
+            ("null_series", {"kind": "LifecycleQuery", "series": None}),
+            ("wrapped_query", {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}}),
+        ]
+    )
+    def test_raises_for_invalid_serialized_query(self, _name, query):
+        with self.assertRaises(ValidationError) as context:
+            RequireAtLeastOneSeries().validate_serialized_query(query)
+
+        self.assertEqual(context.exception.get_codes(), ["insight_requires_at_least_one_series"])
+
 
 class TestDisallowUnsupportedDataWarehouseSettings(BaseTest):
     def _context(self, query: LifecycleQuery) -> QueryValidationContext:

--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -89,6 +89,7 @@ from posthog.hogql_queries.legacy_compatibility.feature_flag import get_query_me
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.hogql_queries.query_runner import BLOCKING_EXECUTION_MODES, ExecutionMode, execution_mode_from_refresh
 from posthog.hogql_queries.refresh_policy import ComputeSurface, resolve_execution_mode
+from posthog.hogql_queries.validation.rules import RequireAtLeastOneSeries
 from posthog.kafka_client.topics import KAFKA_METRICS_TIME_TO_SEE_DATA
 from posthog.models import Filter, User
 from posthog.models.activity_logging.activity_log import (
@@ -597,27 +598,12 @@ class InsightFilterOverrideContext(BaseModel):
 
 
 def _validate_saved_insight_query(query: dict[str, Any] | None) -> None:
-    if query is None:
-        return
-
-    source = query.get("source") if query.get("kind") == "InsightVizNode" else query
-    if not isinstance(source, dict):
-        return
-
-    query_kind = source.get("kind")
-    if query_kind not in {"TrendsQuery", "StickinessQuery", "LifecycleQuery"}:
-        return
-
-    series = source.get("series")
-    if not isinstance(series, list) or not series:
+    try:
+        RequireAtLeastOneSeries().validate_serialized_query(query)
+    except ValidationError as error:
         raise serializers.ValidationError(
-            {
-                "query": serializers.ErrorDetail(
-                    f"{query_kind.removesuffix('Query')} insights require at least one series.",
-                    code="insight_requires_at_least_one_series",
-                )
-            }
-        )
+            {"query": error.detail}
+        ) from error
 
 
 @extend_schema_serializer(deprecate_fields=["dashboards"])

--- a/products/product_analytics/backend/presentation/insight.py
+++ b/products/product_analytics/backend/presentation/insight.py
@@ -596,6 +596,30 @@ class InsightFilterOverrideContext(BaseModel):
     )
 
 
+def _validate_saved_insight_query(query: dict[str, Any] | None) -> None:
+    if query is None:
+        return
+
+    source = query.get("source") if query.get("kind") == "InsightVizNode" else query
+    if not isinstance(source, dict):
+        return
+
+    query_kind = source.get("kind")
+    if query_kind not in {"TrendsQuery", "StickinessQuery", "LifecycleQuery"}:
+        return
+
+    series = source.get("series")
+    if not isinstance(series, list) or not series:
+        raise serializers.ValidationError(
+            {
+                "query": serializers.ErrorDetail(
+                    f"{query_kind.removesuffix('Query')} insights require at least one series.",
+                    code="insight_requires_at_least_one_series",
+                )
+            }
+        )
+
+
 @extend_schema_serializer(deprecate_fields=["dashboards"])
 class InsightSerializer(InsightBasicSerializer):
     result = serializers.SerializerMethodField()
@@ -720,6 +744,7 @@ class InsightSerializer(InsightBasicSerializer):
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         query = attrs.get("query") if "query" in attrs else None
+        _validate_saved_insight_query(query)
         using_legacy_filters = "filters" in attrs and attrs.get("filters") is not None and query in (None, {})
         if using_legacy_filters and is_legacy_insight_filters_blocked(
             self.context["request"].user, self.context["get_team"]()

--- a/products/product_analytics/backend/tests/api/test_insight_query.py
+++ b/products/product_analytics/backend/tests/api/test_insight_query.py
@@ -186,6 +186,27 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             expected_status=status.HTTP_201_CREATED,
         )
 
+    @parameterized.expand(
+        [
+            ("trends", {"kind": "TrendsQuery", "series": []}),
+            ("stickiness", {"kind": "StickinessQuery", "series": []}),
+            ("lifecycle", {"kind": "LifecycleQuery", "series": []}),
+            ("missing_series", {"kind": "TrendsQuery"}),
+            ("null_series", {"kind": "TrendsQuery", "series": None}),
+            ("unknown_field", {"kind": "TrendsQuery", "series": [], "unknown": True}),
+        ]
+    )
+    def test_cannot_save_insight_query_without_series(self, _name: str, query: dict) -> None:
+        insight_count_before = Insight.objects.count()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/", {"name": "Invalid insight", "query": query}
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "insight_requires_at_least_one_series" in str(response.json())
+        assert Insight.objects.count() == insight_count_before
+
     def test_can_list_insights_including_those_with_only_queries(self) -> None:
         self.dashboard_api.create_insight({"name": "Insight with filters"})
         self.dashboard_api.create_insight(
@@ -331,6 +352,28 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         assert stored_query["kind"] == "InsightVizNode"
         assert stored_query["source"]["kind"] == "FunnelsQuery"
 
+    def test_cannot_update_insight_to_query_without_series(self) -> None:
+        insight_id, _ = self.dashboard_api.create_insight(
+            {
+                "name": "Insight to update",
+                "query": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                },
+            }
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight_id}",
+            {"query": {"kind": "TrendsQuery", "series": []}},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert Insight.objects.get(pk=insight_id).query == {
+            "kind": "InsightVizNode",
+            "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+        }
+
     @parameterized.expand(
         [
             (
@@ -408,3 +451,13 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         error_body = str(response.json())
         assert "This query can't be saved" in error_body
         assert "Traceback" not in error_body
+
+    def test_mcp_create_rejects_query_without_series(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={"name": "Invalid insight", "query": {"kind": "TrendsQuery", "series": []}},
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "insight_requires_at_least_one_series" in str(response.json())


### PR DESCRIPTION
## Problem

- An API client can save a Trends, Stickiness, or Lifecycle insight with no series.

```text
POST /api/projects/:project_id/insights/
{ "query": { "kind": "TrendsQuery", "series": [] } }

→ InsightSerializer accepts the request
→ Insight.objects.create(...) stores the invalid insight
→ A dashboard renders the insight later
→ The query runner rejects the empty series
→ The user sees an error tile
```

- Evidence: The [Inbox report](https://us.posthog.com/project/2/inbox/reports/019ff613-f69e-7f2a-8be3-a1dda7e3e600?sort=created_at%3Adesc) found persisted cases concentrated in a historical API-client burst.
- The report also separates unsaved malformed web URLs from persisted insights.
- **Why:** Reject the invalid request at save time, before it can become a dashboard error.

## Changes

- `RequireAtLeastOneSeries` now validates both executable queries and serialized API payloads.

```text
POST / PATCH / MCP save request
→ RequireAtLeastOneSeries checks query source kind and series
→ Trends, Stickiness, or Lifecycle has no usable series
→ return 400 insight_requires_at_least_one_series
→ do not create or update the insight
→ no invalid dashboard tile exists
```

- The serializer maps the shared rule error into the API field-error response.
- The rule rejects empty, missing, null, and malformed series values.

> [!NOTE]
> This guards writes through the Insights API. Direct model writers, including dashboard templates, remain out of scope.

## How did you test this code?

- Added validation-rule and API cases for empty, missing, null, and malformed series values.
- Added API cases for update and MCP save paths.
- Ran Ruff, Python compilation, and a direct validation-rule smoke check.
- Not run to completion: the database-backed suite stalled during local initialization.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This change rejects invalid API input and does not alter documented workflows.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the fix after investigating invalid saved insight queries.
- Skills used: `writing-tests`, `qa-team`, and `writing-pr-descriptions`.
- QA identified malformed series inputs that bypassed the first implementation.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*