### PR TITLE
ci(tasks-agent): redeploy the worker when posthog/settings/temporal.py changes

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -444,7 +444,7 @@ jobs:
             - name: Check for changes that affect Tasks Agent Temporal worker
               id: check_changes_tasks_agent_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/ai/posthog_code_slack_|^posthog/temporal/ai/slack_app/|^products/slack_app/backend|^products/tasks/backend|^posthog/tasks/|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/ai/posthog_code_slack_|^posthog/temporal/ai/slack_app/|^products/slack_app/backend|^products/tasks/backend|^posthog/tasks/|^posthog/settings/temporal.py$|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

A change to `posthog/settings/temporal.py` does not redeploy the tasks-agent Temporal worker. Its deploy filter in `container-images-cd.yml` lists the tasks code paths but not the settings module the worker reads, so a settings-only merge (today: the per-run gateway token cap default) rolls to the workers whose filters do include the file and sits undeployed on the one it was for, until an unrelated tasks change happens to land.

## Changes

- Add `posthog/settings/temporal.py` to the tasks-agent worker's deploy filter. The error-tracking worker's filter already lists it; this brings tasks-agent in line. Mechanical.

Sixteen other worker filters also omit the file. Left alone here so the change is reviewable on its own; a sweep is a separate decision.

## How did you test this code?

Filter regex only. Authored by an agent; not run locally, since the step only executes in the master CD workflow.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Authored by Claude Opus 5 with Brandon; requires human review.
