### PR TITLE
fix(storybook): wait for experiment funnel chart before snapshotting

### DIFF
--- a/frontend/src/scenes/experiments/stories/ExperimentStoppedWithConclusion.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentStoppedWithConclusion.stories.tsx
@@ -25,6 +25,12 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2025-01-27',
         pageUrl: urls.experiment(EXPERIMENT_STOPPED_WITH_CONCLUSION.id),
+        testOptions: {
+            // The funnel chart only renders once the metric result AND the exposure query have
+            // both resolved. The loader wait covers the metric table alone, so wait for the chart
+            // itself to avoid snapshotting before it appears.
+            waitForSelector: '[data-attr="experiment-funnel-chart"]',
+        },
     },
     decorators: [
         mswDecorator({

--- a/frontend/src/scenes/experiments/stories/ExperimentStoppedWithConclusion.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentStoppedWithConclusion.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { makeDelay } from 'lib/utils/async'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -62,5 +61,4 @@ export default meta
 
 type Story = StoryObj<{}>
 
-// Small delay to ensure charts render completely
-export const ExperimentStoppedWithConclusion: Story = { play: makeDelay(500) }
+export const ExperimentStoppedWithConclusion: Story = {}

--- a/frontend/src/scenes/experiments/stories/ExperimentWithFunnelMetric.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentWithFunnelMetric.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { makeDelay } from 'lib/utils/async'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -54,5 +53,4 @@ export default meta
 
 type Story = StoryObj<{}>
 
-// Small delay to ensure charts render completely
-export const ExperimentWithFunnelMetric: Story = { play: makeDelay(500) }
+export const ExperimentWithFunnelMetric: Story = {}

--- a/frontend/src/scenes/experiments/stories/ExperimentWithFunnelMetric.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentWithFunnelMetric.stories.tsx
@@ -18,6 +18,12 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2025-01-27',
         pageUrl: urls.experiment(EXPERIMENT_WITH_FUNNEL_METRIC.id),
+        testOptions: {
+            // The funnel chart only renders once the metric result AND the exposure query have
+            // both resolved. The loader wait covers the metric table alone, so wait for the chart
+            // itself to avoid snapshotting before it appears.
+            waitForSelector: '[data-attr="experiment-funnel-chart"]',
+        },
     },
     decorators: [
         mswDecorator({

--- a/frontend/src/scenes/experiments/stories/ExperimentWithMultiStepFunnelMetric.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentWithMultiStepFunnelMetric.stories.tsx
@@ -18,6 +18,12 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2025-01-27',
         pageUrl: urls.experiment(EXPERIMENT_WITH_MULTI_STEP_FUNNEL_METRIC.id),
+        testOptions: {
+            // The funnel chart only renders once the metric result AND the exposure query have
+            // both resolved. The loader wait covers the metric table alone, so wait for the chart
+            // itself to avoid snapshotting before it appears.
+            waitForSelector: '[data-attr="experiment-funnel-chart"]',
+        },
     },
     decorators: [
         mswDecorator({

--- a/frontend/src/scenes/experiments/stories/ExperimentWithMultiStepFunnelMetric.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentWithMultiStepFunnelMetric.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { makeDelay } from 'lib/utils/async'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -56,5 +55,4 @@ export default meta
 
 type Story = StoryObj<{}>
 
-// Small delay to ensure charts render completely
-export const ExperimentWithMultiStepFunnelMetric: Story = { play: makeDelay(500) }
+export const ExperimentWithMultiStepFunnelMetric: Story = {}


### PR DESCRIPTION
## Problem

The storybook visual-regression snapshot for experiment funnel-metric stories flakes: the funnel graph sometimes renders in the screenshot and sometimes does not.

The funnel chart only renders once both the metric result and the exposure query have resolved. The test-runner's loader wait covers the metric table alone, so under CI contention the snapshot can be taken before the chart appears.

## Changes

- The snapshot now waits for the funnel chart to render before capturing, so the funnel graph content is deterministic. Mechanical: adds `testOptions.waitForSelector` to the three experiment funnel-metric stories.

## How did you test this code?

Ran the affected storybook tests locally with the built Storybook. The reported story passes 5 consecutive runs with the funnel content present; all three changed stories pass. The flake itself is CI-specific and did not reproduce locally even under CPU contention, so this validation is analytical plus a local regression check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing behavior changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: pi coding agent. Skills invoked: fixing-flaky-tests, writing-pr-descriptions.
- Root cause: the funnel chart renders only after both the metric result and the separate exposure query resolve; the storybook loader wait covers only the metric table, so the snapshot could race the chart render.
- Fix: wait for the funnel chart selector before snapshotting, matching the existing `waitForSelector` pattern used by other chart stories.
- Two sibling stories that use the same funnel chart got the same fix; two Frequentist stories that do not render the funnel chart in the main view were left unchanged.
