### PR TITLE
fix(capture): clamp the rate limiter Redis TTL to two windows

### DIFF
--- a/rust/common/limiters/GLOBAL_RATE_LIMITER.md
+++ b/rust/common/limiters/GLOBAL_RATE_LIMITER.md
@@ -260,7 +260,7 @@ only if you're also changing the window/sync intervals.
 
 | Parameter | Default | Description |
 |---|---|---|
-| `global_cache_ttl` | 120s (2 × window) | `EXPIRE` TTL on Redis epoch keys. Must be ≥ 2 × `window_interval` so both epoch keys survive for reads |
+| `global_cache_ttl` | 2 × `window_interval` | `EXPIRE` TTL on Redis epoch keys. Clamped up to 2 × `window_interval` at construction so both epoch keys survive for reads. The default is derived from the *default* window, so a caller that changes `window_interval` and leaves this alone is corrected rather than silently under-enforcing |
 | `global_read_timeout` | 100ms | Timeout for batched MGET reads |
 | `global_write_timeout` | 100ms | Timeout for batched INCRBY writes |
 | `redis_key_prefix` | `@posthog/global_rate_limiter` | Prefix for all Redis keys (capture derives from `capture_mode`) |
@@ -278,8 +278,9 @@ only if you're also changing the window/sync intervals.
 
   │◄── window_interval (60s) ──►│
   │                              │
-  │  global_cache_ttl (120s = 2×window)                                  │
-  │  Redis epoch keys expire after this, ensuring old counters clean up  │
+  │  global_cache_ttl (2×window, clamped at construction)                │
+  │  Redis epoch keys expire after this. Below 2×window the previous     │
+  │  epoch key dies while reads still need it, and the estimate drops.   │
   │◄─────────────────────────────────────────────────────────────────────►│
   │                                                                      │
   │  local_cache_idle_timeout (300s)                                     │
@@ -300,8 +301,22 @@ only if you're also changing the window/sync intervals.
   a shorter idle timeout reclaims slots faster, keeping the cache responsive.
 - `local_cache_ttl` acts as an upper bound on how stale an entry can get
   before being forced to re-sync from scratch on next access.
-- `global_cache_ttl` is Redis hygiene — it only needs to be ≥ 2 × `window_interval`.
-  Making it much larger wastes Redis memory on dead keys.
+- `global_cache_ttl` is an enforcement requirement, not only Redis hygiene.
+  Reads consult the current and previous epoch, so the previous epoch's key is
+  still needed for a full window after its last write. Below 2 × `window_interval`
+  it expires early, `weighted_count` reads `prev_count` as 0, and the fleet
+  estimate is understated for the rest of every window — always toward
+  under-limiting. `GlobalRateLimiterImpl::new` clamps it up and logs a warning.
+  Making it much larger than 2 × `window_interval` wastes Redis memory on dead keys.
+
+**All three TTLs are clamped at construction**, because each one expiring inside
+the window it serves causes silent under-enforcement:
+
+| Parameter | Clamped to at least | What an undersized value breaks |
+|---|---|---|
+| `local_cache_idle_timeout` | `window_interval` | Entries expire mid-window and the next request takes the always-allowed miss path |
+| `local_cache_ttl` | `window_interval` | Same, on the absolute expiry path |
+| `global_cache_ttl` | 2 × `window_interval` | The previous epoch key dies while reads still need it, so `prev_count` reads as 0 |
 
 ## Request Flow
 

--- a/rust/common/limiters/src/global_rate_limiter.rs
+++ b/rust/common/limiters/src/global_rate_limiter.rs
@@ -543,6 +543,25 @@ impl GlobalRateLimiterImpl {
             );
             config.local_cache_ttl = config.window_interval;
         }
+        // Reads consult the current and the previous epoch, so the previous
+        // epoch's Redis key is still needed for a full window after its last
+        // write. A TTL below 2 x window_interval expires that key while it is
+        // still being read, and `weighted_count` then takes `prev_count` as 0.
+        // That understates the fleet estimate for the rest of the window and
+        // under-enforces. `global_cache_ttl` has a default derived from the
+        // default window, so any caller that changes the window without
+        // changing the TTL lands here.
+        let min_global_cache_ttl = config.window_interval * 2;
+        if config.global_cache_ttl < min_global_cache_ttl {
+            warn!(
+                scope,
+                global_cache_ttl = ?config.global_cache_ttl,
+                window_interval = ?config.window_interval,
+                "global_cache_ttl below 2x window_interval expires the previous \
+                 epoch key while reads still need it; clamping to 2x window_interval"
+            );
+            config.global_cache_ttl = min_global_cache_ttl;
+        }
         let config = config;
 
         let cache = Cache::builder()
@@ -2109,6 +2128,35 @@ mod tests {
                 Duration::from_secs(expected_secs),
                 "idle_timeout={idle_secs}s against a 60s window should resolve to {expected_secs}s -- \
                  an idle timeout inside the window expires entries mid-window and silently under-enforces"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_global_cache_ttl_clamped_up_to_two_windows() {
+        // (configured_ttl_secs, expected_secs) against test_config()'s 60s window
+        let cases = vec![
+            (30, 120),  // below one window
+            (60, 120),  // one window: still expires the previous epoch early
+            (119, 120), // just below the bound
+            (120, 120), // exactly at the bound: untouched
+            (600, 600), // above: untouched
+        ];
+
+        for (ttl_secs, expected_secs) in cases {
+            let client = Arc::new(MockRedisClient::new());
+            let config = GlobalRateLimiterConfig {
+                global_cache_ttl: Duration::from_secs(ttl_secs),
+                ..test_config()
+            };
+            let limiter = GlobalRateLimiterImpl::new(config, vec![client]).unwrap();
+
+            assert_eq!(
+                limiter.config.global_cache_ttl,
+                Duration::from_secs(expected_secs),
+                "global_cache_ttl={ttl_secs}s against a 60s window should resolve to {expected_secs}s -- \
+                 a TTL under 2x the window expires the previous epoch key while reads still \
+                 need it, so weighted_count takes prev_count as 0 and under-enforces"
             );
         }
     }

--- a/rust/common/limiters/tests/global_rate_limiter_integration_tests.rs
+++ b/rust/common/limiters/tests/global_rate_limiter_integration_tests.rs
@@ -106,15 +106,18 @@ async fn test_epoch_key_ttl_expiry() {
 
     let mut config = test_config("ttl_expiry");
     // `new()` holds global_cache_ttl at 2 x window_interval, so a TTL short
-    // enough to observe inside a test needs an equally short window.
-    config.window_interval = Duration::from_secs(1);
-    config.global_cache_ttl = Duration::from_secs(2);
+    // enough to observe inside a test needs a short window too. The tick purges
+    // any deferred write whose epoch has aged past the readable pair, which at
+    // a 2s window is 2-4s after the write. The tick runs every 100ms, so that
+    // margin holds even on a loaded CI runner; a 1s window would not.
+    config.window_interval = Duration::from_secs(2);
+    config.global_cache_ttl = Duration::from_secs(4);
     let redis_arc: Arc<dyn Client + Send + Sync> = Arc::new(redis.clone());
     let limiter = GlobalRateLimiterImpl::new(config.clone(), vec![redis_arc]).unwrap();
 
-    // Pin the write and the epoch lookup to one timestamp. A one-second window
-    // rolls the epoch between the two otherwise, and the test reads a key the
-    // write never touched.
+    // Pin the write and the epoch lookup to one timestamp. A short window rolls
+    // the epoch between the two otherwise, and the test reads a key the write
+    // never touched.
     let now = Utc::now();
     let _ = limiter.check_limit("ttl_key", 10, Some(now)).await;
 
@@ -126,7 +129,7 @@ async fn test_epoch_key_ttl_expiry() {
         results[0].is_some()
     });
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
     let results = redis.mget(vec![redis_key]).await.unwrap();
     assert!(results[0].is_none(), "Key should have expired after TTL");

--- a/rust/common/limiters/tests/global_rate_limiter_integration_tests.rs
+++ b/rust/common/limiters/tests/global_rate_limiter_integration_tests.rs
@@ -105,13 +105,19 @@ async fn test_epoch_key_ttl_expiry() {
     };
 
     let mut config = test_config("ttl_expiry");
+    // `new()` holds global_cache_ttl at 2 x window_interval, so a TTL short
+    // enough to observe inside a test needs an equally short window.
+    config.window_interval = Duration::from_secs(1);
     config.global_cache_ttl = Duration::from_secs(2);
     let redis_arc: Arc<dyn Client + Send + Sync> = Arc::new(redis.clone());
     let limiter = GlobalRateLimiterImpl::new(config.clone(), vec![redis_arc]).unwrap();
 
-    let _ = limiter.check_limit("ttl_key", 10, None).await;
-
+    // Pin the write and the epoch lookup to one timestamp. A one-second window
+    // rolls the epoch between the two otherwise, and the test reads a key the
+    // write never touched.
     let now = Utc::now();
+    let _ = limiter.check_limit("ttl_key", 10, Some(now)).await;
+
     let epoch = epoch_from_timestamp(now, config.window_interval);
     let redis_key = epoch_key(&config.redis_key_prefix, "ttl_key", epoch);
 


### PR DESCRIPTION
## Problem

Every project rate-limited by capture gets a free pass for 60 seconds out of every 180. The limiter reads two Redis epoch counters, but the previous epoch's key expires before the limiter stops reading it, so for the last third of every window the count is understated by up to a third. The bias only ever runs toward under-limiting.

## Changes

- Projects over their limit are now measured correctly for the whole window, so the limiter stops releasing them for the last 60 seconds of each one.
- `GlobalRateLimiterImpl::new` clamps the Redis epoch TTL up to twice the window and logs a warning.
- The same function already clamps two local cache TTLs for this exact hazard. The Redis one was the only one with a documented requirement and no check.
- The clamp corrects config rather than refusing to boot, matching the existing convention there.
- Design doc gains a table of all three clamps, and no longer calls this one Redis hygiene.
- Nothing user-visible changes.

> [!NOTE]
> **Redis memory rises.** Epoch keys live for the TTL, so at the current 180s window this moves the TTL from 120s to 360s and the live key count from about 1.07M to about 2.40M in prod-US (from the `distinct_id_usage` census). That is 4.25% to roughly 9.5% of the 43 GiB `capture-globalratelimit-prod-redis` group, which has zero evictions today. Once the window moves to 120s the TTL becomes 240s and the live set falls to about 1.8M (roughly 7.1%). This is the largest Redis effect in the stack and it lands here, not in the charts change.

## How did you test this code?

- `test_global_cache_ttl_clamped_up_to_two_windows` covers below, at, and above the bound. It catches the regression this fixes: raising the window and leaving the TTL behind.
- `test_epoch_key_ttl_expiry` asked for a 2s TTL against a 60s window, which the clamp now corrects. It moves to a 2s window with a 4s TTL, and pins its write and epoch lookup to one timestamp. The old version computed the epoch after the write and could read a key the write never touched. A 1s window was tried first and rejected: the tick's stale-epoch purge would drop the write if the tick lagged past about one second.

Ran locally under flox against a local Redis: the `limiters` unit and integration suites, the 35 capture-side limiter tests, `cargo clippy -p limiters --all-targets -D warnings`.

Not run: the wider capture suite, or anything needing the dev stack. No production verification.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`rust/common/limiters/GLOBAL_RATE_LIMITER.md` is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5) while investigating why the limiter missed bursty keys during an overflow-lane backlog. Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

`hogli review` could not run: the Greptile CLI install fails here with `EPERM` on `~/.config/posthog/tools/greptile`. The Greptile bot reviewed the PR instead; its one finding (test flake margin) is addressed in the second commit.

The size of the estimate dip is arithmetic from `weighted_count`, not a production measurement. The fleet-wide magnitude is unmeasured: the drift histogram is missing from the high-resolution metrics datasource, and 60s metric dedup cannot resolve a 180s period.

Base of a five-PR stack.

No customer data or internal operational detail appears in this PR.
