### PR TITLE
fix(signals): allow deferring pending and failed reports

### DIFF
--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -388,7 +388,8 @@ suppressed → resolved (resolve an archived report straight out of the archive;
 # - suppressed transitions back to potential, or straight to the researched status it held before
 #   being archived (ready | pending_input | resolved | failed) — see restore_target_status()
 # - any non-deleted status can transition to deleted or suppressed
-# - snooze = transition to potential with snooze_for=N (sets signals_at_run = signal_count + N)
+# - reset/snooze = transition in_progress | pending_input | ready | resolved | failed → potential;
+#   snooze_for=N sets signals_at_run = signal_count + N
 suppressed → potential
 any (except deleted) → deleted
 any (except deleted) → suppressed

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -368,8 +368,8 @@ class SignalReport(UUIDModel):
                 self.error = error
                 updated_fields.update(["title", "summary", "error"])
 
-            # Reset to potential (from in_progress via actionability judge, from suppressed, or by user snooze on a ready report)
-            case (S.IN_PROGRESS | S.SUPPRESSED | S.READY | S.RESOLVED, S.POTENTIAL):
+            # Reset to potential (from in_progress via actionability judge, from suppressed, or by user snooze)
+            case (S.IN_PROGRESS | S.PENDING_INPUT | S.SUPPRESSED | S.READY | S.RESOLVED | S.FAILED, S.POTENTIAL):
                 self.promoted_at = None
                 updated_fields.add("promoted_at")
                 if self.status == S.SUPPRESSED:

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -1641,9 +1641,16 @@ class TestSignalReportSuppressionAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_snooze_for_delays_repromotion(self):
+    @parameterized.expand(
+        [
+            ("ready", SignalReport.Status.READY),
+            ("pending_input", SignalReport.Status.PENDING_INPUT),
+            ("failed", SignalReport.Status.FAILED),
+        ]
+    )
+    def test_snooze_for_delays_repromotion(self, _name, initial_status):
         report = SignalReport.objects.create(
-            team=self.team, status=SignalReport.Status.READY, title="t", summary="s", signal_count=5
+            team=self.team, status=initial_status, title="t", summary="s", signal_count=5
         )
         response = self.client.post(
             self._state_url(str(report.id)),


### PR DESCRIPTION
## Problem

Defer fails when someone uses it on a report awaiting input or marked failed.

The desktop already sends the same snooze request for these states, but the Signals state machine rejects both transitions.

## Changes

- Snoozing now returns ready, awaiting-input, and failed reports to the potential state until new evidence arrives.
- The Signals architecture reference documents the supported reset and snooze transitions.
- The desktop follow-up is stacked in [#89800](https://github.com/PostHog/posthog/pull/89800).

## How did you test this code?

- Extended API coverage guards snoozing across ready, awaiting-input, and failed reports.
- Python formatting, lint, and preflight pass. The database-backed test needs Postgres and will run in CI.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the Signals architecture reference with the supported reset and snooze transitions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex worked through PostHog Desktop. Skills used: `/posthog-desktop`, `/writing-tests`, `/writing-pr-descriptions`, `/reviewing-before-pr`, and `/stacking-prs`.

The local Greptile CLI was unavailable. A fallback diff review verified the state transition and corrected its documentation; the PR keeps the normal bot review enabled.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*