### PR TITLE
feat(warehouse-sources): let fan-out children read webhook-synced parents

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/stripe/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/stripe/test_stripe_source.py
@@ -1282,11 +1282,14 @@ async def test_fanout_pages_the_customer_listing_with_reuse_disabled(team, mock_
     assert sorted(probed) == PROBED_CUSTOMERS
 
 
+@pytest.mark.parametrize("parent_sync_type", ["full_refresh", "webhook"])
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_fanout_reads_the_parent_from_the_warehouse(team, mock_stripe_api, external_data_source):
+async def test_fanout_reads_the_parent_from_the_warehouse(
+    team, mock_stripe_api, external_data_source, parent_sync_type
+):
     """The conversion: same child rows, without a single request for the parent listing."""
-    parent = await _customer_schema(external_data_source, team, "full_refresh")
+    parent = await _customer_schema(external_data_source, team, parent_sync_type)
     child = await _balance_transaction_child(external_data_source, team)
 
     _, listing, probed = await _sync_parent_then_child(
@@ -1317,25 +1320,21 @@ async def test_both_paths_write_the_same_child_rows(team, mock_stripe_api, exter
     assert sorted(map(str, warehouse_response.results)) == sorted(map(str, api_response.results))
 
 
-@pytest.mark.parametrize("parent_sync_type", ["webhook", "append"])
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_a_parent_the_gate_refuses_keeps_the_api_path(
-    team, mock_stripe_api, external_data_source, parent_sync_type
-):
+async def test_a_parent_the_gate_refuses_keeps_the_api_path(team, mock_stripe_api, external_data_source):
     """Only sync types that hold one row per key are readable; the rest fall back, never fail.
 
-    `append` accumulates a row per sync and webhook is not on the allow-list yet, so both must
-    leave the sweep exactly where it was.
+    `append` accumulates a row per sync, so reading it would fan the child out once per copy.
     """
-    parent = await _customer_schema(external_data_source, team, parent_sync_type)
+    parent = await _customer_schema(external_data_source, team, "append")
     child = await _balance_transaction_child(external_data_source, team)
 
     _, listing, probed = await _sync_parent_then_child(
         team, external_data_source, parent, child, mock_stripe_api, reuse_enabled=True
     )
 
-    assert listing, f"a {parent_sync_type} parent must not be read from the warehouse"
+    assert listing, "an append parent must not be read from the warehouse"
     assert sorted(probed) == PROBED_CUSTOMERS
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -121,17 +121,26 @@ def _get_external_data_schema(schema_id: uuid.UUID, team_id: int) -> ExternalDat
     )
 
 
+# An allow-list, not a deny-list: every sync type here leaves one row per key, and the reader
+# streams the table with no dedupe state. Append keeps a row per sync and CDC keeps change
+# history, so either would fan the child out once per duplicate. Webhook qualifies because its
+# drains merge on the primary key — the pipeline maps it to `sync_type = "incremental"`.
+WAREHOUSE_READABLE_PARENT_SYNC_TYPES = frozenset(
+    {
+        ExternalDataSchema.SyncType.FULL_REFRESH,
+        ExternalDataSchema.SyncType.INCREMENTAL,
+        ExternalDataSchema.SyncType.WEBHOOK,
+    }
+)
+
+
 def _parent_unusable_reason(parent: ExternalDataSchema | None) -> str | None:
     """Why a fan-out child can't read this parent from the warehouse, or None when it can."""
     if parent is None:
         return "missing"
     if not parent.should_sync:
         return "disabled"
-    if not (parent.is_incremental or parent.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH):
-        # An allow-list, not a deny-list: only merge and full-refresh parents hold one row per
-        # key. Append accumulates a row per sync, and CDC keeps change history, so the reader —
-        # which streams the table as-is, with no dedupe state — would fan the child out once
-        # per duplicate. New sync types have to opt in here deliberately.
+    if parent.sync_type not in WAREHOUSE_READABLE_PARENT_SYNC_TYPES:
         return "unsupported_sync_type"
     if not parent.initial_sync_complete:
         return "no_initial_sync"

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -708,10 +708,15 @@ async def test_unusable_parent_falls_back_to_the_api_path(parent):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "sync_type",
-    [ExternalDataSchema.SyncType.INCREMENTAL, ExternalDataSchema.SyncType.FULL_REFRESH],
+    [
+        ExternalDataSchema.SyncType.INCREMENTAL,
+        ExternalDataSchema.SyncType.FULL_REFRESH,
+        ExternalDataSchema.SyncType.WEBHOOK,
+    ],
 )
 async def test_synced_parent_uses_the_warehouse_path(sync_type):
-    # Merge and full-refresh parents both hold one row per key, so both drive the reader.
+    # Every sync type here leaves one row per key, so each drives the reader. Webhook qualifies
+    # because its drains merge on the primary key rather than appending.
     with (
         mock.patch.object(module, "database_sync_to_async_pool", new=_passthrough),
         mock.patch.object(module, "is_fanout_warehouse_reuse_enabled", return_value=True),


### PR DESCRIPTION
## Problem

- Teams whose Stripe customer list is kept fresh by webhooks get no benefit from warehouse parent reuse, even though their stored copy is more current than the API listing they pay to re-download on every run.
- The eligibility rule admits `full_refresh` and `incremental` parents only. That is **1,602 of the 65,927 weekly `CustomerBalanceTransaction` runs**, about 1.2% of the time those syncs spend.
- Webhook-synced parents are **23,930 runs a week**, roughly 43% of that time. They were excluded by how the rule was written, not by a property they lack.

## Changes

- A fan-out child can now read a parent whose sync type is `webhook`, so those runs stop re-paging the customer listing and read the stored table instead.
- Webhook drains merge on the primary key: the pipeline maps `is_webhook` to `sync_type = "incremental"` alongside the incremental sweeps ([pipeline_v3.py](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py#L162)). One row per key is exactly what the rule exists to check, so this admits a parent that already satisfied it.
- The check now tests membership in a named set of sync types rather than a boolean chain. The previous spelling mixed `is_incremental` with a `sync_type` comparison, which is what made an equivalent sync type easy to miss.
- `append` and `cdc` stay refused, unchanged. Both keep more than one row per key, and the reader streams the table with no dedupe state.

> [!NOTE]
> Inert on merge, like the layer below it. The path still needs the `warehouse-fanout-parent-reuse` flag, so nothing changes until a team is opted in.

> [!WARNING]
> Webhook parents can hold permanent gaps that `incremental` parents cannot. An incremental sweep re-lists everything and self-heals; a webhook table only receives what its drains delivered, so customers created while delivery was down never arrive. A child reading such a parent inherits the gap and never syncs those customers' balance transactions. The existing `data_imports.fanout_parent_rows_consumed` metric measures that drift directly by comparing warehouse fan-out size against the API path, and reuse falls back to the API whenever a parent is unreadable, so the exposure is measured rather than silent. Worth watching on the first opted-in teams.

## How did you test this code?

**Unit — `test_synced_parent_uses_the_warehouse_path`.** Extended the existing parameterized case with `WEBHOOK`. Catches a revert of the allow-list entry. The refusal cases for `append`, `cdc`, missing, disabled and never-synced parents already existed and are unchanged.

**End to end — `test_fanout_reads_the_parent_from_the_warehouse`.** Parameterized over `full_refresh` and `webhook`, asserting zero requests to `/v1/customers` and the same probed customers on both. This is the one that proves the wiring rather than the predicate: it runs the real workflow, writes the parent's Delta table, and re-reads it.

Removing `WEBHOOK` from the allow-list fails `test_fanout_reads_the_parent_from_the_warehouse[webhook]` while `[full_refresh]` still passes, so the new case is not vacuous. `test_a_parent_the_gate_refuses_keeps_the_api_path` loses its `webhook` case and keeps `append`; the e2e case count is unchanged.

**Not done:** no manual or live-account verification of a webhook-synced parent. The gap-hole risk in the warning above is reasoned from how drains and sweeps differ, not observed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, stacked on #88745 which introduces the Stripe conversion this widens.

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`, `/posthog-skill-store:dc-review-pr`.

The session began expecting this change to need two new guards — a per-table duplicate check and a webhook-liveness check. Reading the pipeline removed both. Duplicates come from a first-sync append artifact that `incremental` parents share, so admitting webhook adds no new exposure there; a stalled webhook is no more stale than a failing incremental sweep, which the rule already tolerates. Both were dropped rather than built. What reading the pipeline did surface is the gap-hole risk in the warning above, which is genuinely specific to webhook parents and is documented rather than guarded.

Cohort sizes come from the production mirrors in the dogfood project, aggregated across the fleet; no single team's data is named.
