### PR TITLE
fix(cdp): stop an unroutable queue from crash-looping the worker

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -4,6 +4,7 @@ import { captureException } from '~/common/utils/posthog'
 
 import { HealthCheckResult, PluginsServerConfig } from '../../types'
 import { JobQueue } from '../services/job-queue/job-queue.interface'
+import { UnroutableInvocationsError } from '../services/job-queue/shared'
 import {
     CYCLOTRON_INVOCATION_JOB_QUEUES,
     CyclotronJobInvocation,
@@ -260,7 +261,33 @@ export class CdpCyclotronWorker<
 
     @instrumented({ key: 'cdpConsumer.backgroundTask.queueInvocationResults', timeoutMs: 15_000, sendException: false })
     protected async queueInvocationResults(invocations: CyclotronJobInvocationResult[]) {
-        await this.cyclotronJobQueue.queueInvocationResults(invocations)
+        try {
+            await this.cyclotronJobQueue.queueInvocationResults(invocations)
+        } catch (e) {
+            if (!(e instanceof UnroutableInvocationsError)) {
+                throw e
+            }
+
+            // These jobs target a queue with no topic on this cluster, so they can never run.
+            // Record a terminal row for each and let the batch commit, rather than rethrowing:
+            // a rethrow latches the consumer's fatal error and exits the process, and the offset
+            // is never committed, so the restart replays the same message and the partition
+            // stalls for every team on it. Same reasoning as the poison-pill guard in
+            // loadHogFunctions, and the same ordering — record before the job is let go, or the
+            // run sits in 'running' forever and cannot be re-run.
+            captureException(e)
+            await Promise.all(
+                e.invocations.map((invocation) =>
+                    this.invocationResultsService.invocationResultsRowsService.recordTerminalFailureDurably(
+                        invocation,
+                        {
+                            errorKind: 'unroutable_queue',
+                            error: `This invocation was routed to the "${invocation.queue}" queue, which this worker cannot deliver to, so it was dropped.`,
+                        }
+                    )
+                )
+            )
+        }
     }
 
     public override async start() {

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.test.ts
@@ -1,4 +1,8 @@
-import { migrateKafkaCyclotronInvocation } from './job-queue-kafka'
+import { UnknownTopicError } from '~/common/utils/db/error'
+
+import { CyclotronJobInvocation, CyclotronJobQueueKind } from '../../types'
+import { CyclotronJobQueueKafka, migrateKafkaCyclotronInvocation } from './job-queue-kafka'
+import { UnroutableInvocationsError } from './shared'
 
 describe('CyclotronJobQueueKafka', () => {
     describe('migrateKafkaCyclotronInvocation', () => {
@@ -91,6 +95,65 @@ describe('CyclotronJobQueueKafka', () => {
                   "teamId": 1,
                 }
             `)
+        })
+    })
+
+    describe('queueInvocations', () => {
+        const buildQueue = (produce: jest.Mock): CyclotronJobQueueKafka => {
+            const queue = new CyclotronJobQueueKafka(
+                undefined,
+                {
+                    CDP_CYCLOTRON_COMPRESS_KAFKA_DATA: false,
+                    CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: '',
+                } as any,
+                10
+            )
+            ;(queue as any).kafkaProducer = { produce }
+            return queue
+        }
+
+        const invocation = (id: string, queue: CyclotronJobQueueKind): CyclotronJobInvocation => ({
+            id,
+            teamId: 1,
+            functionId: 'fn-1',
+            state: {},
+            queue,
+            queuePriority: 0,
+        })
+
+        // 'email' is served only by Postgres, so cdp_cyclotron_email exists on no cluster. Producing
+        // to it must not take the worker down: that is what stalls the partition for every other
+        // team, and a restart just replays the same message.
+        it('reports unroutable invocations instead of throwing the produce error', async () => {
+            const produce = jest.fn(({ topic }: { topic: string }) =>
+                topic === 'cdp_cyclotron_email'
+                    ? Promise.reject(new UnknownTopicError(topic, new Error('Broker: Unknown topic or partition')))
+                    : Promise.resolve()
+            )
+            const queue = buildQueue(produce)
+
+            const error = await queue
+                .queueInvocations([invocation('a', 'hog'), invocation('b', 'email')])
+                .then(() => null)
+                .catch((e) => e)
+
+            expect(error).toBeInstanceOf(UnroutableInvocationsError)
+            expect(error.invocations.map((x: CyclotronJobInvocation) => x.id)).toEqual(['b'])
+            // The routable job is still produced — one undeliverable job must not hold up the batch.
+            expect(produce).toHaveBeenCalledTimes(2)
+        })
+
+        it('rethrows any other produce error so the batch is retried', async () => {
+            const boom = new Error('broker unavailable')
+            const queue = buildQueue(jest.fn(() => Promise.reject(boom)))
+
+            await expect(queue.queueInvocations([invocation('a', 'hog')])).rejects.toBe(boom)
+        })
+
+        it('resolves when every invocation is routable', async () => {
+            const queue = buildQueue(jest.fn(() => Promise.resolve()))
+
+            await expect(queue.queueInvocations([invocation('a', 'hog')])).resolves.toBeUndefined()
         })
     })
 })

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -8,6 +8,7 @@ import { compress, uncompress } from 'snappy'
 
 import { KafkaConsumerInterface, createKafkaConsumer } from '~/common/kafka/consumer'
 import { KafkaProducerWrapper } from '~/common/kafka/producer'
+import { UnknownTopicError } from '~/common/utils/db/error'
 import { parseJSON } from '~/common/utils/json-parse'
 import { logger } from '~/common/utils/logger'
 
@@ -15,7 +16,14 @@ import { HealthCheckResult, HealthCheckResultError } from '../../../types'
 import { CdpConfig } from '../../config'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
 import { JobQueue } from './job-queue.interface'
-import { cdpJobSizeCompressedKb, cdpJobSizeKb, createInvocationSanitizer, observeConsumedBatch } from './shared'
+import {
+    UnroutableInvocationsError,
+    cdpCyclotronUnroutableInvocations,
+    cdpJobSizeCompressedKb,
+    cdpJobSizeKb,
+    createInvocationSanitizer,
+    observeConsumedBatch,
+} from './shared'
 
 export class CyclotronJobQueueKafka implements JobQueue {
     private kafkaConsumer?: KafkaConsumerInterface
@@ -104,7 +112,10 @@ export class CyclotronJobQueueKafka implements JobQueue {
             }
         })
 
-        await Promise.all(
+        // Ids rather than invocations, so the produce closures stay lightweight (see above).
+        const unroutableIds: string[] = []
+
+        const settled = await Promise.allSettled(
             messages.map(async (msg) => {
                 const value = this.config.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA
                     ? await compress(msg.jsonString)
@@ -119,25 +130,54 @@ export class CyclotronJobQueueKafka implements JobQueue {
                     teamId: msg.teamId.toString(),
                 }
 
-                await producer
-                    .produce({
+                try {
+                    await producer.produce({
                         value: Buffer.from(value),
                         key: Buffer.from(msg.id),
                         topic: `cdp_cyclotron_${msg.queue}`,
                         headers,
                     })
-                    .catch((e) => {
-                        logger.error('🔄', 'Error producing kafka message', {
+                } catch (e) {
+                    if (e instanceof UnknownTopicError) {
+                        // Collected, not thrown: this job can never be delivered, and throwing
+                        // would kill the worker and stall the partition for everyone else on it.
+                        cdpCyclotronUnroutableInvocations.labels(msg.queue).inc()
+                        logger.error('🔄', 'cdp_cyclotron_unroutable_invocation', {
                             error: String(e),
+                            topic: e.topic,
+                            queue: msg.queue,
                             teamId: msg.teamId,
                             functionId: msg.functionId,
-                            payloadSizeKb: value.length / 1024,
                         })
+                        unroutableIds.push(msg.id)
+                        return
+                    }
 
-                        throw e
+                    logger.error('🔄', 'Error producing kafka message', {
+                        error: String(e),
+                        teamId: msg.teamId,
+                        functionId: msg.functionId,
+                        payloadSizeKb: value.length / 1024,
                     })
+
+                    throw e
+                }
             })
         )
+
+        // Every other produce failure keeps today's behaviour: rethrow, so a transient broker
+        // problem retries the batch rather than silently dropping work.
+        const rejected = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+        if (rejected) {
+            throw rejected.reason
+        }
+
+        if (unroutableIds.length) {
+            const byId = new Map(invocations.map((x) => [x.id, x]))
+            throw new UnroutableInvocationsError(
+                unroutableIds.map((id) => byId.get(id)).filter((x): x is CyclotronJobInvocation => !!x)
+            )
+        }
     }
 
     // Kafka jobs don't need explicit dequeue — they're just dropped

--- a/nodejs/src/cdp/services/job-queue/shared.ts
+++ b/nodejs/src/cdp/services/job-queue/shared.ts
@@ -37,6 +37,29 @@ const cdpCyclotronJobsProcessed = new Counter({
     labelNames: ['queue', 'source'],
 })
 
+export const cdpCyclotronUnroutableInvocations = new Counter({
+    name: 'cdp_cyclotron_unroutable_invocations',
+    help: 'Invocations failed because their target queue has no topic on this cluster. Every increment is a job that cannot run, so alert on any sustained non-zero rate.',
+    labelNames: ['queue'],
+})
+
+/**
+ * Raised when a batch held invocations whose target queue has no topic on this cluster.
+ *
+ * These are carried out of the produce path instead of being thrown as the raw produce error, so
+ * the consumer can record a terminal failure for each one and let the batch commit. A raw throw
+ * latches the consumer's fatal-error flag and exits the process, and the offset is never
+ * committed, so the restart replays the same message. That stalls the partition for every team on
+ * it, indefinitely.
+ */
+export class UnroutableInvocationsError extends Error {
+    constructor(public readonly invocations: CyclotronJobInvocation[]) {
+        const queues = [...new Set(invocations.map((x) => x.queue))].join(', ')
+        super(`${invocations.length} invocation(s) target queue(s) [${queues}] with no topic on this cluster`)
+        this.name = 'UnroutableInvocationsError'
+    }
+}
+
 /**
  * Records throughput and batch utilization for a consumed batch.
  * `cdp_cyclotron_batch_utilization` is consumed by KEDA to autoscale the cyclotron workers, so this

--- a/nodejs/src/common/kafka/producer.test.ts
+++ b/nodejs/src/common/kafka/producer.test.ts
@@ -1,5 +1,6 @@
 import { HighLevelProducer } from 'node-rdkafka'
 
+import { UnknownTopicError } from '../utils/db/error'
 import { KafkaProducerWrapper } from './producer'
 
 describe('KafkaProducerWrapper.produce', () => {
@@ -34,5 +35,31 @@ describe('KafkaProducerWrapper.produce', () => {
     it('treats partition 0 as explicit, not as a missing value', async () => {
         await wrapper.produce({ topic: 't', key: Buffer.from('k'), value: Buffer.from('v'), partition: 0 })
         expect(produceMock.mock.calls[0][1]).toBe(0)
+    })
+
+    // A missing topic reaches the delivery callback in more than one shape. Broker code 3 and local
+    // code -188 are the documented ones, but a broker that answers the metadata request slowly
+    // enough reports it with code -1 and only the librdkafka text. All three have to classify as
+    // unroutable, because the caller drops those jobs instead of retrying the batch forever.
+    it.each([
+        ['broker code', { code: 3, message: 'Broker: Unknown topic or partition' }],
+        ['local code', { code: -188, message: 'Local: Unknown topic' }],
+        ['code-less delivery report', { code: -1, message: 'unknown topic or partition' }],
+    ])('reports an absent topic as unroutable: %s', async (_label, error) => {
+        produceMock.mockImplementation((...args: any[]) => args[args.length - 1](error, null))
+
+        await expect(
+            wrapper.produce({ topic: 'cdp_cyclotron_email', key: null, value: Buffer.from('v') })
+        ).rejects.toBeInstanceOf(UnknownTopicError)
+    })
+
+    it('leaves an unrelated produce failure as it is', async () => {
+        produceMock.mockImplementation((...args: any[]) =>
+            args[args.length - 1]({ code: 7, message: 'Broker: Request timed out' }, null)
+        )
+
+        await expect(wrapper.produce({ topic: 't', key: null, value: Buffer.from('v') })).rejects.not.toBeInstanceOf(
+            UnknownTopicError
+        )
     })
 })

--- a/nodejs/src/common/kafka/producer.ts
+++ b/nodejs/src/common/kafka/producer.ts
@@ -23,6 +23,20 @@ import { ProducerStatsTracker } from './kafka-producer-metrics'
 // node-rdkafka exposes no typed constant for these, so the numbers are inlined the same way the
 // MessageSizeTooLarge check below inlines 10.
 const UNKNOWN_TOPIC_ERROR_CODES = new Set([3, -188])
+// A delivery report for an absent topic does not always carry one of those codes — a broker that
+// answers the metadata request slowly enough surfaces the failure through the produce callback with
+// code -1 and only the librdkafka text. Matching the text as well keeps the classification working
+// there, which is where the crash loop was observed.
+const UNKNOWN_TOPIC_MESSAGE = /unknown topic or (partition|part)/i
+
+function isUnknownTopicError(error: unknown): boolean {
+    const code = (error as LibrdKafkaError)?.code
+    if (typeof code === 'number' && UNKNOWN_TOPIC_ERROR_CODES.has(code)) {
+        return true
+    }
+    const message = (error as Error)?.message
+    return typeof message === 'string' && UNKNOWN_TOPIC_MESSAGE.test(message)
+}
 
 /** This class is a wrapper around the rdkafka producer, and does very little.
  *
@@ -204,7 +218,7 @@ export class KafkaProducerWrapper {
                 error_code: errorCode,
             })
 
-            if (typeof errorCode === 'number' && UNKNOWN_TOPIC_ERROR_CODES.has(errorCode)) {
+            if (isUnknownTopicError(error)) {
                 // Classified before isRetriable on purpose. The topic is absent from this cluster,
                 // so the produce cannot succeed however many times it is retried, and librdkafka
                 // only populates isRetriable when the underlying error happens to carry it.

--- a/nodejs/src/common/kafka/producer.ts
+++ b/nodejs/src/common/kafka/producer.ts
@@ -14,10 +14,15 @@ import { Counter, Histogram, Summary } from 'prom-client'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
-import { DependencyUnavailableError, MessageSizeTooLarge } from '../utils/db/error'
+import { DependencyUnavailableError, MessageSizeTooLarge, UnknownTopicError } from '../utils/db/error'
 import { logger } from '../utils/logger'
 import { KafkaConfigTarget, getKafkaConfigFromEnv } from './config'
 import { ProducerStatsTracker } from './kafka-producer-metrics'
+
+// node-rdkafka ERR_UNKNOWN_TOPIC_OR_PART (broker, 3) and ERR__UNKNOWN_TOPIC (local, -188).
+// node-rdkafka exposes no typed constant for these, so the numbers are inlined the same way the
+// MessageSizeTooLarge check below inlines 10.
+const UNKNOWN_TOPIC_ERROR_CODES = new Set([3, -188])
 
 /** This class is a wrapper around the rdkafka producer, and does very little.
  *
@@ -199,7 +204,13 @@ export class KafkaProducerWrapper {
                 error_code: errorCode,
             })
 
-            if ((error as LibrdKafkaError).isRetriable) {
+            if (typeof errorCode === 'number' && UNKNOWN_TOPIC_ERROR_CODES.has(errorCode)) {
+                // Classified before isRetriable on purpose. The topic is absent from this cluster,
+                // so the produce cannot succeed however many times it is retried, and librdkafka
+                // only populates isRetriable when the underlying error happens to carry it.
+                // Handing this to a caller that retries is what turns one message into a crash loop.
+                throw new UnknownTopicError(topic, error)
+            } else if ((error as LibrdKafkaError).isRetriable) {
                 // If we get a retriable error, bubble that up so that the
                 // caller can retry.
                 throw new DependencyUnavailableError(error.message, 'Kafka', error)

--- a/nodejs/src/common/utils/db/error.ts
+++ b/nodejs/src/common/utils/db/error.ts
@@ -20,6 +20,24 @@ export class MessageSizeTooLarge extends Error {
     readonly isRetriable = false
 }
 
+/**
+ * The target topic does not exist on the cluster this producer is connected to.
+ *
+ * Permanent by construction: the topic does not appear because we asked again. A caller must
+ * handle the message instead of retrying it, or the same message fails forever.
+ */
+export class UnknownTopicError extends Error {
+    constructor(topic: string, error: Error) {
+        super(`Kafka topic "${topic}" does not exist on this cluster`)
+        this.name = 'UnknownTopicError'
+        this.topic = topic
+        this.error = error
+    }
+    readonly topic: string
+    readonly error: Error
+    readonly isRetriable = false
+}
+
 export class RedisOperationError extends Error {
     constructor(message: string, error: Error, operation: string, logContext?: Record<string, any>) {
         super(message)


### PR DESCRIPTION
## Problem

A CDP worker that produces to a Kafka topic which does not exist on its cluster kills its own pod, and keeps killing it.

The produce error is rethrown out of `queueInvocations`, lands in the consumer's `fatalError` latch (`consumer-v2.ts:369`), throws out of the consume loop (`:280`), and reaches `base-server.ts:201` as an unhandled rejection, which exits the process. The offset was never committed, so the restart consumes the same message and dies the same way. One undeliverable job stalls the partition for every team on it, indefinitely.

This is reachable today. `job-queue-kafka.ts` derives the topic mechanically as `` `cdp_cyclotron_${queue}` ``, and the `email` queue is served **only** by Postgres — the email worker is constructed with a `CyclotronJobQueuePostgresV2` (`server.ts:345-352`), never a Kafka consumer. So `cdp_cyclotron_email` exists on no cluster. The hog worker gets a single Kafka queue and no Postgres fallback (`server.ts:252`), and `hog-executor-async.service.ts:151` routes an email send onward whenever `invocation.queue !== 'email'` — it asks *"am I already the email worker?"*, never *"can my job queue reach the email queue?"*. A destination that reaches `sendEmail` therefore produces to a phantom topic.

[#89177](https://github.com/PostHog/posthog/pull/89177) stops that particular function from being saved. This PR is about the blast radius when an invariant like it is violated again: a job we cannot deliver should fail, not take the partition down with it.

## Changes

- **A produce to a non-existent topic now fails the job, not the pod.** The affected invocations get a terminal failure row (`errorKind: 'unroutable_queue'`) with a message naming the queue, the batch commits, and the partition keeps draining. Previously the run hung in `running` forever and could not be re-run, because the pod died before recording anything.
- **`UnknownTopicError`** classifies librdkafka's unknown-topic codes (`3` broker, `-188` local), and the librdkafka text when the delivery report carries neither. A broker that answers the metadata request slowly enough reports the missing topic through the produce callback with code `-1` and only the message, which the codes alone miss. It is checked *before* `isRetriable` on purpose — the topic does not appear because we asked again, and librdkafka only populates `isRetriable` when the underlying error happens to carry it, so relying on that ordering is what allowed the crash loop.
- **`UnroutableInvocationsError`** carries those invocations out of the produce path so the consumer can record them. Throwing the raw produce error is what reaches the fatal latch.
- **Every other produce error keeps today's behaviour** — rethrown, so a transient broker problem still retries the batch rather than silently dropping work. `Promise.allSettled` replaces `Promise.all` so one undeliverable job no longer decides the fate of the routable ones in the same batch.
- **`cdp_cyclotron_unroutable_invocations{queue}`** counts every drop. Dropping a job is only acceptable if it is loud, so this is the thing to alert on — any sustained non-zero rate means jobs are being lost. The alert rule lives in `PostHog/charts` and is a follow-up.

This follows the poison-pill guard already in `cdp-cyclotron-worker.consumer.ts:120` ("crash-loops the worker on a single poison-pill message, stalling the whole partition. Drop it instead so the batch can make progress"), including its ordering: record the terminal row before letting the job go.

## How did you test this code?

Driven end to end on a local stack, against the real failure rather than a simulated one.

Setup: `auto_create_topics_enabled=false` on the local broker, so `cdp_cyclotron_email` genuinely did not exist. An email destination (`template-email`, sender integration on maildev) fired from a real capture event, so its result routed to the `email` queue and produced to that topic.

The first run reproduced the crash loop **with this branch applied**:

<details><summary>Worker log, branch as first pushed</summary>

```
17:24:18 WARN  Kafka produce callback timeout for topic "cdp_cyclotron_email"
17:24:38 ERROR kafka_produce_error topic: "cdp_cyclotron_email" error_code: -1 error: "unknown topic or partition"
17:24:38 ERROR Error producing kafka message  functionId: 01a043c6-beeb-...
17:24:38 ERROR kafka_consumer_v2_loop_error groupId: "cdp-cyclotron-hog-consumer"
17:24:38 ERROR Unhandled Promise Rejection
17:24:38 ERROR Shutting down due to error: Broker: Unknown topic or partition
```

</details>

The delivery report carried code `-1`, so the `{3, -188}` set did not match it, the produce error was rethrown, and the pod died about 30 seconds after each boot. That happened twice in a row before the classification was widened to match the message too.

After the fix, the same event on the same setup:

- The worker stays up. Health returned 200 more than 100 seconds after the send, where it previously exited within 35.
- `cdp_cyclotron_unroutable_invocations{queue="email"} 1`.
- `hog_invocation_results` holds `status=failed`, `error_kind=unroutable_queue`, message `This invocation was routed to the "email" queue, which this worker cannot deliver to, so it was dropped.`
- The Invocations tab shows that run as failed, with the reason:

![unr-invocations](https://raw.githubusercontent.com/PostHog/pr-assets/c1d054356a52cbe9c026357a33b9adfb51532beb/2026/08/70351728-6d44-4bd2-8368-d4c29ae7270f.png)

Unit tests: `job-queue-kafka.test.ts` covers the unroutable invocation leaving the routable one in its batch produced, any other produce error still rethrown, and an all-routable batch resolving. `producer.test.ts` adds the three shapes an absent topic arrives in (broker `3`, local `-188`, code-less `-1`) and one unrelated failure that must not classify as unroutable.

Not tested: a real MSK or WarpStream broker. Which of the three error shapes production returns is unverified, which is the reason the classifier now accepts all three.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code), following up on review feedback on [#89177](https://github.com/PostHog/posthog/pull/89177) asking that the worker "not crash-loop but potentially crash controlled and alert so we know something is borked".

Worth recording what changed during the investigation: the first read was "a topic is missing, catch the error". Tracing the wiring showed the topic can never exist — `email` is a Postgres-only queue and the Kafka job queue mints a topic name for it regardless — so this is a routing gap, not an infrastructure outage, and no retry policy could ever fix it. That is what settled the design on fail-the-job-and-count rather than retry or a preflight topic check. It also showed the existing shutdown is already graceful; what was missing is that it was unconditional, and therefore infinite.

Separately, `CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING` is set in ~23 places in `PostHog/charts` and read by no line of code in this repo (a Dec 2025 log fixture at `products/logs/backend/test/test_logs.jsonnd:902` shows it being logged at startup, so the per-queue producer routing was removed and the config left behind). It reads as though `email` is routed to Postgres. Not touched here, but it should be restored or deleted.

A later session drove the failure on a local stack rather than at the producer boundary, which is what surfaced the code-less delivery report the first classification missed. Skills invoked: `writing-pr-descriptions`, `posthog-local-e2e-qa`.

No customer data, identifiers or session material is present in the diff or this description.

