### PR TITLE
perf(metrics): source metric name picker from metric_series

### DIFF
--- a/products/metrics/backend/metric_names_query_runner.py
+++ b/products/metrics/backend/metric_names_query_runner.py
@@ -1,10 +1,12 @@
 """Distinct metric names for a team's picker UI.
 
-Queries `posthog.metrics` directly rather than `metric_attributes`: `metric_name`
-is a top-level column on the source table with a `set(100)` skip index
-(`idx_metric_name_set`) purpose-built for this lookup. Materialising it into
-the attributes table would require a new MV with negligible upside given the
-cardinality (10s — low 100s of distinct names per team).
+Queries `posthog.metric_series` (one row per unique metric + label-set) rather
+than the raw `posthog.metrics` datapoint table. The picker only needs the set
+of names, and `metric_series` holds one row per series instead of one per data
+point, so the scan is proportional to series count rather than emission volume.
+`metric_name` is the second column of the series table's ORDER BY and
+`last_seen` records recency directly, so both the grouping and the ordering
+follow the table's own layout.
 
 Surfaces `metric_type` alongside the name so the viewer can hint at the
 type-appropriate default aggregation (gauge -> avg, counter/sum -> sum, etc.)
@@ -42,23 +44,21 @@ class MetricNamesQueryRunner:
         self.lookback = lookback
 
     def run(self) -> list[dict[str, Any]]:
-        # ILIKE on metric_name uses the bloom filter side of the skip index;
-        # any() on metric_type collapses to the single canonical type per
-        # name (a metric name shouldn't change type — if it does, we get the
-        # most-recent answer ClickHouse picks, which is fine for a picker).
+        # any() on metric_type collapses to the single canonical type per name
+        # (a metric name shouldn't change type — if it does, we get whichever
+        # answer ClickHouse picks, which is fine for a picker).
         query = parse_select(
             """
                 SELECT
                     metric_name AS name,
-                    any(metric_type) AS metric_type,
-                    max(timestamp) AS last_seen
-                FROM posthog.metrics
-                WHERE timestamp > now() - {lookback}
+                    any(metric_type) AS metric_type
+                FROM posthog.metric_series
+                WHERE last_seen > now() - {lookback}
                   AND metric_name ILIKE {search_pattern}
                 GROUP BY metric_name
                 ORDER BY
                     lower(metric_name) = lower({exact}) DESC,
-                    last_seen DESC
+                    max(last_seen) DESC
                 LIMIT {limit}
             """,
             placeholders={

--- a/products/metrics/backend/tests/test_anomaly.py
+++ b/products/metrics/backend/tests/test_anomaly.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from posthog.clickhouse.client import sync_execute
 
 from products.metrics.backend.facade.api import characterize_metric_anomaly
-from products.metrics.backend.tests._seeder import seed_metric
+from products.metrics.backend.tests._seeder import seed_metric, seed_metric_event
 
 
 class TestCharacterizeAnomaly(ClickhouseTestMixin, APIBaseTest):
@@ -19,6 +19,8 @@ class TestCharacterizeAnomaly(ClickhouseTestMixin, APIBaseTest):
     def setUp(self):
         super().setUp()
         sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+        sync_execute("TRUNCATE TABLE IF EXISTS metric_series1")
+        sync_execute("TRUNCATE TABLE IF EXISTS metric_samples1")
         # 20-minute window: minutes 0-9 baseline (steady ~10), minutes 10-19
         # anomaly (jumps to ~100 from minute 12).
         self.start = (timezone.now() - dt.timedelta(hours=1)).replace(second=0, microsecond=0)
@@ -41,6 +43,12 @@ class TestCharacterizeAnomaly(ClickhouseTestMixin, APIBaseTest):
             metric_type="gauge",
             points=[(self.start + dt.timedelta(minutes=m), 5.0) for m in range(20)],
             labels={"shard": "b"},
+        )
+        seed_metric_event(
+            team_id=self.team.id,
+            metric_name="queue_depth",
+            metric_type="gauge",
+            points=[(self.start, 10.0)],
         )
 
     def _characterize(self, **overrides):
@@ -155,6 +163,12 @@ class TestCharacterizeAnomaly(ClickhouseTestMixin, APIBaseTest):
             metric_type="sum",
             is_monotonic=True,
             points=[(self.start + dt.timedelta(minutes=m), float(m * 60)) for m in range(20)],
+        )
+        seed_metric_event(
+            team_id=self.team.id,
+            metric_name="reqs_total",
+            metric_type="sum",
+            points=[(self.start, 0.0)],
         )
         report = self._characterize(metric_name="reqs_total")
         self.assertEqual(report.aggregation, "rate")

--- a/products/metrics/backend/tests/test_metric_names_query_runner.py
+++ b/products/metrics/backend/tests/test_metric_names_query_runner.py
@@ -9,7 +9,7 @@ from rest_framework import status
 from posthog.clickhouse.client import sync_execute
 
 from products.metrics.backend.metric_names_query_runner import MetricNamesQueryRunner
-from products.metrics.backend.tests._seeder import seed_metric
+from products.metrics.backend.tests._seeder import seed_metric_event
 
 
 def _seed_point(
@@ -20,7 +20,7 @@ def _seed_point(
     timestamp: dt.datetime,
     metric_type: str = "gauge",
 ) -> None:
-    seed_metric(team_id=team_id, metric_name=metric_name, points=[(timestamp, value)], metric_type=metric_type)
+    seed_metric_event(team_id=team_id, metric_name=metric_name, points=[(timestamp, value)], metric_type=metric_type)
 
 
 class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
@@ -28,7 +28,8 @@ class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def setUp(self):
         super().setUp()
-        sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+        sync_execute("TRUNCATE TABLE IF EXISTS metric_series1")
+        sync_execute("TRUNCATE TABLE IF EXISTS metric_samples1")
 
     def test_rejects_out_of_range_limit(self):
         with self.assertRaises(ValueError):
@@ -130,7 +131,8 @@ class TestMetricsValuesAPI(ClickhouseTestMixin, APIBaseTest):
 
     def setUp(self):
         super().setUp()
-        sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+        sync_execute("TRUNCATE TABLE IF EXISTS metric_series1")
+        sync_execute("TRUNCATE TABLE IF EXISTS metric_samples1")
 
     def test_values_requires_authentication(self):
         self.client.logout()


### PR DESCRIPTION
## Problem

Opening the metric picker in the metrics product is slow on high-traffic teams: it scanned the raw `metrics` datapoint table.

- The picker read one row per emission over the lookback window and computed `max(timestamp)` per name, so its cost grew with ingested volume rather than with the number of metrics.
- `metric_series` already holds one row per unique metric series, with `metric_name` as the second `ORDER BY` column and a `last_seen` column for recency.

## Changes

- The metric picker now returns the same names, ordered the same way, but reads `posthog.metric_series` instead of `posthog.metrics`. Its scan is proportional to series count, not emission volume.
- Ordering uses `max(last_seen)` directly instead of `max(timestamp)`; `last_seen` is not returned, only used to sort.
- `_default_aggregation` (anomaly type auto-pick) reuses this runner, so it now reads the metric's type from `metric_series` too. Behavior is unchanged where both tables are populated.
- Mechanical: test fixtures for the picker and anomaly type auto-pick now seed `metric_series` (via `seed_metric_event`) instead of `metrics1`, matching the table the code reads.

> [!NOTE]
> This assumes `metric_series` is populated wherever `metrics` is. Both are fed from the same ingest pipeline, but if a team has `metrics` rows without `metric_series` rows, its picker would return fewer names until the series table catches up.

## How did you test this code?

- `hogli test products/metrics/backend/tests/test_metric_names_query_runner.py` — 13 pass.
- `hogli test products/metrics/backend/tests/test_anomaly.py products/metrics/backend/tests/test_investigation.py` — 19 pass.
- Full `products/metrics/backend/tests/` run: only two failures, both pre-existing on master (a local `TeamCustomerAnalyticsConfig` fixture issue in the generic query endpoint, unrelated to this change).
- New test coverage: `test_counter_auto_picks_rate` now seeds the series row it needs, so it genuinely exercises the type lookup again instead of passing on the `avg` fallback.
- Not verified: production behavior; no prod query was run to confirm `metric_series` parity with `metrics` per team.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). The work started from an investigation into slow metrics attribute queries, which found the picker path scanning the raw datapoint table. Skills invoked: `/writing-pr-descriptions`. `/writing-tests` was considered; the test edits are a fixture-source swap to match the new data source, keeping every assertion, so no new coverage was designed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
