### PR TITLE
chore(capture): publish the rate limiter window as a gauge

### DIFF
--- a/.agents/skills/monitoring-capture-service/SKILL.md
+++ b/.agents/skills/monitoring-capture-service/SKILL.md
@@ -108,6 +108,7 @@ metrics and CloudWatch ElastiCache metrics.
 - Optional read replica: `GLOBAL_RATE_LIMIT_REDIS_READER_URL`
 - Toggle: `GLOBAL_RATE_LIMIT_ENABLED` (may be off in some envs during rollout)
 - Metrics: `global_rate_limiter_*` (direct), `capture_events_rerouted_overflow{reason="rate_limited"}` (proxy signal)
+- `global_rate_limiter_window_seconds{scope}` publishes each process's window. The AI byte budget is shared between capture-analytics and capture-ai through a prefix with no `capture_mode`, and the epoch number derives from the window, so the two deployments disagreeing on this gauge means the shared budget has split
 - CloudWatch cluster id: `capture-globalratelimit-prod-redis`
 
 **3. Event Restrictions Redis** (`EVENT_RESTRICTIONS_REDIS_URL`)

--- a/rust/common/limiters/GLOBAL_RATE_LIMITER.md
+++ b/rust/common/limiters/GLOBAL_RATE_LIMITER.md
@@ -253,6 +253,14 @@ TTL:   2 × window_interval (120s for 60s window)
 
 Only 2 keys per entity exist at any time (current + previous epoch).
 
+**Two deployments that share a key prefix must agree on `window_interval`.**
+The epoch number is `floor(unix / window_interval)`, so a mismatch puts each
+deployment on a different key namespace and silently splits the shared counter.
+Capture's AI byte budget is one such namespace: its prefix deliberately carries
+no `capture_mode`, so capture-analytics and capture-ai draw on one budget. The
+`global_rate_limiter_window_seconds{scope}` gauge publishes the value each
+process is running, so an alert can compare them.
+
 ### Configuration
 
 #### Rate limiting behavior

--- a/rust/common/limiters/GLOBAL_RATE_LIMITER.md
+++ b/rust/common/limiters/GLOBAL_RATE_LIMITER.md
@@ -428,6 +428,7 @@ When multiple Redis instances are configured, work is partitioned by consistent 
 | `global_rate_limiter_sync_tier_gauge` | Gauge | Entity distribution across tiers (scanned every `TIER_SCAN_INTERVAL_TICKS`) |
 | `global_rate_limiter_tier_transitions_total` | Counter | Tier promotion/demotion events |
 | `global_rate_limiter_cache_size` | Gauge | Live local cache entry count vs cap |
+| `global_rate_limiter_window_seconds` | Gauge | Configured `window_interval` per scope. Deployments that share a Redis key prefix must report the same value, or their epoch keys diverge and the shared counter splits |
 | `global_rate_limiter_eviction_total` | Counter | Cache evictions by cause (size/expired/explicit) |
 | `global_rate_limiter_estimate_drift` | Histogram | Local vs Redis accuracy |
 | `global_rate_limiter_sync_staleness_ms` | Histogram | Real staleness at access time |

--- a/rust/common/limiters/src/global_rate_limiter.rs
+++ b/rust/common/limiters/src/global_rate_limiter.rs
@@ -35,6 +35,7 @@ const GLOBAL_RATE_LIMITER_PIPELINE_HISTOGRAM: &str = "global_rate_limiter_pipeli
 const GLOBAL_RATE_LIMITER_TICK_HISTOGRAM: &str = "global_rate_limiter_tick_ms";
 const GLOBAL_RATE_LIMITER_PIPELINE_SIZE_HISTOGRAM: &str = "global_rate_limiter_pipeline_size";
 const GLOBAL_RATE_LIMITER_PENDING_SYNC_SIZE_GAUGE: &str = "global_rate_limiter_pending_sync_size";
+const GLOBAL_RATE_LIMITER_WINDOW_GAUGE: &str = "global_rate_limiter_window_seconds";
 const GLOBAL_RATE_LIMITER_SYNC_TIER_GAUGE: &str = "global_rate_limiter_sync_tier_gauge";
 const GLOBAL_RATE_LIMITER_TIER_TRANSITIONS_COUNTER: &str =
     "global_rate_limiter_tier_transitions_total";
@@ -1016,7 +1017,7 @@ impl GlobalRateLimiterImpl {
 
         // Cache-size gauge every tick (O(1)); per-tier distribution via a
         // throttled full scan (slow-moving, see TIER_SCAN_INTERVAL_TICKS).
-        Self::emit_cache_gauges(cache, scope, tick_n);
+        Self::emit_cache_gauges(cache, scope, tick_n, config.window_interval);
 
         // Take a bounded slice of the pending set rather than all of it. The
         // remainder stays queued, so a backlog surfaces as sync staleness instead
@@ -1452,9 +1453,23 @@ impl GlobalRateLimiterImpl {
     /// distribution needs a full `cache.iter()` scan, so it runs only every
     /// `TIER_SCAN_INTERVAL_TICKS`: the distribution moves slowly and prod metrics
     /// dedup to 60s, so scanning every tick would be wasted work under load.
-    fn emit_cache_gauges(cache: &Cache<String, CacheEntry>, scope: &'static str, tick_n: u64) {
+    fn emit_cache_gauges(
+        cache: &Cache<String, CacheEntry>,
+        scope: &'static str,
+        tick_n: u64,
+        window_interval: Duration,
+    ) {
         metrics::gauge!(GLOBAL_RATE_LIMITER_CACHE_SIZE_GAUGE, "scope" => scope)
             .set(cache.entry_count() as f64);
+
+        // The window sets Redis epoch numbering, so two deployments that share a
+        // key namespace must agree on it. Capture's AI byte budget is one such
+        // namespace: its prefix carries no capture_mode, so capture-analytics and
+        // capture-ai draw on one budget. A disagreement splits that budget in two
+        // with no error and no log, so publish the value each deployment is
+        // actually running and let an alert compare them.
+        metrics::gauge!(GLOBAL_RATE_LIMITER_WINDOW_GAUGE, "scope" => scope)
+            .set(window_interval.as_secs_f64());
 
         if tick_n.is_multiple_of(TIER_SCAN_INTERVAL_TICKS) {
             let tier_counts = Self::scan_tier_counts(cache);


### PR DESCRIPTION
## Problem

capture-analytics and capture-ai share one AI byte budget in Redis, and the Redis key name is derived from the rate limit window. If the two deployments ever run different windows, they write to different keys and the shared budget silently splits in two, with no error, no log, and no metric.

A config check can prove the values in git agree. It cannot prove the running fleet agrees, because a rolling deploy has both values live at once.

## Changes

- Each capture process now publishes the rate limit window it is running, as `global_rate_limiter_window_seconds{scope}`.
- An alert comparing that gauge across capture-analytics and capture-ai catches a split budget, including one caused by a partial rollout.
- The gauge is emitted on the existing background tick, next to `cache_size`. No new work on the request path.
- Design doc gains the rule that two deployments sharing a key prefix must agree on the window.
- The capture monitoring skill gains the new metric and what a disagreement means.
- Nothing user-visible changes.

## How did you test this code?

No new tests. The change sets one gauge from existing config on a code path already covered by the tick tests, and there is no realistic regression a unit test would catch that asserting `gauge.set` was called would not just mirror the implementation.

Ran locally under flox: the `limiters` suite (0 failures) and `cargo clippy -p limiters --all-targets -D warnings`.

The alert itself is not in this PR. It belongs wherever capture alerting lives, and needs the gauge deployed to both deployments first.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`rust/common/limiters/GLOBAL_RATE_LIMITER.md` and `.agents/skills/monitoring-capture-service/SKILL.md` are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

`hogli review` could not run: the Greptile CLI install fails here with `EPERM` on `~/.config/posthog/tools/greptile`.

Top layer of a four-PR stack on #89753. The shared window knob is a known smell, kept deliberately rather than split into a separate AI byte setting, because the AI byte threshold scales with the window so the sustained limit does not move. This gauge plus a config lint are the price of keeping it.

No customer data or internal operational detail appears in this PR.
