### PR TITLE
fix(access-control): show objects shared with everyone in the project in lists

### DIFF
--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -1125,8 +1125,8 @@ class UserAccessControl:
 
         # Apply filtering logic based on resource-level access
         if not self.has_resource_access(resource) and decision.allowed_ids:
-            # User has "none" resource access but specific object access
-            # Only show objects they have explicit access to (plus created objects)
+            # User has "none" resource access but some objects' own rules grant access.
+            # Only show those objects (plus objects they created)
             if model_has_creator:
                 queryset = queryset.filter(Q(id__in=decision.allowed_ids) | Q(created_by=self._user))
             else:
@@ -1146,7 +1146,8 @@ class UserAccessControl:
 
         Explicit-wins: if a resource_id has any explicit (role/member) rule, the object is
         allowed when any explicit rule grants non-"none", otherwise blocked. With no explicit
-        rule, the object is blocked only when every default rule is "none".
+        rule, the default ("everyone in the project") rules decide the same way: any non-"none"
+        default rule allows the object, all-"none" blocks it.
 
         Reads the `role_id` / `organization_member_id` columns rather than the `.role` /
         `.organization_member` FK accessors — equivalent result (id is None iff the relation is
@@ -1171,7 +1172,8 @@ class UserAccessControl:
             if not explicit_access_controls:
                 if all(access_level == NO_ACCESS_LEVEL for access_level in access_levels):
                     blocked_resource_ids.add(resource_id)
-                # No explicit controls for this object - don't block it
+                else:
+                    allowed_resource_ids.add(resource_id)
                 continue
 
             # Check if user has any non-"none" access to this specific object
@@ -1221,8 +1223,8 @@ class UserAccessControl:
         where they hold object-level grants but no resource-level access at all.
 
         This is the allowlist branch of `filter_queryset_by_access_level`: with "none" at the
-        resource level, REST serves the route and narrows rows to the explicitly granted objects
-        instead of merely removing denied ones. HogQL consumers must narrow the same way — a
+        resource level, REST serves the route and narrows rows to the objects whose own rules
+        grant access instead of merely removing denied ones. HogQL consumers must narrow the same way — a
         resource absent from this mapping falls back to removing `blocked_resource_ids_by_scope`.
 
         Empty for org admins and when there is no team / EE / entitlement, matching

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -1286,6 +1286,40 @@ class TestSpecificObjectAccessControl(BaseUserAccessControlTest):
         assert self.notebook_3.id in notebook_ids  # Created by user
         assert self.notebook_2.id not in notebook_ids  # No access
 
+    def test_filter_queryset_allowlists_objects_granted_to_everyone(self):
+        from products.notebooks.backend.models import Notebook
+
+        # Resource-level "none", but notebook_1 is shared with everyone in the project
+        self._create_access_control(resource="notebook", access_level="none")
+        self._create_access_control(resource="notebook", resource_id=str(self.notebook_1.id), access_level="editor")
+
+        self._clear_uac_caches()
+
+        notebook_ids = list(
+            self.user_access_control.filter_queryset_by_access_level(Notebook.objects.all()).values_list(
+                "id", flat=True
+            )
+        )
+        assert self.notebook_1.id in notebook_ids  # Granted to everyone on the object
+        assert self.notebook_3.id in notebook_ids  # Created by user
+        assert self.notebook_2.id not in notebook_ids
+
+        # A member-level "none" row on the same object overrides the everyone grant
+        self._create_access_control(
+            resource="notebook",
+            resource_id=str(self.notebook_1.id),
+            access_level="none",
+            organization_member=self.organization_membership,
+        )
+        self._clear_uac_caches()
+
+        notebook_ids = list(
+            self.user_access_control.filter_queryset_by_access_level(Notebook.objects.all()).values_list(
+                "id", flat=True
+            )
+        )
+        assert self.notebook_1.id not in notebook_ids
+
     def test_filter_queryset_by_access_level_with_resource_access(self):
         """Test queryset filtering when user has resource-level access"""
         from products.notebooks.backend.models import Notebook

--- a/products/access_control/backend/tests/test_user_access_control_pbt.py
+++ b/products/access_control/backend/tests/test_user_access_control_pbt.py
@@ -432,8 +432,8 @@ def oracle_blocked_and_allowed_object_ids(
 ) -> tuple[set[str], set[str]]:
     # Mirrors _blocked_and_allowed_object_ids over the rows visible to self.user
     # (only MATCHING targets survive _filter_options). Explicit (role/member) rows
-    # decide an object: any non-"none" explicit row allows it, otherwise it's blocked.
-    # With no explicit row, the object is blocked only when every default row is "none".
+    # decide an object when present, otherwise the default rows decide: any
+    # non-"none" deciding row allows the object, all-"none" blocks it.
     blocked: set[str] = set()
     allowed: set[str] = set()
     for resource_id, specs in object_specs_by_id.items():
@@ -441,11 +441,8 @@ def oracle_blocked_and_allowed_object_ids(
         if not matching:
             continue
         explicit = [s for s in matching if s.target != "team_default"]
-        if not explicit:
-            if all(s.level == NO_ACCESS_LEVEL for s in matching):
-                blocked.add(resource_id)
-            continue
-        if any(s.level != NO_ACCESS_LEVEL for s in explicit):
+        deciding = explicit or matching
+        if any(s.level != NO_ACCESS_LEVEL for s in deciding):
             allowed.add(resource_id)
         else:
             blocked.add(resource_id)


### PR DESCRIPTION
## Problem

A user with resource-level "No access" loses objects from lists that they can still open by URL. Example: dashboards are "No access" for the user, one dashboard is shared as "Everyone in the project: editor". The dashboard opens from a direct link, but the dashboards list does not show it.

The list allowlist only counted member and role grants. A default ("everyone in the project") grant on the object never counted, so the list and the detail endpoint disagreed.

## Changes

- Lists, search, and HogQL-visible schema now include objects whose own default rule grants access, for users with no resource-level access. Objects shared with a member or role behaved this way already; the everyone-share now matches.
- A personal or role "No access" row on the same object still hides it: explicit rows decide before the default row.
- Code: `_blocked_and_allowed_object_ids` now adds an object to the allowed set when its default rows grant a level above "none". Two lines plus docstrings.
- `allowlisted_resource_ids_by_scope` inherits the change, so the HogQL guard, the schema gate, and `ee/api/subscription.py` widen the same way. The change is additive only: nothing newly readable, since the detail endpoint already served these objects.

Independent of the refactor in #89361; whichever lands second rebases a small conflict in the same method.

## How did you test this code?

- New test `test_filter_queryset_allowlists_objects_granted_to_everyone`: catches the regression where an everyone-share disappears from lists under resource-level "none", and asserts a member "none" row still overrides the grant. No existing test covered the default-grant shape.
- Updated the property-based oracle (`oracle_blocked_and_allowed_object_ids`) to the new rule; the PBT suite holds the implementation, the HogQL guard derivation, and REST filtering to that oracle across arbitrary row configurations.
- Not run locally (worktree checkout) — relying on CI for the suite results.

## Automatic notifications

- [x] Publish to changelog?

## Docs update

None — `posthog/hogql/ACCESS_CONTROL.md` does not state the old allowlist rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: /writing-tests, /writing-pr-descriptions.
- Behavior change made deliberately after reviewing the gap: the fix moves lists to agree with the detail endpoint, and matches the rule the upcoming most-specific resolution enforces everywhere.
