### PR TITLE
feat(warehouse_sources): promote OpenAI source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai/source.py
@@ -47,7 +47,7 @@ class OpenAISource(ResumableSource[OpenAISourceConfig, OpenAIResumeConfig]):
             name=SchemaExternalDataSourceType.OPEN_AI,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="OpenAI",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             caption="""Enter your OpenAI Admin API key to pull your organization's API usage, cost, and admin data into the PostHog Data warehouse.
 
 Create an Admin API key (prefixed `sk-admin...`) in your [OpenAI organization settings](https://platform.openai.com/settings/organization/admin-keys). Only organization owners can create one; a regular project API key cannot read organization usage or costs.""",


### PR DESCRIPTION
## Problem

The OpenAI data-warehouse source has been in Alpha since it launched. Alpha signals "new, lightly tested," which understates how much it is now used. People connecting OpenAI see an Alpha label that no longer reflects the connector's maturity.

## Changes

- The OpenAI source now shows a **Beta** label in the new-source wizard instead of Alpha.
- Mechanical: single `releaseStatus` value change from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` in the source config. No feature flag or other gating is attached to this source, so nothing else changes.

It qualifies on current 7-day metrics:

- Used by at least 30 teams (need ≥ 30).
- Import error rate below 5% (need < 5%).

Connector behavior, schemas, and sync logic are untouched — this is a status promotion only.

## How did you test this code?

No new behavior to test — `releaseStatus` is a display label read at runtime from `get_source_config`, not part of the generated configs or sync path. No existing test asserts the source's release status, so nothing regresses. Relied on CI for the standard source-registry and schema checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change — the source doc does not state a release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Automated promotion of a warehouse source's release stage. Invoked the `/implementing-warehouse-sources` skill to confirm where release status lives and the `ReleaseStatus` enum convention. The change is a one-line status flip; no customer or session data is present in this diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
