### PR TITLE
chore(ci): lint precompressed artifact uploads

### DIFF
--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -17,6 +17,7 @@ import pytest
 from click.testing import CliRunner
 from hogli_commands.workflow_lint.check import CheckResult, WorkflowCheck
 from hogli_commands.workflow_lint.checks import CHECKS, _build_lookup, get_check
+from hogli_commands.workflow_lint.checks.artifact_compression import ArtifactCompressionCheck
 from hogli_commands.workflow_lint.checks.cache_writes import (
     _can_run_on_branch_ref,
     _is_gated,
@@ -1100,6 +1101,94 @@ class TestCacheWriteGateCheck:
     )
     def test_push_trigger_is_default_only(self, on: object, default_only: bool) -> None:
         assert _push_trigger_is_default_only(on) is default_only
+
+
+# ---------------------------------------------------------------------------
+# ArtifactCompressionCheck
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactCompressionCheck:
+    def test_allows_default_compression_for_text_artifacts(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: My
+            on: [push]
+            jobs:
+              report:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/upload-artifact@v7
+                    with:
+                      path: junit.xml
+            """,
+        )
+
+        assert ArtifactCompressionCheck().run(_read_all(tmp_path)).issues == []
+
+    def test_allows_precompressed_artifacts_at_level_zero(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: My
+            on: [push]
+            jobs:
+              package:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/upload-artifact@v7
+                    with:
+                      compression-level: 0
+                      path: |
+                        dist/app.dmg
+                        dist/latest.yml
+            """,
+        )
+
+        assert ArtifactCompressionCheck().run(_read_all(tmp_path)).issues == []
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "dist/app.AppImage",
+            "dist/app.blockmap",
+            "dist/app.deb",
+            "dist/app.dmg",
+            "dist/app.exe",
+            "dist/app.rpm",
+            "dist/app.tgz",
+            "dist/app.whl",
+            "dist/app.zip",
+            "schema.sql.gz",
+        ],
+    )
+    def test_rejects_default_compression_for_precompressed_artifacts(self, tmp_path: Path, path: str) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            f"""
+            name: My
+            on: [push]
+            jobs:
+              package:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: actions/upload-artifact@v7
+                    with:
+                      path: {path}
+            """,
+        )
+
+        result = ArtifactCompressionCheck().run(_read_all(tmp_path))
+
+        assert len(result.issues) == 1
+        assert "default zlib compression" in result.issues[0].message
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
@@ -12,6 +12,7 @@ up first.
 from __future__ import annotations
 
 from ..check import WorkflowCheck
+from .artifact_compression import ArtifactCompressionCheck
 from .cache_writes import CacheWriteGateCheck
 from .checkout_full_depth import CheckoutFullDepthCheck
 from .dorny_negation import DornyNegationCheck
@@ -30,6 +31,7 @@ CHECKS: list[WorkflowCheck] = [
     CacheWriteGateCheck(),
     RequiredGateCheck(),
     PrEventFanoutCheck(),
+    ArtifactCompressionCheck(),
 ]
 
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/artifact_compression.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/artifact_compression.py
@@ -1,0 +1,61 @@
+"""Precompressed artifacts should bypass upload-artifact's outer zlib pass."""
+
+from __future__ import annotations
+
+import re
+
+from ..check import CheckResult, Issue, WorkflowCheck
+from ..model import Step, Workflow
+
+PRECOMPRESSED_PATH_RE = re.compile(
+    r"\.(?:7z|appimage|blockmap|br|bz2|deb|dmg|exe|gz|msi|pkg|rpm|tgz|whl|xz|zip)(?:$|[\s*?}\]])",
+    re.IGNORECASE,
+)
+
+
+def _is_artifact_upload(step: Step) -> bool:
+    return step.uses is not None and step.uses.lower().startswith("actions/upload-artifact@")
+
+
+def _includes_precompressed_path(step: Step) -> bool:
+    if step.with_ is None:
+        return False
+    path = step.with_.get("path")
+    return isinstance(path, str) and PRECOMPRESSED_PATH_RE.search(path) is not None
+
+
+def _disables_outer_compression(step: Step) -> bool:
+    if step.with_ is None:
+        return False
+    return step.with_.get("compression-level") in (0, "0")
+
+
+class ArtifactCompressionCheck(WorkflowCheck):
+    id = "WF009-artifact-compression"
+    label = "artifact compression"
+    description = "precompressed artifact uploads disable redundant outer compression"
+
+    @property
+    def fix_hint(self) -> str | None:
+        return "Set `compression-level: 0` when an upload-artifact path contains packaged or compressed files."
+
+    def run(self, workflows: list[Workflow]) -> CheckResult:
+        result = CheckResult()
+        for workflow in workflows:
+            for job in workflow.jobs:
+                for step in job.steps:
+                    if (
+                        _is_artifact_upload(step)
+                        and _includes_precompressed_path(step)
+                        and not _disables_outer_compression(step)
+                    ):
+                        result.issues.append(
+                            Issue(
+                                workflow=workflow.path.name,
+                                job=job.name,
+                                step=step.ref,
+                                message="precompressed artifact path uses the default zlib compression level",
+                                file=str(workflow.path),
+                            )
+                        )
+        return result


### PR DESCRIPTION
## Problem

CI authors can accidentally add expensive recompression when uploading packaged artifacts.

The existing workflow checks do not distinguish text artifacts from `.zip`, `.dmg`, and other compressed formats.

## Changes

- Workflow lint now rejects precompressed paths that use `upload-artifact`'s default zlib level.
- Authors fix the error by setting `compression-level: 0`.
- This layer follows the artifact fixes in the PR below it.

## How did you test this code?

- `hogli test tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py`
- `bin/hogli lint:workflows`
- `uv run mypy --cache-fine-grained .`
- `hogli ci:preflight --fix --against perf/ci-skip-artifact-recompression`

The parameterized cases guard every packaged format used by the fixed workflows.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The lint error includes the required fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi added the prevention layer after applying the current workflow fixes.

Skills invoked: `/authoring-ci-workflows`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/running-ci-preflight`, `/stacking-prs`, and `/wt`.
