### PR TITLE
fix(google_search_console): retry truncated Search Analytics response bodies

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -376,7 +376,25 @@ def _query_search_analytics(
             continue
 
         if response.ok:
-            return response.json().get("rows", [])
+            try:
+                return response.json().get("rows", [])
+            except requests.exceptions.ChunkedEncodingError:
+                # The body streams via chunked transfer-encoding and can still be cut off
+                # mid-read after a 200 with a good `response` object — a dropped connection
+                # after headers rather than before, so it lands here instead of the
+                # ConnectionError/Timeout handling above. Same transient class; retry inline,
+                # then let Temporal retry the activity once the inline budget is spent.
+                if attempt == QUOTA_MAX_RETRIES:
+                    raise
+                wait = QUOTA_BACKOFF_BASE_SECONDS * (2**attempt)
+                logger.warning(
+                    "GSC response body truncated, backing off",
+                    site_url=site_url,
+                    attempt=attempt,
+                    wait_seconds=wait,
+                )
+                time.sleep(wait)
+                continue
 
         # Surface Google's real reason (e.g. usageLimits/quotaExceeded vs forbidden) —
         # raise_for_status() discards the body where that distinction lives.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -880,6 +880,41 @@ def test_query_read_timeout_bubbles_after_max_retries(monkeypatch):
     assert session.post.call_count == QUOTA_MAX_RETRIES + 1
 
 
+def test_query_retries_truncated_body_then_succeeds(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    truncated = _fake_response(200)
+    truncated.json.side_effect = requests.exceptions.ChunkedEncodingError("Connection broken: IncompleteRead(...)")
+    session = mock.MagicMock()
+    session.post.side_effect = [
+        truncated,
+        _fake_response(200, {"rows": [{"keys": ["2026-04-15"], "clicks": 1}]}),
+    ]
+
+    rows = _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert rows == [{"keys": ["2026-04-15"], "clicks": 1}]
+    assert session.post.call_count == 2
+
+
+def test_query_truncated_body_bubbles_after_max_retries(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    truncated = _fake_response(200)
+    truncated.json.side_effect = requests.exceptions.ChunkedEncodingError("Connection broken: IncompleteRead(...)")
+    session = mock.MagicMock()
+    session.post.return_value = truncated
+
+    # A persistently truncated response body (chunked transfer cut off mid-read) exhausts the
+    # inline budget and surfaces the real ChunkedEncodingError (retryable at the activity level).
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert session.post.call_count == QUOTA_MAX_RETRIES + 1
+
+
 def test_query_retries_transient_token_refresh_error_then_succeeds(monkeypatch):
     monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
     monkeypatch.setattr(gsc, "_throttle", lambda _site: None)


### PR DESCRIPTION
## Problem

A Search Analytics sync failed and surfaced in error tracking as a `ChunkedEncodingError`: the response body was truncated mid-stream while a customer's Google Search Console data synced. See [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a040ba-6c88-7e00-8c96-4153ddd52ee2).

`_query_search_analytics` already retries a dropped connection or a timeout that happens before the response arrives. A connection that drops while the response body is still streaming raises `requests.exceptions.ChunkedEncodingError` instead, which is a sibling exception, not a subclass, of the ones already handled. That error came from a code path with no retry handling at all and bubbled up immediately.

## Changes

- A truncated Search Analytics response body now retries inline with the same backoff as a dropped connection or a timeout, instead of failing the sync on the first blip.
- After the inline retry budget is spent, the error still bubbles up so Temporal retries the whole activity, matching the existing behavior for the other transient cases in this function.

## How did you test this code?

Added two cases mirroring the existing `ConnectionError`/`ReadTimeout` coverage in `test_google_search_console.py`:
- `test_query_retries_truncated_body_then_succeeds` — a truncated body followed by a good response returns the rows, catching a regression where this exception type bypasses the retry loop entirely.
- `test_query_truncated_body_bubbles_after_max_retries` — a persistently truncated body exhausts the inline budget and still raises, so Temporal's activity-level retry stays intact.

Ran the full `google_search_console` test suite locally (`pytest products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/`), plus `ruff check`, `ruff format --check`, and `mypy` on the changed file. Not run: an end-to-end sync against the live Google Search Console API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools to pull the full stack trace and confirm the failure originates in `google_search_console.py`'s `_query_search_analytics`. Used `/writing-tests` before adding test coverage and `/writing-pr-descriptions` before drafting this description. `hogli review` (Greptile) was unavailable in this sandbox (CLI not installed); ran the harness's own `/code-review` (low effort) over the diff as the documented fallback, which found no issues. This PR does not carry the `no-greptile` label since the fallback review does not satisfy that gate — the bot will review as usual.