### PR TITLE
feat(workflows): add taxonomy entries for $workflows_email_* events

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListPropertiesLogic.test.ts
@@ -166,11 +166,15 @@ describe('sessionRecordingsListPropertiesLogic', () => {
         }).toDispatchActions(['loadPropertiesForSessionsSuccess'])
 
         expect(issuedQueries).toHaveLength(1)
-        expect(issuedQueries[0]).toContain('any(session.$entry_utm_medium) as $entry_utm_medium')
-        expect(issuedQueries[0]).toContain('any(session.$channel_type) as $channel_type')
+        // The WHERE clause lists every core event name, so a pin can only be found absent by looking
+        // at the select list. Searching the whole query trips over an unrelated event that shares the
+        // pin's name as a substring.
+        const selectList = issuedQueries[0].split('FROM events')[0]
+        expect(selectList).toContain('any(session.$entry_utm_medium) as $entry_utm_medium')
+        expect(selectList).toContain('any(session.$channel_type) as $channel_type')
         // non-session pins must not leak into the query
-        expect(issuedQueries[0]).not.toContain('email')
-        expect(issuedQueries[0]).not.toContain('Start')
+        expect(selectList).not.toContain('email')
+        expect(selectList).not.toContain('Start')
 
         expect(logic.values.recordingPropertiesById['s1']).toMatchObject({
             $browser: 'Chrome',

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4138,7 +4138,7 @@
             "label": "Workflow email delivered"
         },
         "$workflows_email_failed": {
-            "description": "Fires when a workflow email was never attempted. This usually means the PostHog email service found a virus in the message.",
+            "description": "Fires when a workflow email could not be sent. The cause is a failed call to the email provider, a template that did not render, or a message the provider rejected, most often because it contained a virus.",
             "label": "Workflow email failed"
         },
         "$workflows_email_link_clicked": {

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4125,6 +4125,42 @@
             "description": "Automatically captured web vitals data.",
             "label": "Web vitals"
         },
+        "$workflows_email_blocked": {
+            "description": "Fires when a recipient reports a workflow email as spam. Despite the event name, this does not count blocked mail: it counts spam complaints that mailbox providers pass back through their feedback loops. Gmail does not send those reports, so a Gmail user marking an email as spam is not counted here. Workflow metrics show the same count as \"Marked as spam\".",
+            "label": "Workflow email marked as spam"
+        },
+        "$workflows_email_bounced": {
+            "description": "Fires when a workflow email bounces.",
+            "label": "Workflow email bounced"
+        },
+        "$workflows_email_delivered": {
+            "description": "Fires when a workflow email reaches the recipient's inbox, confirmed by their mail server accepting it.",
+            "label": "Workflow email delivered"
+        },
+        "$workflows_email_failed": {
+            "description": "Fires when a workflow email was never attempted. This usually means the PostHog email service found a virus in the message.",
+            "label": "Workflow email failed"
+        },
+        "$workflows_email_link_clicked": {
+            "description": "Fires when a recipient clicks a link in a workflow email. Emails sent without click tracking can never record a click, so they are missing from this count.",
+            "label": "Workflow email link clicked"
+        },
+        "$workflows_email_opened": {
+            "description": "Fires when a recipient opens a workflow email. Emails sent without open tracking can never record an open, so they are missing from this count.",
+            "label": "Workflow email opened"
+        },
+        "$workflows_email_sent": {
+            "description": "Fires when a workflow sends an email to a recipient.",
+            "label": "Workflow email sent"
+        },
+        "$workflows_email_tracking_consent_updated": {
+            "description": "Fires when a recipient changes whether workflow emails can track their opens and clicks, on the email preferences page.",
+            "label": "Workflow email tracking consent updated"
+        },
+        "$workflows_email_unsubscribed": {
+            "description": "Fires when a recipient unsubscribes from workflow emails, through the one-click unsubscribe link or the preferences page. The `category` property holds the message category they left, or `$all` when they opted out of everything.",
+            "label": "Workflow email unsubscribed"
+        },
         "All events": {
             "description": "This is a wildcard that matches all events.",
             "label": "All events"

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4138,7 +4138,7 @@
             "label": "Workflow email delivered"
         },
         "$workflows_email_failed": {
-            "description": "Fires when a workflow email could not be sent. The cause is a failed call to the email provider, a template that did not render, or a message the provider rejected, most often because it contained a virus.",
+            "description": "Fires when a workflow email could not be sent. This covers a failed call to the email provider, a template that did not render, a message the provider rejected for containing a virus, and a misconfigured email step, such as a sender that no longer exists or a domain that is not verified.",
             "label": "Workflow email failed"
         },
         "$workflows_email_link_clicked": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -501,7 +501,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$workflows_email_failed": {
             "label": "Workflow email failed",
-            "description": "Fires when a workflow email could not be sent. The cause is a failed call to the email provider, a template that did not render, or a message the provider rejected, most often because it contained a virus.",
+            "description": "Fires when a workflow email could not be sent. This covers a failed call to the email provider, a template that did not render, a message the provider rejected for containing a virus, and a misconfigured email step, such as a sender that no longer exists or a domain that is not verified.",
         },
         "$workflows_email_opened": {
             "label": "Workflow email opened",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -488,6 +488,45 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Slack message received",
             "description": "Fires when a message is posted in a Slack channel PostHog is connected to.",
         },
+        # Descriptions here must stay in step with the matching workflow email metric definitions in
+        # products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts, since the two surfaces
+        # count the same thing.
+        "$workflows_email_sent": {
+            "label": "Workflow email sent",
+            "description": "Fires when a workflow sends an email to a recipient.",
+        },
+        "$workflows_email_delivered": {
+            "label": "Workflow email delivered",
+            "description": "Fires when a workflow email reaches the recipient's inbox, confirmed by their mail server accepting it.",
+        },
+        "$workflows_email_failed": {
+            "label": "Workflow email failed",
+            "description": "Fires when a workflow email was never attempted. This usually means the PostHog email service found a virus in the message.",
+        },
+        "$workflows_email_opened": {
+            "label": "Workflow email opened",
+            "description": "Fires when a recipient opens a workflow email. Emails sent without open tracking can never record an open, so they are missing from this count.",
+        },
+        "$workflows_email_link_clicked": {
+            "label": "Workflow email link clicked",
+            "description": "Fires when a recipient clicks a link in a workflow email. Emails sent without click tracking can never record a click, so they are missing from this count.",
+        },
+        "$workflows_email_bounced": {
+            "label": "Workflow email bounced",
+            "description": "Fires when a workflow email bounces.",
+        },
+        "$workflows_email_blocked": {
+            "label": "Workflow email marked as spam",
+            "description": 'Fires when a recipient reports a workflow email as spam. Despite the event name, this does not count blocked mail: it counts spam complaints that mailbox providers pass back through their feedback loops. Gmail does not send those reports, so a Gmail user marking an email as spam is not counted here. Workflow metrics show the same count as "Marked as spam".',
+        },
+        "$workflows_email_unsubscribed": {
+            "label": "Workflow email unsubscribed",
+            "description": "Fires when a recipient unsubscribes from workflow emails, through the one-click unsubscribe link or the preferences page. The `category` property holds the message category they left, or `$all` when they opted out of everything.",
+        },
+        "$workflows_email_tracking_consent_updated": {
+            "label": "Workflow email tracking consent updated",
+            "description": "Fires when a recipient changes whether workflow emails can track their opens and clicks, on the email preferences page.",
+        },
     },
     "elements": {
         "tag_name": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -501,7 +501,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$workflows_email_failed": {
             "label": "Workflow email failed",
-            "description": "Fires when a workflow email was never attempted. This usually means the PostHog email service found a virus in the message.",
+            "description": "Fires when a workflow email could not be sent. The cause is a failed call to the email provider, a template that did not render, or a message the provider rejected, most often because it contained a virus.",
         },
         "$workflows_email_opened": {
             "label": "Workflow email opened",

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -255,7 +255,7 @@ export const WORKFLOW_EMAIL_METRICS: Record<
     email_failed: {
         name: 'Failed',
         description:
-            'Total number of emails that could not be sent. The cause is a failed call to the email provider, a template that did not render, or a message the provider rejected, most often because it contained a virus.',
+            'Total number of emails that could not be sent. This covers a failed call to the email provider, a template that did not render, a message the provider rejected for containing a virus, and a misconfigured email step, such as a sender that no longer exists or a domain that is not verified.',
         color: METRIC_COLORS['Failed'],
         metricNames: ['email_failed'],
     },

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -255,7 +255,7 @@ export const WORKFLOW_EMAIL_METRICS: Record<
     email_failed: {
         name: 'Failed',
         description:
-            'Total number of emails that were not attempted to be sent. This typically indicates the PostHog email service determined the email contained a virus.',
+            'Total number of emails that could not be sent. The cause is a failed call to the email provider, a template that did not render, or a message the provider rejected, most often because it contained a virus.',
         color: METRIC_COLORS['Failed'],
         metricNames: ['email_failed'],
     },


### PR DESCRIPTION
## Problem

Anyone building an insight on workflow email activity meets nine bare event names in the event picker, with no description on any of them.

- `$workflows_email_blocked` is the trap: it counts spam complaints, not blocked mail, and nothing on that surface says so.
- The plugin server's email tracking service emits seven of the events; the unsubscribe and preferences views emit the other two.
- `core-filter-definitions-by-group.json` had no entry for any of them, so the picker, the insight builder and the taxonomic filter fall back to the raw name.

## Changes

- The event picker now shows a label and a description for each of the nine `$workflows_email_*` events.
- "Workflow email marked as spam" says `$workflows_email_blocked` counts spam complaints from mailbox provider feedback loops, and that Gmail sends no such reports.
- The workflow Metrics tile for Failed no longer says the email was never attempted. That event also fires when the call to the email provider fails and when a template does not render, so both surfaces now name all three causes.
- Descriptions otherwise follow the metric definitions in `workflowMetricsSummaryLogic.ts`, so the Metrics tab and the event picker describe the same counts.
- Mechanical: the entries go in `posthog/taxonomy/taxonomy.py`, and `pnpm run taxonomy:build` regenerates the JSON the frontend reads.

Before, in the product analytics series picker:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/d282d1aaaaa55e94ae8320c560e98670d783b22a/2026/08/73fd7897-792b-499b-b245-f478ea055995.png)

After:

![after](https://raw.githubusercontent.com/PostHog/pr-assets/d282d1aaaaa55e94ae8320c560e98670d783b22a/2026/08/980f7580-3753-4cfa-ac36-67e61b9e675e.png)

## How did you test this code?

- The screenshots come from the local dev stack running this branch, driven through a browser: log in, open a new trend, search the series picker for `workflows_email`, hover the spam row. The before shot is the same session with the generated JSON reverted.
- `sessionRecordingsListPropertiesLogic` asserted that a pinned `email` property stays out of the generated query by searching the whole query string. That query lists every core event name in its `WHERE` clause, so `$workflows_email_sent` broke it. The assertions now read the select list, which is where a leaked pin would appear. Breaking the filter under test still fails them, checked locally.
- Not run: `hogli review` (Greptile). The CLI is absent from this sandbox and flox is unavailable here, so the review ran on the PR instead. Its one finding, the failed-email wording, is fixed above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code in a PostHog Desktop cloud task. Skills invoked: `/writing-user-facing-copy` for the descriptions, `/writing-pr-descriptions` for this body, `/setting-up-devbox` when checking the result in a running app, and `/writing-tests` before touching the session recordings assertions.

Decisions worth flagging:

- The request pointed at the generated JSON. The entries went into `posthog/taxonomy/taxonomy.py` instead, since a build script owns that file.
- The request named eight events. `$workflows_email_tracking_consent_updated` is included as a ninth: the preferences page emits it behind the same team flag, and it had the same gap.
- Greptile flagged only the taxonomy description as too narrow. The Metrics tile made the same claim, so both moved rather than letting the two surfaces drift apart.

`$workflows_conversion` has the same gap and is left alone here, since it sits outside the `$workflows_email_*` family.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
