### PR TITLE
fix(desktop): wait for the step set before showing an onboarding step

### DIFF
--- a/products/desktop/packages/core/src/onboarding/steps.test.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.test.ts
@@ -9,6 +9,7 @@ import {
   type OnboardingStep,
   previousStep,
   stepDirection,
+  stepGatesResolved,
 } from "./steps";
 
 type StepGates = Parameters<typeof computeActiveSteps>[0];
@@ -73,6 +74,39 @@ describe("computeActiveSteps", () => {
     expect(
       computeActiveSteps({ ...allSteps, consentRequired: false }),
     ).not.toContain("consent");
+  });
+});
+
+describe("stepGatesResolved", () => {
+  const resolved: StepGates = {
+    hasGithubIntegration: false,
+    cliReady: false,
+    projectCount: 2,
+    consentRequired: true,
+  };
+
+  it("holds until every gate has answered", () => {
+    expect(stepGatesResolved(resolved)).toBe(true);
+  });
+
+  it.each<keyof StepGates>([
+    "hasGithubIntegration",
+    "cliReady",
+    "projectCount",
+    "consentRequired",
+  ])("stays unresolved while %s is pending", (gate) => {
+    expect(stepGatesResolved({ ...resolved, [gate]: undefined })).toBe(false);
+  });
+
+  it("treats every falsy answer as an answer", () => {
+    expect(
+      stepGatesResolved({
+        hasGithubIntegration: false,
+        cliReady: false,
+        projectCount: 0,
+        consentRequired: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/products/desktop/packages/core/src/onboarding/steps.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.ts
@@ -21,7 +21,7 @@ export interface DetectedRepo {
   branch?: string;
 }
 
-export function computeActiveSteps(options: {
+export interface StepGates {
   /** Undefined while the integrations query is loading; the step only drops on a confirmed connection. */
   hasGithubIntegration: boolean | undefined;
   /** Undefined while the local git and gh checks are loading. */
@@ -29,7 +29,25 @@ export function computeActiveSteps(options: {
   /** Undefined until the project list has loaded, so a slow list cannot skip a real choice. */
   projectCount: number | undefined;
   consentRequired: boolean | undefined;
-}): OnboardingStep[] {
+}
+
+/**
+ * Whether every gate has an answer. An unresolved gate keeps its step in the
+ * active set, so until this returns true the step the user stands on is
+ * provisional and a resolving gate can still drop it. Analytics must wait for
+ * this, or a step nobody chose to leave is recorded as viewed and then
+ * abandoned. Add every new gate here as well as to `computeActiveSteps`.
+ */
+export function stepGatesResolved(gates: StepGates): boolean {
+  return (
+    gates.hasGithubIntegration !== undefined &&
+    gates.cliReady !== undefined &&
+    gates.projectCount !== undefined &&
+    gates.consentRequired !== undefined
+  );
+}
+
+export function computeActiveSteps(options: StepGates): OnboardingStep[] {
   return ONBOARDING_STEPS.filter((step) => {
     if (step === "project-select" && options.projectCount === 1) return false;
     if (step === "consent" && options.consentRequired === false) return false;

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -163,11 +163,10 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
   }, []);
 
   const viewedStepRef = useRef<OnboardingStep | null>(null);
-  // A step counts as viewed once its gates have answered and it survives in the
-  // active set. Two paths depend on that wait. A step recorded before the gates
-  // answer can still be dropped, which reports a view that no person can
-  // advance. A step entered by the self-heal in useOnboardingFlow has no other
-  // tracking path, which reports an advance with no matching view.
+  // Recorded on the same condition that renders a step, so the flow cannot show
+  // a step it did not record. A step entered by the self-heal in
+  // useOnboardingFlow reaches the person through here too, and has no other
+  // tracking path.
   useEffect(() => {
     if (!stepsResolved || currentIndex < 0) return;
     if (viewedStepRef.current === currentStep) return;
@@ -330,7 +329,16 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
   return (
     <FullScreenLayout footerRight={footerRight} onOpenSupport={onOpenSupport}>
       <AnimatePresence mode="wait" custom={direction}>
-        {currentStep === "project-select" && (
+        {!stepsResolved && (
+          <div
+            key="resolving-steps"
+            className="flex min-h-0 w-full flex-1 items-center justify-center"
+          >
+            <div className="size-5 animate-spin rounded-full border-(--gray-6) border-2 border-t-(--gray-11)" />
+          </div>
+        )}
+
+        {stepsResolved && currentStep === "project-select" && (
           <motion.div
             key="project-select"
             custom={direction}
@@ -345,7 +353,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
           </motion.div>
         )}
 
-        {currentStep === "consent" && (
+        {stepsResolved && currentStep === "consent" && (
           <motion.div
             key="consent"
             custom={direction}
@@ -365,7 +373,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
           </motion.div>
         )}
 
-        {currentStep === "connect-github" && (
+        {stepsResolved && currentStep === "connect-github" && (
           <motion.div
             key="connect-github"
             custom={direction}
@@ -380,7 +388,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
           </motion.div>
         )}
 
-        {currentStep === "install-cli" && (
+        {stepsResolved && currentStep === "install-cli" && (
           <motion.div
             key="install-cli"
             custom={direction}
@@ -395,7 +403,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
           </motion.div>
         )}
 
-        {currentStep === "select-repo" && (
+        {stepsResolved && currentStep === "select-repo" && (
           <motion.div
             key="select-repo"
             custom={direction}

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -28,6 +28,7 @@ import { ConnectGitHubStep } from "@posthog/ui/features/onboarding/components/Co
 import { InstallCliStep } from "@posthog/ui/features/onboarding/components/InstallCliStep";
 import { useOnboardingFlow } from "@posthog/ui/features/onboarding/hooks/useOnboardingFlow";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
+import type { OnboardingStep } from "@posthog/ui/features/onboarding/types";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { shipIt } from "@posthog/ui/primitives/confetti";
 import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
@@ -77,6 +78,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     hasGithubIntegration,
     consentSatisfied,
     consentRequirement,
+    stepsResolved,
   } = useOnboardingFlow();
   const completeOnboarding = useOnboardingStore(
     (state) => state.completeOnboarding,
@@ -156,15 +158,27 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
   const flowStartedAtRef = useRef(Date.now());
   const stepEnteredAtRef = useRef(Date.now());
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: fires once on mount; subsequent step views fire from handleNext/handleBack
   useEffect(() => {
     track(ANALYTICS_EVENTS.ONBOARDING_STARTED);
+  }, []);
+
+  const viewedStepRef = useRef<OnboardingStep | null>(null);
+  // A step counts as viewed once its gates have answered and it survives in the
+  // active set. Two paths depend on that wait. A step recorded before the gates
+  // answer can still be dropped, which reports a view that no person can
+  // advance. A step entered by the self-heal in useOnboardingFlow has no other
+  // tracking path, which reports an advance with no matching view.
+  useEffect(() => {
+    if (!stepsResolved || currentIndex < 0) return;
+    if (viewedStepRef.current === currentStep) return;
+    viewedStepRef.current = currentStep;
     track(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, {
       step_id: currentStep,
       step_index: currentIndex,
       total_steps: activeSteps.length,
     });
-  }, []);
+    stepEnteredAtRef.current = Date.now();
+  }, [stepsResolved, currentStep, currentIndex, activeSteps.length]);
 
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -195,17 +209,6 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     );
   };
 
-  const trackStepViewed = (stepIndex: number) => {
-    const stepId = activeSteps[stepIndex];
-    if (!stepId) return;
-    track(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, {
-      step_id: stepId,
-      step_index: stepIndex,
-      total_steps: activeSteps.length,
-    });
-    stepEnteredAtRef.current = Date.now();
-  };
-
   const handleNext = (context?: StepCompletedContext) => {
     if (
       currentStep === "consent" &&
@@ -218,13 +221,11 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     const safeContext =
       context && "nativeEvent" in context ? undefined : context;
     trackStepCompleted(safeContext);
-    trackStepViewed(currentIndex + 1);
     next();
   };
 
   const handleBack = () => {
     if (currentStep === "consent" && consentSubmitting) return;
-    trackStepViewed(currentIndex - 1);
     back();
   };
 

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -12,6 +12,7 @@ import {
   nearestActiveStep,
   type OnboardingStep,
   stepDirection,
+  stepGatesResolved,
 } from "@posthog/core/onboarding/steps";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -214,16 +215,17 @@ export function useOnboardingFlow() {
       ? consentRequirement
       : undefined;
 
-  const activeSteps = useMemo(
-    () =>
-      computeActiveSteps({
-        hasGithubIntegration,
-        cliReady,
-        projectCount,
-        consentRequired,
-      }),
+  const stepGates = useMemo(
+    () => ({
+      hasGithubIntegration,
+      cliReady,
+      projectCount,
+      consentRequired,
+    }),
     [hasGithubIntegration, cliReady, projectCount, consentRequired],
   );
+  const activeSteps = useMemo(() => computeActiveSteps(stepGates), [stepGates]);
+  const stepsResolved = stepGatesResolved(stepGates);
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {
@@ -261,6 +263,7 @@ export function useOnboardingFlow() {
     currentIndex,
     totalSteps: activeSteps.length,
     activeSteps,
+    stepsResolved,
     isFirstStep,
     isLastStep,
     direction: directionRef.current,

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -36,6 +36,9 @@ import {
 
 export type { DetectedRepo };
 
+/** How long the flow waits on a gate that neither answers nor fails. */
+const GATE_WAIT_MS = 2_500;
+
 export function useOnboardingFlow() {
   const hostClient = useHostTRPCClient();
   const { localWorkspaces } = useHostCapabilities();
@@ -135,18 +138,19 @@ export function useOnboardingFlow() {
     ],
   );
 
-  const { data: githubUserIntegrations } = useUserGithubIntegrations();
+  const { data: githubUserIntegrations, isPending: githubIntegrationsPending } =
+    useUserGithubIntegrations();
   // The install-cli step only offers git and gh, so a ready toolchain skips it.
   // InstallCliStep reuses these cached results when the step does render.
   const trpc = useHostTRPC();
   // Cloud-only hosts serve no git procedures, and the CLI step is moot there.
-  const { data: gitStatus } = useQuery(
+  const { data: gitStatus, isPending: gitStatusPending } = useQuery(
     trpc.git.getGitStatus.queryOptions(undefined, {
       staleTime: 30_000,
       enabled: localWorkspaces,
     }),
   );
-  const { data: ghStatus } = useQuery(
+  const { data: ghStatus, isPending: ghStatusPending } = useQuery(
     trpc.git.getGhStatus.queryOptions(undefined, {
       staleTime: 30_000,
       enabled: localWorkspaces,
@@ -161,14 +165,23 @@ export function useOnboardingFlow() {
       setCliReady(true);
       return;
     }
-    if (gitStatus === undefined || ghStatus === undefined) return;
+    if (gitStatusPending || ghStatusPending) return;
     setCliReady(
-      gitStatus.installed && ghStatus.installed && ghStatus.authenticated,
+      gitStatus?.installed === true &&
+        ghStatus?.installed === true &&
+        ghStatus?.authenticated === true,
     );
-  }, [cliReady, localWorkspaces, gitStatus, ghStatus]);
-  const hasGithubIntegration = githubUserIntegrations
-    ? githubUserIntegrations.length > 0
-    : undefined;
+  }, [
+    cliReady,
+    localWorkspaces,
+    gitStatus,
+    ghStatus,
+    gitStatusPending,
+    ghStatusPending,
+  ]);
+  const hasGithubIntegration = githubIntegrationsPending
+    ? undefined
+    : (githubUserIntegrations?.length ?? 0) > 0;
   // Counted off the store rather than through useProjects, whose auto-select
   // effect would then run in a second place and re-clear the query cache.
   const orgProjectsMap = useAuthStateValue((state) => state.orgProjectsMap);
@@ -206,10 +219,15 @@ export function useOnboardingFlow() {
     );
   }, [consent]);
 
+  // A failed lookup is an answer for step selection, because it can no longer
+  // drop the step. Every gate falls open on failure and keeps the step it
+  // governs, which is what an unresolved gate already did.
   const consentRequired =
-    consentRequirement?.organizationId === consent.organizationId
-      ? consentRequirement?.required
-      : undefined;
+    consent.status === "error"
+      ? true
+      : consentRequirement?.organizationId === consent.organizationId
+        ? consentRequirement?.required
+        : undefined;
   const sampledConsentRequirement =
     consentRequirement?.organizationId === consent.organizationId
       ? consentRequirement
@@ -225,7 +243,16 @@ export function useOnboardingFlow() {
     [hasGithubIntegration, cliReady, projectCount, consentRequired],
   );
   const activeSteps = useMemo(() => computeActiveSteps(stepGates), [stepGates]);
-  const stepsResolved = stepGatesResolved(stepGates);
+
+  // Every gate falls open on failure, so this normally settles on its own. The
+  // timer covers a lookup that neither answers nor fails, where holding the
+  // flow forever would be worse than showing a step a late gate can still drop.
+  const [gateWaitElapsed, setGateWaitElapsed] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setGateWaitElapsed(true), GATE_WAIT_MS);
+    return () => clearTimeout(timer);
+  }, []);
+  const stepsResolved = stepGatesResolved(stepGates) || gateWaitElapsed;
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {

--- a/products/desktop/packages/ui/src/features/onboarding/onboardingStore.test.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/onboardingStore.test.ts
@@ -2,14 +2,31 @@ import { describe, expect, it } from "vitest";
 import { migrateOnboardingState } from "./onboardingStore";
 
 describe("migrateOnboardingState", () => {
-  it("moves a persisted invite-code step forward", () => {
-    const migrated = migrateOnboardingState({
-      currentStep: "invite-code",
-      hasCompletedOnboarding: false,
-      hasShippedFirstPr: false,
-      selectedProjectId: 1,
-    });
+  const persisted = (currentStep: string) => ({
+    currentStep,
+    hasCompletedOnboarding: false,
+    hasShippedFirstPr: false,
+    selectedProjectId: 1,
+  });
 
-    expect(migrated.currentStep).toBe("consent");
+  it("moves a persisted invite-code step forward", () => {
+    expect(migrateOnboardingState(persisted("invite-code")).currentStep).toBe(
+      "consent",
+    );
+  });
+
+  it.each(["welcome", "import-config"])(
+    "resets the retired %s step to the start of the flow",
+    (step) => {
+      expect(migrateOnboardingState(persisted(step)).currentStep).toBe(
+        "project-select",
+      );
+    },
+  );
+
+  it("leaves a step of the current flow alone", () => {
+    expect(migrateOnboardingState(persisted("select-repo")).currentStep).toBe(
+      "select-repo",
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/onboarding/onboardingStore.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/onboardingStore.ts
@@ -1,4 +1,7 @@
-import type { OnboardingStep } from "@posthog/ui/features/onboarding/types";
+import {
+  ONBOARDING_STEPS,
+  type OnboardingStep,
+} from "@posthog/ui/features/onboarding/types";
 import { logger } from "@posthog/ui/shell/logger";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -37,6 +40,12 @@ export function migrateOnboardingState(
   if ((state.currentStep as string) === "invite-code") {
     return { ...state, currentStep: "consent" };
   }
+  // A step id from a retired set, for example "welcome", renders no branch in
+  // the flow, so it shows an empty card until the runtime self-heal moves the
+  // person off it. Reset any other unknown step to the start of the flow.
+  if (!ONBOARDING_STEPS.includes(state.currentStep)) {
+    return { ...state, currentStep: ONBOARDING_STEPS[0] };
+  }
   return state;
 }
 
@@ -61,7 +70,7 @@ export const useOnboardingStore = create<OnboardingStore>()(
     }),
     {
       name: "onboarding-store",
-      version: 1,
+      version: 2,
       migrate: migrateOnboardingState,
       partialize: (state) => ({
         currentStep: state.currentStep,


### PR DESCRIPTION
## Problem

Onboarding shows you the project picker before it knows whether you need it, then takes it away again. Anyone with one project gets a flash of a screen they never had to fill in.

- The flow renders the project picker on mount. Four lookups then decide the real step set: your project count, whether your org needs consent, whether GitHub is connected, and whether local `git` and `gh` are ready.
- A person with one project has that step dropped and is moved on, having seen it for a frame.
- The same flash corrupts the funnel. `project-select` records 439 people viewing and 122 advancing over 3 days for non-staff, against roughly 98% on every other step.
- `consent` records 110 viewing and 171 advancing, more completions than views, because a person moved into it by the self-heal arrives with no view event.
- A retired step id from an older build also reaches analytics through the same path, which is where [the report behind this PR](https://us.posthog.com/project/2/inbox/01a03ea8-f64e-79ee-9456-2df88a9ca881) started.

## Changes

- Onboarding now waits on a small spinner until it knows which steps you need, then shows the first real one. No screen appears and then disappears.
- A person who rehydrates onto a step retired in an older build lands on the start of the flow instead of an empty card.
- Step views are recorded on the same condition that renders a step, so the flow cannot show a step it did not record, and a step entered by the self-heal is recorded too.
- A failed lookup now counts as an answer and falls open, keeping the step it governs. This matches what an unresolved lookup already did for step selection, and it stops a dead query holding the flow open or silencing its events.
- A 2.5 second bounded wait covers a lookup that neither answers nor fails.
- `handleNext` previously recorded the next step's view before `next()` ran, which named the wrong step whenever the step set shifted in between. That path is gone.
- `stepGatesResolved` in `packages/core/src/onboarding/steps.ts` reports whether all four lookups have answered. Add every new one there as well as to `computeActiveSteps`.
- `migrateOnboardingState` resets an unknown persisted step, keeping the existing `invite-code` mapping ahead of it so a person mid-flow moves forward to `consent` rather than back. The store version goes to 2, because version 1 shipped alongside that mapping in 5d54be6 and a state already saved at version 1 never called `migrate`.
- The `computeActiveSteps` options object becomes a named `StepGates` type. Mechanical.

Supersedes [#89463](https://github.com/PostHog/posthog/pull/89463), now closed.

> [!NOTE]
> Step view counts change the day this ships. `project-select` views drop by roughly the number of people who hold one project. `consent` views rise to meet its completions. Treat pre-merge and post-merge funnel numbers as separate series.

## How did you test this code?

- Added `stepGatesResolved` cases to `packages/core/src/onboarding/steps.test.ts`. They catch a lookup added to `computeActiveSteps` and forgotten in `stepGatesResolved`, which would let a step render before its step set is known.
- Extended `packages/ui/src/features/onboarding/onboardingStore.test.ts` with a retired-step case and a current-step case. They catch a migration that drops the `invite-code` mapping, and one that resets a valid step.
- Extended both existing test files rather than adding new ones, since each behavior sits beside coverage that already existed.
- Ran the `@posthog/core` and `@posthog/ui` vitest suites locally.
- **Not covered by tests:** the fall-open behavior on a failed lookup, and the bounded wait. Both live in `useOnboardingFlow` and would need a component-level render with three mocked query sources, which is a poor trade at that level. Worth a reviewer's eye instead.
- **Not run:** the app itself. The spinner and the corrected counts are a prediction from the code paths, not something observed against a live client.
- Two pre-existing typecheck errors in `@posthog/core` come from stale `@posthog/shared` and `@posthog/agent` build output and appear on an unmodified tree as well.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The work started from a self-driving inbox report about a single retired `welcome` step id. Investigating why that report cleared the scout's bar surfaced the two funnel numbers above, which share one cause with it.

The branch first tried to fix this by making analytics wait for the step set while leaving the guessy render alone. Greptile's review found the flaw: a lookup that never answers would suppress every step view for that person while onboarding stayed usable, replacing one broken denominator with another. That pointed at the render being the actual defect, so the flow now waits instead of guessing, and recording on render is correct again.

The branch also carried the rehydration guard from #89463 after that PR was closed as superseded.

The funnel numbers in Problem come from queries against project 2 in this session. No customer data, session content, or internal material is quoted anywhere in this PR.
