### PR TITLE
feat(dashboards): filter dashboards by clicked tag

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.test.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.test.tsx
@@ -21,7 +21,11 @@ jest.mock('lib/lemon-ui/LemonTable', () => ({
         <div>
             {bulkSelection ? bulkSelection.renderActions(mockCtx) : null}
             {dataSource.map((row: any) => (
-                <div key={row.id}>{columns.at(-1).render(undefined, row)}</div>
+                <div key={row.id}>
+                    {columns.map((column: any, index: number) =>
+                        column.render ? <span key={index}>{column.render(row[column.dataIndex], row)}</span> : null
+                    )}
+                </div>
             ))}
         </div>
     ),
@@ -98,5 +102,44 @@ describe('DashboardsTable move to folder', () => {
         renderTable([1, 2], [1, 2], [])
         fireEvent.click(screen.getByText('Move to folder'))
         expect(moveDashboardsToFolder).not.toHaveBeenCalled()
+    })
+
+    it('filters dashboards by a clicked tag', () => {
+        const setFilters = jest.fn()
+        ;(useActions as jest.Mock).mockReturnValue({
+            unpinDashboard: jest.fn(),
+            pinDashboard: jest.fn(),
+            tableSortingChanged: jest.fn(),
+            setFilters,
+            showDuplicateDashboardModal: jest.fn(),
+            showDeleteDashboardModal: jest.fn(),
+            moveDashboardsToFolder,
+        })
+        ;(useValues as jest.Mock).mockReturnValue({
+            tableSorting: null,
+            filters: { search: '' },
+            currentTeam: { id: 1 },
+            filedDashboardIds: new Set([1]),
+        })
+
+        render(
+            <DashboardsTable
+                dashboards={
+                    [
+                        {
+                            id: 1,
+                            name: 'Dashboard 1',
+                            tags: ['finance'],
+                            user_access_level: AccessControlLevel.Editor,
+                        },
+                    ] as any
+                }
+                dashboardsLoading={false}
+            />
+        )
+
+        fireEvent.click(screen.getByText('finance'))
+
+        expect(setFilters).toHaveBeenCalledWith({ tags: ['finance'] })
     })
 })

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -177,7 +177,9 @@ export function DashboardsTable({
             title: 'Tags',
             dataIndex: 'tags' as keyof DashboardType,
             render: function Render(tags: DashboardType['tags']) {
-                return tags ? <ObjectTags tags={[...tags].sort()} staticOnly /> : null
+                return tags ? (
+                    <ObjectTags tags={[...tags].sort()} staticOnly onTagClick={(tag) => setFilters({ tags: [tag] })} />
+                ) : null
             },
         } as LemonTableColumn<DashboardType, keyof DashboardType | undefined>,
         {


### PR DESCRIPTION
## Problem

- Dashboard list users cannot filter by a tag shown directly on a dashboard row.
- Users must open the filter menu and find the tag before narrowing the list.

## Changes

- Clicking a dashboard tag now filters the list to dashboards with that tag.
- Existing tag appearance and filtering controls remain unchanged.
- No screenshot included because the change adds behavior without changing the visual layout.

## How did you test this code?

- Added a regression test for clicking a dashboard tag and applying the matching filter.
- Focused dashboard table tests pass.
- Frontend formatting and lint pass.
- Full frontend type-check remains blocked by unrelated existing errors in shared UI and PostHog AI test-type files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update needed.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted)
- **Agent and tools:** Codex with repository shell, Jest, frontend formatting, lint, and CI preflight.
- **Skills invoked:** `/placing-product-frontend-code` and `/writing-pr-descriptions`.
- The implementation reuses the existing `ObjectTags` click callback and dashboard filter state.
- Local dashboard data received varied tags for interaction testing; no local data changes are included in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*