### PR TITLE
fix(logs,tracing): stop attribute row buttons stacking duplicate filters

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.test.ts
@@ -141,6 +141,25 @@ describe('logsViewerFiltersLogic', () => {
         })
     })
 
+    // The reconciliation rules themselves are covered in logsFilterAdd.test.ts; this pins that the
+    // attribute row buttons go through them, which they did not — a repeat click used to stack an
+    // identical chip, and a `+` after a `-` used to leave a pair matching no log.
+    describe('addFilter', () => {
+        it.each([
+            ['a repeat click', PropertyOperator.Exact, PropertyOperator.Exact],
+            ['a click cancelling an exclusion', PropertyOperator.IsNot, PropertyOperator.Exact],
+        ])('leaves one chip after %s', async (_label, first, second) => {
+            logic.actions.addFilter('service_name', 'api', first, PropertyFilterType.Log)
+            logic.actions.addFilter('service_name', 'api', second, PropertyFilterType.Log)
+            await expectLogic(logic).toFinishAllListeners()
+
+            const inner = logic.values.filters.filterGroup.values[0] as UniversalFiltersGroup
+            expect(inner.values).toEqual([
+                { key: 'service_name', value: ['api'], operator: second, type: PropertyFilterType.Log },
+            ])
+        })
+    })
+
     describe('setFilterGroup fallback', () => {
         it('falls back to default when given invalid filterGroup', async () => {
             logic.actions.setFilterGroup(null as any)

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -34,7 +34,10 @@ import {
     SEVERITY_LEVEL_FILTER,
     setFacetIncluded,
 } from 'products/logs/frontend/components/LogsViewer/FacetRail/facetFilters'
-import { LogsFilterTarget } from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterAdd'
+import {
+    LogsFilterTarget,
+    mergeFilterIntoValues,
+} from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterAdd'
 
 export const DEFAULT_DATE_RANGE = { date_from: '-1h', date_to: null }
 const VALID_SEVERITY_LEVELS: readonly LogSeverityLevel[] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
@@ -366,17 +369,17 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
         addFilter: ({ key, value, operator, propertyType }) => {
             const currentGroup = values.filters.filterGroup.values[0] as UniversalFiltersGroup
 
+            // Reconciled rather than appended, so clicking the same attribute row twice does not
+            // stack a duplicate chip, and including a value cancels a standing exclusion of it.
+            // Same rules the search bar and the facet rail apply.
             const newGroup: UniversalFiltersGroup = {
                 ...currentGroup,
-                values: [
-                    ...currentGroup.values,
-                    {
-                        key,
-                        value: [value],
-                        operator,
-                        type: propertyType,
-                    } as UniversalFiltersGroupValue,
-                ],
+                values: mergeFilterIntoValues(currentGroup.values, {
+                    key,
+                    value: [value],
+                    operator,
+                    type: propertyType,
+                } as UniversalFiltersGroupValue),
             }
 
             actions.setFilterGroup({ ...values.filters.filterGroup, values: [newGroup] }, false)

--- a/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic.ts
@@ -372,15 +372,20 @@ export const logsViewerFiltersLogic = kea<logsViewerFiltersLogicType>([
             // Reconciled rather than appended, so clicking the same attribute row twice does not
             // stack a duplicate chip, and including a value cancels a standing exclusion of it.
             // Same rules the search bar and the facet rail apply.
-            const newGroup: UniversalFiltersGroup = {
-                ...currentGroup,
-                values: mergeFilterIntoValues(currentGroup.values, {
-                    key,
-                    value: [value],
-                    operator,
-                    type: propertyType,
-                } as UniversalFiltersGroupValue),
+            const reconciled = mergeFilterIntoValues(currentGroup.values, {
+                key,
+                value: [value],
+                operator,
+                type: propertyType,
+            } as UniversalFiltersGroupValue)
+
+            if (equal(reconciled, currentGroup.values)) {
+                // The click landed on filters that already say this. Writing an equal group would
+                // reload the list, the patterns pivot and the group-by breakdown for no change.
+                return
             }
+
+            const newGroup: UniversalFiltersGroup = { ...currentGroup, values: reconciled }
 
             actions.setFilterGroup({ ...values.filters.filterGroup, values: [newGroup] }, false)
         },

--- a/products/tracing/frontend/components/VirtualizedSpanList/SpanAttributes.tsx
+++ b/products/tracing/frontend/components/VirtualizedSpanList/SpanAttributes.tsx
@@ -13,6 +13,9 @@ import { tracingFiltersLogic } from 'products/tracing/frontend/tracingFiltersLog
 
 const APPLIED_INDICATOR_MS = 2000
 
+// The indicator names the state the click leaves behind, not the write, because a click on a value
+// already filtered reconciles to the same group and writes nothing (see spanFilterAdd.ts).
+
 interface AttributeRow {
     key: string
     value: string
@@ -69,7 +72,7 @@ export function SpanAttributes({
                       render: (_: unknown, record: AttributeRow) => (
                           <div className="flex gap-x-0">
                               {appliedFilter?.key === record.key && appliedFilter.direction === 'include' ? (
-                                  <LemonButton size="xsmall" tooltip="Filter added">
+                                  <LemonButton size="xsmall" tooltip="Filter applied">
                                       <IconCheck className="text-success" />
                                   </LemonButton>
                               ) : (
@@ -86,7 +89,7 @@ export function SpanAttributes({
                                   </LemonButton>
                               )}
                               {appliedFilter?.key === record.key && appliedFilter.direction === 'exclude' ? (
-                                  <LemonButton size="xsmall" tooltip="Filter added">
+                                  <LemonButton size="xsmall" tooltip="Filter applied">
                                       <IconCheck className="text-success" />
                                   </LemonButton>
                               ) : (

--- a/products/tracing/frontend/spanFilterAdd.ts
+++ b/products/tracing/frontend/spanFilterAdd.ts
@@ -1,0 +1,111 @@
+/**
+ * Reconciling a filter added from a span attribute row with the filters the bar already holds.
+ *
+ * The row buttons used to append unconditionally, so clicking `+` twice left two identical chips,
+ * and clicking `+` after `-` on the same value left `attr = x` beside `attr ≠ x`, which matches no
+ * span. The rules below keep the invariant the facet rail keeps (see FacetRail/facets.ts): one
+ * filter per attribute and polarity, and no value on both sides at once.
+ */
+
+import { PropertyFilterType, PropertyFilterValue, PropertyOperator, UniversalFiltersGroup } from '~/types'
+
+type FilterEntry = UniversalFiltersGroup['values'][number]
+
+// The parts of a property filter this module reads. AnyPropertyFilter is a union whose members
+// disagree on `operator` and `value`, and spreading one back produces a type nothing accepts, so
+// entries are narrowed to this shape and cast back at the boundary — same approach as facets.ts.
+interface ReconcilableFilter {
+    key: string
+    type: PropertyFilterType
+    operator?: PropertyOperator
+    value?: PropertyFilterValue
+}
+
+// A row button only ever writes one of these two. Any other operator on the same key (an
+// `icontains` typed into the bar) is a legitimate AND, so it neither absorbs nor blocks a click.
+const OPPOSITE_OPERATOR: Partial<Record<PropertyOperator, PropertyOperator>> = {
+    [PropertyOperator.Exact]: PropertyOperator.IsNot,
+    [PropertyOperator.IsNot]: PropertyOperator.Exact,
+}
+
+function asFilter(entry: FilterEntry): ReconcilableFilter | null {
+    if (entry == null || typeof entry !== 'object' || 'values' in entry || !('key' in entry) || !('type' in entry)) {
+        return null
+    }
+    const filter = entry as unknown as ReconcilableFilter
+    return filter.key != null && filter.type != null ? filter : null
+}
+
+// Values are compared as strings because that is what the attribute rows and the URL round-trip
+// them as, but the stored value keeps its own type.
+function valueKey(value: unknown): string {
+    return String(value)
+}
+
+function filterValues(filter: ReconcilableFilter): unknown[] {
+    if (Array.isArray(filter.value)) {
+        return filter.value
+    }
+    return filter.value != null ? [filter.value] : []
+}
+
+function withValues(filter: ReconcilableFilter, values: unknown[]): FilterEntry {
+    return { ...filter, value: values } as unknown as FilterEntry
+}
+
+export interface SpanFilterMerge {
+    /** The inner group's values with `incoming` folded in. */
+    values: FilterEntry[]
+    /**
+     * The entry that ended up carrying the incoming value — the one just appended, or the existing
+     * filter it merged into. The bar addresses chips by identity, so it needs this rather than an
+     * index.
+     */
+    filter: FilterEntry
+}
+
+/**
+ * Add `incoming` to `values`, folding it into an existing filter on the same attribute where that is
+ * what the click meant:
+ *
+ * - an equality filter merges its values into the matching polarity, so clicking the same row again
+ *   changes nothing, and drops those values from the opposite polarity, so `= x` cancels a standing
+ *   `≠ x` instead of contradicting it
+ * - anything else appends
+ */
+export function mergeSpanFilter(values: FilterEntry[], incoming: FilterEntry): SpanFilterMerge {
+    const filter = asFilter(incoming)
+    const operator = filter?.operator
+    const opposite = operator ? OPPOSITE_OPERATOR[operator] : undefined
+    const incomingValues = filter ? filterValues(filter) : []
+    if (!filter || !operator || !opposite || incomingValues.length === 0) {
+        return { values: [...values, incoming], filter: incoming }
+    }
+
+    const incomingKeys = incomingValues.map(valueKey)
+    let merged: FilterEntry | null = null
+    const reconciled = values
+        .map((entry): FilterEntry | null => {
+            const existing = asFilter(entry)
+            if (!existing || existing.type !== filter.type || existing.key !== filter.key) {
+                return entry
+            }
+            if (existing.operator === operator) {
+                const kept = filterValues(existing)
+                const keptKeys = kept.map(valueKey)
+                merged = withValues(existing, [
+                    ...kept,
+                    ...incomingValues.filter((v) => !keptKeys.includes(valueKey(v))),
+                ])
+                return merged
+            }
+            if (existing.operator === opposite) {
+                const remaining = filterValues(existing).filter((v) => !incomingKeys.includes(valueKey(v)))
+                return remaining.length > 0 ? withValues(existing, remaining) : null
+            }
+            return entry
+        })
+        .filter((entry): entry is FilterEntry => entry !== null)
+
+    return merged ? { values: reconciled, filter: merged } : { values: [...reconciled, incoming], filter: incoming }
+}

--- a/products/tracing/frontend/spanFilterAdd.ts
+++ b/products/tracing/frontend/spanFilterAdd.ts
@@ -5,7 +5,13 @@
  * and clicking `+` after `-` on the same value left `attr = x` beside `attr ≠ x`, which matches no
  * span. The rules below keep the invariant the facet rail keeps (see FacetRail/facets.ts): one
  * filter per attribute and polarity, and no value on both sides at once.
+ *
+ * Logs holds the same rules in Filters/logsFilterAdd.ts, over a superset that also reconciles the
+ * ambiguous `log` / `log_attribute` pair its picker produces. Two copies is what the products
+ * convention allows; a third consumer is the point to lift the shared core into lib/.
  */
+
+import { uniqueBy } from 'lib/utils/arrays'
 
 import { PropertyFilterType, PropertyFilterValue, PropertyOperator, UniversalFiltersGroup } from '~/types'
 
@@ -83,29 +89,32 @@ export function mergeSpanFilter(values: FilterEntry[], incoming: FilterEntry): S
     }
 
     const incomingKeys = incomingValues.map(valueKey)
+    const reconciled: FilterEntry[] = []
     let merged: FilterEntry | null = null
-    const reconciled = values
-        .map((entry): FilterEntry | null => {
-            const existing = asFilter(entry)
-            if (!existing || existing.type !== filter.type || existing.key !== filter.key) {
-                return entry
-            }
-            if (existing.operator === operator) {
-                const kept = filterValues(existing)
-                const keptKeys = kept.map(valueKey)
-                merged = withValues(existing, [
-                    ...kept,
-                    ...incomingValues.filter((v) => !keptKeys.includes(valueKey(v))),
-                ])
-                return merged
-            }
-            if (existing.operator === opposite) {
-                const remaining = filterValues(existing).filter((v) => !incomingKeys.includes(valueKey(v)))
-                return remaining.length > 0 ? withValues(existing, remaining) : null
-            }
-            return entry
-        })
-        .filter((entry): entry is FilterEntry => entry !== null)
 
-    return merged ? { values: reconciled, filter: merged } : { values: [...reconciled, incoming], filter: incoming }
+    for (const entry of values) {
+        const existing = asFilter(entry)
+        if (!existing || existing.type !== filter.type || existing.key !== filter.key) {
+            reconciled.push(entry)
+            continue
+        }
+        if (existing.operator === operator) {
+            merged = withValues(existing, uniqueBy([...filterValues(existing), ...incomingValues], valueKey))
+            reconciled.push(merged)
+            continue
+        }
+        if (existing.operator === opposite) {
+            const remaining = filterValues(existing).filter((v) => !incomingKeys.includes(valueKey(v)))
+            if (remaining.length > 0) {
+                reconciled.push(withValues(existing, remaining))
+            }
+            continue
+        }
+        reconciled.push(entry)
+    }
+
+    if (merged) {
+        return { values: reconciled, filter: merged }
+    }
+    return { values: [...reconciled, incoming], filter: incoming }
 }

--- a/products/tracing/frontend/tracingFiltersLogic.test.ts
+++ b/products/tracing/frontend/tracingFiltersLogic.test.ts
@@ -193,6 +193,41 @@ describe('tracingFiltersLogic', () => {
             const inner = logic.values.filterGroup.values[0] as UniversalFiltersGroup
             expect(logic.values.suppressAutoOpenFilter).toBe(inner.values[inner.values.length - 1])
         })
+
+        // The row buttons are one click away from each other, so a repeat click used to stack an
+        // identical chip and a `+` after a `-` used to leave a pair matching no span. The
+        // suppression assertion pins the merged entry, not the discarded incoming one — the bar
+        // matches by identity, so a stale reference pops the editor open on a chip nobody touched.
+        it('folds a repeat click into the chip already there', () => {
+            logic.actions.addFilter('http.method', 'GET')
+            logic.actions.addFilter('http.method', 'GET')
+
+            const inner = logic.values.filterGroup.values[0] as UniversalFiltersGroup
+            expect(inner.values).toEqual([
+                {
+                    key: 'http.method',
+                    value: ['GET'],
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.SpanAttribute,
+                },
+            ])
+            expect(logic.values.suppressAutoOpenFilter).toBe(inner.values[0])
+        })
+
+        it('cancels a standing exclusion instead of contradicting it', () => {
+            logic.actions.addFilter('http.method', 'GET', PropertyOperator.IsNot)
+            logic.actions.addFilter('http.method', 'GET', PropertyOperator.Exact)
+
+            const inner = logic.values.filterGroup.values[0] as UniversalFiltersGroup
+            expect(inner.values).toEqual([
+                {
+                    key: 'http.method',
+                    value: ['GET'],
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.SpanAttribute,
+                },
+            ])
+        })
     })
 
     describe('refreshDeferredFilters', () => {

--- a/products/tracing/frontend/tracingFiltersLogic.test.ts
+++ b/products/tracing/frontend/tracingFiltersLogic.test.ts
@@ -214,6 +214,16 @@ describe('tracingFiltersLogic', () => {
             expect(logic.values.suppressAutoOpenFilter).toBe(inner.values[0])
         })
 
+        // Separate from the fold test above, which needs the flag already armed by its first add.
+        it('does not defer a refresh for a click that changes nothing', () => {
+            logic.actions.addFilter('http.method', 'GET')
+            logic.actions.refreshDeferredFilters()
+
+            logic.actions.addFilter('http.method', 'GET')
+
+            expect(logic.values.hasDeferredFilterRefresh).toBe(false)
+        })
+
         it('cancels a standing exclusion instead of contradicting it', () => {
             logic.actions.addFilter('http.method', 'GET', PropertyOperator.IsNot)
             logic.actions.addFilter('http.method', 'GET', PropertyOperator.Exact)

--- a/products/tracing/frontend/tracingFiltersLogic.ts
+++ b/products/tracing/frontend/tracingFiltersLogic.ts
@@ -436,12 +436,13 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
                 suppressAutoOpenForFilter: (_, { filter }) => filter,
             },
         ],
-        // Set when a filter is added while the trace drawer is open (so its query is deferred);
-        // cleared once that deferred query has actually run.
+        // Set when a filter write skips its own query (the drawer is covering the list);
+        // cleared once that deferred query has actually run. Keyed on the write rather than on
+        // `addFilter`, so a click that reconciles to the filters already applied defers nothing.
         hasDeferredFilterRefresh: [
             false,
             {
-                addFilter: () => true,
+                setFilterGroup: (state, { skipQuery }) => skipQuery || state,
                 refreshDeferredFilters: () => false,
             },
         ],
@@ -565,6 +566,12 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
                 operator,
                 type: propertyType,
             } as UniversalFiltersGroupValue)
+
+            if (equal(merged.values, currentGroup.values)) {
+                // The click landed on filters that already say this. Writing an equal group would
+                // re-render the bar and defer a re-query for a filter set that never moved.
+                return
+            }
 
             const newGroup: UniversalFiltersGroup = { ...currentGroup, values: merged.values }
 

--- a/products/tracing/frontend/tracingFiltersLogic.ts
+++ b/products/tracing/frontend/tracingFiltersLogic.ts
@@ -25,6 +25,8 @@ import {
     UniversalFiltersGroupValue,
 } from '~/types'
 
+import { mergeSpanFilter } from 'products/tracing/frontend/spanFilterAdd'
+
 export const DEFAULT_DATE_RANGE: DateRange = { date_from: '-1h', date_to: null }
 export const DEFAULT_TIMEZONE: string = 'UTC'
 export const DEFAULT_SERVICE_NAMES: string[] = []
@@ -554,14 +556,19 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
     listeners(({ actions, values }) => ({
         addFilter: ({ key, value, operator, propertyType }) => {
             const currentGroup = values.filterGroup.values[0] as UniversalFiltersGroup
-            const newFilterValue = { key, value: [value], operator, type: propertyType } as UniversalFiltersGroupValue
 
-            const newGroup: UniversalFiltersGroup = {
-                ...currentGroup,
-                values: [...currentGroup.values, newFilterValue],
-            }
+            // Reconciled rather than appended, so clicking the same attribute row twice does not
+            // stack a duplicate chip, and including a value cancels a standing exclusion of it.
+            const merged = mergeSpanFilter(currentGroup.values, {
+                key,
+                value: [value],
+                operator,
+                type: propertyType,
+            } as UniversalFiltersGroupValue)
 
-            actions.suppressAutoOpenForFilter(newFilterValue)
+            const newGroup: UniversalFiltersGroup = { ...currentGroup, values: merged.values }
+
+            actions.suppressAutoOpenForFilter(merged.filter as UniversalFiltersGroupValue)
             // Update the chips immediately, but defer the actual query — added from inside the
             // trace drawer, so re-querying now would only change data the drawer is covering.
             actions.setFilterGroup({ ...values.filterGroup, values: [newGroup] }, true)


### PR DESCRIPTION
## Problem

- Filtering from a log or span attribute row breaks on the second click: the same chip lands in the filter bar again, once per click.
- Clicking `+` after `-` on one value leaves `attr = x` beside `attr != x`, so the list goes empty.
- The `addFilter` listener in both products appended to the filter group without reading what was already in it.

## Changes

- The `+` and `-` buttons on an attribute row now leave one chip per attribute and polarity, however many times someone clicks.
- Including a value now clears a standing exclusion of that value, instead of contradicting it.
- A click that resolves to the filters already applied writes nothing. It used to reload the logs list, patterns pivot and group-by breakdown, and to arm a tracing re-query that ran when the trace drawer closed.
- The span attribute row confirms with "Filter applied", which holds whether the click added the filter or found it already there.
- Logs routes the buttons through `mergeFilterIntoValues`, the reconciliation its search bar and facet rail already use. Tracing gets the same rules in a new `spanFilterAdd` module.
- Nothing else looks different. The buttons and the chips are unchanged; only the number of chips a repeat click produces is.

## How did you test this code?

- Jest cases in `tracingFiltersLogic.test.ts` and `logsViewerFiltersLogic.test.ts`: a repeat click leaves one chip, `+` after `-` leaves only the inclusion, and a click that changes nothing defers no refresh. None of those regressions had a test.
- One tracing case pins that `suppressAutoOpenFilter` points at the merged entry. The bar matches chips by identity, so a stale reference pops an editor open on a chip nobody touched.
- The logs case is a wiring guard only. `logsFilterAdd.test.ts` already covers the reconciliation rules themselves.
- Known limit, left alone: duplicate chips already in a saved view or URL from before this change are merged into, not collapsed. The query result is unaffected, since the duplicate predicate is idempotent.
- Not run: the app in a browser, and `hogli review` (the Greptile CLI is absent from this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a report that the attribute row buttons stack duplicates. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/simplify`, `/code-review high --fix`, `/writing-user-facing-copy`.

Logs already held the reconciliation this needs, so the logs half is three lines. The open question was tracing, which has no equivalent helper. Importing the logs one would have coupled two products through a filter internal, and its target reconciliation is specific to the ambiguous `log` / `log_attribute` pair. A compact tracing-local module was the smaller commitment; promoting a shared one is the right move at a third consumer.

The review pass added the no-op guards and the copy fix. One behavior worth a reviewer's eye: in logs, an attribute row click on a key that collides with a facet rail column now folds into the rail's filter, because `reconcileTarget` treats `log` and `log_attribute` as one target. That rule predates this change and already applied to the search bar; this puts the row buttons under it too.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1787766141040379)*
