### PR TITLE
fix(replay): scale player with zoom to avoid crash

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -36,16 +36,19 @@ export const PlayerFrame = (): JSX.Element => {
 
             const parentDimensions = frameRef.current.parentElement.getBoundingClientRect()
 
-            // Cap at 0.999 instead of 1 to avoid a Chrome GPU compositing bug where
-            // an identity transform (scale(1)) causes the iframe layer to paint outside
-            // its clipping bounds, overlapping the rest of the UI.
             const scale = Math.min(
                 parentDimensions.width / dimensions.width,
                 parentDimensions.height / dimensions.height,
-                0.999
+                1
             )
 
-            player.replayer.wrapper.style.transform = `scale(${scale})`
+            // Scale with `zoom` instead of `transform: scale()`. A decimal transform scale
+            // promotes the large replay iframe to a composited layer, which WebKit
+            // re-rasterizes at pinch-zoom scale and crashes the tab on iOS (FB13816677).
+            // `zoom` scales through layout, so no oversized layer exists. This also avoids
+            // the Chrome GPU bug where an identity transform painted the iframe layer
+            // outside its clipping bounds, which previously forced a 0.999 scale cap.
+            player.replayer.wrapper.style.setProperty('zoom', String(scale))
 
             setScale(scale)
         },


### PR DESCRIPTION
## Problem

Pinch-zooming a replay on an iPhone crashes the browser tab. Outside fullscreen WebKit silently reloads the page and playback restarts. In fullscreen the user gets the frozen crash screen.

- The player fits the rrweb iframe to its container with a decimal `transform: scale()`, which promotes the native-resolution iframe to a composited layer.
- On pinch, WebKit re-rasterizes that layer at pinch scale × device pixel ratio and the content process runs out of memory. This structure matches Apple's [FB13816677](https://openradar.appspot.com/FB13816677); [WebKit bug 172206](https://bugs.webkit.org/show_bug.cgi?id=172206) describes the same crash-then-reload behavior.

## Changes

- The player scales the replay with CSS `zoom` instead of `transform: scale()`. `zoom` scales through layout, so no composited layer exists and pinch-zoom behaves like on any page.
- The scale cap moved from 0.999 to 1. It only dodged a Chrome identity-transform bug that cannot occur without a transform.

## How did you test this code?

- Playwright checks (throwaway, not committed) in Chromium and WebKit 26.4: `zoom` scales iframe content in both engines, and a mock of the player's DOM renders pixel-identical with `transform: scale(0.375)` and `zoom: 0.375`.
- Not verified: the pinch crash on a physical iPhone. Desktop Playwright cannot reproduce WebKit's pinch rasterization, which is also why there is no automated test.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
