### PR TITLE
fix(signals): raise the default per-run gateway token cap to $10

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -70,9 +70,11 @@ SANDBOX_AI_GATEWAY_PRODUCTS: str | None = get_from_env("SANDBOX_AI_GATEWAY_PRODU
 SANDBOX_AI_GATEWAY_MINT_KEY: str | None = get_from_env("SANDBOX_AI_GATEWAY_MINT_KEY", None, optional=True)
 # Per-run spend cap and token lifetime for minted scoped tokens. The cap bounds one
 # runaway run; the daily bound per team is cap x the scheduler's runs-per-day limit.
+# The cap must fit a run's real spend plus its in-flight admission holds: a cap near
+# typical spend ends runs after the work is written and before it is committed.
 # TTL 0 (the default) derives TASKS_MAX_RUN_DURATION_SECONDS + 1h so a capped run
 # never outlives its token; a positive value overrides.
-SANDBOX_AI_GATEWAY_TOKEN_CAP_USD: str = get_from_env("SANDBOX_AI_GATEWAY_TOKEN_CAP_USD", "5")
+SANDBOX_AI_GATEWAY_TOKEN_CAP_USD: str = get_from_env("SANDBOX_AI_GATEWAY_TOKEN_CAP_USD", "10")
 # Per-team per-run cap overrides as a JSON object of team id to dollars, e.g. {"2": "10"}.
 SANDBOX_AI_GATEWAY_TOKEN_CAP_USD_OVERRIDES: str = get_from_env("SANDBOX_AI_GATEWAY_TOKEN_CAP_USD_OVERRIDES", "")
 SANDBOX_AI_GATEWAY_TOKEN_TTL_SECONDS: int = get_from_env("SANDBOX_AI_GATEWAY_TOKEN_TTL_SECONDS", 0, type_cast=int)


### PR DESCRIPTION
## Problem

Signals implementation runs on the Go gateway die mid-flight about 9% of the time, after the code is written and before it is committed, because every run's scoped gateway token is capped at the `$5` default of `SANDBOX_AI_GATEWAY_TOKEN_CAP_USD`. Killed runs die at about $3.5 of real spend with the rest of the cap parked in in-flight holds. Uncapped runs before the cutover put 0.36% above $5 and 0.14% above $10.

## Changes

- `SANDBOX_AI_GATEWAY_TOKEN_CAP_USD` defaults to `"10"`. A run now needs about $8 of real spend plus its in-flight holds to hit the cap, which pre-cutover data puts at well under 1% of runs. The per-team overrides map is unchanged.

## How did you test this code?

`test_ai_gateway_token.py` sets the cap explicitly and never asserts the default, so no test changes. Authored by an agent: `ruff check` and `ruff format --check` pass on the file; the module's tests and the pre-commit hook could not run locally (stale local venv), so CI is the evidence for them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Authored by Claude Opus 5 with Brandon; requires human review.
