### PR TITLE
chore(mcp-analytics): require review across domain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,19 @@ posthog/temporal/data_modeling/run_workflow.py @PostHog/team-data-modeling
 # Dev sandbox provides important protection in local dev
 bin/dev-sandbox* @PostHog/team-security
 
+# MCP Analytics relies on a cross-repo event contract with no shared type boundary.
+# Producers can change without failing product consumers, so team review gates both ends.
+products/mcp_analytics/** @PostHog/team-mcp-analytics
+posthog/temporal/mcp_analytics/** @PostHog/team-mcp-analytics
+services/mcp/src/hono/analytics.ts @PostHog/team-mcp-analytics
+services/mcp/src/lib/posthog/analytics.ts @PostHog/team-mcp-analytics
+services/mcp/tests/hono/analytics.test.ts @PostHog/team-mcp-analytics
+services/mcp/tests/unit/posthog/analytics.test.ts @PostHog/team-mcp-analytics
+services/mcp/src/generated/mcp_analytics/** @PostHog/team-mcp-analytics
+services/mcp/src/tools/generated/mcp_analytics.ts @PostHog/team-mcp-analytics
+docs/published/docs/mcp-analytics/** @PostHog/team-mcp-analytics
+bin/inject_mcp_intents.py @PostHog/team-mcp-analytics
+
 # The MCP store catalog is a fleet-wide trust decision, not ordinary code: a merged entry
 # becomes (probe permitting) an active server template in every environment on the next
 # deploy — installable by all tenants and feeding tool results into their LLM agents. The


### PR DESCRIPTION
## Problem

MCP Analytics reviewers have no blocking approval gate for changes across the product's event contract.

Distributed ownership routes non-blocking reviews for product and Temporal code, but other domain-specific surfaces remain outside that routing.

## Changes

- MCP Analytics reviewers now approve changes to the product, Temporal workflow, telemetry producers, generated bindings, tests, documentation, and local tooling.
- Shared MCP infrastructure and global registries remain outside the rule.
- This change affects review routing only; it does not change user-facing behavior.

## How did you test this code?

- The GitHub-faithful CODEOWNERS matcher selected `team-mcp-analytics` for each covered path and excluded representative shared paths.
- `hogli ci:preflight --fix` and the strict pre-push check completed successfully.
- Not run: local Greptile review because Flox could not install the optional CLI.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is required because this change only affects review routing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change with the `/establishing-code-ownership`, `/writing-code-comments`, `/running-ci-preflight`, and `/writing-pr-descriptions` skills.
