### PR TITLE
feat(desktop): replace automatic report chat with actions

### DIFF
--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -75,10 +75,6 @@ export const CHANNEL_REPORTS_FLAG = "posthog-desktop-channel-reports";
  */
 export const REPORTS_INBOX_FLAG = "posthog-desktop-reports-inbox";
 
-/** Experiment: open the report chat panel when a report detail loads. */
-export const REPORT_CHAT_DEFAULT_OPEN_FLAG =
-  "posthog-desktop-report-chat-default-open";
-
 /**
  * One-report-at-a-time keyboard triage inside the reports inbox. On by
  * default in dev builds for iteration (see useTriageFocusEnabled); off in

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
 vi.mock("@posthog/ui/features/inbox/hooks/useReportTasks", () => ({
   findContinuableImplementationTask,
   findLatestDiscussionTask: () => null,
+  findPendingStartedTaskId: () => null,
   useReportTasks,
 }));
 
@@ -54,14 +55,29 @@ vi.mock("@posthog/ui/features/sessions/components/EmbeddedSessionView", () => ({
 
 import { ReportChatSidebar } from "./ReportChatSidebar";
 
-const report = {
+const report: SignalReport = {
   id: "report-1",
   title: "Some report",
+  summary: "A report summary",
   status: "ready",
+  total_weight: 1,
+  signal_count: 1,
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+  artefact_count: 1,
   implementation_pr_url: null,
-} as SignalReport;
+};
 
-const task = { id: "task-1" } as Task;
+const task: Task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Discuss report",
+  description: "",
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+  origin_product: "signals",
+};
 
 const suggestionLabels = [
   "Fix this issue",

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.test.tsx
@@ -1,0 +1,107 @@
+import type { SignalReport, Task } from "@posthog/shared/types";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findContinuableImplementationTask, useQuery, useReportTasks } =
+  vi.hoisted(() => ({
+    findContinuableImplementationTask: vi.fn(),
+    useQuery: vi.fn(),
+    useReportTasks: vi.fn(),
+  }));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery,
+    useQueryClient: () => ({
+      setQueryData: vi.fn(),
+      invalidateQueries: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@posthog/ui/features/inbox/hooks/useReportTasks", () => ({
+  findContinuableImplementationTask,
+  findLatestDiscussionTask: () => null,
+  useReportTasks,
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
+  useTaskChannels: () => ({ generalChannel: null }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useDiscussReport", () => ({
+  useDiscussReport: () => ({ discussReport: vi.fn(), isDiscussing: false }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
+  useReportActionTracker: () => vi.fn(),
+}));
+
+vi.mock("@posthog/ui/router/useOpenTask", () => ({
+  useOpenTask: () => vi.fn(),
+}));
+
+vi.mock("@posthog/ui/primitives/ResizableSidebar", () => ({
+  ResizableSidebar: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@posthog/ui/features/sessions/components/EmbeddedSessionView", () => ({
+  EmbeddedSessionView: () => <div>Existing conversation</div>,
+}));
+
+import { ReportChatSidebar } from "./ReportChatSidebar";
+
+const report = {
+  id: "report-1",
+  title: "Some report",
+  status: "ready",
+  implementation_pr_url: null,
+} as SignalReport;
+
+const task = { id: "task-1" } as Task;
+
+const suggestionLabels = [
+  "Fix this issue",
+  "Investigate further",
+  "Visualize in a Canvas",
+  "Continue the fix",
+  "Continue the analysis",
+];
+
+describe("ReportChatSidebar", () => {
+  beforeEach(() => {
+    findContinuableImplementationTask.mockReturnValue(null);
+    useQuery.mockReturnValue({ data: null });
+    useReportTasks.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it("starts with only report context and a question composer", () => {
+    render(<ReportChatSidebar report={report} />);
+
+    expect(
+      screen.getByLabelText("Question about this report"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/full report and its evidence already in context/),
+    ).toBeInTheDocument();
+    for (const label of suggestionLabels) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+
+  it("does not add report action suggestions below an existing conversation", () => {
+    findContinuableImplementationTask.mockReturnValue(task);
+    useQuery.mockReturnValue({ data: task });
+    useReportTasks.mockReturnValue({ data: [task], isLoading: false });
+
+    render(<ReportChatSidebar report={report} />);
+
+    expect(screen.getByText("Existing conversation")).toBeInTheDocument();
+    for (const label of suggestionLabels) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -1,10 +1,6 @@
 import {
   ArrowsOutSimpleIcon,
   ChatCircleIcon,
-  GitPullRequestIcon,
-  MagnifyingGlassIcon,
-  ShapesIcon,
-  WrenchIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import {
@@ -150,29 +146,6 @@ function ReportChatConversation({
   const { insertPendingContent, getDraft, requestFocus } = useDraftStore(
     (s) => s.actions,
   );
-  const [sendingPrompt, setSendingPrompt] = useState<string | null>(null);
-  const workPrompt = report.implementation_pr_url
-    ? "Continue working on this report and its existing pull request. Re-read the analysis and take the next concrete step toward resolving it."
-    : "Continue investigating this report. Analyze the evidence and take the next concrete step.";
-  const workLabel = report.implementation_pr_url
-    ? "Continue the fix"
-    : "Continue the analysis";
-  const canvasPrompt =
-    "Create a canvas that visualizes this report using its evidence and relevant live data.";
-
-  const sendSuggestedPrompt = useCallback(
-    async (prompt: string, sendPrompt: (text: string) => Promise<boolean>) => {
-      if (sendingPrompt) return;
-      setSendingPrompt(prompt);
-      try {
-        await sendPrompt(prompt);
-      } finally {
-        setSendingPrompt(null);
-      }
-    },
-    [sendingPrompt],
-  );
-
   // A highlighted passage is appended into the session composer, after anything
   // already typed rather than replacing it. Inserting (rather than rewriting the
   // draft) keeps chips and file attachments the user already added, and reaches
@@ -203,37 +176,7 @@ function ReportChatConversation({
     );
   }
 
-  return (
-    <EmbeddedSessionView
-      task={task}
-      threadActions={({ sendPrompt, isPromptPending }) => (
-        <div className="flex items-center gap-2 border-border border-t px-3 py-3">
-          <Button
-            type="button"
-            variant="primary"
-            className="h-9 flex-1 rounded-lg px-4 text-[13px]"
-            loading={sendingPrompt === workPrompt}
-            disabled={isPromptPending || sendingPrompt !== null}
-            onClick={() => void sendSuggestedPrompt(workPrompt, sendPrompt)}
-          >
-            <GitPullRequestIcon size={15} />
-            {workLabel}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            className="h-9 flex-1 rounded-lg px-4 text-[13px]"
-            loading={sendingPrompt === canvasPrompt}
-            disabled={isPromptPending || sendingPrompt !== null}
-            onClick={() => void sendSuggestedPrompt(canvasPrompt, sendPrompt)}
-          >
-            <ShapesIcon size={15} />
-            Visualize in a Canvas
-          </Button>
-        </div>
-      )}
-    />
-  );
+  return <EmbeddedSessionView task={task} />;
 }
 
 // The report has no conversation yet: one question starts it, with the full
@@ -303,42 +246,6 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
     void discussReport(trimmed);
   }, [starterDraft, isDiscussing, discussReport, fireAction]);
 
-  // Canned starter prompts go through the same privacy-safe path as submit:
-  // the analytics event records that a question was asked, never its text.
-  const ask = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed || isDiscussing) return;
-      fireAction("discuss", { has_question: true });
-      void discussReport(trimmed);
-    },
-    [isDiscussing, discussReport, fireAction],
-  );
-
-  const starterPrompts = [
-    {
-      label: "Fix this issue",
-      prompt:
-        "Fix the issue in this report. Investigate the root cause, implement the fix, and open a pull request.",
-      Icon: WrenchIcon,
-      variant: "primary" as const,
-    },
-    {
-      label: "Investigate further",
-      prompt:
-        "Continue investigating this report. Analyze the evidence and explain the most useful next step.",
-      Icon: MagnifyingGlassIcon,
-      variant: "outline" as const,
-    },
-    {
-      label: "Visualize in a Canvas",
-      prompt:
-        "Create a canvas that visualizes this report using its evidence and relevant live data.",
-      Icon: ShapesIcon,
-      variant: "outline" as const,
-    },
-  ];
-
   return (
     <div className="flex h-full flex-col justify-between gap-3 p-3">
       <div className="flex flex-col gap-1 pt-1">
@@ -346,24 +253,6 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
           The agent joins with the full report and its evidence already in
           context. Highlight any part of the report to quote it here.
         </span>
-        <div className="mt-2 grid gap-2">
-          {starterPrompts.map(({ label, prompt, Icon, variant }) => (
-            <Button
-              key={label}
-              type="button"
-              variant={variant}
-              className="h-10 justify-start rounded-lg px-4 text-[13px]"
-              // Once the composer holds a typed draft or a quoted passage, the
-              // one-click chips step aside — firing a chip must not silently
-              // discard what the user wrote or highlighted.
-              disabled={isDiscussing || starterDraft.trim().length > 0}
-              onClick={() => ask(prompt)}
-            >
-              <Icon size={16} />
-              {label}
-            </Button>
-          ))}
-        </div>
       </div>
       <form
         className="flex flex-col gap-2"
@@ -394,9 +283,9 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
             type="submit"
             variant="primary"
             size="sm"
-            disabled={!starterDraft.trim() || isDiscussing}
+            loading={isDiscussing}
+            disabled={!starterDraft.trim()}
           >
-            {isDiscussing && <Spinner />}
             Start chat
           </Button>
         </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -15,6 +15,7 @@ import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useRepo
 import {
   findContinuableImplementationTask,
   findLatestDiscussionTask,
+  findPendingStartedTaskId,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
@@ -54,13 +55,13 @@ export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
   // The durable association arrives via the report's task_run artefacts; a
   // task started seconds ago is bridged by the store until it does. The session
   // bridge wins so a newly started canvas, fix, or discussion takes the dock
-  // over immediately.
+  // over immediately, then expires once the durable association arrives.
   const { data: reportTasks, isLoading: tasksLoading } = useReportTasks(
     report.id,
     report.status,
   );
   const taskId =
-    startedTaskId ??
+    findPendingStartedTaskId(reportTasks, startedTaskId) ??
     findContinuableImplementationTask(reportTasks)?.id ??
     findLatestDiscussionTask(reportTasks)?.id ??
     null;

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
@@ -1,4 +1,5 @@
 import type { SignalReport, Task } from "@posthog/shared/types";
+import type { ReportTaskData } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -19,17 +20,35 @@ vi.mock(
 
 import { ReportChatToggle } from "./ReportChatToggle";
 
-const report = {
+const report: SignalReport = {
   id: "report-1",
+  title: "Some report",
+  summary: "A report summary",
   status: "ready",
-} as SignalReport;
+  total_weight: 1,
+  signal_count: 1,
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+  artefact_count: 1,
+};
+
+const task: Task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Discuss report",
+  description: "",
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+  origin_product: "signals",
+};
 
 const discussionTask = {
-  task: { id: "task-1" } as Task,
+  task,
   purpose: "discussion",
   purposeLabel: "Discussion",
   startedAt: "2026-08-26T00:00:00.000Z",
-};
+} satisfies ReportTaskData;
 
 describe("ReportChatToggle", () => {
   beforeEach(() => {
@@ -47,14 +66,10 @@ describe("ReportChatToggle", () => {
     const openButton = screen.getByLabelText("Open existing chat");
     expect(
       openButton.querySelector('[data-slot="conversation-indicator"]'),
-    ).toHaveClass("absolute", "-top-1", "-right-1", "bg-(--blue-9)");
-    expect(openButton.querySelector('[data-slot="chat-icon"]')).toHaveClass(
-      "absolute",
-      "inset-0",
-      "items-center",
-      "justify-center",
-    );
-    expect(openButton.querySelector('[data-slot="dot"]')).toBeNull();
+    ).toBeInTheDocument();
+    expect(
+      openButton.querySelector('[data-slot="chat-icon"]'),
+    ).toBeInTheDocument();
     expect(openButton).not.toHaveTextContent("Chat");
     expect(openButton).toHaveAttribute("aria-pressed", "false");
 

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
@@ -45,7 +45,11 @@ describe("ReportChatToggle", () => {
     render(<ReportChatToggle report={report} />);
 
     const openButton = screen.getByLabelText("Open existing chat");
-    expect(openButton.querySelector('[data-slot="dot"]')).not.toBeNull();
+    expect(openButton.querySelector('[data-slot="dot"]')).toHaveClass(
+      "absolute",
+      "-top-1",
+      "-right-1",
+    );
     expect(openButton).not.toHaveTextContent("Chat");
     expect(openButton).toHaveAttribute("aria-pressed", "false");
 

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
@@ -44,16 +44,16 @@ describe("ReportChatToggle", () => {
     const user = userEvent.setup();
     render(<ReportChatToggle report={report} />);
 
-    const openButton = screen.getByLabelText(
-      "Open chat (existing conversation)",
-    );
+    const openButton = screen.getByLabelText("Open existing chat");
     expect(openButton.querySelector('[data-slot="dot"]')).not.toBeNull();
+    expect(openButton).not.toHaveTextContent("Chat");
     expect(openButton).toHaveAttribute("aria-pressed", "false");
 
     await user.click(openButton);
 
-    expect(
-      screen.getByLabelText("Close chat (existing conversation)"),
-    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Close chat")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
@@ -45,11 +45,16 @@ describe("ReportChatToggle", () => {
     render(<ReportChatToggle report={report} />);
 
     const openButton = screen.getByLabelText("Open existing chat");
-    expect(openButton.querySelector('[data-slot="dot"]')).toHaveClass(
+    expect(
+      openButton.querySelector('[data-slot="conversation-indicator"]'),
+    ).toHaveClass("absolute", "-top-1", "-right-1", "bg-(--blue-9)");
+    expect(openButton.querySelector('[data-slot="chat-icon"]')).toHaveClass(
       "absolute",
-      "-top-1",
-      "-right-1",
+      "inset-0",
+      "items-center",
+      "justify-center",
     );
+    expect(openButton.querySelector('[data-slot="dot"]')).toBeNull();
     expect(openButton).not.toHaveTextContent("Chat");
     expect(openButton).toHaveAttribute("aria-pressed", "false");
 

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.test.tsx
@@ -1,0 +1,59 @@
+import type { SignalReport, Task } from "@posthog/shared/types";
+import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useReportTasks } = vi.hoisted(() => ({ useReportTasks: vi.fn() }));
+
+vi.mock(
+  "@posthog/ui/features/inbox/hooks/useReportTasks",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@posthog/ui/features/inbox/hooks/useReportTasks")
+      >();
+    return { ...actual, useReportTasks };
+  },
+);
+
+import { ReportChatToggle } from "./ReportChatToggle";
+
+const report = {
+  id: "report-1",
+  status: "ready",
+} as SignalReport;
+
+const discussionTask = {
+  task: { id: "task-1" } as Task,
+  purpose: "discussion",
+  purposeLabel: "Discussion",
+  startedAt: "2026-08-26T00:00:00.000Z",
+};
+
+describe("ReportChatToggle", () => {
+  beforeEach(() => {
+    useReportChatPanelStore.setState({
+      open: false,
+      startedTaskIdByReport: {},
+    });
+    useReportTasks.mockReturnValue({ data: [discussionTask] });
+  });
+
+  it("toggles chat and marks a report with an existing conversation", async () => {
+    const user = userEvent.setup();
+    render(<ReportChatToggle report={report} />);
+
+    const openButton = screen.getByLabelText(
+      "Open chat (existing conversation)",
+    );
+    expect(openButton.querySelector('[data-slot="dot"]')).not.toBeNull();
+    expect(openButton).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(openButton);
+
+    expect(
+      screen.getByLabelText("Close chat (existing conversation)"),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -14,8 +14,6 @@ import {
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 
-const HEADER_ACTION_CLASS = "h-7 gap-1.5 px-2.5 text-[12px]";
-
 export function ReportChatToggle({ report }: { report: SignalReport }) {
   const chatOpen = useReportChatPanelStore((state) => state.open);
   const setChatOpen = useReportChatPanelStore((state) => state.setOpen);
@@ -27,10 +25,11 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
     startedTaskId !== null ||
     findContinuableImplementationTask(reportTasks) !== null ||
     findLatestDiscussionTask(reportTasks) !== null;
-  const actionLabel = chatOpen ? "Close chat" : "Open chat";
-  const accessibleLabel = hasConversation
-    ? `${actionLabel} (existing conversation)`
-    : actionLabel;
+  const actionLabel = chatOpen
+    ? "Close chat"
+    : hasConversation
+      ? "Open existing chat"
+      : "Open chat";
 
   return (
     <Tooltip>
@@ -39,20 +38,25 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
           <Button
             type="button"
             variant={chatOpen ? "primary" : "outline"}
-            size="xs"
-            className={HEADER_ACTION_CLASS}
-            aria-label={accessibleLabel}
+            size="icon-xs"
+            className="relative h-7 w-7"
+            aria-label={actionLabel}
             aria-pressed={chatOpen}
             data-attr="report-chat-toggle"
             onClick={() => setChatOpen(!chatOpen)}
           />
         }
       >
-        <ChatCircleIcon />
-        Chat
-        {hasConversation && <Dot variant="info" />}
+        <ChatCircleIcon size={14} />
+        {hasConversation && (
+          <Dot
+            aria-hidden
+            variant="info"
+            className="-top-0.5 -right-0.5 absolute"
+          />
+        )}
       </TooltipTrigger>
-      <TooltipContent side="bottom">{accessibleLabel}</TooltipContent>
+      <TooltipContent side="bottom">{actionLabel}</TooltipContent>
     </Tooltip>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -43,6 +43,7 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
             className={HEADER_ACTION_CLASS}
             aria-label={accessibleLabel}
             aria-pressed={chatOpen}
+            data-attr="report-chat-toggle"
             onClick={() => setChatOpen(!chatOpen)}
           />
         }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -46,12 +46,18 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
           />
         }
       >
-        <ChatCircleIcon size={14} />
+        <span
+          aria-hidden
+          data-slot="chat-icon"
+          className="absolute inset-0 flex items-center justify-center"
+        >
+          <ChatCircleIcon size={14} />
+        </span>
         {hasConversation && (
           <span
             aria-hidden
-            data-slot="dot"
-            className="-top-1 -right-1 absolute size-2 rounded-full bg-primary ring-2 ring-chrome"
+            data-slot="conversation-indicator"
+            className="-top-1 -right-1 absolute size-2 rounded-full bg-(--blue-9) ring-2 ring-chrome"
           />
         )}
       </TooltipTrigger>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -1,7 +1,6 @@
 import { ChatCircleIcon } from "@phosphor-icons/react";
 import {
   Button,
-  Dot,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -49,10 +48,10 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
       >
         <ChatCircleIcon size={14} />
         {hasConversation && (
-          <Dot
+          <span
             aria-hidden
-            variant="info"
-            className="-top-0.5 -right-0.5 absolute"
+            data-slot="dot"
+            className="-top-1 -right-1 absolute size-2 rounded-full bg-primary ring-2 ring-chrome"
           />
         )}
       </TooltipTrigger>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -9,6 +9,7 @@ import type { SignalReport } from "@posthog/shared/types";
 import {
   findContinuableImplementationTask,
   findLatestDiscussionTask,
+  findPendingStartedTaskId,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
@@ -21,7 +22,7 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
   );
   const { data: reportTasks } = useReportTasks(report.id, report.status);
   const hasConversation =
-    startedTaskId !== null ||
+    findPendingStartedTaskId(reportTasks, startedTaskId) !== null ||
     findContinuableImplementationTask(reportTasks) !== null ||
     findLatestDiscussionTask(reportTasks) !== null;
   const actionLabel = chatOpen

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -1,0 +1,57 @@
+import { ChatCircleIcon } from "@phosphor-icons/react";
+import {
+  Button,
+  Dot,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import {
+  findContinuableImplementationTask,
+  findLatestDiscussionTask,
+  useReportTasks,
+} from "@posthog/ui/features/inbox/hooks/useReportTasks";
+import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+
+const HEADER_ACTION_CLASS = "h-7 gap-1.5 px-2.5 text-[12px]";
+
+export function ReportChatToggle({ report }: { report: SignalReport }) {
+  const chatOpen = useReportChatPanelStore((state) => state.open);
+  const setChatOpen = useReportChatPanelStore((state) => state.setOpen);
+  const startedTaskId = useReportChatPanelStore(
+    (state) => state.startedTaskIdByReport[report.id] ?? null,
+  );
+  const { data: reportTasks } = useReportTasks(report.id, report.status);
+  const hasConversation =
+    startedTaskId !== null ||
+    findContinuableImplementationTask(reportTasks) !== null ||
+    findLatestDiscussionTask(reportTasks) !== null;
+  const actionLabel = chatOpen ? "Close chat" : "Open chat";
+  const accessibleLabel = hasConversation
+    ? `${actionLabel} (existing conversation)`
+    : actionLabel;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant={chatOpen ? "primary" : "outline"}
+            size="xs"
+            className={HEADER_ACTION_CLASS}
+            aria-label={accessibleLabel}
+            aria-pressed={chatOpen}
+            onClick={() => setChatOpen(!chatOpen)}
+          />
+        }
+      >
+        <ChatCircleIcon />
+        Chat
+        {hasConversation && <Dot variant="info" />}
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{accessibleLabel}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -99,7 +99,13 @@ function ReportDetailContent({
           primaryAction={
             <ReportDetailActions report={report} placement="header" />
           }
-          aboveSummary={<ReportVerdictBanner report={report} />}
+          aboveSummary={
+            <ReportVerdictBanner
+              key={report.id}
+              report={report}
+              initialEngagementOnly
+            />
+          }
           summarySection={{ Icon: FileTextIcon, title: "Summary" }}
           footer={<ReportFeedbackFooter report={report} />}
           evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -1,7 +1,5 @@
 import { FileTextIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
-import { REPORT_CHAT_DEFAULT_OPEN_FLAG } from "@posthog/shared";
 import type { SignalReport } from "@posthog/shared/types";
-import { useFeatureFlagVariant } from "@posthog/ui/features/feature-flags/useFeatureFlagVariant";
 import {
   AskAboutSelection,
   quoteSelection,
@@ -11,6 +9,7 @@ import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDet
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
+import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -73,15 +72,13 @@ function ReportDetailContent({
   const chatOpen = useReportChatPanelStore((s) => s.open);
   const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
   const setPendingQuote = useReportChatPanelStore((s) => s.setPendingQuote);
-  const defaultOpenVariant = useFeatureFlagVariant(
-    REPORT_CHAT_DEFAULT_OPEN_FLAG,
-  );
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: each report should start in its assigned default state rather than inherit the previous report's panel state.
+  // Each report opens as a document. Conversation remains explicit through the action box.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the route changes to another report.
   useEffect(() => {
-    setChatOpen(defaultOpenVariant !== "control");
-  }, [defaultOpenVariant, report.id, setChatOpen]);
+    setChatOpen(false);
+  }, [report.id, setChatOpen]);
 
   const handleAsk = useCallback(
     (text: string) => {
@@ -102,6 +99,7 @@ function ReportDetailContent({
           primaryAction={
             <ReportDetailActions report={report} placement="header" />
           }
+          aboveSummary={<ReportVerdictBanner report={report} />}
           summarySection={{ Icon: FileTextIcon, title: "Summary" }}
           footer={<ReportFeedbackFooter report={report} />}
           evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -26,6 +26,7 @@ import type { SignalReport } from "@posthog/shared/types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/useChannelReportsEnabled";
 import { RefundReportDialog } from "@posthog/ui/features/inbox/components/RefundReportDialog";
+import { ReportChatToggle } from "@posthog/ui/features/inbox/components/ReportChatToggle";
 import { useCreateCanvasReport } from "@posthog/ui/features/inbox/hooks/useCreateCanvasReport";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useRefundReport } from "@posthog/ui/features/inbox/hooks/useRefundReport";
@@ -194,6 +195,7 @@ export function ReportDetailActions({
     return (
       <>
         {githubButton}
+        <ReportChatToggle report={report} />
         {canDefer && (
           <Tooltip>
             <TooltipTrigger

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowSquareOutIcon,
-  ChatCircleIcon,
   ClockIcon,
   CopyIcon,
   DotsThreeIcon,
@@ -63,7 +62,6 @@ export function ReportDetailActions({
 
   const fireAction = useReportActionTracker(report);
   const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
-  const chatOpen = useReportChatPanelStore((s) => s.open);
 
   // Canvases started from a report file into the report's space, or #general
   // when the report has none — a task without a channel shows in no space's
@@ -196,18 +194,6 @@ export function ReportDetailActions({
     return (
       <>
         {githubButton}
-        {!chatOpen && (
-          <Button
-            type="button"
-            variant="primary"
-            size="xs"
-            className={HEADER_ACTION_CLASS}
-            onClick={() => setChatOpen(true)}
-          >
-            <ChatCircleIcon size={14} />
-            Chat with this report
-          </Button>
-        )}
         {canDefer && (
           <Tooltip>
             <TooltipTrigger

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -1,0 +1,95 @@
+import type { SignalReport, Task } from "@posthog/shared/types";
+import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useReportTasks } = vi.hoisted(() => ({ useReportTasks: vi.fn() }));
+
+vi.mock(
+  "@posthog/ui/features/inbox/hooks/useReportTasks",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@posthog/ui/features/inbox/hooks/useReportTasks")
+      >();
+    return { ...actual, useReportTasks };
+  },
+);
+
+vi.mock("@posthog/ui/features/inbox/hooks/useCreatePrReport", () => ({
+  useCreatePrReport: () => ({ createPrReport: vi.fn(), isCreatingPr: false }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxBulkActions", () => ({
+  useInboxBulkActions: () => ({
+    isSnoozing: false,
+    snoozeDisabledReason: null,
+    snoozeSelected: vi.fn(),
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReportDismissAction", () => ({
+  useInboxReportDismissAction: () => ({
+    dialog: null,
+    openDialog: vi.fn(),
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
+  useInboxReportArtefacts: () => ({ data: { results: [] } }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
+  useReportActionTracker: () => vi.fn(),
+}));
+
+import { ReportVerdictBanner } from "./ReportVerdictBanner";
+
+const report = {
+  id: "report-1",
+  status: "ready",
+  actionability: "not_actionable",
+  implementation_pr_url: null,
+  implementation_pr_merged: false,
+} as SignalReport;
+
+const discussionTask = {
+  task: { id: "task-1" } as Task,
+  purpose: "discussion",
+  purposeLabel: "Discussion",
+  startedAt: "2026-08-26T00:00:00.000Z",
+};
+
+describe("ReportVerdictBanner", () => {
+  beforeEach(() => {
+    useReportChatPanelStore.setState({
+      open: false,
+      startedTaskIdByReport: {},
+    });
+    useReportTasks.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it("hides the non-selectable detail actions after engagement", async () => {
+    const user = userEvent.setup();
+    render(<ReportVerdictBanner report={report} initialEngagementOnly />);
+
+    const askButton = screen.getByText("Ask about it");
+    expect(askButton.closest(".select-none")).not.toBeNull();
+
+    await user.click(askButton);
+
+    expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
+  });
+
+  it("stays hidden when the report already has a discussion", () => {
+    useReportTasks.mockReturnValue({
+      data: [discussionTask],
+      isLoading: false,
+    });
+
+    render(<ReportVerdictBanner report={report} initialEngagementOnly />);
+
+    expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -1,10 +1,30 @@
 import type { SignalReport, Task } from "@posthog/shared/types";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useReportTasks } = vi.hoisted(() => ({ useReportTasks: vi.fn() }));
+const {
+  discussReport,
+  invalidateQueries,
+  setQueryData,
+  useDiscussReport,
+  useReportTasks,
+} = vi.hoisted(() => ({
+  discussReport: vi.fn(),
+  invalidateQueries: vi.fn(),
+  setQueryData: vi.fn(),
+  useDiscussReport: vi.fn(),
+  useReportTasks: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries, setQueryData }),
+  };
+});
 
 vi.mock(
   "@posthog/ui/features/inbox/hooks/useReportTasks",
@@ -19,6 +39,17 @@ vi.mock(
 
 vi.mock("@posthog/ui/features/inbox/hooks/useCreatePrReport", () => ({
   useCreatePrReport: () => ({ createPrReport: vi.fn(), isCreatingPr: false }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useDiscussReport", () => ({
+  useDiscussReport,
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
+  useTaskChannels: () => ({
+    generalChannel: { id: "general-channel" },
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@posthog/ui/features/inbox/hooks/useInboxBulkActions", () => ({
@@ -62,15 +93,28 @@ const discussionTask = {
 };
 
 describe("ReportVerdictBanner", () => {
+  let onDiscussionCreated: ((task: Task) => void) | undefined;
+
   beforeEach(() => {
     useReportChatPanelStore.setState({
       open: false,
       startedTaskIdByReport: {},
     });
     useReportTasks.mockReturnValue({ data: [], isLoading: false });
+    discussReport.mockReset();
+    discussReport.mockResolvedValue(undefined);
+    invalidateQueries.mockReset();
+    setQueryData.mockReset();
+    onDiscussionCreated = undefined;
+    useDiscussReport.mockImplementation(
+      (options: { onTaskCreated?: (task: Task) => void }) => {
+        onDiscussionCreated = options.onTaskCreated;
+        return { discussReport, isDiscussing: false };
+      },
+    );
   });
 
-  it("hides the non-selectable detail actions after engagement", async () => {
+  it("starts a discussion and hides the non-selectable actions after creation", async () => {
     const user = userEvent.setup();
     render(<ReportVerdictBanner report={report} initialEngagementOnly />);
 
@@ -79,7 +123,16 @@ describe("ReportVerdictBanner", () => {
 
     await user.click(askButton);
 
+    expect(discussReport).toHaveBeenCalledWith();
+    expect(screen.getByText("Ask about it")).toBeInTheDocument();
+
+    act(() => onDiscussionCreated?.(discussionTask.task));
+
     expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
+    expect(setQueryData).toHaveBeenCalled();
+    expect(
+      useReportChatPanelStore.getState().startedTaskIdByReport[report.id],
+    ).toBe(discussionTask.task.id);
   });
 
   it("stays hidden when the report already has a discussion", () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -1,4 +1,5 @@
 import type { SignalReport, Task } from "@posthog/shared/types";
+import type { ReportTaskData } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -77,20 +78,38 @@ vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
 
 import { ReportVerdictBanner } from "./ReportVerdictBanner";
 
-const report = {
+const report: SignalReport = {
   id: "report-1",
+  title: "Some report",
+  summary: "A report summary",
   status: "ready",
+  total_weight: 1,
+  signal_count: 1,
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+  artefact_count: 1,
   actionability: "not_actionable",
   implementation_pr_url: null,
   implementation_pr_merged: false,
-} as SignalReport;
+};
+
+const task: Task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Discuss report",
+  description: "",
+  created_at: "2026-08-26T00:00:00.000Z",
+  updated_at: "2026-08-26T00:00:00.000Z",
+  origin_product: "signals",
+};
 
 const discussionTask = {
-  task: { id: "task-1" } as Task,
+  task,
   purpose: "discussion",
   purposeLabel: "Discussion",
   startedAt: "2026-08-26T00:00:00.000Z",
-};
+} satisfies ReportTaskData;
 
 describe("ReportVerdictBanner", () => {
   let onDiscussionCreated: ((task: Task) => void) | undefined;

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -35,6 +35,7 @@ import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useRepo
 import {
   findContinuableImplementationTask,
   findLatestDiscussionTask,
+  findPendingStartedTaskId,
   getTaskPrUrl,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
@@ -127,7 +128,7 @@ export function ReportVerdictBanner({
     (state) => state.startedTaskIdByReport[report.id] ?? null,
   );
   const hasPriorEngagement =
-    startedTaskId !== null ||
+    findPendingStartedTaskId(reportTasks, startedTaskId) !== null ||
     hasExistingPr ||
     findLatestDiscussionTask(reportTasks) !== null;
 
@@ -399,7 +400,9 @@ export function ReportVerdictBanner({
         type="button"
         variant="outline"
         loading={isDiscussing}
-        disabled={isCreatingPr || awaitingChannel || reportTasksLoading}
+        disabled={
+          isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading
+        }
         onClick={handleAsk}
         className={buttonClass}
       >

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -24,8 +24,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
-import type { SignalReport } from "@posthog/shared/types";
+import type { SignalReport, Task } from "@posthog/shared/types";
+import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
+import { useDiscussReport } from "@posthog/ui/features/inbox/hooks/useDiscussReport";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
@@ -37,7 +39,9 @@ import {
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const isMac =
@@ -130,12 +134,30 @@ export function ReportVerdictBanner({
   const verdict = deriveReportVerdict(report, { hasExistingPr });
 
   const fireAction = useReportActionTracker(report);
+  const queryClient = useQueryClient();
 
   const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
   const rememberStartedTask = useReportChatPanelStore(
     (s) => s.rememberStartedTask,
   );
   const [engaged, setEngaged] = useState(false);
+  const { generalChannel, isLoading: channelsLoading } = useTaskChannels();
+  const taskChannelId = report.channel_id ?? generalChannel?.id ?? null;
+  const awaitingChannel = taskChannelId === null && channelsLoading;
+
+  const handleTaskCreated = useCallback(
+    (task: Task) => {
+      queryClient.setQueryData(taskDetailQuery(task.id).queryKey, task);
+      rememberStartedTask(report.id, task.id);
+      setEngaged(true);
+      setChatOpen(true);
+      void queryClient.invalidateQueries({
+        queryKey: ["inbox", "report-tasks", report.id],
+      });
+      onEngaged?.();
+    },
+    [queryClient, rememberStartedTask, report.id, setChatOpen, onEngaged],
+  );
 
   const { createPrReport, isCreatingPr } = useCreatePrReport({
     reportId: report.id,
@@ -145,12 +167,13 @@ export function ReportVerdictBanner({
     // the view advance. A failed create (offline, missing repo/integration/
     // model, API error) never reaches here, so the report and its actions stay
     // put instead of opening an empty dock or, in triage, navigating away.
-    onTaskCreated: (task) => {
-      rememberStartedTask(report.id, task.id);
-      setEngaged(true);
-      setChatOpen(true);
-      onEngaged?.();
-    },
+    onTaskCreated: handleTaskCreated,
+  });
+  const { discussReport, isDiscussing } = useDiscussReport({
+    report,
+    channelId: taskChannelId,
+    redirectOnSuccess: false,
+    onTaskCreated: handleTaskCreated,
   });
 
   const [prOpen, setPrOpen] = useState(false);
@@ -198,6 +221,30 @@ export function ReportVerdictBanner({
     setChatOpen(true);
     onEngaged?.();
   }, [continuableTask, fireAction, setChatOpen, onEngaged]);
+
+  const handleAsk = useCallback(() => {
+    if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
+      return;
+    }
+    fireAction("discuss", { has_question: false });
+    if (hasPriorEngagement) {
+      setEngaged(true);
+      setChatOpen(true);
+      onEngaged?.();
+      return;
+    }
+    void discussReport();
+  }, [
+    isCreatingPr,
+    isDiscussing,
+    awaitingChannel,
+    reportTasksLoading,
+    fireAction,
+    hasPriorEngagement,
+    setChatOpen,
+    onEngaged,
+    discussReport,
+  ]);
 
   // The banner carries the report's one action: create the PR, or continue the
   // one in flight. Offer it whenever the report can start a PR (`canCreatePr`
@@ -265,7 +312,7 @@ export function ReportVerdictBanner({
           <Button
             type="button"
             variant="primary"
-            disabled={isCreatingPr || !continuableTask}
+            disabled={isCreatingPr || isDiscussing || !continuableTask}
             onClick={handleContinuePr}
             className={buttonClass}
           >
@@ -303,7 +350,7 @@ export function ReportVerdictBanner({
               <Button
                 type="button"
                 variant="primary"
-                disabled={isCreatingPr}
+                disabled={isCreatingPr || isDiscussing}
                 className={buttonClass}
               >
                 {isCreatingPr ? <Spinner /> : <GitPullRequestIcon size={15} />}
@@ -339,7 +386,7 @@ export function ReportVerdictBanner({
                 type="button"
                 variant="primary"
                 size="sm"
-                disabled={isCreatingPr}
+                disabled={isCreatingPr || isDiscussing}
                 onClick={handleCreatePr}
               >
                 Fix & monitor
@@ -351,12 +398,9 @@ export function ReportVerdictBanner({
       <Button
         type="button"
         variant="outline"
-        onClick={() => {
-          fireAction("discuss");
-          setEngaged(true);
-          setChatOpen(true);
-          onEngaged?.();
-        }}
+        loading={isDiscussing}
+        disabled={isCreatingPr || awaitingChannel || reportTasksLoading}
+        onClick={handleAsk}
         className={buttonClass}
       >
         <ChatCircleIcon size={16} />

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -1,6 +1,7 @@
 import {
   ArchiveIcon,
   ArrowSquareOutIcon,
+  ChatCircleIcon,
   ClockIcon,
   GitPullRequestIcon,
 } from "@phosphor-icons/react";
@@ -193,7 +194,7 @@ export function ReportVerdictBanner({
     report.status === "resolved" ||
     report.status === "suppressed" ||
     report.status === "deleted";
-  const showActions = !isTerminalReport && (canCreatePr || hasExistingPr);
+  const showActions = !isTerminalReport;
 
   // One key fires the primary action (triage mode passes "f"): continue the
   // task when a PR exists, otherwise start the fix with no extra direction.
@@ -326,6 +327,19 @@ export function ReportVerdictBanner({
           </PopoverContent>
         </Popover>
       ) : null}
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => {
+          fireAction("discuss");
+          setChatOpen(true);
+          onEngaged?.();
+        }}
+        className={buttonClass}
+      >
+        <ChatCircleIcon size={16} />
+        Ask about it
+      </Button>
       {canArchiveHere && !compact && (
         <Tooltip>
           <TooltipTrigger

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -32,6 +32,7 @@ import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInb
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 import {
   findContinuableImplementationTask,
+  findLatestDiscussionTask,
   getTaskPrUrl,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
@@ -64,6 +65,8 @@ interface ReportVerdictBannerProps {
   variant?: ReportVerdictBannerVariant;
   /** Key that fires the primary action (triage mode passes "f"). */
   actionHotkey?: string;
+  /** Hide the full banner after the reader starts or resumes report work. */
+  initialEngagementOnly?: boolean;
   /**
    * Called after an action opens the report's conversation dock. Surfaces
    * without a dock (the triage card) navigate to the report here.
@@ -80,6 +83,7 @@ export function ReportVerdictBanner({
   report,
   variant = "full",
   actionHotkey,
+  initialEngagementOnly = false,
   onEngaged,
 }: ReportVerdictBannerProps) {
   const compact = variant === "header-actions";
@@ -115,6 +119,13 @@ export function ReportVerdictBanner({
   const existingPrUrl =
     livePrUrl ?? (continuableTask ? getTaskPrUrl(continuableTask) : null);
   const hasExistingPr = !!existingPrUrl || !!continuableTask;
+  const startedTaskId = useReportChatPanelStore(
+    (state) => state.startedTaskIdByReport[report.id] ?? null,
+  );
+  const hasPriorEngagement =
+    startedTaskId !== null ||
+    hasExistingPr ||
+    findLatestDiscussionTask(reportTasks) !== null;
 
   const verdict = deriveReportVerdict(report, { hasExistingPr });
 
@@ -124,6 +135,7 @@ export function ReportVerdictBanner({
   const rememberStartedTask = useReportChatPanelStore(
     (s) => s.rememberStartedTask,
   );
+  const [engaged, setEngaged] = useState(false);
 
   const { createPrReport, isCreatingPr } = useCreatePrReport({
     reportId: report.id,
@@ -135,6 +147,7 @@ export function ReportVerdictBanner({
     // put instead of opening an empty dock or, in triage, navigating away.
     onTaskCreated: (task) => {
       rememberStartedTask(report.id, task.id);
+      setEngaged(true);
       setChatOpen(true);
       onEngaged?.();
     },
@@ -181,6 +194,7 @@ export function ReportVerdictBanner({
     fireAction("open_pr");
     // The conversation opens docked beside the report — the full task page
     // stays one click away in the dock header.
+    setEngaged(true);
     setChatOpen(true);
     onEngaged?.();
   }, [continuableTask, fireAction, setChatOpen, onEngaged]);
@@ -236,6 +250,13 @@ export function ReportVerdictBanner({
     handleContinuePr,
     handleCreatePr,
   ]);
+
+  if (
+    initialEngagementOnly &&
+    (reportTasksLoading || engaged || hasPriorEngagement)
+  ) {
+    return null;
+  }
 
   const actionsRow = showActions ? (
     <div className="flex flex-wrap items-center gap-2.5">
@@ -332,6 +353,7 @@ export function ReportVerdictBanner({
         variant="outline"
         onClick={() => {
           fireAction("discuss");
+          setEngaged(true);
           setChatOpen(true);
           onEngaged?.();
         }}
@@ -387,7 +409,7 @@ export function ReportVerdictBanner({
   return (
     <div
       className={cn(
-        "flex flex-col gap-3 rounded-lg border p-4",
+        "flex select-none flex-col gap-3 rounded-lg border p-4",
         TONE_CLASS[verdict.tone],
       )}
     >

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   findContinuableImplementationTask,
   findLatestDiscussionTask,
+  findPendingStartedTaskId,
   getTaskPrUrl,
   type ReportTaskData,
   type ReportTaskPurpose,
@@ -24,7 +25,7 @@ function makeTask(
     if (run.prState) output.pr_state = run.prState;
   }
   const latest_run: TaskRun | undefined = run
-    ? ({
+    ? {
         id: `${id}-run`,
         task: id,
         team: 1,
@@ -32,14 +33,12 @@ function makeTask(
         status: run.status ?? "in_progress",
         log_url: "",
         error_message: null,
-        output: run.prUrl
-          ? { pr_url: run.prUrl, ...(run.prMerged ? { pr_merged: true } : {}) }
-          : null,
+        output,
         state: {},
         created_at: "2026-06-24T10:00:00Z",
         updated_at: "2026-06-24T10:00:00Z",
         completed_at: null,
-      } as TaskRun)
+      }
     : undefined;
   return {
     id,
@@ -51,7 +50,7 @@ function makeTask(
     updated_at: "2026-06-24T10:00:00Z",
     origin_product: "signals",
     latest_run,
-  } as Task;
+  };
 }
 
 function entry(
@@ -144,16 +143,17 @@ describe("findContinuableImplementationTask", () => {
   });
 });
 
-describe("findLatestDiscussionTask", () => {
-  it("returns the newest discussion and ignores other purposes", () => {
-    const older = entry(makeTask("old-chat"), "discussion");
-    older.startedAt = "2026-06-20T10:00:00Z";
-    const newer = entry(makeTask("new-chat"), "discussion");
-    newer.startedAt = "2026-06-24T10:00:00Z";
-    const impl = entry(makeTask("impl", { prUrl: "https://gh/pr/1" }));
-    expect(findLatestDiscussionTask([impl, older, newer])).toBe(newer.task);
-    expect(findLatestDiscussionTask([impl])).toBeNull();
-    expect(findLatestDiscussionTask(undefined)).toBeNull();
+describe("findPendingStartedTaskId", () => {
+  it("bridges a started task until it appears in the report tasks", () => {
+    expect(findPendingStartedTaskId(undefined, "started")).toBe("started");
+    expect(findPendingStartedTaskId([], "started")).toBe("started");
+    expect(
+      findPendingStartedTaskId([entry(makeTask("started"))], "started"),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no started task", () => {
+    expect(findPendingStartedTaskId([], null)).toBeNull();
   });
 });
 

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -184,3 +184,13 @@ export function findLatestDiscussionTask(
     t.startedAt > latest.startedAt ? t : latest,
   ).task;
 }
+
+export function findPendingStartedTaskId(
+  reportTasks: ReportTaskData[] | undefined,
+  startedTaskId: string | null,
+): string | null {
+  if (!startedTaskId) return null;
+  return reportTasks?.some(({ task }) => task.id === startedTaskId)
+    ? null
+    : startedTaskId;
+}


### PR DESCRIPTION
## Problem

Self-driving reports force chat open before readers choose to engage, then lack a clear way to return after chat closes.

The action box remains after engagement, inviting repeated clicks and allowing accidental text selection.

## Changes

- Reports now open as documents with a non-selectable initial action box.
- “Ask about it” starts a report-linked chat and requests a brief readout.
- The action box disappears after chat or implementation starts.
- Reports with an existing discussion or implementation task keep the action box hidden.
- An icon-only header button toggles the sidebar and shows its open state.
- A blue dot marks reports with an existing conversation.
- “Fix & monitor” starts implementation with a report-specific prompt.
- Report chat no longer contains suggestion actions.
- The obsolete automatic-open experiment flag is removed.
- Screenshots are unavailable because the isolated Electron profile was signed out.

## How did you test this code?

Added coverage for starting a discussion, retaining failed actions for retry, and hiding the action box after task creation.

Added coverage for the icon-only chat toggle, conversation indicator, and absence of chat suggestions.

The full desktop UI suite, desktop typechecks, and lint passed. Manual report verification was unavailable because the isolated Electron profile was signed out.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This adjusts an in-app interaction without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested UI change using the `posthog-desktop`, `test-electron-app`, `writing-tests`, `writing-ui-components`, `writing-user-facing-copy`, `writing-pr-descriptions`, and `reviewing-before-pr` skills. The local Greptile command was unavailable, so Codex reviewed the final diff directly.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*