### PR TITLE
feat(cdp): include match events in the managed-alert boundary

### DIFF
--- a/nodejs/src/cdp/managed-alert-events.ts
+++ b/nodejs/src/cdp/managed-alert-events.ts
@@ -1,6 +1,6 @@
 // Mirror of `posthog/cdp/internal_events.py`. The managed-alert event boundary and the legacy
 // insight-alert exemption must match the Python side exactly, so keep the two in sync.
-export const MANAGED_ALERT_EVENT_PATTERN = /^\$[a-z0-9_]+_alert_(firing|resolved|errored|auto_disabled)$/
+export const MANAGED_ALERT_EVENT_PATTERN = /^\$[a-z0-9_]+_alert_(firing|resolved|errored|auto_disabled|match)$/
 export const LEGACY_INSIGHT_ALERT_EVENT = '$insight_alert_firing'
 
 /** Return whether an internal event is reserved for an alert-owned destination. */

--- a/posthog/cdp/internal_events.py
+++ b/posthog/cdp/internal_events.py
@@ -16,7 +16,7 @@ logger = structlog.get_logger(__name__)
 # Single source of truth for the managed-alert event boundary. Also used as a Postgres regex
 # filter (products/cdp hog_function queryset) and mirrored in the Node CDP consumer, so keep it
 # POSIX-compatible (no (?:...) groups).
-MANAGED_ALERT_EVENT_PATTERN = r"^\$[a-z0-9_]+_alert_(firing|resolved|errored|auto_disabled)$"
+MANAGED_ALERT_EVENT_PATTERN = r"^\$[a-z0-9_]+_alert_(firing|resolved|errored|auto_disabled|match)$"
 LEGACY_INSIGHT_ALERT_EVENT = "$insight_alert_firing"
 _MANAGED_ALERT_EVENT = re.compile(MANAGED_ALERT_EVENT_PATTERN)
 


### PR DESCRIPTION
## Problem

The vision alerts stack adds a `match` event kind, but the managed-alert event boundary that reserves alert events for alert-owned destinations does not cover it. The Python create-time gate and the Node delivery-time mirror ship in different stack layers (#88403 and #88404) because the migrations-separation check keeps migrations and `nodejs/**` apart.

Suggested in review on #88404: land both sides of the boundary together, ahead of the stack.

## Changes

- `$<product>_alert_match` events now count as managed on both the Python gate and the Node mirror, in one PR, so the two sides never diverge in production.
- No user-visible change: no product emits a match event until the vision alerts stack lands.
- The identical one-line changes inside #88403 and #88404 become no-ops when the stack merges.

## How did you test this code?

The pattern is a one-line union addition on each side; an import-time assertion run locally confirms `$replay_vision_alert_match` matches and the legacy insight exemption still holds. No existing test enumerates the kinds.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Agent-authored on request, extracting a reviewer suggestion from #88404 into a standalone PR off master. Skills invoked: `/writing-pr-descriptions`.

**Public artifact:** nothing here came from a customer conversation, ticket, or log.
