### PR TITLE
fix(aio): show every answer of a split feedback submission on a trace

### DIFF
--- a/products/ai_observability/frontend/feedback-view/FeedbackViewDisplay.tsx
+++ b/products/ai_observability/frontend/feedback-view/FeedbackViewDisplay.tsx
@@ -8,7 +8,7 @@ import { urls } from 'scenes/urls'
 import { aiObservabilityTraceLogic } from '../aiObservabilityTraceLogic'
 import { feedbackViewLogic } from './feedbackViewLogic'
 import { SurveyResponseCard } from './survey-responses/SurveyResponseCard'
-import { getSurveyIdFromEvent, groupEventsBySubmission } from './survey-responses/utils'
+import { getSurveyIdFromEvent, groupEventsBySubmission, selectUnansweredShownEvents } from './survey-responses/utils'
 import { FeedbackSurveyWizard } from './wizard/FeedbackSurveyWizard'
 
 export function FeedbackViewDisplay(): JSX.Element {
@@ -30,10 +30,7 @@ export function FeedbackViewDisplay(): JSX.Element {
 
     const surveyResponseEvents = (surveyEvents ?? []).filter((e) => e.event === 'survey sent')
     const groupedResponses = groupEventsBySubmission(surveyResponseEvents, surveys)
-
-    // survey events are deduped on survey_id (and implicitly trace_id), so we'll
-    // only have 'survey shown' events here if there was no survey response
-    const surveyShownEvents = (surveyEvents ?? []).filter((e) => e.event === 'survey shown')
+    const surveyShownEvents = selectUnansweredShownEvents(surveyEvents ?? [])
 
     // A response whose `$survey_id` matches no survey in this project has no questions to render
     // against, so it is dropped above. Say so, instead of leaving the trace looking uninstrumented.

--- a/products/ai_observability/frontend/feedback-view/feedbackViewLogic.ts
+++ b/products/ai_observability/frontend/feedback-view/feedbackViewLogic.ts
@@ -126,6 +126,12 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
             {
                 loadSurveyEvents: async (createdAt: string) => {
                     const date = dayjs(createdAt)
+                    // One submission can span several `survey sent` events, and each event carries
+                    // only the answers it collected, so every event has to come back and be merged
+                    // by `groupEventsBySubmission`. Keeping one event per survey here would drop
+                    // the answers on all the others. Ascending timestamp order lets the merge keep
+                    // the latest answer for a question. The row bound guards against a runaway
+                    // trace, because a trace holds one submission per survey.
                     const response = await api.queryHogQL(
                         hogql`
                             SELECT uuid, event, timestamp, properties
@@ -133,8 +139,8 @@ export const feedbackViewLogic = kea<feedbackViewLogicType>([
                             WHERE (event = 'survey sent' OR event = 'survey shown')
                                 AND properties.$ai_trace_id = ${props.traceId}
                                 AND timestamp >= ${date}
-                            ORDER BY if(event = 'survey sent', 0, 1)
-                            LIMIT 1 BY properties.$survey_id
+                            ORDER BY timestamp ASC
+                            LIMIT 1000
                         `,
                         { productKey: 'llm_analytics' }
                     )

--- a/products/ai_observability/frontend/feedback-view/survey-responses/utils.test.ts
+++ b/products/ai_observability/frontend/feedback-view/survey-responses/utils.test.ts
@@ -1,0 +1,101 @@
+import { LLMTraceEvent } from '~/queries/schema/schema-general'
+import { Survey, SurveyQuestionType } from '~/types'
+
+import { groupEventsBySubmission, selectUnansweredShownEvents } from './utils'
+
+const SURVEY_ID = '0199ed4a-5c03-0000-3220-df21df612e95'
+
+const surveys: Record<string, Survey> = {
+    [SURVEY_ID]: {
+        id: SURVEY_ID,
+        name: 'AI response feedback',
+        questions: [
+            { id: 'q1', type: SurveyQuestionType.Rating, question: 'Was this helpful?' },
+            { id: 'q2', type: SurveyQuestionType.Open, question: 'Tell us more' },
+        ],
+    } as unknown as Survey,
+}
+
+const sentEvent = (id: string, properties: Record<string, unknown>): LLMTraceEvent => ({
+    id,
+    event: 'survey sent',
+    createdAt: '2024-01-01T00:00:00Z',
+    properties: { $survey_id: SURVEY_ID, ...properties },
+})
+
+const shownEvent = (id: string): LLMTraceEvent => ({
+    id,
+    event: 'survey shown',
+    createdAt: '2024-01-01T00:00:00Z',
+    properties: { $survey_id: SURVEY_ID },
+})
+
+describe('feedback view survey response utils', () => {
+    describe('groupEventsBySubmission', () => {
+        it('merges answers across a submission split over several events', () => {
+            const grouped = groupEventsBySubmission(
+                [
+                    sentEvent('e1', {
+                        $survey_submission_id: 's1',
+                        $survey_response_q1: 2,
+                        $survey_completed: false,
+                    }),
+                    sentEvent('e2', {
+                        $survey_submission_id: 's1',
+                        $survey_response_q2: 'it invented a hedgehog',
+                        $survey_completed: true,
+                    }),
+                ],
+                surveys
+            )
+
+            expect(grouped).toHaveLength(1)
+            expect(grouped[0].isComplete).toBe(true)
+            expect(grouped[0].responses.map((r) => [r.questionIndex, r.value])).toEqual([
+                [0, 2],
+                [1, 'it invented a hedgehog'],
+            ])
+        })
+
+        it('keeps the latest answer when a question is answered twice', () => {
+            const grouped = groupEventsBySubmission(
+                [
+                    sentEvent('e1', { $survey_submission_id: 's1', $survey_response_q1: 1 }),
+                    sentEvent('e2', { $survey_submission_id: 's1', $survey_response_q1: 2, $survey_completed: true }),
+                ],
+                surveys
+            )
+
+            expect(grouped[0].responses).toEqual([expect.objectContaining({ questionIndex: 0, value: 2 })])
+        })
+
+        it('keeps events without a submission ID as separate responses', () => {
+            const grouped = groupEventsBySubmission(
+                [
+                    sentEvent('e1', { $survey_response_q1: 1, $survey_completed: true }),
+                    sentEvent('e2', { $survey_response_q1: 2, $survey_completed: true }),
+                ],
+                surveys
+            )
+
+            expect(grouped).toHaveLength(2)
+        })
+    })
+
+    describe('selectUnansweredShownEvents', () => {
+        it('drops the impression for a survey that was answered', () => {
+            const kept = selectUnansweredShownEvents([
+                shownEvent('e1'),
+                sentEvent('e2', { $survey_response_q1: 1, $survey_completed: true }),
+            ])
+
+            expect(kept).toEqual([])
+        })
+
+        it('collapses duplicate impressions for one survey', () => {
+            const kept = selectUnansweredShownEvents([shownEvent('e1'), shownEvent('e2')])
+
+            expect(kept.map((e) => e.id)).toEqual(['e1'])
+        })
+    })
+})

--- a/products/ai_observability/frontend/feedback-view/survey-responses/utils.ts
+++ b/products/ai_observability/frontend/feedback-view/survey-responses/utils.ts
@@ -23,6 +23,17 @@ export function getSurveyIdFromEvent(event: LLMTraceEvent): string | null {
     return isString(surveyId) ? surveyId.toLowerCase() : null
 }
 
+/**
+ * Merges a trace's `survey sent` events into one response for each `$survey_submission_id`.
+ *
+ * A submission can arrive as several events, for example a thumbs rating and then a free-text
+ * follow-up. Each event holds only the answers it collected, so the answers must be merged across
+ * the submission's events instead of read from any single one.
+ *
+ * Callers must pass the events in ascending timestamp order. A question answered more than once
+ * keeps its latest non-empty value, which matches how the responses API merges a submission with
+ * `argMaxIf(answer, timestamp, isNotNull(answer))`.
+ */
 export function groupEventsBySubmission(events: LLMTraceEvent[], surveys: Record<string, Survey>): GroupedResponse[] {
     const submissionMap = new Map<string, GroupedResponse>()
 
@@ -54,7 +65,9 @@ export function groupEventsBySubmission(events: LLMTraceEvent[], surveys: Record
 
             if (value != null && value !== '') {
                 const existing = submission.responses.find((r) => r.questionIndex === i)
-                if (!existing) {
+                if (existing) {
+                    existing.value = value
+                } else {
                     submission.responses.push({ questionIndex: i, question, value })
                 }
             }
@@ -65,5 +78,47 @@ export function groupEventsBySubmission(events: LLMTraceEvent[], surveys: Record
         }
     }
 
+    // Answers arrive in event order, so a submission whose later event answered an earlier
+    // question would otherwise render its questions out of order.
+    for (const submission of submissionMap.values()) {
+        submission.responses.sort((a, b) => a.questionIndex - b.questionIndex)
+    }
+
     return Array.from(submissionMap.values())
+}
+
+/**
+ * Picks the `survey shown` events that deserve a "shown but received no response" card.
+ *
+ * A survey with a `survey sent` event on the same trace was answered, so its impression is not
+ * worth a card. An instrumented app can also send `survey shown` more than once for one survey,
+ * so only the first of each survives.
+ */
+export function selectUnansweredShownEvents(events: LLMTraceEvent[]): LLMTraceEvent[] {
+    const answeredSurveyIds = new Set<string>()
+    for (const event of events) {
+        const surveyId = getSurveyIdFromEvent(event)
+        if (event.event === 'survey sent' && surveyId) {
+            answeredSurveyIds.add(surveyId)
+        }
+    }
+
+    // A `survey shown` event without a readable `$survey_id` still renders, as an unnamed survey.
+    // Keying those together collapses them into the single card they used to get.
+    const shownBySurvey = new Map<string, LLMTraceEvent>()
+    for (const event of events) {
+        if (event.event !== 'survey shown') {
+            continue
+        }
+        const surveyId = getSurveyIdFromEvent(event)
+        if (surveyId && answeredSurveyIds.has(surveyId)) {
+            continue
+        }
+        const key = surveyId ?? ''
+        if (!shownBySurvey.has(key)) {
+            shownBySurvey.set(key, event)
+        }
+    }
+
+    return Array.from(shownBySurvey.values())
 }


### PR DESCRIPTION
## Problem

The Feedback tab on an LLM trace shows only part of a feedback submission. A user who rates a response with thumbs and then writes a follow-up gets one card holding one of the two answers, and which one survives is arbitrary.

- The trace query keeps one `survey sent` event per survey with `LIMIT 1 BY properties.$survey_id`.
- A submission split across two events loses the event that lost that tiebreak.
- `groupEventsBySubmission` already merges a submission's events. It never receives more than one, so the merge cannot run.

The [manual capture docs](https://posthog.com/docs/ai-observability/user-feedback/manual-event-capture) now tell integrators to re-send every answer on the completed event, which routes around this. Anyone who instrumented before that still loses answers.

Refs #76121

## Changes

- The Feedback tab now shows every answer in a submission on one card.
- Duplicate "shown but received no response" cards no longer appear for one survey.
- The trace query returns all of a trace's survey events in ascending timestamp order.
- A question answered twice keeps its latest value, matching how the responses API merges a submission with `argMaxIf`.
- `selectUnansweredShownEvents` takes over the impression dedupe that `LIMIT 1 BY` used to do.
- Answers sort by question index, so a later event answering an earlier question does not reorder the card.

The sort is the only part with no user-visible effect on the documented event pattern.

> [!NOTE]
> This is the trace surface only. The survey Results tab has the same defect and its own fix in #86403.

No screenshots: this sandbox has no dev stack or ClickHouse, so the tab could not be rendered against a real trace.

## How did you test this code?

New unit tests in `products/ai_observability/frontend/feedback-view/survey-responses/utils.test.ts`. `groupEventsBySubmission` and `selectUnansweredShownEvents` had no tests before.

- Split submission merge: guards the merge now that the query returns every event of a submission.
- Latest answer wins: this PR changed the merge from first-wins to last-wins, so a re-answered question would otherwise show a stale value.
- Impression dedupe: the SQL used to guarantee this, and these cases guard the TypeScript that replaced it.

Not run: the HogQL change itself is unverified against a real trace, for the reason above. `hogli` is absent from this sandbox, so no local Greptile review ran.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The docs already describe the cumulative pattern that works on every surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in PostHog Desktop. The work started from a request to review the comments on the docs PR above. Reading the surfaces that consume `$survey_submission_id` turned up this one, which #76119 and #86403 both leave untouched and which no issue covered.

The PR is unassigned because the driver's GitHub handle was not verified in session.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Public artifact: the originating docs PR came from a support ticket. No ticket content, customer name, or session data appears in the diff or here. The test fixtures were written from the property shape in the public docs.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
