### PR TITLE
fix(cohorts): correct recalculation cadence in Last calculated tooltip

### DIFF
--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -99,7 +99,7 @@ export function Cohorts(): JSX.Element {
         {
             title: 'Last calculated',
             tooltip:
-                'PostHog calculates what users belong to each cohort. This is then used when filtering on cohorts in the Trends page etc. Calculating happens every 24 hours, or whenever a cohort is updated',
+                'PostHog calculates which people belong to each cohort, and uses that membership when you filter by the cohort. Recalculation runs on a rolling schedule, typically about once a day, and again as soon as you edit the cohort.',
             render: function RenderCalculation(_: any, cohort: CohortType) {
                 if (cohort.is_static) {
                     return <>N/A</>


### PR DESCRIPTION
## Problem

The cohorts list tells users that recalculation "happens every 24 hours". That reads as a guarantee, and users plan analyses around it.

Recalculation is throughput-bound, not interval-based. A cohort becomes eligible once its last calculation is older than `MAX_AGE_MINUTES`, then the scheduler takes a fixed number of cohorts oldest-first on each run (`posthog/tasks/calculate_cohort.py`). The interval a given cohort actually gets depends on how many dynamic cohorts the instance holds.

The tooltip also omits that editing a cohort recalculates it immediately (`posthog/api/cohort.py:1403`).

## Changes

- The "Last calculated" tooltip now describes a rolling schedule that is typically about daily, rather than a fixed 24-hour cycle.
- The tooltip now states that editing a cohort recalculates it right away.
- Copy only. No behavior changes.

Before:

> PostHog calculates what users belong to each cohort. This is then used when filtering on cohorts in the Trends page etc. Calculating happens every 24 hours, or whenever a cohort is updated

After:

> PostHog calculates which people belong to each cohort, and uses that membership when you filter by the cohort. Recalculation runs on a rolling schedule, typically about once a day, and again as soon as you edit the cohort.

No screenshot: the diff is the text of an existing tooltip, quoted above in full. Nothing else in the column renders differently.

## How did you test this code?

Nothing was run. This sandbox has no `node_modules` and no `hogli`, so lint, typecheck, Storybook and the local Greptile review could not run. The diff is one string literal.

No new tests. A tooltip's wording has no regression an automated test should pin.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The same claim appears in the cohorts FAQ on posthog.com, corrected in [PostHog/posthog.com#19753](https://github.com/PostHog/posthog.com/pull/19753). That PR also adds the guidance this wording implies: filter on a property directly when you need a segment that is always current.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-user-facing-copy` for the tooltip wording, `/writing-pr-descriptions` for this body.

One correction shaped the result. The first pass through the code read `MAX_AGE_MINUTES = 15` as the recalculation cadence and concluded the "24 hours" copy was simply wrong. That was a misreading. `MAX_AGE_MINUTES` gates eligibility only, and throughput sets the real interval, since `enqueue_cohorts_to_calculate` takes `CALCULATE_X_PARALLEL_COHORTS_DURING_DAY`/`_NIGHT` cohorts oldest-first per run. The staleness gauges in `update_cohort_metrics` bucket at 24, 36 and 48 hours, which suggests roughly daily is the expected range. The new wording avoids naming an interval it cannot promise, instead of swapping one precise number for another.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
