### PR TITLE
fix(flags): name group targeting in the flag property type help text

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -326,7 +326,7 @@ class _FeatureFlagFilterPropertyBaseSerializer(serializers.Serializer):
     type = serializers.ChoiceField(
         choices=_FEATURE_FLAG_FILTER_NON_FLAG_TYPE_CHOICES,
         required=False,
-        help_text="Property filter type. To target a group type, set `group` and pair it with `group_type_index`.",
+        help_text="Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.",
     )
     cohort_name = serializers.CharField(
         required=False,
@@ -336,7 +336,7 @@ class _FeatureFlagFilterPropertyBaseSerializer(serializers.Serializer):
     group_type_index = serializers.IntegerField(
         required=False,
         allow_null=True,
-        help_text="Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.",
+        help_text="Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.",
     )
 
 

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -326,7 +326,7 @@ class _FeatureFlagFilterPropertyBaseSerializer(serializers.Serializer):
     type = serializers.ChoiceField(
         choices=_FEATURE_FLAG_FILTER_NON_FLAG_TYPE_CHOICES,
         required=False,
-        help_text="Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.",
+        help_text="Property filter type. To target a group type, set `group` and pair it with `group_type_index`.",
     )
     cohort_name = serializers.CharField(
         required=False,
@@ -336,7 +336,7 @@ class _FeatureFlagFilterPropertyBaseSerializer(serializers.Serializer):
     group_type_index = serializers.IntegerField(
         required=False,
         allow_null=True,
-        help_text="Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.",
+        help_text="Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.",
     )
 
 

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -326,7 +326,7 @@ class _FeatureFlagFilterPropertyBaseSerializer(serializers.Serializer):
     type = serializers.ChoiceField(
         choices=_FEATURE_FLAG_FILTER_NON_FLAG_TYPE_CHOICES,
         required=False,
-        help_text="Property filter type. Common values are 'person' and 'cohort'.",
+        help_text="Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.",
     )
     cohort_name = serializers.CharField(
         required=False,
@@ -336,7 +336,7 @@ class _FeatureFlagFilterPropertyBaseSerializer(serializers.Serializer):
     group_type_index = serializers.IntegerField(
         required=False,
         allow_null=True,
-        help_text="Group type index when using group-based filters.",
+        help_text="Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.",
     )
 
 

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -59,7 +59,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -71,7 +71,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -110,7 +110,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -122,7 +122,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -151,7 +151,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -163,7 +163,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -206,7 +206,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -218,7 +218,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -253,7 +253,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -265,7 +265,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -313,7 +313,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -359,7 +359,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -59,7 +59,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -71,7 +71,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -110,7 +110,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -122,7 +122,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -151,7 +151,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -163,7 +163,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -206,7 +206,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -218,7 +218,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -253,7 +253,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -265,7 +265,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -313,7 +313,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -359,7 +359,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -59,7 +59,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -71,7 +71,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -110,7 +110,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -122,7 +122,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -151,7 +151,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -163,7 +163,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -206,7 +206,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -218,7 +218,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -253,7 +253,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -265,7 +265,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -313,7 +313,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -359,7 +359,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -37,7 +37,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -47,7 +47,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     value: zod
                                         .unknown()
@@ -85,7 +85,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -95,7 +95,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -117,7 +117,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -127,7 +127,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -148,7 +148,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -158,7 +158,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum([
@@ -187,7 +187,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -197,7 +197,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -225,7 +225,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -253,7 +253,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -313,7 +313,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -323,7 +323,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     value: zod
                                         .unknown()
@@ -361,7 +361,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -371,7 +371,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -393,7 +393,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -403,7 +403,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -424,7 +424,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -434,7 +434,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum([
@@ -463,7 +463,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -473,7 +473,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -501,7 +501,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -529,7 +529,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -590,7 +590,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -600,7 +600,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     value: zod
                                         .unknown()
@@ -638,7 +638,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -648,7 +648,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -670,7 +670,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -680,7 +680,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -701,7 +701,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -711,7 +711,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum([
@@ -740,7 +740,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -750,7 +750,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -778,7 +778,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -806,7 +806,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -37,7 +37,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -46,7 +46,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     value: zod
                                         .unknown()
                                         .describe(
@@ -83,7 +85,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -92,7 +94,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
                                         .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -113,7 +117,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -122,7 +126,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                         .describe(
@@ -142,7 +148,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -151,7 +157,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum([
                                             'semver_gt',
@@ -179,7 +187,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -188,7 +196,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
                                         .describe(
@@ -214,7 +224,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
                                         .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -240,7 +252,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
                                         .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -299,7 +313,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -308,7 +322,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     value: zod
                                         .unknown()
                                         .describe(
@@ -345,7 +361,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -354,7 +370,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
                                         .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -375,7 +393,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -384,7 +402,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                         .describe(
@@ -404,7 +424,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -413,7 +433,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum([
                                             'semver_gt',
@@ -441,7 +463,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -450,7 +472,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
                                         .describe(
@@ -476,7 +500,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
                                         .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -502,7 +528,9 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
                                         .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -562,7 +590,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -571,7 +599,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     value: zod
                                         .unknown()
                                         .describe(
@@ -608,7 +638,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -617,7 +647,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
                                         .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -638,7 +670,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -647,7 +679,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                         .describe(
@@ -667,7 +701,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -676,7 +710,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum([
                                             'semver_gt',
@@ -704,7 +740,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -713,7 +749,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
                                         .describe(
@@ -739,7 +777,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
                                         .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -765,7 +805,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
                                         .describe('\* `flag_evaluates_to` - flag_evaluates_to')

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -37,7 +37,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -47,7 +47,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     value: zod
                                         .unknown()
@@ -85,7 +85,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -95,7 +95,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -117,7 +117,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -127,7 +127,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -148,7 +148,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -158,7 +158,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum([
@@ -187,7 +187,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -197,7 +197,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -225,7 +225,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -253,7 +253,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -313,7 +313,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -323,7 +323,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     value: zod
                                         .unknown()
@@ -361,7 +361,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -371,7 +371,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -393,7 +393,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -403,7 +403,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -424,7 +424,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -434,7 +434,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum([
@@ -463,7 +463,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -473,7 +473,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -501,7 +501,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -529,7 +529,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -590,7 +590,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -600,7 +600,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     value: zod
                                         .unknown()
@@ -638,7 +638,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -648,7 +648,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -670,7 +670,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -680,7 +680,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -701,7 +701,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -711,7 +711,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum([
@@ -740,7 +740,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -750,7 +750,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -778,7 +778,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -806,7 +806,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -37,7 +37,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -47,7 +47,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     value: zod
                                         .unknown()
@@ -85,7 +85,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -95,7 +95,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -117,7 +117,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -127,7 +127,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -148,7 +148,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -158,7 +158,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum([
@@ -187,7 +187,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -197,7 +197,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -225,7 +225,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -253,7 +253,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -313,7 +313,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -323,7 +323,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     value: zod
                                         .unknown()
@@ -361,7 +361,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -371,7 +371,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -393,7 +393,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -403,7 +403,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -424,7 +424,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -434,7 +434,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum([
@@ -463,7 +463,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -473,7 +473,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -501,7 +501,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -529,7 +529,7 @@ export const ExperimentHoldoutsUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -590,7 +590,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -600,7 +600,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     value: zod
                                         .unknown()
@@ -638,7 +638,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -648,7 +648,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -670,7 +670,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -680,7 +680,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -701,7 +701,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -711,7 +711,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum([
@@ -740,7 +740,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -750,7 +750,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -778,7 +778,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -806,7 +806,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -630,7 +630,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -642,7 +642,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -681,7 +681,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -693,7 +693,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -722,7 +722,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -734,7 +734,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -777,7 +777,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -789,7 +789,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -824,7 +824,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -836,7 +836,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -884,7 +884,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -930,7 +930,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -630,7 +630,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -642,7 +642,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -681,7 +681,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -693,7 +693,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -722,7 +722,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -734,7 +734,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -777,7 +777,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -789,7 +789,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -824,7 +824,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -836,7 +836,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -884,7 +884,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -930,7 +930,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -630,7 +630,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -642,7 +642,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -681,7 +681,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -693,7 +693,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -722,7 +722,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -734,7 +734,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -777,7 +777,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -789,7 +789,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -824,7 +824,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -836,7 +836,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -884,7 +884,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -930,7 +930,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -206,7 +206,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -215,7 +215,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         value: zod
                                             .unknown()
                                             .describe(
@@ -252,7 +254,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -261,7 +263,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
                                             .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -282,7 +286,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -291,7 +295,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                             .describe(
@@ -311,7 +317,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -320,7 +326,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum([
                                                 'semver_gt',
@@ -348,7 +356,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -357,7 +365,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
                                             .describe(
@@ -383,7 +393,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
                                             .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -409,7 +421,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
                                             .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -633,7 +647,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -642,7 +656,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         value: zod
                                             .unknown()
                                             .describe(
@@ -679,7 +695,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -688,7 +704,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
                                             .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -709,7 +727,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -718,7 +736,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                             .describe(
@@ -738,7 +758,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -747,7 +767,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum([
                                                 'semver_gt',
@@ -775,7 +797,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -784,7 +806,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
                                             .describe(
@@ -810,7 +834,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
                                             .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -836,7 +862,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
                                             .describe('\* `flag_evaluates_to` - flag_evaluates_to')

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -206,7 +206,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -216,7 +216,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         value: zod
                                             .unknown()
@@ -254,7 +254,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -264,7 +264,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -286,7 +286,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -296,7 +296,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -317,7 +317,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -327,7 +327,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum([
@@ -356,7 +356,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -366,7 +366,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -394,7 +394,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -422,7 +422,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
@@ -647,7 +647,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -657,7 +657,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         value: zod
                                             .unknown()
@@ -695,7 +695,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -705,7 +705,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -727,7 +727,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -737,7 +737,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -758,7 +758,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -768,7 +768,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum([
@@ -797,7 +797,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -807,7 +807,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -835,7 +835,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -863,7 +863,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -206,7 +206,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -216,7 +216,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         value: zod
                                             .unknown()
@@ -254,7 +254,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -264,7 +264,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -286,7 +286,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -296,7 +296,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -317,7 +317,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -327,7 +327,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum([
@@ -356,7 +356,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -366,7 +366,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -394,7 +394,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -422,7 +422,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
@@ -647,7 +647,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -657,7 +657,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         value: zod
                                             .unknown()
@@ -695,7 +695,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -705,7 +705,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -727,7 +727,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -737,7 +737,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -758,7 +758,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -768,7 +768,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum([
@@ -797,7 +797,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -807,7 +807,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -835,7 +835,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -863,7 +863,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -206,7 +206,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -216,7 +216,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         value: zod
                                             .unknown()
@@ -254,7 +254,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -264,7 +264,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -286,7 +286,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -296,7 +296,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -317,7 +317,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -327,7 +327,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum([
@@ -356,7 +356,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -366,7 +366,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -394,7 +394,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -422,7 +422,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
@@ -647,7 +647,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -657,7 +657,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         value: zod
                                             .unknown()
@@ -695,7 +695,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -705,7 +705,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -727,7 +727,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -737,7 +737,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -758,7 +758,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -768,7 +768,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum([
@@ -797,7 +797,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -807,7 +807,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -835,7 +835,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -863,7 +863,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -444,7 +444,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -456,7 +456,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -495,7 +495,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -507,7 +507,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -536,7 +536,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -548,7 +548,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -591,7 +591,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -603,7 +603,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -638,7 +638,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -650,7 +650,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -698,7 +698,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -744,7 +744,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -444,7 +444,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -456,7 +456,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -495,7 +495,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -507,7 +507,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -536,7 +536,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -548,7 +548,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -591,7 +591,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -603,7 +603,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -638,7 +638,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. Common values are 'person' and 'cohort'.
+    /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -650,7 +650,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -698,7 +698,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null
@@ -744,7 +744,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index when using group-based filters.
+     * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -444,7 +444,7 @@ export const FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -456,7 +456,7 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -495,7 +495,7 @@ export const ExistenceOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -507,7 +507,7 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -536,7 +536,7 @@ export const DateOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -548,7 +548,7 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -591,7 +591,7 @@ export const FeatureFlagFilterPropertySemverSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -603,7 +603,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -638,7 +638,7 @@ export const FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi = {
 export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
-    /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+    /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
      *
      * * `cohort` - cohort
      * * `person` - person
@@ -650,7 +650,7 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -698,7 +698,7 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null
@@ -744,7 +744,7 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     cohort_name?: string | null
     /**
-     * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+     * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
      * @nullable
      */
     group_type_index?: number | null

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -99,7 +99,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -109,7 +109,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -151,7 +151,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -161,7 +161,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -187,7 +187,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -197,7 +197,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -222,7 +222,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -232,7 +232,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -265,7 +265,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -275,7 +275,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -307,7 +307,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -339,7 +339,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
@@ -1059,7 +1059,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1069,7 +1069,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -1111,7 +1111,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1121,7 +1121,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -1147,7 +1147,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1157,7 +1157,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -1182,7 +1182,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1192,7 +1192,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -1225,7 +1225,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1235,7 +1235,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -1267,7 +1267,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -1299,7 +1299,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -99,7 +99,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -109,7 +109,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -151,7 +151,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -161,7 +161,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -187,7 +187,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -197,7 +197,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -222,7 +222,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -232,7 +232,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -265,7 +265,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -275,7 +275,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -307,7 +307,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -339,7 +339,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
@@ -1059,7 +1059,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1069,7 +1069,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -1111,7 +1111,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1121,7 +1121,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -1147,7 +1147,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1157,7 +1157,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -1182,7 +1182,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1192,7 +1192,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -1225,7 +1225,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1235,7 +1235,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -1267,7 +1267,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -1299,7 +1299,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -99,7 +99,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -108,7 +108,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             value: zod
                                                 .unknown()
                                                 .describe(
@@ -149,7 +151,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -158,7 +160,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
                                                 .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -183,7 +187,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -192,7 +196,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                                 .describe(
@@ -216,7 +222,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -225,7 +231,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum([
                                                     'semver_gt',
@@ -257,7 +265,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -266,7 +274,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
                                                 .describe(
@@ -296,7 +306,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
                                                 .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -326,7 +338,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
                                                 .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -1045,7 +1059,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1054,7 +1068,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             value: zod
                                                 .unknown()
                                                 .describe(
@@ -1095,7 +1111,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1104,7 +1120,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
                                                 .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -1129,7 +1147,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1138,7 +1156,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                                 .describe(
@@ -1162,7 +1182,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1171,7 +1191,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum([
                                                     'semver_gt',
@@ -1203,7 +1225,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1212,7 +1234,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
                                                 .describe(
@@ -1242,7 +1266,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
                                                 .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -1272,7 +1298,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
                                                 .describe('\* `flag_evaluates_to` - flag_evaluates_to')

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -99,7 +99,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -109,7 +109,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -151,7 +151,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -161,7 +161,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -187,7 +187,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -197,7 +197,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -222,7 +222,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -232,7 +232,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -265,7 +265,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -275,7 +275,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -307,7 +307,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -339,7 +339,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
@@ -1059,7 +1059,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1069,7 +1069,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -1111,7 +1111,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1121,7 +1121,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -1147,7 +1147,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1157,7 +1157,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -1182,7 +1182,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1192,7 +1192,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -1225,7 +1225,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1235,7 +1235,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -1267,7 +1267,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -1299,7 +1299,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33203,7 +33203,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyGenericSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Common values are 'person' and 'cohort'.
+      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33215,7 +33215,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33243,7 +33243,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyExistsSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Common values are 'person' and 'cohort'.
+      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33255,7 +33255,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33271,7 +33271,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyDateSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Common values are 'person' and 'cohort'.
+      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33283,7 +33283,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33326,7 +33326,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertySemverSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Common values are 'person' and 'cohort'.
+      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33338,7 +33338,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33373,7 +33373,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyMultiContainsSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Common values are 'person' and 'cohort'.
+      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33385,7 +33385,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33433,7 +33433,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33479,7 +33479,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index when using group-based filters.
+         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
          * @nullable
          */
       group_type_index?: number | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33203,7 +33203,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyGenericSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33215,7 +33215,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33243,7 +33243,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyExistsSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33255,7 +33255,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33271,7 +33271,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyDateSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33283,7 +33283,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33326,7 +33326,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertySemverSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33338,7 +33338,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33373,7 +33373,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyMultiContainsSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.
+      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33385,7 +33385,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33433,7 +33433,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33479,7 +33479,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set.
+         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
          * @nullable
          */
       group_type_index?: number | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33203,7 +33203,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyGenericSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+      /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33215,7 +33215,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33243,7 +33243,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyExistsSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+      /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33255,7 +33255,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33271,7 +33271,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyDateSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+      /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33283,7 +33283,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33326,7 +33326,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertySemverSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+      /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33338,7 +33338,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33373,7 +33373,7 @@ export namespace Schemas {
     export interface FeatureFlagFilterPropertyMultiContainsSchema {
       /** Property key used in this feature flag condition. */
       key: string;
-      /** Property filter type. To target a group type, set `group` and pair it with `group_type_index`.
+      /** Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.
        *
        * * `cohort` - cohort
        * * `person` - person
@@ -33385,7 +33385,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33433,7 +33433,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;
@@ -33479,7 +33479,7 @@ export namespace Schemas {
          */
       cohort_name?: string | null;
       /**
-         * Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.
+         * Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`.
          * @nullable
          */
       group_type_index?: number | null;

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -57,7 +57,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -66,7 +66,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     value: zod
                                         .unknown()
                                         .describe(
@@ -103,7 +105,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -112,7 +114,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
                                         .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -133,7 +137,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -142,7 +146,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                         .describe(
@@ -162,7 +168,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -171,7 +177,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum([
                                             'semver_gt',
@@ -199,7 +207,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -208,7 +216,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
                                         .describe(
@@ -234,7 +244,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
                                         .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -260,7 +272,9 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
                                         .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -338,7 +352,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -347,7 +361,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     value: zod
                                         .unknown()
                                         .describe(
@@ -384,7 +400,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -393,7 +409,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
                                         .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -414,7 +432,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -423,7 +441,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                         .describe(
@@ -443,7 +463,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -452,7 +472,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum([
                                             'semver_gt',
@@ -480,7 +502,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -489,7 +511,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
                                         .describe(
@@ -515,7 +539,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
                                         .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -541,7 +567,9 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                     group_type_index: zod
                                         .number()
                                         .nullish()
-                                        .describe('Group type index when using group-based filters.'),
+                                        .describe(
+                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                        ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
                                         .describe('\* `flag_evaluates_to` - flag_evaluates_to')

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -57,7 +57,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -67,7 +67,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     value: zod
                                         .unknown()
@@ -105,7 +105,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -115,7 +115,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -137,7 +137,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -147,7 +147,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -168,7 +168,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -178,7 +178,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum([
@@ -207,7 +207,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -217,7 +217,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -245,7 +245,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -273,7 +273,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -352,7 +352,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -362,7 +362,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     value: zod
                                         .unknown()
@@ -400,7 +400,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -410,7 +410,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -432,7 +432,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -442,7 +442,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -463,7 +463,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -473,7 +473,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum([
@@ -502,7 +502,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                            "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -512,7 +512,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -540,7 +540,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -568,7 +568,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                            "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -57,7 +57,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -67,7 +67,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     value: zod
                                         .unknown()
@@ -105,7 +105,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -115,7 +115,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -137,7 +137,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -147,7 +147,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -168,7 +168,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -178,7 +178,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum([
@@ -207,7 +207,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -217,7 +217,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -245,7 +245,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -273,7 +273,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -352,7 +352,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -362,7 +362,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     value: zod
                                         .unknown()
@@ -400,7 +400,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -410,7 +410,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -432,7 +432,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -442,7 +442,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -463,7 +463,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -473,7 +473,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum([
@@ -502,7 +502,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -512,7 +512,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -540,7 +540,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -568,7 +568,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -57,7 +57,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -67,7 +67,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     value: zod
                                         .unknown()
@@ -105,7 +105,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -115,7 +115,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -137,7 +137,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -147,7 +147,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -168,7 +168,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -178,7 +178,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum([
@@ -207,7 +207,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -217,7 +217,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -245,7 +245,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -273,7 +273,7 @@ export const ExperimentHoldoutsCreateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])
@@ -352,7 +352,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -362,7 +362,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     value: zod
                                         .unknown()
@@ -400,7 +400,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -410,7 +410,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_set', 'is_not_set'])
@@ -432,7 +432,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -442,7 +442,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -463,7 +463,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -473,7 +473,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum([
@@ -502,7 +502,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                         .optional()
                                         .describe(
-                                            "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                            "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                         ),
                                     cohort_name: zod
                                         .string()
@@ -512,7 +512,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['icontains_multi', 'not_icontains_multi'])
@@ -540,7 +540,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['in', 'not_in'])
@@ -568,7 +568,7 @@ export const ExperimentHoldoutsPartialUpdateBody = /* @__PURE__ */ zod
                                         .number()
                                         .nullish()
                                         .describe(
-                                            "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         ),
                                     operator: zod
                                         .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -139,7 +139,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -149,7 +149,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         value: zod
                                             .unknown()
@@ -187,7 +187,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -197,7 +197,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -219,7 +219,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -229,7 +229,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -250,7 +250,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -260,7 +260,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum([
@@ -289,7 +289,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -299,7 +299,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -327,7 +327,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -355,7 +355,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
@@ -521,7 +521,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -531,7 +531,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         value: zod
                                             .unknown()
@@ -569,7 +569,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -579,7 +579,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -601,7 +601,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -611,7 +611,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -632,7 +632,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -642,7 +642,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum([
@@ -671,7 +671,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -681,7 +681,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -709,7 +709,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -737,7 +737,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -139,7 +139,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -149,7 +149,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         value: zod
                                             .unknown()
@@ -187,7 +187,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -197,7 +197,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -219,7 +219,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -229,7 +229,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -250,7 +250,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -260,7 +260,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum([
@@ -289,7 +289,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -299,7 +299,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -327,7 +327,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -355,7 +355,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
@@ -521,7 +521,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -531,7 +531,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         value: zod
                                             .unknown()
@@ -569,7 +569,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -579,7 +579,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -601,7 +601,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -611,7 +611,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -632,7 +632,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -642,7 +642,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum([
@@ -671,7 +671,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -681,7 +681,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -709,7 +709,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -737,7 +737,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -139,7 +139,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -148,7 +148,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         value: zod
                                             .unknown()
                                             .describe(
@@ -185,7 +187,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -194,7 +196,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
                                             .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -215,7 +219,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -224,7 +228,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                             .describe(
@@ -244,7 +250,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -253,7 +259,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum([
                                                 'semver_gt',
@@ -281,7 +289,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -290,7 +298,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
                                             .describe(
@@ -316,7 +326,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
                                             .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -342,7 +354,9 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
                                             .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -507,7 +521,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -516,7 +530,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         value: zod
                                             .unknown()
                                             .describe(
@@ -553,7 +569,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -562,7 +578,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
                                             .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -583,7 +601,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -592,7 +610,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                             .describe(
@@ -612,7 +632,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -621,7 +641,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum([
                                                 'semver_gt',
@@ -649,7 +671,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -658,7 +680,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
                                             .describe(
@@ -684,7 +708,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
                                             .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -710,7 +736,9 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                         group_type_index: zod
                                             .number()
                                             .nullish()
-                                            .describe('Group type index when using group-based filters.'),
+                                            .describe(
+                                                "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
                                             .describe('\* `flag_evaluates_to` - flag_evaluates_to')

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -139,7 +139,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -149,7 +149,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         value: zod
                                             .unknown()
@@ -187,7 +187,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -197,7 +197,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -219,7 +219,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -229,7 +229,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -250,7 +250,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -260,7 +260,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum([
@@ -289,7 +289,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -299,7 +299,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -327,7 +327,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -355,7 +355,7 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])
@@ -521,7 +521,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -531,7 +531,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         value: zod
                                             .unknown()
@@ -569,7 +569,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -579,7 +579,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_set', 'is_not_set'])
@@ -601,7 +601,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -611,7 +611,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -632,7 +632,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -642,7 +642,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum([
@@ -671,7 +671,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .describe('\* `cohort` - cohort\n\* `person` - person\n\* `group` - group')
                                             .optional()
                                             .describe(
-                                                "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                             ),
                                         cohort_name: zod
                                             .string()
@@ -681,7 +681,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['icontains_multi', 'not_icontains_multi'])
@@ -709,7 +709,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['in', 'not_in'])
@@ -737,7 +737,7 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             .number()
                                             .nullish()
                                             .describe(
-                                                "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                             ),
                                         operator: zod
                                             .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -133,7 +133,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -143,7 +143,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -185,7 +185,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -195,7 +195,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -221,7 +221,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -231,7 +231,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -256,7 +256,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -266,7 +266,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -299,7 +299,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -309,7 +309,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -341,7 +341,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -373,7 +373,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
@@ -1012,7 +1012,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1022,7 +1022,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -1064,7 +1064,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1074,7 +1074,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -1100,7 +1100,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1110,7 +1110,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -1135,7 +1135,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1145,7 +1145,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -1178,7 +1178,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1188,7 +1188,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -1220,7 +1220,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -1252,7 +1252,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -133,7 +133,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -143,7 +143,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -185,7 +185,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -195,7 +195,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -221,7 +221,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -231,7 +231,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -256,7 +256,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -266,7 +266,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -299,7 +299,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -309,7 +309,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -341,7 +341,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -373,7 +373,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
@@ -1012,7 +1012,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1022,7 +1022,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -1064,7 +1064,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1074,7 +1074,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -1100,7 +1100,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1110,7 +1110,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -1135,7 +1135,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1145,7 +1145,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -1178,7 +1178,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1188,7 +1188,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -1220,7 +1220,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -1252,7 +1252,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -133,7 +133,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -143,7 +143,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -185,7 +185,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -195,7 +195,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -221,7 +221,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -231,7 +231,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -256,7 +256,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -266,7 +266,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -299,7 +299,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -309,7 +309,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -341,7 +341,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -373,7 +373,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
@@ -1012,7 +1012,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1022,7 +1022,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             value: zod
                                                 .unknown()
@@ -1064,7 +1064,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1074,7 +1074,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
@@ -1100,7 +1100,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1110,7 +1110,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
@@ -1135,7 +1135,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1145,7 +1145,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum([
@@ -1178,7 +1178,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    'Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group'
+                                                    "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1188,7 +1188,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
@@ -1220,7 +1220,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
@@ -1252,7 +1252,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 .number()
                                                 .nullish()
                                                 .describe(
-                                                    'Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set.'
+                                                    "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -133,7 +133,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -142,7 +142,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             value: zod
                                                 .unknown()
                                                 .describe(
@@ -183,7 +185,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -192,7 +194,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
                                                 .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -217,7 +221,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -226,7 +230,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                                 .describe(
@@ -250,7 +256,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -259,7 +265,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum([
                                                     'semver_gt',
@@ -291,7 +299,7 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -300,7 +308,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
                                                 .describe(
@@ -330,7 +340,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
                                                 .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -360,7 +372,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
                                                 .describe('\* `flag_evaluates_to` - flag_evaluates_to')
@@ -998,7 +1012,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1007,7 +1021,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             value: zod
                                                 .unknown()
                                                 .describe(
@@ -1048,7 +1064,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1057,7 +1073,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_set', 'is_not_set'])
                                                 .describe('\* `is_set` - is_set\n\* `is_not_set` - is_not_set')
@@ -1082,7 +1100,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1091,7 +1109,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['is_date_exact', 'is_date_before', 'is_date_after'])
                                                 .describe(
@@ -1115,7 +1135,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1124,7 +1144,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum([
                                                     'semver_gt',
@@ -1156,7 +1178,7 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                                 )
                                                 .optional()
                                                 .describe(
-                                                    "Property filter type. Common values are 'person' and 'cohort'.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
+                                                    "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n\* `cohort` - cohort\n\* `person` - person\n\* `group` - group"
                                                 ),
                                             cohort_name: zod
                                                 .string()
@@ -1165,7 +1187,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['icontains_multi', 'not_icontains_multi'])
                                                 .describe(
@@ -1195,7 +1219,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['in', 'not_in'])
                                                 .describe('\* `in` - in\n\* `not_in` - not_in')
@@ -1225,7 +1251,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                                             group_type_index: zod
                                                 .number()
                                                 .nullish()
-                                                .describe('Group type index when using group-based filters.'),
+                                                .describe(
+                                                    "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                ),
                                             operator: zod
                                                 .enum(['flag_evaluates_to'])
                                                 .describe('\* `flag_evaluates_to` - flag_evaluates_to')

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
@@ -120,7 +120,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -147,7 +147,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -180,7 +180,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -192,7 +192,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -225,7 +225,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -237,7 +237,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -271,7 +271,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -293,7 +293,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -327,7 +327,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -339,7 +339,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -376,7 +376,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -421,7 +421,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
@@ -120,7 +120,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -147,7 +147,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -180,7 +180,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -192,7 +192,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -225,7 +225,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -237,7 +237,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -271,7 +271,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -293,7 +293,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -327,7 +327,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -339,7 +339,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -376,7 +376,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -421,7 +421,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/create-feature-flag.json
@@ -120,7 +120,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -147,7 +147,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -180,7 +180,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -192,7 +192,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -225,7 +225,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -237,7 +237,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -271,7 +271,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -293,7 +293,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -327,7 +327,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -339,7 +339,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -376,7 +376,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -421,7 +421,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-create.json
@@ -54,7 +54,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -81,7 +81,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -114,7 +114,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -126,7 +126,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -159,7 +159,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -171,7 +171,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -205,7 +205,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -227,7 +227,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -261,7 +261,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -273,7 +273,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -310,7 +310,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -355,7 +355,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-create.json
@@ -54,7 +54,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -81,7 +81,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -114,7 +114,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -126,7 +126,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -159,7 +159,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -171,7 +171,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -205,7 +205,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -227,7 +227,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -261,7 +261,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -273,7 +273,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -310,7 +310,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -355,7 +355,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-create.json
@@ -54,7 +54,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -81,7 +81,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -114,7 +114,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -126,7 +126,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -159,7 +159,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -171,7 +171,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -205,7 +205,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -227,7 +227,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -261,7 +261,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -273,7 +273,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -310,7 +310,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -355,7 +355,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-partial-update.json
@@ -54,7 +54,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -81,7 +81,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -114,7 +114,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -126,7 +126,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -159,7 +159,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -171,7 +171,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -205,7 +205,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -227,7 +227,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -261,7 +261,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -273,7 +273,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -310,7 +310,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -355,7 +355,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index when using group-based filters."
+                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-partial-update.json
@@ -54,7 +54,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -81,7 +81,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -114,7 +114,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -126,7 +126,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -159,7 +159,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -171,7 +171,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -205,7 +205,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -227,7 +227,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -261,7 +261,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -273,7 +273,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -310,7 +310,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -355,7 +355,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-holdouts-partial-update.json
@@ -54,7 +54,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -81,7 +81,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -114,7 +114,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -126,7 +126,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -159,7 +159,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -171,7 +171,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -205,7 +205,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -227,7 +227,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -261,7 +261,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -273,7 +273,7 @@
                                             "type": "string"
                                         },
                                         "type": {
-                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                             "enum": ["cohort", "person", "group"],
                                             "type": "string"
                                         },
@@ -310,7 +310,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",
@@ -355,7 +355,7 @@
                                                     "type": "null"
                                                 }
                                             ],
-                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                         },
                                         "key": {
                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
@@ -773,7 +773,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -800,7 +800,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -833,7 +833,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -845,7 +845,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -878,7 +878,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -894,7 +894,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -928,7 +928,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -950,7 +950,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -984,7 +984,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -996,7 +996,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1033,7 +1033,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1078,7 +1078,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
@@ -773,7 +773,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -800,7 +800,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -833,7 +833,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -845,7 +845,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -878,7 +878,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -894,7 +894,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -928,7 +928,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -950,7 +950,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -984,7 +984,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -996,7 +996,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1033,7 +1033,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1078,7 +1078,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
@@ -773,7 +773,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -800,7 +800,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -833,7 +833,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -845,7 +845,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -878,7 +878,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -894,7 +894,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -928,7 +928,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -950,7 +950,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -984,7 +984,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -996,7 +996,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1033,7 +1033,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1078,7 +1078,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
@@ -804,7 +804,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -831,7 +831,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -864,7 +864,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -876,7 +876,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -909,7 +909,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -925,7 +925,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -959,7 +959,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -981,7 +981,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1015,7 +1015,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1027,7 +1027,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1064,7 +1064,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1109,7 +1109,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                            "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
@@ -804,7 +804,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -831,7 +831,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -864,7 +864,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -876,7 +876,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -909,7 +909,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -925,7 +925,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -959,7 +959,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -981,7 +981,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1015,7 +1015,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1027,7 +1027,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1064,7 +1064,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1109,7 +1109,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                            "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
@@ -804,7 +804,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -831,7 +831,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -864,7 +864,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -876,7 +876,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -909,7 +909,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -925,7 +925,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -959,7 +959,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -981,7 +981,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1015,7 +1015,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1027,7 +1027,7 @@
                                                             "type": "string"
                                                         },
                                                         "type": {
-                                                            "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                            "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                             "enum": ["cohort", "person", "group"],
                                                             "type": "string"
                                                         },
@@ -1064,7 +1064,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",
@@ -1109,7 +1109,7 @@
                                                                     "type": "null"
                                                                 }
                                                             ],
-                                                            "description": "Group type index when using group-based filters."
+                                                            "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                         },
                                                         "key": {
                                                             "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
@@ -124,7 +124,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -151,7 +151,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -184,7 +184,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -196,7 +196,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -229,7 +229,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -241,7 +241,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -275,7 +275,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -297,7 +297,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -331,7 +331,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -343,7 +343,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -380,7 +380,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -425,7 +425,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
+                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
@@ -124,7 +124,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -151,7 +151,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -184,7 +184,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -196,7 +196,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -229,7 +229,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -241,7 +241,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -275,7 +275,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -297,7 +297,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -331,7 +331,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -343,7 +343,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. To target a group type, set `group` and pair it with `group_type_index`.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property. Use `group` with `group_type_index` to filter on a group's properties.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -380,7 +380,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -425,7 +425,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index that a `group` property targets. Match the `aggregation_group_type_index` on its condition set."
+                                                    "description": "Group type index a `group` filter reads properties from. Defaults to the condition set's `aggregation_group_type_index`."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/update-feature-flag.json
@@ -124,7 +124,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -151,7 +151,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -184,7 +184,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -196,7 +196,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -229,7 +229,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -241,7 +241,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -275,7 +275,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -297,7 +297,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -331,7 +331,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -343,7 +343,7 @@
                                                     "type": "string"
                                                 },
                                                 "type": {
-                                                    "description": "Property filter type. Common values are 'person' and 'cohort'.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
+                                                    "description": "Property filter type. Set it on every property, and pair 'group' with group_type_index to target a group type.\n\n* `cohort` - cohort\n* `person` - person\n* `group` - group",
                                                     "enum": ["cohort", "person", "group"],
                                                     "type": "string"
                                                 },
@@ -380,7 +380,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",
@@ -425,7 +425,7 @@
                                                             "type": "null"
                                                         }
                                                     ],
-                                                    "description": "Group type index when using group-based filters."
+                                                    "description": "Group type index that a 'group' property targets. Match the aggregation_group_type_index on its condition set."
                                                 },
                                                 "key": {
                                                     "description": "Property key used in this feature flag condition.",


### PR DESCRIPTION
## Problem

Setting up group targeting through the API or an MCP tool means putting `type: "group"` on a property filter, but that field's description named only person and cohort.

The prose contradicted the choices list drf-spectacular renders directly beneath it, which already showed `cohort`, `person`, and `group`.

That string is what every generated client shows for the parameter. It also reaches six MCP tool schemas, so it is what a model reads when deciding whether to set `type` at all.

Refs #46501.

## Changes

- The `type` description names `group` and pairs it with `group_type_index`.
- The `group_type_index` description says to match the condition set's `aggregation_group_type_index`.
- Both read as guidance rather than as stated rules. The cross-field validator that would make them binding runs in log-only mode in production, and `type` stays optional on purpose while that rollout is staged.
- 16 generated files restate the two strings. Mechanical output of `hogli build:openapi` and `vitest run -u`.

Nothing in the product looks different. The only surfaces that change are API reference text, generated client types, and MCP tool schemas.

## How did you test this code?

No manual testing. The change has no runtime behavior, because these serializers are schema-only and never validate a request.

- `hogli build:openapi` regenerated the clients, and re-running it leaves the tree clean.
- No new tests. The regenerated snapshots are the coverage, and `check-openapi-types` fails on any drift.
- One MCP snapshot run failed once and did not reproduce across three later runs. The failing test could not be captured before the output scrolled.

Not checked: anything needing a database or a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The API reference regenerates from these serializers, so it picks up the new text automatically. No separate docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 5).
- Skills invoked: `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/simplify`, `/review-code`, `/reviewing-before-pr`, `/writing-pr-descriptions`, `/plain-writing`, `/create-pr`.
- An earlier draft stated the `group_type_index` rule as a requirement, with "required when type is 'group'" and "must match". I backed both out. The field is optional, the validator that would enforce the match runs in log-only mode in production, and the Rust evaluator resolves a property's own index ahead of its condition's aggregation. The shipped wording is the shape every layer accepts.
- Local review: the Greptile CLI could not install in this sandbox, so the local pass was the harness fallback (`/review-code`, seven agents over the branch diff). It produced one finding, a garden-path sentence in the `group_type_index` text, which is fixed. The independent review is still the bot's, so no `no-greptile` label.
- Public artifact: nothing in this diff, its commits, or this description carries material from the agent session that is not already in this repo.

https://claude.ai/code/session_01Ccq8u3ZawBoidc1ChRd69V