### PR TITLE
feat(metrics): pivot from a metric to its logs and traces

### DIFF
--- a/products/metrics/frontend/components/MetricsRelatedMenu.tsx
+++ b/products/metrics/frontend/components/MetricsRelatedMenu.tsx
@@ -1,0 +1,80 @@
+import { useValues } from 'kea'
+
+import { LemonButton, LemonMenu, LemonMenuItem, LemonMenuItems } from '@posthog/lemon-ui'
+
+import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
+
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { serviceViewerUrl } from 'products/logs/frontend/components/LogsServices/serviceViewerUrl'
+import { tracingUrlForService } from 'products/tracing/frontend/traceLinks'
+
+import { metricsViewerLogic } from './metricsViewerLogic'
+
+/**
+ * The metric -> logs / traces pivot.
+ *
+ * Both destinations inherit the chart's service scope and time window, so the jump lands on the
+ * same slice of the same incident. Where the metric carries exemplars there is an exact
+ * metric -> trace link already (the chart's markers and the Samples tab); this covers the case
+ * where all you have is a service and a window.
+ */
+export function MetricsRelatedMenu(): JSX.Element {
+    const { correlationServices, dateFrom, dateTo } = useValues(metricsViewerLogic)
+
+    const logsDisabledReason = getAccessControlDisabledReason(AccessControlResourceType.Logs, AccessControlLevel.Viewer)
+    const tracingDisabledReason = getAccessControlDisabledReason(
+        AccessControlResourceType.Tracing,
+        AccessControlLevel.Viewer
+    )
+
+    const dateRange = { date_from: dateFrom, date_to: dateTo }
+
+    const itemsForService = (serviceName: string): LemonMenuItem[] => [
+        {
+            label: 'Logs',
+            to: serviceViewerUrl(serviceName, { dateRange }),
+            disabledReason: logsDisabledReason,
+        },
+        {
+            label: 'Error logs',
+            to: serviceViewerUrl(serviceName, { dateRange, severityLevels: ['error'] }),
+            disabledReason: logsDisabledReason,
+        },
+        {
+            label: 'Traces',
+            to: tracingUrlForService(serviceName, { dateRange }),
+            disabledReason: tracingDisabledReason,
+        },
+    ]
+
+    // One service reads better as a flat list; several need naming, or the items are ambiguous.
+    const items: LemonMenuItems =
+        correlationServices.length === 1
+            ? itemsForService(correlationServices[0])
+            : correlationServices.map((serviceName) => ({
+                  title: serviceName,
+                  items: itemsForService(serviceName),
+              }))
+
+    if (!correlationServices.length) {
+        return (
+            <LemonButton
+                size="small"
+                type="secondary"
+                disabledReason="Filter or group by a service to jump to its logs and traces"
+                data-attr="metrics-viewer-related"
+            >
+                Related
+            </LemonButton>
+        )
+    }
+
+    return (
+        <LemonMenu items={items}>
+            <LemonButton size="small" type="secondary" data-attr="metrics-viewer-related">
+                Related
+            </LemonButton>
+        </LemonMenu>
+    )
+}

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -47,6 +47,7 @@ import { MetricNameFilter } from './MetricNameFilter'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { type MetricsExemplar } from './MetricsExemplarMarkers'
 import { MetricsLogsSourceTag } from './MetricsLogsSourceTag'
+import { MetricsRelatedMenu } from './MetricsRelatedMenu'
 import { metricsSamplesLogic } from './metricsSamplesLogic'
 import { MetricsSamplesPanel } from './MetricsSamplesPanel'
 import { MetricsSeriesChart } from './MetricsSeriesChart'
@@ -317,6 +318,7 @@ export const MetricsViewer = (): JSX.Element => {
                             disabledReason={metricsViewerDisabledReason}
                         />
                         <MetricsGroupByButton disabledReason={metricsViewerDisabledReason} />
+                        <MetricsRelatedMenu />
                         {anomalyBadge && <MetricsAnomalyTag anomaly={anomalyBadge} />}
                         <MetricsLogsSourceTag metricName={metricName} />
                     </div>

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -380,9 +380,9 @@ export interface metricsViewerLogicMeta {
         ) => MetricsQuery | null
         queryFilters: (filterGroup: UniversalFiltersGroup) => _MetricFilterApi[]
         selectedServices: (filterGroup: UniversalFiltersGroup) => string[]
+        correlationServices: (selectedServices: string[], queryResults: _MetricSeriesApi[]) => string[]
         attributeEndpointFilters: (dateFrom: string | null, dateTo: string | null) => Record<string, string>
         chartSeries: (queryResults: _MetricSeriesApi[]) => MetricsChartSeries[]
-        correlationServices: (selectedServices: string[], queryResults: _MetricSeriesApi[]) => string[]
         hasResults: (queryResults: _MetricSeriesApi[]) => boolean
         anomalyBadge: (anomalyReport: _MetricAnomalyReportApi | null) => MetricsAnomalyBadge | null
     }

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -34,6 +34,8 @@ import { canCreateMetricsInsight, canViewMetrics } from 'products/metrics/fronte
 
 import type { Node } from '../../../../frontend/src/queries/schema/schema-general'
 import type { _MetricNameApi } from '../generated/api.schemas'
+import { EMPTY_SERVICE_PATTERN, SERVICE_NAME_KEY } from '../metricsAttributes'
+import { correlationServiceNames } from '../metricsLinks'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import type { MetricNameItem } from './metricNamePickerLogic'
 import type { MetricsChartSeries } from './metricsSeries'
@@ -47,6 +49,8 @@ export const METRIC_AGGREGATIONS: MetricAggregation[] = ['sum', 'avg', 'count', 
 /** Narrows an untrusted value (a URL param, a saved link) to an aggregation the backend accepts. */
 export const isMetricAggregation = (value: unknown): value is MetricAggregation =>
     typeof value === 'string' && METRIC_AGGREGATIONS.includes(value as MetricAggregation)
+
+export { EMPTY_SERVICE_PATTERN, SERVICE_NAME_KEY }
 
 export type MetricsViewerSeries = _MetricSeriesApi
 
@@ -141,14 +145,6 @@ const propertyFilterToMetricFilter = (filter: UniversalFilterValue): _MetricFilt
 const flattenFilterValues = (group: UniversalFiltersGroup): UniversalFilterValue[] =>
     group.values.flatMap((value) => (isUniversalGroupFilterLike(value) ? flattenFilterValues(value) : [value]))
 
-// Ingestion promotes `service.name` to its own column, so it is the one label the
-// picker can be narrowed by cheaply — see MetricNamesQueryRunner.
-export const SERVICE_NAME_KEY = 'service_name'
-
-// The anchored regex standing in for senders that set no service name: the empty
-// string cannot survive the filter pipeline, which drops empty chip values.
-export const EMPTY_SERVICE_PATTERN = '^$'
-
 /** The services a chip pins the query to, or `[]` when it isn't a membership test. */
 const serviceChipValues = (chip: UniversalFilterValue): string[] => {
     const operator = 'operator' in chip ? chip.operator : undefined
@@ -195,6 +191,7 @@ export interface metricsViewerLogicValues {
     }[]
     attributeKeyOptionsLoading: boolean
     chartSeries: MetricsChartSeries[]
+    correlationServices: string[]
     dateFrom: string | null
     dateTo: string | null
     filterGroup: UniversalFiltersGroup
@@ -385,6 +382,7 @@ export interface metricsViewerLogicMeta {
         selectedServices: (filterGroup: UniversalFiltersGroup) => string[]
         attributeEndpointFilters: (dateFrom: string | null, dateTo: string | null) => Record<string, string>
         chartSeries: (queryResults: _MetricSeriesApi[]) => MetricsChartSeries[]
+        correlationServices: (selectedServices: string[], queryResults: _MetricSeriesApi[]) => string[]
         hasResults: (queryResults: _MetricSeriesApi[]) => boolean
         anomalyBadge: (anomalyReport: _MetricAnomalyReportApi | null) => MetricsAnomalyBadge | null
     }
@@ -809,6 +807,16 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                 }
                 return serviceChipValues(chips[0])
             },
+        ],
+        // Services the logs and traces pivots can be scoped to: the pinned service filter, or
+        // failing that whichever services the chart is grouped by.
+        correlationServices: [
+            (s) => [s.selectedServices, s.queryResults],
+            (selectedServices: string[], results: MetricsViewerSeries[]): string[] =>
+                correlationServiceNames(
+                    selectedServices,
+                    results.map((series) => series.labels)
+                ),
         ],
         // Scopes the filter bar's key/value suggestions to the viewer's window; splatted onto the
         // taxonomic endpoints as query params.

--- a/products/metrics/frontend/metricsAttributes.ts
+++ b/products/metrics/frontend/metricsAttributes.ts
@@ -1,0 +1,12 @@
+// Attribute keys shared by the viewer's filter bar and the cross-product link builders. A leaf
+// module on purpose: metricsLinks and metricsViewerLogic both need these, and importing one from
+// the other would put a kea logic in an import cycle.
+
+/** Ingestion promotes `service.name` to its own column, so this is the one label queries can narrow by cheaply. */
+export const SERVICE_NAME_KEY = 'service_name'
+
+/**
+ * The anchored regex standing in for senders that set no service name: the empty string cannot
+ * survive the filter pipeline, which drops empty chip values.
+ */
+export const EMPTY_SERVICE_PATTERN = '^$'

--- a/products/metrics/frontend/metricsLinks.test.ts
+++ b/products/metrics/frontend/metricsLinks.test.ts
@@ -2,7 +2,7 @@ import { combineUrl } from 'kea-router'
 
 import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { metricUrl, metricsUrlForService } from './metricsLinks'
+import { correlationServiceNames, metricUrl, metricsUrlForService } from './metricsLinks'
 
 describe('metricsLinks', () => {
     const paramsOf = (url: string): Record<string, any> => combineUrl(url).searchParams
@@ -66,6 +66,49 @@ describe('metricsLinks', () => {
     it('scopes a service link to the window the caller was looking at', () => {
         expect(paramsOf(metricsUrlForService('checkout', { dateFrom: '-30m', dateTo: null }))).toMatchObject({
             dateFrom: '-30m',
+        })
+    })
+
+    describe('correlationServiceNames', () => {
+        // Which services the logs/traces pivot offers. Getting this wrong sends someone to an
+        // empty log view during an incident, which teaches them not to click it again.
+        it('prefers the services the filter bar pinned', () => {
+            expect(correlationServiceNames(['checkout'], [{ service_name: 'billing' }])).toEqual(['checkout'])
+        })
+
+        it('falls back to the services the chart is grouped by', () => {
+            expect(correlationServiceNames([], [{ service_name: 'billing' }, { service_name: 'checkout' }])).toEqual([
+                'billing',
+                'checkout',
+            ])
+        })
+
+        it.each([['service_name'], ['service.name']])('reads the %s group-by label', (key) => {
+            expect(correlationServiceNames([], [{ [key]: 'checkout' }])).toEqual(['checkout'])
+        })
+
+        it('de-duplicates services split across several series', () => {
+            expect(
+                correlationServiceNames(
+                    [],
+                    [
+                        { service_name: 'checkout', http_status: '200' },
+                        { service_name: 'checkout', http_status: '500' },
+                    ]
+                )
+            ).toEqual(['checkout'])
+        })
+
+        it.each([
+            ['no scope at all', [] as string[], [{ http_status: '200' }]],
+            ['the unknown-service chip', [''], []],
+        ])('offers nothing for %s, rather than a link to everything', (_name, selected, labels) => {
+            expect(correlationServiceNames(selected, labels)).toEqual([])
+        })
+
+        it('caps the list so a wide group-by cannot render hundreds of menu items', () => {
+            const labels = Array.from({ length: 30 }, (_, i) => ({ service_name: `svc-${i}` }))
+            expect(correlationServiceNames([], labels)).toHaveLength(12)
         })
     })
 })

--- a/products/metrics/frontend/metricsLinks.ts
+++ b/products/metrics/frontend/metricsLinks.ts
@@ -4,7 +4,7 @@ import { urls } from 'scenes/urls'
 
 import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
 
-import { SERVICE_NAME_KEY } from './components/metricsViewerLogic'
+import { SERVICE_NAME_KEY } from './metricsAttributes'
 
 /**
  * The metrics viewer's URL contract, in one place.
@@ -74,6 +74,44 @@ export const metricUrl = (params: MetricLinkParams): string => {
     }
 
     return combineUrl(urls.metrics(), searchParams).url
+}
+
+/**
+ * Ingest promotes `service.name` to a column, but a group-by carries whichever spelling the user
+ * picked, so both reach the results as label keys.
+ */
+const SERVICE_LABEL_KEYS = [SERVICE_NAME_KEY, 'service.name']
+
+/** At most this many services in the Related menu — a wide group-by would otherwise fill the screen. */
+export const MAX_CORRELATION_SERVICES = 12
+
+/**
+ * The services a logs or traces pivot can be scoped to, given what the chart currently shows.
+ *
+ * A pinned service filter is the user's stated scope, so it wins. Failing that, a chart grouped by
+ * service names its own services. With neither, there is nothing honest to link to: an unscoped
+ * jump into logs lands on every service in the project, which reads as a broken link.
+ */
+export const correlationServiceNames = (
+    selectedServices: string[],
+    seriesLabels: Record<string, string>[]
+): string[] => {
+    // `selectedServices` reports the "unknown service" chip as an empty string, which is a real
+    // selection in metrics but cannot be expressed as a logs or traces service filter.
+    const pinned = selectedServices.filter(Boolean)
+    if (pinned.length) {
+        return pinned.slice(0, MAX_CORRELATION_SERVICES)
+    }
+
+    const grouped = new Set<string>()
+    for (const labels of seriesLabels) {
+        for (const key of SERVICE_LABEL_KEYS) {
+            if (labels[key]) {
+                grouped.add(labels[key])
+            }
+        }
+    }
+    return [...grouped].sort().slice(0, MAX_CORRELATION_SERVICES)
 }
 
 /** "Show me this service's metrics", the pivot Logs and Tracing offer. */

--- a/products/tracing/frontend/traceLinks.test.ts
+++ b/products/tracing/frontend/traceLinks.test.ts
@@ -1,4 +1,6 @@
-import { traceLookupDateRange, traceUrl } from './traceLinks'
+import { combineUrl } from 'kea-router'
+
+import { traceLookupDateRange, traceUrl, tracingUrlForService } from './traceLinks'
 
 describe('traceLinks', () => {
     it.each([
@@ -18,6 +20,25 @@ describe('traceLinks', () => {
         expect(traceLookupDateRange('2026-06-11T08:00:00.000Z')).toEqual({
             date_from: '2026-06-11T07:00:00.000Z',
             date_to: '2026-06-11T09:00:00.000Z',
+        })
+    })
+
+    describe('tracingUrlForService', () => {
+        const paramsOf = (url: string): Record<string, any> => combineUrl(url).searchParams
+
+        it('carries the service as a list, so a name with a comma stays one service', () => {
+            // tracingSceneLogic reads this back through parseTagsFilter, which splits a bare
+            // string on commas — 'checkout,v2' would arrive as two services.
+            expect(paramsOf(tracingUrlForService('checkout,v2')).serviceNames).toEqual(['checkout,v2'])
+        })
+
+        it('carries the window the caller was looking at', () => {
+            const url = tracingUrlForService('checkout', { dateRange: { date_from: '-30m', date_to: null } })
+            expect(JSON.parse(paramsOf(url).dateRange)).toEqual({ date_from: '-30m', date_to: null })
+        })
+
+        it('omits the window when the caller has none', () => {
+            expect(paramsOf(tracingUrlForService('checkout'))).not.toHaveProperty('dateRange')
         })
     })
 })

--- a/products/tracing/frontend/traceLinks.ts
+++ b/products/tracing/frontend/traceLinks.ts
@@ -3,8 +3,12 @@
 // root timestamp so a cold load can bound the ClickHouse lookup (the table is time-keyed and OTel
 // trace ids embed no timestamp — an unhinted id lookup would scan the whole retention window).
 
+import { combineUrl } from 'kea-router'
+
 import { dayjs } from 'lib/dayjs'
 import { urls } from 'scenes/urls'
+
+import type { DateRange } from '~/queries/schema/schema-general'
 
 export interface TraceLinkParams {
     traceId: string
@@ -28,6 +32,18 @@ export function traceUrl({ traceId, spanId, ts }: TraceLinkParams): string {
 /** Absolute, shareable URL for a trace view. */
 export function absoluteTraceUrl(params: TraceLinkParams): string {
     return urls.absolute(traceUrl(params))
+}
+
+/**
+ * Spans for one service over a window — the pivot other products offer when they know a service
+ * and a time range but no trace id. The service goes in as a list because `tracingSceneLogic`
+ * reads it back through `parseTagsFilter`, which splits a bare string on commas.
+ */
+export function tracingUrlForService(serviceName: string, { dateRange }: { dateRange?: DateRange } = {}): string {
+    return combineUrl(urls.tracing(), {
+        serviceNames: [serviceName],
+        ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+    }).url
 }
 
 /** The window a `ts`-hinted cold load queries: ±1h is generous for any single trace's spans. */


### PR DESCRIPTION
## Problem

Someone staring at a spike on a metric chart has no way into the logs or traces behind it. They open Logs in a new tab, retype the service, retype the time range, and hope they matched the window.

The one exception is exemplars: where a metric carries them, the chart's markers and the Samples tab already jump to an exact trace. That covers counters and histograms with sampled traces attached — not gauges, and not any metric whose exemplars fall outside the spike. The common case, where all you have is a service and a window, had nothing.

Stacked on #89768, which made metrics views addressable in the first place.

## Changes

- The metrics viewer has a **Related** menu. It opens Logs, error logs, or Tracing for the service the chart is showing, over the same time window.
- The menu names the services rather than guessing. It uses the service the filter bar is pinned to; failing that, the services a group-by has split the chart into. With neither, the button is disabled and says so, because an unscoped jump lands on every service in the project and reads as a broken link.
- Several services each get their own titled section, so the items are never ambiguous about which service they open.
- Items are hidden behind the same access checks as the destination products, so a link never leads somewhere the viewer cannot go.
- Mechanical: `tracingUrlForService()` joins `traceLinks.ts` next to the existing `traceUrl()`; `SERVICE_NAME_KEY` and `EMPTY_SERVICE_PATTERN` move to a leaf module.

That last move is worth a reviewer's eye. The link builders and `metricsViewerLogic` both need those constants, and importing either from the other puts a kea logic in an import cycle — the failure mode is a module-init `ReferenceError`, not a lint warning.

### Screenshot

The chart is grouped by service, so the menu names all three and gives each its own section:

![Related menu with per-service Logs, Error logs and Traces](https://raw.githubusercontent.com/PostHog/pr-assets/b6041b5bab9960e3d8c07462b085ccf5bac63e70/2026/08/25dfa1be-247a-485e-878f-b322ce6ca524.png)

## How did you test this code?

The screenshot above is a real click on the Related button. The scene runs in Storybook against mocked metrics endpoints, so the screenshot shows the real components, layout and interaction, but fixture data rather than a query result. The harness stories are local and not part of this diff.

Tests are on the pure pieces, per the testing skill's preference for logic over component renders:

- `correlationServiceNames` in `metricsLinks.test.ts` — which services the pivot offers, including the two ways to get nothing (no scope, and the "unknown service" chip, which is a real metrics selection but cannot be expressed as a logs service filter). Also the cap, so a wide group-by cannot render hundreds of menu items.
- `tracingUrlForService` in `traceLinks.test.ts` — the service goes in as a list, because `tracingSceneLogic` reads it back through `parseTagsFilter` and a bare string splits on commas.

Ran `products/metrics`, `products/tracing` and `products/logs` Jest suites locally; CI reports the counts.

Not covered: `MetricsRelatedMenu` itself has no render test — it is glue over the tested helpers, and the skill steers away from component renders for that. Also unverified: that the destination views are actually non-empty for a given service, which depends on the three products agreeing on `service_name` values in a real project.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — metrics is behind the `metrics` alpha flag and undocumented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, second layer of an investigation into what Application Metrics needs to reach parity with comparable products, with correlation as the focus.

Worth knowing for review: mapping the three products first showed the join keys already line up. `service_name` is a first-class column on `logs34`, `trace_spans` and `metric_series1`; `resource_attributes` is the same map type on all three; `trace_id` is base64 at rest and hex at the boundary everywhere. So this needed no backend and no unified-tagging project — it is UI over conventions that already hold.

The direction chosen here is metrics to logs and traces. The reverse links (a log row to its trace, which is missing today despite the column being rendered, and logs or traces to a service's metrics) are the next layer rather than part of this one.

Skills invoked: `/writing-tests`.

