### PR TITLE
perf(ci): skip static precompression in hogbox previews

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -738,14 +738,11 @@ jobs:
                   pnpm --filter=@posthog/frontend build:products
                   pnpm --filter=@posthog/frontend build
 
-            - name: Collect static files
+            - name: Collect static files without compression
               # The image-bitmap-data-url-worker-*.js.map files are already mirrored
               # into frontend/dist/ by copyRRWebWorkerFiles() in frontend/build.mjs
               # (see common/esbuilder/utils.mjs), which runs as part of the
               # `pnpm --filter=@posthog/frontend build` step above. No extra cp needed.
-              #
-              # Chromium fetches static over loopback here, so the pre-compressed .br
-              # and .gz variants are never read and only cost collectstatic time.
               env:
                   STATIC_PRECOMPRESS: '0'
               run: python manage.py collectstatic --noinput

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -743,6 +743,11 @@ jobs:
               # into frontend/dist/ by copyRRWebWorkerFiles() in frontend/build.mjs
               # (see common/esbuilder/utils.mjs), which runs as part of the
               # `pnpm --filter=@posthog/frontend build` step above. No extra cp needed.
+              #
+              # Chromium fetches static over loopback here, so the pre-compressed .br
+              # and .gz variants are never read and only cost collectstatic time.
+              env:
+                  STATIC_PRECOMPRESS: '0'
               run: python manage.py collectstatic --noinput
             - name: Create test database
               shell: bash

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -446,28 +446,20 @@ if DEBUG:
     # duplicate destinations for no gain.
     STATICFILES_DIRS.append(os.path.join(BASE_DIR, "frontend/public"))
 
-# CompressedManifest: collectstatic pre-generates .br and .gz (brotli is
-# already a dependency) so WhiteNoise serves compressed bytes from disk and
-# the envoy edge — which otherwise gzips static per request (Contour's
-# default compression filter) — skips recompression since Content-Encoding
-# is already set. Same Manifest base class: hashed names unchanged.
-#
-# STATIC_PRECOMPRESS gates only what collectstatic writes. WhiteNoise probes for
-# .br and .gz on disk per request, so clearing it on a serving process does nothing;
-# only the build that ran collectstatic decides whether they exist.
+# WhiteNoise serves precompressed files when present, so this only controls collectstatic output.
 if TEST:
-    _staticfiles_backend = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    _staticfiles_storage_backend = "django.contrib.staticfiles.storage.StaticFilesStorage"
 elif get_from_env("STATIC_PRECOMPRESS", True, type_cast=str_to_bool):
-    _staticfiles_backend = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    _staticfiles_storage_backend = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 else:
-    _staticfiles_backend = "whitenoise.storage.ManifestStaticFilesStorage"
+    _staticfiles_storage_backend = "whitenoise.storage.ManifestStaticFilesStorage"
 
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        "BACKEND": _staticfiles_backend,
+        "BACKEND": _staticfiles_storage_backend,
     },
 }
 # Never emit .map.gz/.map.br: the production image deletes *.map after the

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -445,21 +445,29 @@ if DEBUG:
     # a second source for 1300+ identical assets would make collectstatic warn about
     # duplicate destinations for no gain.
     STATICFILES_DIRS.append(os.path.join(BASE_DIR, "frontend/public"))
+
+# CompressedManifest: collectstatic pre-generates .br and .gz (brotli is
+# already a dependency) so WhiteNoise serves compressed bytes from disk and
+# the envoy edge — which otherwise gzips static per request (Contour's
+# default compression filter) — skips recompression since Content-Encoding
+# is already set. Same Manifest base class: hashed names unchanged.
+#
+# STATIC_PRECOMPRESS gates only what collectstatic writes. WhiteNoise probes for
+# .br and .gz on disk per request, so clearing it on a serving process does nothing;
+# only the build that ran collectstatic decides whether they exist.
+if TEST:
+    _staticfiles_backend = "django.contrib.staticfiles.storage.StaticFilesStorage"
+elif get_from_env("STATIC_PRECOMPRESS", True, type_cast=str_to_bool):
+    _staticfiles_backend = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+else:
+    _staticfiles_backend = "whitenoise.storage.ManifestStaticFilesStorage"
+
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        # CompressedManifest: collectstatic pre-generates .br and .gz (brotli is
-        # already a dependency) so WhiteNoise serves compressed bytes from disk and
-        # the envoy edge — which otherwise gzips static per request (Contour's
-        # default compression filter) — skips recompression since Content-Encoding
-        # is already set. Same Manifest base class: hashed names unchanged.
-        "BACKEND": (
-            "django.contrib.staticfiles.storage.StaticFilesStorage"
-            if TEST
-            else "whitenoise.storage.CompressedManifestStaticFilesStorage"
-        ),
+        "BACKEND": _staticfiles_backend,
     },
 }
 # Never emit .map.gz/.map.br: the production image deletes *.map after the

--- a/tools/hogbox-preview/hogbox_preview/stack.py
+++ b/tools/hogbox-preview/hogbox_preview/stack.py
@@ -598,10 +598,8 @@ class PostHogPreviewStack:
         # so settings import is fine; collectstatic itself needs no live DB.
         import pathlib
 
-        # Upload and collectstatic are separately timed: together they're ~260s,
-        # a third of the whole wait, and they were one opaque block — the dist
-        # is chunked over the exec API, so "slow upload" and "slow collectstatic"
-        # need very different fixes.
+        # Time upload and collectstatic separately because the exec transfer and
+        # static processing require different fixes.
         with timing.span("frontend-dist-upload"):
             tar = pathlib.Path(self.frontend_dist_tar).read_bytes()
             self.backend.write_file(f"{self.repo_dir}/frontend/dist.tgz", tar)
@@ -613,8 +611,8 @@ class PostHogPreviewStack:
             f"cd {self.repo_dir} && "
             "rm -rf frontend/dist && mkdir -p frontend/dist staticfiles && "
             "tar xzf frontend/dist.tgz -C frontend/dist --strip-components=1 && "
-            f"{compose} run --rm -T -e STATIC_COLLECTION=1 -e SKIP_SERVICE_VERSION_REQUIREMENTS=1 "
-            "web python manage.py collectstatic --noinput"
+            f"{compose} run --rm -T -e STATIC_COLLECTION=1 -e STATIC_PRECOMPRESS=0 "
+            "-e SKIP_SERVICE_VERSION_REQUIREMENTS=1 web python manage.py collectstatic --noinput"
         )
         self.backend.run_long(script, name="frontend", timeout=900)
         timing.stage("frontend swap done (collectstatic done)")

--- a/tools/hogbox-preview/hogbox_preview/stack.py
+++ b/tools/hogbox-preview/hogbox_preview/stack.py
@@ -611,8 +611,9 @@ class PostHogPreviewStack:
             f"cd {self.repo_dir} && "
             "rm -rf frontend/dist && mkdir -p frontend/dist staticfiles && "
             "tar xzf frontend/dist.tgz -C frontend/dist --strip-components=1 && "
-            f"{compose} run --rm -T -e STATIC_COLLECTION=1 -e STATIC_PRECOMPRESS=0 "
-            "-e SKIP_SERVICE_VERSION_REQUIREMENTS=1 web python manage.py collectstatic --noinput"
+            f"{compose} run --rm -T "
+            "-e STATIC_COLLECTION=1 -e STATIC_PRECOMPRESS=0 -e SKIP_SERVICE_VERSION_REQUIREMENTS=1 "
+            "web python manage.py collectstatic --noinput"
         )
         self.backend.run_long(script, name="frontend", timeout=900)
         timing.stage("frontend swap done (collectstatic done)")

--- a/tools/hogbox-preview/tests/test_swap_frontend.py
+++ b/tools/hogbox-preview/tests/test_swap_frontend.py
@@ -42,8 +42,7 @@ class _RecordingBackend:
 
     def __init__(self):
         self.files: dict[str, bytes | str] = {}
-        self.long_runs: list[str] = []
-        self.long_scripts: list[str] = []
+        self.long_runs: dict[str, str] = {}
         self.attached = False
         self.health_waited = False
 
@@ -61,8 +60,7 @@ class _RecordingBackend:
         self.files[remote_path] = content
 
     def run_long(self, script, *, name, timeout: int = 1800, interval: int = 3) -> ExecResult:
-        self.long_runs.append(name)
-        self.long_scripts.append(script)
+        self.long_runs[name] = script
         return ExecResult(0, "", "")
 
     def wait_http_ok(self, url_path, *, expect=200, timeout=600, interval=3) -> None:
@@ -105,8 +103,8 @@ class SwapFrontendOnlyTest(unittest.TestCase):
         self.assertIn(f"SECRET_KEY={_EXISTING_KEY}", override)
 
         # Ran the swap (collectstatic) then recreated web, then waited for health.
-        self.assertEqual(backend.long_runs, ["frontend", "up-web"])
-        self.assertIn("-e STATIC_PRECOMPRESS=0", backend.long_scripts[0])
+        self.assertEqual(list(backend.long_runs), ["frontend", "up-web"])
+        self.assertIn("STATIC_PRECOMPRESS=0", backend.long_runs["frontend"])
         self.assertTrue(backend.health_waited)
         self.assertEqual(url, backend.web_url)
 

--- a/tools/hogbox-preview/tests/test_swap_frontend.py
+++ b/tools/hogbox-preview/tests/test_swap_frontend.py
@@ -43,6 +43,7 @@ class _RecordingBackend:
     def __init__(self):
         self.files: dict[str, bytes | str] = {}
         self.long_runs: list[str] = []
+        self.long_scripts: list[str] = []
         self.attached = False
         self.health_waited = False
 
@@ -61,6 +62,7 @@ class _RecordingBackend:
 
     def run_long(self, script, *, name, timeout: int = 1800, interval: int = 3) -> ExecResult:
         self.long_runs.append(name)
+        self.long_scripts.append(script)
         return ExecResult(0, "", "")
 
     def wait_http_ok(self, url_path, *, expect=200, timeout=600, interval=3) -> None:
@@ -104,6 +106,7 @@ class SwapFrontendOnlyTest(unittest.TestCase):
 
         # Ran the swap (collectstatic) then recreated web, then waited for health.
         self.assertEqual(backend.long_runs, ["frontend", "up-web"])
+        self.assertIn("-e STATIC_PRECOMPRESS=0", backend.long_scripts[0])
         self.assertTrue(backend.health_waited)
         self.assertEqual(url, backend.web_url)
 


### PR DESCRIPTION
## Problem

Engineers wait about three extra minutes while each Hogbox preview processes frontend static files.

| Path | Precompression | Time |
| --- | --- | ---: |
| [Hogbox frontend swap](https://github.com/PostHog/posthog/actions/runs/32982366372/job/98221976632) | On | 212.2s |
| [E2E `collectstatic`](https://github.com/PostHog/posthog/actions/runs/32979597148/job/98214100534) | On | 209.5s |
| [E2E `collectstatic`](https://github.com/PostHog/posthog/actions/runs/32980082748/job/98215663886) | Off | 26.3s |

The E2E comparison saves 183.3 seconds, or 87%. Hogbox currently spends the same time on this stage.

## Changes

- Hogbox previews skip Brotli and gzip generation while retaining hashed static filenames.
- Production builds keep precompression enabled.
- The swap test guards the preview-only setting.

Before:

```mermaid
flowchart LR
    A[Frontend archive] --> B[Hash static files]
    B --> C[Brotli and gzip]
    C --> D[Preview ready]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,B,C phBlue;
    class D phYellow;
```

After:

```mermaid
flowchart LR
    A[Frontend archive] --> B[Hash static files]
    B --> D[Preview ready]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,B phBlue;
    class D phYellow;
```

## How did you test this code?

- The Hogbox preview unit suite verifies that the swap command disables precompression.
- The linked E2E runs measure the same `collectstatic` setting with identical static file counts.
- Not verified: post-change Hogbox timing or response compression. The trusted deploy runs the tool from `master`, not this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The preview interface does not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented and measured this follow-up to #89300. Skills invoked: `/authoring-ci-workflows`, `/ci-actions-auditor`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/running-ci-preflight`, `/stacking-prs`, and `/wt`.
