### PR TITLE
fix(desktop): record an onboarding step view once the step is settled

### DIFF
--- a/products/desktop/packages/core/src/onboarding/steps.test.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.test.ts
@@ -9,6 +9,7 @@ import {
   type OnboardingStep,
   previousStep,
   stepDirection,
+  stepGatePending,
 } from "./steps";
 
 type StepGates = Parameters<typeof computeActiveSteps>[0];
@@ -74,6 +75,34 @@ describe("computeActiveSteps", () => {
       computeActiveSteps({ ...allSteps, consentRequired: false }),
     ).not.toContain("consent");
   });
+});
+
+describe("stepGatePending", () => {
+  it.each<{ step: OnboardingStep; gate: keyof StepGates }>([
+    { step: "project-select", gate: "projectCount" },
+    { step: "consent", gate: "consentRequired" },
+    { step: "install-cli", gate: "hasGithubIntegration" },
+    { step: "install-cli", gate: "cliReady" },
+  ])("holds $step while $gate has not answered", ({ step, gate }) => {
+    const answered: StepGates = {
+      hasGithubIntegration: false,
+      cliReady: false,
+      projectCount: 2,
+      consentRequired: true,
+    };
+
+    expect(stepGatePending(step, answered)).toBe(false);
+    expect(stepGatePending(step, { ...answered, [gate]: undefined })).toBe(
+      true,
+    );
+  });
+
+  it.each<OnboardingStep>(["connect-github", "select-repo"])(
+    "never holds %s, which no gate can drop",
+    (step) => {
+      expect(stepGatePending(step, allSteps)).toBe(false);
+    },
+  );
 });
 
 describe("nearestActiveStep", () => {

--- a/products/desktop/packages/core/src/onboarding/steps.ts
+++ b/products/desktop/packages/core/src/onboarding/steps.ts
@@ -21,7 +21,7 @@ export interface DetectedRepo {
   branch?: string;
 }
 
-export function computeActiveSteps(options: {
+export interface StepGates {
   /** Undefined while the integrations query is loading; the step only drops on a confirmed connection. */
   hasGithubIntegration: boolean | undefined;
   /** Undefined while the local git and gh checks are loading. */
@@ -29,7 +29,9 @@ export function computeActiveSteps(options: {
   /** Undefined until the project list has loaded, so a slow list cannot skip a real choice. */
   projectCount: number | undefined;
   consentRequired: boolean | undefined;
-}): OnboardingStep[] {
+}
+
+export function computeActiveSteps(options: StepGates): OnboardingStep[] {
   return ONBOARDING_STEPS.filter((step) => {
     if (step === "project-select" && options.projectCount === 1) return false;
     if (step === "consent" && options.consentRequired === false) return false;
@@ -43,6 +45,27 @@ export function computeActiveSteps(options: {
     }
     return true;
   });
+}
+
+/**
+ * Whether a gate that governs `step` has not answered yet. An unanswered gate
+ * keeps its step in the active set, so the step is on screen but a later answer
+ * can still take it away. Analytics waits for this to be false, or it records a
+ * view for a step the person never had to complete.
+ */
+export function stepGatePending(
+  step: OnboardingStep,
+  options: StepGates,
+): boolean {
+  if (step === "project-select") return options.projectCount === undefined;
+  if (step === "consent") return options.consentRequired === undefined;
+  if (step === "install-cli") {
+    return (
+      options.hasGithubIntegration === undefined ||
+      options.cliReady === undefined
+    );
+  }
+  return false;
 }
 
 /**

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -34,6 +34,7 @@ import { InstallCliStep } from "@posthog/ui/features/onboarding/components/Insta
 import { useOnboardingFlow } from "@posthog/ui/features/onboarding/hooks/useOnboardingFlow";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import { saveOnboardingRepository } from "@posthog/ui/features/onboarding/saveOnboardingRepository";
+import type { OnboardingStep } from "@posthog/ui/features/onboarding/types";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { shipIt } from "@posthog/ui/primitives/confetti";
 import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
@@ -239,6 +240,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     hasGithubIntegration,
     consentSatisfied,
     consentRequirement,
+    currentStepPending,
   } = useOnboardingFlow();
   const completeOnboarding = useOnboardingStore(
     (state) => state.completeOnboarding,
@@ -279,15 +281,25 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
   const flowStartedAtRef = useRef(Date.now());
   const stepEnteredAtRef = useRef(Date.now());
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: fires once on mount; subsequent step views fire from handleNext/handleBack
   useEffect(() => {
     track(ANALYTICS_EVENTS.ONBOARDING_STARTED);
+  }, []);
+
+  const viewedStepRef = useRef<OnboardingStep | null>(null);
+  // Recorded once the step can no longer be taken away, which covers the two
+  // paths that had no correct one: a step shown before its gate answers, and a
+  // step entered by the self-heal in useOnboardingFlow.
+  useEffect(() => {
+    if (currentIndex < 0 || currentStepPending) return;
+    if (viewedStepRef.current === currentStep) return;
+    viewedStepRef.current = currentStep;
     track(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, {
       step_id: currentStep,
       step_index: currentIndex,
       total_steps: activeSteps.length,
     });
-  }, []);
+    stepEnteredAtRef.current = Date.now();
+  }, [currentStep, currentIndex, currentStepPending, activeSteps.length]);
 
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -318,17 +330,6 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     );
   };
 
-  const trackStepViewed = (stepIndex: number) => {
-    const stepId = activeSteps[stepIndex];
-    if (!stepId) return;
-    track(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, {
-      step_id: stepId,
-      step_index: stepIndex,
-      total_steps: activeSteps.length,
-    });
-    stepEnteredAtRef.current = Date.now();
-  };
-
   const handleNext = (context?: StepCompletedContext) => {
     if (
       currentStep === "consent" &&
@@ -341,13 +342,11 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     const safeContext =
       context && "nativeEvent" in context ? undefined : context;
     trackStepCompleted(safeContext);
-    trackStepViewed(currentIndex + 1);
     next();
   };
 
   const handleBack = () => {
     if (currentStep === "consent" && consentSubmitting) return;
-    trackStepViewed(currentIndex - 1);
     back();
   };
 

--- a/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/OnboardingFlow.tsx
@@ -285,20 +285,31 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     track(ANALYTICS_EVENTS.ONBOARDING_STARTED);
   }, []);
 
-  const viewedStepRef = useRef<OnboardingStep | null>(null);
-  // Recorded once the step can no longer be taken away, which covers the two
-  // paths that had no correct one: a step shown before its gate answers, and a
-  // step entered by the self-heal in useOnboardingFlow.
+  // Entry is when the person arrives on the step, which is not always when the
+  // view is recorded: a pending gate delays the view but not the reading.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentStep is the trigger, not a value the body reads
   useEffect(() => {
-    if (currentIndex < 0 || currentStepPending) return;
-    if (viewedStepRef.current === currentStep) return;
+    stepEnteredAtRef.current = Date.now();
+  }, [currentStep]);
+
+  const viewedStepRef = useRef<OnboardingStep | null>(null);
+  const recordStepViewed = () => {
+    if (currentIndex < 0 || viewedStepRef.current === currentStep) return;
     viewedStepRef.current = currentStep;
     track(ANALYTICS_EVENTS.ONBOARDING_STEP_VIEWED, {
       step_id: currentStep,
       step_index: currentIndex,
       total_steps: activeSteps.length,
     });
-    stepEnteredAtRef.current = Date.now();
+  };
+
+  // The ordinary path: the step settles while the person is reading it. This
+  // also covers a step entered by the self-heal in useOnboardingFlow, which
+  // reaches the person without passing through handleNext.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: recordStepViewed reads the same values these deps carry
+  useEffect(() => {
+    if (currentStepPending) return;
+    recordStepViewed();
   }, [currentStep, currentIndex, currentStepPending, activeSteps.length]);
 
   useEffect(() => {
@@ -341,6 +352,9 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
     // into capture properties poisons the whole analytics batch.
     const safeContext =
       context && "nativeEvent" in context ? undefined : context;
+    // A person can leave a step before its gate answers, which the effect above
+    // skips. Record the view first, so a completion never arrives without one.
+    recordStepViewed();
     trackStepCompleted(safeContext);
     next();
   };
@@ -362,6 +376,7 @@ export function OnboardingFlow({ onOpenSupport }: OnboardingFlowProps) {
   const handleComplete = async (repoSkipped: boolean) => {
     if (isCompleting) return;
     setIsCompleting(true);
+    recordStepViewed();
     if (repoSkipped) {
       track(ANALYTICS_EVENTS.ONBOARDING_STEP_SKIPPED, {
         step_id: currentStep,

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -135,7 +135,8 @@ export function useOnboardingFlow() {
     ],
   );
 
-  const { data: githubUserIntegrations } = useUserGithubIntegrations();
+  const { data: githubUserIntegrations, isPending: githubIntegrationsPending } =
+    useUserGithubIntegrations();
   // The install-cli step only offers git and gh, so a ready toolchain skips it.
   // InstallCliStep reuses these cached results when the step does render.
   const trpc = useHostTRPC();
@@ -166,9 +167,12 @@ export function useOnboardingFlow() {
       gitStatus.installed && ghStatus.installed && ghStatus.authenticated,
     );
   }, [cliReady, localWorkspaces, gitStatus, ghStatus]);
-  const hasGithubIntegration = githubUserIntegrations
-    ? githubUserIntegrations.length > 0
-    : undefined;
+  // Read the pending state, not the data: the query retries and then leaves
+  // `data` undefined, which would hold the install-cli gate open for the rest
+  // of the session. A failed lookup keeps the step, same as an unanswered one.
+  const hasGithubIntegration = githubIntegrationsPending
+    ? undefined
+    : (githubUserIntegrations?.length ?? 0) > 0;
   // Counted off the store rather than through useProjects, whose auto-select
   // effect would then run in a second place and re-clear the query cache.
   const orgProjectsMap = useAuthStateValue((state) => state.orgProjectsMap);

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -12,6 +12,7 @@ import {
   nearestActiveStep,
   type OnboardingStep,
   stepDirection,
+  stepGatePending,
 } from "@posthog/core/onboarding/steps";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -205,25 +206,24 @@ export function useOnboardingFlow() {
     );
   }, [consent]);
 
+  // A failed lookup keeps the step, same as an unanswered one, but it answers
+  // the gate. Otherwise the step shows with its view never recorded.
   const consentRequired =
-    consentRequirement?.organizationId === consent.organizationId
-      ? consentRequirement?.required
-      : undefined;
+    consent.status === "error"
+      ? true
+      : consentRequirement?.organizationId === consent.organizationId
+        ? consentRequirement?.required
+        : undefined;
   const sampledConsentRequirement =
     consentRequirement?.organizationId === consent.organizationId
       ? consentRequirement
       : undefined;
 
-  const activeSteps = useMemo(
-    () =>
-      computeActiveSteps({
-        hasGithubIntegration,
-        cliReady,
-        projectCount,
-        consentRequired,
-      }),
+  const stepGates = useMemo(
+    () => ({ hasGithubIntegration, cliReady, projectCount, consentRequired }),
     [hasGithubIntegration, cliReady, projectCount, consentRequired],
   );
+  const activeSteps = useMemo(() => computeActiveSteps(stepGates), [stepGates]);
 
   useEffect(() => {
     if (!activeSteps.includes(currentStep)) {
@@ -259,6 +259,7 @@ export function useOnboardingFlow() {
   return {
     currentStep,
     currentIndex,
+    currentStepPending: stepGatePending(currentStep, stepGates),
     totalSteps: activeSteps.length,
     activeSteps,
     isFirstStep,

--- a/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/hooks/useOnboardingFlow.ts
@@ -16,10 +16,7 @@ import {
 } from "@posthog/core/onboarding/steps";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
-import {
-  useAuthStateFetched,
-  useAuthStateValue,
-} from "@posthog/ui/features/auth/store";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useOrgConsent } from "@posthog/ui/features/consent/useOrgConsent";
 import { useUserGithubIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
@@ -181,16 +178,21 @@ export function useOnboardingFlow() {
       state.desktopAccess.projectId === state.currentProjectId &&
       state.desktopAccess.status === "allowed",
   );
-  const authFetched = useAuthStateFetched();
+  // Anonymous bootstrap also reports fetched, with an empty map, so the count
+  // has to wait for authentication or it settles the gate at zero before the
+  // person signs in on the project-select card.
+  const isAuthenticated = useAuthStateValue(
+    (state) => state.status === "authenticated",
+  );
   const projectCount = useMemo(
     () =>
-      authFetched
+      isAuthenticated
         ? Object.values(orgProjectsMap).reduce(
             (total, org) => total + org.projects.length,
             0,
           )
         : undefined,
-    [authFetched, orgProjectsMap],
+    [isAuthenticated, orgProjectsMap],
   );
   const consent = useOrgConsent(hasDesktopAccess);
   const consentSatisfied =

--- a/products/desktop/packages/ui/src/features/onboarding/onboardingStore.test.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/onboardingStore.test.ts
@@ -2,14 +2,31 @@ import { describe, expect, it } from "vitest";
 import { migrateOnboardingState } from "./onboardingStore";
 
 describe("migrateOnboardingState", () => {
-  it("moves a persisted invite-code step forward", () => {
-    const migrated = migrateOnboardingState({
-      currentStep: "invite-code",
-      hasCompletedOnboarding: false,
-      hasShippedFirstPr: false,
-      selectedProjectId: 1,
-    });
+  const persisted = (currentStep: string) => ({
+    currentStep,
+    hasCompletedOnboarding: false,
+    hasShippedFirstPr: false,
+    selectedProjectId: 1,
+  });
 
-    expect(migrated.currentStep).toBe("consent");
+  it("moves a persisted invite-code step forward", () => {
+    expect(migrateOnboardingState(persisted("invite-code")).currentStep).toBe(
+      "consent",
+    );
+  });
+
+  it.each(["welcome", "import-config"])(
+    "resets the retired %s step to the start of the flow",
+    (step) => {
+      expect(migrateOnboardingState(persisted(step)).currentStep).toBe(
+        "project-select",
+      );
+    },
+  );
+
+  it("leaves a step of the current flow alone", () => {
+    expect(migrateOnboardingState(persisted("select-repo")).currentStep).toBe(
+      "select-repo",
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/onboarding/onboardingStore.ts
+++ b/products/desktop/packages/ui/src/features/onboarding/onboardingStore.ts
@@ -1,3 +1,4 @@
+import { ONBOARDING_STEPS } from "@posthog/core/onboarding/steps";
 import type { OnboardingStep } from "@posthog/ui/features/onboarding/types";
 import { logger } from "@posthog/ui/shell/logger";
 import { create } from "zustand";
@@ -37,6 +38,11 @@ export function migrateOnboardingState(
   if ((state.currentStep as string) === "invite-code") {
     return { ...state, currentStep: "consent" };
   }
+  // A step id from a retired set, for example "welcome", renders no branch in
+  // the flow, so the person sees an empty card until the self-heal moves them.
+  if (!ONBOARDING_STEPS.includes(state.currentStep)) {
+    return { ...state, currentStep: ONBOARDING_STEPS[0] };
+  }
   return state;
 }
 
@@ -61,7 +67,7 @@ export const useOnboardingStore = create<OnboardingStore>()(
     }),
     {
       name: "onboarding-store",
-      version: 1,
+      version: 2,
       migrate: migrateOnboardingState,
       partialize: (state) => ({
         currentStep: state.currentStep,


### PR DESCRIPTION
## Problem

The desktop onboarding funnel reports two steps wrong, so the canvas the team reads gives a false picture of where people drop.

- `project-select` records 439 people viewing and 122 advancing over 3 days for non-staff, against roughly 98% on every other step.
- `consent` records 110 viewing and 171 advancing, which is more completions than views.
- The flow shows the project picker before it knows your project count. Everyone records a view on mount, then the step is dropped for anyone holding one project.
- The self-heal that moves a person off a dropped step emitted nothing, so anyone it moved into `consent` advanced with no matching view.
- A retired `welcome` step id from an older build reaches analytics the same way, which is where [the report behind this PR](https://us.posthog.com/project/2/inbox/01a03ea8-f64e-79ee-9456-2df88a9ca881) started.

## Changes

- Nothing about the flow looks or behaves differently. The steps, their order, and the copy are unchanged.
- One effect records the view, once no pending lookup can still drop the step. `stepGatePending` in `packages/core/src/onboarding/steps.ts` answers that per step, so a step no lookup can drop is never held.
- `handleNext` and `handleBack` no longer record views. They record the completion and move the step, and the effect follows.
- `handleNext` previously recorded the next step's view before `next()` ran, which named the wrong step whenever the step set shifted in between. That path is gone.
- A completion can never precede its view. `handleNext` and `handleComplete` record the view first, which covers a person who leaves a step before its gate answers, through the button or the right-arrow hotkey.
- A failed consent or GitHub integrations lookup now answers its gate instead of holding it open. Both still keep the step, as an unanswered lookup did, so a dead query cannot silence that step's view. The integrations query retries three times and then leaves `data` undefined, which would otherwise hold `install-cli` pending for the rest of the session.
- `project-select` no longer records its view before sign-in. Anonymous bootstrap reports an empty org map as fetched, which settled the project count at zero. The count now waits for the authenticated status, so the gate stays pending while the person signs in on that card.
- Step entry is tracked on step change, separately from the view, so a delayed view no longer measures `duration_seconds` from the previous step.
- A person who rehydrates onto a step retired in an older build lands on the start of the flow instead of an empty card. The `invite-code` mapping stays ahead of that reset so a person mid-flow still moves forward to `consent`.
- The store version goes to 2, because version 1 shipped alongside that mapping in 5d54be6 and a state already saved at version 1 never called `migrate`.
- The `computeActiveSteps` options object becomes a named `StepGates` type. Mechanical.

> [!NOTE]
> Step view counts change the day this ships. `project-select` views drop by roughly the number of people who hold one project. `consent` views rise to meet its completions. Treat pre-merge and post-merge funnel numbers as separate series.

## How did you test this code?

- Added `stepGatePending` cases to `packages/core/src/onboarding/steps.test.ts`. They catch a step wired to the wrong lookup, or a lookup added to `computeActiveSteps` and forgotten here, which would record a view for a step that is then dropped.
- Extended `packages/ui/src/features/onboarding/onboardingStore.test.ts` with retired-step and current-step cases. They catch a migration that drops the `invite-code` mapping, and one that resets a valid step.
- Extended both existing test files rather than adding new ones, since each behavior sits beside coverage that already existed.
- Ran the `@posthog/core` and `@posthog/ui` vitest suites locally.
- **Not covered:** the lookup-error paths and the anonymous-bootstrap project gate, which live in `useOnboardingFlow` and would need a component render with mocked query sources. Poor trade at that level; worth a reviewer's eye. The pending-gate behavior itself is covered in `steps.test.ts`.
- **Not run:** the app itself. The corrected counts are a prediction from the code paths, not a measurement.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The work started from a self-driving inbox report about a single retired `welcome` step id. Investigating why that report cleared the scout's bar surfaced the two funnel numbers above, which share one cause with it.

This replaces #89543, which grew a spinner, a global wait on every lookup, and a timeout to bound that wait. Each of those existed only to contain the previous one, and the spinner made everyone wait on `gh auth status`, a network call that cannot affect which step comes first. Waiting per step removes all of it. #89463 was closed earlier as superseded; its rehydration guard is carried here.

ReviewHog found both error paths after the first push: the consent gate was fixed and the integrations gate was not, and a pending step could still be completed through the hotkey. Recording the view from the navigation handlers closes that for every step and every path, rather than disabling a button with no feedback. A second round found the anonymous-bootstrap hole in the project gate, fixed as above; its other finding, a background-refetch race on the integrations gate, is declined in the thread as a sub-second race whose fix would flap on every window focus.

The funnel numbers in Problem come from queries against project 2 in this session. No customer data, session content, or internal material is quoted anywhere in this PR.


