### PR TITLE
fix(tasks): restore inbox scout chat replies and explain refused sends

### DIFF
--- a/products/posthog_ai/frontend/lib/load-error.ts
+++ b/products/posthog_ai/frontend/lib/load-error.ts
@@ -17,14 +17,13 @@ export function apiErrorReason(errorObject: unknown): string | null {
 }
 
 /** Best-effort human message for a failed load: explicit `error` string first, then the
- * `ApiError` reason, then a plain `Error.message`, else a generic fallback. */
+ * `ApiError` detail/statusText, then a plain `Error.message`, else a generic fallback. */
 export function loadErrorMessage(error: string, errorObject: unknown): string {
     if (error) {
         return error
     }
-    const reason = apiErrorReason(errorObject)
-    if (reason) {
-        return reason
+    if (errorObject instanceof ApiError && (errorObject.detail || errorObject.statusText)) {
+        return errorObject.detail || errorObject.statusText || 'Something went wrong.'
     }
     if (errorObject instanceof Error && errorObject.message) {
         return errorObject.message

--- a/products/posthog_ai/frontend/lib/load-error.ts
+++ b/products/posthog_ai/frontend/lib/load-error.ts
@@ -5,14 +5,26 @@ export function isApiNotFound(errorObject: unknown): boolean {
     return errorObject instanceof ApiError && errorObject.status === 404
 }
 
+export function apiErrorReason(errorObject: unknown): string | null {
+    if (!(errorObject instanceof ApiError)) {
+        return null
+    }
+    const bodyError = errorObject.data?.error
+    if (typeof bodyError === 'string' && bodyError) {
+        return bodyError
+    }
+    return errorObject.detail || errorObject.statusText || null
+}
+
 /** Best-effort human message for a failed load: explicit `error` string first, then the
- * `ApiError` detail/statusText, then a plain `Error.message`, else a generic fallback. */
+ * `ApiError` reason, then a plain `Error.message`, else a generic fallback. */
 export function loadErrorMessage(error: string, errorObject: unknown): string {
     if (error) {
         return error
     }
-    if (errorObject instanceof ApiError && (errorObject.detail || errorObject.statusText)) {
-        return errorObject.detail || errorObject.statusText || 'Something went wrong.'
+    const reason = apiErrorReason(errorObject)
+    if (reason) {
+        return reason
     }
     if (errorObject instanceof Error && errorObject.message) {
         return errorObject.message

--- a/products/posthog_ai/frontend/logics/runInteractionLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runInteractionLogic.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { ApiError } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
 import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
@@ -354,10 +355,29 @@ describe('runInteractionLogic', () => {
             logic.actions.submitComposerForm()
         }).toFinishAllListeners()
 
-        expect(lemonToast.error).toHaveBeenCalled()
+        expect(lemonToast.error).toHaveBeenCalledWith('Failed to send message. Please try again.')
         expect(logic.values.composerForm.draft).toBe('ship it')
         expect(logic.values.sending).toBe(false)
         expect(toolEvents.values.applyBackTargetClaims[RUN_ID]).toBeUndefined()
+    })
+
+    it('toasts the reason the server gave when the send is refused', async () => {
+        ;(tasksRunsCommandCreate as jest.Mock).mockRejectedValue(
+            new ApiError('API request failed with status: 403', 403, undefined, {
+                type: 'permission_denied',
+                code: 'code_access_required',
+                error: 'PostHog Desktop access is required to run tasks in the cloud.',
+            })
+        )
+        setThinking(false)
+        logic.actions.setComposerFormValues({ draft: 'ship it' })
+
+        await expectLogic(logic, () => {
+            logic.actions.submitComposerForm()
+        }).toFinishAllListeners()
+
+        expect(lemonToast.error).toHaveBeenCalledWith('PostHog Desktop access is required to run tasks in the cloud.')
+        expect(logic.values.composerForm.draft).toBe('ship it')
     })
 
     it('starts a fresh run seeded with the message when the run is terminal', async () => {

--- a/products/posthog_ai/frontend/logics/runInteractionLogic.ts
+++ b/products/posthog_ai/frontend/logics/runInteractionLogic.ts
@@ -30,6 +30,7 @@ import {
     type WarmTaskResumeRequestApi,
 } from 'products/tasks/frontend/generated/api.schemas'
 
+import { apiErrorReason } from '../lib/load-error'
 import { type AttachedContextItem, attachedContextItemKey } from '../types/contextTypes'
 import type { PermissionRequestRecord } from '../types/streamTypes'
 import { contextItemLine, wrapWithPosthogContext } from '../utils/posthogContextBlock'
@@ -821,7 +822,7 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
                     // The SSE echo (`pushHumanMessage`) reopens the turn — always the raw text the user typed.
                     actions.pushHumanMessage(content)
                     markPendingContextSent(pendingContext)
-                } catch {
+                } catch (failure) {
                     actions.releaseApplyBackTargets(streamKey)
                     // Restore unsent content for retry, preserving send order — draft content goes back ahead of
                     // anything typed during the failed send, queue content re-stages ahead of anything staged since.
@@ -832,7 +833,7 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
                     } else {
                         actions.prependQueuedMessage(content)
                     }
-                    lemonToast.error('Failed to send message. Please try again.')
+                    lemonToast.error(apiErrorReason(failure) ?? 'Failed to send message. Please try again.')
                 } finally {
                     actions.setSending(false)
                 }
@@ -896,9 +897,9 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
                     } else {
                         actions.releaseApplyBackTargets(streamKey)
                     }
-                } catch {
+                } catch (failure) {
                     actions.releaseApplyBackTargets(claimedStreamKey)
-                    lemonToast.error('Failed to start a new run. Please try again.')
+                    lemonToast.error(apiErrorReason(failure) ?? 'Failed to start a new run. Please try again.')
                 } finally {
                     actions.setStartingRun(false)
                 }

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -880,7 +880,13 @@ class Task(DeletedMetaFields, models.Model):
             )
             if user_github_integration_is_usable(user_github_integration):
                 github_user_integration = user_github_integration.integration if user_github_integration else None
-        elif authorship_mode == PrAuthorshipMode.BOT and repository and github_integration is None:
+        elif (
+            authorship_mode == PrAuthorshipMode.BOT
+            and (
+                repository or origin_product not in (Task.OriginProduct.SIGNALS_CHAT, Task.OriginProduct.SIGNAL_REPORT)
+            )
+            and github_integration is None
+        ):
             # If BOT starts a task, provides a repo, but there's no team GitHub Integration,
             # then use the user_id BOT provided and get user's GitHub Integration instead
             user_github_integration = resolve_user_github_integration_for_task(

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -880,7 +880,7 @@ class Task(DeletedMetaFields, models.Model):
             )
             if user_github_integration_is_usable(user_github_integration):
                 github_user_integration = user_github_integration.integration if user_github_integration else None
-        elif authorship_mode == PrAuthorshipMode.BOT and github_integration is None:
+        elif authorship_mode == PrAuthorshipMode.BOT and repository and github_integration is None:
             # If BOT starts a task, provides a repo, but there's no team GitHub Integration,
             # then use the user_id BOT provided and get user's GitHub Integration instead
             user_github_integration = resolve_user_github_integration_for_task(

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -378,6 +378,39 @@ class TestTask(TestCase):
         self.assertEqual(task.github_user_integration, user_integration)
         mock_execute_workflow.assert_called_once()
 
+    @parameterized.expand(
+        [
+            (Task.OriginProduct.SIGNALS_CHAT,),
+            (Task.OriginProduct.SIGNAL_REPORT,),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_repoless_inbox_task_takes_no_user_integration(self, origin_product, mock_execute_workflow):
+        user = User.objects.create(email=f"repoless-{origin_product}@test.com")
+        OrganizationMembership.objects.create(user=user, organization=self.organization)
+        UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+            integration_id="install-1",
+            config={"installation_id": "install-1"},
+            sensitive_config={"access_token": "ghs_user_install"},
+            repository_cache=[{"full_name": "posthog/posthog", "id": 1}],
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            task = Task.create_and_run(
+                team=self.team,
+                title="Inbox chat",
+                description="Chat",
+                origin_product=origin_product,
+                user_id=user.id,
+                repository=None,
+            )
+
+        self.assertIsNone(task.github_user_integration)
+        self.assertIsNone(task.github_integration)
+        self.assertEqual(task.repositories, [])
+
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_create_and_run_signal_report_raises_when_no_integration_anywhere(self, mock_execute_workflow):
         user = User.objects.create(email="signal-no-int@test.com")

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -380,15 +380,16 @@ class TestTask(TestCase):
 
     @parameterized.expand(
         [
-            (Task.OriginProduct.SIGNALS_CHAT,),
-            (Task.OriginProduct.SIGNAL_REPORT,),
+            (Task.OriginProduct.SIGNALS_CHAT, False),
+            (Task.OriginProduct.SIGNAL_REPORT, False),
+            (Task.OriginProduct.POSTHOG_AI, True),
         ]
     )
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_create_and_run_repoless_inbox_task_takes_no_user_integration(self, origin_product, mock_execute_workflow):
+    def test_repoless_task_github_identity_follows_origin(self, origin_product, keeps_identity, mock_execute_workflow):
         user = User.objects.create(email=f"repoless-{origin_product}@test.com")
         OrganizationMembership.objects.create(user=user, organization=self.organization)
-        UserIntegration.objects.create(
+        user_integration = UserIntegration.objects.create(
             user=user,
             kind=UserIntegration.IntegrationKind.GITHUB,
             integration_id="install-1",
@@ -400,14 +401,17 @@ class TestTask(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             task = Task.create_and_run(
                 team=self.team,
-                title="Inbox chat",
+                title="Repo-less task",
                 description="Chat",
                 origin_product=origin_product,
                 user_id=user.id,
                 repository=None,
             )
 
-        self.assertIsNone(task.github_user_integration)
+        if keeps_identity:
+            self.assertEqual(task.github_user_integration, user_integration)
+        else:
+            self.assertIsNone(task.github_user_integration)
         self.assertIsNone(task.github_integration)
         self.assertEqual(task.repositories, [])
 


### PR DESCRIPTION
## Problem

Someone who has connected a personal GitHub account cannot reply to an Inbox scout chat or a repo-less report discussion. Every reply fails with "Failed to send message. Please try again.", and retrying cannot fix it. Broken since #82993 for users without PostHog Desktop access.

- The reply endpoint returns 403 `code_access_required`, because [task_exempt_from_code_access](https://github.com/PostHog/posthog/blob/2046e645730213590ab6846e2c777c84649cccbb/products/tasks/backend/facade/api.py#L811) requires `github_user_integration` to be null.
- Task creation set that field: the [bot-authorship fallback](https://github.com/PostHog/posthog/blob/2046e645730213590ab6846e2c777c84649cccbb/products/tasks/backend/models.py#L825) resolves the creator's GitHub integration by repository, and with no repository every install matches, so the first one was pinned.
- The composer's catch block discarded the error, so every refusal toasted the same retry prompt.

## Changes

- Repo-less `signals_chat` and `signal_report` tasks no longer take a personal GitHub identity, so their replies pass the exemption. The origin scoping mirrors the token-injection guard in [provision_sandbox](https://github.com/PostHog/posthog/blob/2046e645730213590ab6846e2c777c84649cccbb/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py#L366); every other origin keeps its identity, including repo-less PostHog AI tasks, which clone in-chat with it (a first, broader cut keyed on the repository broke that; ReviewHog caught it).
- The composer now toasts the server's reason, e.g. "PostHog Desktop access is required to run tasks in the cloud.", for refused sends and refused new runs. Other failures keep the existing copy.
- Relaxing the exemption instead was rejected: a GitHub identity grants code capability in the sandbox, so a task carrying one must stay gated.
- Existing broken rows are not backfilled. Scout chats are throwaway; one new chat recovers.

No UI layout changed; only which sentence a toast carries.

## How did you test this code?

Automated only. Each new test fails on master (or on the broken intermediate state) with the reported symptom:

- `test_repoless_task_github_identity_follows_origin`: inbox origins take no identity, `posthog_ai` keeps it.
- "toasts the reason the server gave when the send is refused": fails with the generic retry copy without the fix.

Suites run locally: tasks backend models/API/utils, scout chat API, and the four Jest suites around the composer. Not run: repo-wide mypy, `hogli review` (Greptile CLI install fails locally). `typescript:check` shows only pre-existing quill resolution errors in untouched products.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) investigated a support report and wrote this PR. Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`. The report described scout creation failing; the reporter's event stream showed chats starting fine and the first reply 403ing, which led to the access gate and then the creation path. Commits 3 and 4 correct two overreaches in earlier commits: a no-op `loadErrorMessage` change, and the repository-keyed gate that regressed Max (per ReviewHog's review). Still open for the sandbox-credentials owners: whether repo-less non-inbox tasks should carry a personal GitHub identity at all.

Public artifact: no session material; fixtures use `posthog/posthog` and invented tokens.
