### PR TITLE
fix(capture): charge the rate limiter for every evaluated event

### DIFF
--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -518,7 +518,8 @@ async fn process_events_inner(
                 // restriction covers, so the limiter would start from zero if
                 // the restriction were lifted. The charge is cheap: the check
                 // reads the local cache and hands its count to a batched
-                // background writer, so it costs no Redis round trip.
+                // background writer, so it costs no inline Redis round trip. At
+                // most it queues one batched read for the next tick.
                 let limited = limiter.is_limited(&cache_key, 1).await.is_some();
 
                 // The limiter has nothing left to take away from an event whose
@@ -564,11 +565,11 @@ async fn process_events_inner(
             }
 
             if already_disabled_event_count > 0 {
-                counter!(
-                    "capture_global_rate_limiter_skipped",
-                    "reason" => "person_processing_already_disabled",
-                )
-                .increment(already_disabled_event_count);
+                // Charged against the limiter but not re-stamped: person
+                // processing was already off. Mirrors v1's
+                // `capture_v1_rate_limiter{outcome="already_disabled"}`.
+                counter!("capture_global_rate_limiter_already_disabled")
+                    .increment(already_disabled_event_count);
             }
 
             if limited_event_count > 0 {

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -497,46 +497,39 @@ async fn process_events_inner(
     //      end state matches, but the pass order differs.
     //   2. Lane assignment is a single `DataType::from_event_name` match in
     //      legacy versus assign-then-reroute in v1.
-    //   3. Events whose person processing was already off: v1 skips its stamps
-    //      entirely (so such an event is never rerouted to overflow) and reports
-    //      it as outcome="already_disabled". Legacy still stamps and reroutes it,
-    //      and still counts it in the metric and log below; only the warning
-    //      excludes it. So legacy's limited count can exceed its warned count,
-    //      where v1's cannot.
-    // Both paths consult the same shared limiter for every non-dropped event, so
-    // per-key counts are identical regardless of which pipeline serves the key.
+    // Both paths charge the same shared limiter for every non-dropped event,
+    // including events whose person processing is already off, so per-key counts
+    // are identical regardless of which pipeline serves the key.
     // Import is unaffected by both: the GRL never runs (guard below) and no
     // overflowable lane is reachable, so behavior is identical across paths.
     if context.capture_mode.applies_global_rate_limit() {
         if let Some(ref limiter) = global_rate_limiter {
             let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
             let mut limited_event_count: u64 = 0;
-            // Narrower than the tallies above: events an upstream event
-            // restriction had already taken person processing away from are
-            // excluded. The limiter didn't change their fate, so telling the
-            // customer we skipped person processing for them would inflate the
-            // count and name distinct_ids the limit never affected. v1 draws the
-            // same line via `already_disabled` in
-            // `v1::analytics::process::apply_token_distinct_id_limits`.
-            let mut warned_distinct_ids: HashSet<&str> = HashSet::new();
-            let mut warned_event_count: u64 = 0;
             let mut already_disabled_event_count: u64 = 0;
             for event in events.iter_mut() {
-                // Person processing is already off, which at this point can only
-                // come from an event restriction: the burst limiter runs after
-                // this stage in `stamp_overflow_reason`, and the limiter's own
-                // stamp is set below. The limiter has nothing left to take away
-                // from this event, so consulting it would change nothing and
-                // still cost a local cache miss and a Redis round trip.
+                let cache_key =
+                    GlobalRateLimitKey::TokenDistinctId(&context.token, &event.event.distinct_id)
+                        .to_cache_key();
+                // Charge every event, including one whose person processing an
+                // event restriction already took away. The verdict cannot be
+                // acted on for that event, but its volume still belongs in the
+                // key's fleet count. Leaving it out understates a key that a
+                // restriction covers, so the limiter would start from zero if
+                // the restriction were lifted. The charge is cheap: the check
+                // reads the local cache and hands its count to a batched
+                // background writer, so it costs no Redis round trip.
+                let limited = limiter.is_limited(&cache_key, 1).await.is_some();
+
+                // The limiter has nothing left to take away from an event whose
+                // person processing is already off, so stamp nothing and leave
+                // it out of the customer-facing tallies below.
                 if event.metadata.skip_person_processing {
                     already_disabled_event_count += 1;
                     continue;
                 }
-                let cache_key =
-                    GlobalRateLimitKey::TokenDistinctId(&context.token, &event.event.distinct_id)
-                        .to_cache_key();
-                if limiter.is_limited(&cache_key, 1).await.is_some() {
-                    let already_disabled = event.metadata.skip_person_processing;
+
+                if limited {
                     event.metadata.skip_person_processing = true;
                     // Reroute the hot key to overflow. AnalyticsMain only: historical
                     // never overflows, the AI lane keeps its dedicated topic (v1
@@ -547,10 +540,6 @@ async fn process_events_inner(
                     }
                     limited_distinct_ids.insert(&event.event.distinct_id);
                     limited_event_count += 1;
-                    if !already_disabled {
-                        warned_distinct_ids.insert(&event.event.distinct_id);
-                        warned_event_count += 1;
-                    }
                 }
             }
             if limited_event_count > 0 {
@@ -582,13 +571,13 @@ async fn process_events_inner(
                 .increment(already_disabled_event_count);
             }
 
-            if warned_event_count > 0 {
+            if limited_event_count > 0 {
                 emit_rate_limit_warning(
                     ingestion_warning_emitter.as_deref(),
                     &request_context(context),
                     CAPTURE_LEGACY_RATE_LIMIT,
-                    &warned_distinct_ids,
-                    warned_event_count,
+                    &limited_distinct_ids,
+                    limited_event_count,
                 );
             }
         }

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -954,8 +954,8 @@ async fn apply_token_distinct_id_limits(
         // upstream). The verdict cannot be acted on for that event, but its
         // volume still belongs in the key's fleet count, and the v0 path charges
         // it too. The charge is cheap: the check reads the local cache and hands
-        // its count to a batched background writer, so it costs no Redis round
-        // trip.
+        // its count to a batched background writer, so it costs no inline Redis
+        // round trip. At most it queues one batched read for the next tick.
         let limited = limiter.is_limited(&cache_key, 1).await.is_some();
 
         // The limiter has nothing left to take away here, so stamp nothing.

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -163,8 +163,9 @@ pub async fn process_batch(
     //      `crate::overflow_parity` pins that across the whole matrix.
     //   2. Lane assignment is assign-then-reroute in v1 versus a single
     //      `DataType::from_event_name` match in legacy.
-    // Both paths consult the same shared limiter for every non-dropped event, so
-    // per-key counts are identical regardless of which pipeline serves the key.
+    // Both paths charge the same shared limiter for every non-dropped event,
+    // including events whose person processing is already off, so per-key counts
+    // are identical regardless of which pipeline serves the key.
     // Import is unaffected by both: the GRL never runs (guard below) and no
     // overflowable lane is reachable, so behavior is identical across paths.
     if state.capture_mode.applies_global_rate_limit() {
@@ -919,9 +920,10 @@ async fn apply_ai_byte_limits(
 /// Per-batch tally of how the shared global rate limiter classified each
 /// evaluated event. All three fields count events (not distinct_ids), so
 /// `allowed + limited + already_disabled` equals the number of non-Drop events
-/// reaching this stage. Only `allowed + limited` were consulted against the
-/// limiter: an `already_disabled` event is skipped before the call, so it does
-/// not appear in the limiter's own per-key counts.
+/// reaching this stage. All three were charged against the limiter: an
+/// `already_disabled` event is charged and then skipped before the stamps, so
+/// its volume appears in the limiter's per-key counts while its fate does not
+/// change.
 #[derive(Debug, Default, PartialEq, Eq)]
 struct TokenDistinctIdTally {
     allowed: u64,
@@ -944,12 +946,19 @@ async fn apply_token_distinct_id_limits(
         if event.result != EventResult::Ok {
             continue;
         }
-        // Person processing is already off for this event (illegal distinct_id,
-        // an ops restriction, or a force-limited key upstream). The limiter has
-        // nothing left to take away, so it is not consulted at all: the stamps
-        // below would be redundant, and the call itself would cost a local cache
-        // miss and a Redis round trip for a decision that cannot be acted on.
-        // The event's volume therefore does not count toward the shared window.
+        let cache_key =
+            GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
+                .to_cache_key();
+        // Charge every event, including one whose person processing is already
+        // off (illegal distinct_id, an ops restriction, or a force-limited key
+        // upstream). The verdict cannot be acted on for that event, but its
+        // volume still belongs in the key's fleet count, and the v0 path charges
+        // it too. The charge is cheap: the check reads the local cache and hands
+        // its count to a batched background writer, so it costs no Redis round
+        // trip.
+        let limited = limiter.is_limited(&cache_key, 1).await.is_some();
+
+        // The limiter has nothing left to take away here, so stamp nothing.
         //
         // A merely rate-limited burst does NOT land here: it sets
         // `spread_partitions` without touching person processing, so such an
@@ -958,11 +967,6 @@ async fn apply_token_distinct_id_limits(
             already_disabled_count += 1;
             continue;
         }
-
-        let cache_key =
-            GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
-                .to_cache_key();
-        let limited = limiter.is_limited(&cache_key, 1).await.is_some();
 
         if limited {
             event.result = EventResult::Warning;
@@ -2744,10 +2748,10 @@ mod tests {
     #[tokio::test]
     async fn td_limits_skips_events_with_person_processing_already_off() {
         // An event that already has person processing disabled (illegal
-        // distinct_id, ops restriction, or burst overflow) is not consulted
-        // against the shared limiter at all: the limiter has nothing left to take
-        // away, so the call would cost a Redis round trip for a decision that
-        // cannot be acted on. Its stamping is left untouched.
+        // distinct_id, ops restriction, or burst overflow) is still charged
+        // against the shared limiter, because its volume belongs in the key's
+        // fleet count. Its stamping is left untouched, because the limiter has
+        // nothing left to take away.
         let (limiter, calls) = mock_limiter_with_log(vec!["phc_tok:user-1"]);
         let ctx = td_context();
         let mut events = vec![
@@ -2760,13 +2764,12 @@ mod tests {
 
         apply_token_distinct_id_limits(&limiter, &ctx, None, &mut events).await;
 
-        // The already-flagged event was never consulted, so it costs no Redis work.
         assert!(
-            !calls
+            calls
                 .lock()
                 .unwrap()
                 .contains(&"phc_tok:user-1".to_string()),
-            "already-disabled event must not be consulted"
+            "already-disabled event must still charge the key's fleet count"
         );
         // Its stamping is untouched: result stays Ok, no overflow reroute.
         let flagged = find_by_did(&events, "user-1");
@@ -2783,12 +2786,11 @@ mod tests {
 
     #[tokio::test]
     async fn td_limits_evaluates_only_events_it_can_act_on() {
-        // Parity with legacy (`events::analytics`): the shared limiter is
-        // consulted for every event whose fate it can still change, so per-key
-        // counts are identical regardless of which pipeline serves the key. A
-        // dropped event and one whose person processing is already off are both
-        // excluded, for opposite reasons: one is gone, the other is already at
-        // the outcome the limiter would impose.
+        // Parity with legacy (`events::analytics`): the shared limiter is charged
+        // for every event that reaches this stage, including one whose person
+        // processing is already off, so per-key counts are identical regardless
+        // of which pipeline serves the key. Only a dropped event is excluded,
+        // because its bytes never reach a topic.
         let (limiter, calls) = mock_limiter_with_log(vec![]);
         let ctx = td_context();
         let mut events = vec![
@@ -2808,8 +2810,8 @@ mod tests {
         seen.sort();
         assert_eq!(
             seen,
-            vec!["phc_tok:user-1".to_string()],
-            "limiter must be consulted only for events it can still act on"
+            vec!["phc_tok:user-1".to_string(), "phc_tok:user-2".to_string()],
+            "every event reaching this stage charges the limiter; only drops are excluded"
         );
         assert_eq!(
             tally,
@@ -2819,9 +2821,13 @@ mod tests {
                 already_disabled: 1,
             }
         );
-        // Invariant: `allowed + limited` accounts for exactly the consulted events,
-        // so the emitted counters stay commensurable with the limiter's own counts.
-        assert_eq!(tally.allowed + tally.limited, seen.len() as u64);
+        // Invariant: the three tally fields account for exactly the charged
+        // events, so the emitted counters stay commensurable with the limiter's
+        // own per-key counts.
+        assert_eq!(
+            tally.allowed + tally.limited + tally.already_disabled,
+            seen.len() as u64
+        );
     }
 
     #[tokio::test]

--- a/rust/capture/tests/integration_person_processing_matrix.rs
+++ b/rust/capture/tests/integration_person_processing_matrix.rs
@@ -140,8 +140,10 @@ impl Batch {
 }
 
 /// Count limiter evaluations on the recorder the caller installed. Each
-/// evaluation increments this counter exactly once, so it measures the Redis
-/// work the skip exists to avoid.
+/// evaluation increments this counter exactly once, so it measures how much of
+/// the batch reached the limiter. Every event that reaches the stage is charged,
+/// including one whose person processing an upstream restriction already took
+/// away, so its volume stays in the key's fleet count.
 fn consultations(snapshotter: &metrics_util::debugging::Snapshotter) -> u64 {
     snapshotter
         .snapshot()
@@ -443,24 +445,25 @@ fn v1_lane(topic: &str) -> Lane {
     Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 // The skip-person restriction alone: person processing off and the key dropped,
-// on the main lane, and the limiter is never consulted.
+// on the main lane. The limiter is still charged, but it stamps nothing.
 #[case::skip_person(
     Inputs { skip_person_restriction: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[case::skip_person_personless(
     Inputs { skip_person_restriction: true, personless: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
-// The restriction shadows the limiter entirely: the key is over its window, but
-// the limiter is skipped, so nothing reroutes it.
+// The restriction shadows the limiter's stamps: the key is over its window, but
+// the restriction already took person processing away, so nothing reroutes it.
+// The charge still lands.
 #[case::skip_person_and_rate_limited(
     Inputs { skip_person_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[case::skip_person_and_rate_limited_personless(
     Inputs { skip_person_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 // The overflow restriction alone moves the lane but leaves person processing on,
 // so the key survives.
@@ -485,21 +488,21 @@ fn v1_lane(topic: &str) -> Lane {
 // Both restrictions: the overflow lane from one, the dropped key from the other.
 #[case::both_restrictions(
     Inputs { skip_person_restriction: true, overflow_restriction: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[case::both_restrictions_personless(
     Inputs { skip_person_restriction: true, overflow_restriction: true, personless: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
-// All three: the limiter is still skipped, and the restrictions alone produce
-// the same wire outcome the limiter would have.
+// All three: the limiter stamps nothing, and the restrictions alone produce the
+// same wire outcome the limiter would have.
 #[case::everything(
     Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[case::everything_personless(
     Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, personless: true, restricted_distinct_id: None },
-    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[tokio::test]
 async fn person_processing_and_routing_matrix(#[case] inputs: Inputs, #[case] expected: Observed) {
@@ -522,11 +525,14 @@ async fn person_processing_and_routing_matrix(#[case] inputs: Inputs, #[case] ex
 /// keys from the limiter.
 ///
 /// The skip is a per-event decision, so a batch mixing a restricted key with an
-/// unrestricted one has to split: the restricted events skip the limiter and
-/// keep the main lane, while the unrestricted ones are still consulted and still
-/// rerouted once they exceed the window. Hoisting the check to the batch, or
-/// keying it on the token rather than the event, would silently stop rate
-/// limiting every other key belonging to a token that has any restriction at all.
+/// unrestricted one has to split: the restricted events keep the main lane and
+/// take no stamps, while the unrestricted ones are still rerouted once they
+/// exceed the window. Hoisting the check to the batch, or keying it on the token
+/// rather than the event, would silently stop rate limiting every other key
+/// belonging to a token that has any restriction at all.
+///
+/// Every event charges the limiter, restricted or not, so the consultation count
+/// covers the whole batch.
 #[rstest]
 #[case::skip_person(false)]
 #[case::skip_person_and_force_overflow(true)]
@@ -559,10 +565,10 @@ async fn restriction_filtered_to_one_distinct_id_leaves_other_keys_rate_limited(
         ("v0", run_v0(inputs, &batch).await),
         ("v1", run_v1(inputs, &batch).await),
     ] {
-        // Only the two unrestricted events cost a limiter evaluation.
         assert_eq!(
-            observed.limiter_consultations, 2,
-            "{path}: the limiter must be consulted for the unrestricted key only"
+            observed.limiter_consultations, 4,
+            "{path}: every event charges the limiter, so a restricted key's volume \
+             stays in its own fleet count"
         );
 
         for i in 0..2 {


### PR DESCRIPTION
## Problem

When an ops restriction turns off person processing for a distinct id, capture stopped counting that distinct id's events against its rate limit entirely. The limiter then sees a fraction of the key's real traffic, and would start from zero if the restriction were ever lifted.

## Changes

- Every event now counts toward its key's rate limit, including events an ops restriction already covers.
- The stamping stays gated: an event whose person processing is already off gets no new stamps, because there is nothing left to take away.
- No event changes lane, partition key, or Kafka header. The routing matrix asserts the same wire outcome as before; only the consultation counts move.
- Removes dead code in the v0 path. The guard above `already_disabled` returns first, so it was always false.
- Corrects a comment claiming the limiter check costs a Redis round trip. It reads the local cache and queues a batched background write.
- Nothing user-visible changes.

## How did you test this code?

- Updated `td_limits_skips_events_with_person_processing_already_off` and `td_limits_evaluates_only_events_it_can_act_on` to the new contract: charged, but not stamped.
- Updated 8 cases in `integration_person_processing_matrix` from 0 consultations to 2. Every case asserts an unchanged `Record`, which is what proves the wire outcome did not move.
- `restriction_filtered_to_one_distinct_id_leaves_other_keys_rate_limited` now expects 4 consultations instead of 2. It is the guard that a restricted key's volume stays in its own fleet count.

Ran locally under flox: the full `capture` suite (1440 tests, 0 failures) and `cargo clippy -p capture --all-targets -D warnings`.

Not run: anything needing the full dev stack. No production verification.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

`hogli review` could not run: the Greptile CLI install fails here with `EPERM` on `~/.config/posthog/tools/greptile`.

Third layer of a four-PR stack on #89727. The skipped volume measured about 0.3% of evaluated traffic, so this is correctness rather than an urgent fix.

No customer data or internal operational detail appears in this PR.
