### PR TITLE
feat(logs): link a log to its trace and a service to its metrics

### DIFF
--- a/products/logs/frontend/components/LogsServices/LogsServicesV2.tsx
+++ b/products/logs/frontend/components/LogsServices/LogsServicesV2.tsx
@@ -70,7 +70,12 @@ export function LogsServicesV2(): JSX.Element {
                 {viewMode === 'grid' ? (
                     <ServicesGrid />
                 ) : (
-                    <ServicesList services={sortedServices} loading={servicesDataLoading} searchTerm={searchTerm} />
+                    <ServicesList
+                        services={sortedServices}
+                        loading={servicesDataLoading}
+                        searchTerm={searchTerm}
+                        dateFrom={dateFrom}
+                    />
                 )}
             </div>
         </div>

--- a/products/logs/frontend/components/LogsServices/ServicesList.test.tsx
+++ b/products/logs/frontend/components/LogsServices/ServicesList.test.tsx
@@ -1,8 +1,11 @@
 import { render } from '@testing-library/react'
 
 import type { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, AccessControlResourceType, AppContext } from '~/types'
 
 import type { ServiceRow } from './logsServicesLogic'
 import { ServicesList } from './ServicesList'
@@ -31,8 +34,21 @@ describe('ServicesList', () => {
         initKeaTests()
     })
 
-    const renderList = (services: ServiceRow[] = SERVICES): HTMLElement =>
-        render(<ServicesList services={services} loading={false} searchTerm="" />).container
+    const renderList = (services: ServiceRow[] = SERVICES, dateFrom = '-1h'): HTMLElement =>
+        render(<ServicesList services={services} loading={false} searchTerm="" dateFrom={dateFrom} />).container
+
+    /** The metrics link is gated on the alpha flag and on metrics access, so a row only shows it for both. */
+    const enableMetricsLink = (): void => {
+        window.POSTHOG_APP_CONTEXT = {
+            ...window.POSTHOG_APP_CONTEXT,
+            resource_access_control: {
+                ...window.POSTHOG_APP_CONTEXT?.resource_access_control,
+                [AccessControlResourceType.Metrics]: AccessControlLevel.Viewer,
+            },
+        } as AppContext
+        featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.METRICS]: true })
+    }
 
     it('keeps the DOM bounded by the viewport, not by the number of services', () => {
         const rows = renderList().querySelectorAll('[data-attr="logs-services-row"]')
@@ -63,5 +79,16 @@ describe('ServicesList', () => {
 
     it('states how many services matched and how far they scroll', () => {
         expect(renderList().textContent).toContain('2,400 services, about 134 screens')
+    })
+
+    // Metrics defaults to the last hour. Without the window the user picked here, a service
+    // busy over seven days opens on an hour of chart and reads as though it has no traffic.
+    it('opens metrics on the window the services list is showing', () => {
+        enableMetricsLink()
+        const href = renderList([service('checkout')], '-7d')
+            .querySelector('[data-attr="logs-services-row-metrics"]')
+            ?.getAttribute('href')
+
+        expect(href).toContain('dateFrom=-7d')
     })
 })

--- a/products/logs/frontend/components/LogsServices/ServicesList.tsx
+++ b/products/logs/frontend/components/LogsServices/ServicesList.tsx
@@ -9,6 +9,11 @@ import { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils/numbers'
 
+import {
+    useCanViewServiceMetrics,
+    ViewServiceMetricsButton,
+} from 'products/metrics/frontend/components/ViewServiceMetricsButton'
+
 import { NO_SERVICE_LABEL, ServiceRow } from './logsServicesLogic'
 import { copyServiceDeepLink, serviceViewerUrl } from './serviceViewerUrl'
 
@@ -20,6 +25,9 @@ const HEADER_HEIGHT = 28
 
 /** Shared by the header and every row so the columns line up either side of the scroller. */
 const COLUMN_TEMPLATE = 'grid grid-cols-[minmax(0,1fr)_6rem_5rem_12rem] items-center gap-2'
+
+/** Width the row actions reserve. The metrics link is flag-gated, so it changes the count. */
+const actionsWidthClass = (withMetricsLink: boolean): string => (withMetricsLink ? 'w-12' : 'w-6')
 
 interface ServicesListProps {
     services: ServiceRow[]
@@ -33,7 +41,8 @@ interface ServicesListProps {
  * it returns 25 rows or all of them, because the LIMIT lands after the GROUP BY.
  */
 export function ServicesList({ services, loading, searchTerm }: ServicesListProps): JSX.Element {
-    const rowProps = useMemo(() => ({ services }), [services])
+    const withMetricsLink = useCanViewServiceMetrics()
+    const rowProps = useMemo(() => ({ services, withMetricsLink }), [services, withMetricsLink])
 
     if (loading && services.length === 0) {
         return (
@@ -67,7 +76,7 @@ export function ServicesList({ services, loading, searchTerm }: ServicesListProp
                         <div className="h-6 shrink-0 text-xs text-muted px-2">
                             {densitySubtitle(services.length, screenCount(services.length, listHeight), !!searchTerm)}
                         </div>
-                        <ServicesListHeader />
+                        <ServicesListHeader withMetricsLink={withMetricsLink} />
                         <List<ServicesListRowProps>
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{ width, height: listHeight }}
@@ -95,7 +104,7 @@ function densitySubtitle(serviceCount: number, screens: number, searching: boole
     return screens <= 1 ? label : `${label}, about ${humanFriendlyNumber(screens)} screens`
 }
 
-function ServicesListHeader(): JSX.Element {
+function ServicesListHeader({ withMetricsLink }: { withMetricsLink: boolean }): JSX.Element {
     return (
         <div className="h-7 shrink-0 flex items-center gap-2 pr-2 border-b text-xs font-semibold text-secondary uppercase tracking-wide">
             <div className={cn(COLUMN_TEMPLATE, 'flex-1 min-w-0 pl-2')}>
@@ -104,14 +113,15 @@ function ServicesListHeader(): JSX.Element {
                 <span className="text-right">Error rate</span>
                 <span>Rules</span>
             </div>
-            {/* Matches the share button, which has no column title of its own. */}
-            <span className="w-6 shrink-0" />
+            {/* Matches the row actions, which have no column title of their own. */}
+            <span className={cn('shrink-0', actionsWidthClass(withMetricsLink))} />
         </div>
     )
 }
 
 interface ServicesListRowProps {
     services: ServiceRow[]
+    withMetricsLink: boolean
 }
 
 function ServicesListRow({
@@ -119,6 +129,7 @@ function ServicesListRow({
     index,
     style,
     services,
+    withMetricsLink,
 }: {
     ariaAttributes: { 'aria-posinset': number; 'aria-setsize': number; role: 'listitem' }
     index: number
@@ -158,18 +169,27 @@ function ServicesListRow({
                 </Tooltip>
             )}
             {deepLinkable ? (
-                <Tooltip title="Copy a link to the viewer filtered to this service">
-                    <LemonButton
+                <>
+                    <ViewServiceMetricsButton
+                        serviceName={service.service_name}
                         size="xsmall"
                         noPadding
-                        icon={<IconShare />}
-                        onClick={() => copyServiceDeepLink(service.service_name)}
-                        data-attr="logs-services-row-share"
+                        iconOnly
+                        data-attr="logs-services-row-metrics"
                     />
-                </Tooltip>
+                    <Tooltip title="Copy a link to the viewer filtered to this service">
+                        <LemonButton
+                            size="xsmall"
+                            noPadding
+                            icon={<IconShare />}
+                            onClick={() => copyServiceDeepLink(service.service_name)}
+                            data-attr="logs-services-row-share"
+                        />
+                    </Tooltip>
+                </>
             ) : (
-                /* Holds the share button's width so the columns line up across every row. */
-                <span className="w-6 shrink-0" />
+                /* Holds the row actions' width so the columns line up across every row. */
+                <span className={cn('shrink-0', actionsWidthClass(withMetricsLink))} />
             )}
         </div>
     )

--- a/products/logs/frontend/components/LogsServices/ServicesList.tsx
+++ b/products/logs/frontend/components/LogsServices/ServicesList.tsx
@@ -26,8 +26,12 @@ const HEADER_HEIGHT = 28
 /** Shared by the header and every row so the columns line up either side of the scroller. */
 const COLUMN_TEMPLATE = 'grid grid-cols-[minmax(0,1fr)_6rem_5rem_12rem] items-center gap-2'
 
-/** Width the row actions reserve. The metrics link is flag-gated, so it changes the count. */
-const actionsWidthClass = (withMetricsLink: boolean): string => (withMetricsLink ? 'w-12' : 'w-6')
+/**
+ * Width the row actions reserve, so the header and the no-service placeholder line up with a
+ * normal row. The metrics link is flag-gated, so it changes the count — and two buttons also sit
+ * either side of the row's `gap-2`, which the reservation has to include.
+ */
+const actionsWidthClass = (withMetricsLink: boolean): string => (withMetricsLink ? 'w-14' : 'w-6')
 
 interface ServicesListProps {
     services: ServiceRow[]

--- a/products/logs/frontend/components/LogsServices/ServicesList.tsx
+++ b/products/logs/frontend/components/LogsServices/ServicesList.tsx
@@ -38,15 +38,17 @@ interface ServicesListProps {
     loading: boolean
     /** Both the empty state and the subtitle read differently for a search result than for the whole project. */
     searchTerm: string
+    /** The window these counts cover, so the metrics link opens on it rather than the metrics default. */
+    dateFrom: string
 }
 
 /**
  * Every service in the project, in one scroller. The aggregates query costs the same whether
  * it returns 25 rows or all of them, because the LIMIT lands after the GROUP BY.
  */
-export function ServicesList({ services, loading, searchTerm }: ServicesListProps): JSX.Element {
+export function ServicesList({ services, loading, searchTerm, dateFrom }: ServicesListProps): JSX.Element {
     const withMetricsLink = useCanViewServiceMetrics()
-    const rowProps = useMemo(() => ({ services, withMetricsLink }), [services, withMetricsLink])
+    const rowProps = useMemo(() => ({ services, withMetricsLink, dateFrom }), [services, withMetricsLink, dateFrom])
 
     if (loading && services.length === 0) {
         return (
@@ -126,6 +128,7 @@ function ServicesListHeader({ withMetricsLink }: { withMetricsLink: boolean }): 
 interface ServicesListRowProps {
     services: ServiceRow[]
     withMetricsLink: boolean
+    dateFrom: string
 }
 
 function ServicesListRow({
@@ -134,6 +137,7 @@ function ServicesListRow({
     style,
     services,
     withMetricsLink,
+    dateFrom,
 }: {
     ariaAttributes: { 'aria-posinset': number; 'aria-setsize': number; role: 'listitem' }
     index: number
@@ -176,6 +180,7 @@ function ServicesListRow({
                 <>
                     <ViewServiceMetricsButton
                         serviceName={service.service_name}
+                        dateFrom={dateFrom}
                         size="xsmall"
                         noPadding
                         iconOnly

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -142,7 +142,7 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
                                 timestamp={selectedLog.timestamp}
                                 size="xsmall"
                                 type="secondary"
-                                data-attr="logs-viewer-view-trace"
+                                data-attr="logs-details-view-trace"
                             />
                             {sessionId && (
                                 <ViewRecordingButton

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -13,6 +13,7 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 import { CopyLogButton, copyLogRaw } from 'products/logs/frontend/components/LogsViewer/CopyLogButton'
 import { LogContextSelector } from 'products/logs/frontend/components/LogsViewer/LogContextSelector/LogContextSelector'
 import { LogDetailsTabContent } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/Details/LogDetailsTab'
+import { ViewTraceButton } from 'products/tracing/frontend/components/ViewTraceButton'
 
 import { logsViewerLogic } from '../logsViewerLogic'
 import { LogComments } from './LogComments'
@@ -134,15 +135,25 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
                                 </div>
                             </div>
                         </div>
-                        {sessionId && (
-                            <ViewRecordingButton
-                                sessionId={sessionId}
+                        <div className="flex items-center gap-1">
+                            <ViewTraceButton
+                                traceId={selectedLog.trace_id}
+                                spanId={selectedLog.span_id}
                                 timestamp={selectedLog.timestamp}
                                 size="xsmall"
-                                openPlayerIn={RecordingPlayerType.Modal}
-                                checkRecordingExists
+                                type="secondary"
+                                data-attr="logs-viewer-view-trace"
                             />
-                        )}
+                            {sessionId && (
+                                <ViewRecordingButton
+                                    sessionId={sessionId}
+                                    timestamp={selectedLog.timestamp}
+                                    size="xsmall"
+                                    openPlayerIn={RecordingPlayerType.Modal}
+                                    checkRecordingExists
+                                />
+                            )}
+                        </div>
                     </div>
                 </LemonDrawer.Header>
                 <LemonDrawer.Content>

--- a/products/metrics/frontend/components/ViewServiceMetricsButton.test.tsx
+++ b/products/metrics/frontend/components/ViewServiceMetricsButton.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, AccessControlResourceType, AppContext } from '~/types'
+
+import { ViewServiceMetricsButton } from './ViewServiceMetricsButton'
+
+describe('ViewServiceMetricsButton', () => {
+    const setAccess = (level: AccessControlLevel | undefined): void => {
+        window.POSTHOG_APP_CONTEXT = {
+            ...window.POSTHOG_APP_CONTEXT,
+            resource_access_control: {
+                ...window.POSTHOG_APP_CONTEXT?.resource_access_control,
+                [AccessControlResourceType.Metrics]: level,
+            },
+        } as AppContext
+    }
+
+    beforeEach(() => {
+        initKeaTests()
+        featureFlagLogic.mount()
+    })
+
+    afterEach(() => cleanup())
+
+    const renderButton = ({ flagOn = true, ...props }: any): void => {
+        featureFlagLogic.actions.setFeatureFlags([], flagOn ? { [FEATURE_FLAGS.METRICS]: true } : {})
+        render(
+            <Provider>
+                <ViewServiceMetricsButton {...props} />
+            </Provider>
+        )
+    }
+
+    // Metrics is in private alpha behind a flag. A link rendered without it lands on the waitlist
+    // screen, not a chart — a dead end reached from a GA product.
+    it.each([
+        ['the metrics flag is off', { serviceName: 'checkout', flagOn: false }, AccessControlLevel.Viewer],
+        ['the user cannot view metrics', { serviceName: 'checkout' }, undefined],
+        ['there is no service name', { serviceName: '' }, AccessControlLevel.Viewer],
+    ])('renders nothing when %s', (_name, props, level) => {
+        setAccess(level)
+        renderButton(props)
+        expect(screen.queryByText('View metrics')).not.toBeInTheDocument()
+    })
+
+    it('links to the service, carrying the window the caller was on', () => {
+        setAccess(AccessControlLevel.Viewer)
+        renderButton({ serviceName: 'checkout', dateFrom: '-30m' })
+
+        const href = screen.getByText('View metrics').closest('a')?.getAttribute('href')
+        expect(href).toContain('dateFrom=-30m')
+        expect(href).toContain('checkout')
+    })
+})

--- a/products/metrics/frontend/components/ViewServiceMetricsButton.tsx
+++ b/products/metrics/frontend/components/ViewServiceMetricsButton.tsx
@@ -1,0 +1,61 @@
+import { IconGraph } from '@posthog/icons'
+import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+import { canViewMetrics } from 'products/metrics/frontend/metricsAccess'
+import { metricsUrlForService } from 'products/metrics/frontend/metricsLinks'
+
+export interface ViewServiceMetricsButtonProps extends Pick<
+    LemonButtonProps,
+    'size' | 'type' | 'className' | 'noPadding' | 'data-attr'
+> {
+    serviceName: string | null | undefined
+    /** Opens the viewer on the window the caller was looking at, rather than the metrics default. */
+    dateFrom?: string | null
+    dateTo?: string | null
+    iconOnly?: boolean
+}
+
+/**
+ * Whether a metrics link would actually reach a chart for this team.
+ *
+ * Exported for callers that reserve layout space for the button, so a hidden button does not leave
+ * a column misaligned. `ViewServiceMetricsButton` applies the same check itself.
+ */
+export function useCanViewServiceMetrics(): boolean {
+    const metricsEnabled = useFeatureFlag('METRICS')
+    return metricsEnabled && canViewMetrics()
+}
+
+/**
+ * "Show me this service's metrics", for Logs and Tracing to drop into a service row or a span.
+ *
+ * Metrics owns this gate rather than each caller, because the product is in private alpha behind a
+ * flag: a link rendered without it lands on the waitlist screen instead of a chart, and callers
+ * would each have to remember that.
+ */
+export function ViewServiceMetricsButton({
+    serviceName,
+    dateFrom,
+    dateTo,
+    iconOnly,
+    ...buttonProps
+}: ViewServiceMetricsButtonProps): JSX.Element | null {
+    const canViewServiceMetrics = useCanViewServiceMetrics()
+
+    if (!serviceName || !canViewServiceMetrics) {
+        return null
+    }
+
+    return (
+        <LemonButton
+            icon={<IconGraph />}
+            to={metricsUrlForService(serviceName, { dateFrom, dateTo })}
+            tooltip={iconOnly ? `Metrics for ${serviceName}` : undefined}
+            {...buttonProps}
+        >
+            {iconOnly ? undefined : 'View metrics'}
+        </LemonButton>
+    )
+}

--- a/products/tracing/frontend/components/ViewTraceButton.test.tsx
+++ b/products/tracing/frontend/components/ViewTraceButton.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, AccessControlResourceType, AppContext } from '~/types'
+
+import { ViewTraceButton } from './ViewTraceButton'
+
+describe('ViewTraceButton', () => {
+    beforeEach(() => {
+        window.POSTHOG_APP_CONTEXT = {
+            ...window.POSTHOG_APP_CONTEXT,
+            resource_access_control: {
+                ...window.POSTHOG_APP_CONTEXT?.resource_access_control,
+                [AccessControlResourceType.Tracing]: AccessControlLevel.Viewer,
+            },
+        } as AppContext
+        initKeaTests()
+    })
+
+    afterEach(() => cleanup())
+
+    const renderButton = (props: Parameters<typeof ViewTraceButton>[0]): void => {
+        render(
+            <Provider>
+                <ViewTraceButton {...props} />
+            </Provider>
+        )
+    }
+
+    // A log row without a trace is the common case, not an edge case. Rendering the button anyway
+    // would link to `/tracing?trace=`, and one dead link teaches people to stop clicking it.
+    it.each([
+        ['an absent trace id', undefined],
+        ['an empty trace id', ''],
+        ['a null trace id', null],
+    ])('renders nothing for %s', (_name, traceId) => {
+        renderButton({ traceId })
+        expect(screen.queryByText('View trace')).not.toBeInTheDocument()
+    })
+
+    it('links to the trace, anchored on the span and hinted with the timestamp', () => {
+        renderButton({ traceId: 'abc123', spanId: 'def456', timestamp: '2026-06-11T08:00:00.000Z' })
+
+        expect(screen.getByText('View trace').closest('a')).toHaveAttribute(
+            'href',
+            expect.stringContaining('trace=abc123')
+        )
+        // The timestamp bounds the cold-load query; without it the lookup scans the whole
+        // retention window, because OTel trace ids embed no time.
+        expect(screen.getByText('View trace').closest('a')?.getAttribute('href')).toContain('ts=')
+    })
+})

--- a/products/tracing/frontend/components/ViewTraceButton.test.tsx
+++ b/products/tracing/frontend/components/ViewTraceButton.test.tsx
@@ -41,6 +41,17 @@ describe('ViewTraceButton', () => {
         expect(screen.queryByText('View trace')).not.toBeInTheDocument()
     })
 
+    it('renders nothing without tracing access, rather than a disabled button', () => {
+        // Matches how the trace links logs already has behave.
+        window.POSTHOG_APP_CONTEXT = {
+            ...window.POSTHOG_APP_CONTEXT,
+            resource_access_control: { [AccessControlResourceType.Tracing]: AccessControlLevel.None },
+        } as AppContext
+
+        renderButton({ traceId: 'abc123' })
+        expect(screen.queryByText('View trace')).not.toBeInTheDocument()
+    })
+
     it('links to the trace, anchored on the span and hinted with the timestamp', () => {
         renderButton({ traceId: 'abc123', spanId: 'def456', timestamp: '2026-06-11T08:00:00.000Z' })
 

--- a/products/tracing/frontend/components/ViewTraceButton.tsx
+++ b/products/tracing/frontend/components/ViewTraceButton.tsx
@@ -29,7 +29,8 @@ export function ViewTraceButton({
     ...buttonProps
 }: ViewTraceButtonProps): JSX.Element | null {
     // Most rows have no trace. Rendering a link to nothing is worse than rendering nothing.
-    if (!traceId) {
+    // Hidden rather than disabled without access, matching the trace links logs already has.
+    if (!traceId || getAccessControlDisabledReason(AccessControlResourceType.Tracing, AccessControlLevel.Viewer)) {
         return null
     }
 
@@ -38,10 +39,6 @@ export function ViewTraceButton({
             icon={<IconGraph />}
             to={traceUrl({ traceId, spanId, ts: timestamp })}
             tooltip={iconOnly ? 'View the trace this came from' : undefined}
-            disabledReason={getAccessControlDisabledReason(
-                AccessControlResourceType.Tracing,
-                AccessControlLevel.Viewer
-            )}
             {...buttonProps}
         >
             {iconOnly ? undefined : 'View trace'}

--- a/products/tracing/frontend/components/ViewTraceButton.tsx
+++ b/products/tracing/frontend/components/ViewTraceButton.tsx
@@ -1,0 +1,50 @@
+import { IconGraph } from '@posthog/icons'
+import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
+
+import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
+
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { traceUrl } from 'products/tracing/frontend/traceLinks'
+
+export interface ViewTraceButtonProps extends Pick<LemonButtonProps, 'size' | 'type' | 'className' | 'data-attr'> {
+    /** Hex trace id, as every product's query runner returns it. */
+    traceId: string | null | undefined
+    /** Anchors the waterfall on one span. */
+    spanId?: string | null
+    /** Bounds the cold-load lookup — OTel trace ids embed no timestamp. */
+    timestamp?: string | null
+    iconOnly?: boolean
+}
+
+/**
+ * The shared "go to this trace" entry point, for anything that carries a trace id: a log row, an
+ * error event, a metric sample. Mirrors logs' `ViewLogsButton`.
+ */
+export function ViewTraceButton({
+    traceId,
+    spanId,
+    timestamp,
+    iconOnly,
+    ...buttonProps
+}: ViewTraceButtonProps): JSX.Element | null {
+    // Most rows have no trace. Rendering a link to nothing is worse than rendering nothing.
+    if (!traceId) {
+        return null
+    }
+
+    return (
+        <LemonButton
+            icon={<IconGraph />}
+            to={traceUrl({ traceId, spanId, ts: timestamp })}
+            tooltip={iconOnly ? 'View the trace this came from' : undefined}
+            disabledReason={getAccessControlDisabledReason(
+                AccessControlResourceType.Tracing,
+                AccessControlLevel.Viewer
+            )}
+            {...buttonProps}
+        >
+            {iconOnly ? undefined : 'View trace'}
+        </LemonButton>
+    )
+}


### PR DESCRIPTION
## Problem

A log row knows which trace it came from. The query runner selects `trace_id` and `span_id`, decodes them to hex, and the table can even show them as columns — but they were text, not links. Reading an error log and wanting the request behind it meant copying the id and pasting it into the Tracing search.

The trace side has had this for a while: a trace opens its logs in an embedded viewer with the scope pinned. The return trip did not exist.

Separately, the logs services table lists every service in the project with no route to that service's charts.

Top of the stack behind #89768 and #89770, which made metrics addressable and added the metric-to-logs pivot.

## Changes

- Opening a log now offers **View trace**, beside the existing View recording. It anchors the waterfall on the log's span and carries the timestamp, which bounds the lookup — OTel trace ids embed no time, so an unhinted lookup scans the whole retention window.
- The logs services table gets a **metrics** link per service.
- Both are shared components (`ViewTraceButton`, `ViewServiceMetricsButton`) rather than inline links, so error tracking and replay can reuse them instead of hand-rolling the URL a fourth time.
- Each hides itself when the destination is unreachable: no trace id on the row, no access, or metrics still behind its private-alpha flag. A link that lands on a waitlist screen is worse than no link.
- Mechanical: the services table's action column now sizes itself from a single helper, so the header, the rows, and the no-service placeholder stay aligned whether or not the metrics link renders.

### Screenshots

Opening a log now offers **View trace** beside the existing View recording:

![View trace in the log details drawer](https://raw.githubusercontent.com/PostHog/pr-assets/dfc677b60808c170fe5aa92198eea0b254a0c5ca/2026/08/d6299f4c-0c28-46ce-89e3-01553827f420.png)

Every service row carries a metrics link next to the share button, with the header and the rows staying aligned:

![Metrics link on every service row](https://raw.githubusercontent.com/PostHog/pr-assets/aa9043fa1b41090076c326ba703e2972e2bc719b/2026/08/6acb6cf5-fa93-417c-b919-2a1c28df3343.png)

## How did you test this code?

The screenshots above are real renders: a log row opened to its drawer, and the services table with the metrics link present. The scene runs in Storybook against mocked metrics endpoints, so the screenshot shows the real components, layout and interaction, but fixture data rather than a query result. The harness stories are local and not part of this diff.

Both new components have small render tests aimed at one failure each, the dead link:

- `ViewTraceButton` renders nothing for an absent, empty, or null trace id. A log without a trace is the common case, and `/tracing?trace=` is a dead end.
- `ViewServiceMetricsButton` renders nothing when the metrics flag is off, when the user lacks access, or when there is no service name.

These are render tests rather than logic tests because "renders nothing" is the whole contract and there is no logic layer to aim at. Ran the `products/metrics`, `products/tracing` and `products/logs` suites locally; CI reports counts.

Not covered: that a link actually lands on populated data, which depends on the three products agreeing on `service_name` and `trace_id` values in a real project.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, final layer of a correlation-focused pass over Application Metrics, Logs and Tracing.

Two things a reviewer might want to weigh in on. First, the gating lives inside the components rather than at each call site, because the caller forgetting the metrics alpha flag is the likely mistake and it fails silently into a waitlist screen. `useCanViewServiceMetrics` is exported for callers that need to reserve layout space for a button that may not render — that is what keeps the services table aligned.

Second, this crosses product boundaries (logs importing from tracing and metrics). That follows what is already there: metrics imports `traceLinks` from tracing, and tracing embeds the logs viewer.

Skills invoked: `/writing-tests`.

