### PR TITLE
fix(desktop): apply report search to archived results

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -1,0 +1,128 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  archivedReports: [] as SignalReport[],
+  fetchNextPage: vi.fn(),
+  searchQuery: "",
+}));
+
+vi.mock("@posthog/ui/features/feature-flags/useTriageFocusEnabled", () => ({
+  useTriageFocusEnabled: () => false,
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxAllReports", () => ({
+  useInboxAllReports: () => ({
+    scopedReports: [],
+    allReports: [],
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    searchQuery: mocks.searchQuery,
+    totalCount: 0,
+    scope: "entire_project",
+    isSuccess: true,
+    sourceProductFilter: [],
+    priorityFilter: [],
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
+  useInboxReportsInfinite: () => ({
+    allReports: mocks.archivedReports,
+    isLoading: false,
+    hasNextPage: true,
+    fetchNextPage: mocks.fetchNextPage,
+    isFetchingNextPage: false,
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxSectionCounts", () => ({
+  useInboxSectionCounts: () => ({
+    decision: 0,
+    decisionPr: 0,
+    monitoring: 0,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useTrackReportsInboxViewed", () => ({
+  useTrackReportsInboxViewed: () => undefined,
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReportDismissAction", () => ({
+  useInboxReportDismissAction: () => ({
+    actionButton: null,
+    dialog: null,
+  }),
+}));
+
+vi.mock(
+  "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack",
+  () => ({ SuggestedReviewerAvatarStack: () => null }),
+);
+
+vi.mock(
+  "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge",
+  () => ({ SignalReportPriorityBadge: () => null }),
+);
+
+vi.mock("@posthog/ui/features/inbox/components/ReportRestoreButton", () => ({
+  ReportRestoreButton: () => null,
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/InboxSearchFilterBar", () => ({
+  InboxSearchFilterBar: () => null,
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/InboxScopeSelect", () => ({
+  InboxScopeSelect: () => null,
+}));
+
+import { ReportsInboxView } from "./ReportsInboxView";
+
+function archivedReport(id: string, title: string): SignalReport {
+  return {
+    id,
+    title,
+    summary: null,
+    status: "suppressed",
+    total_weight: 1,
+    signal_count: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    artefact_count: 0,
+    implementation_pr_url: null,
+  };
+}
+
+describe("ReportsInboxView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.archivedReports = [
+      archivedReport("matching-report", "Checkout errors"),
+      archivedReport("hidden-report", "Slow dashboards"),
+    ];
+    mocks.searchQuery = "checkout";
+    useInboxSignalsFilterStore.setState({
+      searchQuery: "checkout",
+      sourceProductFilter: [],
+      priorityFilter: [],
+      prFilter: "all",
+    });
+  });
+
+  it("applies report search to the resolved and archived section", async () => {
+    render(<ReportsInboxView />);
+
+    await userEvent.click(screen.getByText("Resolved & archived"));
+
+    expect(screen.getByText("Checkout errors")).toBeInTheDocument();
+    expect(screen.queryByText("Slow dashboards")).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchNextPage).toHaveBeenCalledOnce());
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -595,14 +595,15 @@ function ResolvedSection({ searchQuery }: { searchQuery: string }) {
           <div className="flex justify-center py-3">
             <Spinner />
           </div>
-        ) : matchingReports.length === 0 && !canAutoPageSearch ? (
-          <p className="px-1 py-2 text-[13.5px] text-gray-10">
-            {searchActive
-              ? "No resolved or archived reports match your search. Try a different search."
-              : "Nothing resolved or archived yet."}
-          </p>
         ) : (
           <div className="flex flex-col gap-1">
+            {matchingReports.length === 0 && !canAutoPageSearch && (
+              <p className="px-1 py-2 text-[13.5px] text-gray-10">
+                {searchActive
+                  ? "No resolved or archived reports match your search. Try a different search."
+                  : "Nothing resolved or archived yet."}
+              </p>
+            )}
             {matchingReports.map((report) => (
               <InboxReportRow key={report.id} report={report} />
             ))}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -10,6 +10,7 @@ import {
 } from "@phosphor-icons/react";
 import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
 import {
+  filterReportsBySearch,
   INBOX_DISMISSED_STATUS_FILTER,
   REPORTS_INBOX_STATUS_FILTER,
 } from "@posthog/core/inbox/reportFiltering";
@@ -341,7 +342,7 @@ export function ReportsInboxView() {
                   )}
                 </>
               )}
-              <ResolvedSection />
+              <ResolvedSection searchQuery={searchQuery} />
             </>
           )}
         </div>
@@ -551,7 +552,7 @@ function InboxReportRow({ report }: { report: SignalReport }) {
 
 // Archived and resolved reports come from their own server-side fetch, so the
 // section fetches lazily on first expand and stays collapsed by default.
-function ResolvedSection() {
+function ResolvedSection({ searchQuery }: { searchQuery: string }) {
   const [expanded, setExpanded] = useState(false);
   const {
     allReports,
@@ -563,6 +564,19 @@ function ResolvedSection() {
     { status: INBOX_DISMISSED_STATUS_FILTER, ordering: "-updated_at" },
     { enabled: expanded, pageSize: 25 },
   );
+  const matchingReports = useMemo(
+    () => filterReportsBySearch(allReports, searchQuery),
+    [allReports, searchQuery],
+  );
+  const searchActive = searchQuery.trim().length > 0;
+  const canAutoPageSearch =
+    searchActive && hasNextPage && allReports.length < AUTOPAGE_REPORT_LIMIT;
+
+  useEffect(() => {
+    if (!expanded || !canAutoPageSearch || isFetchingNextPage) return;
+    void fetchNextPage();
+  }, [expanded, canAutoPageSearch, isFetchingNextPage, fetchNextPage]);
+
   return (
     <section className="flex flex-col gap-1.5">
       <button
@@ -581,16 +595,23 @@ function ResolvedSection() {
           <div className="flex justify-center py-3">
             <Spinner />
           </div>
-        ) : allReports.length === 0 ? (
+        ) : matchingReports.length === 0 && !canAutoPageSearch ? (
           <p className="px-1 py-2 text-[13.5px] text-gray-10">
-            Nothing resolved or archived yet.
+            {searchActive
+              ? "No resolved or archived reports match your search. Try a different search."
+              : "Nothing resolved or archived yet."}
           </p>
         ) : (
           <div className="flex flex-col gap-1">
-            {allReports.map((report) => (
+            {matchingReports.map((report) => (
               <InboxReportRow key={report.id} report={report} />
             ))}
-            {hasNextPage && (
+            {isFetchingNextPage && (
+              <div className="flex justify-center py-2">
+                <Spinner />
+              </div>
+            )}
+            {hasNextPage && !canAutoPageSearch && (
               <Button
                 type="button"
                 variant="link-muted"
@@ -599,7 +620,7 @@ function ResolvedSection() {
                 disabled={isFetchingNextPage}
                 onClick={() => fetchNextPage()}
               >
-                {isFetchingNextPage ? <Spinner /> : "Show more"}
+                Show more
               </Button>
             )}
           </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -552,7 +552,11 @@ function InboxReportRow({ report }: { report: SignalReport }) {
 
 // Archived and resolved reports come from their own server-side fetch, so the
 // section fetches lazily on first expand and stays collapsed by default.
-function ResolvedSection({ searchQuery }: { searchQuery: string }) {
+function ResolvedSection({
+  searchQuery,
+}: {
+  searchQuery: string;
+}): React.JSX.Element {
   const [expanded, setExpanded] = useState(false);
   const {
     allReports,


### PR DESCRIPTION
## Problem

People searching the Self-driving inbox still see unrelated reports after expanding “Resolved & archived”.

**Why:** Inbox search should narrow every report section, regardless of report status.

## Changes

- “Resolved & archived” now applies the same title, summary, and report ID search as active sections.
- Active searches load more terminal pages up to the existing cap. Larger archives keep the manual “Show more” control.
- No screenshot: the layout is unchanged. The search only changes which existing rows appear.

## How did you test this code?

Added coverage that expands the terminal section, keeps the matching report, hides an unrelated report, and continues pagination. Relevant automated tests and type checks passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix aligns existing search behavior and does not change the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex. Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/reviewing-before-pr`, and `/writing-pr-descriptions`.

The fallback local review fixed manual pagination at the automatic loading cap. Greptile was unavailable because its CLI dependency was missing.

Public artifact check: the change and description use repository-only context.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
