### PR TITLE
fix(surveys): preserve newlines in hosted open text

### DIFF
--- a/frontend/src/scenes/surveys/hosted-canvas/HostedSurveyCanvas.tsx
+++ b/frontend/src/scenes/surveys/hosted-canvas/HostedSurveyCanvas.tsx
@@ -9,6 +9,7 @@ import { type CSSProperties } from 'react'
 import { IconPlus, IconThumbsDown, IconThumbsUp, IconTrash } from '@posthog/icons'
 
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
+import { platformCommandControlKey } from 'lib/utils/dom'
 import { defaultSurveyAppearance } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { canQuestionSkipSubmitButton, isThumbQuestion, sanitizeHTML } from 'scenes/surveys/utils'
@@ -386,11 +387,15 @@ function QuestionCanvas({ question, index }: { question: SurveyQuestion; index: 
 // hint set rendered by `posthog/templates/surveys/public_survey.html` so the
 // canvas matches what respondents actually see.
 function KeyboardHints({ questionType }: { questionType: SurveyQuestionType }): JSX.Element {
-    const chips: { kbd: string; label: string }[] = [{ kbd: '\u21B5', label: 'submit' }]
+    const chips: { kbd: string; label: string }[] =
+        questionType === SurveyQuestionType.Open
+            ? [
+                  { kbd: '\u21B5', label: 'new line' },
+                  { kbd: platformCommandControlKey('\u21B5'), label: 'submit' },
+              ]
+            : [{ kbd: '\u21B5', label: 'submit' }]
 
-    if (questionType === SurveyQuestionType.Open) {
-        chips.push({ kbd: '\u21E7 \u21B5', label: 'new line' })
-    } else if (questionType === SurveyQuestionType.SingleChoice) {
+    if (questionType === SurveyQuestionType.SingleChoice) {
         chips.push({ kbd: '\u2191 \u2193', label: 'select' })
     } else if (questionType === SurveyQuestionType.MultipleChoice) {
         chips.push({ kbd: '\u2191 \u2193', label: 'select' })

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -218,7 +218,10 @@
                     return
                 }
 
-                if (event.key === 'Enter' && !event.shiftKey) {
+                const target = event.target
+                if (target instanceof HTMLElement && target.tagName === 'TEXTAREA') return
+
+                if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
                     const submitButton = container.querySelector('.form-submit:not([disabled])')
                     if (!submitButton) return
                     event.preventDefault()
@@ -228,7 +231,6 @@
                 }
 
                 if (isArrowKey(event.key)) {
-                    const target = event.target
                     if (target instanceof HTMLElement) {
                         const tag = target.tagName
                         if (tag === 'TEXTAREA') return
@@ -334,11 +336,13 @@
             const labels = getKeyboardHintLabels()
             const chip = (kbd, label) =>
                 `<span class="survey-keyhint-row"><kbd class="survey-kbd">${kbd}</kbd><span class="survey-keyhint-label">${label}</span></span>`
+            const commandEnter = navigator.platform.includes('Mac') ? '⌘↵' : 'Ctrl + ↵'
 
-            const chips = [chip('↵', labels.submit)]
-            if (currentType === 'open') {
-                chips.push(chip('⇧ ↵', labels.newline))
-            } else if (currentType === 'single_choice') {
+            const chips =
+                currentType === 'open'
+                    ? [chip('↵', labels.newline), chip(commandEnter, labels.submit)]
+                    : [chip('↵', labels.submit)]
+            if (currentType === 'single_choice') {
                 chips.push(chip('↑ ↓', labels.select))
             } else if (currentType === 'multiple_choice') {
                 chips.push(chip('↑ ↓', labels.select))


### PR DESCRIPTION
## Problem

Hosted survey respondents can accidentally submit an open-text answer when they press Enter to start a new line.

The hosted page intercepts Enter before the survey SDK can apply its standard multiline behavior.

## Changes

Hosted open-text questions now follow standard multiline behavior:

| Input | Before | After |
| --- | --- | --- |
| Enter | Submit | New line |
| Cmd+Enter on macOS | Submit | Submit |
| Ctrl+Enter elsewhere | Submit | Submit |

- The hosted page now leaves textarea key handling to the survey SDK.
- The respondent hint and hosted editor preview show the platform-specific submit shortcut.
- Choice, rating, and link questions keep their existing keyboard behavior.
- Screenshot not included because keyboard behavior was not browser-tested locally.

## How did you test this code?

- `hogli test products/surveys/backend/api/test/test_external_surveys.py`
- `pnpm --filter=@posthog/frontend typescript:check`
- Focused Oxlint and Oxfmt checks on the changed frontend component.
- `hogli ci:preflight --fix`
- Browser behavior remains unchecked; the backend suite verifies template rendering but does not execute inline JavaScript.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. The hosted shortcut hint documents the behavior beside the affected input.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used local repository tooling and GitHub CLI. Skills invoked: `/writing-ui-components`, `/writing-tests`, `/announcing-behavior-changes`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

No private external material informed the change.
