### PR TITLE
feat(analytics): add PayGateMini feature detail

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -57,7 +57,7 @@ export function AccessControlObject(props: AccessControlLogicProps): JSX.Element
                     )}
                 </h2>
                 <p>{props.description}</p>
-                <PayGateMini feature={AvailableFeature.ACCESS_CONTROL}>
+                <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="access-control-object-settings">
                     <div className="deprecated-space-y-6">
                         {canEditAccessControls === false ? (
                             <LemonBanner type="warning">
@@ -77,7 +77,7 @@ export function AccessControlObject(props: AccessControlLogicProps): JSX.Element
                         <AccessControlObjectUsers />
 
                         {/* Put this inside of Advanced Permissions (access control) so two aren't shown at once */}
-                        <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
+                        <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS} featureDetail="access-control-object-roles">
                             <AccessControlObjectRoles />
                         </PayGateMini>
                     </div>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -77,7 +77,10 @@ export function AccessControlObject(props: AccessControlLogicProps): JSX.Element
                         <AccessControlObjectUsers />
 
                         {/* Put this inside of Advanced Permissions (access control) so two aren't shown at once */}
-                        <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS} featureDetail="access-control-object-roles">
+                        <PayGateMini
+                            feature={AvailableFeature.ROLE_BASED_ACCESS}
+                            featureDetail="access-control-object-roles"
+                        >
                             <AccessControlObjectRoles />
                         </PayGateMini>
                     </div>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlDefaultSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlDefaultSettings.tsx
@@ -26,7 +26,7 @@ export function AccessControlDefaultSettings({ projectId }: { projectId: string 
     } = defaults ?? {}
 
     return (
-        <PayGateMini feature={AvailableFeature.ACCESS_CONTROL}>
+        <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="resource-access-control-default-settings">
             <div className="space-y-4">
                 <div className="p-3 bg-surface-primary rounded border border-border flex flex-row justify-between items-center">
                     <div>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
@@ -115,7 +115,7 @@ function AccessControlTabContainer(props: { activeTab: AccessControlsTab; childr
     if (props.activeTab === 'roles') {
         return (
             <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS} featureDetail="resource-access-controls-roles">
-                <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="resource-access-controls">
+                <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="access-control-roles">
                     {props.children}
                 </PayGateMini>
             </PayGateMini>
@@ -123,7 +123,7 @@ function AccessControlTabContainer(props: { activeTab: AccessControlsTab; childr
     }
     if (props.activeTab === 'members') {
         return (
-            <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="resource-access-controls">
+            <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="access-control-members">
                 {props.children}
             </PayGateMini>
         )

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
@@ -114,13 +114,19 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
 function AccessControlTabContainer(props: { activeTab: AccessControlsTab; children?: React.ReactNode }): JSX.Element {
     if (props.activeTab === 'roles') {
         return (
-            <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
-                <PayGateMini feature={AvailableFeature.ACCESS_CONTROL}>{props.children}</PayGateMini>
+            <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS} featureDetail="resource-access-controls-roles">
+                <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="resource-access-controls">
+                    {props.children}
+                </PayGateMini>
             </PayGateMini>
         )
     }
     if (props.activeTab === 'members') {
-        return <PayGateMini feature={AvailableFeature.ACCESS_CONTROL}>{props.children}</PayGateMini>
+        return (
+            <PayGateMini feature={AvailableFeature.ACCESS_CONTROL} featureDetail="resource-access-controls">
+                {props.children}
+            </PayGateMini>
+        )
     }
 
     return <>{props.children}</>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -100,6 +100,7 @@ export const SidePanelActivity = (): JSX.Element => {
             <SidePanelPaneHeader title="Team activity" />
             <PayGateMini
                 feature={AvailableFeature.AUDIT_LOGS}
+                featureDetail="activity-log-side-panel"
                 className="flex flex-col flex-1 overflow-hidden"
                 overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
             >

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -283,6 +283,7 @@ export const ActivityLog = ({ scope, id, caption, startingPage = 1 }: ActivityLo
             {caption && <div className="page-caption">{caption}</div>}
             <PayGateMini
                 feature={AvailableFeature.AUDIT_LOGS}
+                featureDetail="activity-log"
                 overrideShouldShowGate={user?.is_impersonated || !!featureFlags[FEATURE_FLAGS.AUDIT_LOGS_ACCESS]}
             >
                 <ActivityLogContents scope={scope} id={id} caption={caption} startingPage={startingPage} />

--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -21,6 +21,12 @@ export type PayGateMiniProps = PayGateMiniLogicProps & {
      * The content to show when the feature is available. Will show nothing if children is undefined.
      */
     children?: React.ReactNode
+    /**
+     * A human-readable identifier for the specific UI surface being gated.
+     * This is included in pay gate analytics to distinguish multiple surfaces
+     * that use the same billing feature.
+     */
+    featureDetail?: string
     overrideShouldShowGate?: boolean
     className?: string
     background?: boolean
@@ -43,6 +49,7 @@ export type PayGateMiniProps = PayGateMiniLogicProps & {
  */
 export function PayGateMini({
     feature,
+    featureDetail,
     currentUsage,
     className,
     children,
@@ -66,11 +73,12 @@ export function PayGateMini({
             posthog.capture('pay gate shown', {
                 product_key: productWithFeature?.type,
                 feature: feature,
+                feature_detail: featureDetail,
                 gate_variant: gateVariant,
                 cta_label: ctaLabel,
             })
         }
-    }, [gateVariant, ctaLabel]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [feature, featureDetail, gateVariant, ctaLabel, productWithFeature?.type])
 
     const handleCtaClick = (): void => {
         if (handleSubmit) {
@@ -79,6 +87,7 @@ export function PayGateMini({
         posthog.capture('pay gate CTA clicked', {
             product_key: productWithFeature?.type,
             feature: feature,
+            feature_detail: featureDetail,
             gate_variant: gateVariant,
             cta_label: ctaLabel,
         })

--- a/frontend/src/lib/components/UpgradeModal/UpgradeModal.tsx
+++ b/frontend/src/lib/components/UpgradeModal/UpgradeModal.tsx
@@ -56,6 +56,7 @@ export function UpgradeModal(): JSX.Element {
             <div className="max-w-2xl">
                 <PayGateMini
                     feature={upgradeModalFeatureKey}
+                    featureDetail="upgrade-modal"
                     currentUsage={upgradeModalFeatureUsage ?? undefined}
                     isGrandfathered={upgradeModalIsGrandfathered ?? undefined}
                     background={false}

--- a/frontend/src/scenes/audit-logs/AdvancedActivityLogsScene.tsx
+++ b/frontend/src/scenes/audit-logs/AdvancedActivityLogsScene.tsx
@@ -87,7 +87,11 @@ export function AdvancedActivityLogsScene(): JSX.Element | null {
                     forceIcon: <IconNotification />,
                 }}
             />
-            <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
+            <PayGateMini
+                feature={AvailableFeature.AUDIT_LOGS}
+                featureDetail="advanced-activity-logs"
+                overrideShouldShowGate={user?.is_impersonated}
+            >
                 <LemonTabs
                     activeKey={isOrganizationView ? 'logs' : activeTab}
                     onChange={(key) => setActiveTab(key as 'logs' | 'exports')}

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -352,7 +352,10 @@ export function DefinitionEdit(rawProps: DefinitionLogicProps): JSX.Element {
                             title="Access control"
                             description="Control who can see this property's values, and who can edit them from the PostHog UI."
                         >
-                            <PayGateMini feature={AvailableFeature.PROPERTY_ACCESS_CONTROL}>
+                            <PayGateMini
+                                feature={AvailableFeature.PROPERTY_ACCESS_CONTROL}
+                                featureDetail="property-definition-access-control"
+                            >
                                 <PropertyAccessControl
                                     propertyDefinitionId={editDefinition.id}
                                     teamId={currentTeamId}

--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -9,6 +9,7 @@ export function GroupsIntroduction(): JSX.Element {
     return (
         <PayGateMini
             feature={AvailableFeature.GROUP_ANALYTICS}
+            featureDetail="groups-introduction"
             className="py-8"
             docsLink="https://posthog.com/docs/user-guides/group-analytics"
         >

--- a/frontend/src/scenes/hog-functions/list/NotificationsPane.tsx
+++ b/frontend/src/scenes/hog-functions/list/NotificationsPane.tsx
@@ -53,7 +53,7 @@ export function NotificationsPane({
     const { openDialog } = useActions(newNotificationDialogLogic(logicProps))
 
     return (
-        <PayGateMini feature={requiredFeature}>
+        <PayGateMini feature={requiredFeature} featureDetail={`hog-function-notifications-${subTemplateId}`}>
             <div>
                 <p>{description}</p>
                 <HogFunctionList

--- a/frontend/src/scenes/hog-functions/list/NotificationsPane.tsx
+++ b/frontend/src/scenes/hog-functions/list/NotificationsPane.tsx
@@ -53,7 +53,7 @@ export function NotificationsPane({
     const { openDialog } = useActions(newNotificationDialogLogic(logicProps))
 
     return (
-        <PayGateMini feature={requiredFeature} featureDetail={`hog-function-notifications-${subTemplateId}`}>
+        <PayGateMini feature={requiredFeature} featureDetail="hog-function-notifications">
             <div>
                 <p>{description}</p>
                 <HogFunctionList

--- a/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
@@ -35,7 +35,7 @@ export function PathsAdvanced({ insightProps, ...rest }: EditorFilterProps): JSX
 
     return (
         <div className="flex flex-col gap-4">
-            <PayGateMini feature={AvailableFeature.PATHS_ADVANCED}>
+            <PayGateMini feature={AvailableFeature.PATHS_ADVANCED} featureDetail="paths-advanced-filter">
                 <div className="flex flex-col gap-2">
                     <LemonLabel info="Determines the maximum number of path nodes that can be generated. If necessary certain items will be grouped.">
                         Maximum number of paths

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
@@ -28,7 +28,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
     return (
         <>
             <h2 className="font-semibold text-lg my-4">Correlation analysis</h2>
-            <PayGateMini feature={AvailableFeature.CORRELATION_ANALYSIS}>
+            <PayGateMini feature={AvailableFeature.CORRELATION_ANALYSIS} featureDetail="funnel-correlation-analysis">
                 <div className="funnel-correlation">
                     <FunnelCorrelationSkewWarning />
                     <FunnelCorrelationTable />

--- a/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlaybackScene.tsx
+++ b/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlaybackScene.tsx
@@ -32,6 +32,7 @@ export function SessionRecordingFilePlaybackScene(): JSX.Element {
         return (
             <PayGateMini
                 feature={AvailableFeature.RECORDINGS_FILE_EXPORT}
+                featureDetail="session-recording-file-export"
                 className="py-8"
                 docsLink="https://posthog.com/docs/user-guides/session-recordings"
             />

--- a/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
+++ b/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
@@ -23,7 +23,11 @@ export function ActivityLogSettings(): JSX.Element {
     const effectiveRestriction = user?.is_impersonated ? null : restrictedReason
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} featureDetail="activity-log-retention" overrideShouldShowGate={user?.is_impersonated}>
+        <PayGateMini
+            feature={AvailableFeature.AUDIT_LOGS}
+            featureDetail="activity-log-retention"
+            overrideShouldShowGate={user?.is_impersonated}
+        >
             <div className="flex">
                 <p>
                     <LemonButton to={urls.advancedActivityLogs()} type="primary" disabledReason={effectiveRestriction}>
@@ -49,7 +53,11 @@ export function ActivityLogOrgLevelSettings(): JSX.Element {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} featureDetail="activity-log-retention" overrideShouldShowGate={user?.is_impersonated}>
+        <PayGateMini
+            feature={AvailableFeature.AUDIT_LOGS}
+            featureDetail="activity-log-retention"
+            overrideShouldShowGate={user?.is_impersonated}
+        >
             <div>
                 <p className="flex items-center gap-1">
                     Include organization-level activity logs in this project.
@@ -91,7 +99,11 @@ export function ActivityLogNotifications(): JSX.Element | null {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} featureDetail="activity-log-retention" overrideShouldShowGate={user?.is_impersonated}>
+        <PayGateMini
+            feature={AvailableFeature.AUDIT_LOGS}
+            featureDetail="activity-log-retention"
+            overrideShouldShowGate={user?.is_impersonated}
+        >
             <div>
                 <p className="flex items-center gap-1">
                     Create notifications to get notified of activity logs.

--- a/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
+++ b/frontend/src/scenes/settings/environment/ActivityLogSettings.tsx
@@ -23,7 +23,7 @@ export function ActivityLogSettings(): JSX.Element {
     const effectiveRestriction = user?.is_impersonated ? null : restrictedReason
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
+        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} featureDetail="activity-log-retention" overrideShouldShowGate={user?.is_impersonated}>
             <div className="flex">
                 <p>
                     <LemonButton to={urls.advancedActivityLogs()} type="primary" disabledReason={effectiveRestriction}>
@@ -49,7 +49,7 @@ export function ActivityLogOrgLevelSettings(): JSX.Element {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
+        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} featureDetail="activity-log-retention" overrideShouldShowGate={user?.is_impersonated}>
             <div>
                 <p className="flex items-center gap-1">
                     Include organization-level activity logs in this project.
@@ -91,7 +91,7 @@ export function ActivityLogNotifications(): JSX.Element | null {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} overrideShouldShowGate={user?.is_impersonated}>
+        <PayGateMini feature={AvailableFeature.AUDIT_LOGS} featureDetail="activity-log-retention" overrideShouldShowGate={user?.is_impersonated}>
             <div>
                 <p className="flex items-center gap-1">
                     Create notifications to get notified of activity logs.

--- a/frontend/src/scenes/settings/environment/DataColorThemes.tsx
+++ b/frontend/src/scenes/settings/environment/DataColorThemes.tsx
@@ -29,7 +29,7 @@ export function DataColorThemes(): JSX.Element {
     const themes = _themes || []
 
     return (
-        <PayGateMini feature={AvailableFeature.DATA_COLOR_THEMES}>
+        <PayGateMini feature={AvailableFeature.DATA_COLOR_THEMES} featureDetail="data-color-themes-settings">
             <div className="deprecated-space-y-4">
                 <p>
                     These themes can be used in insights. You can also set a default theme for all insights below. For

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -90,7 +90,7 @@ function LinkedFlagSelector(): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <PayGateMini feature={AvailableFeature.REPLAY_FEATURE_FLAG_BASED_RECORDING}>
+        <PayGateMini feature={AvailableFeature.REPLAY_FEATURE_FLAG_BASED_RECORDING} featureDetail="replay-feature-flag-trigger">
             <IngestionControls.FlagTrigger
                 logicKey="session-replay-linked-flag"
                 flag={currentTeam?.session_recording_linked_flag ?? null}
@@ -248,7 +248,7 @@ function Sampling(): JSX.Element {
     const storedSampleRate = currentTeam?.session_recording_sample_rate
 
     return (
-        <PayGateMini feature={AvailableFeature.SESSION_REPLAY_SAMPLING}>
+        <PayGateMini feature={AvailableFeature.SESSION_REPLAY_SAMPLING} featureDetail="session-replay-sampling">
             <div className="flex flex-col gap-2">
                 <div className="flex flex-row justify-between items-center">
                     <LemonLabel className="text-base">
@@ -279,7 +279,7 @@ function MobileSampling(): JSX.Element {
     const storedSampleRate = currentTeam?.session_recording_sample_rate
 
     return (
-        <PayGateMini feature={AvailableFeature.SESSION_REPLAY_SAMPLING}>
+        <PayGateMini feature={AvailableFeature.SESSION_REPLAY_SAMPLING} featureDetail="session-replay-sampling">
             <div className="flex flex-col gap-2">
                 <div className="flex flex-row justify-between items-center">
                     <LemonLabel className="text-base">
@@ -340,7 +340,7 @@ function MobileMinimumDuration(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM}>
+        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM} featureDetail="replay-minimum-recording-duration">
             <div className="flex flex-col gap-2">
                 <div className="flex flex-row justify-between items-center">
                     <LemonLabel className="text-base">
@@ -371,7 +371,7 @@ function MinimumDurationSetting(): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM}>
+        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM} featureDetail="replay-minimum-recording-duration">
             <div className="flex flex-col gap-2">
                 <div className="flex flex-row justify-between items-center">
                     <LemonLabel className="text-base">

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -90,7 +90,10 @@ function LinkedFlagSelector(): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <PayGateMini feature={AvailableFeature.REPLAY_FEATURE_FLAG_BASED_RECORDING} featureDetail="replay-feature-flag-trigger">
+        <PayGateMini
+            feature={AvailableFeature.REPLAY_FEATURE_FLAG_BASED_RECORDING}
+            featureDetail="replay-feature-flag-trigger"
+        >
             <IngestionControls.FlagTrigger
                 logicKey="session-replay-linked-flag"
                 flag={currentTeam?.session_recording_linked_flag ?? null}
@@ -340,7 +343,10 @@ function MobileMinimumDuration(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM} featureDetail="replay-minimum-recording-duration">
+        <PayGateMini
+            feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM}
+            featureDetail="replay-minimum-recording-duration"
+        >
             <div className="flex flex-col gap-2">
                 <div className="flex flex-row justify-between items-center">
                     <LemonLabel className="text-base">
@@ -371,7 +377,10 @@ function MinimumDurationSetting(): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
 
     return (
-        <PayGateMini feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM} featureDetail="replay-minimum-recording-duration">
+        <PayGateMini
+            feature={AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM}
+            featureDetail="replay-minimum-recording-duration"
+        >
             <div className="flex flex-col gap-2">
                 <div className="flex flex-row justify-between items-center">
                     <LemonLabel className="text-base">

--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -154,7 +154,7 @@ export function ApprovalPolicies(): JSX.Element {
     ]
 
     return (
-        <PayGateMini feature={AvailableFeature.APPROVALS}>
+        <PayGateMini feature={AvailableFeature.APPROVALS} featureDetail="approval-policies">
             <div className="space-y-4">
                 <div className="flex justify-end items-center">
                     <LemonButton type="primary" onClick={() => setIsCreating(true)} disabledReason={restrictionReason}>

--- a/frontend/src/scenes/settings/organization/Approvals/ChangeRequestsList.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ChangeRequestsList.tsx
@@ -119,7 +119,7 @@ export function ChangeRequestsList(): JSX.Element {
     ]
 
     return (
-        <PayGateMini feature={AvailableFeature.APPROVALS}>
+        <PayGateMini feature={AvailableFeature.APPROVALS} featureDetail="approval-change-requests">
             <div className="space-y-4">
                 <div className={cn('flex flex-wrap gap-2 justify-between')}>
                     <div className="flex gap-2 items-center">

--- a/frontend/src/scenes/settings/organization/Members.tsx
+++ b/frontend/src/scenes/settings/organization/Members.tsx
@@ -378,7 +378,10 @@ export function Members(): JSX.Element | null {
                 }
             />
             <h3 className="mt-4">Two-factor authentication</h3>
-            <PayGateMini feature={AvailableFeature.TWOFA_ENFORCEMENT} featureDetail="organization-members-two-factor-authentication">
+            <PayGateMini
+                feature={AvailableFeature.TWOFA_ENFORCEMENT}
+                featureDetail="organization-members-two-factor-authentication"
+            >
                 <p>Require all organization members to use two-factor authentication.</p>
                 <LemonSwitch
                     label="Enforce 2FA"
@@ -390,7 +393,10 @@ export function Members(): JSX.Element | null {
             </PayGateMini>
 
             <h3 className="mt-4">Invite settings</h3>
-            <PayGateMini feature={AvailableFeature.ORGANIZATION_INVITE_SETTINGS} featureDetail="organization-member-and-project-invites">
+            <PayGateMini
+                feature={AvailableFeature.ORGANIZATION_INVITE_SETTINGS}
+                featureDetail="organization-member-and-project-invites"
+            >
                 <p>Control who can send organization invites.</p>
                 <LemonSwitch
                     label={
@@ -424,7 +430,10 @@ export function Members(): JSX.Element | null {
             {posthog.isFeatureEnabled(FEATURE_FLAGS.MEMBERS_CAN_USE_PERSONAL_API_KEYS) && (
                 <>
                     <h3 className="mt-4">Security settings</h3>
-                    <PayGateMini feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS} featureDetail="organization-members-personal-api-key-access">
+                    <PayGateMini
+                        feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}
+                        featureDetail="organization-members-personal-api-key-access"
+                    >
                         <p>Configure security permissions for organization members.</p>
                         <LemonSwitch
                             label={

--- a/frontend/src/scenes/settings/organization/Members.tsx
+++ b/frontend/src/scenes/settings/organization/Members.tsx
@@ -378,7 +378,7 @@ export function Members(): JSX.Element | null {
                 }
             />
             <h3 className="mt-4">Two-factor authentication</h3>
-            <PayGateMini feature={AvailableFeature.TWOFA_ENFORCEMENT}>
+            <PayGateMini feature={AvailableFeature.TWOFA_ENFORCEMENT} featureDetail="organization-members-two-factor-authentication">
                 <p>Require all organization members to use two-factor authentication.</p>
                 <LemonSwitch
                     label="Enforce 2FA"
@@ -390,7 +390,7 @@ export function Members(): JSX.Element | null {
             </PayGateMini>
 
             <h3 className="mt-4">Invite settings</h3>
-            <PayGateMini feature={AvailableFeature.ORGANIZATION_INVITE_SETTINGS}>
+            <PayGateMini feature={AvailableFeature.ORGANIZATION_INVITE_SETTINGS} featureDetail="organization-member-and-project-invites">
                 <p>Control who can send organization invites.</p>
                 <LemonSwitch
                     label={
@@ -424,7 +424,7 @@ export function Members(): JSX.Element | null {
             {posthog.isFeatureEnabled(FEATURE_FLAGS.MEMBERS_CAN_USE_PERSONAL_API_KEYS) && (
                 <>
                     <h3 className="mt-4">Security settings</h3>
-                    <PayGateMini feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}>
+                    <PayGateMini feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS} featureDetail="organization-members-personal-api-key-access">
                         <p>Configure security permissions for organization members.</p>
                         <LemonSwitch
                             label={

--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
@@ -83,7 +83,10 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
     ]
 
     return (
-        <PayGateMini feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}>
+        <PayGateMini
+            feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}
+            featureDetail="organization-personal-api-keys"
+        >
             <div className="mb-2">
                 <LemonInput
                     type="search"

--- a/frontend/src/scenes/settings/organization/OrganizationSecuritySettings.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationSecuritySettings.tsx
@@ -28,7 +28,10 @@ export function OrganizationSecuritySettings(): JSX.Element | null {
 
     return (
         <>
-            <PayGateMini feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}>
+            <PayGateMini
+                feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}
+                featureDetail="organization-sharing-and-member-visibility"
+            >
                 <LemonSwitch
                     label={
                         <span>

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/EnforceVerifiedDomains.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/EnforceVerifiedDomains.tsx
@@ -37,7 +37,7 @@ export function EnforceVerifiedDomains(): JSX.Element {
     }
 
     return (
-        <PayGateMini feature={AvailableFeature.AUTOMATIC_PROVISIONING}>
+        <PayGateMini feature={AvailableFeature.AUTOMATIC_PROVISIONING} featureDetail="enforce-verified-domains">
             <p>
                 Only allow people with an email address on a verified domain into this organization. Invites to other
                 domains are blocked, and existing members on other domains lose access.

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.tsx
@@ -82,7 +82,7 @@ export function VerifiedDomains(): JSX.Element {
     })
 
     return (
-        <PayGateMini feature={AvailableFeature.AUTOMATIC_PROVISIONING}>
+        <PayGateMini feature={AvailableFeature.AUTOMATIC_PROVISIONING} featureDetail="verified-domains">
             <p>
                 Enable users to sign up automatically with an email address on verified domains and enforce SSO for
                 accounts under your domains.

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceModal.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceModal.tsx
@@ -177,7 +177,11 @@ export function SurveyAppearanceModal({
                 <LemonModal.Content className="flex flex-col md:flex-row flex-1 h-full gap-4 overflow-hidden">
                     <div className="flex-1 overflow-y-auto flex flex-col gap-2 pr-1">
                         {!surveysStylingAvailable && (
-                            <PayGateMini feature={AvailableFeature.SURVEYS_STYLING} className="mb-4">
+                            <PayGateMini
+                                feature={AvailableFeature.SURVEYS_STYLING}
+                                featureDetail="survey-appearance-modal"
+                                className="mb-4"
+                            >
                                 <></>
                             </PayGateMini>
                         )}

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
@@ -60,7 +60,7 @@ export function Customization({
     return (
         <div className="flex flex-col divide-y divide-border [&>*]:py-5 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
             {!surveysStylingAvailable && (
-                <PayGateMini feature={AvailableFeature.SURVEYS_STYLING}>
+                <PayGateMini feature={AvailableFeature.SURVEYS_STYLING} featureDetail="survey-customization">
                     <></>
                 </PayGateMini>
             )}

--- a/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
@@ -86,7 +86,7 @@ export function AppearanceStep(): JSX.Element {
 
                 {/* Paywall */}
                 {!surveysStylingAvailable && (
-                    <PayGateMini feature={AvailableFeature.SURVEYS_STYLING}>
+                    <PayGateMini feature={AvailableFeature.SURVEYS_STYLING} featureDetail="survey-appearance-wizard">
                         <></>
                     </PayGateMini>
                 )}


### PR DESCRIPTION
## Problem

Billing-gated UI surfaces currently share only a coarse billing feature key, making it difficult to identify which specific interface drove an upgrade. The gate analytics now needs a stable UI-level detail for conversion analysis.

## Changes

- Added an optional `featureDetail` prop to `PayGateMini`.
- Included the detail as `feature_detail` in both `pay gate shown` and `pay gate CTA clicked` events.
- Added descriptive details to existing production PayGateMini usages.

## How did you test this code?

- `git diff --check` passed.
- Targeted formatting and linting could not run because frontend dependencies are not installed in the checkout.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The product analytics instrumentation skill was used. The prop is optional for compatibility, while current production call sites provide stable surface identifiers for immediate analysis.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
