### PR TITLE
chore(ci): shadow merge-commit change detection

### DIFF
--- a/.depot/actions/paths-filter/README.md
+++ b/.depot/actions/paths-filter/README.md
@@ -65,6 +65,22 @@ changed:
   - added|modified: ['src/**', '!src/vendor/**']
 ```
 
+## Shadow comparison (opt-in)
+
+Set `PATHS_FILTER_SHADOW_POSTHOG_TOKEN` on a step to have that run compare the API's
+changed-file list against the same list derived from the pull request's merge commit,
+and send the verdict to PostHog. The comparison never changes what the filter answers.
+
+```yaml
+- uses: ./.github/actions/paths-filter
+  env:
+    PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+```
+
+Without the variable the action does no extra work. Set it in one workflow that runs on
+every pull request; that keeps the merge-ref fetch off the critical path of the other
+gating jobs. This is temporary, and goes away with the decision it exists to inform.
+
 ## Rebuilding after source changes
 
 The action runs the committed `dist/index.js` bundle. After editing anything under `src/`,

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -3,39 +3,62 @@ import {PullRequest} from '@octokit/webhooks-types'
 import {ChangeStatus} from '../src/file'
 import {compareWithMergeCommit} from '../src/shadow'
 
-const exec = jest.requireMock('@actions/exec') as {getExecOutput: jest.Mock}
+const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
 
-jest.mock('@actions/exec', () => ({getExecOutput: jest.fn()}))
+jest.mock('child_process', () => ({execFile: jest.fn()}))
 jest.mock('@actions/core', () => ({info: jest.fn(), warning: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
 
 const HEAD = 'a'.repeat(40)
 const GIT_DIR = '/tmp/runner/paths-filter-shadow.git'
+const PAST_ANY_BUDGET_MS = 120000
+
+type ExecFileArgs = [string, string[], {signal: AbortSignal}, (error: Error | null, stdout: string) => void]
+
+const pullRequest = {number: 42, head: {sha: HEAD}} as PullRequest
 
 describe('shadow merge-commit comparison', () => {
+  beforeEach(() => {
+    process.env.RUNNER_TEMP = '/tmp/runner'
+    process.env.GITHUB_SERVER_URL = 'https://github.com'
+    process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
+    cp.execFile.mockReset()
+  })
+
   // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
   // whichever repository it runs in. Steps after this action read history from the
   // workspace checkout: ci-dagster and ci-e2e-playwright resolve
   // `git merge-base HEAD^2 origin/<base>` there, and an empty merge base silently
   // drops their schema cache. So every call has to name the scratch git dir.
   test('never runs git against the job workspace', async () => {
-    process.env.RUNNER_TEMP = '/tmp/runner'
-    process.env.GITHUB_SERVER_URL = 'https://github.com'
-    process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
-    exec.getExecOutput.mockReset()
     for (const stdout of ['', '', HEAD, 'a.ts\0']) {
-      exec.getExecOutput.mockResolvedValueOnce({exitCode: 0, stdout, stderr: ''})
+      cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout))
     }
 
-    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], {
-      number: 42,
-      head: {sha: HEAD}
-    } as PullRequest)
+    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
 
     expect(result.verdict).toBe('match')
-    const calls = exec.getExecOutput.mock.calls.map(c => c[1] as string[])
+    const calls = cp.execFile.mock.calls.map(c => c[1] as string[])
     expect(calls[0]).toEqual(['init', '--bare', '--quiet', GIT_DIR])
     for (const argv of calls.slice(1)) {
       expect(argv.slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
     }
+  })
+
+  // The budget only bounds the job if it also stops the git process. An exec that returns
+  // no handle on the child leaves the fetch running, and the action's process stays open
+  // until git exits, which is the wall-clock cost the budget exists to prevent.
+  test('stops git when the budget expires', async () => {
+    cp.execFile.mockImplementation(() => undefined)
+    jest.useFakeTimers()
+
+    const pending = compareWithMergeCommit([], pullRequest)
+    await jest.advanceTimersByTimeAsync(PAST_ANY_BUDGET_MS)
+    const result = await pending
+
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('budget')
+    const [, , options] = cp.execFile.mock.calls[0] as ExecFileArgs
+    expect(options.signal.aborted).toBe(true)
+    jest.useRealTimers()
   })
 })

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,0 +1,78 @@
+import {PullRequest} from '@octokit/webhooks-types'
+
+import {ChangeStatus, File} from '../src/file'
+import {compareWithMergeCommit} from '../src/shadow'
+
+const exec = jest.requireMock('@actions/exec') as {getExecOutput: jest.Mock}
+
+jest.mock('@actions/exec', () => ({getExecOutput: jest.fn()}))
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  startGroup: jest.fn(),
+  endGroup: jest.fn(),
+  setOutput: jest.fn()
+}))
+
+const HEAD = 'a'.repeat(40)
+const pr = {number: 42, head: {sha: HEAD}} as PullRequest
+
+function apiFiles(...names: string[]): File[] {
+  return names.map(filename => ({filename, status: ChangeStatus.Modified}))
+}
+
+// Each entry answers one `git` call, in the order shadow.ts makes them:
+// fetch, rev-list --parents, rev-parse ^2, diff.
+function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): void {
+  exec.getExecOutput.mockReset()
+  for (const r of responses) {
+    exec.getExecOutput.mockResolvedValueOnce({exitCode: r.exitCode ?? 0, stdout: r.stdout ?? '', stderr: ''})
+  }
+}
+
+describe('shadow merge-commit comparison', () => {
+  it('reports a match when both sides list the same files', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nb.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
+    expect(result.verdict).toBe('match')
+  })
+
+  it('reports a mismatch and names the files each side is missing', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nc.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
+    expect(result.verdict).toBe('mismatch')
+    expect(result.onlyInApi).toEqual(['b.ts'])
+    expect(result.onlyInGit).toEqual(['c.ts'])
+  })
+
+  // A merge ref GitHub has not recomputed since the last push describes an older
+  // head. Reading it would silently attribute the wrong changes to this PR.
+  it('refuses a stale merge ref instead of comparing against it', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${'c'.repeat(40)}`}, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('stale')
+  })
+
+  it('reports unavailable when the checkout has no second parent', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)}`})
+    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('second parent')
+  })
+
+  it('reports unavailable when the merge ref cannot be fetched', async () => {
+    gitResponses({exitCode: 1})
+    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('merge ref')
+  })
+
+  // The API path turns a rename into a delete of the old name plus an add of the
+  // new one, and `git diff --no-renames` emits the same pair.
+  it('matches a rename that the API reported as two entries', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'new.ts\nold.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('new.ts', 'old.ts'), pr)
+    expect(result.verdict).toBe('match')
+  })
+})

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -6,15 +6,31 @@ import {compareWithMergeCommit} from '../src/shadow'
 const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
 
 jest.mock('child_process', () => ({execFile: jest.fn()}))
-jest.mock('@actions/core', () => ({info: jest.fn(), warning: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
+jest.mock('@actions/core', () => ({info: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
 
 const HEAD = 'a'.repeat(40)
+const OTHER_SHA = 'b'.repeat(40)
 const GIT_DIR = '/tmp/runner/paths-filter-shadow.git'
 const PAST_ANY_BUDGET_MS = 120000
 
-type ExecFileArgs = [string, string[], {signal: AbortSignal}, (error: Error | null, stdout: string) => void]
+type ExecFileArgs = [
+  string,
+  string[],
+  {signal: AbortSignal},
+  (error: Error | null, stdout: string, stderr: string) => void
+]
 
 const pullRequest = {number: 42, head: {sha: HEAD}} as PullRequest
+
+function stubGit(...stdouts: string[]): void {
+  for (const stdout of stdouts) {
+    cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout, ''))
+  }
+}
+
+function argvOf(call: number): string[] {
+  return cp.execFile.mock.calls[call][1] as string[]
+}
 
 describe('shadow merge-commit comparison', () => {
   beforeEach(() => {
@@ -24,29 +40,50 @@ describe('shadow merge-commit comparison', () => {
     cp.execFile.mockReset()
   })
 
-  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
-  // whichever repository it runs in. Steps after this action read history from the
-  // workspace checkout: ci-dagster and ci-e2e-playwright resolve
-  // `git merge-base HEAD^2 origin/<base>` there, and an empty merge base silently
-  // drops their schema cache. So every call has to name the scratch git dir.
+  // A git call that forgets the scratch dir runs against the job workspace, where a
+  // --depth or --filter fetch drops the schema cache of every later step in the job.
   test('never runs git against the job workspace', async () => {
-    for (const stdout of ['', '', HEAD, 'a.ts\0']) {
-      cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout))
-    }
+    stubGit('', '', HEAD, 'a.ts\0')
 
     const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
 
     expect(result.verdict).toBe('match')
-    const calls = cp.execFile.mock.calls.map(c => c[1] as string[])
-    expect(calls[0]).toEqual(['init', '--bare', '--quiet', GIT_DIR])
-    for (const argv of calls.slice(1)) {
-      expect(argv.slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
+    expect(argvOf(0)).toContain(GIT_DIR)
+    for (let call = 1; call < cp.execFile.mock.calls.length; call++) {
+      expect(argvOf(call).slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
     }
   })
 
-  // The budget only bounds the job if it also stops the git process. An exec that returns
-  // no handle on the child leaves the fetch running, and the action's process stays open
-  // until git exits, which is the wall-clock cost the budget exists to prevent.
+  // Losing this guard scores a merge ref from an earlier push as this pull request's
+  // changes, which fills the measurement with mismatches that mean nothing.
+  test('refuses a stale merge ref instead of comparing against it', async () => {
+    stubGit('', '', OTHER_SHA)
+
+    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
+
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toBe('stale-merge-ref')
+  })
+
+  // Losing --no-renames reports one path where the API path reports two, so every
+  // rename reads as a mismatch.
+  test('matches a rename that the API reported as two entries', async () => {
+    stubGit('', '', HEAD, 'old.ts\0new.ts\0')
+
+    const result = await compareWithMergeCommit(
+      [
+        {filename: 'new.ts', status: ChangeStatus.Added},
+        {filename: 'old.ts', status: ChangeStatus.Deleted}
+      ],
+      pullRequest
+    )
+
+    expect(result.verdict).toBe('match')
+    expect(cp.execFile.mock.calls.map(c => c[1])).toContainEqual(expect.arrayContaining(['--no-renames']))
+  })
+
+  // An exec with no handle on the child leaves the fetch running after the budget gives
+  // up, and the action's process stays open until git exits.
   test('stops git when the budget expires', async () => {
     cp.execFile.mockImplementation(() => undefined)
     jest.useFakeTimers()
@@ -56,7 +93,7 @@ describe('shadow merge-commit comparison', () => {
     const result = await pending
 
     expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('budget')
+    expect(result.reason).toBe('budget-exceeded')
     const [, , options] = cp.execFile.mock.calls[0] as ExecFileArgs
     expect(options.signal.aborted).toBe(true)
     jest.useRealTimers()

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,116 +1,41 @@
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {ChangeStatus, File} from '../src/file'
+import {ChangeStatus} from '../src/file'
 import {compareWithMergeCommit} from '../src/shadow'
 
 const exec = jest.requireMock('@actions/exec') as {getExecOutput: jest.Mock}
 
 jest.mock('@actions/exec', () => ({getExecOutput: jest.fn()}))
-jest.mock('@actions/core', () => ({
-  info: jest.fn(),
-  warning: jest.fn(),
-  startGroup: jest.fn(),
-  endGroup: jest.fn()
-}))
+jest.mock('@actions/core', () => ({info: jest.fn(), warning: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
 
 const HEAD = 'a'.repeat(40)
-const pr = {number: 42, head: {sha: HEAD}} as PullRequest
-
-function apiFiles(...names: string[]): File[] {
-  return names.map(filename => ({filename, status: ChangeStatus.Modified}))
-}
-
-// Each entry answers one call, in the order shadow.ts makes them:
-// init, fetch, rev-parse ^2, diff.
-function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): void {
-  exec.getExecOutput.mockReset()
-  for (const r of responses) {
-    exec.getExecOutput.mockResolvedValueOnce({exitCode: r.exitCode ?? 0, stdout: r.stdout ?? '', stderr: ''})
-  }
-}
-
-const INIT_OK = {}
-const FETCH_OK = {}
-const HEAD_OK = {stdout: HEAD}
-
-function argvFor(call: number): string[] {
-  return exec.getExecOutput.mock.calls[call][1] as string[]
-}
+const GIT_DIR = '/tmp/runner/paths-filter-shadow.git'
 
 describe('shadow merge-commit comparison', () => {
-  beforeEach(() => {
+  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
+  // whichever repository it runs in. Steps after this action read history from the
+  // workspace checkout: ci-dagster and ci-e2e-playwright resolve
+  // `git merge-base HEAD^2 origin/<base>` there, and an empty merge base silently
+  // drops their schema cache. So every call has to name the scratch git dir.
+  test('never runs git against the job workspace', async () => {
     process.env.RUNNER_TEMP = '/tmp/runner'
     process.env.GITHUB_SERVER_URL = 'https://github.com'
     process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
-  })
-
-  it('reports a match when both sides list the same files', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0b.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
-    expect(result.verdict).toBe('match')
-  })
-
-  it('reports a mismatch and names the files each side is missing', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0c.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
-    expect(result.verdict).toBe('mismatch')
-    expect(result.onlyInApi).toEqual(['b.ts'])
-    expect(result.onlyInGit).toEqual(['c.ts'])
-  })
-
-  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
-  // whichever repository it runs in. Steps after this action read history from the
-  // workspace checkout, so every call has to name the scratch git dir.
-  it('never runs git against the job workspace', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0'})
-    await compareWithMergeCommit(apiFiles('a.ts'), pr)
-
-    expect(argvFor(0)).toEqual(['init', '--bare', '--quiet', '/tmp/runner/paths-filter-shadow.git'])
-    for (let call = 1; call < exec.getExecOutput.mock.calls.length; call++) {
-      expect(argvFor(call).slice(0, 2)).toEqual(['--git-dir', '/tmp/runner/paths-filter-shadow.git'])
+    exec.getExecOutput.mockReset()
+    for (const stdout of ['', '', HEAD, 'a.ts\0']) {
+      exec.getExecOutput.mockResolvedValueOnce({exitCode: 0, stdout, stderr: ''})
     }
-    expect(argvFor(1)).toContain('--depth=2')
-    expect(argvFor(1)).toContain('--filter=blob:none')
-  })
 
-  // git quotes a path containing a newline or a non-ASCII byte unless output is
-  // NUL-delimited, and a quoted path would read as a file neither side has.
-  it('reads NUL-delimited diff output', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0dir/b c.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts', 'dir/b c.ts'), pr)
+    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], {
+      number: 42,
+      head: {sha: HEAD}
+    } as PullRequest)
+
     expect(result.verdict).toBe('match')
-    expect(argvFor(3)).toContain('-z')
-  })
-
-  // A merge ref GitHub has not recomputed since the last push describes an older
-  // head. Reading it would silently attribute the wrong changes to this pull request.
-  it('refuses a stale merge ref instead of comparing against it', async () => {
-    gitResponses(INIT_OK, FETCH_OK, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
-    expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('stale')
-  })
-
-  it('reports unavailable when the merge ref has no second parent', async () => {
-    gitResponses(INIT_OK, FETCH_OK, {exitCode: 128})
-    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
-    expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('second parent')
-  })
-
-  it('reports unavailable when the merge ref cannot be fetched', async () => {
-    gitResponses(INIT_OK, {exitCode: 128})
-    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
-    expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('merge ref')
-  })
-
-  // The API path turns a rename into a delete of the old name plus an add of the new
-  // one, and `git diff --no-renames` emits the same pair.
-  it('matches a rename that the API reported as two entries', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'new.ts\0old.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('new.ts', 'old.ts'), pr)
-    expect(result.verdict).toBe('match')
-    expect(argvFor(3)).toContain('--no-renames')
+    const calls = exec.getExecOutput.mock.calls.map(c => c[1] as string[])
+    expect(calls[0]).toEqual(['init', '--bare', '--quiet', GIT_DIR])
+    for (const argv of calls.slice(1)) {
+      expect(argv.slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
+    }
   })
 })

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -10,8 +10,7 @@ jest.mock('@actions/core', () => ({
   info: jest.fn(),
   warning: jest.fn(),
   startGroup: jest.fn(),
-  endGroup: jest.fn(),
-  setOutput: jest.fn()
+  endGroup: jest.fn()
 }))
 
 const HEAD = 'a'.repeat(40)
@@ -21,8 +20,8 @@ function apiFiles(...names: string[]): File[] {
   return names.map(filename => ({filename, status: ChangeStatus.Modified}))
 }
 
-// Each entry answers one `git` call, in the order shadow.ts makes them:
-// fetch, rev-list --parents, rev-parse ^2, diff.
+// Each entry answers one call, in the order shadow.ts makes them:
+// init, fetch, rev-parse ^2, diff.
 function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): void {
   exec.getExecOutput.mockReset()
   for (const r of responses) {
@@ -30,49 +29,88 @@ function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): voi
   }
 }
 
+const INIT_OK = {}
+const FETCH_OK = {}
+const HEAD_OK = {stdout: HEAD}
+
+function argvFor(call: number): string[] {
+  return exec.getExecOutput.mock.calls[call][1] as string[]
+}
+
 describe('shadow merge-commit comparison', () => {
+  beforeEach(() => {
+    process.env.RUNNER_TEMP = '/tmp/runner'
+    process.env.GITHUB_SERVER_URL = 'https://github.com'
+    process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
+  })
+
   it('reports a match when both sides list the same files', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nb.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0b.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
     expect(result.verdict).toBe('match')
   })
 
   it('reports a mismatch and names the files each side is missing', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nc.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0c.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
     expect(result.verdict).toBe('mismatch')
     expect(result.onlyInApi).toEqual(['b.ts'])
     expect(result.onlyInGit).toEqual(['c.ts'])
   })
 
+  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
+  // whichever repository it runs in. Steps after this action read history from the
+  // workspace checkout, so every call has to name the scratch git dir.
+  it('never runs git against the job workspace', async () => {
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0'})
+    await compareWithMergeCommit(apiFiles('a.ts'), pr)
+
+    expect(argvFor(0)).toEqual(['init', '--bare', '--quiet', '/tmp/runner/paths-filter-shadow.git'])
+    for (let call = 1; call < exec.getExecOutput.mock.calls.length; call++) {
+      expect(argvFor(call).slice(0, 2)).toEqual(['--git-dir', '/tmp/runner/paths-filter-shadow.git'])
+    }
+    expect(argvFor(1)).toContain('--depth=2')
+    expect(argvFor(1)).toContain('--filter=blob:none')
+  })
+
+  // git quotes a path containing a newline or a non-ASCII byte unless output is
+  // NUL-delimited, and a quoted path would read as a file neither side has.
+  it('reads NUL-delimited diff output', async () => {
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0dir/b c.ts\0'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts', 'dir/b c.ts'), pr)
+    expect(result.verdict).toBe('match')
+    expect(argvFor(3)).toContain('-z')
+  })
+
   // A merge ref GitHub has not recomputed since the last push describes an older
-  // head. Reading it would silently attribute the wrong changes to this PR.
+  // head. Reading it would silently attribute the wrong changes to this pull request.
   it('refuses a stale merge ref instead of comparing against it', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${'c'.repeat(40)}`}, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toContain('stale')
   })
 
-  it('reports unavailable when the checkout has no second parent', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)}`})
+  it('reports unavailable when the merge ref has no second parent', async () => {
+    gitResponses(INIT_OK, FETCH_OK, {exitCode: 128})
     const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toContain('second parent')
   })
 
   it('reports unavailable when the merge ref cannot be fetched', async () => {
-    gitResponses({exitCode: 1})
+    gitResponses(INIT_OK, {exitCode: 128})
     const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toContain('merge ref')
   })
 
-  // The API path turns a rename into a delete of the old name plus an add of the
-  // new one, and `git diff --no-renames` emits the same pair.
+  // The API path turns a rename into a delete of the old name plus an add of the new
+  // one, and `git diff --no-renames` emits the same pair.
   it('matches a rename that the API reported as two entries', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'new.ts\nold.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'new.ts\0old.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('new.ts', 'old.ts'), pr)
     expect(result.verdict).toBe('match')
+    expect(argvFor(3)).toContain('--no-renames')
   })
 })

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42972,10 +42972,10 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.compareWithMergeCommit = compareWithMergeCommit;
 exports.report = report;
+const child_process_1 = __nccwpck_require__(5317);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
-const exec_1 = __nccwpck_require__(5236);
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
@@ -42998,6 +42998,10 @@ const EVENT_NAME = 'paths_filter_shadow_compared';
 const BUDGET_MS = 20000;
 const CAPTURE_TIMEOUT_MS = 5000;
 const LIST_CAP = 50;
+// A queue branch carries the cumulative batch diff, so the path list can be far larger
+// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// which drops the population the comparison most needs to measure.
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000;
 // Every git call is confined to a scratch repository. `--depth` and `--filter`
@@ -43006,20 +43010,23 @@ const API_FILE_CAP = 3000;
 // ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
 // after this action returns, and an empty merge base there silently drops their
 // schema cache.
-async function git(gitDir, args) {
-    const res = await (0, exec_1.getExecOutput)('git', ['--git-dir', gitDir, ...args], {
-        ignoreReturnCode: true,
-        silent: true
-    });
-    return { code: res.exitCode, out: res.stdout.trim() };
+async function git(gitDir, args, signal) {
+    return run(['--git-dir', gitDir, ...args], signal);
 }
-async function scratchRepo() {
-    const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
-    const init = await (0, exec_1.getExecOutput)('git', ['init', '--bare', '--quiet', gitDir], {
-        ignoreReturnCode: true,
-        silent: true
+// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
+// on the child process, so a fetch the budget gave up on keeps running and holds the
+// action's process open until it finishes, past the budget it was supposed to obey.
+async function run(args, signal) {
+    return new Promise(resolve => {
+        (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout) => {
+            resolve({ code: error ? 1 : 0, out: stdout.trim() });
+        });
     });
-    if (init.exitCode !== 0) {
+}
+async function scratchRepo(signal) {
+    const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
+    const init = await run(['init', '--bare', '--quiet', gitDir], signal);
+    if (init.code !== 0) {
         throw new Error('cannot create scratch repository');
     }
     return gitDir;
@@ -43038,8 +43045,8 @@ function originUrl() {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
-async function localChangedFiles(pr) {
-    const gitDir = await scratchRepo();
+async function localChangedFiles(pr, signal) {
+    const gitDir = await scratchRepo(signal);
     const fetched = await git(gitDir, [
         '-c',
         'http.lowSpeedLimit=1000',
@@ -43051,11 +43058,11 @@ async function localChangedFiles(pr) {
         `--depth=${MERGE_REF_FETCH_DEPTH}`,
         originUrl(),
         `refs/pull/${pr.number}/merge`
-    ]);
+    ], signal);
     if (fetched.code !== 0) {
         throw new Error('no merge ref');
     }
-    const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2']);
+    const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal);
     if (head.code !== 0) {
         throw new Error('merge ref has no second parent');
     }
@@ -43065,7 +43072,7 @@ async function localChangedFiles(pr) {
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`. -z because git quotes a
     // path holding a newline or a non-ASCII byte in the default format.
-    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD']);
+    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
         throw new Error('diff failed');
     }
@@ -43084,16 +43091,20 @@ function compare(apiFiles, gitFiles) {
         onlyInGit: onlyInGit.slice(0, LIST_CAP)
     };
 }
-function budgeted(work, ms) {
+async function budgeted(work, ms) {
+    const controller = new AbortController();
     let timer;
     const expiry = new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms);
+        timer = setTimeout(() => {
+            controller.abort();
+            reject(new Error(`exceeded ${ms}ms budget`));
+        }, ms);
     });
-    return Promise.race([work, expiry]).finally(() => clearTimeout(timer));
+    return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
 async function compareWithMergeCommit(apiFiles, pr) {
     try {
-        return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS));
+        return compare(apiFiles, await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS));
     }
     catch (error) {
         return {

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42687,6 +42687,7 @@ const github = __importStar(__nccwpck_require__(3228));
 const filter_1 = __nccwpck_require__(9037);
 const file_1 = __nccwpck_require__(3765);
 const git = __importStar(__nccwpck_require__(1243));
+const shadow = __importStar(__nccwpck_require__(5763));
 const shell_escape_1 = __nccwpck_require__(6880);
 const csv_escape_1 = __nccwpck_require__(6146);
 async function run() {
@@ -42753,7 +42754,9 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
-                return await getChangedFilesFromApi(token, pr);
+                const apiFiles = await getChangedFilesFromApi(token, pr);
+                await shadow.report(apiFiles, pr);
+                return apiFiles;
             }
             if (github.context.eventName === 'pull_request_target') {
                 // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -42924,6 +42927,151 @@ function getErrorMessage(error) {
     return String(error);
 }
 run();
+
+
+/***/ }),
+
+/***/ 5763:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.compareWithMergeCommit = compareWithMergeCommit;
+exports.report = report;
+const core = __importStar(__nccwpck_require__(7484));
+const exec_1 = __nccwpck_require__(5236);
+// Compares the API's changed-file list against the same list derived locally from
+// the pull request's merge commit, and reports disagreement without acting on it.
+// The API result stays authoritative, so a wrong local answer can only produce a
+// log line. Removing the API call later is only safe once this has run quiet
+// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
+// and PRs GitHub has not finished computing a merge ref for.
+//
+// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
+// commit the branch picked up when master was merged into it as the PR's own work.
+// The merge commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+const MERGE_REF_FETCH_DEPTH = 2;
+async function git(args) {
+    const res = await (0, exec_1.getExecOutput)('git', args, { ignoreReturnCode: true, silent: true });
+    return { code: res.exitCode, out: res.stdout.trim() };
+}
+// The merge ref is not guaranteed to be present or current: a shallow checkout has
+// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
+// the second parent to equal the head SHA rejects a stale ref rather than reading
+// it as this PR's changes.
+async function localChangedFiles(pr) {
+    const fetched = await git([
+        'fetch',
+        '--no-tags',
+        '--filter=blob:none',
+        `--depth=${MERGE_REF_FETCH_DEPTH}`,
+        'origin',
+        `refs/pull/${pr.number}/merge`
+    ]);
+    if (fetched.code !== 0) {
+        throw new Error('no merge ref');
+    }
+    const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD']);
+    if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+        throw new Error('merge ref has no second parent');
+    }
+    const head = await git(['rev-parse', 'FETCH_HEAD^2']);
+    if (head.code !== 0 || head.out !== pr.head.sha) {
+        throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
+    }
+    // --no-renames so a rename arrives as a delete plus an add, which is the shape
+    // the API path builds by hand from `previous_filename`.
+    const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD']);
+    if (diff.code !== 0) {
+        throw new Error('diff failed');
+    }
+    return diff.out.split('\n').filter(Boolean);
+}
+function compare(apiFiles, gitFiles) {
+    const api = new Set(apiFiles.map(f => f.filename));
+    const local = new Set(gitFiles);
+    const onlyInApi = [...api].filter(f => !local.has(f));
+    const onlyInGit = [...local].filter(f => !api.has(f));
+    return {
+        verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+        apiCount: api.size,
+        gitCount: local.size,
+        onlyInApi: onlyInApi.slice(0, 20),
+        onlyInGit: onlyInGit.slice(0, 20)
+    };
+}
+async function compareWithMergeCommit(apiFiles, pr) {
+    try {
+        return compare(apiFiles, await localChangedFiles(pr));
+    }
+    catch (error) {
+        return {
+            verdict: 'unavailable',
+            reason: error instanceof Error ? error.message : String(error),
+            apiCount: apiFiles.length
+        };
+    }
+}
+// Never throws: the filter's real answer is already computed by the time this runs,
+// so nothing here is worth failing a CI job over.
+async function report(apiFiles, pr) {
+    try {
+        core.startGroup('Shadow: merge-commit change detection');
+        const result = await compareWithMergeCommit(apiFiles, pr);
+        if (result.verdict === 'match') {
+            core.info(`shadow: match (${result.apiCount} files)`);
+        }
+        else if (result.verdict === 'unavailable') {
+            core.info(`shadow: unavailable (${result.reason})`);
+        }
+        else {
+            core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+                `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
+        }
+        core.setOutput('shadow_verdict', result.verdict);
+    }
+    catch (error) {
+        core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);
+    }
+    finally {
+        core.endGroup();
+    }
+}
 
 
 /***/ }),

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42980,8 +42980,8 @@ const core = __importStar(__nccwpck_require__(7484));
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: merged pull requests, very large
-// diffs, and ones GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: very large diffs, and ones GitHub
+// has not finished computing a merge ref for.
 //
 // Detecting changes from `base.sha..HEAD` instead reports every commit the branch
 // picked up when the base was merged into it as the pull request's own work, which
@@ -42991,43 +42991,59 @@ const core = __importStar(__nccwpck_require__(7484));
 const MERGE_REF_FETCH_DEPTH = 2;
 const POSTHOG_HOST = 'https://us.i.posthog.com';
 const EVENT_NAME = 'paths_filter_shadow_compared';
-// A change-detection job is on the critical path of every workflow, so the whole
-// comparison gets a wall-clock budget and gives up rather than holding the job to
-// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
-// the budget covers everything else.
+// A change-detection job is on the critical path of every workflow, so the comparison
+// and the capture that follows it share one wall-clock budget, and give up rather than
+// holding the job to its timeout-minutes. The git-level low-speed settings cover a
+// stalled transfer; the budget covers everything else.
 const BUDGET_MS = 20000;
-const CAPTURE_TIMEOUT_MS = 5000;
+const CAPTURE_FLOOR_MS = 500;
 const LIST_CAP = 50;
 // A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
 // which drops the population the comparison most needs to measure.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
+const DETAIL_CAP = 200;
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000;
-// Every git call is confined to a scratch repository. `--depth` and `--filter`
-// rewrite `.git/shallow` and the promisor config of whatever repository they run
-// in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
-// after this action returns, and an empty merge base there silently drops their
-// schema cache.
+class Unavailable extends Error {
+    constructor(reason, detail) {
+        super(`${reason}: ${detail}`);
+        this.reason = reason;
+        this.detail = detail;
+    }
+}
+// Every git call that reads or writes history names the scratch repository. `--depth`
+// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
+// they run in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
+// this action returns, and an empty merge base there silently drops their schema cache.
 async function git(gitDir, args, signal) {
     return run(['--git-dir', gitDir, ...args], signal);
 }
 // The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
 // on the child process, so a fetch the budget gave up on keeps running and holds the
 // action's process open until it finishes, past the budget it was supposed to obey.
+//
+// stdout is returned raw. A caller that reads a path list must not trim it, because a
+// tracked path can begin with a space, and that path sorts first in the -z output.
 async function run(args, signal) {
     return new Promise(resolve => {
-        (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout) => {
-            resolve({ code: error ? 1 : 0, out: stdout.trim() });
+        (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout, stderr) => {
+            resolve({ code: error ? 1 : 0, out: stdout, err: stderr.trim() });
         });
     });
+}
+function firstLine(stderr) {
+    return stderr.slice(0, DETAIL_CAP).split('\n')[0] || 'no stderr';
+}
+function messageOf(error) {
+    return error instanceof Error ? error.message : String(error);
 }
 async function scratchRepo(signal) {
     const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
     const init = await run(['init', '--bare', '--quiet', gitDir], signal);
     if (init.code !== 0) {
-        throw new Error('cannot create scratch repository');
+        throw new Unavailable('no-scratch-repo', firstLine(init.err));
     }
     return gitDir;
 }
@@ -43038,7 +43054,7 @@ function originUrl() {
     const server = process.env.GITHUB_SERVER_URL;
     const repo = process.env.GITHUB_REPOSITORY;
     if (!server || !repo) {
-        throw new Error('cannot resolve origin url');
+        throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset');
     }
     return `${server}/${repo}`;
 }
@@ -43060,35 +43076,53 @@ async function localChangedFiles(pr, signal) {
         `refs/pull/${pr.number}/merge`
     ], signal);
     if (fetched.code !== 0) {
-        throw new Error('no merge ref');
+        throw new Unavailable('no-merge-ref', firstLine(fetched.err));
     }
     const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal);
     if (head.code !== 0) {
-        throw new Error('merge ref has no second parent');
+        throw new Unavailable('no-second-parent', firstLine(head.err));
     }
-    if (head.out !== pr.head.sha) {
-        throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
+    const headSha = head.out.trim();
+    if (headSha !== pr.head.sha) {
+        throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`);
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`. -z because git quotes a
     // path holding a newline or a non-ASCII byte in the default format.
     const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
-        throw new Error('diff failed');
+        throw new Unavailable('diff-failed', firstLine(diff.err));
     }
     return diff.out.split('\0').filter(Boolean);
 }
-function compare(apiFiles, gitFiles) {
-    const api = new Set(apiFiles.map(f => f.filename));
-    const local = new Set(gitFiles);
-    const onlyInApi = [...api].filter(f => !local.has(f));
-    const onlyInGit = [...local].filter(f => !api.has(f));
+// A queue branch can differ by thousands of paths, which is neither readable in a log
+// line nor worth carrying as an event property. The count answers how far apart the two
+// answers are, and the sample answers what kind of path is involved.
+function difference(from, against) {
+    const sample = [];
+    let count = 0;
+    for (const filename of from) {
+        if (against.has(filename)) {
+            continue;
+        }
+        count++;
+        if (sample.length < LIST_CAP) {
+            sample.push(filename);
+        }
+    }
+    return { count, sample };
+}
+function compare(api, local) {
+    const onlyInApi = difference(api, local);
+    const onlyInGit = difference(local, api);
     return {
-        verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+        verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
+        reason: null,
+        detail: null,
         apiCount: api.size,
         gitCount: local.size,
-        onlyInApi: onlyInApi.slice(0, LIST_CAP),
-        onlyInGit: onlyInGit.slice(0, LIST_CAP)
+        onlyInApi,
+        onlyInGit
     };
 }
 async function budgeted(work, ms) {
@@ -43097,54 +43131,59 @@ async function budgeted(work, ms) {
     const expiry = new Promise((_, reject) => {
         timer = setTimeout(() => {
             controller.abort();
-            reject(new Error(`exceeded ${ms}ms budget`));
+            reject(new Unavailable('budget-exceeded', `${ms}ms`));
         }, ms);
     });
     return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
 async function compareWithMergeCommit(apiFiles, pr) {
+    const api = new Set(apiFiles.map(f => f.filename));
     try {
-        return compare(apiFiles, await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS));
+        const gitFiles = await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS);
+        return compare(api, new Set(gitFiles));
     }
     catch (error) {
         return {
             verdict: 'unavailable',
-            reason: error instanceof Error ? error.message : String(error),
-            apiCount: apiFiles.length
+            reason: error instanceof Unavailable ? error.reason : 'unknown',
+            detail: error instanceof Unavailable ? error.detail : messageOf(error),
+            apiCount: api.size,
+            gitCount: null,
+            onlyInApi: { count: 0, sample: [] },
+            onlyInGit: { count: 0, sample: [] }
         };
     }
 }
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-// Forks get no secrets, so the token is absent there and the capture is skipped.
-async function capture(result, pr, durationMs) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
-    const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
-    if (!apiKey) {
-        return;
-    }
+async function capture(apiKey, result, pr, durationMs) {
+    var _a;
     const repo = process.env.GITHUB_REPOSITORY || null;
-    const headRef = (_b = (_a = pr.head) === null || _a === void 0 ? void 0 : _a.ref) !== null && _b !== void 0 ? _b : null;
     const properties = {
         repo,
         verdict: result.verdict,
-        reason: (_c = result.reason) !== null && _c !== void 0 ? _c : null,
+        reason: result.reason,
+        detail: result.detail,
         api_count: result.apiCount,
-        git_count: (_d = result.gitCount) !== null && _d !== void 0 ? _d : null,
-        only_in_api: (_e = result.onlyInApi) !== null && _e !== void 0 ? _e : [],
-        only_in_git: (_f = result.onlyInGit) !== null && _f !== void 0 ? _f : [],
+        git_count: result.gitCount,
+        only_in_api: result.onlyInApi.sample,
+        only_in_api_count: result.onlyInApi.count,
+        only_in_git: result.onlyInGit.sample,
+        only_in_git_count: result.onlyInGit.count,
         // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-        // API returned, and what the pull request payload says it should have been.
-        api_truncated: result.apiCount >= API_FILE_CAP,
-        pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+        // API returned, and what the pull request payload says it should have been. The
+        // count has to come from the payload, because `api_count` counts a rename twice:
+        // the API path expands each renamed row into an add plus a delete.
+        api_truncated: pr.changed_files >= API_FILE_CAP,
+        pr_changed_files: pr.changed_files,
         pr_number: pr.number,
-        head_sha: (_h = (_g = pr.head) === null || _g === void 0 ? void 0 : _g.sha) !== null && _h !== void 0 ? _h : null,
-        head_ref: headRef,
-        base_ref: (_k = (_j = pr.base) === null || _j === void 0 ? void 0 : _j.ref) !== null && _k !== void 0 ? _k : null,
+        head_sha: pr.head.sha,
+        head_ref: pr.head.ref,
+        base_ref: pr.base.ref,
         // Queue branches carry the cumulative batch diff and page far more than a human
         // pull request, so they are the population worth reading separately.
-        branch_class: (headRef === null || headRef === void 0 ? void 0 : headRef.startsWith('trunk-merge/')) ? 'trunk-merge' : 'pull-request',
-        is_fork: ((_m = (_l = pr.head) === null || _l === void 0 ? void 0 : _l.repo) === null || _m === void 0 ? void 0 : _m.full_name) !== repo,
+        branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
+        is_fork: ((_a = pr.head.repo) === null || _a === void 0 ? void 0 : _a.full_name) !== repo,
         duration_ms: durationMs,
         workflow: process.env.GITHUB_WORKFLOW || null,
         job: process.env.GITHUB_JOB || null,
@@ -43160,36 +43199,49 @@ async function capture(result, pr, durationMs) {
             distinct_id: repo || 'paths-filter-shadow',
             properties
         }),
-        signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+        // Whatever the comparison did not spend, so the step's ceiling stays the budget.
+        signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
     });
     if (!res.ok) {
         throw new Error(`capture ${res.status}`);
     }
 }
+function summarize(result) {
+    if (result.verdict === 'unavailable') {
+        return `unavailable (${result.reason}: ${result.detail})`;
+    }
+    if (result.verdict === 'mismatch') {
+        return (`MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+            `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`);
+    }
+    return `match (${result.apiCount} files)`;
+}
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
+//
+// The token gates the comparison itself, not just the capture. Every workflow that
+// detects changes runs this action, so a comparison whose result cannot be recorded
+// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
+// nobody reads. Fork pull requests get no secrets, so they take this path too.
 async function report(apiFiles, pr) {
+    const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
+    if (!apiKey) {
+        return;
+    }
     try {
         core.startGroup('Shadow: merge-commit change detection');
         const startedAt = Date.now();
         const result = await compareWithMergeCommit(apiFiles, pr);
         const durationMs = Date.now() - startedAt;
-        if (result.verdict === 'mismatch') {
-            core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-                `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
-        }
-        else if (result.verdict === 'unavailable') {
-            core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`);
-        }
-        else {
-            core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`);
-        }
-        await capture(result, pr, durationMs).catch(error => {
-            core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`);
+        // core.info even for a mismatch: a warning becomes an annotation on the run summary
+        // and the checks page, which reads as a problem with the pull request.
+        core.info(`shadow: ${summarize(result)} in ${durationMs}ms`);
+        await capture(apiKey, result, pr, durationMs).catch(error => {
+            core.info(`shadow: capture skipped (${messageOf(error)})`);
         });
     }
     catch (error) {
-        core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);
+        core.info(`shadow: skipped (${messageOf(error)})`);
     }
     finally {
         core.endGroup();

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42989,6 +42989,17 @@ const exec_1 = __nccwpck_require__(5236);
 // commit's first parent is the base GitHub actually merged against, so
 // `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 const MERGE_REF_FETCH_DEPTH = 2;
+const POSTHOG_HOST = 'https://us.i.posthog.com';
+const EVENT_NAME = 'paths_filter_shadow_compared';
+// A change-detection job is on the critical path of every workflow, so the whole
+// comparison gets a wall-clock budget and gives up rather than holding the job to
+// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
+// the budget covers everything else.
+const BUDGET_MS = 20000;
+const CAPTURE_TIMEOUT_MS = 5000;
+const LIST_CAP = 50;
+// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
+const API_FILE_CAP = 3000;
 // Every git call is confined to a scratch repository. `--depth` and `--filter`
 // rewrite `.git/shallow` and the promisor config of whatever repository they run
 // in, and steps later in the same job read history from the workspace checkout:
@@ -43016,33 +43027,29 @@ async function scratchRepo() {
 // The workspace remote carries no credentials of its own: actions/checkout keeps the
 // token in an http.extraheader the scratch repository does not inherit. A private
 // remote therefore reports unavailable rather than comparing against a partial fetch.
-async function originUrl() {
+function originUrl() {
     const server = process.env.GITHUB_SERVER_URL;
     const repo = process.env.GITHUB_REPOSITORY;
-    if (server && repo) {
-        return `${server}/${repo}`;
-    }
-    const remote = await (0, exec_1.getExecOutput)('git', ['remote', 'get-url', 'origin'], {
-        ignoreReturnCode: true,
-        silent: true
-    });
-    if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+    if (!server || !repo) {
         throw new Error('cannot resolve origin url');
     }
-    return remote.stdout.trim();
+    return `${server}/${repo}`;
 }
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr) {
     const gitDir = await scratchRepo();
-    const url = await originUrl();
     const fetched = await git(gitDir, [
+        '-c',
+        'http.lowSpeedLimit=1000',
+        '-c',
+        'http.lowSpeedTime=10',
         'fetch',
         '--no-tags',
         '--filter=blob:none',
         `--depth=${MERGE_REF_FETCH_DEPTH}`,
-        url,
+        originUrl(),
         `refs/pull/${pr.number}/merge`
     ]);
     if (fetched.code !== 0) {
@@ -43056,7 +43063,8 @@ async function localChangedFiles(pr) {
         throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
-    // the API path builds by hand from `previous_filename`.
+    // the API path builds by hand from `previous_filename`. -z because git quotes a
+    // path holding a newline or a non-ASCII byte in the default format.
     const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD']);
     if (diff.code !== 0) {
         throw new Error('diff failed');
@@ -43072,13 +43080,20 @@ function compare(apiFiles, gitFiles) {
         verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
         apiCount: api.size,
         gitCount: local.size,
-        onlyInApi: onlyInApi.slice(0, 20),
-        onlyInGit: onlyInGit.slice(0, 20)
+        onlyInApi: onlyInApi.slice(0, LIST_CAP),
+        onlyInGit: onlyInGit.slice(0, LIST_CAP)
     };
+}
+function budgeted(work, ms) {
+    let timer;
+    const expiry = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms);
+    });
+    return Promise.race([work, expiry]).finally(() => clearTimeout(timer));
 }
 async function compareWithMergeCommit(apiFiles, pr) {
     try {
-        return compare(apiFiles, await localChangedFiles(pr));
+        return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS));
     }
     catch (error) {
         return {
@@ -43088,22 +43103,79 @@ async function compareWithMergeCommit(apiFiles, pr) {
         };
     }
 }
+// Without this the only record of a divergence is a log line in one job of one run,
+// which is unreadable at the volume that makes the comparison worth running.
+// Forks get no secrets, so the token is absent there and the capture is skipped.
+async function capture(result, pr, durationMs) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
+    const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
+    if (!apiKey) {
+        return;
+    }
+    const repo = process.env.GITHUB_REPOSITORY || null;
+    const headRef = (_b = (_a = pr.head) === null || _a === void 0 ? void 0 : _a.ref) !== null && _b !== void 0 ? _b : null;
+    const properties = {
+        repo,
+        verdict: result.verdict,
+        reason: (_c = result.reason) !== null && _c !== void 0 ? _c : null,
+        api_count: result.apiCount,
+        git_count: (_d = result.gitCount) !== null && _d !== void 0 ? _d : null,
+        only_in_api: (_e = result.onlyInApi) !== null && _e !== void 0 ? _e : [],
+        only_in_git: (_f = result.onlyInGit) !== null && _f !== void 0 ? _f : [],
+        // pulls/{n}/files truncates silently, so record both sides of the tell: what the
+        // API returned, and what the pull request payload says it should have been.
+        api_truncated: result.apiCount >= API_FILE_CAP,
+        pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+        pr_number: pr.number,
+        head_sha: (_h = (_g = pr.head) === null || _g === void 0 ? void 0 : _g.sha) !== null && _h !== void 0 ? _h : null,
+        head_ref: headRef,
+        base_ref: (_k = (_j = pr.base) === null || _j === void 0 ? void 0 : _j.ref) !== null && _k !== void 0 ? _k : null,
+        // Queue branches carry the cumulative batch diff and page far more than a human
+        // pull request, so they are the population worth reading separately.
+        branch_class: (headRef === null || headRef === void 0 ? void 0 : headRef.startsWith('trunk-merge/')) ? 'trunk-merge' : 'pull-request',
+        is_fork: ((_m = (_l = pr.head) === null || _l === void 0 ? void 0 : _l.repo) === null || _m === void 0 ? void 0 : _m.full_name) !== repo,
+        duration_ms: durationMs,
+        workflow: process.env.GITHUB_WORKFLOW || null,
+        job: process.env.GITHUB_JOB || null,
+        run_id: process.env.GITHUB_RUN_ID || null,
+        run_attempt: process.env.GITHUB_RUN_ATTEMPT || null
+    };
+    const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            api_key: apiKey,
+            event: EVENT_NAME,
+            distinct_id: repo || 'paths-filter-shadow',
+            properties
+        }),
+        signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+    });
+    if (!res.ok) {
+        throw new Error(`capture ${res.status}`);
+    }
+}
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
 async function report(apiFiles, pr) {
     try {
         core.startGroup('Shadow: merge-commit change detection');
+        const startedAt = Date.now();
         const result = await compareWithMergeCommit(apiFiles, pr);
-        if (result.verdict === 'match') {
-            core.info(`shadow: match (${result.apiCount} files)`);
-        }
-        else if (result.verdict === 'unavailable') {
-            core.info(`shadow: unavailable (${result.reason})`);
-        }
-        else {
+        const durationMs = Date.now() - startedAt;
+        if (result.verdict === 'mismatch') {
             core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
                 `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
         }
+        else if (result.verdict === 'unavailable') {
+            core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`);
+        }
+        else {
+            core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`);
+        }
+        await capture(result, pr, durationMs).catch(error => {
+            core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`);
+        });
     }
     catch (error) {
         core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42972,55 +42972,96 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.compareWithMergeCommit = compareWithMergeCommit;
 exports.report = report;
+const os = __importStar(__nccwpck_require__(857));
+const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
 const exec_1 = __nccwpck_require__(5236);
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
-// and PRs GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: merged pull requests, very large
+// diffs, and ones GitHub has not finished computing a merge ref for.
 //
-// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
-// commit the branch picked up when master was merged into it as the PR's own work.
-// The merge commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
+// picked up when the base was merged into it as the pull request's own work, which
+// is wrong by thousands of files on a branch that has taken master in. The merge
+// commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 const MERGE_REF_FETCH_DEPTH = 2;
-async function git(args) {
-    const res = await (0, exec_1.getExecOutput)('git', args, { ignoreReturnCode: true, silent: true });
+// Every git call is confined to a scratch repository. `--depth` and `--filter`
+// rewrite `.git/shallow` and the promisor config of whatever repository they run
+// in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
+// after this action returns, and an empty merge base there silently drops their
+// schema cache.
+async function git(gitDir, args) {
+    const res = await (0, exec_1.getExecOutput)('git', ['--git-dir', gitDir, ...args], {
+        ignoreReturnCode: true,
+        silent: true
+    });
     return { code: res.exitCode, out: res.stdout.trim() };
 }
-// The merge ref is not guaranteed to be present or current: a shallow checkout has
-// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
-// the second parent to equal the head SHA rejects a stale ref rather than reading
-// it as this PR's changes.
+async function scratchRepo() {
+    const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
+    const init = await (0, exec_1.getExecOutput)('git', ['init', '--bare', '--quiet', gitDir], {
+        ignoreReturnCode: true,
+        silent: true
+    });
+    if (init.exitCode !== 0) {
+        throw new Error('cannot create scratch repository');
+    }
+    return gitDir;
+}
+// The workspace remote carries no credentials of its own: actions/checkout keeps the
+// token in an http.extraheader the scratch repository does not inherit. A private
+// remote therefore reports unavailable rather than comparing against a partial fetch.
+async function originUrl() {
+    const server = process.env.GITHUB_SERVER_URL;
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (server && repo) {
+        return `${server}/${repo}`;
+    }
+    const remote = await (0, exec_1.getExecOutput)('git', ['remote', 'get-url', 'origin'], {
+        ignoreReturnCode: true,
+        silent: true
+    });
+    if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+        throw new Error('cannot resolve origin url');
+    }
+    return remote.stdout.trim();
+}
+// The merge ref is not guaranteed to be present or current: GitHub recomputes it
+// asynchronously after a push. Requiring the second parent to equal the head SHA
+// rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr) {
-    const fetched = await git([
+    const gitDir = await scratchRepo();
+    const url = await originUrl();
+    const fetched = await git(gitDir, [
         'fetch',
         '--no-tags',
         '--filter=blob:none',
         `--depth=${MERGE_REF_FETCH_DEPTH}`,
-        'origin',
+        url,
         `refs/pull/${pr.number}/merge`
     ]);
     if (fetched.code !== 0) {
         throw new Error('no merge ref');
     }
-    const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD']);
-    if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+    const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2']);
+    if (head.code !== 0) {
         throw new Error('merge ref has no second parent');
     }
-    const head = await git(['rev-parse', 'FETCH_HEAD^2']);
-    if (head.code !== 0 || head.out !== pr.head.sha) {
+    if (head.out !== pr.head.sha) {
         throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`.
-    const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD']);
+    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD']);
     if (diff.code !== 0) {
         throw new Error('diff failed');
     }
-    return diff.out.split('\n').filter(Boolean);
+    return diff.out.split('\0').filter(Boolean);
 }
 function compare(apiFiles, gitFiles) {
     const api = new Set(apiFiles.map(f => f.filename));
@@ -43063,7 +43104,6 @@ async function report(apiFiles, pr) {
             core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
                 `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
         }
-        core.setOutput('shadow_verdict', result.verdict);
     }
     catch (error) {
         core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);

--- a/.depot/actions/paths-filter/src/main.ts
+++ b/.depot/actions/paths-filter/src/main.ts
@@ -7,6 +7,7 @@ import {PullRequest, PushEvent} from '@octokit/webhooks-types'
 import {Filter, FilterResults} from './filter'
 import {File, ChangeStatus} from './file'
 import * as git from './git'
+import * as shadow from './shadow'
 import {backslashEscape, shellEscape} from './list-format/shell-escape'
 import {csvEscape} from './list-format/csv-escape'
 
@@ -83,7 +84,9 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
-        return await getChangedFilesFromApi(token, pr)
+        const apiFiles = await getChangedFilesFromApi(token, pr)
+        await shadow.report(apiFiles, pr)
+        return apiFiles
       }
       if (github.context.eventName === 'pull_request_target') {
         // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -21,6 +21,19 @@ import {File} from './file'
 // `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 
 const MERGE_REF_FETCH_DEPTH = 2
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+const EVENT_NAME = 'paths_filter_shadow_compared'
+
+// A change-detection job is on the critical path of every workflow, so the whole
+// comparison gets a wall-clock budget and gives up rather than holding the job to
+// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
+// the budget covers everything else.
+const BUDGET_MS = 20000
+const CAPTURE_TIMEOUT_MS = 5000
+const LIST_CAP = 50
+
+// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
+const API_FILE_CAP = 3000
 
 type Verdict = 'match' | 'mismatch' | 'unavailable'
 
@@ -62,20 +75,13 @@ async function scratchRepo(): Promise<string> {
 // The workspace remote carries no credentials of its own: actions/checkout keeps the
 // token in an http.extraheader the scratch repository does not inherit. A private
 // remote therefore reports unavailable rather than comparing against a partial fetch.
-async function originUrl(): Promise<string> {
+function originUrl(): string {
   const server = process.env.GITHUB_SERVER_URL
   const repo = process.env.GITHUB_REPOSITORY
-  if (server && repo) {
-    return `${server}/${repo}`
-  }
-  const remote = await getExecOutput('git', ['remote', 'get-url', 'origin'], {
-    ignoreReturnCode: true,
-    silent: true
-  })
-  if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+  if (!server || !repo) {
     throw new Error('cannot resolve origin url')
   }
-  return remote.stdout.trim()
+  return `${server}/${repo}`
 }
 
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
@@ -83,14 +89,17 @@ async function originUrl(): Promise<string> {
 // rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr: PullRequest): Promise<string[]> {
   const gitDir = await scratchRepo()
-  const url = await originUrl()
 
   const fetched = await git(gitDir, [
+    '-c',
+    'http.lowSpeedLimit=1000',
+    '-c',
+    'http.lowSpeedTime=10',
     'fetch',
     '--no-tags',
     '--filter=blob:none',
     `--depth=${MERGE_REF_FETCH_DEPTH}`,
-    url,
+    originUrl(),
     `refs/pull/${pr.number}/merge`
   ])
   if (fetched.code !== 0) {
@@ -106,7 +115,8 @@ async function localChangedFiles(pr: PullRequest): Promise<string[]> {
   }
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
-  // the API path builds by hand from `previous_filename`.
+  // the API path builds by hand from `previous_filename`. -z because git quotes a
+  // path holding a newline or a non-ASCII byte in the default format.
   const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'])
   if (diff.code !== 0) {
     throw new Error('diff failed')
@@ -123,14 +133,22 @@ function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
     verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
     apiCount: api.size,
     gitCount: local.size,
-    onlyInApi: onlyInApi.slice(0, 20),
-    onlyInGit: onlyInGit.slice(0, 20)
+    onlyInApi: onlyInApi.slice(0, LIST_CAP),
+    onlyInGit: onlyInGit.slice(0, LIST_CAP)
   }
+}
+
+function budgeted<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms)
+  })
+  return Promise.race([work, expiry]).finally(() => clearTimeout(timer)) as Promise<T>
 }
 
 export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
   try {
-    return compare(apiFiles, await localChangedFiles(pr))
+    return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS))
   } catch (error) {
     return {
       verdict: 'unavailable',
@@ -140,22 +158,81 @@ export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest):
   }
 }
 
+// Without this the only record of a divergence is a log line in one job of one run,
+// which is unreadable at the volume that makes the comparison worth running.
+// Forks get no secrets, so the token is absent there and the capture is skipped.
+async function capture(result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
+  const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
+  if (!apiKey) {
+    return
+  }
+  const repo = process.env.GITHUB_REPOSITORY || null
+  const headRef = pr.head?.ref ?? null
+  const properties = {
+    repo,
+    verdict: result.verdict,
+    reason: result.reason ?? null,
+    api_count: result.apiCount,
+    git_count: result.gitCount ?? null,
+    only_in_api: result.onlyInApi ?? [],
+    only_in_git: result.onlyInGit ?? [],
+    // pulls/{n}/files truncates silently, so record both sides of the tell: what the
+    // API returned, and what the pull request payload says it should have been.
+    api_truncated: result.apiCount >= API_FILE_CAP,
+    pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+    pr_number: pr.number,
+    head_sha: pr.head?.sha ?? null,
+    head_ref: headRef,
+    base_ref: pr.base?.ref ?? null,
+    // Queue branches carry the cumulative batch diff and page far more than a human
+    // pull request, so they are the population worth reading separately.
+    branch_class: headRef?.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
+    is_fork: pr.head?.repo?.full_name !== repo,
+    duration_ms: durationMs,
+    workflow: process.env.GITHUB_WORKFLOW || null,
+    job: process.env.GITHUB_JOB || null,
+    run_id: process.env.GITHUB_RUN_ID || null,
+    run_attempt: process.env.GITHUB_RUN_ATTEMPT || null
+  }
+  const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      api_key: apiKey,
+      event: EVENT_NAME,
+      distinct_id: repo || 'paths-filter-shadow',
+      properties
+    }),
+    signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+  })
+  if (!res.ok) {
+    throw new Error(`capture ${res.status}`)
+  }
+}
+
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
 export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
   try {
     core.startGroup('Shadow: merge-commit change detection')
+    const startedAt = Date.now()
     const result = await compareWithMergeCommit(apiFiles, pr)
-    if (result.verdict === 'match') {
-      core.info(`shadow: match (${result.apiCount} files)`)
-    } else if (result.verdict === 'unavailable') {
-      core.info(`shadow: unavailable (${result.reason})`)
-    } else {
+    const durationMs = Date.now() - startedAt
+
+    if (result.verdict === 'mismatch') {
       core.warning(
         `shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
           `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
       )
+    } else if (result.verdict === 'unavailable') {
+      core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`)
+    } else {
+      core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`)
     }
+
+    await capture(result, pr, durationMs).catch(error => {
+      core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`)
+    })
   } catch (error) {
     core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
   } finally {

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -1,3 +1,6 @@
+import * as os from 'os'
+import * as path from 'path'
+
 import * as core from '@actions/core'
 import {getExecOutput} from '@actions/exec'
 import {PullRequest} from '@octokit/webhooks-types'
@@ -8,13 +11,14 @@ import {File} from './file'
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
-// and PRs GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: merged pull requests, very large
+// diffs, and ones GitHub has not finished computing a merge ref for.
 //
-// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
-// commit the branch picked up when master was merged into it as the PR's own work.
-// The merge commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
+// picked up when the base was merged into it as the pull request's own work, which
+// is wrong by thousands of files on a branch that has taken master in. The merge
+// commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 
 const MERGE_REF_FETCH_DEPTH = 2
 
@@ -29,45 +33,85 @@ interface ShadowResult {
   onlyInGit?: string[]
 }
 
-async function git(args: string[]): Promise<{code: number; out: string}> {
-  const res = await getExecOutput('git', args, {ignoreReturnCode: true, silent: true})
+// Every git call is confined to a scratch repository. `--depth` and `--filter`
+// rewrite `.git/shallow` and the promisor config of whatever repository they run
+// in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
+// after this action returns, and an empty merge base there silently drops their
+// schema cache.
+async function git(gitDir: string, args: string[]): Promise<{code: number; out: string}> {
+  const res = await getExecOutput('git', ['--git-dir', gitDir, ...args], {
+    ignoreReturnCode: true,
+    silent: true
+  })
   return {code: res.exitCode, out: res.stdout.trim()}
 }
 
-// The merge ref is not guaranteed to be present or current: a shallow checkout has
-// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
-// the second parent to equal the head SHA rejects a stale ref rather than reading
-// it as this PR's changes.
+async function scratchRepo(): Promise<string> {
+  const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
+  const init = await getExecOutput('git', ['init', '--bare', '--quiet', gitDir], {
+    ignoreReturnCode: true,
+    silent: true
+  })
+  if (init.exitCode !== 0) {
+    throw new Error('cannot create scratch repository')
+  }
+  return gitDir
+}
+
+// The workspace remote carries no credentials of its own: actions/checkout keeps the
+// token in an http.extraheader the scratch repository does not inherit. A private
+// remote therefore reports unavailable rather than comparing against a partial fetch.
+async function originUrl(): Promise<string> {
+  const server = process.env.GITHUB_SERVER_URL
+  const repo = process.env.GITHUB_REPOSITORY
+  if (server && repo) {
+    return `${server}/${repo}`
+  }
+  const remote = await getExecOutput('git', ['remote', 'get-url', 'origin'], {
+    ignoreReturnCode: true,
+    silent: true
+  })
+  if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+    throw new Error('cannot resolve origin url')
+  }
+  return remote.stdout.trim()
+}
+
+// The merge ref is not guaranteed to be present or current: GitHub recomputes it
+// asynchronously after a push. Requiring the second parent to equal the head SHA
+// rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr: PullRequest): Promise<string[]> {
-  const fetched = await git([
+  const gitDir = await scratchRepo()
+  const url = await originUrl()
+
+  const fetched = await git(gitDir, [
     'fetch',
     '--no-tags',
     '--filter=blob:none',
     `--depth=${MERGE_REF_FETCH_DEPTH}`,
-    'origin',
+    url,
     `refs/pull/${pr.number}/merge`
   ])
   if (fetched.code !== 0) {
     throw new Error('no merge ref')
   }
 
-  const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD'])
-  if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+  const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'])
+  if (head.code !== 0) {
     throw new Error('merge ref has no second parent')
   }
-
-  const head = await git(['rev-parse', 'FETCH_HEAD^2'])
-  if (head.code !== 0 || head.out !== pr.head.sha) {
+  if (head.out !== pr.head.sha) {
     throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`)
   }
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
   // the API path builds by hand from `previous_filename`.
-  const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD'])
+  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'])
   if (diff.code !== 0) {
     throw new Error('diff failed')
   }
-  return diff.out.split('\n').filter(Boolean)
+  return diff.out.split('\0').filter(Boolean)
 }
 
 function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
@@ -112,7 +156,6 @@ export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
           `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
       )
     }
-    core.setOutput('shadow_verdict', result.verdict)
   } catch (error) {
     core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
   } finally {

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -11,8 +11,8 @@ import {File} from './file'
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: merged pull requests, very large
-// diffs, and ones GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: very large diffs, and ones GitHub
+// has not finished computing a merge ref for.
 //
 // Detecting changes from `base.sha..HEAD` instead reports every commit the branch
 // picked up when the base was merged into it as the pull request's own work, which
@@ -24,59 +24,100 @@ const MERGE_REF_FETCH_DEPTH = 2
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 const EVENT_NAME = 'paths_filter_shadow_compared'
 
-// A change-detection job is on the critical path of every workflow, so the whole
-// comparison gets a wall-clock budget and gives up rather than holding the job to
-// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
-// the budget covers everything else.
+// A change-detection job is on the critical path of every workflow, so the comparison
+// and the capture that follows it share one wall-clock budget, and give up rather than
+// holding the job to its timeout-minutes. The git-level low-speed settings cover a
+// stalled transfer; the budget covers everything else.
 const BUDGET_MS = 20000
-const CAPTURE_TIMEOUT_MS = 5000
+const CAPTURE_FLOOR_MS = 500
 const LIST_CAP = 50
 
 // A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
 // which drops the population the comparison most needs to measure.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024
+const DETAIL_CAP = 200
 
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000
 
 type Verdict = 'match' | 'mismatch' | 'unavailable'
 
-interface ShadowResult {
-  verdict: Verdict
-  reason?: string
-  apiCount: number
-  gitCount?: number
-  onlyInApi?: string[]
-  onlyInGit?: string[]
+// A closed set, because this is the field the comparison is grouped by once the events
+// land. Git's own words go in `detail`, which is free text and unbounded.
+type Reason =
+  | 'no-scratch-repo'
+  | 'no-origin-url'
+  | 'no-merge-ref'
+  | 'no-second-parent'
+  | 'stale-merge-ref'
+  | 'diff-failed'
+  | 'budget-exceeded'
+  | 'unknown'
+
+class Unavailable extends Error {
+  constructor(readonly reason: Reason, readonly detail: string) {
+    super(`${reason}: ${detail}`)
+  }
 }
 
-// Every git call is confined to a scratch repository. `--depth` and `--filter`
-// rewrite `.git/shallow` and the promisor config of whatever repository they run
-// in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
-// after this action returns, and an empty merge base there silently drops their
-// schema cache.
-async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+interface Difference {
+  count: number
+  sample: string[]
+}
+
+interface ShadowResult {
+  verdict: Verdict
+  reason: Reason | null
+  detail: string | null
+  apiCount: number
+  gitCount: number | null
+  onlyInApi: Difference
+  onlyInGit: Difference
+}
+
+interface GitResult {
+  code: number
+  out: string
+  err: string
+}
+
+// Every git call that reads or writes history names the scratch repository. `--depth`
+// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
+// they run in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
+// this action returns, and an empty merge base there silently drops their schema cache.
+async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<GitResult> {
   return run(['--git-dir', gitDir, ...args], signal)
 }
 
 // The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
 // on the child process, so a fetch the budget gave up on keeps running and holds the
 // action's process open until it finishes, past the budget it was supposed to obey.
-async function run(args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+//
+// stdout is returned raw. A caller that reads a path list must not trim it, because a
+// tracked path can begin with a space, and that path sorts first in the -z output.
+async function run(args: string[], signal: AbortSignal): Promise<GitResult> {
   return new Promise(resolve => {
-    execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout) => {
-      resolve({code: error ? 1 : 0, out: stdout.trim()})
+    execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout, stderr) => {
+      resolve({code: error ? 1 : 0, out: stdout, err: stderr.trim()})
     })
   })
+}
+
+function firstLine(stderr: string): string {
+  return stderr.slice(0, DETAIL_CAP).split('\n')[0] || 'no stderr'
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 async function scratchRepo(signal: AbortSignal): Promise<string> {
   const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
   const init = await run(['init', '--bare', '--quiet', gitDir], signal)
   if (init.code !== 0) {
-    throw new Error('cannot create scratch repository')
+    throw new Unavailable('no-scratch-repo', firstLine(init.err))
   }
   return gitDir
 }
@@ -88,7 +129,7 @@ function originUrl(): string {
   const server = process.env.GITHUB_SERVER_URL
   const repo = process.env.GITHUB_REPOSITORY
   if (!server || !repo) {
-    throw new Error('cannot resolve origin url')
+    throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset')
   }
   return `${server}/${repo}`
 }
@@ -116,15 +157,16 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
     signal
   )
   if (fetched.code !== 0) {
-    throw new Error('no merge ref')
+    throw new Unavailable('no-merge-ref', firstLine(fetched.err))
   }
 
   const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal)
   if (head.code !== 0) {
-    throw new Error('merge ref has no second parent')
+    throw new Unavailable('no-second-parent', firstLine(head.err))
   }
-  if (head.out !== pr.head.sha) {
-    throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`)
+  const headSha = head.out.trim()
+  if (headSha !== pr.head.sha) {
+    throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`)
   }
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
@@ -132,22 +174,40 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
   // path holding a newline or a non-ASCII byte in the default format.
   const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
-    throw new Error('diff failed')
+    throw new Unavailable('diff-failed', firstLine(diff.err))
   }
   return diff.out.split('\0').filter(Boolean)
 }
 
-function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
-  const api = new Set(apiFiles.map(f => f.filename))
-  const local = new Set(gitFiles)
-  const onlyInApi = [...api].filter(f => !local.has(f))
-  const onlyInGit = [...local].filter(f => !api.has(f))
+// A queue branch can differ by thousands of paths, which is neither readable in a log
+// line nor worth carrying as an event property. The count answers how far apart the two
+// answers are, and the sample answers what kind of path is involved.
+function difference(from: Set<string>, against: Set<string>): Difference {
+  const sample: string[] = []
+  let count = 0
+  for (const filename of from) {
+    if (against.has(filename)) {
+      continue
+    }
+    count++
+    if (sample.length < LIST_CAP) {
+      sample.push(filename)
+    }
+  }
+  return {count, sample}
+}
+
+function compare(api: Set<string>, local: Set<string>): ShadowResult {
+  const onlyInApi = difference(api, local)
+  const onlyInGit = difference(local, api)
   return {
-    verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+    verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
+    reason: null,
+    detail: null,
     apiCount: api.size,
     gitCount: local.size,
-    onlyInApi: onlyInApi.slice(0, LIST_CAP),
-    onlyInGit: onlyInGit.slice(0, LIST_CAP)
+    onlyInApi,
+    onlyInGit
   }
 }
 
@@ -157,54 +217,59 @@ async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number
   const expiry = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       controller.abort()
-      reject(new Error(`exceeded ${ms}ms budget`))
+      reject(new Unavailable('budget-exceeded', `${ms}ms`))
     }, ms)
   })
   return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
 export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
+  const api = new Set(apiFiles.map(f => f.filename))
   try {
-    return compare(apiFiles, await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS))
+    const gitFiles = await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS)
+    return compare(api, new Set(gitFiles))
   } catch (error) {
     return {
       verdict: 'unavailable',
-      reason: error instanceof Error ? error.message : String(error),
-      apiCount: apiFiles.length
+      reason: error instanceof Unavailable ? error.reason : 'unknown',
+      detail: error instanceof Unavailable ? error.detail : messageOf(error),
+      apiCount: api.size,
+      gitCount: null,
+      onlyInApi: {count: 0, sample: []},
+      onlyInGit: {count: 0, sample: []}
     }
   }
 }
 
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-// Forks get no secrets, so the token is absent there and the capture is skipped.
-async function capture(result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
-  const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
-  if (!apiKey) {
-    return
-  }
+async function capture(apiKey: string, result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY || null
-  const headRef = pr.head?.ref ?? null
   const properties = {
     repo,
     verdict: result.verdict,
-    reason: result.reason ?? null,
+    reason: result.reason,
+    detail: result.detail,
     api_count: result.apiCount,
-    git_count: result.gitCount ?? null,
-    only_in_api: result.onlyInApi ?? [],
-    only_in_git: result.onlyInGit ?? [],
+    git_count: result.gitCount,
+    only_in_api: result.onlyInApi.sample,
+    only_in_api_count: result.onlyInApi.count,
+    only_in_git: result.onlyInGit.sample,
+    only_in_git_count: result.onlyInGit.count,
     // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-    // API returned, and what the pull request payload says it should have been.
-    api_truncated: result.apiCount >= API_FILE_CAP,
-    pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+    // API returned, and what the pull request payload says it should have been. The
+    // count has to come from the payload, because `api_count` counts a rename twice:
+    // the API path expands each renamed row into an add plus a delete.
+    api_truncated: pr.changed_files >= API_FILE_CAP,
+    pr_changed_files: pr.changed_files,
     pr_number: pr.number,
-    head_sha: pr.head?.sha ?? null,
-    head_ref: headRef,
-    base_ref: pr.base?.ref ?? null,
+    head_sha: pr.head.sha,
+    head_ref: pr.head.ref,
+    base_ref: pr.base.ref,
     // Queue branches carry the cumulative batch diff and page far more than a human
     // pull request, so they are the population worth reading separately.
-    branch_class: headRef?.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
-    is_fork: pr.head?.repo?.full_name !== repo,
+    branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
+    is_fork: pr.head.repo?.full_name !== repo,
     duration_ms: durationMs,
     workflow: process.env.GITHUB_WORKFLOW || null,
     job: process.env.GITHUB_JOB || null,
@@ -220,38 +285,54 @@ async function capture(result: ShadowResult, pr: PullRequest, durationMs: number
       distinct_id: repo || 'paths-filter-shadow',
       properties
     }),
-    signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+    // Whatever the comparison did not spend, so the step's ceiling stays the budget.
+    signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
   })
   if (!res.ok) {
     throw new Error(`capture ${res.status}`)
   }
 }
 
+function summarize(result: ShadowResult): string {
+  if (result.verdict === 'unavailable') {
+    return `unavailable (${result.reason}: ${result.detail})`
+  }
+  if (result.verdict === 'mismatch') {
+    return (
+      `MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+      `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`
+    )
+  }
+  return `match (${result.apiCount} files)`
+}
+
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
+//
+// The token gates the comparison itself, not just the capture. Every workflow that
+// detects changes runs this action, so a comparison whose result cannot be recorded
+// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
+// nobody reads. Fork pull requests get no secrets, so they take this path too.
 export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
+  const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
+  if (!apiKey) {
+    return
+  }
   try {
     core.startGroup('Shadow: merge-commit change detection')
     const startedAt = Date.now()
     const result = await compareWithMergeCommit(apiFiles, pr)
     const durationMs = Date.now() - startedAt
 
-    if (result.verdict === 'mismatch') {
-      core.warning(
-        `shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-          `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
-      )
-    } else if (result.verdict === 'unavailable') {
-      core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`)
-    } else {
-      core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`)
-    }
+    // core.info even for a mismatch: a warning becomes an annotation on the run summary
+    // and the checks page, which reads as a problem with the pull request.
+    core.info(`shadow: ${summarize(result)} in ${durationMs}ms`)
 
-    await capture(result, pr, durationMs).catch(error => {
-      core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`)
+    await capture(apiKey, result, pr, durationMs).catch(error => {
+      core.info(`shadow: capture skipped (${messageOf(error)})`)
     })
   } catch (error) {
-    core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
+    core.info(`shadow: skipped (${messageOf(error)})`)
   } finally {
     core.endGroup()
   }

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -1,0 +1,121 @@
+import * as core from '@actions/core'
+import {getExecOutput} from '@actions/exec'
+import {PullRequest} from '@octokit/webhooks-types'
+
+import {File} from './file'
+
+// Compares the API's changed-file list against the same list derived locally from
+// the pull request's merge commit, and reports disagreement without acting on it.
+// The API result stays authoritative, so a wrong local answer can only produce a
+// log line. Removing the API call later is only safe once this has run quiet
+// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
+// and PRs GitHub has not finished computing a merge ref for.
+//
+// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
+// commit the branch picked up when master was merged into it as the PR's own work.
+// The merge commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+
+const MERGE_REF_FETCH_DEPTH = 2
+
+type Verdict = 'match' | 'mismatch' | 'unavailable'
+
+interface ShadowResult {
+  verdict: Verdict
+  reason?: string
+  apiCount: number
+  gitCount?: number
+  onlyInApi?: string[]
+  onlyInGit?: string[]
+}
+
+async function git(args: string[]): Promise<{code: number; out: string}> {
+  const res = await getExecOutput('git', args, {ignoreReturnCode: true, silent: true})
+  return {code: res.exitCode, out: res.stdout.trim()}
+}
+
+// The merge ref is not guaranteed to be present or current: a shallow checkout has
+// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
+// the second parent to equal the head SHA rejects a stale ref rather than reading
+// it as this PR's changes.
+async function localChangedFiles(pr: PullRequest): Promise<string[]> {
+  const fetched = await git([
+    'fetch',
+    '--no-tags',
+    '--filter=blob:none',
+    `--depth=${MERGE_REF_FETCH_DEPTH}`,
+    'origin',
+    `refs/pull/${pr.number}/merge`
+  ])
+  if (fetched.code !== 0) {
+    throw new Error('no merge ref')
+  }
+
+  const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD'])
+  if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+    throw new Error('merge ref has no second parent')
+  }
+
+  const head = await git(['rev-parse', 'FETCH_HEAD^2'])
+  if (head.code !== 0 || head.out !== pr.head.sha) {
+    throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`)
+  }
+
+  // --no-renames so a rename arrives as a delete plus an add, which is the shape
+  // the API path builds by hand from `previous_filename`.
+  const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD'])
+  if (diff.code !== 0) {
+    throw new Error('diff failed')
+  }
+  return diff.out.split('\n').filter(Boolean)
+}
+
+function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
+  const api = new Set(apiFiles.map(f => f.filename))
+  const local = new Set(gitFiles)
+  const onlyInApi = [...api].filter(f => !local.has(f))
+  const onlyInGit = [...local].filter(f => !api.has(f))
+  return {
+    verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+    apiCount: api.size,
+    gitCount: local.size,
+    onlyInApi: onlyInApi.slice(0, 20),
+    onlyInGit: onlyInGit.slice(0, 20)
+  }
+}
+
+export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
+  try {
+    return compare(apiFiles, await localChangedFiles(pr))
+  } catch (error) {
+    return {
+      verdict: 'unavailable',
+      reason: error instanceof Error ? error.message : String(error),
+      apiCount: apiFiles.length
+    }
+  }
+}
+
+// Never throws: the filter's real answer is already computed by the time this runs,
+// so nothing here is worth failing a CI job over.
+export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
+  try {
+    core.startGroup('Shadow: merge-commit change detection')
+    const result = await compareWithMergeCommit(apiFiles, pr)
+    if (result.verdict === 'match') {
+      core.info(`shadow: match (${result.apiCount} files)`)
+    } else if (result.verdict === 'unavailable') {
+      core.info(`shadow: unavailable (${result.reason})`)
+    } else {
+      core.warning(
+        `shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+          `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
+      )
+    }
+    core.setOutput('shadow_verdict', result.verdict)
+  } catch (error) {
+    core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
+  } finally {
+    core.endGroup()
+  }
+}

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -1,8 +1,8 @@
+import {execFile} from 'child_process'
 import * as os from 'os'
 import * as path from 'path'
 
 import * as core from '@actions/core'
-import {getExecOutput} from '@actions/exec'
 import {PullRequest} from '@octokit/webhooks-types'
 
 import {File} from './file'
@@ -32,6 +32,11 @@ const BUDGET_MS = 20000
 const CAPTURE_TIMEOUT_MS = 5000
 const LIST_CAP = 50
 
+// A queue branch carries the cumulative batch diff, so the path list can be far larger
+// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// which drops the population the comparison most needs to measure.
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024
+
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000
 
@@ -52,21 +57,25 @@ interface ShadowResult {
 // ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
 // after this action returns, and an empty merge base there silently drops their
 // schema cache.
-async function git(gitDir: string, args: string[]): Promise<{code: number; out: string}> {
-  const res = await getExecOutput('git', ['--git-dir', gitDir, ...args], {
-    ignoreReturnCode: true,
-    silent: true
-  })
-  return {code: res.exitCode, out: res.stdout.trim()}
+async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+  return run(['--git-dir', gitDir, ...args], signal)
 }
 
-async function scratchRepo(): Promise<string> {
-  const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
-  const init = await getExecOutput('git', ['init', '--bare', '--quiet', gitDir], {
-    ignoreReturnCode: true,
-    silent: true
+// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
+// on the child process, so a fetch the budget gave up on keeps running and holds the
+// action's process open until it finishes, past the budget it was supposed to obey.
+async function run(args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+  return new Promise(resolve => {
+    execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout) => {
+      resolve({code: error ? 1 : 0, out: stdout.trim()})
+    })
   })
-  if (init.exitCode !== 0) {
+}
+
+async function scratchRepo(signal: AbortSignal): Promise<string> {
+  const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
+  const init = await run(['init', '--bare', '--quiet', gitDir], signal)
+  if (init.code !== 0) {
     throw new Error('cannot create scratch repository')
   }
   return gitDir
@@ -87,26 +96,30 @@ function originUrl(): string {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
-async function localChangedFiles(pr: PullRequest): Promise<string[]> {
-  const gitDir = await scratchRepo()
+async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<string[]> {
+  const gitDir = await scratchRepo(signal)
 
-  const fetched = await git(gitDir, [
-    '-c',
-    'http.lowSpeedLimit=1000',
-    '-c',
-    'http.lowSpeedTime=10',
-    'fetch',
-    '--no-tags',
-    '--filter=blob:none',
-    `--depth=${MERGE_REF_FETCH_DEPTH}`,
-    originUrl(),
-    `refs/pull/${pr.number}/merge`
-  ])
+  const fetched = await git(
+    gitDir,
+    [
+      '-c',
+      'http.lowSpeedLimit=1000',
+      '-c',
+      'http.lowSpeedTime=10',
+      'fetch',
+      '--no-tags',
+      '--filter=blob:none',
+      `--depth=${MERGE_REF_FETCH_DEPTH}`,
+      originUrl(),
+      `refs/pull/${pr.number}/merge`
+    ],
+    signal
+  )
   if (fetched.code !== 0) {
     throw new Error('no merge ref')
   }
 
-  const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'])
+  const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal)
   if (head.code !== 0) {
     throw new Error('merge ref has no second parent')
   }
@@ -117,7 +130,7 @@ async function localChangedFiles(pr: PullRequest): Promise<string[]> {
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
   // the API path builds by hand from `previous_filename`. -z because git quotes a
   // path holding a newline or a non-ASCII byte in the default format.
-  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'])
+  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
     throw new Error('diff failed')
   }
@@ -138,17 +151,21 @@ function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
   }
 }
 
-function budgeted<T>(work: Promise<T>, ms: number): Promise<T> {
+async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number): Promise<T> {
+  const controller = new AbortController()
   let timer: NodeJS.Timeout
   const expiry = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms)
+    timer = setTimeout(() => {
+      controller.abort()
+      reject(new Error(`exceeded ${ms}ms budget`))
+    }, ms)
   })
-  return Promise.race([work, expiry]).finally(() => clearTimeout(timer)) as Promise<T>
+  return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
 export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
   try {
-    return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS))
+    return compare(apiFiles, await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS))
   } catch (error) {
     return {
       verdict: 'unavailable',

--- a/.github/actions/paths-filter/README.md
+++ b/.github/actions/paths-filter/README.md
@@ -65,6 +65,22 @@ changed:
   - added|modified: ['src/**', '!src/vendor/**']
 ```
 
+## Shadow comparison (opt-in)
+
+Set `PATHS_FILTER_SHADOW_POSTHOG_TOKEN` on a step to have that run compare the API's
+changed-file list against the same list derived from the pull request's merge commit,
+and send the verdict to PostHog. The comparison never changes what the filter answers.
+
+```yaml
+- uses: ./.github/actions/paths-filter
+  env:
+    PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+```
+
+Without the variable the action does no extra work. Set it in one workflow that runs on
+every pull request; that keeps the merge-ref fetch off the critical path of the other
+gating jobs. This is temporary, and goes away with the decision it exists to inform.
+
 ## Rebuilding after source changes
 
 The action runs the committed `dist/index.js` bundle. After editing anything under `src/`,

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -3,39 +3,62 @@ import {PullRequest} from '@octokit/webhooks-types'
 import {ChangeStatus} from '../src/file'
 import {compareWithMergeCommit} from '../src/shadow'
 
-const exec = jest.requireMock('@actions/exec') as {getExecOutput: jest.Mock}
+const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
 
-jest.mock('@actions/exec', () => ({getExecOutput: jest.fn()}))
+jest.mock('child_process', () => ({execFile: jest.fn()}))
 jest.mock('@actions/core', () => ({info: jest.fn(), warning: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
 
 const HEAD = 'a'.repeat(40)
 const GIT_DIR = '/tmp/runner/paths-filter-shadow.git'
+const PAST_ANY_BUDGET_MS = 120000
+
+type ExecFileArgs = [string, string[], {signal: AbortSignal}, (error: Error | null, stdout: string) => void]
+
+const pullRequest = {number: 42, head: {sha: HEAD}} as PullRequest
 
 describe('shadow merge-commit comparison', () => {
+  beforeEach(() => {
+    process.env.RUNNER_TEMP = '/tmp/runner'
+    process.env.GITHUB_SERVER_URL = 'https://github.com'
+    process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
+    cp.execFile.mockReset()
+  })
+
   // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
   // whichever repository it runs in. Steps after this action read history from the
   // workspace checkout: ci-dagster and ci-e2e-playwright resolve
   // `git merge-base HEAD^2 origin/<base>` there, and an empty merge base silently
   // drops their schema cache. So every call has to name the scratch git dir.
   test('never runs git against the job workspace', async () => {
-    process.env.RUNNER_TEMP = '/tmp/runner'
-    process.env.GITHUB_SERVER_URL = 'https://github.com'
-    process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
-    exec.getExecOutput.mockReset()
     for (const stdout of ['', '', HEAD, 'a.ts\0']) {
-      exec.getExecOutput.mockResolvedValueOnce({exitCode: 0, stdout, stderr: ''})
+      cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout))
     }
 
-    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], {
-      number: 42,
-      head: {sha: HEAD}
-    } as PullRequest)
+    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
 
     expect(result.verdict).toBe('match')
-    const calls = exec.getExecOutput.mock.calls.map(c => c[1] as string[])
+    const calls = cp.execFile.mock.calls.map(c => c[1] as string[])
     expect(calls[0]).toEqual(['init', '--bare', '--quiet', GIT_DIR])
     for (const argv of calls.slice(1)) {
       expect(argv.slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
     }
+  })
+
+  // The budget only bounds the job if it also stops the git process. An exec that returns
+  // no handle on the child leaves the fetch running, and the action's process stays open
+  // until git exits, which is the wall-clock cost the budget exists to prevent.
+  test('stops git when the budget expires', async () => {
+    cp.execFile.mockImplementation(() => undefined)
+    jest.useFakeTimers()
+
+    const pending = compareWithMergeCommit([], pullRequest)
+    await jest.advanceTimersByTimeAsync(PAST_ANY_BUDGET_MS)
+    const result = await pending
+
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('budget')
+    const [, , options] = cp.execFile.mock.calls[0] as ExecFileArgs
+    expect(options.signal.aborted).toBe(true)
+    jest.useRealTimers()
   })
 })

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,0 +1,78 @@
+import {PullRequest} from '@octokit/webhooks-types'
+
+import {ChangeStatus, File} from '../src/file'
+import {compareWithMergeCommit} from '../src/shadow'
+
+const exec = jest.requireMock('@actions/exec') as {getExecOutput: jest.Mock}
+
+jest.mock('@actions/exec', () => ({getExecOutput: jest.fn()}))
+jest.mock('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  startGroup: jest.fn(),
+  endGroup: jest.fn(),
+  setOutput: jest.fn()
+}))
+
+const HEAD = 'a'.repeat(40)
+const pr = {number: 42, head: {sha: HEAD}} as PullRequest
+
+function apiFiles(...names: string[]): File[] {
+  return names.map(filename => ({filename, status: ChangeStatus.Modified}))
+}
+
+// Each entry answers one `git` call, in the order shadow.ts makes them:
+// fetch, rev-list --parents, rev-parse ^2, diff.
+function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): void {
+  exec.getExecOutput.mockReset()
+  for (const r of responses) {
+    exec.getExecOutput.mockResolvedValueOnce({exitCode: r.exitCode ?? 0, stdout: r.stdout ?? '', stderr: ''})
+  }
+}
+
+describe('shadow merge-commit comparison', () => {
+  it('reports a match when both sides list the same files', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nb.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
+    expect(result.verdict).toBe('match')
+  })
+
+  it('reports a mismatch and names the files each side is missing', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nc.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
+    expect(result.verdict).toBe('mismatch')
+    expect(result.onlyInApi).toEqual(['b.ts'])
+    expect(result.onlyInGit).toEqual(['c.ts'])
+  })
+
+  // A merge ref GitHub has not recomputed since the last push describes an older
+  // head. Reading it would silently attribute the wrong changes to this PR.
+  it('refuses a stale merge ref instead of comparing against it', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${'c'.repeat(40)}`}, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('stale')
+  })
+
+  it('reports unavailable when the checkout has no second parent', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)}`})
+    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('second parent')
+  })
+
+  it('reports unavailable when the merge ref cannot be fetched', async () => {
+    gitResponses({exitCode: 1})
+    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toContain('merge ref')
+  })
+
+  // The API path turns a rename into a delete of the old name plus an add of the
+  // new one, and `git diff --no-renames` emits the same pair.
+  it('matches a rename that the API reported as two entries', async () => {
+    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'new.ts\nold.ts\n'})
+    const result = await compareWithMergeCommit(apiFiles('new.ts', 'old.ts'), pr)
+    expect(result.verdict).toBe('match')
+  })
+})

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -6,15 +6,31 @@ import {compareWithMergeCommit} from '../src/shadow'
 const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
 
 jest.mock('child_process', () => ({execFile: jest.fn()}))
-jest.mock('@actions/core', () => ({info: jest.fn(), warning: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
+jest.mock('@actions/core', () => ({info: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
 
 const HEAD = 'a'.repeat(40)
+const OTHER_SHA = 'b'.repeat(40)
 const GIT_DIR = '/tmp/runner/paths-filter-shadow.git'
 const PAST_ANY_BUDGET_MS = 120000
 
-type ExecFileArgs = [string, string[], {signal: AbortSignal}, (error: Error | null, stdout: string) => void]
+type ExecFileArgs = [
+  string,
+  string[],
+  {signal: AbortSignal},
+  (error: Error | null, stdout: string, stderr: string) => void
+]
 
 const pullRequest = {number: 42, head: {sha: HEAD}} as PullRequest
+
+function stubGit(...stdouts: string[]): void {
+  for (const stdout of stdouts) {
+    cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout, ''))
+  }
+}
+
+function argvOf(call: number): string[] {
+  return cp.execFile.mock.calls[call][1] as string[]
+}
 
 describe('shadow merge-commit comparison', () => {
   beforeEach(() => {
@@ -24,29 +40,50 @@ describe('shadow merge-commit comparison', () => {
     cp.execFile.mockReset()
   })
 
-  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
-  // whichever repository it runs in. Steps after this action read history from the
-  // workspace checkout: ci-dagster and ci-e2e-playwright resolve
-  // `git merge-base HEAD^2 origin/<base>` there, and an empty merge base silently
-  // drops their schema cache. So every call has to name the scratch git dir.
+  // A git call that forgets the scratch dir runs against the job workspace, where a
+  // --depth or --filter fetch drops the schema cache of every later step in the job.
   test('never runs git against the job workspace', async () => {
-    for (const stdout of ['', '', HEAD, 'a.ts\0']) {
-      cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout))
-    }
+    stubGit('', '', HEAD, 'a.ts\0')
 
     const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
 
     expect(result.verdict).toBe('match')
-    const calls = cp.execFile.mock.calls.map(c => c[1] as string[])
-    expect(calls[0]).toEqual(['init', '--bare', '--quiet', GIT_DIR])
-    for (const argv of calls.slice(1)) {
-      expect(argv.slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
+    expect(argvOf(0)).toContain(GIT_DIR)
+    for (let call = 1; call < cp.execFile.mock.calls.length; call++) {
+      expect(argvOf(call).slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
     }
   })
 
-  // The budget only bounds the job if it also stops the git process. An exec that returns
-  // no handle on the child leaves the fetch running, and the action's process stays open
-  // until git exits, which is the wall-clock cost the budget exists to prevent.
+  // Losing this guard scores a merge ref from an earlier push as this pull request's
+  // changes, which fills the measurement with mismatches that mean nothing.
+  test('refuses a stale merge ref instead of comparing against it', async () => {
+    stubGit('', '', OTHER_SHA)
+
+    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
+
+    expect(result.verdict).toBe('unavailable')
+    expect(result.reason).toBe('stale-merge-ref')
+  })
+
+  // Losing --no-renames reports one path where the API path reports two, so every
+  // rename reads as a mismatch.
+  test('matches a rename that the API reported as two entries', async () => {
+    stubGit('', '', HEAD, 'old.ts\0new.ts\0')
+
+    const result = await compareWithMergeCommit(
+      [
+        {filename: 'new.ts', status: ChangeStatus.Added},
+        {filename: 'old.ts', status: ChangeStatus.Deleted}
+      ],
+      pullRequest
+    )
+
+    expect(result.verdict).toBe('match')
+    expect(cp.execFile.mock.calls.map(c => c[1])).toContainEqual(expect.arrayContaining(['--no-renames']))
+  })
+
+  // An exec with no handle on the child leaves the fetch running after the budget gives
+  // up, and the action's process stays open until git exits.
   test('stops git when the budget expires', async () => {
     cp.execFile.mockImplementation(() => undefined)
     jest.useFakeTimers()
@@ -56,7 +93,7 @@ describe('shadow merge-commit comparison', () => {
     const result = await pending
 
     expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('budget')
+    expect(result.reason).toBe('budget-exceeded')
     const [, , options] = cp.execFile.mock.calls[0] as ExecFileArgs
     expect(options.signal.aborted).toBe(true)
     jest.useRealTimers()

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,116 +1,41 @@
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {ChangeStatus, File} from '../src/file'
+import {ChangeStatus} from '../src/file'
 import {compareWithMergeCommit} from '../src/shadow'
 
 const exec = jest.requireMock('@actions/exec') as {getExecOutput: jest.Mock}
 
 jest.mock('@actions/exec', () => ({getExecOutput: jest.fn()}))
-jest.mock('@actions/core', () => ({
-  info: jest.fn(),
-  warning: jest.fn(),
-  startGroup: jest.fn(),
-  endGroup: jest.fn()
-}))
+jest.mock('@actions/core', () => ({info: jest.fn(), warning: jest.fn(), startGroup: jest.fn(), endGroup: jest.fn()}))
 
 const HEAD = 'a'.repeat(40)
-const pr = {number: 42, head: {sha: HEAD}} as PullRequest
-
-function apiFiles(...names: string[]): File[] {
-  return names.map(filename => ({filename, status: ChangeStatus.Modified}))
-}
-
-// Each entry answers one call, in the order shadow.ts makes them:
-// init, fetch, rev-parse ^2, diff.
-function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): void {
-  exec.getExecOutput.mockReset()
-  for (const r of responses) {
-    exec.getExecOutput.mockResolvedValueOnce({exitCode: r.exitCode ?? 0, stdout: r.stdout ?? '', stderr: ''})
-  }
-}
-
-const INIT_OK = {}
-const FETCH_OK = {}
-const HEAD_OK = {stdout: HEAD}
-
-function argvFor(call: number): string[] {
-  return exec.getExecOutput.mock.calls[call][1] as string[]
-}
+const GIT_DIR = '/tmp/runner/paths-filter-shadow.git'
 
 describe('shadow merge-commit comparison', () => {
-  beforeEach(() => {
+  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
+  // whichever repository it runs in. Steps after this action read history from the
+  // workspace checkout: ci-dagster and ci-e2e-playwright resolve
+  // `git merge-base HEAD^2 origin/<base>` there, and an empty merge base silently
+  // drops their schema cache. So every call has to name the scratch git dir.
+  test('never runs git against the job workspace', async () => {
     process.env.RUNNER_TEMP = '/tmp/runner'
     process.env.GITHUB_SERVER_URL = 'https://github.com'
     process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
-  })
-
-  it('reports a match when both sides list the same files', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0b.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
-    expect(result.verdict).toBe('match')
-  })
-
-  it('reports a mismatch and names the files each side is missing', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0c.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
-    expect(result.verdict).toBe('mismatch')
-    expect(result.onlyInApi).toEqual(['b.ts'])
-    expect(result.onlyInGit).toEqual(['c.ts'])
-  })
-
-  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
-  // whichever repository it runs in. Steps after this action read history from the
-  // workspace checkout, so every call has to name the scratch git dir.
-  it('never runs git against the job workspace', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0'})
-    await compareWithMergeCommit(apiFiles('a.ts'), pr)
-
-    expect(argvFor(0)).toEqual(['init', '--bare', '--quiet', '/tmp/runner/paths-filter-shadow.git'])
-    for (let call = 1; call < exec.getExecOutput.mock.calls.length; call++) {
-      expect(argvFor(call).slice(0, 2)).toEqual(['--git-dir', '/tmp/runner/paths-filter-shadow.git'])
+    exec.getExecOutput.mockReset()
+    for (const stdout of ['', '', HEAD, 'a.ts\0']) {
+      exec.getExecOutput.mockResolvedValueOnce({exitCode: 0, stdout, stderr: ''})
     }
-    expect(argvFor(1)).toContain('--depth=2')
-    expect(argvFor(1)).toContain('--filter=blob:none')
-  })
 
-  // git quotes a path containing a newline or a non-ASCII byte unless output is
-  // NUL-delimited, and a quoted path would read as a file neither side has.
-  it('reads NUL-delimited diff output', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0dir/b c.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts', 'dir/b c.ts'), pr)
+    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], {
+      number: 42,
+      head: {sha: HEAD}
+    } as PullRequest)
+
     expect(result.verdict).toBe('match')
-    expect(argvFor(3)).toContain('-z')
-  })
-
-  // A merge ref GitHub has not recomputed since the last push describes an older
-  // head. Reading it would silently attribute the wrong changes to this pull request.
-  it('refuses a stale merge ref instead of comparing against it', async () => {
-    gitResponses(INIT_OK, FETCH_OK, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
-    expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('stale')
-  })
-
-  it('reports unavailable when the merge ref has no second parent', async () => {
-    gitResponses(INIT_OK, FETCH_OK, {exitCode: 128})
-    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
-    expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('second parent')
-  })
-
-  it('reports unavailable when the merge ref cannot be fetched', async () => {
-    gitResponses(INIT_OK, {exitCode: 128})
-    const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
-    expect(result.verdict).toBe('unavailable')
-    expect(result.reason).toContain('merge ref')
-  })
-
-  // The API path turns a rename into a delete of the old name plus an add of the new
-  // one, and `git diff --no-renames` emits the same pair.
-  it('matches a rename that the API reported as two entries', async () => {
-    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'new.ts\0old.ts\0'})
-    const result = await compareWithMergeCommit(apiFiles('new.ts', 'old.ts'), pr)
-    expect(result.verdict).toBe('match')
-    expect(argvFor(3)).toContain('--no-renames')
+    const calls = exec.getExecOutput.mock.calls.map(c => c[1] as string[])
+    expect(calls[0]).toEqual(['init', '--bare', '--quiet', GIT_DIR])
+    for (const argv of calls.slice(1)) {
+      expect(argv.slice(0, 2)).toEqual(['--git-dir', GIT_DIR])
+    }
   })
 })

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -10,8 +10,7 @@ jest.mock('@actions/core', () => ({
   info: jest.fn(),
   warning: jest.fn(),
   startGroup: jest.fn(),
-  endGroup: jest.fn(),
-  setOutput: jest.fn()
+  endGroup: jest.fn()
 }))
 
 const HEAD = 'a'.repeat(40)
@@ -21,8 +20,8 @@ function apiFiles(...names: string[]): File[] {
   return names.map(filename => ({filename, status: ChangeStatus.Modified}))
 }
 
-// Each entry answers one `git` call, in the order shadow.ts makes them:
-// fetch, rev-list --parents, rev-parse ^2, diff.
+// Each entry answers one call, in the order shadow.ts makes them:
+// init, fetch, rev-parse ^2, diff.
 function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): void {
   exec.getExecOutput.mockReset()
   for (const r of responses) {
@@ -30,49 +29,88 @@ function gitResponses(...responses: {exitCode?: number; stdout?: string}[]): voi
   }
 }
 
+const INIT_OK = {}
+const FETCH_OK = {}
+const HEAD_OK = {stdout: HEAD}
+
+function argvFor(call: number): string[] {
+  return exec.getExecOutput.mock.calls[call][1] as string[]
+}
+
 describe('shadow merge-commit comparison', () => {
+  beforeEach(() => {
+    process.env.RUNNER_TEMP = '/tmp/runner'
+    process.env.GITHUB_SERVER_URL = 'https://github.com'
+    process.env.GITHUB_REPOSITORY = 'PostHog/posthog'
+  })
+
   it('reports a match when both sides list the same files', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nb.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0b.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
     expect(result.verdict).toBe('match')
   })
 
   it('reports a mismatch and names the files each side is missing', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'a.ts\nc.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0c.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('a.ts', 'b.ts'), pr)
     expect(result.verdict).toBe('mismatch')
     expect(result.onlyInApi).toEqual(['b.ts'])
     expect(result.onlyInGit).toEqual(['c.ts'])
   })
 
+  // A --depth or --filter fetch rewrites the shallow boundary and promisor config of
+  // whichever repository it runs in. Steps after this action read history from the
+  // workspace checkout, so every call has to name the scratch git dir.
+  it('never runs git against the job workspace', async () => {
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0'})
+    await compareWithMergeCommit(apiFiles('a.ts'), pr)
+
+    expect(argvFor(0)).toEqual(['init', '--bare', '--quiet', '/tmp/runner/paths-filter-shadow.git'])
+    for (let call = 1; call < exec.getExecOutput.mock.calls.length; call++) {
+      expect(argvFor(call).slice(0, 2)).toEqual(['--git-dir', '/tmp/runner/paths-filter-shadow.git'])
+    }
+    expect(argvFor(1)).toContain('--depth=2')
+    expect(argvFor(1)).toContain('--filter=blob:none')
+  })
+
+  // git quotes a path containing a newline or a non-ASCII byte unless output is
+  // NUL-delimited, and a quoted path would read as a file neither side has.
+  it('reads NUL-delimited diff output', async () => {
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'a.ts\0dir/b c.ts\0'})
+    const result = await compareWithMergeCommit(apiFiles('a.ts', 'dir/b c.ts'), pr)
+    expect(result.verdict).toBe('match')
+    expect(argvFor(3)).toContain('-z')
+  })
+
   // A merge ref GitHub has not recomputed since the last push describes an older
-  // head. Reading it would silently attribute the wrong changes to this PR.
+  // head. Reading it would silently attribute the wrong changes to this pull request.
   it('refuses a stale merge ref instead of comparing against it', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${'c'.repeat(40)}`}, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, {stdout: 'c'.repeat(40)}, {stdout: 'a.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toContain('stale')
   })
 
-  it('reports unavailable when the checkout has no second parent', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)}`})
+  it('reports unavailable when the merge ref has no second parent', async () => {
+    gitResponses(INIT_OK, FETCH_OK, {exitCode: 128})
     const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toContain('second parent')
   })
 
   it('reports unavailable when the merge ref cannot be fetched', async () => {
-    gitResponses({exitCode: 1})
+    gitResponses(INIT_OK, {exitCode: 128})
     const result = await compareWithMergeCommit(apiFiles('a.ts'), pr)
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toContain('merge ref')
   })
 
-  // The API path turns a rename into a delete of the old name plus an add of the
-  // new one, and `git diff --no-renames` emits the same pair.
+  // The API path turns a rename into a delete of the old name plus an add of the new
+  // one, and `git diff --no-renames` emits the same pair.
   it('matches a rename that the API reported as two entries', async () => {
-    gitResponses({}, {stdout: `m ${'b'.repeat(40)} ${HEAD}`}, {stdout: HEAD}, {stdout: 'new.ts\nold.ts\n'})
+    gitResponses(INIT_OK, FETCH_OK, HEAD_OK, {stdout: 'new.ts\0old.ts\0'})
     const result = await compareWithMergeCommit(apiFiles('new.ts', 'old.ts'), pr)
     expect(result.verdict).toBe('match')
+    expect(argvFor(3)).toContain('--no-renames')
   })
 })

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42972,10 +42972,10 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.compareWithMergeCommit = compareWithMergeCommit;
 exports.report = report;
+const child_process_1 = __nccwpck_require__(5317);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
-const exec_1 = __nccwpck_require__(5236);
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
@@ -42998,6 +42998,10 @@ const EVENT_NAME = 'paths_filter_shadow_compared';
 const BUDGET_MS = 20000;
 const CAPTURE_TIMEOUT_MS = 5000;
 const LIST_CAP = 50;
+// A queue branch carries the cumulative batch diff, so the path list can be far larger
+// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// which drops the population the comparison most needs to measure.
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000;
 // Every git call is confined to a scratch repository. `--depth` and `--filter`
@@ -43006,20 +43010,23 @@ const API_FILE_CAP = 3000;
 // ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
 // after this action returns, and an empty merge base there silently drops their
 // schema cache.
-async function git(gitDir, args) {
-    const res = await (0, exec_1.getExecOutput)('git', ['--git-dir', gitDir, ...args], {
-        ignoreReturnCode: true,
-        silent: true
-    });
-    return { code: res.exitCode, out: res.stdout.trim() };
+async function git(gitDir, args, signal) {
+    return run(['--git-dir', gitDir, ...args], signal);
 }
-async function scratchRepo() {
-    const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
-    const init = await (0, exec_1.getExecOutput)('git', ['init', '--bare', '--quiet', gitDir], {
-        ignoreReturnCode: true,
-        silent: true
+// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
+// on the child process, so a fetch the budget gave up on keeps running and holds the
+// action's process open until it finishes, past the budget it was supposed to obey.
+async function run(args, signal) {
+    return new Promise(resolve => {
+        (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout) => {
+            resolve({ code: error ? 1 : 0, out: stdout.trim() });
+        });
     });
-    if (init.exitCode !== 0) {
+}
+async function scratchRepo(signal) {
+    const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
+    const init = await run(['init', '--bare', '--quiet', gitDir], signal);
+    if (init.code !== 0) {
         throw new Error('cannot create scratch repository');
     }
     return gitDir;
@@ -43038,8 +43045,8 @@ function originUrl() {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
-async function localChangedFiles(pr) {
-    const gitDir = await scratchRepo();
+async function localChangedFiles(pr, signal) {
+    const gitDir = await scratchRepo(signal);
     const fetched = await git(gitDir, [
         '-c',
         'http.lowSpeedLimit=1000',
@@ -43051,11 +43058,11 @@ async function localChangedFiles(pr) {
         `--depth=${MERGE_REF_FETCH_DEPTH}`,
         originUrl(),
         `refs/pull/${pr.number}/merge`
-    ]);
+    ], signal);
     if (fetched.code !== 0) {
         throw new Error('no merge ref');
     }
-    const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2']);
+    const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal);
     if (head.code !== 0) {
         throw new Error('merge ref has no second parent');
     }
@@ -43065,7 +43072,7 @@ async function localChangedFiles(pr) {
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`. -z because git quotes a
     // path holding a newline or a non-ASCII byte in the default format.
-    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD']);
+    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
         throw new Error('diff failed');
     }
@@ -43084,16 +43091,20 @@ function compare(apiFiles, gitFiles) {
         onlyInGit: onlyInGit.slice(0, LIST_CAP)
     };
 }
-function budgeted(work, ms) {
+async function budgeted(work, ms) {
+    const controller = new AbortController();
     let timer;
     const expiry = new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms);
+        timer = setTimeout(() => {
+            controller.abort();
+            reject(new Error(`exceeded ${ms}ms budget`));
+        }, ms);
     });
-    return Promise.race([work, expiry]).finally(() => clearTimeout(timer));
+    return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
 async function compareWithMergeCommit(apiFiles, pr) {
     try {
-        return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS));
+        return compare(apiFiles, await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS));
     }
     catch (error) {
         return {

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42687,6 +42687,7 @@ const github = __importStar(__nccwpck_require__(3228));
 const filter_1 = __nccwpck_require__(9037);
 const file_1 = __nccwpck_require__(3765);
 const git = __importStar(__nccwpck_require__(1243));
+const shadow = __importStar(__nccwpck_require__(5763));
 const shell_escape_1 = __nccwpck_require__(6880);
 const csv_escape_1 = __nccwpck_require__(6146);
 async function run() {
@@ -42753,7 +42754,9 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
-                return await getChangedFilesFromApi(token, pr);
+                const apiFiles = await getChangedFilesFromApi(token, pr);
+                await shadow.report(apiFiles, pr);
+                return apiFiles;
             }
             if (github.context.eventName === 'pull_request_target') {
                 // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -42924,6 +42927,151 @@ function getErrorMessage(error) {
     return String(error);
 }
 run();
+
+
+/***/ }),
+
+/***/ 5763:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.compareWithMergeCommit = compareWithMergeCommit;
+exports.report = report;
+const core = __importStar(__nccwpck_require__(7484));
+const exec_1 = __nccwpck_require__(5236);
+// Compares the API's changed-file list against the same list derived locally from
+// the pull request's merge commit, and reports disagreement without acting on it.
+// The API result stays authoritative, so a wrong local answer can only produce a
+// log line. Removing the API call later is only safe once this has run quiet
+// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
+// and PRs GitHub has not finished computing a merge ref for.
+//
+// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
+// commit the branch picked up when master was merged into it as the PR's own work.
+// The merge commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+const MERGE_REF_FETCH_DEPTH = 2;
+async function git(args) {
+    const res = await (0, exec_1.getExecOutput)('git', args, { ignoreReturnCode: true, silent: true });
+    return { code: res.exitCode, out: res.stdout.trim() };
+}
+// The merge ref is not guaranteed to be present or current: a shallow checkout has
+// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
+// the second parent to equal the head SHA rejects a stale ref rather than reading
+// it as this PR's changes.
+async function localChangedFiles(pr) {
+    const fetched = await git([
+        'fetch',
+        '--no-tags',
+        '--filter=blob:none',
+        `--depth=${MERGE_REF_FETCH_DEPTH}`,
+        'origin',
+        `refs/pull/${pr.number}/merge`
+    ]);
+    if (fetched.code !== 0) {
+        throw new Error('no merge ref');
+    }
+    const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD']);
+    if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+        throw new Error('merge ref has no second parent');
+    }
+    const head = await git(['rev-parse', 'FETCH_HEAD^2']);
+    if (head.code !== 0 || head.out !== pr.head.sha) {
+        throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
+    }
+    // --no-renames so a rename arrives as a delete plus an add, which is the shape
+    // the API path builds by hand from `previous_filename`.
+    const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD']);
+    if (diff.code !== 0) {
+        throw new Error('diff failed');
+    }
+    return diff.out.split('\n').filter(Boolean);
+}
+function compare(apiFiles, gitFiles) {
+    const api = new Set(apiFiles.map(f => f.filename));
+    const local = new Set(gitFiles);
+    const onlyInApi = [...api].filter(f => !local.has(f));
+    const onlyInGit = [...local].filter(f => !api.has(f));
+    return {
+        verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+        apiCount: api.size,
+        gitCount: local.size,
+        onlyInApi: onlyInApi.slice(0, 20),
+        onlyInGit: onlyInGit.slice(0, 20)
+    };
+}
+async function compareWithMergeCommit(apiFiles, pr) {
+    try {
+        return compare(apiFiles, await localChangedFiles(pr));
+    }
+    catch (error) {
+        return {
+            verdict: 'unavailable',
+            reason: error instanceof Error ? error.message : String(error),
+            apiCount: apiFiles.length
+        };
+    }
+}
+// Never throws: the filter's real answer is already computed by the time this runs,
+// so nothing here is worth failing a CI job over.
+async function report(apiFiles, pr) {
+    try {
+        core.startGroup('Shadow: merge-commit change detection');
+        const result = await compareWithMergeCommit(apiFiles, pr);
+        if (result.verdict === 'match') {
+            core.info(`shadow: match (${result.apiCount} files)`);
+        }
+        else if (result.verdict === 'unavailable') {
+            core.info(`shadow: unavailable (${result.reason})`);
+        }
+        else {
+            core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+                `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
+        }
+        core.setOutput('shadow_verdict', result.verdict);
+    }
+    catch (error) {
+        core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);
+    }
+    finally {
+        core.endGroup();
+    }
+}
 
 
 /***/ }),

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42980,8 +42980,8 @@ const core = __importStar(__nccwpck_require__(7484));
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: merged pull requests, very large
-// diffs, and ones GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: very large diffs, and ones GitHub
+// has not finished computing a merge ref for.
 //
 // Detecting changes from `base.sha..HEAD` instead reports every commit the branch
 // picked up when the base was merged into it as the pull request's own work, which
@@ -42991,43 +42991,59 @@ const core = __importStar(__nccwpck_require__(7484));
 const MERGE_REF_FETCH_DEPTH = 2;
 const POSTHOG_HOST = 'https://us.i.posthog.com';
 const EVENT_NAME = 'paths_filter_shadow_compared';
-// A change-detection job is on the critical path of every workflow, so the whole
-// comparison gets a wall-clock budget and gives up rather than holding the job to
-// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
-// the budget covers everything else.
+// A change-detection job is on the critical path of every workflow, so the comparison
+// and the capture that follows it share one wall-clock budget, and give up rather than
+// holding the job to its timeout-minutes. The git-level low-speed settings cover a
+// stalled transfer; the budget covers everything else.
 const BUDGET_MS = 20000;
-const CAPTURE_TIMEOUT_MS = 5000;
+const CAPTURE_FLOOR_MS = 500;
 const LIST_CAP = 50;
 // A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
 // which drops the population the comparison most needs to measure.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
+const DETAIL_CAP = 200;
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000;
-// Every git call is confined to a scratch repository. `--depth` and `--filter`
-// rewrite `.git/shallow` and the promisor config of whatever repository they run
-// in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
-// after this action returns, and an empty merge base there silently drops their
-// schema cache.
+class Unavailable extends Error {
+    constructor(reason, detail) {
+        super(`${reason}: ${detail}`);
+        this.reason = reason;
+        this.detail = detail;
+    }
+}
+// Every git call that reads or writes history names the scratch repository. `--depth`
+// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
+// they run in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
+// this action returns, and an empty merge base there silently drops their schema cache.
 async function git(gitDir, args, signal) {
     return run(['--git-dir', gitDir, ...args], signal);
 }
 // The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
 // on the child process, so a fetch the budget gave up on keeps running and holds the
 // action's process open until it finishes, past the budget it was supposed to obey.
+//
+// stdout is returned raw. A caller that reads a path list must not trim it, because a
+// tracked path can begin with a space, and that path sorts first in the -z output.
 async function run(args, signal) {
     return new Promise(resolve => {
-        (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout) => {
-            resolve({ code: error ? 1 : 0, out: stdout.trim() });
+        (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout, stderr) => {
+            resolve({ code: error ? 1 : 0, out: stdout, err: stderr.trim() });
         });
     });
+}
+function firstLine(stderr) {
+    return stderr.slice(0, DETAIL_CAP).split('\n')[0] || 'no stderr';
+}
+function messageOf(error) {
+    return error instanceof Error ? error.message : String(error);
 }
 async function scratchRepo(signal) {
     const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
     const init = await run(['init', '--bare', '--quiet', gitDir], signal);
     if (init.code !== 0) {
-        throw new Error('cannot create scratch repository');
+        throw new Unavailable('no-scratch-repo', firstLine(init.err));
     }
     return gitDir;
 }
@@ -43038,7 +43054,7 @@ function originUrl() {
     const server = process.env.GITHUB_SERVER_URL;
     const repo = process.env.GITHUB_REPOSITORY;
     if (!server || !repo) {
-        throw new Error('cannot resolve origin url');
+        throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset');
     }
     return `${server}/${repo}`;
 }
@@ -43060,35 +43076,53 @@ async function localChangedFiles(pr, signal) {
         `refs/pull/${pr.number}/merge`
     ], signal);
     if (fetched.code !== 0) {
-        throw new Error('no merge ref');
+        throw new Unavailable('no-merge-ref', firstLine(fetched.err));
     }
     const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal);
     if (head.code !== 0) {
-        throw new Error('merge ref has no second parent');
+        throw new Unavailable('no-second-parent', firstLine(head.err));
     }
-    if (head.out !== pr.head.sha) {
-        throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
+    const headSha = head.out.trim();
+    if (headSha !== pr.head.sha) {
+        throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`);
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`. -z because git quotes a
     // path holding a newline or a non-ASCII byte in the default format.
     const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
-        throw new Error('diff failed');
+        throw new Unavailable('diff-failed', firstLine(diff.err));
     }
     return diff.out.split('\0').filter(Boolean);
 }
-function compare(apiFiles, gitFiles) {
-    const api = new Set(apiFiles.map(f => f.filename));
-    const local = new Set(gitFiles);
-    const onlyInApi = [...api].filter(f => !local.has(f));
-    const onlyInGit = [...local].filter(f => !api.has(f));
+// A queue branch can differ by thousands of paths, which is neither readable in a log
+// line nor worth carrying as an event property. The count answers how far apart the two
+// answers are, and the sample answers what kind of path is involved.
+function difference(from, against) {
+    const sample = [];
+    let count = 0;
+    for (const filename of from) {
+        if (against.has(filename)) {
+            continue;
+        }
+        count++;
+        if (sample.length < LIST_CAP) {
+            sample.push(filename);
+        }
+    }
+    return { count, sample };
+}
+function compare(api, local) {
+    const onlyInApi = difference(api, local);
+    const onlyInGit = difference(local, api);
     return {
-        verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+        verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
+        reason: null,
+        detail: null,
         apiCount: api.size,
         gitCount: local.size,
-        onlyInApi: onlyInApi.slice(0, LIST_CAP),
-        onlyInGit: onlyInGit.slice(0, LIST_CAP)
+        onlyInApi,
+        onlyInGit
     };
 }
 async function budgeted(work, ms) {
@@ -43097,54 +43131,59 @@ async function budgeted(work, ms) {
     const expiry = new Promise((_, reject) => {
         timer = setTimeout(() => {
             controller.abort();
-            reject(new Error(`exceeded ${ms}ms budget`));
+            reject(new Unavailable('budget-exceeded', `${ms}ms`));
         }, ms);
     });
     return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
 async function compareWithMergeCommit(apiFiles, pr) {
+    const api = new Set(apiFiles.map(f => f.filename));
     try {
-        return compare(apiFiles, await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS));
+        const gitFiles = await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS);
+        return compare(api, new Set(gitFiles));
     }
     catch (error) {
         return {
             verdict: 'unavailable',
-            reason: error instanceof Error ? error.message : String(error),
-            apiCount: apiFiles.length
+            reason: error instanceof Unavailable ? error.reason : 'unknown',
+            detail: error instanceof Unavailable ? error.detail : messageOf(error),
+            apiCount: api.size,
+            gitCount: null,
+            onlyInApi: { count: 0, sample: [] },
+            onlyInGit: { count: 0, sample: [] }
         };
     }
 }
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-// Forks get no secrets, so the token is absent there and the capture is skipped.
-async function capture(result, pr, durationMs) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
-    const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
-    if (!apiKey) {
-        return;
-    }
+async function capture(apiKey, result, pr, durationMs) {
+    var _a;
     const repo = process.env.GITHUB_REPOSITORY || null;
-    const headRef = (_b = (_a = pr.head) === null || _a === void 0 ? void 0 : _a.ref) !== null && _b !== void 0 ? _b : null;
     const properties = {
         repo,
         verdict: result.verdict,
-        reason: (_c = result.reason) !== null && _c !== void 0 ? _c : null,
+        reason: result.reason,
+        detail: result.detail,
         api_count: result.apiCount,
-        git_count: (_d = result.gitCount) !== null && _d !== void 0 ? _d : null,
-        only_in_api: (_e = result.onlyInApi) !== null && _e !== void 0 ? _e : [],
-        only_in_git: (_f = result.onlyInGit) !== null && _f !== void 0 ? _f : [],
+        git_count: result.gitCount,
+        only_in_api: result.onlyInApi.sample,
+        only_in_api_count: result.onlyInApi.count,
+        only_in_git: result.onlyInGit.sample,
+        only_in_git_count: result.onlyInGit.count,
         // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-        // API returned, and what the pull request payload says it should have been.
-        api_truncated: result.apiCount >= API_FILE_CAP,
-        pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+        // API returned, and what the pull request payload says it should have been. The
+        // count has to come from the payload, because `api_count` counts a rename twice:
+        // the API path expands each renamed row into an add plus a delete.
+        api_truncated: pr.changed_files >= API_FILE_CAP,
+        pr_changed_files: pr.changed_files,
         pr_number: pr.number,
-        head_sha: (_h = (_g = pr.head) === null || _g === void 0 ? void 0 : _g.sha) !== null && _h !== void 0 ? _h : null,
-        head_ref: headRef,
-        base_ref: (_k = (_j = pr.base) === null || _j === void 0 ? void 0 : _j.ref) !== null && _k !== void 0 ? _k : null,
+        head_sha: pr.head.sha,
+        head_ref: pr.head.ref,
+        base_ref: pr.base.ref,
         // Queue branches carry the cumulative batch diff and page far more than a human
         // pull request, so they are the population worth reading separately.
-        branch_class: (headRef === null || headRef === void 0 ? void 0 : headRef.startsWith('trunk-merge/')) ? 'trunk-merge' : 'pull-request',
-        is_fork: ((_m = (_l = pr.head) === null || _l === void 0 ? void 0 : _l.repo) === null || _m === void 0 ? void 0 : _m.full_name) !== repo,
+        branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
+        is_fork: ((_a = pr.head.repo) === null || _a === void 0 ? void 0 : _a.full_name) !== repo,
         duration_ms: durationMs,
         workflow: process.env.GITHUB_WORKFLOW || null,
         job: process.env.GITHUB_JOB || null,
@@ -43160,36 +43199,49 @@ async function capture(result, pr, durationMs) {
             distinct_id: repo || 'paths-filter-shadow',
             properties
         }),
-        signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+        // Whatever the comparison did not spend, so the step's ceiling stays the budget.
+        signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
     });
     if (!res.ok) {
         throw new Error(`capture ${res.status}`);
     }
 }
+function summarize(result) {
+    if (result.verdict === 'unavailable') {
+        return `unavailable (${result.reason}: ${result.detail})`;
+    }
+    if (result.verdict === 'mismatch') {
+        return (`MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+            `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`);
+    }
+    return `match (${result.apiCount} files)`;
+}
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
+//
+// The token gates the comparison itself, not just the capture. Every workflow that
+// detects changes runs this action, so a comparison whose result cannot be recorded
+// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
+// nobody reads. Fork pull requests get no secrets, so they take this path too.
 async function report(apiFiles, pr) {
+    const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
+    if (!apiKey) {
+        return;
+    }
     try {
         core.startGroup('Shadow: merge-commit change detection');
         const startedAt = Date.now();
         const result = await compareWithMergeCommit(apiFiles, pr);
         const durationMs = Date.now() - startedAt;
-        if (result.verdict === 'mismatch') {
-            core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-                `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
-        }
-        else if (result.verdict === 'unavailable') {
-            core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`);
-        }
-        else {
-            core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`);
-        }
-        await capture(result, pr, durationMs).catch(error => {
-            core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`);
+        // core.info even for a mismatch: a warning becomes an annotation on the run summary
+        // and the checks page, which reads as a problem with the pull request.
+        core.info(`shadow: ${summarize(result)} in ${durationMs}ms`);
+        await capture(apiKey, result, pr, durationMs).catch(error => {
+            core.info(`shadow: capture skipped (${messageOf(error)})`);
         });
     }
     catch (error) {
-        core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);
+        core.info(`shadow: skipped (${messageOf(error)})`);
     }
     finally {
         core.endGroup();

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42989,6 +42989,17 @@ const exec_1 = __nccwpck_require__(5236);
 // commit's first parent is the base GitHub actually merged against, so
 // `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 const MERGE_REF_FETCH_DEPTH = 2;
+const POSTHOG_HOST = 'https://us.i.posthog.com';
+const EVENT_NAME = 'paths_filter_shadow_compared';
+// A change-detection job is on the critical path of every workflow, so the whole
+// comparison gets a wall-clock budget and gives up rather than holding the job to
+// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
+// the budget covers everything else.
+const BUDGET_MS = 20000;
+const CAPTURE_TIMEOUT_MS = 5000;
+const LIST_CAP = 50;
+// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
+const API_FILE_CAP = 3000;
 // Every git call is confined to a scratch repository. `--depth` and `--filter`
 // rewrite `.git/shallow` and the promisor config of whatever repository they run
 // in, and steps later in the same job read history from the workspace checkout:
@@ -43016,33 +43027,29 @@ async function scratchRepo() {
 // The workspace remote carries no credentials of its own: actions/checkout keeps the
 // token in an http.extraheader the scratch repository does not inherit. A private
 // remote therefore reports unavailable rather than comparing against a partial fetch.
-async function originUrl() {
+function originUrl() {
     const server = process.env.GITHUB_SERVER_URL;
     const repo = process.env.GITHUB_REPOSITORY;
-    if (server && repo) {
-        return `${server}/${repo}`;
-    }
-    const remote = await (0, exec_1.getExecOutput)('git', ['remote', 'get-url', 'origin'], {
-        ignoreReturnCode: true,
-        silent: true
-    });
-    if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+    if (!server || !repo) {
         throw new Error('cannot resolve origin url');
     }
-    return remote.stdout.trim();
+    return `${server}/${repo}`;
 }
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr) {
     const gitDir = await scratchRepo();
-    const url = await originUrl();
     const fetched = await git(gitDir, [
+        '-c',
+        'http.lowSpeedLimit=1000',
+        '-c',
+        'http.lowSpeedTime=10',
         'fetch',
         '--no-tags',
         '--filter=blob:none',
         `--depth=${MERGE_REF_FETCH_DEPTH}`,
-        url,
+        originUrl(),
         `refs/pull/${pr.number}/merge`
     ]);
     if (fetched.code !== 0) {
@@ -43056,7 +43063,8 @@ async function localChangedFiles(pr) {
         throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
-    // the API path builds by hand from `previous_filename`.
+    // the API path builds by hand from `previous_filename`. -z because git quotes a
+    // path holding a newline or a non-ASCII byte in the default format.
     const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD']);
     if (diff.code !== 0) {
         throw new Error('diff failed');
@@ -43072,13 +43080,20 @@ function compare(apiFiles, gitFiles) {
         verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
         apiCount: api.size,
         gitCount: local.size,
-        onlyInApi: onlyInApi.slice(0, 20),
-        onlyInGit: onlyInGit.slice(0, 20)
+        onlyInApi: onlyInApi.slice(0, LIST_CAP),
+        onlyInGit: onlyInGit.slice(0, LIST_CAP)
     };
+}
+function budgeted(work, ms) {
+    let timer;
+    const expiry = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms);
+    });
+    return Promise.race([work, expiry]).finally(() => clearTimeout(timer));
 }
 async function compareWithMergeCommit(apiFiles, pr) {
     try {
-        return compare(apiFiles, await localChangedFiles(pr));
+        return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS));
     }
     catch (error) {
         return {
@@ -43088,22 +43103,79 @@ async function compareWithMergeCommit(apiFiles, pr) {
         };
     }
 }
+// Without this the only record of a divergence is a log line in one job of one run,
+// which is unreadable at the volume that makes the comparison worth running.
+// Forks get no secrets, so the token is absent there and the capture is skipped.
+async function capture(result, pr, durationMs) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
+    const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
+    if (!apiKey) {
+        return;
+    }
+    const repo = process.env.GITHUB_REPOSITORY || null;
+    const headRef = (_b = (_a = pr.head) === null || _a === void 0 ? void 0 : _a.ref) !== null && _b !== void 0 ? _b : null;
+    const properties = {
+        repo,
+        verdict: result.verdict,
+        reason: (_c = result.reason) !== null && _c !== void 0 ? _c : null,
+        api_count: result.apiCount,
+        git_count: (_d = result.gitCount) !== null && _d !== void 0 ? _d : null,
+        only_in_api: (_e = result.onlyInApi) !== null && _e !== void 0 ? _e : [],
+        only_in_git: (_f = result.onlyInGit) !== null && _f !== void 0 ? _f : [],
+        // pulls/{n}/files truncates silently, so record both sides of the tell: what the
+        // API returned, and what the pull request payload says it should have been.
+        api_truncated: result.apiCount >= API_FILE_CAP,
+        pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+        pr_number: pr.number,
+        head_sha: (_h = (_g = pr.head) === null || _g === void 0 ? void 0 : _g.sha) !== null && _h !== void 0 ? _h : null,
+        head_ref: headRef,
+        base_ref: (_k = (_j = pr.base) === null || _j === void 0 ? void 0 : _j.ref) !== null && _k !== void 0 ? _k : null,
+        // Queue branches carry the cumulative batch diff and page far more than a human
+        // pull request, so they are the population worth reading separately.
+        branch_class: (headRef === null || headRef === void 0 ? void 0 : headRef.startsWith('trunk-merge/')) ? 'trunk-merge' : 'pull-request',
+        is_fork: ((_m = (_l = pr.head) === null || _l === void 0 ? void 0 : _l.repo) === null || _m === void 0 ? void 0 : _m.full_name) !== repo,
+        duration_ms: durationMs,
+        workflow: process.env.GITHUB_WORKFLOW || null,
+        job: process.env.GITHUB_JOB || null,
+        run_id: process.env.GITHUB_RUN_ID || null,
+        run_attempt: process.env.GITHUB_RUN_ATTEMPT || null
+    };
+    const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            api_key: apiKey,
+            event: EVENT_NAME,
+            distinct_id: repo || 'paths-filter-shadow',
+            properties
+        }),
+        signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+    });
+    if (!res.ok) {
+        throw new Error(`capture ${res.status}`);
+    }
+}
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
 async function report(apiFiles, pr) {
     try {
         core.startGroup('Shadow: merge-commit change detection');
+        const startedAt = Date.now();
         const result = await compareWithMergeCommit(apiFiles, pr);
-        if (result.verdict === 'match') {
-            core.info(`shadow: match (${result.apiCount} files)`);
-        }
-        else if (result.verdict === 'unavailable') {
-            core.info(`shadow: unavailable (${result.reason})`);
-        }
-        else {
+        const durationMs = Date.now() - startedAt;
+        if (result.verdict === 'mismatch') {
             core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
                 `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
         }
+        else if (result.verdict === 'unavailable') {
+            core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`);
+        }
+        else {
+            core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`);
+        }
+        await capture(result, pr, durationMs).catch(error => {
+            core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`);
+        });
     }
     catch (error) {
         core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42972,55 +42972,96 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.compareWithMergeCommit = compareWithMergeCommit;
 exports.report = report;
+const os = __importStar(__nccwpck_require__(857));
+const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
 const exec_1 = __nccwpck_require__(5236);
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
-// and PRs GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: merged pull requests, very large
+// diffs, and ones GitHub has not finished computing a merge ref for.
 //
-// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
-// commit the branch picked up when master was merged into it as the PR's own work.
-// The merge commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
+// picked up when the base was merged into it as the pull request's own work, which
+// is wrong by thousands of files on a branch that has taken master in. The merge
+// commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 const MERGE_REF_FETCH_DEPTH = 2;
-async function git(args) {
-    const res = await (0, exec_1.getExecOutput)('git', args, { ignoreReturnCode: true, silent: true });
+// Every git call is confined to a scratch repository. `--depth` and `--filter`
+// rewrite `.git/shallow` and the promisor config of whatever repository they run
+// in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
+// after this action returns, and an empty merge base there silently drops their
+// schema cache.
+async function git(gitDir, args) {
+    const res = await (0, exec_1.getExecOutput)('git', ['--git-dir', gitDir, ...args], {
+        ignoreReturnCode: true,
+        silent: true
+    });
     return { code: res.exitCode, out: res.stdout.trim() };
 }
-// The merge ref is not guaranteed to be present or current: a shallow checkout has
-// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
-// the second parent to equal the head SHA rejects a stale ref rather than reading
-// it as this PR's changes.
+async function scratchRepo() {
+    const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
+    const init = await (0, exec_1.getExecOutput)('git', ['init', '--bare', '--quiet', gitDir], {
+        ignoreReturnCode: true,
+        silent: true
+    });
+    if (init.exitCode !== 0) {
+        throw new Error('cannot create scratch repository');
+    }
+    return gitDir;
+}
+// The workspace remote carries no credentials of its own: actions/checkout keeps the
+// token in an http.extraheader the scratch repository does not inherit. A private
+// remote therefore reports unavailable rather than comparing against a partial fetch.
+async function originUrl() {
+    const server = process.env.GITHUB_SERVER_URL;
+    const repo = process.env.GITHUB_REPOSITORY;
+    if (server && repo) {
+        return `${server}/${repo}`;
+    }
+    const remote = await (0, exec_1.getExecOutput)('git', ['remote', 'get-url', 'origin'], {
+        ignoreReturnCode: true,
+        silent: true
+    });
+    if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+        throw new Error('cannot resolve origin url');
+    }
+    return remote.stdout.trim();
+}
+// The merge ref is not guaranteed to be present or current: GitHub recomputes it
+// asynchronously after a push. Requiring the second parent to equal the head SHA
+// rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr) {
-    const fetched = await git([
+    const gitDir = await scratchRepo();
+    const url = await originUrl();
+    const fetched = await git(gitDir, [
         'fetch',
         '--no-tags',
         '--filter=blob:none',
         `--depth=${MERGE_REF_FETCH_DEPTH}`,
-        'origin',
+        url,
         `refs/pull/${pr.number}/merge`
     ]);
     if (fetched.code !== 0) {
         throw new Error('no merge ref');
     }
-    const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD']);
-    if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+    const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2']);
+    if (head.code !== 0) {
         throw new Error('merge ref has no second parent');
     }
-    const head = await git(['rev-parse', 'FETCH_HEAD^2']);
-    if (head.code !== 0 || head.out !== pr.head.sha) {
+    if (head.out !== pr.head.sha) {
         throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`);
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`.
-    const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD']);
+    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD']);
     if (diff.code !== 0) {
         throw new Error('diff failed');
     }
-    return diff.out.split('\n').filter(Boolean);
+    return diff.out.split('\0').filter(Boolean);
 }
 function compare(apiFiles, gitFiles) {
     const api = new Set(apiFiles.map(f => f.filename));
@@ -43063,7 +43104,6 @@ async function report(apiFiles, pr) {
             core.warning(`shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
                 `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`);
         }
-        core.setOutput('shadow_verdict', result.verdict);
     }
     catch (error) {
         core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`);

--- a/.github/actions/paths-filter/src/main.ts
+++ b/.github/actions/paths-filter/src/main.ts
@@ -7,6 +7,7 @@ import {PullRequest, PushEvent} from '@octokit/webhooks-types'
 import {Filter, FilterResults} from './filter'
 import {File, ChangeStatus} from './file'
 import * as git from './git'
+import * as shadow from './shadow'
 import {backslashEscape, shellEscape} from './list-format/shell-escape'
 import {csvEscape} from './list-format/csv-escape'
 
@@ -83,7 +84,9 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
-        return await getChangedFilesFromApi(token, pr)
+        const apiFiles = await getChangedFilesFromApi(token, pr)
+        await shadow.report(apiFiles, pr)
+        return apiFiles
       }
       if (github.context.eventName === 'pull_request_target') {
         // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -21,6 +21,19 @@ import {File} from './file'
 // `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 
 const MERGE_REF_FETCH_DEPTH = 2
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+const EVENT_NAME = 'paths_filter_shadow_compared'
+
+// A change-detection job is on the critical path of every workflow, so the whole
+// comparison gets a wall-clock budget and gives up rather than holding the job to
+// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
+// the budget covers everything else.
+const BUDGET_MS = 20000
+const CAPTURE_TIMEOUT_MS = 5000
+const LIST_CAP = 50
+
+// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
+const API_FILE_CAP = 3000
 
 type Verdict = 'match' | 'mismatch' | 'unavailable'
 
@@ -62,20 +75,13 @@ async function scratchRepo(): Promise<string> {
 // The workspace remote carries no credentials of its own: actions/checkout keeps the
 // token in an http.extraheader the scratch repository does not inherit. A private
 // remote therefore reports unavailable rather than comparing against a partial fetch.
-async function originUrl(): Promise<string> {
+function originUrl(): string {
   const server = process.env.GITHUB_SERVER_URL
   const repo = process.env.GITHUB_REPOSITORY
-  if (server && repo) {
-    return `${server}/${repo}`
-  }
-  const remote = await getExecOutput('git', ['remote', 'get-url', 'origin'], {
-    ignoreReturnCode: true,
-    silent: true
-  })
-  if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+  if (!server || !repo) {
     throw new Error('cannot resolve origin url')
   }
-  return remote.stdout.trim()
+  return `${server}/${repo}`
 }
 
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
@@ -83,14 +89,17 @@ async function originUrl(): Promise<string> {
 // rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr: PullRequest): Promise<string[]> {
   const gitDir = await scratchRepo()
-  const url = await originUrl()
 
   const fetched = await git(gitDir, [
+    '-c',
+    'http.lowSpeedLimit=1000',
+    '-c',
+    'http.lowSpeedTime=10',
     'fetch',
     '--no-tags',
     '--filter=blob:none',
     `--depth=${MERGE_REF_FETCH_DEPTH}`,
-    url,
+    originUrl(),
     `refs/pull/${pr.number}/merge`
   ])
   if (fetched.code !== 0) {
@@ -106,7 +115,8 @@ async function localChangedFiles(pr: PullRequest): Promise<string[]> {
   }
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
-  // the API path builds by hand from `previous_filename`.
+  // the API path builds by hand from `previous_filename`. -z because git quotes a
+  // path holding a newline or a non-ASCII byte in the default format.
   const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'])
   if (diff.code !== 0) {
     throw new Error('diff failed')
@@ -123,14 +133,22 @@ function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
     verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
     apiCount: api.size,
     gitCount: local.size,
-    onlyInApi: onlyInApi.slice(0, 20),
-    onlyInGit: onlyInGit.slice(0, 20)
+    onlyInApi: onlyInApi.slice(0, LIST_CAP),
+    onlyInGit: onlyInGit.slice(0, LIST_CAP)
   }
+}
+
+function budgeted<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms)
+  })
+  return Promise.race([work, expiry]).finally(() => clearTimeout(timer)) as Promise<T>
 }
 
 export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
   try {
-    return compare(apiFiles, await localChangedFiles(pr))
+    return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS))
   } catch (error) {
     return {
       verdict: 'unavailable',
@@ -140,22 +158,81 @@ export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest):
   }
 }
 
+// Without this the only record of a divergence is a log line in one job of one run,
+// which is unreadable at the volume that makes the comparison worth running.
+// Forks get no secrets, so the token is absent there and the capture is skipped.
+async function capture(result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
+  const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
+  if (!apiKey) {
+    return
+  }
+  const repo = process.env.GITHUB_REPOSITORY || null
+  const headRef = pr.head?.ref ?? null
+  const properties = {
+    repo,
+    verdict: result.verdict,
+    reason: result.reason ?? null,
+    api_count: result.apiCount,
+    git_count: result.gitCount ?? null,
+    only_in_api: result.onlyInApi ?? [],
+    only_in_git: result.onlyInGit ?? [],
+    // pulls/{n}/files truncates silently, so record both sides of the tell: what the
+    // API returned, and what the pull request payload says it should have been.
+    api_truncated: result.apiCount >= API_FILE_CAP,
+    pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+    pr_number: pr.number,
+    head_sha: pr.head?.sha ?? null,
+    head_ref: headRef,
+    base_ref: pr.base?.ref ?? null,
+    // Queue branches carry the cumulative batch diff and page far more than a human
+    // pull request, so they are the population worth reading separately.
+    branch_class: headRef?.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
+    is_fork: pr.head?.repo?.full_name !== repo,
+    duration_ms: durationMs,
+    workflow: process.env.GITHUB_WORKFLOW || null,
+    job: process.env.GITHUB_JOB || null,
+    run_id: process.env.GITHUB_RUN_ID || null,
+    run_attempt: process.env.GITHUB_RUN_ATTEMPT || null
+  }
+  const res = await fetch(`${POSTHOG_HOST}/capture/`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      api_key: apiKey,
+      event: EVENT_NAME,
+      distinct_id: repo || 'paths-filter-shadow',
+      properties
+    }),
+    signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+  })
+  if (!res.ok) {
+    throw new Error(`capture ${res.status}`)
+  }
+}
+
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
 export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
   try {
     core.startGroup('Shadow: merge-commit change detection')
+    const startedAt = Date.now()
     const result = await compareWithMergeCommit(apiFiles, pr)
-    if (result.verdict === 'match') {
-      core.info(`shadow: match (${result.apiCount} files)`)
-    } else if (result.verdict === 'unavailable') {
-      core.info(`shadow: unavailable (${result.reason})`)
-    } else {
+    const durationMs = Date.now() - startedAt
+
+    if (result.verdict === 'mismatch') {
       core.warning(
         `shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
           `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
       )
+    } else if (result.verdict === 'unavailable') {
+      core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`)
+    } else {
+      core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`)
     }
+
+    await capture(result, pr, durationMs).catch(error => {
+      core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`)
+    })
   } catch (error) {
     core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
   } finally {

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -1,3 +1,6 @@
+import * as os from 'os'
+import * as path from 'path'
+
 import * as core from '@actions/core'
 import {getExecOutput} from '@actions/exec'
 import {PullRequest} from '@octokit/webhooks-types'
@@ -8,13 +11,14 @@ import {File} from './file'
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
-// and PRs GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: merged pull requests, very large
+// diffs, and ones GitHub has not finished computing a merge ref for.
 //
-// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
-// commit the branch picked up when master was merged into it as the PR's own work.
-// The merge commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
+// picked up when the base was merged into it as the pull request's own work, which
+// is wrong by thousands of files on a branch that has taken master in. The merge
+// commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
 
 const MERGE_REF_FETCH_DEPTH = 2
 
@@ -29,45 +33,85 @@ interface ShadowResult {
   onlyInGit?: string[]
 }
 
-async function git(args: string[]): Promise<{code: number; out: string}> {
-  const res = await getExecOutput('git', args, {ignoreReturnCode: true, silent: true})
+// Every git call is confined to a scratch repository. `--depth` and `--filter`
+// rewrite `.git/shallow` and the promisor config of whatever repository they run
+// in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
+// after this action returns, and an empty merge base there silently drops their
+// schema cache.
+async function git(gitDir: string, args: string[]): Promise<{code: number; out: string}> {
+  const res = await getExecOutput('git', ['--git-dir', gitDir, ...args], {
+    ignoreReturnCode: true,
+    silent: true
+  })
   return {code: res.exitCode, out: res.stdout.trim()}
 }
 
-// The merge ref is not guaranteed to be present or current: a shallow checkout has
-// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
-// the second parent to equal the head SHA rejects a stale ref rather than reading
-// it as this PR's changes.
+async function scratchRepo(): Promise<string> {
+  const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
+  const init = await getExecOutput('git', ['init', '--bare', '--quiet', gitDir], {
+    ignoreReturnCode: true,
+    silent: true
+  })
+  if (init.exitCode !== 0) {
+    throw new Error('cannot create scratch repository')
+  }
+  return gitDir
+}
+
+// The workspace remote carries no credentials of its own: actions/checkout keeps the
+// token in an http.extraheader the scratch repository does not inherit. A private
+// remote therefore reports unavailable rather than comparing against a partial fetch.
+async function originUrl(): Promise<string> {
+  const server = process.env.GITHUB_SERVER_URL
+  const repo = process.env.GITHUB_REPOSITORY
+  if (server && repo) {
+    return `${server}/${repo}`
+  }
+  const remote = await getExecOutput('git', ['remote', 'get-url', 'origin'], {
+    ignoreReturnCode: true,
+    silent: true
+  })
+  if (remote.exitCode !== 0 || !remote.stdout.trim()) {
+    throw new Error('cannot resolve origin url')
+  }
+  return remote.stdout.trim()
+}
+
+// The merge ref is not guaranteed to be present or current: GitHub recomputes it
+// asynchronously after a push. Requiring the second parent to equal the head SHA
+// rejects a stale ref rather than reading it as this pull request's changes.
 async function localChangedFiles(pr: PullRequest): Promise<string[]> {
-  const fetched = await git([
+  const gitDir = await scratchRepo()
+  const url = await originUrl()
+
+  const fetched = await git(gitDir, [
     'fetch',
     '--no-tags',
     '--filter=blob:none',
     `--depth=${MERGE_REF_FETCH_DEPTH}`,
-    'origin',
+    url,
     `refs/pull/${pr.number}/merge`
   ])
   if (fetched.code !== 0) {
     throw new Error('no merge ref')
   }
 
-  const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD'])
-  if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+  const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'])
+  if (head.code !== 0) {
     throw new Error('merge ref has no second parent')
   }
-
-  const head = await git(['rev-parse', 'FETCH_HEAD^2'])
-  if (head.code !== 0 || head.out !== pr.head.sha) {
+  if (head.out !== pr.head.sha) {
     throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`)
   }
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
   // the API path builds by hand from `previous_filename`.
-  const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD'])
+  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'])
   if (diff.code !== 0) {
     throw new Error('diff failed')
   }
-  return diff.out.split('\n').filter(Boolean)
+  return diff.out.split('\0').filter(Boolean)
 }
 
 function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
@@ -112,7 +156,6 @@ export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
           `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
       )
     }
-    core.setOutput('shadow_verdict', result.verdict)
   } catch (error) {
     core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
   } finally {

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -11,8 +11,8 @@ import {File} from './file'
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
 // log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: merged pull requests, very large
-// diffs, and ones GitHub has not finished computing a merge ref for.
+// across the shapes no offline sample can reach: very large diffs, and ones GitHub
+// has not finished computing a merge ref for.
 //
 // Detecting changes from `base.sha..HEAD` instead reports every commit the branch
 // picked up when the base was merged into it as the pull request's own work, which
@@ -24,59 +24,100 @@ const MERGE_REF_FETCH_DEPTH = 2
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 const EVENT_NAME = 'paths_filter_shadow_compared'
 
-// A change-detection job is on the critical path of every workflow, so the whole
-// comparison gets a wall-clock budget and gives up rather than holding the job to
-// its timeout-minutes. The git-level low-speed settings cover a stalled transfer;
-// the budget covers everything else.
+// A change-detection job is on the critical path of every workflow, so the comparison
+// and the capture that follows it share one wall-clock budget, and give up rather than
+// holding the job to its timeout-minutes. The git-level low-speed settings cover a
+// stalled transfer; the budget covers everything else.
 const BUDGET_MS = 20000
-const CAPTURE_TIMEOUT_MS = 5000
+const CAPTURE_FLOOR_MS = 500
 const LIST_CAP = 50
 
 // A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
 // which drops the population the comparison most needs to measure.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024
+const DETAIL_CAP = 200
 
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000
 
 type Verdict = 'match' | 'mismatch' | 'unavailable'
 
-interface ShadowResult {
-  verdict: Verdict
-  reason?: string
-  apiCount: number
-  gitCount?: number
-  onlyInApi?: string[]
-  onlyInGit?: string[]
+// A closed set, because this is the field the comparison is grouped by once the events
+// land. Git's own words go in `detail`, which is free text and unbounded.
+type Reason =
+  | 'no-scratch-repo'
+  | 'no-origin-url'
+  | 'no-merge-ref'
+  | 'no-second-parent'
+  | 'stale-merge-ref'
+  | 'diff-failed'
+  | 'budget-exceeded'
+  | 'unknown'
+
+class Unavailable extends Error {
+  constructor(readonly reason: Reason, readonly detail: string) {
+    super(`${reason}: ${detail}`)
+  }
 }
 
-// Every git call is confined to a scratch repository. `--depth` and `--filter`
-// rewrite `.git/shallow` and the promisor config of whatever repository they run
-// in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
-// after this action returns, and an empty merge base there silently drops their
-// schema cache.
-async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+interface Difference {
+  count: number
+  sample: string[]
+}
+
+interface ShadowResult {
+  verdict: Verdict
+  reason: Reason | null
+  detail: string | null
+  apiCount: number
+  gitCount: number | null
+  onlyInApi: Difference
+  onlyInGit: Difference
+}
+
+interface GitResult {
+  code: number
+  out: string
+  err: string
+}
+
+// Every git call that reads or writes history names the scratch repository. `--depth`
+// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
+// they run in, and steps later in the same job read history from the workspace checkout:
+// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
+// this action returns, and an empty merge base there silently drops their schema cache.
+async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<GitResult> {
   return run(['--git-dir', gitDir, ...args], signal)
 }
 
 // The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
 // on the child process, so a fetch the budget gave up on keeps running and holds the
 // action's process open until it finishes, past the budget it was supposed to obey.
-async function run(args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+//
+// stdout is returned raw. A caller that reads a path list must not trim it, because a
+// tracked path can begin with a space, and that path sorts first in the -z output.
+async function run(args: string[], signal: AbortSignal): Promise<GitResult> {
   return new Promise(resolve => {
-    execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout) => {
-      resolve({code: error ? 1 : 0, out: stdout.trim()})
+    execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout, stderr) => {
+      resolve({code: error ? 1 : 0, out: stdout, err: stderr.trim()})
     })
   })
+}
+
+function firstLine(stderr: string): string {
+  return stderr.slice(0, DETAIL_CAP).split('\n')[0] || 'no stderr'
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 async function scratchRepo(signal: AbortSignal): Promise<string> {
   const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
   const init = await run(['init', '--bare', '--quiet', gitDir], signal)
   if (init.code !== 0) {
-    throw new Error('cannot create scratch repository')
+    throw new Unavailable('no-scratch-repo', firstLine(init.err))
   }
   return gitDir
 }
@@ -88,7 +129,7 @@ function originUrl(): string {
   const server = process.env.GITHUB_SERVER_URL
   const repo = process.env.GITHUB_REPOSITORY
   if (!server || !repo) {
-    throw new Error('cannot resolve origin url')
+    throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset')
   }
   return `${server}/${repo}`
 }
@@ -116,15 +157,16 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
     signal
   )
   if (fetched.code !== 0) {
-    throw new Error('no merge ref')
+    throw new Unavailable('no-merge-ref', firstLine(fetched.err))
   }
 
   const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal)
   if (head.code !== 0) {
-    throw new Error('merge ref has no second parent')
+    throw new Unavailable('no-second-parent', firstLine(head.err))
   }
-  if (head.out !== pr.head.sha) {
-    throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`)
+  const headSha = head.out.trim()
+  if (headSha !== pr.head.sha) {
+    throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`)
   }
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
@@ -132,22 +174,40 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
   // path holding a newline or a non-ASCII byte in the default format.
   const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
-    throw new Error('diff failed')
+    throw new Unavailable('diff-failed', firstLine(diff.err))
   }
   return diff.out.split('\0').filter(Boolean)
 }
 
-function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
-  const api = new Set(apiFiles.map(f => f.filename))
-  const local = new Set(gitFiles)
-  const onlyInApi = [...api].filter(f => !local.has(f))
-  const onlyInGit = [...local].filter(f => !api.has(f))
+// A queue branch can differ by thousands of paths, which is neither readable in a log
+// line nor worth carrying as an event property. The count answers how far apart the two
+// answers are, and the sample answers what kind of path is involved.
+function difference(from: Set<string>, against: Set<string>): Difference {
+  const sample: string[] = []
+  let count = 0
+  for (const filename of from) {
+    if (against.has(filename)) {
+      continue
+    }
+    count++
+    if (sample.length < LIST_CAP) {
+      sample.push(filename)
+    }
+  }
+  return {count, sample}
+}
+
+function compare(api: Set<string>, local: Set<string>): ShadowResult {
+  const onlyInApi = difference(api, local)
+  const onlyInGit = difference(local, api)
   return {
-    verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+    verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
+    reason: null,
+    detail: null,
     apiCount: api.size,
     gitCount: local.size,
-    onlyInApi: onlyInApi.slice(0, LIST_CAP),
-    onlyInGit: onlyInGit.slice(0, LIST_CAP)
+    onlyInApi,
+    onlyInGit
   }
 }
 
@@ -157,54 +217,59 @@ async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number
   const expiry = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       controller.abort()
-      reject(new Error(`exceeded ${ms}ms budget`))
+      reject(new Unavailable('budget-exceeded', `${ms}ms`))
     }, ms)
   })
   return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
 export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
+  const api = new Set(apiFiles.map(f => f.filename))
   try {
-    return compare(apiFiles, await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS))
+    const gitFiles = await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS)
+    return compare(api, new Set(gitFiles))
   } catch (error) {
     return {
       verdict: 'unavailable',
-      reason: error instanceof Error ? error.message : String(error),
-      apiCount: apiFiles.length
+      reason: error instanceof Unavailable ? error.reason : 'unknown',
+      detail: error instanceof Unavailable ? error.detail : messageOf(error),
+      apiCount: api.size,
+      gitCount: null,
+      onlyInApi: {count: 0, sample: []},
+      onlyInGit: {count: 0, sample: []}
     }
   }
 }
 
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-// Forks get no secrets, so the token is absent there and the capture is skipped.
-async function capture(result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
-  const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
-  if (!apiKey) {
-    return
-  }
+async function capture(apiKey: string, result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY || null
-  const headRef = pr.head?.ref ?? null
   const properties = {
     repo,
     verdict: result.verdict,
-    reason: result.reason ?? null,
+    reason: result.reason,
+    detail: result.detail,
     api_count: result.apiCount,
-    git_count: result.gitCount ?? null,
-    only_in_api: result.onlyInApi ?? [],
-    only_in_git: result.onlyInGit ?? [],
+    git_count: result.gitCount,
+    only_in_api: result.onlyInApi.sample,
+    only_in_api_count: result.onlyInApi.count,
+    only_in_git: result.onlyInGit.sample,
+    only_in_git_count: result.onlyInGit.count,
     // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-    // API returned, and what the pull request payload says it should have been.
-    api_truncated: result.apiCount >= API_FILE_CAP,
-    pr_changed_files: typeof pr.changed_files === 'number' ? pr.changed_files : null,
+    // API returned, and what the pull request payload says it should have been. The
+    // count has to come from the payload, because `api_count` counts a rename twice:
+    // the API path expands each renamed row into an add plus a delete.
+    api_truncated: pr.changed_files >= API_FILE_CAP,
+    pr_changed_files: pr.changed_files,
     pr_number: pr.number,
-    head_sha: pr.head?.sha ?? null,
-    head_ref: headRef,
-    base_ref: pr.base?.ref ?? null,
+    head_sha: pr.head.sha,
+    head_ref: pr.head.ref,
+    base_ref: pr.base.ref,
     // Queue branches carry the cumulative batch diff and page far more than a human
     // pull request, so they are the population worth reading separately.
-    branch_class: headRef?.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
-    is_fork: pr.head?.repo?.full_name !== repo,
+    branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
+    is_fork: pr.head.repo?.full_name !== repo,
     duration_ms: durationMs,
     workflow: process.env.GITHUB_WORKFLOW || null,
     job: process.env.GITHUB_JOB || null,
@@ -220,38 +285,54 @@ async function capture(result: ShadowResult, pr: PullRequest, durationMs: number
       distinct_id: repo || 'paths-filter-shadow',
       properties
     }),
-    signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS)
+    // Whatever the comparison did not spend, so the step's ceiling stays the budget.
+    signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
   })
   if (!res.ok) {
     throw new Error(`capture ${res.status}`)
   }
 }
 
+function summarize(result: ShadowResult): string {
+  if (result.verdict === 'unavailable') {
+    return `unavailable (${result.reason}: ${result.detail})`
+  }
+  if (result.verdict === 'mismatch') {
+    return (
+      `MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+      `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`
+    )
+  }
+  return `match (${result.apiCount} files)`
+}
+
 // Never throws: the filter's real answer is already computed by the time this runs,
 // so nothing here is worth failing a CI job over.
+//
+// The token gates the comparison itself, not just the capture. Every workflow that
+// detects changes runs this action, so a comparison whose result cannot be recorded
+// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
+// nobody reads. Fork pull requests get no secrets, so they take this path too.
 export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
+  const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
+  if (!apiKey) {
+    return
+  }
   try {
     core.startGroup('Shadow: merge-commit change detection')
     const startedAt = Date.now()
     const result = await compareWithMergeCommit(apiFiles, pr)
     const durationMs = Date.now() - startedAt
 
-    if (result.verdict === 'mismatch') {
-      core.warning(
-        `shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-          `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
-      )
-    } else if (result.verdict === 'unavailable') {
-      core.info(`shadow: unavailable (${result.reason}) in ${durationMs}ms`)
-    } else {
-      core.info(`shadow: match (${result.apiCount} files) in ${durationMs}ms`)
-    }
+    // core.info even for a mismatch: a warning becomes an annotation on the run summary
+    // and the checks page, which reads as a problem with the pull request.
+    core.info(`shadow: ${summarize(result)} in ${durationMs}ms`)
 
-    await capture(result, pr, durationMs).catch(error => {
-      core.info(`shadow: capture skipped (${error instanceof Error ? error.message : String(error)})`)
+    await capture(apiKey, result, pr, durationMs).catch(error => {
+      core.info(`shadow: capture skipped (${messageOf(error)})`)
     })
   } catch (error) {
-    core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
+    core.info(`shadow: skipped (${messageOf(error)})`)
   } finally {
     core.endGroup()
   }

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -1,0 +1,121 @@
+import * as core from '@actions/core'
+import {getExecOutput} from '@actions/exec'
+import {PullRequest} from '@octokit/webhooks-types'
+
+import {File} from './file'
+
+// Compares the API's changed-file list against the same list derived locally from
+// the pull request's merge commit, and reports disagreement without acting on it.
+// The API result stays authoritative, so a wrong local answer can only produce a
+// log line. Removing the API call later is only safe once this has run quiet
+// across the PR shapes no offline sample can reach: merged PRs, very large diffs,
+// and PRs GitHub has not finished computing a merge ref for.
+//
+// PostHog/posthog#55830 detected changes from `base.sha..HEAD`, which reports every
+// commit the branch picked up when master was merged into it as the PR's own work.
+// The merge commit's first parent is the base GitHub actually merged against, so
+// `HEAD^1..HEAD` is the PR's own changes and matches what the API returns.
+
+const MERGE_REF_FETCH_DEPTH = 2
+
+type Verdict = 'match' | 'mismatch' | 'unavailable'
+
+interface ShadowResult {
+  verdict: Verdict
+  reason?: string
+  apiCount: number
+  gitCount?: number
+  onlyInApi?: string[]
+  onlyInGit?: string[]
+}
+
+async function git(args: string[]): Promise<{code: number; out: string}> {
+  const res = await getExecOutput('git', args, {ignoreReturnCode: true, silent: true})
+  return {code: res.exitCode, out: res.stdout.trim()}
+}
+
+// The merge ref is not guaranteed to be present or current: a shallow checkout has
+// no parents, and GitHub recomputes the ref asynchronously after a push. Requiring
+// the second parent to equal the head SHA rejects a stale ref rather than reading
+// it as this PR's changes.
+async function localChangedFiles(pr: PullRequest): Promise<string[]> {
+  const fetched = await git([
+    'fetch',
+    '--no-tags',
+    '--filter=blob:none',
+    `--depth=${MERGE_REF_FETCH_DEPTH}`,
+    'origin',
+    `refs/pull/${pr.number}/merge`
+  ])
+  if (fetched.code !== 0) {
+    throw new Error('no merge ref')
+  }
+
+  const parents = await git(['rev-list', '--parents', '-n', '1', 'FETCH_HEAD'])
+  if (parents.code !== 0 || parents.out.split(/\s+/).length !== 3) {
+    throw new Error('merge ref has no second parent')
+  }
+
+  const head = await git(['rev-parse', 'FETCH_HEAD^2'])
+  if (head.code !== 0 || head.out !== pr.head.sha) {
+    throw new Error(`merge ref is stale (^2=${head.out.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)})`)
+  }
+
+  // --no-renames so a rename arrives as a delete plus an add, which is the shape
+  // the API path builds by hand from `previous_filename`.
+  const diff = await git(['diff', '--no-renames', '--name-only', 'FETCH_HEAD^1', 'FETCH_HEAD'])
+  if (diff.code !== 0) {
+    throw new Error('diff failed')
+  }
+  return diff.out.split('\n').filter(Boolean)
+}
+
+function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
+  const api = new Set(apiFiles.map(f => f.filename))
+  const local = new Set(gitFiles)
+  const onlyInApi = [...api].filter(f => !local.has(f))
+  const onlyInGit = [...local].filter(f => !api.has(f))
+  return {
+    verdict: onlyInApi.length === 0 && onlyInGit.length === 0 ? 'match' : 'mismatch',
+    apiCount: api.size,
+    gitCount: local.size,
+    onlyInApi: onlyInApi.slice(0, 20),
+    onlyInGit: onlyInGit.slice(0, 20)
+  }
+}
+
+export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
+  try {
+    return compare(apiFiles, await localChangedFiles(pr))
+  } catch (error) {
+    return {
+      verdict: 'unavailable',
+      reason: error instanceof Error ? error.message : String(error),
+      apiCount: apiFiles.length
+    }
+  }
+}
+
+// Never throws: the filter's real answer is already computed by the time this runs,
+// so nothing here is worth failing a CI job over.
+export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
+  try {
+    core.startGroup('Shadow: merge-commit change detection')
+    const result = await compareWithMergeCommit(apiFiles, pr)
+    if (result.verdict === 'match') {
+      core.info(`shadow: match (${result.apiCount} files)`)
+    } else if (result.verdict === 'unavailable') {
+      core.info(`shadow: unavailable (${result.reason})`)
+    } else {
+      core.warning(
+        `shadow: MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
+          `onlyInApi=${JSON.stringify(result.onlyInApi)} onlyInGit=${JSON.stringify(result.onlyInGit)}`
+      )
+    }
+    core.setOutput('shadow_verdict', result.verdict)
+  } catch (error) {
+    core.info(`shadow: skipped (${error instanceof Error ? error.message : String(error)})`)
+  } finally {
+    core.endGroup()
+  }
+}

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -1,8 +1,8 @@
+import {execFile} from 'child_process'
 import * as os from 'os'
 import * as path from 'path'
 
 import * as core from '@actions/core'
-import {getExecOutput} from '@actions/exec'
 import {PullRequest} from '@octokit/webhooks-types'
 
 import {File} from './file'
@@ -32,6 +32,11 @@ const BUDGET_MS = 20000
 const CAPTURE_TIMEOUT_MS = 5000
 const LIST_CAP = 50
 
+// A queue branch carries the cumulative batch diff, so the path list can be far larger
+// than a human pull request's. execFile's 1 MB default would fail those as `diff failed`,
+// which drops the population the comparison most needs to measure.
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024
+
 // The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
 const API_FILE_CAP = 3000
 
@@ -52,21 +57,25 @@ interface ShadowResult {
 // ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>`
 // after this action returns, and an empty merge base there silently drops their
 // schema cache.
-async function git(gitDir: string, args: string[]): Promise<{code: number; out: string}> {
-  const res = await getExecOutput('git', ['--git-dir', gitDir, ...args], {
-    ignoreReturnCode: true,
-    silent: true
-  })
-  return {code: res.exitCode, out: res.stdout.trim()}
+async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+  return run(['--git-dir', gitDir, ...args], signal)
 }
 
-async function scratchRepo(): Promise<string> {
-  const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
-  const init = await getExecOutput('git', ['init', '--bare', '--quiet', gitDir], {
-    ignoreReturnCode: true,
-    silent: true
+// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
+// on the child process, so a fetch the budget gave up on keeps running and holds the
+// action's process open until it finishes, past the budget it was supposed to obey.
+async function run(args: string[], signal: AbortSignal): Promise<{code: number; out: string}> {
+  return new Promise(resolve => {
+    execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout) => {
+      resolve({code: error ? 1 : 0, out: stdout.trim()})
+    })
   })
-  if (init.exitCode !== 0) {
+}
+
+async function scratchRepo(signal: AbortSignal): Promise<string> {
+  const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
+  const init = await run(['init', '--bare', '--quiet', gitDir], signal)
+  if (init.code !== 0) {
     throw new Error('cannot create scratch repository')
   }
   return gitDir
@@ -87,26 +96,30 @@ function originUrl(): string {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
-async function localChangedFiles(pr: PullRequest): Promise<string[]> {
-  const gitDir = await scratchRepo()
+async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<string[]> {
+  const gitDir = await scratchRepo(signal)
 
-  const fetched = await git(gitDir, [
-    '-c',
-    'http.lowSpeedLimit=1000',
-    '-c',
-    'http.lowSpeedTime=10',
-    'fetch',
-    '--no-tags',
-    '--filter=blob:none',
-    `--depth=${MERGE_REF_FETCH_DEPTH}`,
-    originUrl(),
-    `refs/pull/${pr.number}/merge`
-  ])
+  const fetched = await git(
+    gitDir,
+    [
+      '-c',
+      'http.lowSpeedLimit=1000',
+      '-c',
+      'http.lowSpeedTime=10',
+      'fetch',
+      '--no-tags',
+      '--filter=blob:none',
+      `--depth=${MERGE_REF_FETCH_DEPTH}`,
+      originUrl(),
+      `refs/pull/${pr.number}/merge`
+    ],
+    signal
+  )
   if (fetched.code !== 0) {
     throw new Error('no merge ref')
   }
 
-  const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'])
+  const head = await git(gitDir, ['rev-parse', 'FETCH_HEAD^2'], signal)
   if (head.code !== 0) {
     throw new Error('merge ref has no second parent')
   }
@@ -117,7 +130,7 @@ async function localChangedFiles(pr: PullRequest): Promise<string[]> {
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
   // the API path builds by hand from `previous_filename`. -z because git quotes a
   // path holding a newline or a non-ASCII byte in the default format.
-  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'])
+  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
     throw new Error('diff failed')
   }
@@ -138,17 +151,21 @@ function compare(apiFiles: File[], gitFiles: string[]): ShadowResult {
   }
 }
 
-function budgeted<T>(work: Promise<T>, ms: number): Promise<T> {
+async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number): Promise<T> {
+  const controller = new AbortController()
   let timer: NodeJS.Timeout
   const expiry = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`exceeded ${ms}ms budget`)), ms)
+    timer = setTimeout(() => {
+      controller.abort()
+      reject(new Error(`exceeded ${ms}ms budget`))
+    }, ms)
   })
-  return Promise.race([work, expiry]).finally(() => clearTimeout(timer)) as Promise<T>
+  return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
 export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
   try {
-    return compare(apiFiles, await budgeted(localChangedFiles(pr), BUDGET_MS))
+    return compare(apiFiles, await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS))
   } catch (error) {
     return {
       verdict: 'unavailable',

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -40,6 +40,10 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
+              env:
+                  # Only this workflow reports the shadow comparison. It runs on every PR, so
+                  # one wiring covers every shape without spending a secret at 31 sites.
+                  PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
               if: github.event_name != 'push' # Run all tests on master push
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -41,8 +41,8 @@ jobs:
             - uses: ./.github/actions/paths-filter
               id: filter
               env:
-                  # Only this workflow reports the shadow comparison. It runs on every PR, so
-                  # one wiring covers every shape without spending a secret at 31 sites.
+                  # This workflow opts in for the whole repository. It runs on every pull
+                  # request, so one wiring covers every shape the comparison needs to see.
                   PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
               if: github.event_name != 'push' # Run all tests on master push
               with:


### PR DESCRIPTION
## Problem

Dropping the per-pull-request GitHub files API call is blocked: nothing shows that the same file list can be derived from the pull request's merge commit.

Offline sampling cannot reach the states that decide it, such as a merge ref GitHub has not finished computing and the API's silent 3,000-file cap.

### Before

```mermaid
flowchart LR
    PR[Pull request] --> API[GitHub files API] --> Files[Changed-file list] --> Filter[Path filters] --> Jobs[Selected CI jobs]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class API phRed;
    class Filter phBlue;
    class PR,Jobs phYellow;
    class Files phGray;
```

### This PR

```mermaid
flowchart LR
    PR[Pull request] --> API[GitHub files API] --> Files[API file list] --> Filter[Path filters] --> Jobs[Selected CI jobs]
    PR --> MergeRef[GitHub merge ref] --> Scratch[Scratch Git repository] --> Compare[Shadow comparison]
    Files --> Compare --> Event[PostHog event]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Filter,Compare phBlue;
    class API,MergeRef,Event phRed;
    class PR,Jobs phYellow;
    class Files,Scratch phGray;
```

## Changes

- Every pull request records one event comparing the two file lists. Job selection does not change, and the API answer stays authoritative.
- `ci-python` opts in with a capture token. The action does no extra work without it, so the other 26 gating jobs pay nothing.
- The comparison diffs `HEAD^1..HEAD` of the merge ref in a bare repository under `RUNNER_TEMP`.
- A `--depth` fetch in the workspace checkout would drop the schema cache of later steps in the same job.
- One 20-second budget covers the comparison and the capture. On expiry the git process stops, so the step cannot outlive its budget.
- An unavailable run records a fixed reason code and git's own stderr separately, which keeps the grouping field bounded.
- Nothing looks different to a person outside CI logs. Mechanical: the action is mirrored into `.depot` and both bundles are rebuilt.

## How did you test this code?

Four Jest tests, each verified to fail with its guard removed:

- a git call that skips the scratch directory
- a stale merge ref scored as this pull request's changes
- a lost `--no-renames`, which turns every rename into a mismatch
- a budget that gives up without stopping git

The compiled comparison also ran against the live merge refs of 13 open pull requests, and agreed with the API on all 13 once renames were expanded the way the action expands them.

Not checked: fork pull requests, and the path where the capture token is absent.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The action README documents the opt-in variable and says the comparison is temporary.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code implemented the change; skills invoked: `/code-review`, `/simplify`, `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`.
- Review moved the token check ahead of the git work, and made the budget stop the git process. Before that, 27 gating jobs ran a fetch one could record, and an abandoned fetch outlived the budget.
- Nothing here draws on non-public material.
