### PR TITLE
fix(metabase): stop retrying syncs whose host resolves to an internal IP

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/source.py
@@ -135,6 +135,10 @@ The API key (or user) needs read access to the data you want to sync.""",
             # Deterministic and permanent until the Instance URL is corrected, so stop
             # retrying. Match the stable prefix, not the customer's hostname that follows it.
             "Couldn't resolve the host": "The Metabase Instance URL could not be resolved via DNS. Check that it's spelled correctly and reachable from the public internet, then reconnect.",
+            # `_is_host_safe` raises this when the Instance URL resolves to an internal or
+            # private address (SSRF guard). Deterministic and permanent until the customer
+            # points the source at a publicly reachable host, so stop retrying.
+            "internal or private IP address": "The Metabase Instance URL resolves to an internal or private IP address. Use your instance's public URL, then reconnect.",
         }
 
     def _build_auth(self, config: MetabaseSourceConfig) -> MetabaseAuth:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase_source.py
@@ -57,6 +57,29 @@ class TestMetabaseSource:
         non_retryable = self.source.get_non_retryable_errors()
         assert any(key in err for key in non_retryable)
 
+    def test_internal_ip_host_message_is_classified_non_retryable(self):
+        # `_is_host_safe` raises this exact message when the Instance URL resolves to a
+        # private/internal address (SSRF guard) — a permanent, deterministic failure until the
+        # customer points the source at a public host. Build the message via the real
+        # `_is_host_safe` code path so this test breaks if either side's wording drifts from
+        # the classifier's key.
+        with (
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.is_cloud",
+                return_value=True,
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.get_instance_region",
+                return_value="US",
+            ),
+        ):
+            ok, err = _is_host_safe("10.0.0.5", team_id=999)
+
+        assert not ok
+        assert err is not None
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in err for key in non_retryable)
+
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {s.name for s in schemas} == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

A Metabase sync whose Instance URL resolves to an internal or private IP address retries forever instead of pausing, because the classifier never matches the actual error text.

## Changes

- Add the real SSRF-guard message ("internal or private IP address") as a non-retryable pattern for the Metabase source, so this permanent misconfiguration stops retrying.
- The previously declared `HOST_NOT_ALLOWED_ERROR` fallback text is never the message actually raised for this failure, so it never matched.

## How did you test this code?

Added `test_internal_ip_host_message_is_classified_non_retryable`, which drives the real `_is_host_safe` code path with a private-IP literal host and asserts the resulting message matches a key in `get_non_retryable_errors()` — this is the exact gap that let the error keep retrying. Ran the full `metabase` test suite locally (60 passed) and `ruff check`/`ruff format` on the touched files.

Not run: full repo-wide mypy and a Greptile bot-equivalent review — Greptile CLI and flox were unavailable in this sandbox; ran the `/code-review` fallback instead (no findings).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry classification only, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a live error tracking issue reporting `MetabaseHostNotAllowedError` for a host resolving to an internal/private IP. Traced the raise site in `metabase.py`'s `get_rows` through the shared `_is_host_safe` SSRF guard in `common/mixins.py`, and found the classifier in `source.py`'s `get_non_retryable_errors` only matched a fallback string that is never actually raised for this path. Added the real message as a non-retryable pattern and a regression test exercising the real code path (mirroring the existing DNS-failure test). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/reviewing-before-pr` (Greptile CLI unavailable in this sandbox; ran the `/code-review` fallback instead, no findings survived).