### PR TITLE
chore(insights): deflake the long-loading visual regression story

### DIFF
--- a/frontend/src/lib/lemon-ui/LoadingBar/LoadingBar.tsx
+++ b/frontend/src/lib/lemon-ui/LoadingBar/LoadingBar.tsx
@@ -4,6 +4,10 @@ import { useEffect, useState } from 'react'
 
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// atan(1) / (PI / 2) puts the frozen Storybook bar at a 50% fill
+const STORYBOOK_FROZEN_PROGRESS = 1
 
 export interface SpinnerProps {
     textColored?: boolean
@@ -20,6 +24,9 @@ export interface SpinnerProps {
 export function LoadingBar({ className, loadId, setProgress, progress, wrapperClassName }: SpinnerProps): JSX.Element {
     const [_progress, _setProgress] = useState(0)
     const { isVisible: isPageVisible } = usePageVisibility()
+    // The 50ms ticker below moves the fill on every frame, which makes each
+    // Storybook visual regression capture differ. Freeze the fill there instead.
+    const frozenForStorybook = inStorybook() || inStorybookTestRunner()
 
     useEffect(() => {
         if (loadId && progress) {
@@ -36,7 +43,7 @@ export function LoadingBar({ className, loadId, setProgress, progress, wrapperCl
     }, [_progress, loadId, setProgress])
 
     useEffect(() => {
-        if (!isPageVisible) {
+        if (!isPageVisible || frozenForStorybook) {
             return
         }
 
@@ -58,7 +65,9 @@ export function LoadingBar({ className, loadId, setProgress, progress, wrapperCl
         }, 50)
 
         return () => clearInterval(interval)
-    }, [loadId, isPageVisible])
+    }, [loadId, isPageVisible, frozenForStorybook])
+
+    const displayProgress = frozenForStorybook ? STORYBOOK_FROZEN_PROGRESS : _progress
 
     return (
         <div className={cn(`progress-outer max-w-120 w-full my-3`, wrapperClassName)} data-attr="loading-bar">
@@ -66,7 +75,9 @@ export function LoadingBar({ className, loadId, setProgress, progress, wrapperCl
                 <div
                     className="progress-bar"
                     // eslint-disable-next-line react/forbid-dom-props
-                    style={{ width: Math.round((Math.atan(_progress) / (Math.PI / 2)) * 100 * 1000) / 1000 + '%' }}
+                    style={{
+                        width: Math.round((Math.atan(displayProgress) / (Math.PI / 2)) * 100 * 1000) / 1000 + '%',
+                    }}
                 />
             </div>
         </div>

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -22,7 +22,7 @@ import posthog from 'posthog-js'
 import api, { ApiMethodOptions } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { ConcurrencyController } from 'lib/utils/concurrencyController'
-import { uuid } from 'lib/utils/dom'
+import { inStorybook, inStorybookTestRunner, uuid } from 'lib/utils/dom'
 import { shouldCancelQuery } from 'lib/utils/requests'
 import { UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES } from 'scenes/insights/insightLogic'
 import { compareDataNodeQuery, haveVariablesOrFiltersChanged, validateQuery } from 'scenes/insights/utils/queryUtils'
@@ -143,6 +143,10 @@ export interface DataNodeLogicProps {
 
 export const AUTOLOAD_INTERVAL = 30000
 const LOAD_MORE_ROWS_LIMIT = 10000
+
+// Loading and error states render the query id, so a random id per load
+// makes Storybook visual regression captures differ on every run
+const STORYBOOK_QUERY_ID = '00000000-0000-4000-8000-000000000000'
 
 const VALID_REFRESH_TYPES: ReadonlySet<RefreshType> = new Set([
     'async',
@@ -933,7 +937,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             overrideQuery?: DataNode<Record<string, any>>
         ) => ({
             refresh: sanitizeRefreshType(refresh),
-            queryId: alreadyRunningQueryId || uuid(),
+            queryId: alreadyRunningQueryId || (inStorybook() || inStorybookTestRunner() ? STORYBOOK_QUERY_ID : uuid()),
             pollOnly: !!alreadyRunningQueryId,
             overrideQuery,
         }),


### PR DESCRIPTION
## Problem

The `scenes-app-insights-error-empty-states--long-loading` story fails visual regression at random, flagging unrelated PRs for review.

- Every capture renders a different "Query ID: ..." line, because `dataNodeLogic` generates a fresh client uuid per load.
- The loading bar fill advances on a 50ms JS timer, so each capture catches a different width. The test runner's CSS animation freeze cannot stop a JS-driven style.
- The "Need to speed things up" box was missing from some captures. #74294 fixed that mode by dropping the 15s threshold in Storybook, and the story's `waitForSelector` targets the box, so its presence is guaranteed. The residual noise above still flips the snapshot between clean and changed.
- VR's history for this snapshot shows unchanged master runs at ~0.09% diff, flipping to 2-4.7% structural diffs with no code change ([snapshot history](https://us.posthog.com/project/2/visual_review)).

## Changes

- Storybook captures of loading and error states are now byte-identical across runs. Nothing changes outside Storybook.
- `dataNodeLogic` pins the client query id to a constant in Storybook, so the visible "Query ID" line stops changing. This also covers the sibling error and timeout stories, which render the query id through the same component.
- `LoadingBar` freezes its fill at 50% in Storybook instead of ticking every 50ms.
- Both changes gate on `inStorybook() || inStorybookTestRunner()`, the existing pattern in `EmptyStates.tsx`.

> [!NOTE]
> Other stories that capture a loading state will show a one-time VR diff when the frozen bar first lands, then stay stable.

The story capture after the change (frozen bar, constant query id, suggestions box present):

![tr1-light](https://raw.githubusercontent.com/PostHog/pr-assets/117cd342ac6edfde13249fa73cb9ffa9b9d3279c/2026/08/cd2619d3-df52-421c-899b-1f4281905669.png)

## How did you test this code?

- Ran the story through `@storybook/test-runner` six times against a local Storybook: light and dark captures had the same MD5 on every run. Before the change, ten of ten captures differed.
- The `EmptyStates` sibling stories passed in the same runs.
- `typescript:check` and the `dataNodeLogic` jest suite pass locally.
- Not run: the full Storybook suite. Stories outside `EmptyStates` that render a loading bar were not captured locally; they will show the one-time diff noted above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session. Skills invoked: `/fixing-flaky-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Reproduced the flake by capturing the story ten times with Playwright against a local Storybook, and by pulling this snapshot's artifact history from Visual Review, which showed the box-missing and query-id modes directly in master captures.
- The commit was created via GitHub's API because the local partial clone could not complete a push without backfilling ~580k objects; the remote blobs were verified byte-identical to the locally tested files by comparing `git hash-object` shas.
- `hogli review` (Greptile) was not run: the CLI is unavailable in this environment.