### PR TITLE
fix(data-imports): attach source/schema context to person-property sync failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/person_property_sync_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/person_property_sync_job.py
@@ -84,7 +84,7 @@ async def sync_warehouse_person_properties_activity(inputs: PersonPropertySyncAc
         # tracking rather than dying silently in an abandoned child workflow.
         PERSON_PROPERTY_SYNC_TOTAL.labels(team_id=str(inputs.team_id), outcome="failed").inc()
         log.exception("Person-property sync failed")
-        capture_exception(e)
+        capture_exception(e, inputs.properties_to_log)
         await record_failed_runs(
             team_id=inputs.team_id,
             binding=binding,

--- a/products/warehouse_sources/backend/temporal/data_imports/person_property_sync_job_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/person_property_sync_job_test.py
@@ -1,0 +1,56 @@
+import uuid
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from temporalio.testing import ActivityEnvironment
+
+from products.warehouse_sources.backend.temporal.data_imports.external_product_hooks import (
+    PersonPropertySyncActivityInputs,
+)
+from products.warehouse_sources.backend.temporal.data_imports.person_property_sync_job import (
+    sync_warehouse_person_properties_activity,
+)
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.person_property_sync_job"
+
+
+class TestSyncWarehousePersonPropertiesActivityCapturesFailureContext:
+    """A failed run is only attributable to a source/schema in error tracking if the captured
+    exception carries that context; a bare capture_exception(e) loses it."""
+
+    @patch(f"{MODULE}.capture_exception")
+    @patch(f"{MODULE}.record_failed_runs", new_callable=AsyncMock)
+    @patch(f"{MODULE}.record_started_runs", new_callable=AsyncMock)
+    @patch(f"{MODULE}.run_person_property_sync", new_callable=AsyncMock)
+    @patch(f"{MODULE}.Heartbeater")
+    async def test_capture_exception_receives_source_and_schema_context(
+        self,
+        mock_heartbeater_cls: MagicMock,
+        mock_run_sync: AsyncMock,
+        _mock_record_started: AsyncMock,
+        _mock_record_failed: AsyncMock,
+        mock_capture_exception: MagicMock,
+    ) -> None:
+        mock_heartbeater_cls.return_value.__aenter__ = AsyncMock(return_value=None)
+        mock_heartbeater_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+        error = ConnectionError("failed to connect to all addresses")
+        mock_run_sync.side_effect = error
+
+        inputs = PersonPropertySyncActivityInputs(
+            team_id=1,
+            schema_id=uuid.uuid4(),
+            source_id=uuid.uuid4(),
+            job_id="job-1",
+            source_type="Stripe",
+            schema_name="public.charges",
+            last_synced_at=None,
+        )
+
+        with pytest.raises(ConnectionError):
+            await ActivityEnvironment().run(sync_warehouse_person_properties_activity, inputs)
+
+        mock_capture_exception.assert_called_once_with(error, inputs.properties_to_log)
+        captured_properties = mock_capture_exception.call_args[0][1]
+        assert captured_properties["source_type"] == "Stripe"
+        assert captured_properties["schema_name"] == "public.charges"


### PR DESCRIPTION
## Problem

A failed person-property sync shows up in error tracking with no way to tell which source, schema, or job caused it.

`sync_warehouse_person_properties_activity`'s exception handler calls `capture_exception(e)` with no context. Every other capture site in this same pipeline (`record_started_runs`, `record_completed_runs`, `record_failed_runs` in `person_property_sync.py`, and the trigger path in `person_property_triggers.py`) passes source/schema identity alongside the exception. This one call site was missed.

This surfaced while triaging an error tracking issue for a transient personhog gRPC `UNAVAILABLE` (connection refused) error: the captured event carried no properties beyond the exception itself, so there was no way to scope which source or schema hit it. The underlying gRPC error is a brief infrastructure blip already covered by the existing Temporal retry policy (3 attempts) - no change needed there.

## Changes

- `capture_exception(e)` now passes `inputs.properties_to_log`, so a captured failure carries `team_id`, `schema_id`, `source_id`, `job_id`, `source_type`, and `schema_name`, matching the pattern used elsewhere in this pipeline.

## How did you test this code?

- Added `person_property_sync_job_test.py`: asserts `capture_exception` is called with `inputs.properties_to_log` when `run_person_property_sync` raises. Catches a regression where the activity drops back to a bare `capture_exception(e)` and loses source/schema attribution.
- Ran `ruff check`/`ruff format` and `mypy` on both changed files - clean.
- `hogli`/`flox` are unavailable in this sandbox, so `hogli ci:preflight` and `hogli review` could not be run here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated a real error tracking issue (`_InactiveRpcError` / `UNAVAILABLE` from the personhog gRPC client) via PostHog MCP tools, traced the full call stack, and confirmed the underlying error is a transient personhog outage already handled by Temporal's retry policy.
- While scoping the issue by source/schema, found the exception event carried none of the `person_property_sync` pipeline's usual context properties, and traced that to this one capture site missing them.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- No customer data, tickets, or internal thread content included; the originating error is described from public-safe error tracking fields only.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*