### PR TITLE
fix(desktop): queue concurrent canvas data requests

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.test.ts
@@ -185,4 +185,85 @@ describe("createCanvasHostMessageRouter", () => {
       true,
     );
   });
+
+  it("queues data requests when all concurrency slots are active", async () => {
+    const post = vi.fn();
+    const resolvers: Array<(value: unknown) => void> = [];
+    const onDataRequest = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const route = createCanvasHostMessageRouter({
+      post,
+      callbacks: () => ({ onDataRequest }),
+      hasUserActivation: () => false,
+      openExternal: vi.fn(),
+    });
+
+    const requests = Array.from({ length: 10 }, (_, i) =>
+      route({
+        channel: "posthog-canvas",
+        type: "data-request",
+        id: `query-${i}`,
+        method: "stateGet",
+        payload: { scope: "user", key: `k${i}` },
+      }),
+    );
+
+    await vi.waitFor(() => expect(onDataRequest).toHaveBeenCalledTimes(8));
+    expect(post).not.toHaveBeenCalled();
+
+    resolvers[0]?.(null);
+    await vi.waitFor(() => expect(onDataRequest).toHaveBeenCalledTimes(9));
+    resolvers[1]?.(null);
+    await vi.waitFor(() => expect(onDataRequest).toHaveBeenCalledTimes(10));
+
+    for (const resolve of resolvers) resolve(null);
+    await Promise.all(requests);
+
+    expect(post).toHaveBeenCalledTimes(10);
+    expect(post.mock.calls.every(([message]) => message.ok === true)).toBe(
+      true,
+    );
+  });
+
+  it("rejects data requests when the bounded queue is full", async () => {
+    const post = vi.fn();
+    let releaseRequests: () => void = () => {};
+    const pendingRequest = new Promise<void>((resolve) => {
+      releaseRequests = resolve;
+    });
+    const onDataRequest = vi.fn(() => pendingRequest);
+    const route = createCanvasHostMessageRouter({
+      post,
+      callbacks: () => ({ onDataRequest }),
+      hasUserActivation: () => false,
+      openExternal: vi.fn(),
+    });
+    const message = (id: number) => ({
+      channel: "posthog-canvas" as const,
+      type: "data-request" as const,
+      id: `query-${id}`,
+      method: "stateGet" as const,
+      payload: { scope: "user", key: `k${id}` },
+    });
+
+    const accepted = Array.from({ length: 72 }, (_, i) => route(message(i)));
+    await route(message(72));
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "query-72",
+        ok: false,
+        error: "Canvas data request exceeds runtime limits",
+      }),
+    );
+
+    releaseRequests();
+    await Promise.all(accepted);
+    expect(onDataRequest).toHaveBeenCalledTimes(72);
+  });
 });

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.ts
@@ -12,6 +12,7 @@ const EXTERNAL_OPEN_MIN_INTERVAL_MS = 1_000;
 // a runaway loop must not be able to pile up unbounded concurrent requests,
 // ship oversized payloads, or hold a request slot forever.
 const MAX_CONCURRENT_DATA_REQUESTS = 8;
+const MAX_QUEUED_DATA_REQUESTS = 64;
 const MAX_DATA_REQUEST_BYTES = 64 * 1024;
 const DATA_REQUEST_TIMEOUT_MS = 30_000;
 const REPLAYABLE_SHORTCUT_KEYS = new Set([
@@ -93,6 +94,28 @@ export function createCanvasHostMessageRouter(
 ): (message: CanvasToHostMessage) => Promise<void> {
   let lastExternalOpen = 0;
   let activeDataRequests = 0;
+  const queuedDataRequests: Array<() => void> = [];
+
+  const acquireDataRequestSlot = (): Promise<boolean> => {
+    if (activeDataRequests < MAX_CONCURRENT_DATA_REQUESTS) {
+      activeDataRequests += 1;
+      return Promise.resolve(true);
+    }
+    if (queuedDataRequests.length >= MAX_QUEUED_DATA_REQUESTS) {
+      return Promise.resolve(false);
+    }
+    return new Promise((resolve) => {
+      queuedDataRequests.push(() => {
+        activeDataRequests += 1;
+        resolve(true);
+      });
+    });
+  };
+
+  const releaseDataRequestSlot = (): void => {
+    activeDataRequests -= 1;
+    queuedDataRequests.shift()?.();
+  };
 
   return async (message) => {
     switch (message.type) {
@@ -121,10 +144,7 @@ export function createCanvasHostMessageRouter(
         // starve the canvas's ordinary reads/writes. Its own bound is the
         // host's single-flight guard (one request awaiting approval at a time).
         const holdsSlot = message.method !== "agentRequest";
-        if (
-          (holdsSlot && activeDataRequests >= MAX_CONCURRENT_DATA_REQUESTS) ||
-          !isBoundedPayload(message.payload)
-        ) {
+        if (!isBoundedPayload(message.payload)) {
           options.post({
             channel: "posthog-canvas",
             type: "data-response",
@@ -134,7 +154,16 @@ export function createCanvasHostMessageRouter(
           });
           break;
         }
-        if (holdsSlot) activeDataRequests += 1;
+        if (holdsSlot && !(await acquireDataRequestSlot())) {
+          options.post({
+            channel: "posthog-canvas",
+            type: "data-response",
+            id: message.id,
+            ok: false,
+            error: "Canvas data request exceeds runtime limits",
+          });
+          break;
+        }
         try {
           const call = options
             .callbacks()
@@ -172,7 +201,7 @@ export function createCanvasHostMessageRouter(
             error: error instanceof Error ? error.message : String(error),
           });
         } finally {
-          if (holdsSlot) activeDataRequests -= 1;
+          if (holdsSlot) releaseDataRequestSlot();
         }
         break;
       }

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.ts
@@ -105,16 +105,17 @@ export function createCanvasHostMessageRouter(
       return Promise.resolve(false);
     }
     return new Promise((resolve) => {
-      queuedDataRequests.push(() => {
-        activeDataRequests += 1;
-        resolve(true);
-      });
+      queuedDataRequests.push(() => resolve(true));
     });
   };
 
   const releaseDataRequestSlot = (): void => {
+    const next = queuedDataRequests.shift();
+    if (next) {
+      next();
+      return;
+    }
     activeDataRequests -= 1;
-    queuedDataRequests.shift()?.();
   };
 
   return async (message) => {


### PR DESCRIPTION
## Problem

Canvas dashboards with more than eight independent cards can fail during initial render because the host rejects every request beyond its active limit.

**Why:** Normal dashboards should load reliably while the host still protects itself from runaway canvas code.

## Changes

- Canvas dashboards now wait for an available request slot instead of failing when eight requests are active.
- The host keeps a bounded 64-request FIFO queue and rejects only traffic beyond that limit.
- The existing payload limit, request timeout, and agent-request behavior remain unchanged.
- Nothing looks different after the dashboard finishes loading.

Before:

```mermaid
flowchart LR
  A[Canvas cards] --> B[Eight active requests]
  A --> C[Ninth request rejected]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class A phYellow;
  class B phBlue;
  class C phRed;
```

After:

```mermaid
flowchart LR
  A[Canvas cards] --> B[Bounded FIFO queue]
  B --> C[Eight active requests]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class A phYellow;
  class B phBlue;
  class C phBlue;
```

## How did you test this code?

- Added regression coverage for queued requests resuming as slots open.
- Added regression coverage for rejecting requests beyond the bounded queue.
- Ran the focused router tests, UI typecheck, workspace typecheck, lint, and the UI package test suite.
- Repository preflight was unavailable because this environment lacks `hogli` and `flox`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This changes an internal runtime guard without changing the canvas API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this through PostHog Desktop. Skills invoked: `/posthog-desktop`, `/deslop`, `/thermo-nuclear-code-quality-review`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*