### PR TITLE
fix(surveys): scope Max linked flags to the current team

### DIFF
--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -18,6 +18,7 @@ from posthog.constants import DEFAULT_SURVEY_APPEARANCE
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.surveys.backend.api.survey import SurveySerializerCreateUpdateOnly
 from products.surveys.backend.models import Survey
 from products.surveys.backend.summarization.fetch import fetch_responses
@@ -83,6 +84,13 @@ def get_team_survey_config(team: Team) -> dict[str, Any]:
         "appearance": survey_config.get("appearance", {}),
         "default_settings": {"type": "popover", "enable_partial_responses": True},
     }
+
+
+async def _validate_linked_flag_id(team: Team, linked_flag_id: int | None) -> None:
+    if linked_flag_id is None:
+        return
+    if not await FeatureFlag.objects.filter(pk=linked_flag_id, team_id=team.id).aexists():
+        raise serializers.ValidationError("Feature Flag with this ID does not exist")
 
 
 # SimpleSurveyQuestion attribute -> internal question dict key. Rating-only fields (scale, display)
@@ -361,6 +369,9 @@ class CreateSurveyTool(MaxTool):
                     "error_message": "No questions provided in the survey configuration.",
                 }
 
+            if survey_type != Survey.SurveyType.EXTERNAL_SURVEY:
+                await _validate_linked_flag_id(self._team, linked_flag_id)
+
             survey_data = self._build_survey_data(
                 name=name,
                 description=description,
@@ -578,6 +589,8 @@ class EditSurveyTool(MaxTool):
                     "error": "not_found",
                     "error_message": f"No survey found with ID '{survey_id}' in your team.",
                 }
+
+            await _validate_linked_flag_id(team, linked_flag_id)
 
             update_data: dict[str, Any] = {}
 

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -11,11 +11,19 @@ from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
 from parameterized import parameterized
 
+from posthog.models import Organization, Project, Team
+
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.product_analytics.backend.facade.models import Insight
 from products.surveys.backend.models import Survey
 
 from .max_tools import CreateSurveyTool, EditSurveyTool, SimpleSurveyQuestion, SurveyAnalysisTool
+
+
+async def create_test_team(organization: Organization, name: str) -> Team:
+    project_id = await sync_to_async(Team.objects.increment_id_sequence)()
+    project = await Project.objects.acreate(id=project_id, organization=organization)
+    return await Team.objects.acreate(id=project.id, project=project, organization=organization, name=name)
 
 
 class TestSurveyCreatorTool(BaseTest):
@@ -145,6 +153,28 @@ class TestSurveyCreatorTool(BaseTest):
         survey = await sync_to_async(Survey.objects.select_related("linked_flag").get)(id=artifact["survey_id"])
         assert survey.name == "Feature Flag Survey"
         assert survey.linked_flag_id == flag.id
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_survey_rejects_linked_flag_from_another_organization(self):
+        other_organization = await Organization.objects.acreate(name="Other Organization")
+        other_team = await create_test_team(other_organization, "Other Team")
+        other_flag = await FeatureFlag.objects.acreate(
+            team=other_team,
+            key="other-organization-feature",
+            created_by=self.user,
+        )
+
+        result = await self._setup_tool().ainvoke(
+            {
+                "name": "Cross-organization survey",
+                "questions": [{"type": "open", "question": "How is it going?"}],
+                "linked_flag_id": other_flag.id,
+            }
+        )
+
+        assert "Survey validation failed" in result
+        assert not await Survey.objects.filter(team=self.team, name="Cross-organization survey").aexists()
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
@@ -885,6 +915,29 @@ class TestEditSurveyTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
+    async def test_edit_survey_rejects_linked_flag_from_another_organization(self):
+        other_organization = await Organization.objects.acreate(name="Other Organization")
+        other_team = await create_test_team(other_organization, "Other Team")
+        other_flag = await FeatureFlag.objects.acreate(
+            team=other_team,
+            key="other-organization-feature",
+            created_by=self.user,
+        )
+        survey = await self._create_test_survey()
+
+        result = await self._setup_tool().ainvoke(
+            {
+                "survey_id": str(survey.id),
+                "linked_flag_id": other_flag.id,
+            }
+        )
+
+        assert "Survey validation failed" in result
+        await survey.arefresh_from_db()
+        assert survey.linked_flag_id is None
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
     async def test_edit_survey_can_explicitly_remove_targeting(self):
         tool = self._setup_tool()
         flag = await sync_to_async(FeatureFlag.objects.create)(
@@ -989,8 +1042,6 @@ class TestEditSurveyTool(BaseTest):
     @pytest.mark.django_db
     @pytest.mark.asyncio
     async def test_edit_survey_wrong_team(self):
-        from posthog.models import Organization, Team
-
         other_org = await sync_to_async(Organization.objects.create)(name="Other Org")
         other_team = await sync_to_async(Team.objects.create)(organization=other_org, name="Other Team")
         other_survey = await sync_to_async(Survey.objects.create)(


### PR DESCRIPTION
## Problem

Max survey creation and editing should only link to feature flags in the active team.

## Changes

- Max now validates linked feature flags against the active team.
- Create and edit use the same validation.
- No visual changes.

## How did you test this code?

- Added regression tests for create and edit with a feature flag from another team.
- The existing same-team test covers the allowed path.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. This matches the existing survey API behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex assisted with implementation and verification.
- Skills: /security-audit, /writing-tests, /writing-pr-descriptions, /reviewing-before-pr, and /merging-prs.
- Local review used the Codex fallback because Greptile was unavailable. The PR bot review remains enabled.
- Test fixtures are invented and contain no session-provided data.