### PR TITLE
feat(desktop): install skills-store stubs into the sandbox at session start

### DIFF
--- a/products/desktop/packages/agent/src/posthog-api.test.ts
+++ b/products/desktop/packages/agent/src/posthog-api.test.ts
@@ -230,6 +230,56 @@ describe("PostHogAPIClient", () => {
     );
   });
 
+  it("downloads the skills store bundle as stubs with its header counts", async () => {
+    const client = new PostHogAPIClient({
+      apiUrl: "https://app.posthog.com",
+      getApiKey: vi.fn().mockResolvedValue("token"),
+      projectId: 7,
+    });
+    const bytes = new TextEncoder().encode("zip");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        "X-Skills-Included": "2",
+        "X-Skills-Dropped": "1",
+        "X-Skills-Skipped": "0",
+      }),
+      arrayBuffer: vi.fn().mockResolvedValue(bytes.buffer),
+    });
+
+    const result = await client.downloadSkillsBundle(20);
+
+    expect(result).toEqual({
+      kind: "bundle",
+      bytes,
+      included: 2,
+      dropped: 1,
+      skipped: 0,
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://app.posthog.com/api/projects/7/llm_skills/bundle/?content=stub&limit=20",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+  });
+
+  it.each([
+    [404, { kind: "not_enabled" }],
+    [503, { kind: "error", status: 503 }],
+  ])(
+    "maps a %s from the skills store bundle endpoint without throwing",
+    async (status, expected) => {
+      const client = new PostHogAPIClient({
+        apiUrl: "https://app.posthog.com",
+        getApiKey: vi.fn().mockResolvedValue("token"),
+        projectId: 7,
+      });
+      mockFetch.mockResolvedValueOnce({ ok: false, status });
+
+      await expect(client.downloadSkillsBundle(20)).resolves.toEqual(expected);
+    },
+  );
+
   it.each([
     [
       "includes message_id and text_parts when provided",

--- a/products/desktop/packages/agent/src/posthog-api.test.ts
+++ b/products/desktop/packages/agent/src/posthog-api.test.ts
@@ -259,7 +259,11 @@ describe("PostHogAPIClient", () => {
     });
     expect(mockFetch).toHaveBeenCalledWith(
       "https://app.posthog.com/api/projects/7/llm_skills/bundle/?content=stub&limit=20",
-      expect.objectContaining({ headers: expect.any(Headers) }),
+      expect.objectContaining({
+        headers: expect.any(Headers),
+        // Session start awaits this fetch, so it must be bounded.
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 

--- a/products/desktop/packages/agent/src/posthog-api.ts
+++ b/products/desktop/packages/agent/src/posthog-api.ts
@@ -107,6 +107,18 @@ export interface PeerMessageSendResult {
   message_id?: string | null;
 }
 
+export type SkillsBundleDownloadResult =
+  | {
+      kind: "bundle";
+      bytes: Uint8Array;
+      /** Counts from the `X-Skills-*` response headers. */
+      included: number;
+      dropped: number;
+      skipped: number;
+    }
+  | { kind: "not_enabled" }
+  | { kind: "error"; status: number | null; message?: string };
+
 export type TaskRunUpdate = Partial<
   Pick<
     TaskRun,
@@ -689,6 +701,48 @@ export class PostHogAPIClient {
       return response.arrayBuffer();
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * One zip of the signed-in user's skills-store skills as discovery stubs.
+   * A 404 means the store-in-sandbox flag is off for this user, which is the
+   * common case and not an error; anything else that is not a 200 is reported
+   * with its status so the caller can log it without treating it as "off".
+   */
+  async downloadSkillsBundle(
+    limit: number,
+  ): Promise<SkillsBundleDownloadResult> {
+    const teamId = this.getTeamId();
+    const query = new URLSearchParams({
+      content: "stub",
+      limit: String(limit),
+    });
+    try {
+      const response = await this.performRequestWithRetry(
+        `/api/projects/${teamId}/llm_skills/bundle/?${query.toString()}`,
+      );
+      if (response.status === 404) {
+        return { kind: "not_enabled" };
+      }
+      if (!response.ok) {
+        return { kind: "error", status: response.status };
+      }
+      const readCount = (header: string): number =>
+        Number.parseInt(response.headers.get(header) ?? "0", 10) || 0;
+      return {
+        kind: "bundle",
+        bytes: new Uint8Array(await response.arrayBuffer()),
+        included: readCount("X-Skills-Included"),
+        dropped: readCount("X-Skills-Dropped"),
+        skipped: readCount("X-Skills-Skipped"),
+      };
+    } catch (error) {
+      return {
+        kind: "error",
+        status: null,
+        message: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 

--- a/products/desktop/packages/agent/src/posthog-api.ts
+++ b/products/desktop/packages/agent/src/posthog-api.ts
@@ -721,6 +721,11 @@ export class PostHogAPIClient {
     try {
       const response = await this.performRequestWithRetry(
         `/api/projects/${teamId}/llm_skills/bundle/?${query.toString()}`,
+        {
+          // Session start awaits this; a stalled socket must not hold up the
+          // run. The signal also aborts the body read below.
+          signal: AbortSignal.timeout(API_TRANSFER_TIMEOUT_MS),
+        },
       );
       if (response.status === 404) {
         return { kind: "not_enabled" };

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -139,6 +139,7 @@ import {
   buildStoreSkillsInstructions,
   getStoreSkillRoots,
   installStoreSkillsArchive,
+  listStoreSkillStubs,
   removeStoreSkillStubs,
   STORE_SKILLS_BUNDLE_LIMIT,
 } from "./store-skills";
@@ -3799,11 +3800,15 @@ export class AgentServer {
       );
       if (result.kind === "error") {
         // Stubs from an earlier session stay: a transient failure says nothing
-        // about what the user can still access.
+        // about what the user can still access. The harness still lists them,
+        // so the pointer instructions must stay in the prompt too.
+        const retained = await listStoreSkillStubs(getStoreSkillRoots());
+        this.storeSkillsInstalledCount = retained.length;
         this.logger.warn("Skills store bundle fetch failed", {
           ...context,
           status: result.status,
           ...(result.message && { error: result.message }),
+          retained,
         });
         return;
       }

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -135,6 +135,12 @@ import {
 import { resolveRtkSavings } from "./rtk-savings";
 import { RunUsageAccumulator } from "./run-usage";
 import { jsonRpcRequestSchema, validateCommandParams } from "./schemas";
+import {
+  buildStoreSkillsInstructions,
+  getStoreSkillRoots,
+  installStoreSkillsArchive,
+  STORE_SKILLS_BUNDLE_LIMIT,
+} from "./store-skills";
 import type { AgentServerConfig, ClaudeCodeConfig } from "./types";
 import { waitForFile } from "./wait-for-file";
 
@@ -545,6 +551,7 @@ export class AgentServer {
   // run's state when the first message arrives (see resolveActivationSettings).
   private prewarmedRun = false;
   private prewarmedStartupTurnPending = false;
+  private storeSkillsInstalledCount = 0;
   private autoPublishStateResolved = false;
   private warmReasoningEffortResolved = false;
   private installedSkillBundles = new Set<string>();
@@ -1809,6 +1816,8 @@ export class AgentServer {
       name: process.env.HOSTNAME || "cloud-sandbox",
     };
 
+    // The store skills fetch is independent of the run context, so it overlaps
+    // the context fetch instead of adding its own round trip to session start.
     const [preTaskRun, preTask] = await this.bootTracker.measure(
       "context_fetch",
       () =>
@@ -1827,6 +1836,7 @@ export class AgentServer {
               return null;
             }),
           this.fetchTaskForSessionContext(payload.task_id),
+          this.installStoreSkills(payload.task_id, payload.run_id),
         ]),
     );
     this.taskRepositories =
@@ -3770,6 +3780,56 @@ export class AgentServer {
     return normalizedName;
   }
 
+  /**
+   * Put the user's skills-store skills on disk as discovery stubs before the
+   * harness session starts, so it lists them like any local skill. Skill
+   * bodies stay in the store and cross the PostHog MCP only when a skill is
+   * invoked. Never throws: a sandbox without store skills is the normal case.
+   */
+  private async installStoreSkills(
+    taskId: string,
+    runId: string,
+  ): Promise<void> {
+    this.storeSkillsInstalledCount = 0;
+    const context = { taskId, runId };
+    try {
+      const result = await this.posthogAPI.downloadSkillsBundle(
+        STORE_SKILLS_BUNDLE_LIMIT,
+      );
+      if (result.kind === "not_enabled") {
+        return;
+      }
+      if (result.kind === "error") {
+        this.logger.warn("Skills store bundle fetch failed", {
+          ...context,
+          status: result.status,
+          ...(result.message && { error: result.message }),
+        });
+        return;
+      }
+      if (result.included === 0) {
+        return;
+      }
+      const install = await installStoreSkillsArchive(
+        result.bytes,
+        getStoreSkillRoots(),
+      );
+      this.storeSkillsInstalledCount = install.installed.length;
+      this.logger.info("Installed skills store stubs", {
+        ...context,
+        bytes: result.bytes.byteLength,
+        bundleIncluded: result.included,
+        bundleDropped: result.dropped,
+        bundleSkipped: result.skipped,
+        installed: install.installed,
+        collisions: install.collisions,
+        rejected: install.rejected,
+      });
+    } catch (error) {
+      this.logger.warn("Skills store install failed", { ...context, error });
+    }
+  }
+
   private async waitForRepoReady(): Promise<void> {
     const readyFile = this.config.repoReadyFile;
     if (!readyFile) {
@@ -4302,7 +4362,7 @@ Optimize for the fewest shell round trips.
 When you create a non-code file the user should be able to download (such as a report, chart, image, archive, or data file), call the \`upload_artifact\` tool with its path before your final reply. In your final reply, link to the download URL returned by the tool—never link to the file's local workspace path. Files left in the workspace don't reach the user. Don't upload source code or repository changes—those belong in a commit or PR.`;
 
     // Closes out every branch below, so a new section is added once rather than five times.
-    const commonInstructions = `${signedCommitInstructions}${stackInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}${this.buildSourceControlAccessInstructions()}`;
+    const commonInstructions = `${signedCommitInstructions}${stackInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}${this.buildSourceControlAccessInstructions()}${buildStoreSkillsInstructions(this.storeSkillsInstalledCount)}`;
 
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
     const publicRepoSafetyInstruction = `   - **Public-repo safety.** Treat the target repository as public-readable unless you have verified otherwise. The PR title, description, and commit messages must not contain private operational scale (exact event counts, internal row volumes, customer-usage percentages), customer names / emails / companies, references to internal tickets or incidents, the contents of Slack threads (do not quote or paraphrase what was said), or unreleased roadmap details. Linking to the originating Slack thread is fine and encouraged — Slack links are auth-gated and useful as context — as are channel references like "raised in #team-foo". Describe findings qualitatively ("present on nearly all X events, absent from Y") rather than with quantitative figures pulled from analytics queries — the reasoning that uses those numbers can stay in the thread; the PR copy cannot.`;

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -139,6 +139,7 @@ import {
   buildStoreSkillsInstructions,
   getStoreSkillRoots,
   installStoreSkillsArchive,
+  removeStoreSkillStubs,
   STORE_SKILLS_BUNDLE_LIMIT,
 } from "./store-skills";
 import type { AgentServerConfig, ClaudeCodeConfig } from "./types";
@@ -3796,10 +3797,9 @@ export class AgentServer {
       const result = await this.posthogAPI.downloadSkillsBundle(
         STORE_SKILLS_BUNDLE_LIMIT,
       );
-      if (result.kind === "not_enabled") {
-        return;
-      }
       if (result.kind === "error") {
+        // Stubs from an earlier session stay: a transient failure says nothing
+        // about what the user can still access.
         this.logger.warn("Skills store bundle fetch failed", {
           ...context,
           status: result.status,
@@ -3807,7 +3807,15 @@ export class AgentServer {
         });
         return;
       }
-      if (result.included === 0) {
+      if (result.kind === "not_enabled" || result.included === 0) {
+        const cleanup = await removeStoreSkillStubs(getStoreSkillRoots());
+        if (cleanup.removed.length > 0 || cleanup.errors.length > 0) {
+          this.logger.info("Removed stale skills store stubs", {
+            ...context,
+            removed: cleanup.removed,
+            errors: cleanup.errors,
+          });
+        }
         return;
       }
       const install = await installStoreSkillsArchive(
@@ -3823,7 +3831,9 @@ export class AgentServer {
         bundleSkipped: result.skipped,
         installed: install.installed,
         collisions: install.collisions,
+        removed: install.removed,
         rejected: install.rejected,
+        errors: install.errors,
       });
     } catch (error) {
       this.logger.warn("Skills store install failed", { ...context, error });

--- a/products/desktop/packages/agent/src/server/store-skills.test.ts
+++ b/products/desktop/packages/agent/src/server/store-skills.test.ts
@@ -1,0 +1,150 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { zipSync } from "fflate";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildStoreSkillsInstructions,
+  getStoreSkillRoots,
+  installStoreSkillsArchive,
+} from "./store-skills";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function temporaryHome(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "store-skills-"));
+  directories.push(directory);
+  return directory;
+}
+
+function stubSkillMd(name: string): string {
+  return [
+    "---",
+    `name: ${name}`,
+    `description: ${name} description`,
+    "metadata:",
+    "  version: '3'",
+    "  source: posthog-skills-store",
+    "---",
+    "",
+    `Run skill-get for ${name}.`,
+  ].join("\n");
+}
+
+function bundle(entries: Record<string, string>): Uint8Array {
+  const encoder = new TextEncoder();
+  return zipSync(
+    Object.fromEntries(
+      Object.entries(entries).map(([path, content]) => [
+        path,
+        encoder.encode(content),
+      ]),
+    ),
+  );
+}
+
+const exists = (path: string): Promise<boolean> =>
+  readFile(path, "utf-8").then(
+    () => true,
+    () => false,
+  );
+
+describe("store skills", () => {
+  it("unpacks every stub into every skill root", async () => {
+    const home = await temporaryHome();
+    const roots = getStoreSkillRoots(home);
+
+    const result = await installStoreSkillsArchive(
+      bundle({
+        "tam-quota-forecast/SKILL.md": stubSkillMd("tam-quota-forecast"),
+        "release-notes/SKILL.md": stubSkillMd("release-notes"),
+      }),
+      roots,
+    );
+
+    expect(result).toEqual({
+      installed: ["tam-quota-forecast", "release-notes"],
+      collisions: [],
+      rejected: 0,
+    });
+    for (const root of roots) {
+      await expect(
+        readFile(join(root, "tam-quota-forecast", "SKILL.md"), "utf-8"),
+      ).resolves.toContain("name: tam-quota-forecast");
+      await expect(
+        exists(join(root, "release-notes", "SKILL.md")),
+      ).resolves.toBe(true);
+    }
+  });
+
+  it("never replaces a bundled skill with a stub of the same name, but refreshes its own stubs", async () => {
+    const home = await temporaryHome();
+    const [claudeRoot, agentsRoot] = getStoreSkillRoots(home);
+    const bundledSkill = join(claudeRoot, "querying-posthog-data");
+    await mkdir(bundledSkill, { recursive: true });
+    await writeFile(
+      join(bundledSkill, "SKILL.md"),
+      "---\nname: querying-posthog-data\n---\nThe real skill.",
+    );
+    const staleStub = join(agentsRoot, "release-notes");
+    await mkdir(staleStub, { recursive: true });
+    await writeFile(
+      join(staleStub, "SKILL.md"),
+      stubSkillMd("release-notes").replace("version: '3'", "version: '1'"),
+    );
+
+    const result = await installStoreSkillsArchive(
+      bundle({
+        "querying-posthog-data/SKILL.md": stubSkillMd("querying-posthog-data"),
+        "release-notes/SKILL.md": stubSkillMd("release-notes"),
+      }),
+      [claudeRoot, agentsRoot],
+    );
+
+    expect(result).toEqual({
+      installed: ["querying-posthog-data", "release-notes"],
+      collisions: ["querying-posthog-data"],
+      rejected: 0,
+    });
+    await expect(
+      readFile(join(bundledSkill, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("The real skill.");
+    await expect(
+      readFile(join(agentsRoot, "querying-posthog-data", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("source: posthog-skills-store");
+    await expect(
+      readFile(join(staleStub, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("version: '3'");
+  });
+
+  it.each([
+    ["path traversal", { "../escape/SKILL.md": "x" }],
+    ["absolute path", { "/etc/SKILL.md": "x" }],
+    ["uppercase skill name", { "Bad-Name/SKILL.md": "x" }],
+    ["nested traversal", { "ok-name/../../SKILL.md": "x" }],
+    ["missing SKILL.md", { "ok-name/README.md": "x" }],
+  ])("rejects an archive entry with %s", async (_label, entries) => {
+    const home = await temporaryHome();
+    const roots = getStoreSkillRoots(home);
+
+    const result = await installStoreSkillsArchive(bundle(entries), roots);
+
+    expect(result.installed).toEqual([]);
+    expect(result.rejected).toBeGreaterThan(0);
+    await expect(exists(join(home, "escape", "SKILL.md"))).resolves.toBe(false);
+    await expect(exists(join(home, "SKILL.md"))).resolves.toBe(false);
+  });
+
+  it("adds a prompt section only when a stub was installed", () => {
+    expect(buildStoreSkillsInstructions(0)).toBe("");
+    expect(buildStoreSkillsInstructions(3)).toContain("skill-get");
+  });
+});

--- a/products/desktop/packages/agent/src/server/store-skills.test.ts
+++ b/products/desktop/packages/agent/src/server/store-skills.test.ts
@@ -7,6 +7,7 @@ import {
   buildStoreSkillsInstructions,
   getStoreSkillRoots,
   installStoreSkillsArchive,
+  removeStoreSkillStubs,
 } from "./store-skills";
 
 const directories: string[] = [];
@@ -23,6 +24,11 @@ async function temporaryHome(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), "store-skills-"));
   directories.push(directory);
   return directory;
+}
+
+// Pin the Claude root under the temporary home so a developer's CLAUDE_CONFIG_DIR never leaks in.
+function rootsFor(home: string): string[] {
+  return getStoreSkillRoots({ home, claudeConfigDir: join(home, ".claude") });
 }
 
 function stubSkillMd(name: string): string {
@@ -57,10 +63,21 @@ const exists = (path: string): Promise<boolean> =>
     () => false,
   );
 
+async function writeSkill(
+  root: string,
+  name: string,
+  skillMd: string,
+): Promise<string> {
+  const skillDir = join(root, name);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(join(skillDir, "SKILL.md"), skillMd);
+  return skillDir;
+}
+
 describe("store skills", () => {
   it("unpacks every stub into every skill root", async () => {
     const home = await temporaryHome();
-    const roots = getStoreSkillRoots(home);
+    const roots = rootsFor(home);
 
     const result = await installStoreSkillsArchive(
       bundle({
@@ -73,7 +90,9 @@ describe("store skills", () => {
     expect(result).toEqual({
       installed: ["tam-quota-forecast", "release-notes"],
       collisions: [],
+      removed: [],
       rejected: 0,
+      errors: [],
     });
     for (const root of roots) {
       await expect(
@@ -85,19 +104,33 @@ describe("store skills", () => {
     }
   });
 
+  it("puts the Claude root under CLAUDE_CONFIG_DIR when it is set", () => {
+    expect(
+      getStoreSkillRoots({ home: "/home/u", claudeConfigDir: "/cfg/claude" }),
+    ).toEqual(["/cfg/claude/skills", "/home/u/.agents/skills"]);
+    expect(rootsFor("/home/u")).toEqual([
+      "/home/u/.claude/skills",
+      "/home/u/.agents/skills",
+    ]);
+  });
+
   it("never replaces a bundled skill with a stub of the same name, but refreshes its own stubs", async () => {
     const home = await temporaryHome();
-    const [claudeRoot, agentsRoot] = getStoreSkillRoots(home);
-    const bundledSkill = join(claudeRoot, "querying-posthog-data");
-    await mkdir(bundledSkill, { recursive: true });
-    await writeFile(
-      join(bundledSkill, "SKILL.md"),
+    const [claudeRoot, agentsRoot] = rootsFor(home);
+    const bundledSkill = await writeSkill(
+      claudeRoot,
+      "querying-posthog-data",
       "---\nname: querying-posthog-data\n---\nThe real skill.",
     );
-    const staleStub = join(agentsRoot, "release-notes");
-    await mkdir(staleStub, { recursive: true });
-    await writeFile(
-      join(staleStub, "SKILL.md"),
+    // A real skill whose body mentions the marker text is still a real skill.
+    const mentionsStore = await writeSkill(
+      claudeRoot,
+      "release-notes",
+      "---\nname: release-notes\n---\nStubs carry source: posthog-skills-store in their frontmatter.",
+    );
+    const staleStub = await writeSkill(
+      agentsRoot,
+      "release-notes",
       stubSkillMd("release-notes").replace("version: '3'", "version: '1'"),
     );
 
@@ -111,18 +144,96 @@ describe("store skills", () => {
 
     expect(result).toEqual({
       installed: ["querying-posthog-data", "release-notes"],
-      collisions: ["querying-posthog-data"],
+      collisions: ["querying-posthog-data", "release-notes"],
+      removed: [],
       rejected: 0,
+      errors: [],
     });
     await expect(
       readFile(join(bundledSkill, "SKILL.md"), "utf-8"),
     ).resolves.toContain("The real skill.");
+    await expect(
+      readFile(join(mentionsStore, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("Stubs carry");
     await expect(
       readFile(join(agentsRoot, "querying-posthog-data", "SKILL.md"), "utf-8"),
     ).resolves.toContain("source: posthog-skills-store");
     await expect(
       readFile(join(staleStub, "SKILL.md"), "utf-8"),
     ).resolves.toContain("version: '3'");
+  });
+
+  it("removes stubs from an earlier install that the bundle no longer contains", async () => {
+    const home = await temporaryHome();
+    const roots = rootsFor(home);
+    for (const root of roots) {
+      await writeSkill(root, "lost-access", stubSkillMd("lost-access"));
+      await writeSkill(
+        root,
+        "bundled-skill",
+        "---\nname: bundled-skill\n---\nShipped by the image.",
+      );
+    }
+
+    const result = await installStoreSkillsArchive(
+      bundle({ "still-mine/SKILL.md": stubSkillMd("still-mine") }),
+      roots,
+    );
+
+    expect(result.installed).toEqual(["still-mine"]);
+    expect(result.removed).toEqual(["lost-access"]);
+    for (const root of roots) {
+      await expect(exists(join(root, "lost-access", "SKILL.md"))).resolves.toBe(
+        false,
+      );
+      await expect(
+        exists(join(root, "bundled-skill", "SKILL.md")),
+      ).resolves.toBe(true);
+    }
+  });
+
+  it("removes every stub when the store is off for the user, and leaves real skills", async () => {
+    const home = await temporaryHome();
+    const [claudeRoot, agentsRoot] = rootsFor(home);
+    await writeSkill(claudeRoot, "gone", stubSkillMd("gone"));
+    await writeSkill(
+      claudeRoot,
+      "bundled-skill",
+      "---\nname: bundled-skill\n---\nShipped by the image.",
+    );
+
+    // The second root does not exist yet, which is the state of a fresh sandbox.
+    const result = await removeStoreSkillStubs([claudeRoot, agentsRoot]);
+
+    expect(result).toEqual({ removed: ["gone"], errors: [] });
+    await expect(exists(join(claudeRoot, "gone", "SKILL.md"))).resolves.toBe(
+      false,
+    );
+    await expect(
+      exists(join(claudeRoot, "bundled-skill", "SKILL.md")),
+    ).resolves.toBe(true);
+  });
+
+  it("still installs into a healthy root when another root cannot be written", async () => {
+    const home = await temporaryHome();
+    const [claudeRoot, agentsRoot] = rootsFor(home);
+    // A file where the root directory should be makes every write there fail.
+    await mkdir(join(claudeRoot, ".."), { recursive: true });
+    await writeFile(claudeRoot, "not a directory");
+
+    const result = await installStoreSkillsArchive(
+      bundle({ "still-mine/SKILL.md": stubSkillMd("still-mine") }),
+      [claudeRoot, agentsRoot],
+    );
+
+    expect(result.installed).toEqual(["still-mine"]);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(new Set(result.errors.map((error) => error.root))).toEqual(
+      new Set([claudeRoot]),
+    );
+    await expect(
+      exists(join(agentsRoot, "still-mine", "SKILL.md")),
+    ).resolves.toBe(true);
   });
 
   it.each([
@@ -133,7 +244,7 @@ describe("store skills", () => {
     ["missing SKILL.md", { "ok-name/README.md": "x" }],
   ])("rejects an archive entry with %s", async (_label, entries) => {
     const home = await temporaryHome();
-    const roots = getStoreSkillRoots(home);
+    const roots = rootsFor(home);
 
     const result = await installStoreSkillsArchive(bundle(entries), roots);
 

--- a/products/desktop/packages/agent/src/server/store-skills.test.ts
+++ b/products/desktop/packages/agent/src/server/store-skills.test.ts
@@ -2,17 +2,19 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { zipSync } from "fflate";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildStoreSkillsInstructions,
   getStoreSkillRoots,
   installStoreSkillsArchive,
+  listStoreSkillStubs,
   removeStoreSkillStubs,
 } from "./store-skills";
 
 const directories: string[] = [];
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(
     directories
       .splice(0)
@@ -114,6 +116,22 @@ describe("store skills", () => {
     ]);
   });
 
+  it.each([
+    ["set", "/cfg/claude", "/cfg/claude/skills"],
+    [
+      "empty, which the Claude adapter treats as unset",
+      "",
+      "/home/u/.claude/skills",
+    ],
+  ])(
+    "reads CLAUDE_CONFIG_DIR from the environment when %s",
+    (_label, value, claudeRoot) => {
+      vi.stubEnv("CLAUDE_CONFIG_DIR", value);
+
+      expect(getStoreSkillRoots({ home: "/home/u" })[0]).toBe(claudeRoot);
+    },
+  );
+
   it("never replaces a bundled skill with a stub of the same name, but refreshes its own stubs", async () => {
     const home = await temporaryHome();
     const [claudeRoot, agentsRoot] = rootsFor(home);
@@ -133,22 +151,31 @@ describe("store skills", () => {
       "release-notes",
       stubSkillMd("release-notes").replace("version: '3'", "version: '1'"),
     );
+    // A directory with no SKILL.md yet is somebody's work in progress, not an empty slot.
+    const inProgress = join(agentsRoot, "half-written");
+    await mkdir(inProgress, { recursive: true });
+    await writeFile(join(inProgress, "notes.md"), "draft");
 
     const result = await installStoreSkillsArchive(
       bundle({
         "querying-posthog-data/SKILL.md": stubSkillMd("querying-posthog-data"),
         "release-notes/SKILL.md": stubSkillMd("release-notes"),
+        "half-written/SKILL.md": stubSkillMd("half-written"),
       }),
       [claudeRoot, agentsRoot],
     );
 
     expect(result).toEqual({
-      installed: ["querying-posthog-data", "release-notes"],
-      collisions: ["querying-posthog-data", "release-notes"],
+      installed: ["querying-posthog-data", "release-notes", "half-written"],
+      collisions: ["querying-posthog-data", "release-notes", "half-written"],
       removed: [],
       rejected: 0,
       errors: [],
     });
+    await expect(readFile(join(inProgress, "notes.md"), "utf-8")).resolves.toBe(
+      "draft",
+    );
+    await expect(exists(join(inProgress, "SKILL.md"))).resolves.toBe(false);
     await expect(
       readFile(join(bundledSkill, "SKILL.md"), "utf-8"),
     ).resolves.toContain("The real skill.");
@@ -190,6 +217,23 @@ describe("store skills", () => {
         exists(join(root, "bundled-skill", "SKILL.md")),
       ).resolves.toBe(true);
     }
+  });
+
+  it("lists the stubs on disk so a session that keeps them still gets the pointer guidance", async () => {
+    const home = await temporaryHome();
+    const [claudeRoot, agentsRoot] = rootsFor(home);
+    await writeSkill(claudeRoot, "kept-stub", stubSkillMd("kept-stub"));
+    await writeSkill(agentsRoot, "kept-stub", stubSkillMd("kept-stub"));
+    await writeSkill(agentsRoot, "other-stub", stubSkillMd("other-stub"));
+    await writeSkill(
+      claudeRoot,
+      "bundled-skill",
+      "---\nname: bundled-skill\n---\nShipped by the image.",
+    );
+
+    await expect(
+      listStoreSkillStubs([claudeRoot, agentsRoot]),
+    ).resolves.toEqual(["kept-stub", "other-stub"]);
   });
 
   it("removes every stub when the store is off for the user, and leaves real skills", async () => {

--- a/products/desktop/packages/agent/src/server/store-skills.ts
+++ b/products/desktop/packages/agent/src/server/store-skills.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
 import { unzipSync } from "fflate";
 
@@ -9,8 +10,15 @@ import { unzipSync } from "fflate";
  */
 export const STORE_SKILLS_BUNDLE_LIMIT = 20;
 
-/** Frontmatter marker the store writes into every stub SKILL.md. */
-const STORE_SKILL_MARKER = "source: posthog-skills-store";
+/**
+ * The store stamps every stub's frontmatter with `metadata.source`. Only a
+ * SKILL.md whose frontmatter carries it is treated as disposable: matching the
+ * text anywhere in the file would let a real skill that mentions the store be
+ * deleted on the next install.
+ */
+const STORE_SKILL_MARKER_RE =
+  /^\s+source:\s*['"]?posthog-skills-store['"]?\s*$/m;
+const FRONTMATTER_RE = /^---[^\n]*\n([\s\S]*?)\n---/;
 
 const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
@@ -19,56 +27,114 @@ export interface StoreSkillsInstallResult {
   installed: string[];
   /** Skill names left alone because a non-store skill of that name is already on disk. */
   collisions: string[];
+  /** Stubs from an earlier install that are not in this bundle, removed from at least one root. */
+  removed: string[];
   /** Archive entries dropped for an unsafe name or path. */
   rejected: number;
+  /** Filesystem failures, one per root and skill, so one broken root does not hide the rest. */
+  errors: StoreSkillsInstallError[];
+}
+
+export interface StoreSkillsInstallError {
+  root: string;
+  skillName: string | null;
+  message: string;
+}
+
+export interface StoreSkillRootsOptions {
+  home?: string;
+  /** Where Claude Code keeps user state; `CLAUDE_CONFIG_DIR` moves it off `~/.claude`. */
+  claudeConfigDir?: string;
 }
 
 export function getStoreSkillRoots(
-  home: string = process.env.HOME ?? "/tmp",
+  options: StoreSkillRootsOptions = {},
 ): string[] {
-  return [join(home, ".claude", "skills"), join(home, ".agents", "skills")];
+  const home = options.home ?? homedir();
+  const claudeConfigDir =
+    options.claudeConfigDir ??
+    process.env.CLAUDE_CONFIG_DIR ??
+    join(home, ".claude");
+  return [join(claudeConfigDir, "skills"), join(home, ".agents", "skills")];
 }
 
 /**
  * Unpack a skills-store bundle (`<skill-name>/SKILL.md` per skill) into each
- * skill root. A directory that already holds a skill not written by the store
- * is never replaced: the sandbox image ships bundled PostHog skills into the
- * same roots, and a stub must not shadow a real skill of the same name.
+ * skill root, and remove any stub from an earlier install that the bundle no
+ * longer contains, so a skill the user lost is not advertised on the next
+ * session. A directory that already holds a skill not written by the store is
+ * never replaced: the sandbox image ships bundled PostHog skills into the same
+ * roots, and a stub must not shadow a real skill of the same name.
+ *
+ * Each root is handled on its own: a read-only or missing root is reported in
+ * `errors` and the other roots still get their stubs.
  */
 export async function installStoreSkillsArchive(
   archive: Uint8Array,
   skillRoots: string[],
 ): Promise<StoreSkillsInstallResult> {
   const { skills, rejected } = groupArchiveBySkill(archive);
-  const installed: string[] = [];
-  const collisions: string[] = [];
+  const written = new Set<string>();
+  const collided = new Set<string>();
+  const removed = new Set<string>();
+  const errors: StoreSkillsInstallError[] = [];
 
-  for (const [skillName, files] of skills) {
-    let writtenAnywhere = false;
-    let collided = false;
-    for (const root of skillRoots) {
-      const skillDir = join(root, skillName);
-      if (!(await isReplaceable(skillDir))) {
-        collided = true;
-        continue;
+  for (const root of skillRoots) {
+    for (const [skillName, files] of skills) {
+      try {
+        const skillDir = join(root, skillName);
+        if (!(await isReplaceable(skillDir))) {
+          collided.add(skillName);
+          continue;
+        }
+        await rm(skillDir, { recursive: true, force: true });
+        for (const [relPath, content] of files) {
+          const destination = join(skillDir, relPath);
+          await mkdir(join(destination, ".."), { recursive: true });
+          await writeFile(destination, Buffer.from(content));
+        }
+        written.add(skillName);
+      } catch (error) {
+        errors.push({ root, skillName, message: errorMessage(error) });
       }
-      await rm(skillDir, { recursive: true, force: true });
-      for (const [relPath, content] of files) {
-        const destination = join(skillDir, relPath);
-        await mkdir(join(destination, ".."), { recursive: true });
-        await writeFile(destination, Buffer.from(content));
+    }
+    try {
+      for (const name of await pruneStaleStubs(root, skills)) {
+        removed.add(name);
       }
-      writtenAnywhere = true;
-    }
-    if (writtenAnywhere) {
-      installed.push(skillName);
-    }
-    if (collided) {
-      collisions.push(skillName);
+    } catch (error) {
+      errors.push({ root, skillName: null, message: errorMessage(error) });
     }
   }
 
-  return { installed, collisions, rejected };
+  return {
+    installed: [...skills.keys()].filter((name) => written.has(name)),
+    collisions: [...skills.keys()].filter((name) => collided.has(name)),
+    removed: [...removed].sort(),
+    rejected,
+    errors,
+  };
+}
+
+/**
+ * Remove every stub the store wrote earlier. Used when the bundle is empty or
+ * the feature is off for this user, so stale discovery does not outlive access.
+ */
+export async function removeStoreSkillStubs(
+  skillRoots: string[],
+): Promise<Pick<StoreSkillsInstallResult, "removed" | "errors">> {
+  const removed = new Set<string>();
+  const errors: StoreSkillsInstallError[] = [];
+  for (const root of skillRoots) {
+    try {
+      for (const name of await pruneStaleStubs(root, new Map())) {
+        removed.add(name);
+      }
+    } catch (error) {
+      errors.push({ root, skillName: null, message: errorMessage(error) });
+    }
+  }
+  return { removed: [...removed].sort(), errors };
 }
 
 export function buildStoreSkillsInstructions(installedCount: number): string {
@@ -140,10 +206,56 @@ function isSafeRelativePath(relPath: string): boolean {
   return !!resolved && !resolved.startsWith("..") && !isAbsolute(resolved);
 }
 
+/** Delete store stubs under `root` that are not in `keep`; return their names. */
+async function pruneStaleStubs(
+  root: string,
+  keep: ReadonlyMap<string, unknown>,
+): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    },
+  );
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || keep.has(entry.name)) {
+      continue;
+    }
+    const skillDir = join(root, entry.name);
+    if (await isStoreStub(skillDir)) {
+      await rm(skillDir, { recursive: true, force: true });
+      removed.push(entry.name);
+    }
+  }
+  return removed;
+}
+
 /** True when nothing is there, or when what is there is a stub the store wrote earlier. */
 async function isReplaceable(skillDir: string): Promise<boolean> {
-  const existing = await readFile(join(skillDir, "SKILL.md"), "utf-8").catch(
+  const existing = await readSkillMd(skillDir);
+  return existing === null || hasStoreMarker(existing);
+}
+
+async function isStoreStub(skillDir: string): Promise<boolean> {
+  const existing = await readSkillMd(skillDir);
+  return existing !== null && hasStoreMarker(existing);
+}
+
+/** The SKILL.md text, null when the directory has none, "" when it cannot be read. */
+function readSkillMd(skillDir: string): Promise<string | null> {
+  return readFile(join(skillDir, "SKILL.md"), "utf-8").catch(
     (error: NodeJS.ErrnoException) => (error.code === "ENOENT" ? null : ""),
   );
-  return existing === null || existing.includes(STORE_SKILL_MARKER);
+}
+
+function hasStoreMarker(skillMd: string): boolean {
+  const frontmatter = FRONTMATTER_RE.exec(skillMd)?.[1];
+  return frontmatter !== undefined && STORE_SKILL_MARKER_RE.test(frontmatter);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/products/desktop/packages/agent/src/server/store-skills.ts
+++ b/products/desktop/packages/agent/src/server/store-skills.ts
@@ -1,4 +1,11 @@
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
 import { unzipSync } from "fflate";
@@ -51,10 +58,10 @@ export function getStoreSkillRoots(
   options: StoreSkillRootsOptions = {},
 ): string[] {
   const home = options.home ?? homedir();
+  // `||`, not `??`: the Claude adapter treats an empty CLAUDE_CONFIG_DIR as unset, and so must this.
   const claudeConfigDir =
     options.claudeConfigDir ??
-    process.env.CLAUDE_CONFIG_DIR ??
-    join(home, ".claude");
+    (process.env.CLAUDE_CONFIG_DIR || join(home, ".claude"));
   return [join(claudeConfigDir, "skills"), join(home, ".agents", "skills")];
 }
 
@@ -137,6 +144,23 @@ export async function removeStoreSkillStubs(
   return { removed: [...removed].sort(), errors };
 }
 
+/** Names of the store stubs on disk across the roots, for a session that keeps the previous install. */
+export async function listStoreSkillStubs(
+  skillRoots: string[],
+): Promise<string[]> {
+  const names = new Set<string>();
+  for (const root of skillRoots) {
+    try {
+      for (const name of await listStoreStubs(root)) {
+        names.add(name);
+      }
+    } catch {
+      // A root that cannot be read has no stubs to report.
+    }
+  }
+  return [...names].sort();
+}
+
 export function buildStoreSkillsInstructions(installedCount: number): string {
   if (installedCount === 0) {
     return "";
@@ -211,6 +235,19 @@ async function pruneStaleStubs(
   root: string,
   keep: ReadonlyMap<string, unknown>,
 ): Promise<string[]> {
+  const removed: string[] = [];
+  for (const name of await listStoreStubs(root)) {
+    if (keep.has(name)) {
+      continue;
+    }
+    await rm(join(root, name), { recursive: true, force: true });
+    removed.push(name);
+  }
+  return removed;
+}
+
+/** Names of the directories under `root` whose SKILL.md carries the store marker. */
+async function listStoreStubs(root: string): Promise<string[]> {
   const entries = await readdir(root, { withFileTypes: true }).catch(
     (error: NodeJS.ErrnoException) => {
       if (error.code === "ENOENT") {
@@ -219,24 +256,25 @@ async function pruneStaleStubs(
       throw error;
     },
   );
-  const removed: string[] = [];
+  const names: string[] = [];
   for (const entry of entries) {
-    if (!entry.isDirectory() || keep.has(entry.name)) {
-      continue;
-    }
-    const skillDir = join(root, entry.name);
-    if (await isStoreStub(skillDir)) {
-      await rm(skillDir, { recursive: true, force: true });
-      removed.push(entry.name);
+    if (entry.isDirectory() && (await isStoreStub(join(root, entry.name)))) {
+      names.push(entry.name);
     }
   }
-  return removed;
+  return names;
 }
 
-/** True when nothing is there, or when what is there is a stub the store wrote earlier. */
+/**
+ * True when nothing is there, or when what is there is a stub the store wrote
+ * earlier. A directory with no SKILL.md is somebody else's and is kept.
+ */
 async function isReplaceable(skillDir: string): Promise<boolean> {
-  const existing = await readSkillMd(skillDir);
-  return existing === null || hasStoreMarker(existing);
+  const present = await stat(skillDir).then(
+    () => true,
+    (error: NodeJS.ErrnoException) => error.code !== "ENOENT",
+  );
+  return !present || (await isStoreStub(skillDir));
 }
 
 async function isStoreStub(skillDir: string): Promise<boolean> {

--- a/products/desktop/packages/agent/src/server/store-skills.ts
+++ b/products/desktop/packages/agent/src/server/store-skills.ts
@@ -1,0 +1,149 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative } from "node:path";
+import { unzipSync } from "fflate";
+
+/**
+ * How many skills-store skills a sandbox asks for. The harness lists every
+ * discovered skill's name and description in the system prompt on every turn,
+ * so the cost of a larger bundle is prompt context, not payload size.
+ */
+export const STORE_SKILLS_BUNDLE_LIMIT = 20;
+
+/** Frontmatter marker the store writes into every stub SKILL.md. */
+const STORE_SKILL_MARKER = "source: posthog-skills-store";
+
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export interface StoreSkillsInstallResult {
+  /** Skill names written to at least one skill root. */
+  installed: string[];
+  /** Skill names left alone because a non-store skill of that name is already on disk. */
+  collisions: string[];
+  /** Archive entries dropped for an unsafe name or path. */
+  rejected: number;
+}
+
+export function getStoreSkillRoots(
+  home: string = process.env.HOME ?? "/tmp",
+): string[] {
+  return [join(home, ".claude", "skills"), join(home, ".agents", "skills")];
+}
+
+/**
+ * Unpack a skills-store bundle (`<skill-name>/SKILL.md` per skill) into each
+ * skill root. A directory that already holds a skill not written by the store
+ * is never replaced: the sandbox image ships bundled PostHog skills into the
+ * same roots, and a stub must not shadow a real skill of the same name.
+ */
+export async function installStoreSkillsArchive(
+  archive: Uint8Array,
+  skillRoots: string[],
+): Promise<StoreSkillsInstallResult> {
+  const { skills, rejected } = groupArchiveBySkill(archive);
+  const installed: string[] = [];
+  const collisions: string[] = [];
+
+  for (const [skillName, files] of skills) {
+    let writtenAnywhere = false;
+    let collided = false;
+    for (const root of skillRoots) {
+      const skillDir = join(root, skillName);
+      if (!(await isReplaceable(skillDir))) {
+        collided = true;
+        continue;
+      }
+      await rm(skillDir, { recursive: true, force: true });
+      for (const [relPath, content] of files) {
+        const destination = join(skillDir, relPath);
+        await mkdir(join(destination, ".."), { recursive: true });
+        await writeFile(destination, Buffer.from(content));
+      }
+      writtenAnywhere = true;
+    }
+    if (writtenAnywhere) {
+      installed.push(skillName);
+    }
+    if (collided) {
+      collisions.push(skillName);
+    }
+  }
+
+  return { installed, collisions, rejected };
+}
+
+export function buildStoreSkillsInstructions(installedCount: number): string {
+  if (installedCount === 0) {
+    return "";
+  }
+  return `
+## Skills from the PostHog skills store
+${installedCount} of the user's skills from the PostHog skills store are installed as local skills. Each one's SKILL.md is a pointer, not the skill: when you invoke one, follow the pointer and fetch the skill body with the PostHog MCP \`skill-get\` tool before you act. Never improvise the skill from the pointer text.`;
+}
+
+function groupArchiveBySkill(archive: Uint8Array): {
+  skills: Map<string, Map<string, Uint8Array>>;
+  rejected: number;
+} {
+  const skills = new Map<string, Map<string, Uint8Array>>();
+  const rejectedSkills = new Set<string>();
+  let rejected = 0;
+
+  for (const [entryName, content] of Object.entries(unzipSync(archive))) {
+    const normalized = entryName.replaceAll("\\", "/");
+    if (!normalized || normalized.endsWith("/")) {
+      continue;
+    }
+    const [skillName, ...rest] = normalized.split("/");
+    const relPath = rest.join("/");
+    if (
+      !skillName ||
+      !SKILL_NAME_PATTERN.test(skillName) ||
+      !isSafeRelativePath(relPath)
+    ) {
+      rejected += 1;
+      if (skillName) {
+        rejectedSkills.add(skillName);
+      }
+      continue;
+    }
+    let files = skills.get(skillName);
+    if (!files) {
+      files = new Map();
+      skills.set(skillName, files);
+    }
+    files.set(relPath, content);
+  }
+
+  // A skill with one bad entry is dropped whole rather than installed partially.
+  for (const skillName of rejectedSkills) {
+    skills.delete(skillName);
+  }
+  for (const [skillName, files] of skills) {
+    if (!files.has("SKILL.md")) {
+      skills.delete(skillName);
+      rejected += 1;
+    }
+  }
+
+  return { skills, rejected };
+}
+
+function isSafeRelativePath(relPath: string): boolean {
+  if (!relPath || isAbsolute(relPath)) {
+    return false;
+  }
+  const segments = relPath.split("/");
+  if (segments.some((segment) => !segment || segment === "..")) {
+    return false;
+  }
+  const resolved = relative("/root", join("/root", relPath));
+  return !!resolved && !resolved.startsWith("..") && !isAbsolute(resolved);
+}
+
+/** True when nothing is there, or when what is there is a stub the store wrote earlier. */
+async function isReplaceable(skillDir: string): Promise<boolean> {
+  const existing = await readFile(join(skillDir, "SKILL.md"), "utf-8").catch(
+    (error: NodeJS.ErrnoException) => (error.code === "ENOENT" ? null : ""),
+  );
+  return existing === null || existing.includes(STORE_SKILL_MARKER);
+}

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -864,7 +864,7 @@ class LLMSkillViewSet(
                 "bundle_bytes": len(bundle.zip_bytes),
                 "skills_included": len(bundle.included),
                 "skills_dropped": bundle.dropped_count,
-                "skills_skipped": len(bundle.skipped),
+                "skills_skipped": bundle.skipped_count,
             },
             team=self.team,
             request=request,

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -855,6 +855,20 @@ class LLMSkillViewSet(
             content=query.validated_data["content"],
             limit=query.validated_data["limit"],
         )
+        report_user_action(
+            user,
+            "llma skills bundle downloaded",
+            {
+                "bundle_content": query.validated_data["content"],
+                "bundle_limit": query.validated_data["limit"],
+                "bundle_bytes": len(bundle.zip_bytes),
+                "skills_included": len(bundle.included),
+                "skills_dropped": bundle.dropped_count,
+                "skills_skipped": len(bundle.skipped),
+            },
+            team=self.team,
+            request=request,
+        )
         response = HttpResponse(bundle.zip_bytes, content_type="application/zip")
         response["Content-Disposition"] = 'attachment; filename="skills-bundle.zip"'
         # Counts only: names are unbounded and would blow past proxy header limits for heavy users.

--- a/products/skills/backend/api/test/test_marketplace_endpoints.py
+++ b/products/skills/backend/api/test/test_marketplace_endpoints.py
@@ -456,11 +456,22 @@ class TestSkillBundle(APIBaseTest):
         LLMSkillFile.objects.create(skill=skill, path="scripts/run.py", content="print(1)\n")
         self._create_skill("Bad/Name")
 
-        response = self._fetch()
+        with patch("products.skills.backend.api.skills.report_user_action") as report:
+            response = self._fetch()
 
         assert response.status_code == status.HTTP_200_OK, response.content
         assert response["X-Skills-Included"] == "1"
         assert response["X-Skills-Skipped"] == "1"
+        report.assert_called_once()
+        assert report.call_args.args[1] == "llma skills bundle downloaded"
+        assert report.call_args.args[2] == {
+            "bundle_content": "stub",
+            "bundle_limit": 20,
+            "bundle_bytes": len(response.content),
+            "skills_included": 1,
+            "skills_dropped": 0,
+            "skills_skipped": 1,
+        }
         with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
             assert archive.namelist() == ["mine/SKILL.md"]
             stub = archive.read("mine/SKILL.md").decode()

--- a/products/skills/backend/marketplace/README.md
+++ b/products/skills/backend/marketplace/README.md
@@ -38,6 +38,10 @@ unit-testable against the real `git` binary without booting the app
   `X-Skills-Included`, `X-Skills-Dropped` (over the cap) and `X-Skills-Skipped` (failed the spec
   check, or a legacy name or file path that is not safe to unpack) carry counts; names are logged.
   Behind the `skills-store-in-sandbox` flag (off → 404, flag service unavailable → 503).
+  Every download reports a `llma skills bundle downloaded` event with the counts and byte size.
+  First consumer: the cloud sandbox agent (`products/desktop/packages/agent/src/server/store-skills.ts`)
+  fetches the stub form once at session start and unpacks it into `~/.claude/skills` and
+  `~/.agents/skills`, skipping any name a bundled skill already uses.
   `llm_skill:read`, which the sandbox OAuth token already carries. Throttled per user, so one caller
   cannot 429 the rest of the project. Consumer-facing contract: `docs/internal/skills/skill-bundle-api.md`.
 - **Zip import** — `POST /api/projects/:team/llm_skills/import` (multipart `file` field, a spec


### PR DESCRIPTION
## Problem

A person who saved a skill in the PostHog skills store cannot use it from a cloud task or PostHog AI sandbox. The agent there sees only the skills baked into the image, and the store skills are reachable only by name over the PostHog MCP.

Layer 2 of the skills-in-sandboxes stack. Layer 1 (#89584) adds `GET /llm_skills/bundle/`, one zip of the user's store skills as pointer stubs. Nothing consumes it yet.

## Changes

- The sandbox agent now lists the user's store skills like local skills, so `/my-skill` works in a cloud task once the `skills-store-in-sandbox` flag is on for that user.
  - At session start the agent server fetches the stub bundle with the run's PostHog credential and unpacks one `SKILL.md` per skill into the Claude skills root (`CLAUDE_CONFIG_DIR/skills`, default `~/.claude/skills`) and `~/.agents/skills`.
  - The fetch runs in parallel with the existing run context fetch, so session start gains no round trip. It is bounded by a 30 s timeout so a stalled socket cannot hold the session.
  - A 404 (flag off), a 503 (flag service down), or any error is a no-op with a log line. This is the normal case for most sandboxes.
- A skill the user can no longer reach stops being advertised on the next session of the same sandbox. After each install the agent removes its own earlier stubs that the new bundle no longer contains; a 404 or an empty bundle removes them all. A transient fetch error leaves the previous stubs, since it says nothing about access, and the pointer prompt section stays for them.
- The cloud system prompt gains one section: a store skill's `SKILL.md` is a pointer, so fetch the body with `skill-get` before acting. This guards the one failure mode of the pointer design, an agent improvising from the stub text.
- A stub never replaces a bundled skill of the same name. The image installs PostHog skills into the same roots, and a name collision would shadow a real skill with a pointer. Only a `SKILL.md` whose frontmatter carries `source: posthog-skills-store` counts as a stub, so a real skill that mentions the store in its body is safe, and so is a same-named directory that has no `SKILL.md` yet.
- Each skill root is installed on its own. A read-only or missing `.claude/skills` is reported in the log and `.agents/skills` still gets its stubs.
- Entries with a path outside the skill directory, an unsafe skill name, or no `SKILL.md` are dropped whole.
- The bundle endpoint reports a `llma skills bundle downloaded` event with the counts and byte size. The agent has no analytics path of its own, so the telemetry lives server-side.
- Mechanical: a `downloadSkillsBundle` method on `PostHogAPIClient`, and a README line under the bundle endpoint.

> [!NOTE]
> This ships to sandboxes on the next `@posthog/agent` release and sandbox base image build. The flag `skills-store-in-sandbox` is inactive in every project, so nothing changes for a user until it is turned on.

> [!NOTE]
> The bundle is limited to 20 skills (`STORE_SKILLS_BUNDLE_LIMIT`). Claude Code lists every discovered skill's name and description in the system prompt on every turn, so the bound is prompt context, not payload. Measure with a real sandbox before raising it.

## How did you test this code?

- `store-skills.test.ts`: stubs land in both roots; a bundled skill of the same name survives while a stale stub is refreshed; a real skill that mentions the store marker in its body is never replaced; stubs missing from the new bundle are removed and the off case removes them all while real skills stay; a broken root reports an error and the other root still gets its stubs; `CLAUDE_CONFIG_DIR` moves the Claude root and an empty value means unset; a directory without `SKILL.md` is kept as a collision; the stubs on disk are listed for the fetch-error case; traversal, absolute, malformed-name and no-`SKILL.md` entries never reach disk. No existing test covered any of these paths.
- `posthog-api.test.ts`: the bundle request hits the right URL with an `AbortSignal`, reads the header counts, and 404 / 503 map to `not_enabled` / `error` without throwing. The session start path depends on that mapping.
- `test_marketplace_endpoints.py`: the existing stub test now also asserts the analytics event and its properties.
- Not run: a real sandbox session. The install path is exercised through the pure module tests, not through `_doInitializeSession`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/skills/backend/marketplace/README.md` names the sandbox agent as the first consumer of the bundle endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) working from the `/phs llma-skills` project skill and its sandbox plan. Skills invoked: `/phs`, `/writing-tests`, `/writing-code-comments`, `/improving-drf-endpoints`, `/reviewing-before-pr`, `/writing-pr-descriptions`, `/stacking-prs`.

Decisions across the session: the fetch moved from the `session_dependencies` phase into the `context_fetch` `Promise.all` so it costs no wall-clock; the collision guard was added after noticing the image installs bundled skills into the same `~/.claude/skills` root; the analytics event went into the endpoint rather than the agent because the agent package has no capture path.

The first bot round was addressed in a follow-up commit: stale stubs pruned, marker matched only in the frontmatter, per-root failure isolation, `CLAUDE_CONFIG_DIR`, and the bounded fetch. A second round added the no-`SKILL.md` collision rule, the empty `CLAUDE_CONFIG_DIR` fallback, and the pointer prompt for retained stubs. Declined, with the reason on each thread: treating ownership as install consent (same stance as #89584), Pi runtime support (Pi gets neither bundled nor store skills today, so it is its own piece of work), routing the installer through workspace-server (that rule is for core and ui; this package already owns the same filesystem work), and refilling the bundle after a name collision (an exclusion list belongs on the endpoint).

Local review: `hogli review` could not run (Greptile CLI not signed in on this machine), so no `no-greptile` label; the bot reviews as usual.

Nothing in this PR draws on material outside the repository.

Label `skip-desktop-backend-check`: the backend part is the analytics event on an endpoint that already exists in #89584, and the agent does not depend on it, so the two halves ship safely in either order.

