### PR TITLE
feat(conversations): highlight questions in customer messages

### DIFF
--- a/products/conversations/frontend/components/Chat/Message.tsx
+++ b/products/conversations/frontend/components/Chat/Message.tsx
@@ -116,6 +116,7 @@ export function Message({
                             byline and the lock badge above follow the same colour, so one note is
                             one signal rather than three competing ones. */}
                         <div
+                            data-message-author={message.authorType}
                             className={`border py-2 px-3 rounded-lg ${
                                 isPrivate
                                     ? isAgent

--- a/products/conversations/frontend/components/Chat/QuestionHighlight.stories.tsx
+++ b/products/conversations/frontend/components/Chat/QuestionHighlight.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useRef } from 'react'
+
+import { IconQuestion } from '@posthog/icons'
+import { LemonButton, LemonCard } from '@posthog/lemon-ui'
+
+import type { ChatMessage } from '../../types'
+import { Message } from './Message'
+import { useQuestionHighlight } from './useQuestionHighlight'
+
+// The reading aid for tickets that arrive as one unformatted block: the customer's questions are
+// tinted so the ask is findable without re-reading the whole thing. Our own reply keeps its
+// question plain, which is the distinction worth seeing side by side.
+
+const CUSTOMER_MESSAGE: ChatMessage = {
+    id: 'customer',
+    authorType: 'customer',
+    authorName: 'Testy McTestface',
+    createdAt: '2026-07-25T09:12:00Z',
+    content:
+        "hello from example.com, sorry in advance for the wall of text. we put the snippet on our marketing site last friday and events did start arriving, then on monday morning everything went quiet. nothing changed on our end as far as i can tell, the snippet is still in the head tag and the network tab shows the requests going out with a 200. is there a rate limit on the free plan that we might have hit? we send maybe 40k events a month so i wouldn't have thought so. separately, our staging site reports into the same project, which i now suspect is wrong. should staging have a project of its own, or is there a tidier way to keep the two apart? last thing while i'm here, every person profile shows as anonymous even though we call identify straight after login. thanks for any pointers.",
+}
+
+// A second customer message on the rich-content path. Both renderers are worth showing, because the
+// highlight reads their rendered text nodes rather than either source format.
+const RICH_CUSTOMER_MESSAGE: ChatMessage = {
+    id: 'customer-rich',
+    authorType: 'customer',
+    authorName: 'Testy McTestface',
+    createdAt: '2026-07-25T09:31:00Z',
+    content: 'One more thing. Does the fix need a redeploy, or does it pick up on its own?',
+    richContent: {
+        type: 'doc',
+        content: [
+            {
+                type: 'paragraph',
+                content: [
+                    { type: 'text', text: 'One more thing. Does the fix need a ' },
+                    { type: 'text', marks: [{ type: 'bold' }], text: 'redeploy' },
+                    { type: 'text', text: ', or does it pick up on its own?' },
+                ],
+            },
+        ],
+    },
+}
+
+const TEAM_MESSAGE: ChatMessage = {
+    id: 'team',
+    authorType: 'human',
+    authorName: 'Sample Supportperson',
+    createdAt: '2026-07-25T10:04:00Z',
+    content: 'Thanks for all the detail. Nothing on your account is rate limited. Can you send me the project ID?',
+}
+
+function Thread({ highlighted }: { highlighted: boolean }): JSX.Element {
+    const panelRef = useRef<HTMLDivElement>(null)
+    useQuestionHighlight(panelRef, highlighted)
+
+    return (
+        <div ref={panelRef} className="max-w-2xl">
+            <LemonCard hoverEffect={false} className="flex flex-col p-3">
+                <div className="flex justify-end pb-2">
+                    <LemonButton
+                        size="xsmall"
+                        type="tertiary"
+                        icon={<IconQuestion />}
+                        active={highlighted}
+                        tooltip="Highlight questions in customer messages"
+                    >
+                        Highlight questions
+                    </LemonButton>
+                </div>
+                <Message message={CUSTOMER_MESSAGE} isCustomer />
+                <Message message={RICH_CUSTOMER_MESSAGE} isCustomer />
+                <Message message={TEAM_MESSAGE} isCustomer={false} />
+            </LemonCard>
+        </div>
+    )
+}
+
+const meta: Meta<typeof Thread> = {
+    title: 'Scenes-App/Support/QuestionHighlight',
+    component: Thread,
+    parameters: { layout: 'padded', viewMode: 'story', mockDate: '2026-07-25 12:00:00' },
+}
+export default meta
+
+type Story = StoryObj<typeof Thread>
+
+export const Off: Story = { render: () => <Thread highlighted={false} /> }
+
+export const On: Story = { render: () => <Thread highlighted /> }

--- a/products/conversations/frontend/components/Chat/questionHighlight.scss
+++ b/products/conversations/frontend/components/Chat/questionHighlight.scss
@@ -1,0 +1,6 @@
+// `::highlight()` accepts only colour, background-color, text-decoration, text-shadow and
+// -webkit-text-stroke. Background only: Chromium paints a highlight underline per word, so a
+// decoration here comes out broken across the spaces.
+::highlight(support-question) {
+    background-color: color-mix(in oklab, var(--color-yellow-400) 45%, transparent);
+}

--- a/products/conversations/frontend/components/Chat/questionRanges.test.ts
+++ b/products/conversations/frontend/components/Chat/questionRanges.test.ts
@@ -1,0 +1,21 @@
+import { findQuestionRanges } from './questionRanges'
+
+describe('findQuestionRanges', () => {
+    function rangeTexts(html: string): string[] {
+        const root = document.createElement('div')
+        root.innerHTML = html
+        return findQuestionRanges(root).map((range) => range.toString())
+    }
+
+    test.each([
+        ['a question after a statement', '<p>Hello there. Can you help?</p>', ['Can you help?']],
+        ['a question spanning inline markup', '<p>Can <strong>you</strong> help?</p>', ['Can you help?']],
+        ['two questions in a row', '<p>Why is it slow? Can we fix it?</p>', ['Why is it slow?', 'Can we fix it?']],
+        ['a block boundary', '<ul><li>First</li><li>Why?</li></ul>', ['Why?']],
+        ['a line break', '<p>First<br>Why?</p>', ['Why?']],
+        ['no question at all', '<p>Everything is fine.</p>', []],
+        ['a bare question mark', '<p>Fine. ?</p>', []],
+    ])('handles %s', (_name, html, expected) => {
+        expect(rangeTexts(html)).toEqual(expected)
+    })
+})

--- a/products/conversations/frontend/components/Chat/questionRanges.ts
+++ b/products/conversations/frontend/components/Chat/questionRanges.ts
@@ -1,0 +1,105 @@
+/** Elements the message renderers use to start a new line of text. A sentence never runs across one. */
+const BLOCK_TAGS = new Set(['P', 'LI', 'DIV', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'TD', 'TH', 'PRE'])
+
+/** A sentence ending in one or more question marks, bounded by the previous sentence end or line break. */
+const QUESTION = /[^.!?\n]*\?+/g
+
+const HAS_LETTER = /\p{L}/u
+
+interface Segment {
+    node: Text
+    /** Where this node's text starts in the flattened string. */
+    start: number
+}
+
+function nearestBlock(node: Node): Element | null {
+    let current = node.parentElement
+    while (current) {
+        if (BLOCK_TAGS.has(current.tagName)) {
+            return current
+        }
+        current = current.parentElement
+    }
+    return null
+}
+
+/**
+ * Flattens `root` into one string plus the map back to its text nodes. A block boundary or a `<br>` becomes a
+ * newline, so a sentence can't run from the end of one paragraph into the start of the next.
+ */
+function flatten(root: HTMLElement): { text: string; segments: Segment[] } {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT)
+    const segments: Segment[] = []
+    let text = ''
+    let previousBlock: Element | null = null
+    let seenText = false
+
+    let node = walker.nextNode()
+    while (node) {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+            if ((node as Element).tagName === 'BR') {
+                text += '\n'
+            }
+        } else {
+            const block = nearestBlock(node)
+            if (seenText && block !== previousBlock) {
+                text += '\n'
+            }
+            previousBlock = block
+            seenText = true
+            segments.push({ node: node as Text, start: text.length })
+            text += node.nodeValue ?? ''
+        }
+        node = walker.nextNode()
+    }
+
+    return { text, segments }
+}
+
+/** Resolves a flattened offset to the text node and offset within it. */
+function locate(segments: Segment[], offset: number): { node: Text; offset: number } | null {
+    for (let i = segments.length - 1; i >= 0; i--) {
+        const segment = segments[i]
+        if (offset >= segment.start) {
+            return { node: segment.node, offset: Math.min(offset - segment.start, segment.node.length) }
+        }
+    }
+    return null
+}
+
+/**
+ * Finds every sentence under `root` that ends in a question mark, as ranges over the rendered text nodes.
+ *
+ * Ranges rather than wrapper elements because both message renderers (TipTap and react-markdown) own their
+ * DOM — the caller feeds these to the CSS Custom Highlight API, which needs no markup of its own.
+ */
+export function findQuestionRanges(root: HTMLElement): Range[] {
+    const { text, segments } = flatten(root)
+    if (!text.includes('?')) {
+        return []
+    }
+
+    const ranges: Range[] = []
+    QUESTION.lastIndex = 0
+    let match = QUESTION.exec(text)
+    while (match) {
+        const leading = match[0].length - match[0].trimStart().length
+        const start = match.index + leading
+        const end = match.index + match[0].length
+
+        if (HAS_LETTER.test(match[0])) {
+            const from = locate(segments, start)
+            const to = locate(segments, end)
+            if (from && to) {
+                const range = document.createRange()
+                range.setStart(from.node, from.offset)
+                range.setEnd(to.node, to.offset)
+                ranges.push(range)
+            }
+        }
+
+        match = QUESTION.exec(text)
+    }
+
+    return ranges
+}

--- a/products/conversations/frontend/components/Chat/useQuestionHighlight.ts
+++ b/products/conversations/frontend/components/Chat/useQuestionHighlight.ts
@@ -1,0 +1,61 @@
+import './questionHighlight.scss'
+
+import { RefObject, useEffect } from 'react'
+
+import { findQuestionRanges } from './questionRanges'
+
+const HIGHLIGHT_NAME = 'support-question'
+const CUSTOMER_MESSAGE = '[data-message-author="customer"]'
+
+export function supportsQuestionHighlight(): boolean {
+    return typeof CSS !== 'undefined' && 'highlights' in CSS
+}
+
+/**
+ * Tints every question sentence in the customer messages under `containerRef`.
+ *
+ * One registry entry is shared, so only one panel may have this on at a time.
+ */
+export function useQuestionHighlight<T extends HTMLElement>(containerRef: RefObject<T | null>, enabled: boolean): void {
+    useEffect(() => {
+        const container = containerRef.current
+        if (!enabled || !container || !supportsQuestionHighlight()) {
+            return
+        }
+
+        let frame: number | null = null
+
+        const apply = (): void => {
+            frame = null
+            const ranges = Array.from(container.querySelectorAll<HTMLElement>(CUSTOMER_MESSAGE)).flatMap((message) =>
+                findQuestionRanges(message)
+            )
+            if (ranges.length > 0) {
+                CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges))
+            } else {
+                CSS.highlights.delete(HIGHLIGHT_NAME)
+            }
+        }
+
+        const schedule = (): void => {
+            if (frame === null) {
+                frame = requestAnimationFrame(apply)
+            }
+        }
+
+        // The thread fills in after it mounts — TipTap sets each message's content on its own, and the poll
+        // appends replies — so watch the panel rather than guess which renders matter. This also rebuilds
+        // the ranges when a node they point into is removed.
+        const observer = new MutationObserver(schedule)
+        observer.observe(container, { childList: true, characterData: true, subtree: true })
+        apply()
+
+        return () => {
+            observer.disconnect()
+            if (frame !== null) {
+                cancelAnimationFrame(frame)
+            }
+            CSS.highlights.delete(HIGHLIGHT_NAME)
+        }
+    }, [containerRef, enabled])
+}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconChevronDown } from '@posthog/icons'
+import { IconChevronDown, IconQuestion } from '@posthog/icons'
 import { LemonButton, LemonCard, LemonSelect, LemonTag, Link, Spinner } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -27,6 +27,7 @@ import { AccessControlLevel, AccessControlResourceType, Breadcrumb } from '~/typ
 import { AssigneeIconDisplay, AssigneeLabelDisplay, AssigneeSelect } from '../../components/Assignee'
 import { ChannelsTag, getChannelThreadUrl } from '../../components/Channels/ChannelsTag'
 import { ChatView } from '../../components/Chat/ChatView'
+import { supportsQuestionHighlight, useQuestionHighlight } from '../../components/Chat/useQuestionHighlight'
 import { IdentityBadge } from '../../components/IdentityBadge/IdentityBadge'
 import { SlaDisplay } from '../../components/SlaDisplay'
 import { TicketTags } from '../../components/TicketTags'
@@ -109,6 +110,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         feedbackByMessageId,
         editingMessageId,
         discussionsEnabled,
+        questionsHighlighted,
     } = useValues(logic)
     // The list's filters / saved view ride along in this page's query string
     // (the ticket row carries them through on navigation). Preserve them on the
@@ -132,6 +134,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         startEditingMessage,
         cancelEditingMessage,
         deleteMessage,
+        setQuestionsHighlighted,
     } = useActions(logic)
 
     const { user } = useValues(userLogic)
@@ -189,6 +192,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
     // Above the early returns below: this scene renders a spinner and a not-found state before the
     // thread, and a hook can't be called on only some of those paths.
     const discussionExtras = useDiscussionTimelineExtras(ticket?.id, discussionsEnabled)
+    useQuestionHighlight(chatPanelRef, questionsHighlighted)
 
     if (ticketLoading) {
         return (
@@ -239,6 +243,23 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                 >
                     {/* Main conversation area */}
                     <ChatView
+                        header={
+                            supportsQuestionHighlight() ? (
+                                <div className="flex justify-end pb-2">
+                                    <LemonButton
+                                        size="xsmall"
+                                        type="tertiary"
+                                        icon={<IconQuestion />}
+                                        active={questionsHighlighted}
+                                        onClick={() => setQuestionsHighlighted(!questionsHighlighted)}
+                                        tooltip="Highlight questions in customer messages"
+                                        data-attr="ticket-highlight-questions"
+                                    >
+                                        Highlight questions
+                                    </LemonButton>
+                                </div>
+                            ) : undefined
+                        }
                         threadExtras={[...reportTimelineExtras(linkedReports), ...discussionExtras]}
                         messages={chatMessages}
                         messagesLoading={messagesLoading}

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -263,6 +263,7 @@ export interface supportTicketSceneLogicValues {
     previousTickets: Ticket[]
     previousTicketsLoading: boolean
     priority: TicketPriority | null
+    questionsHighlighted: boolean
     replyRecipientDescription: string
     sidePanelContext: SidePanelSceneContext | null
     snoozedUntil: string | null
@@ -449,6 +450,9 @@ export interface supportTicketSceneLogicActions {
     setPriority: (priority: TicketPriority) => {
         priority: TicketPriority
     }
+    setQuestionsHighlighted: (enabled: boolean) => {
+        enabled: boolean
+    }
     setSnoozedUntil: (snoozedUntil: string | null) => {
         snoozedUntil: string | null
     }
@@ -616,6 +620,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         setDraftIsPrivate: (isPrivate: boolean) => ({ isPrivate }),
         // Per-ticket draft mode override, seeded from the browser-local default on open
         setDraftModeEnabled: (enabled: boolean) => ({ enabled }),
+        setQuestionsHighlighted: (enabled: boolean) => ({ enabled }),
 
         startEditingMessage: (message: ChatMessage) => ({ message }),
         cancelEditingMessage: true,
@@ -868,6 +873,12 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             false,
             {
                 setDraftModeEnabled: (_, { enabled }) => enabled,
+            },
+        ],
+        questionsHighlighted: [
+            false,
+            {
+                setQuestionsHighlighted: (_, { enabled }) => enabled,
             },
         ],
         editingMessageId: [


### PR DESCRIPTION
## Problem

A support agent reading a long unformatted ticket has to re-read the whole message to find what the customer actually asked. AI-written tickets are the common case: several paragraphs, no structure, the question buried mid-sentence.

This is a small reading aid, not a serious feature.

## Changes

- A "Highlight questions" toggle sits above the ticket thread. Turning it on tints every sentence that ends in a question mark inside customer messages.
- Our own replies and private notes stay plain, so the tint marks only what needs an answer.
- The toggle is per ticket and starts off. Opening another ticket starts clean.
- The highlight builds ranges over the rendered text and registers them with the CSS Custom Highlight API. It inserts no markup.
- That avoids the obvious alternative. Both renderers own their DOM: TipTap runs a ProseMirror editor, markdown goes through react-markdown. Wrapping text in `<mark>` means mutating DOM they control, or rewriting two source formats separately.
- The toggle hides on a browser without `CSS.highlights`.
- Mechanical: `Message.tsx` gains a `data-message-author` attribute, which is the selector the highlight uses to find customer messages.

Toggle off:

![questions-off](https://raw.githubusercontent.com/PostHog/pr-assets/450fbd3299a0575c54e66b4cd2e3452726476365/2026/08/052dff6b-7911-4479-b669-bcb8416c04ba.png)

Toggle on:

![questions-on](https://raw.githubusercontent.com/PostHog/pr-assets/76710619b0549dcb2b18fb6fb043e464cc9f941c/2026/08/b5603e63-1d40-4883-b8c1-7e1c576f4e2d.png)

## How did you test this code?

- `questionRanges.test.ts` covers the mapping from flattened text back to DOM ranges. It catches a question spanning inline markup collapsing to a partial range, and a question swallowing the previous list item across a block boundary. No existing test touches this path.
- The screenshots come from the new Storybook story in headless Chromium. The story renders both message renderers, and both themes were checked.
- Not run: the app against a live ticket. Behavior on polled messages and on TipTap's async mount rests on the MutationObserver, which no test covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in PostHog Desktop. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first design threaded a prop through `ChatView` and `MessageList`. The shipped version leaves both untouched and scans the chat panel ref the scene already holds. An earlier style added a highlight underline, dropped once a screenshot showed Chromium painting it per word with gaps.

The sample ticket in the story is invented, as its names make plain.
