### PR TITLE
feat(desktop): track agent action outcomes

### DIFF
--- a/products/desktop/docs/CONVENTIONS.md
+++ b/products/desktop/docs/CONVENTIONS.md
@@ -216,6 +216,8 @@ Main-process events use `trackAppEvent(eventName, properties)` from `apps/code/s
 
 Both clients set `team: "posthog-code"` as a super-property.
 
+Agent action events use `action_id`, `source_task_id`, `tool_call_id`, `action_index`, and `action_kind`. Compose submissions add `resulting_task_id` to `Task created` and set `created_from` to `agent-action`.
+
 ### Event Names
 
 - Format: `Object verbed`.

--- a/products/desktop/packages/core/src/deep-links/identifiers.ts
+++ b/products/desktop/packages/core/src/deep-links/identifiers.ts
@@ -1,4 +1,4 @@
-import type { GithubRef } from "@posthog/shared";
+import type { AgentActionTaskAttribution, GithubRef } from "@posthog/shared";
 import type {
   ANALYTICS_EVENTS,
   DeepLinkIssueFailedProperties,
@@ -26,6 +26,7 @@ export interface TaskInputNavigation {
   initialCloudRepository?: string;
   initialModel?: string;
   initialMode?: string;
+  agentActionAttribution?: AgentActionTaskAttribution;
 }
 
 export type NewTaskLinkAnalytics =

--- a/products/desktop/packages/core/src/deep-links/identifiers.ts
+++ b/products/desktop/packages/core/src/deep-links/identifiers.ts
@@ -1,4 +1,4 @@
-import type { AgentActionTaskAttribution, GithubRef } from "@posthog/shared";
+import type { AgentActionAttribution, GithubRef } from "@posthog/shared";
 import type {
   ANALYTICS_EVENTS,
   DeepLinkIssueFailedProperties,
@@ -26,7 +26,7 @@ export interface TaskInputNavigation {
   initialCloudRepository?: string;
   initialModel?: string;
   initialMode?: string;
-  agentActionAttribution?: AgentActionTaskAttribution;
+  agentActionAttribution?: AgentActionAttribution;
 }
 
 export type NewTaskLinkAnalytics =

--- a/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.test.ts
+++ b/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.test.ts
@@ -33,10 +33,10 @@ describe("NewTaskLinkResolver", () => {
       model: "sonnet",
       mode: "plan",
       agentActionAttribution: {
-        actionId: "action-1",
-        sourceTaskId: "source-task",
-        toolCallId: "tool-call",
-        actionIndex: 0,
+        action_id: "action-1",
+        source_task_id: "source-task",
+        tool_call_id: "tool-call",
+        action_index: 0,
       },
     };
 
@@ -50,10 +50,10 @@ describe("NewTaskLinkResolver", () => {
       initialModel: "sonnet",
       initialMode: "plan",
       agentActionAttribution: {
-        actionId: "action-1",
-        sourceTaskId: "source-task",
-        toolCallId: "tool-call",
-        actionIndex: 0,
+        action_id: "action-1",
+        source_task_id: "source-task",
+        tool_call_id: "tool-call",
+        action_index: 0,
       },
     });
     expect(result.analytics.event).toBe(ANALYTICS_EVENTS.DEEP_LINK_NEW_TASK);

--- a/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.test.ts
+++ b/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.test.ts
@@ -32,6 +32,12 @@ describe("NewTaskLinkResolver", () => {
       repo: "acme/web",
       model: "sonnet",
       mode: "plan",
+      agentActionAttribution: {
+        actionId: "action-1",
+        sourceTaskId: "source-task",
+        toolCallId: "tool-call",
+        actionIndex: 0,
+      },
     };
 
     const result = await resolver.resolve(payload);
@@ -43,6 +49,12 @@ describe("NewTaskLinkResolver", () => {
       initialCloudRepository: "acme/web",
       initialModel: "sonnet",
       initialMode: "plan",
+      agentActionAttribution: {
+        actionId: "action-1",
+        sourceTaskId: "source-task",
+        toolCallId: "tool-call",
+        actionIndex: 0,
+      },
     });
     expect(result.analytics.event).toBe(ANALYTICS_EVENTS.DEEP_LINK_NEW_TASK);
     if (result.analytics.event !== ANALYTICS_EVENTS.DEEP_LINK_NEW_TASK) return;

--- a/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.ts
+++ b/products/desktop/packages/core/src/deep-links/newTaskLinkResolver.ts
@@ -67,6 +67,7 @@ export class NewTaskLinkResolver {
           payload.repo ?? inferRepositoryFromPullRequests(payload.prompt),
         initialModel: payload.model,
         initialMode: payload.mode,
+        agentActionAttribution: payload.agentActionAttribution,
       },
       analytics: {
         event: ANALYTICS_EVENTS.DEEP_LINK_NEW_TASK,

--- a/products/desktop/packages/core/src/links/new-task-link.test.ts
+++ b/products/desktop/packages/core/src/links/new-task-link.test.ts
@@ -185,10 +185,10 @@ describe("NewTaskLinkService", () => {
       expect(listener).toHaveBeenCalledWith(
         expect.objectContaining({
           agentActionAttribution: {
-            actionId: "action-1",
-            sourceTaskId: "source-task",
-            toolCallId: "tool-call",
-            actionIndex: 2,
+            action_id: "action-1",
+            source_task_id: "source-task",
+            tool_call_id: "tool-call",
+            action_index: 2,
           },
         }),
       );

--- a/products/desktop/packages/core/src/links/new-task-link.test.ts
+++ b/products/desktop/packages/core/src/links/new-task-link.test.ts
@@ -170,6 +170,29 @@ describe("NewTaskLinkService", () => {
         model: "opus",
       });
     });
+
+    it("passes complete agent-action attribution to the task composer", () => {
+      const listener = vi.fn();
+      service.on(NewTaskLinkEvent.Action, listener);
+
+      mockDeepLink._invoke(
+        "new",
+        new URLSearchParams(
+          "prompt=test&agent_action_id=action-1&agent_action_source_task_id=source-task&agent_action_tool_call_id=tool-call&agent_action_index=2",
+        ),
+      );
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentActionAttribution: {
+            actionId: "action-1",
+            sourceTaskId: "source-task",
+            toolCallId: "tool-call",
+            actionIndex: 2,
+          },
+        }),
+      );
+    });
   });
 
   describe("handlePlan", () => {

--- a/products/desktop/packages/core/src/links/new-task-link.ts
+++ b/products/desktop/packages/core/src/links/new-task-link.ts
@@ -8,6 +8,7 @@ import {
   MAIN_WINDOW_SERVICE,
 } from "@posthog/platform/main-window";
 import {
+  agentActionAttributionSchema,
   decodePlanBase64,
   type NewTaskLinkPayload,
   type NewTaskSharedParams,
@@ -65,22 +66,15 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
   private handleNew(params: URLSearchParams): boolean {
     const shared = this.extractSharedParams(params);
     const prompt = params.get("prompt") ?? undefined;
-    const actionId = params.get("agent_action_id") ?? undefined;
-    const sourceTaskId = params.get("agent_action_source_task_id") ?? undefined;
-    const toolCallId = params.get("agent_action_tool_call_id") ?? undefined;
     const actionIndexValue = params.get("agent_action_index");
-    const actionIndex = actionIndexValue
-      ? Number.parseInt(actionIndexValue, 10)
-      : undefined;
-    const agentActionAttribution =
-      actionId &&
-      sourceTaskId &&
-      toolCallId &&
-      actionIndex !== undefined &&
-      Number.isInteger(actionIndex) &&
-      actionIndex >= 0
-        ? { actionId, sourceTaskId, toolCallId, actionIndex }
-        : undefined;
+    const parsedAttribution = agentActionAttributionSchema.safeParse({
+      action_id: params.get("agent_action_id"),
+      source_task_id: params.get("agent_action_source_task_id"),
+      tool_call_id: params.get("agent_action_tool_call_id"),
+      action_index: actionIndexValue
+        ? Number.parseInt(actionIndexValue, 10)
+        : undefined,
+    });
 
     if (!prompt && !shared.repo) {
       this.log.warn("New task link requires at least prompt or repo");
@@ -90,7 +84,9 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
     const payload: NewTaskLinkPayload = {
       action: "new",
       prompt,
-      agentActionAttribution,
+      agentActionAttribution: parsedAttribution.success
+        ? parsedAttribution.data
+        : undefined,
       ...shared,
     };
 

--- a/products/desktop/packages/core/src/links/new-task-link.ts
+++ b/products/desktop/packages/core/src/links/new-task-link.ts
@@ -65,6 +65,22 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
   private handleNew(params: URLSearchParams): boolean {
     const shared = this.extractSharedParams(params);
     const prompt = params.get("prompt") ?? undefined;
+    const actionId = params.get("agent_action_id") ?? undefined;
+    const sourceTaskId = params.get("agent_action_source_task_id") ?? undefined;
+    const toolCallId = params.get("agent_action_tool_call_id") ?? undefined;
+    const actionIndexValue = params.get("agent_action_index");
+    const actionIndex = actionIndexValue
+      ? Number.parseInt(actionIndexValue, 10)
+      : undefined;
+    const agentActionAttribution =
+      actionId &&
+      sourceTaskId &&
+      toolCallId &&
+      actionIndex !== undefined &&
+      Number.isInteger(actionIndex) &&
+      actionIndex >= 0
+        ? { actionId, sourceTaskId, toolCallId, actionIndex }
+        : undefined;
 
     if (!prompt && !shared.repo) {
       this.log.warn("New task link requires at least prompt or repo");
@@ -74,6 +90,7 @@ export class NewTaskLinkService extends TypedEventEmitter<NewTaskLinkEvents> {
     const payload: NewTaskLinkPayload = {
       action: "new",
       prompt,
+      agentActionAttribution,
       ...shared,
     };
 

--- a/products/desktop/packages/host-router/src/routers/deep-link.router.ts
+++ b/products/desktop/packages/host-router/src/routers/deep-link.router.ts
@@ -75,25 +75,13 @@ export const deepLinkRouter = router({
     .input(openAgentActionInput)
     .mutation(({ ctx, input }) => {
       const deepLinks = ctx.container.get<IDeepLinkRegistry>(DEEP_LINK_SERVICE);
-      const url = new URL(
-        buildActionUrl(input.action, deepLinks.getProtocol()),
+      return deepLinks.handleUrl(
+        buildActionUrl(
+          input.action,
+          deepLinks.getProtocol(),
+          input.attribution,
+        ),
       );
-      if (input.action.kind === "compose") {
-        url.searchParams.set("agent_action_id", input.attribution.action_id);
-        url.searchParams.set(
-          "agent_action_source_task_id",
-          input.attribution.source_task_id,
-        );
-        url.searchParams.set(
-          "agent_action_tool_call_id",
-          input.attribution.tool_call_id,
-        );
-        url.searchParams.set(
-          "agent_action_index",
-          String(input.attribution.action_index),
-        );
-      }
-      return deepLinks.handleUrl(url.toString());
     }),
 
   onOpenTask: publicProcedure.subscription(async function* (opts) {

--- a/products/desktop/packages/host-router/src/routers/deep-link.router.ts
+++ b/products/desktop/packages/host-router/src/routers/deep-link.router.ts
@@ -75,9 +75,25 @@ export const deepLinkRouter = router({
     .input(openAgentActionInput)
     .mutation(({ ctx, input }) => {
       const deepLinks = ctx.container.get<IDeepLinkRegistry>(DEEP_LINK_SERVICE);
-      return deepLinks.handleUrl(
+      const url = new URL(
         buildActionUrl(input.action, deepLinks.getProtocol()),
       );
+      if (input.action.kind === "compose") {
+        url.searchParams.set("agent_action_id", input.attribution.action_id);
+        url.searchParams.set(
+          "agent_action_source_task_id",
+          input.attribution.source_task_id,
+        );
+        url.searchParams.set(
+          "agent_action_tool_call_id",
+          input.attribution.tool_call_id,
+        );
+        url.searchParams.set(
+          "agent_action_index",
+          String(input.attribution.action_index),
+        );
+      }
+      return deepLinks.handleUrl(url.toString());
     }),
 
   onOpenTask: publicProcedure.subscription(async function* (opts) {

--- a/products/desktop/packages/shared/src/agent-actions.test.ts
+++ b/products/desktop/packages/shared/src/agent-actions.test.ts
@@ -42,6 +42,21 @@ describe("buildActionUrl", () => {
       );
     });
 
+    it("appends trusted attribution for a resulting task", () => {
+      const url = buildActionUrl({ kind: "compose", prompt: "Fix it" }, PROD, {
+        action_id: "task:tool:0",
+        source_task_id: "task",
+        tool_call_id: "tool",
+        action_index: 0,
+      });
+
+      const { params } = parse(url);
+      expect(params.get("agent_action_id")).toBe("task:tool:0");
+      expect(params.get("agent_action_source_task_id")).toBe("task");
+      expect(params.get("agent_action_tool_call_id")).toBe("tool");
+      expect(params.get("agent_action_index")).toBe("0");
+    });
+
     it.each<[string, string]>([
       ["ampersand and query separators", "Ship A & B? #now"],
       ["a plus sign", "Bump limit from 1+1 to 3"],

--- a/products/desktop/packages/shared/src/agent-actions.ts
+++ b/products/desktop/packages/shared/src/agent-actions.ts
@@ -81,7 +81,21 @@ export const showActionSchema = z.discriminatedUnion("kind", [
 
 export type ShowAction = z.infer<typeof showActionSchema>;
 
-export const openAgentActionInput = z.object({ action: agentActionSchema });
+export const agentActionAttributionSchema = z.object({
+  action_id: requiredField,
+  source_task_id: requiredField,
+  tool_call_id: requiredField,
+  action_index: z.number().int().nonnegative(),
+});
+
+export type AgentActionAttribution = z.infer<
+  typeof agentActionAttributionSchema
+>;
+
+export const openAgentActionInput = z.object({
+  action: agentActionSchema,
+  attribution: agentActionAttributionSchema,
+});
 
 /** One button as the renderer draws it: its text, and the verb behind it. */
 export interface ShowActionButton {

--- a/products/desktop/packages/shared/src/agent-actions.ts
+++ b/products/desktop/packages/shared/src/agent-actions.ts
@@ -114,14 +114,24 @@ export function splitShowAction(button: ShowAction): ShowActionButton {
  * blank required field, so every branch can build a whole link. Keep that
  * guarantee at the schema rather than returning a partial link from here.
  */
-export function buildActionUrl(action: AgentAction, scheme: string): string {
+export function buildActionUrl(
+  action: AgentAction,
+  scheme: string,
+  attribution?: AgentActionAttribution,
+): string {
   switch (action.kind) {
     case "compose": {
-      const prompt = `prompt=${encodeURIComponent(action.prompt)}`;
-      const query = action.repo
-        ? `${prompt}&repo=${encodeURIComponent(action.repo)}`
-        : prompt;
-      return `${scheme}://new?${query}`;
+      const query = [`prompt=${encodeURIComponent(action.prompt)}`];
+      if (action.repo) query.push(`repo=${encodeURIComponent(action.repo)}`);
+      if (attribution) {
+        query.push(
+          `agent_action_id=${encodeURIComponent(attribution.action_id)}`,
+          `agent_action_source_task_id=${encodeURIComponent(attribution.source_task_id)}`,
+          `agent_action_tool_call_id=${encodeURIComponent(attribution.tool_call_id)}`,
+          `agent_action_index=${attribution.action_index}`,
+        );
+      }
+      return `${scheme}://new?${query.join("&")}`;
     }
     case "open_space":
       return `${scheme}://channel/${encodeURIComponent(action.channel_id)}`;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -18,7 +18,25 @@ export interface PromptHistorySelectedProperties {
 
 type ExecutionType = "cloud" | "local";
 export type RepositoryProvider = "github" | "gitlab" | "local" | "none";
-type TaskCreatedFrom = "cli" | "command-menu" | "sidebar-worktree";
+type TaskCreatedFrom =
+  | "agent-action"
+  | "cli"
+  | "command-menu"
+  | "sidebar-worktree";
+
+export type AgentActionKind =
+  | "compose"
+  | "open_canvas"
+  | "open_inbox"
+  | "open_space";
+
+export interface AgentActionProperties {
+  action_id: string;
+  source_task_id: string;
+  tool_call_id: string;
+  action_index: number;
+  action_kind: AgentActionKind;
+}
 type RepositorySelectSource = "task-creation" | "task-detail";
 type GitActionType =
   | "push"
@@ -104,6 +122,10 @@ export interface TaskCreateProperties {
   adapter?: Adapter;
   codex_model_access?: ModelAccess;
   claude_model_access?: ModelAccess;
+  resulting_task_id?: string;
+  source_task_id?: string;
+  agent_action_id?: string;
+  agent_action_tool_call_id?: string;
 }
 
 export interface TaskViewProperties {
@@ -1519,6 +1541,9 @@ export const ANALYTICS_EVENTS = {
   // Git operations
   GIT_ACTION_EXECUTED: "Git action executed",
   PR_CREATED: "PR created",
+  AGENT_ACTION_SHOWN: "Agent action shown",
+  AGENT_ACTION_CLICKED: "Agent action clicked",
+  AGENT_ACTION_OPEN_FAILED: "Agent action open failed",
   AGENT_FILE_ACTIVITY: "Agent file activity",
   BRANCH_LINKED: "Branch linked",
   BRANCH_UNLINKED: "Branch unlinked",
@@ -1727,6 +1752,9 @@ export type EventPropertyMap = {
   // Git operations
   [ANALYTICS_EVENTS.GIT_ACTION_EXECUTED]: GitActionExecutedProperties;
   [ANALYTICS_EVENTS.PR_CREATED]: PrCreatedProperties;
+  [ANALYTICS_EVENTS.AGENT_ACTION_SHOWN]: AgentActionProperties;
+  [ANALYTICS_EVENTS.AGENT_ACTION_CLICKED]: AgentActionProperties;
+  [ANALYTICS_EVENTS.AGENT_ACTION_OPEN_FAILED]: AgentActionProperties;
   [ANALYTICS_EVENTS.AGENT_FILE_ACTIVITY]: AgentFileActivityProperties;
   [ANALYTICS_EVENTS.BRANCH_LINKED]: BranchLinkedProperties;
   [ANALYTICS_EVENTS.BRANCH_UNLINKED]: BranchUnlinkedProperties;

--- a/products/desktop/packages/shared/src/deep-links.ts
+++ b/products/desktop/packages/shared/src/deep-links.ts
@@ -116,8 +116,19 @@ export interface NewTaskSharedParams {
   model?: string;
 }
 
+export interface AgentActionTaskAttribution {
+  actionId: string;
+  sourceTaskId: string;
+  toolCallId: string;
+  actionIndex: number;
+}
+
 export type NewTaskLinkPayload =
-  | ({ action: "new"; prompt?: string } & NewTaskSharedParams)
+  | ({
+      action: "new";
+      prompt?: string;
+      agentActionAttribution?: AgentActionTaskAttribution;
+    } & NewTaskSharedParams)
   | ({ action: "plan"; plan: string } & NewTaskSharedParams)
   | ({
       action: "issue";

--- a/products/desktop/packages/shared/src/deep-links.ts
+++ b/products/desktop/packages/shared/src/deep-links.ts
@@ -1,3 +1,4 @@
+import type { AgentActionAttribution } from "./agent-actions";
 import { scoutSkillSlug } from "./scout-naming";
 
 const DEEPLINK_PROTOCOL_PRODUCTION = "posthog-code";
@@ -116,18 +117,11 @@ export interface NewTaskSharedParams {
   model?: string;
 }
 
-export interface AgentActionTaskAttribution {
-  actionId: string;
-  sourceTaskId: string;
-  toolCallId: string;
-  actionIndex: number;
-}
-
 export type NewTaskLinkPayload =
   | ({
       action: "new";
       prompt?: string;
-      agentActionAttribution?: AgentActionTaskAttribution;
+      agentActionAttribution?: AgentActionAttribution;
     } & NewTaskSharedParams)
   | ({ action: "plan"; plan: string } & NewTaskSharedParams)
   | ({

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from "./adapter";
 export {
   type AgentAction,
   type AgentActionAttribution,
+  agentActionAttributionSchema,
   agentActionSchema,
   buildActionUrl,
   openAgentActionInput,
@@ -97,7 +98,6 @@ export {
   pickAllowedModel,
 } from "./cloud-task-models";
 export {
-  type AgentActionTaskAttribution,
   buildInboxDeeplink,
   buildLoopDeeplink,
   buildScoutDeeplink,

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -1,5 +1,8 @@
 export * from "./adapter";
 export {
+  type AgentAction,
+  type AgentActionAttribution,
+  agentActionSchema,
   buildActionUrl,
   openAgentActionInput,
   type ShowActionButton,
@@ -94,6 +97,8 @@ export {
   pickAllowedModel,
 } from "./cloud-task-models";
 export {
+  type AgentActionTaskAttribution,
+  buildInboxDeeplink,
   buildLoopDeeplink,
   buildScoutDeeplink,
   decodePlanBase64,

--- a/products/desktop/packages/ui/src/features/canvas/components/SpaceNewTask.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/SpaceNewTask.tsx
@@ -168,6 +168,8 @@ export function SpaceNewTask({ channelId }: { channelId: string }) {
           initialModel={view.initialModel}
           initialMode={view.initialMode}
           reportAssociation={view.reportAssociation}
+          agentActionAttribution={view.agentActionAttribution}
+          agentActionRequestId={view.agentActionRequestId}
           suggestions={CHANNEL_TASK_SUGGESTIONS}
           onSuggestionSelect={(label) =>
             track(ANALYTICS_EVENTS.CHANNEL_ACTION, {

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
@@ -5,6 +5,9 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 const openAgentAction = vi.hoisted(() => vi.fn());
+const track = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
 
 vi.mock("@posthog/host-router/react", () => ({
   useHostTRPC: () => ({
@@ -16,13 +19,16 @@ vi.mock("@posthog/host-router/react", () => ({
   }),
 }));
 
+import { SessionTaskIdProvider } from "../../useSessionTaskId";
 import { ShowActionsRow } from "./ShowActionsRow";
 
 function renderCard(actions: unknown[]) {
   const toolCall = { toolCallId: "tc", rawInput: { actions } } as ToolCall;
   return render(
     <QueryClientProvider client={new QueryClient()}>
-      <ShowActionsRow toolCall={toolCall} turnComplete />
+      <SessionTaskIdProvider taskId="source-task">
+        <ShowActionsRow toolCall={toolCall} turnComplete />
+      </SessionTaskIdProvider>
     </QueryClientProvider>,
   );
 }
@@ -52,6 +58,19 @@ describe("ShowActionsRow", () => {
     await waitFor(() => expect(openAgentAction).toHaveBeenCalled());
     expect(openAgentAction.mock.calls[0]?.[0]).toEqual({
       action: { kind: "open_space", channel_id: "chan" },
+      attribution: {
+        action_id: "source-task:tc:0",
+        source_task_id: "source-task",
+        tool_call_id: "tc",
+        action_index: 0,
+      },
+    });
+    expect(track).toHaveBeenCalledWith("Agent action clicked", {
+      action_id: "source-task:tc:0",
+      source_task_id: "source-task",
+      tool_call_id: "tc",
+      action_index: 0,
+      action_kind: "open_space",
     });
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
@@ -2,12 +2,16 @@ import type { ToolCall } from "@posthog/ui/features/sessions/types";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const openAgentAction = vi.hoisted(() => vi.fn());
 const track = vi.hoisted(() => vi.fn());
+const visibility = vi.hoisted(() => ({ current: false }));
 
 vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
+vi.mock("@posthog/ui/primitives/hooks/useInView", () => ({
+  useInView: () => [vi.fn(), visibility.current],
+}));
 
 vi.mock("@posthog/host-router/react", () => ({
   useHostTRPC: () => ({
@@ -22,18 +26,27 @@ vi.mock("@posthog/host-router/react", () => ({
 import { SessionTaskIdProvider } from "../../useSessionTaskId";
 import { ShowActionsRow } from "./ShowActionsRow";
 
-function renderCard(actions: unknown[]) {
-  const toolCall = { toolCallId: "tc", rawInput: { actions } } as ToolCall;
-  return render(
+function card(actions: unknown[], toolCallId = "tc") {
+  const toolCall = { toolCallId, rawInput: { actions } } as ToolCall;
+  return (
     <QueryClientProvider client={new QueryClient()}>
       <SessionTaskIdProvider taskId="source-task">
         <ShowActionsRow toolCall={toolCall} turnComplete />
       </SessionTaskIdProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
 }
 
+function renderCard(actions: unknown[], toolCallId?: string) {
+  return render(card(actions, toolCallId));
+}
+
 describe("ShowActionsRow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    visibility.current = false;
+  });
+
   it("draws a button per usable action and drops one that cannot open anything", () => {
     renderCard([
       { kind: "compose", label: "Fix the bug", prompt: "Fix the login bug" },
@@ -72,5 +85,33 @@ describe("ShowActionsRow", () => {
       action_index: 0,
       action_kind: "open_space",
     });
+  });
+
+  it("records each visible action once across remounts", () => {
+    const actions = [
+      { kind: "open_space", label: "Open the space", channel_id: "chan" },
+    ];
+    const first = renderCard(actions, "tc-visible");
+
+    expect(track).not.toHaveBeenCalledWith(
+      "Agent action shown",
+      expect.anything(),
+    );
+
+    visibility.current = true;
+    first.rerender(card(actions, "tc-visible"));
+
+    expect(track).toHaveBeenCalledWith("Agent action shown", {
+      action_id: "source-task:tc-visible:0",
+      source_task_id: "source-task",
+      tool_call_id: "tc-visible",
+      action_index: 0,
+      action_kind: "open_space",
+    });
+
+    first.unmount();
+    renderCard(actions, "tc-visible");
+
+    expect(track).toHaveBeenCalledTimes(1);
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
@@ -1,9 +1,13 @@
 import { readShowActions } from "@posthog/core/sessions/showActions";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
+import { useSessionTaskId } from "@posthog/ui/features/sessions/useSessionTaskId";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { useMutation } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
 
 /**
  * The buttons a `show_actions` call offered, drawn where the agent offered them.
@@ -12,17 +16,45 @@ import { useMutation } from "@tanstack/react-query";
  */
 export function ShowActionsRow({ toolCall }: ToolViewProps) {
   const trpc = useHostTRPC();
+  const sourceTaskId = useSessionTaskId();
+  const buttons = useMemo(
+    () => readShowActions(toolCall.rawInput),
+    [toolCall.rawInput],
+  );
+  const attributionFor = (index: number) => ({
+    action_id: `${sourceTaskId}:${toolCall.toolCallId}:${index}`,
+    source_task_id: sourceTaskId ?? "unknown",
+    tool_call_id: toolCall.toolCallId,
+    action_index: index,
+  });
+  useEffect(() => {
+    if (!sourceTaskId) return;
+    buttons.forEach(({ action }, actionIndex) => {
+      track(ANALYTICS_EVENTS.AGENT_ACTION_SHOWN, {
+        action_id: `${sourceTaskId}:${toolCall.toolCallId}:${actionIndex}`,
+        source_task_id: sourceTaskId,
+        tool_call_id: toolCall.toolCallId,
+        action_index: actionIndex,
+        action_kind: action.kind,
+      });
+    });
+  }, [buttons, sourceTaskId, toolCall.toolCallId]);
   // A click that opens nothing is the failure this tool exists to avoid. One
   // handler covers both ways it happens: the call rejecting leaves `opened`
   // undefined, and the host finding no handler for the link answers false.
   const openAction = useMutation(
     trpc.deepLink.openAgentAction.mutationOptions({
-      onSettled: (opened) => {
-        if (!opened) toast.error("Couldn't open that");
+      onSettled: (opened, _error, variables) => {
+        if (!opened) {
+          toast.error("Couldn't open that");
+          track(ANALYTICS_EVENTS.AGENT_ACTION_OPEN_FAILED, {
+            ...variables.attribution,
+            action_kind: variables.action.kind,
+          });
+        }
       },
     }),
   );
-  const buttons = readShowActions(toolCall.rawInput);
 
   if (buttons.length === 0) return null;
 
@@ -30,17 +62,27 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
   // frames them. A box around them would draw a second frame around nothing.
   return (
     <div className="flex flex-wrap gap-2">
-      {buttons.map(({ label, action }, index) => (
-        <Button
-          key={`${index}-${label}`}
-          variant="outline"
-          size="sm"
-          disabled={openAction.isPending}
-          onClick={() => openAction.mutate({ action })}
-        >
-          {label}
-        </Button>
-      ))}
+      {buttons.map(({ label, action }, index) => {
+        const attribution = attributionFor(index);
+        return (
+          <Button
+            key={`${index}-${label}`}
+            variant="outline"
+            size="sm"
+            disabled={openAction.isPending}
+            onClick={() => {
+              if (!sourceTaskId) return;
+              track(ANALYTICS_EVENTS.AGENT_ACTION_CLICKED, {
+                ...attribution,
+                action_kind: action.kind,
+              });
+              openAction.mutate({ action, attribution });
+            }}
+          >
+            {label}
+          </Button>
+        );
+      })}
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
@@ -1,6 +1,7 @@
 import { readShowActions } from "@posthog/core/sessions/showActions";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
+import type { AgentActionAttribution } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import { useSessionTaskId } from "@posthog/ui/features/sessions/useSessionTaskId";
@@ -8,6 +9,19 @@ import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
+
+function actionAttribution(
+  sourceTaskId: string,
+  toolCallId: string,
+  actionIndex: number,
+): AgentActionAttribution {
+  return {
+    action_id: `${sourceTaskId}:${toolCallId}:${actionIndex}`,
+    source_task_id: sourceTaskId,
+    tool_call_id: toolCallId,
+    action_index: actionIndex,
+  };
+}
 
 /**
  * The buttons a `show_actions` call offered, drawn where the agent offered them.
@@ -21,20 +35,11 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
     () => readShowActions(toolCall.rawInput),
     [toolCall.rawInput],
   );
-  const attributionFor = (index: number) => ({
-    action_id: `${sourceTaskId}:${toolCall.toolCallId}:${index}`,
-    source_task_id: sourceTaskId ?? "unknown",
-    tool_call_id: toolCall.toolCallId,
-    action_index: index,
-  });
   useEffect(() => {
     if (!sourceTaskId) return;
     buttons.forEach(({ action }, actionIndex) => {
       track(ANALYTICS_EVENTS.AGENT_ACTION_SHOWN, {
-        action_id: `${sourceTaskId}:${toolCall.toolCallId}:${actionIndex}`,
-        source_task_id: sourceTaskId,
-        tool_call_id: toolCall.toolCallId,
-        action_index: actionIndex,
+        ...actionAttribution(sourceTaskId, toolCall.toolCallId, actionIndex),
         action_kind: action.kind,
       });
     });
@@ -56,14 +61,18 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
     }),
   );
 
-  if (buttons.length === 0) return null;
+  if (!sourceTaskId || buttons.length === 0) return null;
 
   // No surrounding card: the buttons sit in the conversation, which already
   // frames them. A box around them would draw a second frame around nothing.
   return (
     <div className="flex flex-wrap gap-2">
       {buttons.map(({ label, action }, index) => {
-        const attribution = attributionFor(index);
+        const attribution = actionAttribution(
+          sourceTaskId,
+          toolCall.toolCallId,
+          index,
+        );
         return (
           <Button
             key={`${index}-${label}`}
@@ -71,7 +80,6 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
             size="sm"
             disabled={openAction.isPending}
             onClick={() => {
-              if (!sourceTaskId) return;
               track(ANALYTICS_EVENTS.AGENT_ACTION_CLICKED, {
                 ...attribution,
                 action_kind: action.kind,

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
@@ -5,10 +5,13 @@ import type { AgentActionAttribution } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import { useSessionTaskId } from "@posthog/ui/features/sessions/useSessionTaskId";
+import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
+
+const shownActionIds = new Set<string>();
 
 function actionAttribution(
   sourceTaskId: string,
@@ -31,19 +34,30 @@ function actionAttribution(
 export function ShowActionsRow({ toolCall }: ToolViewProps) {
   const trpc = useHostTRPC();
   const sourceTaskId = useSessionTaskId();
+  const [rowRef, inView] = useInView<HTMLDivElement>({
+    rootMargin: "0px",
+    once: true,
+  });
   const buttons = useMemo(
     () => readShowActions(toolCall.rawInput),
     [toolCall.rawInput],
   );
   useEffect(() => {
-    if (!sourceTaskId) return;
+    if (!sourceTaskId || !inView) return;
     buttons.forEach(({ action }, actionIndex) => {
+      const attribution = actionAttribution(
+        sourceTaskId,
+        toolCall.toolCallId,
+        actionIndex,
+      );
+      if (shownActionIds.has(attribution.action_id)) return;
+      shownActionIds.add(attribution.action_id);
       track(ANALYTICS_EVENTS.AGENT_ACTION_SHOWN, {
-        ...actionAttribution(sourceTaskId, toolCall.toolCallId, actionIndex),
+        ...attribution,
         action_kind: action.kind,
       });
     });
-  }, [buttons, sourceTaskId, toolCall.toolCallId]);
+  }, [buttons, inView, sourceTaskId, toolCall.toolCallId]);
   // A click that opens nothing is the failure this tool exists to avoid. One
   // handler covers both ways it happens: the call rejecting leaves `opened`
   // undefined, and the host finding no handler for the link answers false.
@@ -66,7 +80,7 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
   // No surrounding card: the buttons sit in the conversation, which already
   // frames them. A box around them would draw a second frame around nothing.
   return (
-    <div className="flex flex-wrap gap-2">
+    <div ref={rowRef} className="flex flex-wrap gap-2">
       {buttons.map(({ label, action }, index) => {
         const attribution = actionAttribution(
           sourceTaskId,

--- a/products/desktop/packages/ui/src/features/task-detail/components/NewTaskScreen.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/NewTaskScreen.tsx
@@ -30,6 +30,8 @@ export function NewTaskScreen() {
       initialModel={view.initialModel}
       initialMode={view.initialMode}
       reportAssociation={view.reportAssociation}
+      agentActionAttribution={view.agentActionAttribution}
+      agentActionRequestId={view.agentActionRequestId}
       suggestions={channelsWorld ? CHANNEL_TASK_SUGGESTIONS : undefined}
     />
   );

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -19,6 +19,7 @@ import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ButtonGroup } from "@posthog/quill";
 import {
+  type AgentActionAttribution,
   type AgentRuntime,
   ANALYTICS_EVENTS,
   adapterForModelId,
@@ -155,6 +156,8 @@ interface TaskInputProps {
   initialModel?: string;
   initialMode?: string;
   reportAssociation?: TaskInputReportAssociation;
+  agentActionAttribution?: AgentActionAttribution;
+  agentActionRequestId?: string;
   /** Optional channel CONTEXT.md, appended to the initial prompt as background. */
   channelContext?: string;
   /** Repo-relative context wiki page used instead of injecting the legacy body. */
@@ -226,6 +229,8 @@ export function TaskInput({
   initialModel,
   initialMode,
   reportAssociation,
+  agentActionAttribution,
+  agentActionRequestId,
   channelContext,
   channelContextPath,
   channelContextBlocked = false,
@@ -1078,6 +1083,8 @@ export function TaskInput({
     sandboxEnvironmentId: cloudIds.sandboxEnvironmentId,
     customImageId: cloudIds.customImageId,
     signalReportId: activeReportAssociation?.reportId,
+    agentActionAttribution,
+    agentActionRequestId,
     channelContext: includeChannelContext ? channelContext : undefined,
     channelContextPath: includeChannelContext ? channelContextPath : undefined,
     channelName,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -14,7 +14,7 @@ import type { HostTrpcClient } from "@posthog/host-router/client";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import {
   type Adapter,
-  type AgentActionTaskAttribution,
+  type AgentActionAttribution,
   type AgentRuntime,
   ANALYTICS_EVENTS,
   type ModelAccess,
@@ -142,7 +142,7 @@ async function trackTaskCreated(
   selectedDirectory: string,
   hostClient: HostTrpcClient,
   resultingTaskId: string,
-  attribution?: AgentActionTaskAttribution,
+  attribution?: AgentActionAttribution,
   codexModelAccess?: ModelAccess,
   claudeModelAccess?: ModelAccess,
 ): Promise<void> {
@@ -188,9 +188,9 @@ async function trackTaskCreated(
       codex_model_access: codexModelAccess,
       claude_model_access: claudeModelAccess,
       resulting_task_id: resultingTaskId,
-      source_task_id: attribution?.sourceTaskId,
-      agent_action_id: attribution?.actionId,
-      agent_action_tool_call_id: attribution?.toolCallId,
+      source_task_id: attribution?.source_task_id,
+      agent_action_id: attribution?.action_id,
+      agent_action_tool_call_id: attribution?.tool_call_id,
     });
   } catch (error) {
     log.warn("Failed to track Task created event", { error });
@@ -575,14 +575,9 @@ export function useTaskCreation({
             if (allowNoRepo && channelId) {
               useTaskRepositoryDraftStore.getState().clearDraft(channelId);
             }
-            const agentActionAttribution =
-              useTaskInputPrefillStore.getState().prefill
-                .agentActionAttribution;
-            if (agentActionAttribution) {
-              useTaskInputPrefillStore
-                .getState()
-                .consumeAgentActionAttribution(agentActionAttribution.actionId);
-            }
+            const agentActionAttribution = useTaskInputPrefillStore
+              .getState()
+              .takeAgentActionAttribution();
             void trackTaskCreated(
               input,
               selectedDirectory,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -14,6 +14,7 @@ import type { HostTrpcClient } from "@posthog/host-router/client";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import {
   type Adapter,
+  type AgentActionTaskAttribution,
   type AgentRuntime,
   ANALYTICS_EVENTS,
   type ModelAccess,
@@ -140,6 +141,8 @@ async function trackTaskCreated(
   input: TaskCreationInput,
   selectedDirectory: string,
   hostClient: HostTrpcClient,
+  resultingTaskId: string,
+  attribution?: AgentActionTaskAttribution,
   codexModelAccess?: ModelAccess,
   claudeModelAccess?: ModelAccess,
 ): Promise<void> {
@@ -164,7 +167,7 @@ async function trackTaskCreated(
 
     track(ANALYTICS_EVENTS.TASK_CREATED, {
       auto_run: !!input.executionMode,
-      created_from: "command-menu",
+      created_from: attribution ? "agent-action" : "command-menu",
       repository_provider: input.repository ? "github" : "none",
       workspace_mode: workspaceMode,
       has_branch: !!input.branch,
@@ -184,6 +187,10 @@ async function trackTaskCreated(
       adapter: input.adapter,
       codex_model_access: codexModelAccess,
       claude_model_access: claudeModelAccess,
+      resulting_task_id: resultingTaskId,
+      source_task_id: attribution?.sourceTaskId,
+      agent_action_id: attribution?.actionId,
+      agent_action_tool_call_id: attribution?.toolCallId,
     });
   } catch (error) {
     log.warn("Failed to track Task created event", { error });
@@ -568,10 +575,20 @@ export function useTaskCreation({
             if (allowNoRepo && channelId) {
               useTaskRepositoryDraftStore.getState().clearDraft(channelId);
             }
+            const agentActionAttribution =
+              useTaskInputPrefillStore.getState().prefill
+                .agentActionAttribution;
+            if (agentActionAttribution) {
+              useTaskInputPrefillStore
+                .getState()
+                .consumeAgentActionAttribution(agentActionAttribution.actionId);
+            }
             void trackTaskCreated(
               input,
               selectedDirectory,
               hostClient,
+              result.data.task.id,
+              agentActionAttribution,
               input.codexModelAccess,
               input.claudeModelAccess,
             );

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -100,6 +100,8 @@ interface UseTaskCreationOptions {
   sandboxEnvironmentId?: string;
   customImageId?: string;
   signalReportId?: string;
+  agentActionAttribution?: AgentActionAttribution;
+  agentActionRequestId?: string;
   channelContext?: string;
   channelContextPath?: string;
   submissionBlocked?: boolean;
@@ -219,6 +221,8 @@ export function useTaskCreation({
   sandboxEnvironmentId,
   customImageId,
   signalReportId,
+  agentActionAttribution,
+  agentActionRequestId,
   channelContext,
   channelContextPath,
   submissionBlocked = false,
@@ -298,6 +302,8 @@ export function useTaskCreation({
       const plainPromptText = contentToPlainText(content).trim();
       const serializedContent = contentToXml(content).trim();
       const filePaths = extractFilePaths(content);
+      const submittedAgentActionAttribution = agentActionAttribution;
+      const submittedAgentActionRequestId = agentActionRequestId;
 
       // Held for the whole submit, pre-flight awaits included, so a second
       // Enter lands after `canSubmitBase` has already gone false.
@@ -575,15 +581,17 @@ export function useTaskCreation({
             if (allowNoRepo && channelId) {
               useTaskRepositoryDraftStore.getState().clearDraft(channelId);
             }
-            const agentActionAttribution = useTaskInputPrefillStore
-              .getState()
-              .takeAgentActionAttribution();
+            if (submittedAgentActionRequestId) {
+              useTaskInputPrefillStore
+                .getState()
+                .consumeAgentAction(submittedAgentActionRequestId);
+            }
             void trackTaskCreated(
               input,
               selectedDirectory,
               hostClient,
               result.data.task.id,
-              agentActionAttribution,
+              submittedAgentActionAttribution,
               input.codexModelAccess,
               input.claudeModelAccess,
             );
@@ -701,6 +709,8 @@ export function useTaskCreation({
       sandboxEnvironmentId,
       customImageId,
       signalReportId,
+      agentActionAttribution,
+      agentActionRequestId,
       additionalDirectories,
       channelContext,
       channelContextPath,

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.test.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.test.ts
@@ -7,7 +7,7 @@ describe("taskInputPrefillStore", () => {
     useTaskInputPrefillStore.setState({ prefill: {} });
   });
 
-  it("takes agent action attribution once", () => {
+  it("consumes the matching agent action without clearing the prompt", () => {
     const attribution = {
       action_id: "task-1:tool-1:0",
       source_task_id: "task-1",
@@ -16,17 +16,35 @@ describe("taskInputPrefillStore", () => {
     };
     useTaskInputPrefillStore.getState().setPrefill({
       initialPrompt: "Investigate this",
-      agentActionAttribution: attribution,
+      agentAction: { requestId: "request-1", attribution },
     });
 
+    useTaskInputPrefillStore.getState().consumeAgentAction("request-1");
+
     expect(
-      useTaskInputPrefillStore.getState().takeAgentActionAttribution(),
-    ).toEqual(attribution);
-    expect(
-      useTaskInputPrefillStore.getState().takeAgentActionAttribution(),
+      useTaskInputPrefillStore.getState().prefill.agentAction,
     ).toBeUndefined();
     expect(useTaskInputPrefillStore.getState().prefill.initialPrompt).toBe(
       "Investigate this",
     );
+  });
+
+  it("leaves a newer agent action alone", () => {
+    const attribution = {
+      action_id: "task-2:tool-2:0",
+      source_task_id: "task-2",
+      tool_call_id: "tool-2",
+      action_index: 0,
+    };
+    useTaskInputPrefillStore.getState().setPrefill({
+      agentAction: { requestId: "request-2", attribution },
+    });
+
+    useTaskInputPrefillStore.getState().consumeAgentAction("request-1");
+
+    expect(useTaskInputPrefillStore.getState().prefill.agentAction).toEqual({
+      requestId: "request-2",
+      attribution,
+    });
   });
 });

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.test.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useTaskInputPrefillStore } from "./taskInputPrefillStore";
+
+describe("taskInputPrefillStore", () => {
+  beforeEach(() => {
+    useTaskInputPrefillStore.setState({ prefill: {} });
+  });
+
+  it("takes agent action attribution once", () => {
+    const attribution = {
+      action_id: "task-1:tool-1:0",
+      source_task_id: "task-1",
+      tool_call_id: "tool-1",
+      action_index: 0,
+    };
+    useTaskInputPrefillStore.getState().setPrefill({
+      initialPrompt: "Investigate this",
+      agentActionAttribution: attribution,
+    });
+
+    expect(
+      useTaskInputPrefillStore.getState().takeAgentActionAttribution(),
+    ).toEqual(attribution);
+    expect(
+      useTaskInputPrefillStore.getState().takeAgentActionAttribution(),
+    ).toBeUndefined();
+    expect(useTaskInputPrefillStore.getState().prefill.initialPrompt).toBe(
+      "Investigate this",
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
@@ -1,4 +1,5 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
+import type { AgentActionTaskAttribution } from "@posthog/shared";
 import { create } from "zustand";
 
 export interface TaskInputReportAssociation {
@@ -29,6 +30,7 @@ interface TaskInputPrefill {
   initialMode?: string;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
+  agentActionAttribution?: AgentActionTaskAttribution;
 }
 
 interface PrefillStoreState {
@@ -42,6 +44,7 @@ interface PrefillStoreState {
    * that landed in between is left alone.
    */
   consumePrompt: (requestId: string) => void;
+  consumeAgentActionAttribution: (actionId: string) => void;
 }
 
 // Holds transient state used to prefill the TaskInput screen when navigation
@@ -69,6 +72,17 @@ export const useTaskInputPrefillStore = create<PrefillStoreState>((set) => ({
               initialContent: undefined,
               recoveredFromKey: undefined,
               requestId: undefined,
+            },
+          }
+        : s,
+    ),
+  consumeAgentActionAttribution: (actionId) =>
+    set((s) =>
+      s.prefill.agentActionAttribution?.actionId === actionId
+        ? {
+            prefill: {
+              ...s.prefill,
+              agentActionAttribution: undefined,
             },
           }
         : s,

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
@@ -30,7 +30,10 @@ interface TaskInputPrefill {
   initialMode?: string;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
-  agentActionAttribution?: AgentActionAttribution;
+  agentAction?: {
+    requestId: string;
+    attribution: AgentActionAttribution;
+  };
 }
 
 interface PrefillStoreState {
@@ -44,47 +47,44 @@ interface PrefillStoreState {
    * that landed in between is left alone.
    */
   consumePrompt: (requestId: string) => void;
-  takeAgentActionAttribution: () => AgentActionAttribution | undefined;
+  consumeAgentAction: (requestId: string) => void;
 }
 
 // Holds transient state used to prefill the TaskInput screen when navigation
 // is triggered with options (e.g. deep links, "discuss in new task" flows).
 // Lives outside the URL because the values are large/structured and don't
 // belong in a hash fragment.
-export const useTaskInputPrefillStore = create<PrefillStoreState>(
-  (set, get) => ({
-    prefill: {},
-    setPrefill: (prefill) => set({ prefill }),
-    clearReportAssociation: () =>
-      set((s) => ({
-        prefill: {
-          ...s.prefill,
-          reportAssociation: undefined,
-          initialCloudRepository: undefined,
-        },
-      })),
-    consumePrompt: (requestId) =>
-      set((s) =>
-        s.prefill.requestId === requestId
-          ? {
-              prefill: {
-                ...s.prefill,
-                initialPrompt: undefined,
-                initialContent: undefined,
-                recoveredFromKey: undefined,
-                requestId: undefined,
-              },
-            }
-          : s,
-      ),
-    takeAgentActionAttribution: () => {
-      const attribution = get().prefill.agentActionAttribution;
-      if (attribution) {
-        set((s) => ({
-          prefill: { ...s.prefill, agentActionAttribution: undefined },
-        }));
-      }
-      return attribution;
-    },
-  }),
-);
+export const useTaskInputPrefillStore = create<PrefillStoreState>((set) => ({
+  prefill: {},
+  setPrefill: (prefill) => set({ prefill }),
+  clearReportAssociation: () =>
+    set((s) => ({
+      prefill: {
+        ...s.prefill,
+        reportAssociation: undefined,
+        initialCloudRepository: undefined,
+      },
+    })),
+  consumePrompt: (requestId) =>
+    set((s) =>
+      s.prefill.requestId === requestId
+        ? {
+            prefill: {
+              ...s.prefill,
+              initialPrompt: undefined,
+              initialContent: undefined,
+              recoveredFromKey: undefined,
+              requestId: undefined,
+            },
+          }
+        : s,
+    ),
+  consumeAgentAction: (requestId) =>
+    set((s) =>
+      s.prefill.agentAction?.requestId === requestId
+        ? {
+            prefill: { ...s.prefill, agentAction: undefined },
+          }
+        : s,
+    ),
+}));

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
@@ -1,5 +1,5 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
-import type { AgentActionTaskAttribution } from "@posthog/shared";
+import type { AgentActionAttribution } from "@posthog/shared";
 import { create } from "zustand";
 
 export interface TaskInputReportAssociation {
@@ -30,7 +30,7 @@ interface TaskInputPrefill {
   initialMode?: string;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
-  agentActionAttribution?: AgentActionTaskAttribution;
+  agentActionAttribution?: AgentActionAttribution;
 }
 
 interface PrefillStoreState {
@@ -44,47 +44,47 @@ interface PrefillStoreState {
    * that landed in between is left alone.
    */
   consumePrompt: (requestId: string) => void;
-  consumeAgentActionAttribution: (actionId: string) => void;
+  takeAgentActionAttribution: () => AgentActionAttribution | undefined;
 }
 
 // Holds transient state used to prefill the TaskInput screen when navigation
 // is triggered with options (e.g. deep links, "discuss in new task" flows).
 // Lives outside the URL because the values are large/structured and don't
 // belong in a hash fragment.
-export const useTaskInputPrefillStore = create<PrefillStoreState>((set) => ({
-  prefill: {},
-  setPrefill: (prefill) => set({ prefill }),
-  clearReportAssociation: () =>
-    set((s) => ({
-      prefill: {
-        ...s.prefill,
-        reportAssociation: undefined,
-        initialCloudRepository: undefined,
-      },
-    })),
-  consumePrompt: (requestId) =>
-    set((s) =>
-      s.prefill.requestId === requestId
-        ? {
-            prefill: {
-              ...s.prefill,
-              initialPrompt: undefined,
-              initialContent: undefined,
-              recoveredFromKey: undefined,
-              requestId: undefined,
-            },
-          }
-        : s,
-    ),
-  consumeAgentActionAttribution: (actionId) =>
-    set((s) =>
-      s.prefill.agentActionAttribution?.actionId === actionId
-        ? {
-            prefill: {
-              ...s.prefill,
-              agentActionAttribution: undefined,
-            },
-          }
-        : s,
-    ),
-}));
+export const useTaskInputPrefillStore = create<PrefillStoreState>(
+  (set, get) => ({
+    prefill: {},
+    setPrefill: (prefill) => set({ prefill }),
+    clearReportAssociation: () =>
+      set((s) => ({
+        prefill: {
+          ...s.prefill,
+          reportAssociation: undefined,
+          initialCloudRepository: undefined,
+        },
+      })),
+    consumePrompt: (requestId) =>
+      set((s) =>
+        s.prefill.requestId === requestId
+          ? {
+              prefill: {
+                ...s.prefill,
+                initialPrompt: undefined,
+                initialContent: undefined,
+                recoveredFromKey: undefined,
+                requestId: undefined,
+              },
+            }
+          : s,
+      ),
+    takeAgentActionAttribution: () => {
+      const attribution = get().prefill.agentActionAttribution;
+      if (attribution) {
+        set((s) => ({
+          prefill: { ...s.prefill, agentActionAttribution: undefined },
+        }));
+      }
+      return attribution;
+    },
+  }),
+);

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -1,4 +1,5 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
+import type { AgentActionTaskAttribution } from "@posthog/shared";
 import {
   type TaskInputReportAssociation,
   useTaskInputPrefillStore,
@@ -39,6 +40,7 @@ export interface AppView {
   initialMode?: string;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
+  agentActionAttribution?: AgentActionTaskAttribution;
 }
 
 type Match = { fullPath: string; params: Record<string, string | undefined> };
@@ -160,6 +162,7 @@ export function useAppView(): AppView {
         initialMode: prefill.initialMode,
         folderRunEnvironment: prefill.folderRunEnvironment,
         reportAssociation: prefill.reportAssociation,
+        agentActionAttribution: prefill.agentActionAttribution,
         taskInputRequestId: prefill.requestId,
       };
     }

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -41,6 +41,7 @@ export interface AppView {
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
   agentActionAttribution?: AgentActionAttribution;
+  agentActionRequestId?: string;
 }
 
 type Match = { fullPath: string; params: Record<string, string | undefined> };
@@ -162,7 +163,8 @@ export function useAppView(): AppView {
         initialMode: prefill.initialMode,
         folderRunEnvironment: prefill.folderRunEnvironment,
         reportAssociation: prefill.reportAssociation,
-        agentActionAttribution: prefill.agentActionAttribution,
+        agentActionAttribution: prefill.agentAction?.attribution,
+        agentActionRequestId: prefill.agentAction?.requestId,
         taskInputRequestId: prefill.requestId,
       };
     }

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -1,5 +1,5 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
-import type { AgentActionTaskAttribution } from "@posthog/shared";
+import type { AgentActionAttribution } from "@posthog/shared";
 import {
   type TaskInputReportAssociation,
   useTaskInputPrefillStore,
@@ -40,7 +40,7 @@ export interface AppView {
   initialMode?: string;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
-  agentActionAttribution?: AgentActionTaskAttribution;
+  agentActionAttribution?: AgentActionAttribution;
 }
 
 type Match = { fullPath: string; params: Record<string, string | undefined> };

--- a/products/desktop/packages/ui/src/router/useOpenTask.test.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.test.ts
@@ -92,6 +92,23 @@ describe("openTaskInput channel scoping", () => {
     expect(prefill.initialPrompt).toBeUndefined();
     expect(prefill.requestId).not.toBe(stale);
   });
+
+  it("ties agent action attribution to the prefill request", () => {
+    const attribution = {
+      action_id: "task-1:tool-1:0",
+      source_task_id: "task-1",
+      tool_call_id: "tool-1",
+      action_index: 0,
+    };
+
+    openTaskInput({ agentActionAttribution: attribution });
+
+    const { prefill } = useTaskInputPrefillStore.getState();
+    expect(prefill.agentAction).toEqual({
+      requestId: prefill.requestId,
+      attribution,
+    });
+  });
 });
 
 describe("taskInputPrefillStore.consumePrompt", () => {

--- a/products/desktop/packages/ui/src/router/useOpenTask.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.ts
@@ -1,6 +1,9 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
 import { resolveService, resolveServiceOptional } from "@posthog/di/container";
-import { ANALYTICS_EVENTS } from "@posthog/shared";
+import {
+  type AgentActionTaskAttribution,
+  ANALYTICS_EVENTS,
+} from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { navigateBrowserTab } from "@posthog/ui/features/browser-tabs/imperativeTabNavigation";
 import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/currentChannelStore";
@@ -114,6 +117,7 @@ export interface TaskInputNavigationOptions {
    */
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: { reportId: string; title: string };
+  agentActionAttribution?: AgentActionTaskAttribution;
   /** Ignore whichever space is scoped and file the task nowhere. */
   unscoped?: boolean;
   /**
@@ -148,6 +152,7 @@ export function openTaskInput(
     !!options.initialCloudRepository ||
     !!options.initialModel ||
     !!options.initialMode ||
+    !!options.agentActionAttribution ||
     !!options.reportAssociation;
 
   useTaskInputPrefillStore.setState({
@@ -162,6 +167,7 @@ export function openTaskInput(
       initialMode: options.initialMode,
       folderRunEnvironment: options.folderRunEnvironment,
       reportAssociation: options.reportAssociation,
+      agentActionAttribution: options.agentActionAttribution,
       requestId: hasTransientState
         ? (globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`)
         : undefined,

--- a/products/desktop/packages/ui/src/router/useOpenTask.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.ts
@@ -151,6 +151,9 @@ export function openTaskInput(
     !!options.initialMode ||
     !!options.agentActionAttribution ||
     !!options.reportAssociation;
+  const requestId = hasTransientState
+    ? (globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`)
+    : undefined;
 
   useTaskInputPrefillStore.setState({
     prefill: {
@@ -164,10 +167,11 @@ export function openTaskInput(
       initialMode: options.initialMode,
       folderRunEnvironment: options.folderRunEnvironment,
       reportAssociation: options.reportAssociation,
-      agentActionAttribution: options.agentActionAttribution,
-      requestId: hasTransientState
-        ? (globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`)
-        : undefined,
+      agentAction:
+        options.agentActionAttribution && requestId
+          ? { requestId, attribution: options.agentActionAttribution }
+          : undefined,
+      requestId,
     },
   });
   // In the channels layout every entry point (⌘N, the command menu, the "+")

--- a/products/desktop/packages/ui/src/router/useOpenTask.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.ts
@@ -1,9 +1,6 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
 import { resolveService, resolveServiceOptional } from "@posthog/di/container";
-import {
-  type AgentActionTaskAttribution,
-  ANALYTICS_EVENTS,
-} from "@posthog/shared";
+import { type AgentActionAttribution, ANALYTICS_EVENTS } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { navigateBrowserTab } from "@posthog/ui/features/browser-tabs/imperativeTabNavigation";
 import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/currentChannelStore";
@@ -117,7 +114,7 @@ export interface TaskInputNavigationOptions {
    */
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: { reportId: string; title: string };
-  agentActionAttribution?: AgentActionTaskAttribution;
+  agentActionAttribution?: AgentActionAttribution;
   /** Ignore whichever space is scoped and file the task nowhere. */
   unscoped?: boolean;
   /**


### PR DESCRIPTION
## Problem

People cannot tell whether a Desktop concierge action was shown, accepted, or converted into a submitted task and pull request.

The existing analytics record tasks and pull requests without preserving the concierge action that initiated them.

## Changes

- Desktop records shown, clicked, and failed agent actions with stable action, tool-call, source-task, kind, and index properties.
- Compose actions carry attribution into the new-task composer and the resulting task.
- Submitted tasks expose their resulting task ID and use the `agent-action` creation source.
- Existing action prompts and labels remain excluded from analytics.
- Nothing looks different in the interface.

Before:

```mermaid
flowchart LR
    A[Concierge offer] --> B[New task composer]
    B --> C[Task and pull request]
    C --> D[Unattributed analytics]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phBlue;
    class D phGray;
```

After:

```mermaid
flowchart LR
    A[Concierge action ID] --> B[New task composer]
    B --> C[Resulting task ID]
    C --> D[Task run and pull request]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C,D phBlue;
```

## How did you test this code?

- Extended action-row coverage to catch dropped click attribution.
- Extended deep-link coverage to catch attribution lost before the composer.
- Ran targeted Core and UI tests, Biome checks, and type checks for every touched package.
- Full CI preflight was unavailable because this environment lacks `hogli` and `flox`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the Desktop analytics conventions with the attribution contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used PostHog product analytics, PostHog Desktop, writing-tests, and writing-pr-descriptions skills. The design uses explicit Product Analytics events instead of relying on autocapture.

Public-artifact check: the diff contains no customer material, private operational data, or session-derived content.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*