### PR TITLE
feat(desktop): add direction before report chat

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -133,7 +133,7 @@ describe("ReportVerdictBanner", () => {
     );
   });
 
-  it("starts a discussion and hides the non-selectable actions after creation", async () => {
+  it("starts a discussion with optional direction and hides the actions after creation", async () => {
     const user = userEvent.setup();
     render(<ReportVerdictBanner report={report} initialEngagementOnly />);
 
@@ -141,8 +141,15 @@ describe("ReportVerdictBanner", () => {
     expect(askButton.closest(".select-none")).not.toBeNull();
 
     await user.click(askButton);
+    await user.type(
+      screen.getByLabelText("Optional question for the agent"),
+      "Focus on whether this affects new projects",
+    );
+    await user.click(screen.getByText("Start chat"));
 
-    expect(discussReport).toHaveBeenCalledWith();
+    expect(discussReport).toHaveBeenCalledWith(
+      "Focus on whether this affects new projects",
+    );
     expect(screen.getByText("Ask about it")).toBeInTheDocument();
 
     act(() => onDiscussionCreated?.(discussionTask.task));

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -15,6 +15,9 @@ import {
 import {
   Button,
   cn,
+  Field,
+  FieldDescription,
+  FieldLabel,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -136,8 +139,13 @@ export function ReportVerdictBanner({
 
   const fireAction = useReportActionTracker(report);
   const queryClient = useQueryClient();
+  const [prOpen, setPrOpen] = useState(false);
+  const [prFeedback, setPrFeedback] = useState("");
+  const [askOpen, setAskOpen] = useState(false);
+  const [askQuestion, setAskQuestion] = useState("");
 
   const setChatOpen = useReportChatPanelStore((s) => s.setOpen);
+  const setPendingQuote = useReportChatPanelStore((s) => s.setPendingQuote);
   const rememberStartedTask = useReportChatPanelStore(
     (s) => s.rememberStartedTask,
   );
@@ -150,6 +158,8 @@ export function ReportVerdictBanner({
     (task: Task) => {
       queryClient.setQueryData(taskDetailQuery(task.id).queryKey, task);
       rememberStartedTask(report.id, task.id);
+      setAskOpen(false);
+      setAskQuestion("");
       setEngaged(true);
       setChatOpen(true);
       void queryClient.invalidateQueries({
@@ -176,9 +186,6 @@ export function ReportVerdictBanner({
     redirectOnSuccess: false,
     onTaskCreated: handleTaskCreated,
   });
-
-  const [prOpen, setPrOpen] = useState(false);
-  const [prFeedback, setPrFeedback] = useState("");
 
   // Archive is the "no" beside Fix & monitor's "yes" — a decision, so it lives in
   // the decision row. Offered wherever the report is waiting on a person
@@ -227,21 +234,30 @@ export function ReportVerdictBanner({
     if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
       return;
     }
-    fireAction("discuss", { has_question: false });
+    const trimmed = askQuestion.trim();
+    fireAction("discuss", { has_question: trimmed.length > 0 });
     if (hasPriorEngagement) {
+      if (trimmed) {
+        setPendingQuote(report.id, trimmed);
+      }
+      setAskOpen(false);
+      setAskQuestion("");
       setEngaged(true);
       setChatOpen(true);
       onEngaged?.();
       return;
     }
-    void discussReport();
+    void discussReport(trimmed || undefined);
   }, [
     isCreatingPr,
     isDiscussing,
     awaitingChannel,
     reportTasksLoading,
+    askQuestion,
     fireAction,
     hasPriorEngagement,
+    report.id,
+    setPendingQuote,
     setChatOpen,
     onEngaged,
     discussReport,
@@ -365,20 +381,31 @@ export function ReportVerdictBanner({
             sideOffset={6}
             className="flex w-[420px] flex-col gap-2 p-3"
           >
-            <Textarea
-              aria-label="Optional direction for the agent"
-              autoFocus
-              placeholder="Add direction for the agent (optional)…"
-              rows={4}
-              value={prFeedback}
-              onChange={(event) => setPrFeedback(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                  event.preventDefault();
-                  handleCreatePr();
-                }
-              }}
-            />
+            <Field>
+              <FieldLabel
+                className="sr-only"
+                htmlFor={`report-fix-direction-${report.id}`}
+              >
+                Optional direction for the agent
+              </FieldLabel>
+              <Textarea
+                id={`report-fix-direction-${report.id}`}
+                autoFocus
+                placeholder="Add direction for the agent (optional)…"
+                rows={4}
+                value={prFeedback}
+                onChange={(event) => setPrFeedback(event.target.value)}
+                onKeyDown={(event) => {
+                  if (
+                    event.key === "Enter" &&
+                    (event.metaKey || event.ctrlKey)
+                  ) {
+                    event.preventDefault();
+                    handleCreatePr();
+                  }
+                }}
+              />
+            </Field>
             <div className="flex items-center justify-between gap-2">
               <span className="text-[12px] text-gray-10">
                 {isMac ? "⌘↵" : "Ctrl+↵"} to start
@@ -387,6 +414,7 @@ export function ReportVerdictBanner({
                 type="button"
                 variant="primary"
                 size="sm"
+                loading={isCreatingPr}
                 disabled={isCreatingPr || isDiscussing}
                 onClick={handleCreatePr}
               >
@@ -396,19 +424,84 @@ export function ReportVerdictBanner({
           </PopoverContent>
         </Popover>
       ) : null}
-      <Button
-        type="button"
-        variant="outline"
-        loading={isDiscussing}
-        disabled={
-          isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading
-        }
-        onClick={handleAsk}
-        className={buttonClass}
+      <Popover
+        open={askOpen}
+        onOpenChange={(next) => {
+          setAskOpen(next);
+          if (!next && !isDiscussing) setAskQuestion("");
+        }}
       >
-        <ChatCircleIcon size={16} />
-        Ask about it
-      </Button>
+        <PopoverTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              disabled={
+                isCreatingPr ||
+                isDiscussing ||
+                awaitingChannel ||
+                reportTasksLoading
+              }
+              className={buttonClass}
+            >
+              <ChatCircleIcon size={16} />
+              Ask about it
+            </Button>
+          }
+        />
+        <PopoverContent
+          align="start"
+          side="bottom"
+          sideOffset={6}
+          className="flex w-[420px] flex-col gap-2 p-3"
+        >
+          <Field>
+            <FieldLabel
+              className="sr-only"
+              htmlFor={`report-question-${report.id}`}
+            >
+              Optional question for the agent
+            </FieldLabel>
+            <Textarea
+              id={`report-question-${report.id}`}
+              autoFocus
+              placeholder="Ask a question or add direction (optional)…"
+              rows={4}
+              value={askQuestion}
+              onChange={(event) => setAskQuestion(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  handleAsk();
+                }
+              }}
+            />
+            <FieldDescription>
+              The full report and its evidence are included.
+            </FieldDescription>
+          </Field>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[12px] text-gray-10">
+              {isMac ? "⌘↵" : "Ctrl+↵"} to start
+            </span>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              loading={isDiscussing}
+              disabled={
+                isCreatingPr ||
+                isDiscussing ||
+                awaitingChannel ||
+                reportTasksLoading
+              }
+              onClick={handleAsk}
+            >
+              Start chat
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
       {canArchiveHere && !compact && (
         <Tooltip>
           <TooltipTrigger


### PR DESCRIPTION
## Problem

People cannot add direction before starting a report chat from the action box.

This follows [#89558](https://github.com/PostHog/posthog/pull/89558) and depends on the Defer backend fix in [#89803](https://github.com/PostHog/posthog/pull/89803).

## Changes

- Ask about it now accepts an optional question before starting chat. The full report and evidence remain included as context.
- Screenshot omitted because this environment has no authenticated report session.

## How did you test this code?

- Updated UI coverage verifies that optional direction reaches the new discussion and the action box retires after task creation.
- The affected UI test and UI typecheck pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The backend layer updates its Signals architecture reference.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex worked through PostHog Desktop. Skills used: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/reviewing-before-pr`, and `/stacking-prs`.

The backend change moved into the lower stack layer after review feedback. The local Greptile CLI was unavailable, so this PR keeps the normal bot review enabled.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*