### PR TITLE
fix(visual-review): stop a story deletion failing every batched PR

### DIFF
--- a/products/visual_review/backend/logic/baselines.py
+++ b/products/visual_review/backend/logic/baselines.py
@@ -122,7 +122,12 @@ def _resolve_baselines(repo, run_type: str, branch: str) -> dict[str, str]:
 
 
 def _resolve_baselines_with_merge_base(
-    repo: Repo, run_type: str, branch: str, commit_sha: str | None = None
+    repo: Repo,
+    run_type: str,
+    branch: str,
+    *,
+    rendered_identifiers: set[str],
+    commit_sha: str | None = None,
 ) -> tuple[dict[str, str], int]:
     """Fetch branch baseline merged with merge-base baseline.
 
@@ -131,6 +136,13 @@ def _resolve_baselines_with_merge_base(
     rewrites the full file, and git rebase replays it destructively).
 
     Branch entries win on conflict so approvals are preserved.
+    Healing is limited to identifiers this run rendered. An entry missing
+    from the branch baseline whose story still renders is the rebase loss
+    above. An entry missing from both is one the branch deleted on purpose,
+    and restoring it only manufactures a REMOVED — on a merge-queue branch
+    nobody can approve that away, so it reds the batch until the deleting
+    PR lands.
+
     Identifiers previously approved as REMOVED on this branch are
     tombstoned — healing would otherwise resurrect them from master
     and re-flag them as removed on every subsequent run.
@@ -177,7 +189,11 @@ def _resolve_baselines_with_merge_base(
 
     source_pr_number = github_api._verified_merge_queue_source_pr(github, repo.repo_full_name, branch)
     tombstoned = _tombstoned_identifiers(repo, run_type, branch, source_pr_number=source_pr_number)
-    healable_merge_base = {k: v for k, v in merge_base_baseline.items() if k not in tombstoned}
+    healable_merge_base = {
+        identifier: baseline_hash
+        for identifier, baseline_hash in merge_base_baseline.items()
+        if identifier not in tombstoned and identifier in rendered_identifiers
+    }
 
     healed = set(healable_merge_base) - set(branch_baseline)
     merged = {**healable_merge_base, **branch_baseline}

--- a/products/visual_review/backend/logic/baselines.py
+++ b/products/visual_review/backend/logic/baselines.py
@@ -147,10 +147,11 @@ def _resolve_baselines_with_merge_base(
     tombstoned — healing would otherwise resurrect them from master
     and re-flag them as removed on every subsequent run.
 
-    When *commit_sha* is provided and the run is on the default branch,
-    the baseline is fetched at that exact commit instead of the branch
-    tip.  This prevents a race where a newer commit updates the
-    baseline file before an older commit's VR run completes.
+    When *commit_sha* is provided the baseline is fetched at that exact
+    commit rather than the branch tip. The tip moves under a concurrent
+    push, and an ephemeral merge-queue branch is deleted once its batch
+    resolves — a fetch by branch name then 404s, which is indistinguishable
+    from "no baseline file" and reports the whole suite as new.
 
     Returns (merged_baseline, healed_count).
     """
@@ -162,9 +163,9 @@ def _resolve_baselines_with_merge_base(
 
     default_branch = github_api._get_default_branch(github, repo.repo_full_name)
 
-    # On the default branch, pin the baseline to the exact commit so
-    # that back-to-back pushes don't race against each other.
-    baseline_ref = commit_sha if (commit_sha and branch == default_branch) else branch
+    # Pin the baseline to the exact commit under test so back-to-back pushes
+    # don't race, and so a branch deleted mid-run still resolves.
+    baseline_ref = commit_sha or branch
     branch_baseline = _resolve_baselines_at_ref(repo, github, run_type, baseline_ref)
 
     if branch == default_branch:

--- a/products/visual_review/backend/logic/baselines.py
+++ b/products/visual_review/backend/logic/baselines.py
@@ -171,7 +171,9 @@ def _resolve_baselines_with_merge_base(
     if branch == default_branch:
         return branch_baseline, 0
 
-    merge_base_sha = github_api._get_merge_base_sha(github, repo.repo_full_name, default_branch, branch)
+    # Compare from the same ref the baseline was read at. A deleted branch 404s
+    # here, and healing would then switch off exactly when it is needed.
+    merge_base_sha = github_api._get_merge_base_sha(github, repo.repo_full_name, default_branch, baseline_ref)
     if not merge_base_sha:
         return branch_baseline, 0
 
@@ -188,7 +190,9 @@ def _resolve_baselines_with_merge_base(
     if not merge_base_baseline:
         return branch_baseline, 0
 
-    source_pr_number = github_api._verified_merge_queue_source_pr(github, repo.repo_full_name, branch)
+    source_pr_number = github_api._verified_merge_queue_source_pr(
+        github, repo.repo_full_name, branch, head_ref=baseline_ref
+    )
     tombstoned = _tombstoned_identifiers(repo, run_type, branch, source_pr_number=source_pr_number)
     healable_merge_base = {
         identifier: baseline_hash

--- a/products/visual_review/backend/logic/baselines.py
+++ b/products/visual_review/backend/logic/baselines.py
@@ -136,12 +136,19 @@ def _resolve_baselines_with_merge_base(
     rewrites the full file, and git rebase replays it destructively).
 
     Branch entries win on conflict so approvals are preserved.
-    Healing is limited to identifiers this run rendered. An entry missing
-    from the branch baseline whose story still renders is the rebase loss
-    above. An entry missing from both is one the branch deleted on purpose,
-    and restoring it only manufactures a REMOVED — on a merge-queue branch
-    nobody can approve that away, so it reds the batch until the deleting
-    PR lands.
+    On a merge-queue branch, healing is limited to identifiers this run
+    rendered. An entry missing from the branch baseline whose story still
+    renders is the rebase loss above. An entry missing from both is one the
+    branch deleted on purpose, and restoring it only manufactures a REMOVED
+    that no one on a queue branch can approve, so it reds the batch and every
+    pull request sharing it until the deleting one lands.
+
+    Ordinary branches keep healing everything, because there the REMOVED is
+    the review gate: it is how a reviewer is asked to confirm that a story
+    should go. The queue signal is the server-verified source PR rather than
+    the branch name, which is client-supplied — matching the name alone would
+    let any caller skip that gate. When verification fails the filter stays
+    off, so a GitHub blip costs a red batch rather than a silent removal.
 
     Identifiers previously approved as REMOVED on this branch are
     tombstoned — healing would otherwise resurrect them from master
@@ -194,10 +201,11 @@ def _resolve_baselines_with_merge_base(
         github, repo.repo_full_name, branch, head_ref=baseline_ref
     )
     tombstoned = _tombstoned_identifiers(repo, run_type, branch, source_pr_number=source_pr_number)
+    on_merge_queue_branch = source_pr_number is not None
     healable_merge_base = {
         identifier: baseline_hash
         for identifier, baseline_hash in merge_base_baseline.items()
-        if identifier not in tombstoned and identifier in rendered_identifiers
+        if identifier not in tombstoned and (not on_merge_queue_branch or identifier in rendered_identifiers)
     }
 
     healed = set(healable_merge_base) - set(branch_baseline)

--- a/products/visual_review/backend/logic/github_api.py
+++ b/products/visual_review/backend/logic/github_api.py
@@ -69,7 +69,9 @@ def _get_default_branch(github: GitHubIntegration, repo_full_name: str) -> str:
 _MERGE_QUEUE_BRANCH_RE = re.compile(r"^trunk-merge/pr-(?P<pr_number>\d+)/")
 
 
-def _verified_merge_queue_source_pr(github: GitHubIntegration, repo_full_name: str, branch: str) -> int | None:
+def _verified_merge_queue_source_pr(
+    github: GitHubIntegration, repo_full_name: str, branch: str, head_ref: str | None = None
+) -> int | None:
     """Source PR number for a merge-queue branch, verified against GitHub.
 
     Merge-queue branches (``trunk-merge/pr-<n>/<uuid>``) are freshly
@@ -110,7 +112,10 @@ def _verified_merge_queue_source_pr(github: GitHubIntegration, repo_full_name: s
     if not pr_head_sha:
         return None
 
-    if _get_merge_base_sha(github, repo_full_name, pr_head_sha, branch) != pr_head_sha:
+    # Compare against *head_ref* when the caller has the commit: the branch is
+    # deleted as soon as its batch resolves, and a 404 here reads as "unverified"
+    # and silently drops the inheritance this function exists to grant.
+    if _get_merge_base_sha(github, repo_full_name, pr_head_sha, head_ref or branch) != pr_head_sha:
         logger.warning(
             "visual_review.merge_queue_source_pr_unverified",
             repo=repo_full_name,

--- a/products/visual_review/backend/logic/runs.py
+++ b/products/visual_review/backend/logic/runs.py
@@ -235,14 +235,23 @@ def complete_run(run_id: UUID) -> Run:
 
     repo = run.repo
 
+    # What this run rendered. Read before the baseline so healing can be limited
+    # to it — an entry missing from both the branch baseline and the build is a
+    # deliberate deletion, and healing it back only manufactures a REMOVED.
+    run_identifiers = set(run.snapshots.using(WRITER_DB).values_list("identifier", flat=True))
+
     # Fetch baseline merged with merge-base to heal rebase-induced drift.
     # Branch baseline tracks approvals; merge-base fills entries lost when
     # git rebase replays a full-file bot commit destructively.
-    # Pass commit_sha so default-branch runs fetch the baseline at the
-    # exact commit being tested, avoiding races with concurrent pushes.
+    # Pass commit_sha so the baseline is read at the exact commit being tested,
+    # not at a branch tip that may have moved or been deleted.
     try:
         baseline, healed_count = baselines._resolve_baselines_with_merge_base(
-            repo, run.run_type, run.branch, commit_sha=run.commit_sha
+            repo,
+            run.run_type,
+            run.branch,
+            rendered_identifiers=run_identifiers,
+            commit_sha=run.commit_sha,
         )
     except GitHubRateLimitError:
         # Roll back to PENDING so the caller can retry after the limit resets
@@ -253,7 +262,6 @@ def complete_run(run_id: UUID) -> Run:
         run.save(using=WRITER_DB, update_fields=["metadata"])
 
     # Pre-load tolerated hashes scoped to this run's identifiers and baseline hashes
-    run_identifiers = set(run.snapshots.using(WRITER_DB).values_list("identifier", flat=True))
     baseline_hashes_in_use = set(baseline.values())
     tolerated_lookup: dict[tuple[str, str, str], ToleratedHash] = {}
     if run_identifiers and baseline_hashes_in_use:

--- a/products/visual_review/backend/tests/logic/test_baselines.py
+++ b/products/visual_review/backend/tests/logic/test_baselines.py
@@ -213,18 +213,66 @@ class TestMergeBaseBaselineHealing:
         assert merged == {"A": "h1", "C": "h3"}
         assert healed == 1
 
-    def test_does_not_heal_what_the_run_did_not_render(self, repo, mocker):
-        # A story the branch deleted stays deleted. Healing it back invents a removal.
-        branch_baseline = {"kept": "h1"}
-        merge_base_baseline = {"kept": "h1", "deleted-story": "h2"}
-        self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
+    def test_queue_branch_does_not_heal_what_the_run_did_not_render(self, repo, mocker):
+        # A story the batch deleted stays deleted. Healing it back invents a removal
+        # that nobody on a queue branch can approve away.
+        self._mock_github(
+            mocker,
+            branch_baseline={"kept": "h1"},
+            merge_base_baseline={"kept": "h1", "deleted-story": "h2"},
+            pr_head_sha="source-pr-head",
+            commit_sha_baselines={"batch-sha": {"kept": "h1"}},
+        )
+
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo,
+            "storybook",
+            "trunk-merge/pr-4242/0c2f75d8",
+            rendered_identifiers={"kept"},
+            commit_sha="batch-sha",
+        )
+
+        assert merged == {"kept": "h1"}
+        assert healed == 0
+
+    def test_ordinary_branch_still_heals_a_deleted_story(self, repo, mocker):
+        # Outside the queue the REMOVED is the review gate: it is how a reviewer is
+        # asked to confirm the story should go. Healing has to keep raising it.
+        self._mock_github(
+            mocker,
+            branch_baseline={"kept": "h1"},
+            merge_base_baseline={"kept": "h1", "deleted-story": "h2"},
+        )
 
         merged, healed = baselines._resolve_baselines_with_merge_base(
             repo, "storybook", "my-branch", rendered_identifiers={"kept"}
         )
 
-        assert merged == {"kept": "h1"}
-        assert healed == 0
+        assert merged == {"kept": "h1", "deleted-story": "h2"}
+        assert healed == 1
+
+    def test_unverified_queue_branch_keeps_the_removal_gate(self, repo, mocker):
+        # The branch name is client-supplied. Without GitHub confirming the source
+        # PR is an ancestor, the filter stays off rather than granting a bypass.
+        self._mock_github(
+            mocker,
+            branch_baseline={"kept": "h1"},
+            merge_base_baseline={"kept": "h1", "deleted-story": "h2"},
+            pr_head_sha="source-pr-head",
+            pr_head_is_ancestor=False,
+            commit_sha_baselines={"batch-sha": {"kept": "h1"}},
+        )
+
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo,
+            "storybook",
+            "trunk-merge/pr-4242/0c2f75d8",
+            rendered_identifiers={"kept"},
+            commit_sha="batch-sha",
+        )
+
+        assert merged == {"kept": "h1", "deleted-story": "h2"}
+        assert healed == 1
 
     def test_heals_what_the_run_still_renders(self, repo, mocker):
         # Same missing entry, but the story renders: the rebase loss healing exists for.
@@ -451,6 +499,7 @@ class TestMergeBaseBaselineHealing:
             branch_baseline=batch_baseline,
             merge_base_baseline=master_baseline,
             commit_sha_baselines={"batch-sha": batch_baseline},
+            pr_head_sha="source-pr-head",
         )
 
         artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="h1", storage_path="p/h1")

--- a/products/visual_review/backend/tests/logic/test_baselines.py
+++ b/products/visual_review/backend/tests/logic/test_baselines.py
@@ -108,7 +108,9 @@ class TestMergeBaseBaselineHealing:
         baseline = {"A": "h1", "B": "h2"}
         self._mock_github(mocker, branch_baseline=baseline, merge_base_baseline=baseline)
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"A", "B"}
+        )
 
         assert merged == baseline
         assert healed == 0
@@ -118,7 +120,9 @@ class TestMergeBaseBaselineHealing:
         merge_base_baseline = {"A": "h1", "B": "h2", "C": "h3"}
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"A", "B", "C"}
+        )
 
         assert merged == {"A": "h1", "B": "h2", "C": "h3"}
         assert healed == 2
@@ -128,7 +132,9 @@ class TestMergeBaseBaselineHealing:
         merge_base_baseline = {"A": "master_hash", "B": "h2"}
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"A", "B"}
+        )
 
         assert merged["A"] == "branch_hash"
         assert merged["B"] == "h2"
@@ -139,7 +145,9 @@ class TestMergeBaseBaselineHealing:
         merge_base_baseline = {"A": "h1"}
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"A", "NewStory"}
+        )
 
         assert "NewStory" in merged
         assert merged["NewStory"] == "new_hash"
@@ -149,7 +157,9 @@ class TestMergeBaseBaselineHealing:
         baseline = {"A": "h1"}
         self._mock_github(mocker, branch_baseline=baseline, default_branch="master")
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "master")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "master", rendered_identifiers={"A"}
+        )
 
         assert merged == baseline
         assert healed == 0
@@ -173,7 +183,7 @@ class TestMergeBaseBaselineHealing:
         )
 
         merged, healed = baselines._resolve_baselines_with_merge_base(
-            repo, "storybook", "master", commit_sha=commit_sha
+            repo, "storybook", "master", rendered_identifiers={"A", "B"}, commit_sha=commit_sha
         )
 
         assert merged == expected_baseline
@@ -182,8 +192,8 @@ class TestMergeBaseBaselineHealing:
     def test_non_default_branch_ignores_commit_sha(self, repo, mocker):
         """On non-default branches, commit_sha is ignored — branch name is used."""
         branch_baseline = {"A": "h1"}
-        merge_base_baseline = {"A": "h1", "C": "h3"}
         commit_baseline = {"X": "hx"}  # Should NOT be used
+        merge_base_baseline = {"A": "h1", "C": "h3"}
         self._mock_github(
             mocker,
             branch_baseline=branch_baseline,
@@ -192,18 +202,45 @@ class TestMergeBaseBaselineHealing:
         )
 
         merged, healed = baselines._resolve_baselines_with_merge_base(
-            repo, "storybook", "my-branch", commit_sha="deadbeef"
+            repo, "storybook", "my-branch", rendered_identifiers={"A", "C"}, commit_sha="deadbeef"
         )
 
-        # Should use branch baseline + merge-base healing, NOT the commit baseline
         assert merged == {"A": "h1", "C": "h3"}
+        assert healed == 1
+
+    def test_does_not_heal_what_the_run_did_not_render(self, repo, mocker):
+        """A story deleted on the branch stays deleted — healing it back invents a REMOVED."""
+        branch_baseline = {"kept": "h1"}
+        merge_base_baseline = {"kept": "h1", "deleted-story": "h2"}
+        self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
+
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"kept"}
+        )
+
+        assert merged == {"kept": "h1"}
+        assert healed == 0
+
+    def test_heals_what_the_run_still_renders(self, repo, mocker):
+        """Same missing entry, but the story renders — that is the rebase loss healing exists for."""
+        branch_baseline = {"kept": "h1"}
+        merge_base_baseline = {"kept": "h1", "lost-to-rebase": "h2"}
+        self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
+
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"kept", "lost-to-rebase"}
+        )
+
+        assert merged == {"kept": "h1", "lost-to-rebase": "h2"}
         assert healed == 1
 
     def test_falls_back_on_merge_base_failure(self, repo, mocker):
         branch_baseline = {"A": "h1"}
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_sha=None)
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"A"}
+        )
 
         assert merged == branch_baseline
         assert healed == 0
@@ -216,7 +253,9 @@ class TestMergeBaseBaselineHealing:
             side_effect=[branch_baseline, Exception("GitHub 500")],
         )
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers={"A", "B"}
+        )
 
         assert merged == branch_baseline
         assert healed == 0
@@ -224,7 +263,9 @@ class TestMergeBaseBaselineHealing:
     def test_first_run_both_baselines_empty(self, repo, mocker):
         self._mock_github(mocker, branch_baseline={}, merge_base_baseline={})
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers=set()
+        )
 
         assert merged == {}
         assert healed == 0
@@ -246,7 +287,9 @@ class TestMergeBaseBaselineHealing:
         }
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, "storybook", "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, "storybook", "my-branch", rendered_identifiers=set(merge_base_baseline)
+        )
 
         assert len(merged) == 10
         assert healed == 8
@@ -256,7 +299,11 @@ class TestMergeBaseBaselineHealing:
         """Healed entries classify as unchanged when hashes match."""
         branch_baseline = {"existing": "h1"}
         merge_base_baseline = {"existing": "h1", "healed": "h2"}
-        self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
+        self._mock_github(
+            mocker,
+            branch_baseline=branch_baseline,
+            merge_base_baseline=merge_base_baseline,
+        )
 
         artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="h1", storage_path="p/h1")
         artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="h2", storage_path="p/h2")
@@ -333,6 +380,47 @@ class TestMergeBaseBaselineHealing:
             ),
             team_id=repo.team_id,
         )
+
+        runs.complete_run(run.id)
+
+        run.refresh_from_db()
+        assert run.removed_count == 0
+        assert run.new_count == 0
+        assert run.changed_count == 0
+
+    def test_merge_queue_batch_deleting_a_story_reports_no_removals(self, repo, mocker):
+        """A PR that deletes a story must not red every batch it shares until it lands.
+
+        The batch tree has the story and its baseline entry gone. The merge base is
+        still master, which has both. Healing off the merge base used to restore the
+        entry, and a merge-queue run has no reviewer to approve the removal away, so
+        every co-batched PR failed until the deleting PR merged.
+        """
+        batch_branch = "trunk-merge/pr-4242/0c2f75d8-0c2f-4c2f-8c2f-0c2f75d80c2f"
+        master_baseline = {"kept": "h1", "doomed": "h2"}
+        batch_baseline = {"kept": "h1"}
+        self._mock_github(
+            mocker,
+            branch_baseline=batch_baseline,
+            merge_base_baseline=master_baseline,
+            commit_sha_baselines={"batch-sha": batch_baseline},
+        )
+
+        artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="h1", storage_path="p/h1")
+
+        # The batch renders everything except the story it deleted.
+        run, _ = runs.create_run(
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="batch-sha",
+                branch=batch_branch,
+                pr_number=None,
+                snapshots=[SnapshotManifestItem(identifier="kept", content_hash="h1")],
+            ),
+            team_id=repo.team_id,
+        )
+        mocker.patch("products.visual_review.backend.tasks.tasks.process_run_diffs.delay")
 
         runs.complete_run(run.id)
 
@@ -477,7 +565,9 @@ class TestMergeBaseBaselineHealing:
             review_state=prior_review_state,
         )
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, RunType.STORYBOOK, run_branch)
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, RunType.STORYBOOK, run_branch, rendered_identifiers={"candidate"}
+        )
 
         if expect_tombstoned:
             assert merged == {}
@@ -538,7 +628,9 @@ class TestMergeBaseBaselineHealing:
             review_state=ReviewState.APPROVED,
         )
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, RunType.STORYBOOK, "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, RunType.STORYBOOK, "my-branch", rendered_identifiers={"story-x"}
+        )
 
         # Latest approved outcome is NEW, not REMOVED — tombstone cleared, healing works
         assert "story-x" in merged
@@ -569,7 +661,9 @@ class TestMergeBaseBaselineHealing:
             review_state=ReviewState.APPROVED,
         )
 
-        merged, healed = baselines._resolve_baselines_with_merge_base(repo, RunType.STORYBOOK, "my-branch")
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo, RunType.STORYBOOK, "my-branch", rendered_identifiers={"story-x"}
+        )
 
         assert "story-x" not in merged
         assert healed == 0

--- a/products/visual_review/backend/tests/logic/test_baselines.py
+++ b/products/visual_review/backend/tests/logic/test_baselines.py
@@ -189,14 +189,14 @@ class TestMergeBaseBaselineHealing:
         assert merged == expected_baseline
         assert healed == 0
 
-    def test_non_default_branch_ignores_commit_sha(self, repo, mocker):
-        """On non-default branches, commit_sha is ignored — branch name is used."""
-        branch_baseline = {"A": "h1"}
-        commit_baseline = {"X": "hx"}  # Should NOT be used
+    def test_non_default_branch_pins_to_commit_sha(self, repo, mocker):
+        """A branch deleted mid-run still resolves, because the ref is the commit."""
+        branch_tip_baseline = {"A": "h1", "stale": "h9"}
+        commit_baseline = {"A": "h1"}
         merge_base_baseline = {"A": "h1", "C": "h3"}
         self._mock_github(
             mocker,
-            branch_baseline=branch_baseline,
+            branch_baseline=branch_tip_baseline,
             merge_base_baseline=merge_base_baseline,
             commit_sha_baselines={"deadbeef": commit_baseline},
         )
@@ -233,6 +233,31 @@ class TestMergeBaseBaselineHealing:
 
         assert merged == {"kept": "h1", "lost-to-rebase": "h2"}
         assert healed == 1
+
+    def test_deleted_branch_still_resolves_via_commit_sha(self, repo, mocker):
+        """A merge-queue branch is deleted once its batch resolves.
+
+        Fetching by branch name then 404s, which is indistinguishable from
+        "no baseline file yet" and reports the whole suite as new. The commit
+        outlives the ref, so pinning to it keeps the baseline readable.
+        """
+        self._mock_github(
+            mocker,
+            branch_baseline={},
+            merge_base_sha=None,
+            commit_sha_baselines={"batch-sha": {"A": "h1", "B": "h2"}},
+        )
+
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo,
+            "storybook",
+            "trunk-merge/pr-4242/0c2f75d8",
+            rendered_identifiers={"A", "B"},
+            commit_sha="batch-sha",
+        )
+
+        assert merged == {"A": "h1", "B": "h2"}
+        assert healed == 0
 
     def test_falls_back_on_merge_base_failure(self, repo, mocker):
         branch_baseline = {"A": "h1"}
@@ -303,6 +328,7 @@ class TestMergeBaseBaselineHealing:
             mocker,
             branch_baseline=branch_baseline,
             merge_base_baseline=merge_base_baseline,
+            commit_sha_baselines={"abc": branch_baseline},
         )
 
         artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="h1", storage_path="p/h1")

--- a/products/visual_review/backend/tests/logic/test_baselines.py
+++ b/products/visual_review/backend/tests/logic/test_baselines.py
@@ -57,6 +57,7 @@ class TestMergeBaseBaselineHealing:
         branch_baseline,
         merge_base_baseline=None,
         merge_base_sha="abc123",
+        merge_base_heads=None,
         default_branch="master",
         commit_sha_baselines=None,
         pr_head_sha=None,
@@ -93,6 +94,10 @@ class TestMergeBaseBaselineHealing:
         def fake_merge_base(github, repo_full_name, base, head):
             if pr_head_sha is not None and base == pr_head_sha:
                 return pr_head_sha if pr_head_is_ancestor else "unrelated-sha"
+            # `merge_base_heads` models refs GitHub still knows: a deleted branch
+            # 404s on compare, a commit does not.
+            if merge_base_heads is not None and head not in merge_base_heads:
+                return None
             return merge_base_sha
 
         mocker.patch("products.visual_review.backend.logic.github_api._fetch_baseline_file", side_effect=fake_fetch)
@@ -190,7 +195,7 @@ class TestMergeBaseBaselineHealing:
         assert healed == 0
 
     def test_non_default_branch_pins_to_commit_sha(self, repo, mocker):
-        """A branch deleted mid-run still resolves, because the ref is the commit."""
+        # The tip has moved on; the run is judged against the commit it tested.
         branch_tip_baseline = {"A": "h1", "stale": "h9"}
         commit_baseline = {"A": "h1"}
         merge_base_baseline = {"A": "h1", "C": "h3"}
@@ -209,7 +214,7 @@ class TestMergeBaseBaselineHealing:
         assert healed == 1
 
     def test_does_not_heal_what_the_run_did_not_render(self, repo, mocker):
-        """A story deleted on the branch stays deleted — healing it back invents a REMOVED."""
+        # A story the branch deleted stays deleted. Healing it back invents a removal.
         branch_baseline = {"kept": "h1"}
         merge_base_baseline = {"kept": "h1", "deleted-story": "h2"}
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
@@ -222,7 +227,7 @@ class TestMergeBaseBaselineHealing:
         assert healed == 0
 
     def test_heals_what_the_run_still_renders(self, repo, mocker):
-        """Same missing entry, but the story renders — that is the rebase loss healing exists for."""
+        # Same missing entry, but the story renders: the rebase loss healing exists for.
         branch_baseline = {"kept": "h1"}
         merge_base_baseline = {"kept": "h1", "lost-to-rebase": "h2"}
         self._mock_github(mocker, branch_baseline=branch_baseline, merge_base_baseline=merge_base_baseline)
@@ -235,12 +240,9 @@ class TestMergeBaseBaselineHealing:
         assert healed == 1
 
     def test_deleted_branch_still_resolves_via_commit_sha(self, repo, mocker):
-        """A merge-queue branch is deleted once its batch resolves.
-
-        Fetching by branch name then 404s, which is indistinguishable from
-        "no baseline file yet" and reports the whole suite as new. The commit
-        outlives the ref, so pinning to it keeps the baseline readable.
-        """
+        # A merge-queue branch is deleted once its batch resolves. Fetching by name
+        # then 404s, which reads as "no baseline file yet" and reports the whole
+        # suite as new. The commit outlives the ref.
         self._mock_github(
             mocker,
             branch_baseline={},
@@ -258,6 +260,29 @@ class TestMergeBaseBaselineHealing:
 
         assert merged == {"A": "h1", "B": "h2"}
         assert healed == 0
+
+    def test_deleted_branch_still_heals_because_compare_uses_the_commit(self, repo, mocker):
+        # The compare API is asked from the same ref the baseline was read at.
+        # Asking by branch name 404s once the batch resolves, and healing would
+        # then switch off exactly on the branches that need it.
+        self._mock_github(
+            mocker,
+            branch_baseline={},
+            merge_base_baseline={"kept": "h1", "lost-to-rebase": "h2"},
+            merge_base_heads={"batch-sha"},
+            commit_sha_baselines={"batch-sha": {"kept": "h1"}},
+        )
+
+        merged, healed = baselines._resolve_baselines_with_merge_base(
+            repo,
+            "storybook",
+            "trunk-merge/pr-4242/0c2f75d8",
+            rendered_identifiers={"kept", "lost-to-rebase"},
+            commit_sha="batch-sha",
+        )
+
+        assert merged == {"kept": "h1", "lost-to-rebase": "h2"}
+        assert healed == 1
 
     def test_falls_back_on_merge_base_failure(self, repo, mocker):
         branch_baseline = {"A": "h1"}
@@ -415,13 +440,9 @@ class TestMergeBaseBaselineHealing:
         assert run.changed_count == 0
 
     def test_merge_queue_batch_deleting_a_story_reports_no_removals(self, repo, mocker):
-        """A PR that deletes a story must not red every batch it shares until it lands.
-
-        The batch tree has the story and its baseline entry gone. The merge base is
-        still master, which has both. Healing off the merge base used to restore the
-        entry, and a merge-queue run has no reviewer to approve the removal away, so
-        every co-batched PR failed until the deleting PR merged.
-        """
+        # The batch tree has the story and its entry gone; the merge base still has
+        # both. Healing used to restore the entry, and a queue run has no reviewer to
+        # approve the removal, so every co-batched PR failed until the deleter merged.
         batch_branch = "trunk-merge/pr-4242/0c2f75d8-0c2f-4c2f-8c2f-0c2f75d80c2f"
         master_baseline = {"kept": "h1", "doomed": "h2"}
         batch_baseline = {"kept": "h1"}

--- a/products/visual_review/backend/tests/logic/test_runs.py
+++ b/products/visual_review/backend/tests/logic/test_runs.py
@@ -317,7 +317,7 @@ class TestRunOperations:
         assert completed.is_partial is False
 
     def test_complete_run_passes_commit_sha_to_baseline_resolution(self, repo, mocker):
-        """complete_run passes run.commit_sha so default-branch baselines are pinned."""
+        """complete_run pins the baseline to the commit and limits healing to what rendered."""
         run, _ = runs.create_run(
             CreateRunInput(
                 repo_id=repo.id,
@@ -337,7 +337,13 @@ class TestRunOperations:
 
         runs.complete_run(run.id)
 
-        mock_resolve.assert_called_once_with(repo, RunType.STORYBOOK, "master", commit_sha="deadbeef123")
+        mock_resolve.assert_called_once_with(
+            repo,
+            RunType.STORYBOOK,
+            "master",
+            rendered_identifiers={"A"},
+            commit_sha="deadbeef123",
+        )
 
     def test_create_run_with_purpose(self, repo):
         run, _ = runs.create_run(

--- a/products/visual_review/backend/tests/logic/test_runs.py
+++ b/products/visual_review/backend/tests/logic/test_runs.py
@@ -317,7 +317,7 @@ class TestRunOperations:
         assert completed.is_partial is False
 
     def test_complete_run_passes_commit_sha_to_baseline_resolution(self, repo, mocker):
-        """complete_run pins the baseline to the commit and limits healing to what rendered."""
+        # Pins the baseline to the commit, and limits healing to what rendered.
         run, _ = runs.create_run(
             CreateRunInput(
                 repo_id=repo.id,


### PR DESCRIPTION
## Problem

A pull request that deletes a Storybook story fails the merge queue for every other pull request batched with it, and keeps failing until it lands.

- The deleting branch removes the story and its `snapshots.yml` entry. Both are correct.
- Merge-base healing puts the entry back, because the merge base is still master and master still has it.
- The build has no such story, so the run reports it removed and the job exits non-zero.
- On a pull request this is fine: the reviewer approves the removal, which tombstones the identifier. A merge-queue branch has no reviewer.
- Tombstone inheritance keys off the single pull request number in `trunk-merge/pr-<n>/…`. Trunk batches, so in a batch of several only one member can inherit.

Healing cannot tell a deliberate deletion from the rebase loss it exists for, and in the queue nothing can approve the difference away.

A second failure sits next to it. The baseline is fetched by branch name off the default branch. A merge-queue branch is deleted as soon as its batch resolves, often before diff processing runs, and GitHub then returns 404. The fetch maps that to an empty dict, which is also what it returns for "no baseline file yet". Every snapshot classifies as new. On this repo that hits around a hundred merge-queue runs a month, each reporting the whole suite as new with nothing diffed.

## Changes

- A story deletion no longer reds the batches it shares. Healing now skips identifiers the run did not render.
- A run on a deleted branch now reads its real baseline instead of reporting the whole suite as new. The baseline is fetched at the commit under test on every branch, not only the default one, and the merge-base compare and the queue-branch ancestor check use that same ref.
- `complete_run` reads the rendered identifiers before resolving the baseline rather than after. Mechanical.

Missing from the branch baseline but still rendering stays healed, which is the rebase loss the feature exists for. Missing from both is a deletion. Three shapes are deliberately unchanged: code deleted with the entry kept still flags removed, a render failure still flags removed, an entry deleted with the story kept still flags new.

This is branch-agnostic on purpose. Special-casing `trunk-merge/**` as a default branch would also fix it, but "default branch" already carries the `is_partial` fencing and flakiness scoring, and skipping healing on batch branches would turn today's false removals into false new entries for pull requests whose baseline commit a rebase mangled.

The render filter is limited to merge-queue branches. Deleting a story together with its signed entry needs no forged signature, so applying it everywhere would let a pull request pass visual review with nobody approving the removal. That gate is only useless where no reviewer exists, which is exactly a queue branch. The signal is the server-verified source PR, not the branch name: the name is client-supplied, so matching `trunk-merge/pr-<n>/` would hand the bypass to any caller willing to name a branch that way. When verification fails the filter stays off, so a GitHub blip costs a red batch rather than a silent removal.

Nothing user-visible changes in the UI.

## How did you test this code?

Ran `products/visual_review/backend/tests` locally; the one failure was a call-signature assertion in `test_runs.py`, updated in the first commit.

New tests, and the regression each catches:

- A story deleted on the branch is not healed back. Nothing covered this, which is why the bug shipped.
- The same missing entry, with the story still rendering, is still healed. Guards against fixing the first case by disabling healing.
- A merge-queue batch that deletes a story reports no removals, end to end through `complete_run`. This is the production failure.
- An ordinary branch still heals a deleted story, so the removal keeps asking for an approval.
- A queue branch whose source PR fails verification also keeps healing, so the branch name alone grants nothing.
- A deleted branch still resolves its baseline from the commit SHA rather than reading as an empty baseline, and still heals, because the compare uses that SHA too.

Mutation-checked both fixes. Reverting the render filter fails exactly the deletion test and the batch test and nothing else, so the previous test set could not see this. Reverting the SHA pin fails exactly the two pinning tests.

Not done: no run against a live environment, and the local Greptile pass could not run because the CLI is not installed in this shell.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. The session started from a live merge-queue failure and worked back through production run data and the CI logs to the two causes.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-before-pr`.

Two alternatives were considered and dropped. Treating `trunk-merge/**` as a default branch fixes the removals but gives up healing where batches still need it, for the reason under Changes. Sending the baseline from CI instead of reading it from GitHub removes the 404 entirely, but the server currently guarantees the baseline is what is actually committed, and client-supplied entries could omit or replay signed hashes; the SHA pin removes the motivation without that trade.

Public artifact: everything here comes from this repository, its public CI runs, and this project's own visual review data. No customer material is involved.
