### PR TITLE
fix(dashboards): seed dashboard templates with query-shaped tiles

### DIFF
--- a/posthog/management/commands/ensure_migration_defaults.py
+++ b/posthog/management/commands/ensure_migration_defaults.py
@@ -19,6 +19,9 @@ add_default_themes = _migration_0537.add_default_themes
 # Cannot call those migration functions directly because they use
 # apps.get_model("posthog", "DashboardTemplate") which no longer
 # resolves after the model moved to the dashboards product app.
+# Tiles carry `query`, unlike the legacy `filters` those migrations wrote:
+# `create_from_template` builds each insight from `query` alone, so a
+# filters-shaped tile yields an insight with no definition at all.
 _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
     "template_name": "Product analytics",
     "dashboard_description": (
@@ -31,12 +34,16 @@ _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
             "name": "Daily active users (DAUs)",
             "type": "INSIGHT",
             "color": "blue",
-            "filters": {
-                "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "day",
-                "date_from": "-30d",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview", "math": "dau"}],
+                    "dateRange": {"date_from": "-30d"},
+                    "trendsFilter": {},
+                    "breakdownFilter": {},
+                    "compareFilter": {},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
@@ -48,12 +55,17 @@ _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
             "name": "Weekly active users (WAUs)",
             "type": "INSIGHT",
             "color": "green",
-            "filters": {
-                "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "week",
-                "date_from": "-90d",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview", "math": "dau"}],
+                    "dateRange": {"date_from": "-90d"},
+                    "interval": "week",
+                    "trendsFilter": {},
+                    "breakdownFilter": {},
+                    "compareFilter": {},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},
@@ -65,12 +77,19 @@ _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
             "name": "Retention",
             "type": "INSIGHT",
             "color": "blue",
-            "filters": {
-                "period": "Week",
-                "insight": "RETENTION",
-                "target_entity": {"id": "$pageview", "type": "events"},
-                "retention_type": "retention_first_time",
-                "returning_entity": {"id": "$pageview", "type": "events"},
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "RetentionQuery",
+                    "dateRange": {},
+                    "retentionFilter": {
+                        "period": "Week",
+                        "retentionType": "retention_first_time",
+                        "targetEntity": {"id": "$pageview", "type": "events"},
+                        "returningEntity": {"id": "$pageview", "type": "events"},
+                        "meanRetentionCalculation": "simple",
+                    },
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 6, "y": 5, "minH": 5, "minW": 3},
@@ -82,13 +101,15 @@ _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
             "name": "Growth accounting",
             "type": "INSIGHT",
             "color": "purple",
-            "filters": {
-                "events": [{"id": "$pageview", "type": "events"}],
-                "insight": "LIFECYCLE",
-                "interval": "week",
-                "shown_as": "Lifecycle",
-                "date_from": "-30d",
-                "entity_type": "events",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "LifecycleQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview"}],
+                    "dateRange": {"date_from": "-30d"},
+                    "interval": "week",
+                    "lifecycleFilter": {},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 0, "y": 5, "minH": 5, "minW": 3},
@@ -100,14 +121,16 @@ _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
             "name": "Referring domain (last 14 days)",
             "type": "INSIGHT",
             "color": "black",
-            "filters": {
-                "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
-                "display": "ActionsBarValue",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$referring_domain",
-                "date_from": "-14d",
-                "breakdown_type": "event",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview", "math": "dau"}],
+                    "dateRange": {"date_from": "-14d"},
+                    "breakdownFilter": {"breakdown": "$referring_domain"},
+                    "trendsFilter": {"display": "ActionsBarValue"},
+                    "compareFilter": {},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 0, "y": 10, "minH": 5, "minW": 3},
@@ -119,20 +142,35 @@ _PRODUCT_ANALYTICS_TEMPLATE: dict[str, Any] = {
             "name": "Pageview funnel, by browser",
             "type": "INSIGHT",
             "color": "green",
-            "filters": {
-                "events": [
-                    {"id": "$pageview", "type": "events", "order": 0, "custom_name": "First page view"},
-                    {"id": "$pageview", "type": "events", "order": 1, "custom_name": "Second page view"},
-                    {"id": "$pageview", "type": "events", "order": 2, "custom_name": "Third page view"},
-                ],
-                "layout": "horizontal",
-                "display": "FunnelViz",
-                "insight": "FUNNELS",
-                "interval": "day",
-                "exclusions": [],
-                "breakdown_type": "event",
-                "breakdown": "$browser",
-                "funnel_viz_type": "steps",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "FunnelsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "custom_name": "First page view",
+                        },
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "custom_name": "Second page view",
+                        },
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "custom_name": "Third page view",
+                        },
+                    ],
+                    "dateRange": {},
+                    "interval": "day",
+                    "breakdownFilter": {"breakdown": "$browser"},
+                    "funnelsFilter": {"layout": "horizontal"},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 6, "y": 10, "minH": 5, "minW": 3},
@@ -151,17 +189,23 @@ _FEATURE_FLAG_TEMPLATE: dict[str, Any] = {
         "Overview of engagement with the flagged feature including daily active users and weekly active users."
     ),
     "dashboard_filters": {},
+    # `{ENGAGEMENT}` stands in for a series entry. The browser resolves it against
+    # the variable below before the tiles reach the API, so no placeholder is stored.
     "tiles": [
         {
             "name": "Daily active users (DAUs)",
             "type": "INSIGHT",
             "color": "blue",
-            "filters": {
-                "events": ["{ENGAGEMENT}"],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "day",
-                "date_from": "-30d",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": ["{ENGAGEMENT}"],
+                    "dateRange": {"date_from": "-30d"},
+                    "trendsFilter": {},
+                    "breakdownFilter": {},
+                    "compareFilter": {},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
@@ -173,12 +217,17 @@ _FEATURE_FLAG_TEMPLATE: dict[str, Any] = {
             "name": "Weekly active users (WAUs)",
             "type": "INSIGHT",
             "color": "green",
-            "filters": {
-                "events": ["{ENGAGEMENT}"],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "week",
-                "date_from": "-90d",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": ["{ENGAGEMENT}"],
+                    "dateRange": {"date_from": "-90d"},
+                    "interval": "week",
+                    "trendsFilter": {},
+                    "breakdownFilter": {},
+                    "compareFilter": {},
+                },
             },
             "layouts": {
                 "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},

--- a/posthog/management/commands/test/test_ensure_migration_defaults.py
+++ b/posthog/management/commands/test/test_ensure_migration_defaults.py
@@ -1,0 +1,53 @@
+import re
+from collections.abc import Iterator
+from typing import Any
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.schema import InsightVizNode
+
+from posthog.management.commands.ensure_migration_defaults import _FEATURE_FLAG_TEMPLATE, _PRODUCT_ANALYTICS_TEMPLATE
+
+_PLACEHOLDER = re.compile(r"^\{([A-Z0-9_]+)\}$")
+
+_TEMPLATES = (_PRODUCT_ANALYTICS_TEMPLATE, _FEATURE_FLAG_TEMPLATE)
+
+
+def _insight_tiles() -> Iterator[tuple[str, dict[str, Any], dict[str, Any]]]:
+    for template in _TEMPLATES:
+        for tile in template["tiles"]:
+            if tile.get("type") == "INSIGHT":
+                yield f"{template['template_name']} / {tile['name']}", template, tile
+
+
+def _placeholders(value: Any) -> set[str]:
+    if isinstance(value, str):
+        match = _PLACEHOLDER.match(value)
+        return {match.group(1)} if match else set()
+    if isinstance(value, dict):
+        return set().union(*(_placeholders(v) for v in value.values())) if value else set()
+    if isinstance(value, list):
+        return set().union(*(_placeholders(v) for v in value)) if value else set()
+    return set()
+
+
+class TestSeededDashboardTemplates(SimpleTestCase):
+    @parameterized.expand([(label, template, tile) for label, template, tile in _insight_tiles()])
+    def test_insight_tile_carries_a_query(self, _label: str, _template: dict[str, Any], tile: dict[str, Any]) -> None:
+        assert tile.get("query"), "create_from_template builds insights from `query`, so a tile without one is blank"
+        assert "filters" not in tile, "legacy `filters` is never read; convert with filter_to_query instead"
+
+    @parameterized.expand(
+        [(label, tile) for label, template, tile in _insight_tiles() if not template.get("variables")]
+    )
+    def test_insight_tile_query_matches_the_schema(self, _label: str, tile: dict[str, Any]) -> None:
+        InsightVizNode(**tile["query"])
+
+    @parameterized.expand([(label, template, tile) for label, template, tile in _insight_tiles()])
+    def test_placeholders_resolve_to_a_declared_variable(
+        self, _label: str, template: dict[str, Any], tile: dict[str, Any]
+    ) -> None:
+        declared = {variable["id"] for variable in template.get("variables", [])}
+        assert _placeholders(tile.get("query")) <= declared

--- a/posthog/management/commands/test/test_ensure_migration_defaults.py
+++ b/posthog/management/commands/test/test_ensure_migration_defaults.py
@@ -22,6 +22,22 @@ def _insight_tiles() -> Iterator[tuple[str, dict[str, Any], dict[str, Any]]]:
                 yield f"{template['template_name']} / {tile['name']}", template, tile
 
 
+def _resolve(value: Any, variables: dict[str, dict[str, Any]]) -> Any:
+    if isinstance(value, str):
+        match = _PLACEHOLDER.match(value)
+        variable = variables.get(match.group(1)) if match else None
+        if variable is None:
+            return value
+        # Every variable is an event one, which the browser turns into a series node before the tile reaches the API.
+        default = variable["default"]
+        return {"kind": "EventsNode", "event": default["id"], "name": default["name"], "math": "total"}
+    if isinstance(value, dict):
+        return {key: _resolve(item, variables) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_resolve(item, variables) for item in value]
+    return value
+
+
 def _placeholders(value: Any) -> set[str]:
     if isinstance(value, str):
         match = _PLACEHOLDER.match(value)
@@ -39,11 +55,12 @@ class TestSeededDashboardTemplates(SimpleTestCase):
         assert tile.get("query"), "create_from_template builds insights from `query`, so a tile without one is blank"
         assert "filters" not in tile, "legacy `filters` is never read; convert with filter_to_query instead"
 
-    @parameterized.expand(
-        [(label, tile) for label, template, tile in _insight_tiles() if not template.get("variables")]
-    )
-    def test_insight_tile_query_matches_the_schema(self, _label: str, tile: dict[str, Any]) -> None:
-        InsightVizNode(**tile["query"])
+    @parameterized.expand([(label, template, tile) for label, template, tile in _insight_tiles()])
+    def test_insight_tile_query_matches_the_schema(
+        self, _label: str, template: dict[str, Any], tile: dict[str, Any]
+    ) -> None:
+        variables = {variable["id"]: variable for variable in template.get("variables", [])}
+        InsightVizNode(**_resolve(tile["query"], variables))
 
     @parameterized.expand([(label, template, tile) for label, template, tile in _insight_tiles()])
     def test_placeholders_resolve_to_a_declared_variable(


### PR DESCRIPTION
## Problem

Anyone who builds a dashboard from the seeded "Product analytics" or "Flagged Feature Usage" template gets tiles that render blank. This hits every environment restored from a schema-only dump, which is CI and local dev.

- `create_from_template` builds each insight from the tile's `query` alone.
- Both seeded templates carry the legacy `filters` shape from migrations 0310 and 0328.
- No code reads that key, so each insight is created with no definition at all.

## Changes

- The eight seeded tiles now produce working charts instead of blank ones.
- Each tile carries the query that `filter_to_query` produces from its old filters, so the seed and the runtime conversion in [#89051](https://github.com/PostHog/posthog/pull/89051) agree on one stored shape.
- Queries are written in the compact form, with schema defaults left out. Every one was checked to resolve to the same object as the converter's full output, so dropping a default never changes a chart.
- Empty filter objects such as `"trendsFilter": {}` stay. Removing them resolves to `None` instead of an empty filter, which is a different query.
- Nothing user-visible changes outside these two templates. No product code changed.

> [!NOTE]
> `{ENGAGEMENT}` in the feature flag template stays a placeholder in the stored query. The browser resolves it before the tiles reach the API, so a real series node is what gets saved.

## How did you test this code?

- `test_ensure_migration_defaults.py` pins the invariant: every INSIGHT tile has a `query`, no tile has `filters`, each query validates against `InsightVizNode`, and every placeholder matches a declared variable.
- The regression it catches: a new tile copied in the filters shape. The file's own comment points at migrations 0310 and 0328 as the data source, and those are filters-shaped, so that is the likely next edit. Nothing caught it before, and the failure is silent.
- Both guards were mutation-checked. Reverting one tile to filters shape and misspelling `{ENGAGEMENT}` each turn the suite red.
- Ran locally against Postgres: building a dashboard from both seeded templates yields 8 of 8 insights with a populated `query`, and no tile is skipped.
- Not checked: any browser flow. The variable substitution path was read, not run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop, directed by @thmsobrmlr. This closes a dependency for deleting `filter_to_query.py`, which cannot go while a shipped seed still needs it.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The tile queries were generated by running `filter_to_query` over the existing filters rather than written by hand, then verified per tile against the converter's own output. An attempt to shrink them further by dropping empty filter objects was reverted when the round-trip check showed it changed the resolved query.

One edge found and deliberately left alone: saving an insight whose query still holds an unresolved placeholder makes `generate_query_metadata` raise and swallow a validation error. Only a direct `create_from_template` call can reach it, which the feature flag template's scope prevents, and [#89051](https://github.com/PostHog/posthog/pull/89051) produces the same stored shape either way.
