### PR TITLE
fix(mongodb): fail clearly when a document has no _id field

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py
@@ -578,6 +578,18 @@ def _is_no_cursor_timeout_unsupported(error: OperationFailure) -> bool:
     return any(marker in message for marker in _NO_CURSOR_TIMEOUT_UNSUPPORTED_MARKERS)
 
 
+# A find() against a MongoDB view returns the view pipeline's output, which has no `_id` when the
+# pipeline drops it (a $group on another key, a $project that excludes `_id`). The importer keys
+# every collection on `_id`: primary key, incremental cursor, and Delta merge dedup all read it, so
+# an `_id`-less document can't be synced and retrying never recovers. Raise this instead of the bare
+# `doc["_id"]` KeyError, and match it in the source's get_non_retryable_errors.
+MONGO_DOCUMENT_MISSING_ID_ERROR = (
+    "PostHog couldn't import this MongoDB collection because one of its documents has no _id field. "
+    "PostHog uses _id as the primary key for every collection. This usually means the collection is a "
+    "view whose pipeline removes _id. Sync the underlying collection instead, or add _id to the view."
+)
+
+
 def mongo_source(
     connection_string: str,
     collection_name: str,
@@ -660,6 +672,8 @@ def mongo_source(
                 while True:
                     try:
                         for doc in cursor:
+                            if "_id" not in doc:
+                                raise ValueError(MONGO_DOCUMENT_MISSING_ID_ERROR)
                             last_id = doc["_id"]
                             rows_since_cursor_opened += 1
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mongo import (
     DATABASE_NAME_REQUIRED_ERROR,
+    MONGO_DOCUMENT_MISSING_ID_ERROR,
     _parse_connection_string,
     filter_mongo_incremental_fields,
     get_collection_names,
@@ -140,6 +141,10 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # reach the user — match the stable 'not authorized' fragment. Granting permission is a
             # config change the user must make, so this never recovers on retry.
             "not authorized": _MONGO_NOT_AUTHORIZED_MESSAGE,
+            # A view whose pipeline drops `_id` yields documents the importer can't key on. mongo.py
+            # raises MONGO_DOCUMENT_MISSING_ID_ERROR for this instead of a bare KeyError. Every retry
+            # reads the same `_id`-less documents, so it never recovers. Match our own stable phrase.
+            "one of its documents has no _id field": MONGO_DOCUMENT_MISSING_ID_ERROR,
             "SSL handshake failed": None,
             # Atlas SQL / Data Federation endpoints live under *.query.mongodb.net and are served by
             # a query proxy the standard MongoDB driver can't drive: the handshake is closed, the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -17,6 +17,7 @@ from pymongo.server_description import ServerDescription
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import DEFAULT_CHUNK_SIZE
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mongo import (
+    MONGO_DOCUMENT_MISSING_ID_ERROR,
     MONGO_MAX_CHUNK_ROWS,
     MONGO_MIN_CHUNK_ROWS,
     _adaptive_chunk_size,
@@ -377,6 +378,9 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
                 "bad auth : authentication failed, full error: {'ok': 0, 'errmsg': 'bad auth : "
                 "authentication failed', 'code': 8000, 'codeName': 'AtlasError'}",
             ),
+            # Our own error for a view whose pipeline drops _id — retrying reads the same _id-less
+            # documents forever, so it must be classified non-retryable.
+            ("document_missing_id", MONGO_DOCUMENT_MISSING_ID_ERROR),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),
             ("ssl_failure", "SSL handshake failed: certificate verify failed"),
             # pymongo InvalidURI raised before any network call when credentials in the connection
@@ -459,6 +463,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
             ("unreachable_topology", "Topology Description:", "allowlist"),
             ("atlas_sql_endpoint", "query.mongodb.net", "connection string"),
             ("unescaped_credentials", "must be escaped according to RFC 3986", "connection string"),
+            ("document_missing_id", "one of its documents has no _id field", "view"),
         ]
     )
     def test_pattern_has_friendly_message(self, _name, pattern, expected_substring):
@@ -770,6 +775,17 @@ class TestMongoSourceCursorLifecycle(SimpleTestCase):
         assert collection.find_queries[-1] == {"_id": {"$gt": "2"}}
         # cursors[2] is the read reopened after CursorNotFound; assert it resumes _id-ordered.
         assert collection.cursors[2].sorted_by == ["_id", 1]
+
+    def test_document_without_id_raises_actionable_error(self):
+        # A view whose pipeline drops _id yields documents with no _id, which the importer can't key
+        # on. Regression: get_rows used to crash on doc["_id"] with a bare KeyError('_id'). It must
+        # raise the actionable, non-retryable message instead.
+        collection = _FakeCollection([{"name": "no id here"}])
+
+        with self.assertRaises(ValueError) as ctx:
+            self._run_get_rows(collection)
+
+        assert str(ctx.exception) == MONGO_DOCUMENT_MISSING_ID_ERROR
 
     def test_fallback_cursor_that_expires_without_progress_is_not_retried_forever(self):
         # Resuming re-runs the same query, so a cursor that dies before yielding anything would

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -378,7 +378,7 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
                 "bad auth : authentication failed, full error: {'ok': 0, 'errmsg': 'bad auth : "
                 "authentication failed', 'code': 8000, 'codeName': 'AtlasError'}",
             ),
-            # Our own error for a view whose pipeline drops _id — retrying reads the same _id-less
+            # Our own error for a view whose pipeline drops _id. Retrying reads the same _id-less
             # documents forever, so it must be classified non-retryable.
             ("document_missing_id", MONGO_DOCUMENT_MISSING_ID_ERROR),
             ("dns_failure", "The DNS query name does not exist: example.mongodb.net."),


### PR DESCRIPTION
## Problem

A MongoDB data-warehouse sync would crash mid-import with a bare `KeyError: '_id'` and then keep retrying to no effect, so the source never finished and the user got no actionable reason.

The importer keys every collection on `_id` (primary key, incremental cursor, and Delta merge dedup all read it). A MongoDB view whose aggregation pipeline drops `_id` (a `$group` on another key, or a `$project` that excludes `_id`) returns documents with no `_id`. `get_rows` read `doc["_id"]` on the first such document and raised `KeyError`. The error was retryable, so Temporal retried the same view every time.

Observed in error tracking: <error id="01a03fbe-211b-76e3-8c40-9bdfcbc49048">KeyError '_id'</error>, raised in `mongo.py` `get_rows`.

## Changes

- A sync of a view without `_id` now stops with a clear message telling the user to sync the underlying collection or add `_id` to the view, instead of hanging on retries.
- `get_rows` checks for `_id` before reading it and raises `MONGO_DOCUMENT_MISSING_ID_ERROR` instead of a bare `KeyError`.
- `MongoDBSource.get_non_retryable_errors` matches that message, so the sync stops after the normal non-retryable attempt count rather than retrying an unrecoverable state.

## How did you test this code?

Automated only; this sandbox has no MongoDB or Temporal stack to run an end-to-end sync.

- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py` (81 passed).
- `test_document_without_id_raises_actionable_error` catches the regression: `get_rows` fed a document with no `_id` used to crash with `KeyError('_id')`; it now raises the actionable message. No existing test exercised an `_id`-less document.
- Added a `document_missing_id` case to the non-retryable matcher test, so the raised message stays classified non-retryable if the wording drifts.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MongoDB source. The agent confirmed the issue in PostHog error tracking (stack trace, frequency, that the failure originates in `mongodb/mongo.py`), read the source, and decided this is a fixable-fragility bug whose resulting state is non-retryable, so it both raises a clean error and lists it in `get_non_retryable_errors`.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-before-pr`, `/code-review`.

Local review: `hogli review` was unavailable in this sandbox (no CLI), so the harness `/code-review` fallback ran over the branch diff. It surfaced one finding, an em-dash in a test comment that breaks the repo comment-style rule; fixed in a follow-up commit. The independent Greptile review still runs on this PR as usual.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
