### PR TITLE
fix(mcp): correct how to count skill loads from the body offset

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2337,7 +2337,7 @@
             "label": "MCP session ID"
         },
         "$mcp_skill_body_offset": {
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. Count calls at offset 0 for loads, or all calls for pages read. Set only on reads that succeeded, like `$mcp_skill_name`. Absent when the caller asked for the whole body, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
             "examples": [
                 "0",
                 "5000"
@@ -4522,7 +4522,7 @@
             "label": "MCP session ID"
         },
         "$mcp_skill_body_offset": {
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. Count calls at offset 0 for loads, or all calls for pages read. Set only on reads that succeeded, like `$mcp_skill_name`. Absent when the caller asked for the whole body, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
             "examples": [
                 "0",
                 "5000"
@@ -7297,7 +7297,7 @@
             "label": "MCP session ID"
         },
         "$mcp_skill_body_offset": {
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. Count calls at offset 0 for loads, or all calls for pages read. Set only on reads that succeeded, like `$mcp_skill_name`. Absent when the caller asked for the whole body, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
             "examples": [
                 "0",
                 "5000"

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2337,7 +2337,7 @@
             "label": "MCP session ID"
         },
         "$mcp_skill_body_offset": {
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset, and a first read usually omits the offset \u2014 absent and 0 both mean a first page. Scope the query to `$mcp_tool_name IN ('skill-get', 'llma-skill-get')` before counting: the property is never set on `skill-file-get` or on a failed read, so an absent value outside that scope means 'never paginated' rather than 'first page', and counting it inflates loads. Within the scope, count calls where the offset is absent or 0 for loads, and every call for pages read. Set only on reads that succeeded, like `$mcp_skill_name`.",
             "examples": [
                 "0",
                 "5000"
@@ -4522,7 +4522,7 @@
             "label": "MCP session ID"
         },
         "$mcp_skill_body_offset": {
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset, and a first read usually omits the offset \u2014 absent and 0 both mean a first page. Scope the query to `$mcp_tool_name IN ('skill-get', 'llma-skill-get')` before counting: the property is never set on `skill-file-get` or on a failed read, so an absent value outside that scope means 'never paginated' rather than 'first page', and counting it inflates loads. Within the scope, count calls where the offset is absent or 0 for loads, and every call for pages read. Set only on reads that succeeded, like `$mcp_skill_name`.",
             "examples": [
                 "0",
                 "5000"
@@ -7297,7 +7297,7 @@
             "label": "MCP session ID"
         },
         "$mcp_skill_body_offset": {
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset, and a first read usually omits the offset \u2014 absent and 0 both mean a first page. Scope the query to `$mcp_tool_name IN ('skill-get', 'llma-skill-get')` before counting: the property is never set on `skill-file-get` or on a failed read, so an absent value outside that scope means 'never paginated' rather than 'first page', and counting it inflates loads. Within the scope, count calls where the offset is absent or 0 for loads, and every call for pages read. Set only on reads that succeeded, like `$mcp_skill_name`.",
             "examples": [
                 "0",
                 "5000"

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2721,7 +2721,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_skill_body_offset": {
             "label": "MCP skill body offset",
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset, and a first read usually omits the offset — absent and 0 both mean a first page. Scope the query to `$mcp_tool_name IN ('skill-get', 'llma-skill-get')` before counting: the property is never set on `skill-file-get` or on a failed read, so an absent value outside that scope means 'never paginated' rather than 'first page', and counting it inflates loads. Within the scope, count calls where the offset is absent or 0 for loads, and every call for pages read. Set only on reads that succeeded, like `$mcp_skill_name`.",
             "examples": ["0", "5000"],
         },
         "$mcp_resource_name": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2721,7 +2721,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_skill_body_offset": {
             "label": "MCP skill body offset",
-            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. Count calls at offset 0 for loads, or all calls for pages read. Set only on reads that succeeded, like `$mcp_skill_name`. Absent when the caller asked for the whole body, and never set on `skill-file-get`, which does not paginate.",
+            "description": "Where in a skill's body a `skill-get` started reading. Long bodies come back in slices, so one skill load is several calls that differ only by this offset. A first read usually omits the offset, so count the calls where it is absent or 0 to count loads, and count every call to count pages read. Set only on reads that succeeded, like `$mcp_skill_name`, and never set on `skill-file-get`, which does not paginate.",
             "examples": ["0", "5000"],
         },
         "$mcp_resource_name": {


### PR DESCRIPTION
## Problem

Anyone counting how often a skill is loaded, following the instruction in the `$mcp_skill_body_offset` property description, gets a number far below the truth.

The description says to count calls at offset 0. Live traffic since [#88843](https://github.com/PostHog/posthog/pull/88843) shipped shows that a first read almost always omits `body_offset` altogether — only continuations carry one — so offset 0 covers a small fraction of loads and the rest are silently dropped.

The old text did mention that the offset is absent for a whole-body read, so the fact was there. But the counting sentence is the line a reader copies into a query, and that line was wrong.

## Changes

- The property description now states the rule that matches the data: scope the query to the paginated read, then count calls where the offset is
  **absent or 0** for loads and every call for pages read. A reader who copies the instruction now gets the right number.
- The scope is load-bearing, not a caveat. `skill-file-get` carries a skill name but never an offset, so without it every bundled-file read counts as a
  fresh load — several times the real figure for skills whose files get read often. A failed read has neither property, so it distorts an ungrouped total
  rather than a per-skill breakdown.
- Mechanical: the regenerated `core-filter-definitions-by-group.json`, which is what the property picker actually reads.

No behavior change — the property is emitted exactly as before. This is the description attached to it.

## How did you test this code?

Automated tests: none added or changed. This edits a description string; there is no behavior to pin, and a test asserting the wording would be a change-detector.

Verified instead against live data — the reason the error was found at all. Querying the shipped property showed loads split between calls with no offset and calls with a continuation offset, with offset 0 a small remainder. Grouping by "absent or 0" reproduces the per-skill load counts that `uniq($session_id)` gives independently; grouping by "offset 0" does not come close.

Reviewer feedback found a second error in the same sentence, also verified against live data before changing anything: counting absent offsets without
scoping to the paginated read inflated per-skill loads by several times, worst on skills whose bundled files are read often.

Checked locally: `ruff check` and `ruff format --check` pass, and the regenerated JSON is a description-only diff with no structural churn.

Not checked: the mandated local Greptile review (`hogli review`) could not run — `hogli` is not installed in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The description is the documentation for this property; it is updated here. `posthog/taxonomy/taxonomy.py` is the source and the generated JSON is regenerated in the same commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus) in a PostHog Desktop cloud task, as a follow-up to #88843 after being asked to check that change against production.

The error came from the same session that wrote the original description. The reasoning there was that paging must not be mistaken for usage, which was right; the counting rule chosen to express it was assumed rather than checked against how callers actually paginate. The first query written to check it had a matching bug — a missing property is NULL, so an `empty(toString(...))` test fell through and bucketed absent offsets as continuations, nearly confirming a wrong conclusion. Re-running with an explicit null check gave the real split.

The sentence has now been corrected twice. The original told readers to count offset 0, which misses the loads that omit the offset. The first commit here
replaced it with a rule that is right only under a precondition it never stated. Both times the surrounding text carried the facts and the instruction — the
line a reader actually copies — was the part that was wrong, which is the failure mode worth watching for in property descriptions generally.

Repo skills invoked: `/writing-pr-descriptions`, `/checking-deploy-timing`.

