### PR TITLE
feat(workflows): make SES tenant attribution unconditional

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -148,7 +148,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'SES_ENDPOINT'
         | 'SES_TRACKED_CONFIGURATION_SET'
         | 'SES_UNTRACKED_CONFIGURATION_SET'
-        | 'EMAIL_SES_TENANT_ATTRIBUTION_ENABLED'
         | 'EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD'
         | 'CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN'
         | 'CDP_FETCH_RETRIES'
@@ -421,7 +420,6 @@ export function createCdpCoreServices(
             sesEndpoint: config.SES_ENDPOINT,
             sesTrackedConfigurationSet: config.SES_TRACKED_CONFIGURATION_SET,
             sesUntrackedConfigurationSet: config.SES_UNTRACKED_CONFIGURATION_SET,
-            sesTenantAttributionEnabled: config.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
         },
         deps.integrationManager,
         teamWorkflowsConfigService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -135,11 +135,6 @@ export type CdpConfig = ClickhouseConfig & {
     // Comma-separated allowlist of SNS Topic ARNs the SES webhook accepts events from. Empty string
     // means no restriction (dev/test); production should set this to the workflow SES topic ARN(s).
     SES_ALLOWED_SNS_TOPIC_ARNS: string
-    // When true, sends carry TenantName (team-<team_id>) so SES attributes reputation per team
-    // and its Standard reputation policy can pause a single tenant instead of the shared account.
-    // Off by default: a send naming a tenant whose identity association is missing fails, so this
-    // flips on only after tenant coverage is verified (migrate_ses_tenants --dry-run comes back empty).
-    EMAIL_SES_TENANT_ATTRIBUTION_ENABLED: boolean
 
     // Consecutive soft bounces before an address is auto-suppressed. Tunable without a deploy.
     EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD: number
@@ -311,7 +306,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         SES_TRACKED_CONFIGURATION_SET: 'posthog-messaging',
         SES_UNTRACKED_CONFIGURATION_SET: '',
         SES_ALLOWED_SNS_TOPIC_ARNS: '',
-        EMAIL_SES_TENANT_ATTRIBUTION_ENABLED: false,
         EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD: 5,
 
         // Destination migration diffing

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -73,7 +73,6 @@ describe('Hog Executor', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
-                sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -62,7 +62,6 @@ describe('HogFunctionHandler', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
-                sesTenantAttributionEnabled: false,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.serial.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.serial.test.ts
@@ -81,7 +81,6 @@ describe('Hogflow Executor', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
-                sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -105,7 +105,6 @@ describe('EmailService', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
-                sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),
@@ -130,7 +129,6 @@ describe('EmailService', () => {
                     sesEndpoint: '',
                     sesTrackedConfigurationSet: 'posthog-messaging',
                     sesUntrackedConfigurationSet: '',
-                    sesTenantAttributionEnabled: false,
                 },
                 hub.integrationManager,
                 new TeamWorkflowsConfigService(hub.postgres),
@@ -486,7 +484,6 @@ describe('EmailService', () => {
                         sesEndpoint: hub.SES_ENDPOINT,
                         sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                         sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
-                        sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
                     },
                     hub.integrationManager,
                     new TeamWorkflowsConfigService(hub.postgres),
@@ -731,8 +728,7 @@ describe('EmailService', () => {
         })
 
         describe('SES tenant attribution', () => {
-            it('attributes the send to the team tenant when enabled', async () => {
-                service['sesConfig'].sesTenantAttributionEnabled = true
+            it('attributes the send to the team tenant', async () => {
                 sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
 
                 const result = await service.executeSendEmail(invocation)
@@ -742,18 +738,7 @@ describe('EmailService', () => {
                 expect(sentCommand.input.TenantName).toEqual(`team-${team.id}`)
             })
 
-            it('omits TenantName by default (flag off)', async () => {
-                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
-
-                const result = await service.executeSendEmail(invocation)
-
-                expect(result.error).toBeUndefined()
-                const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
-                expect(sentCommand.input.TenantName).toBeUndefined()
-            })
-
             it('attributes test-panel sends too — they are real SES sends', async () => {
-                service['sesConfig'].sesTenantAttributionEnabled = true
                 sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
 
                 const result = await service.executeSendEmail(invocation, true)

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -117,9 +117,6 @@ export interface EmailServiceConfig {
     // Configuration set without open/click tracking. Empty means not provisioned: tracking-off
     // sends fall back to the tracked set (with a warning) rather than failing.
     sesUntrackedConfigurationSet: string
-    // When true, sends carry TenantName so SES attributes reputation per team. Requires every
-    // sending identity to have a tenant resource association — see EMAIL_SES_TENANT_ATTRIBUTION_ENABLED.
-    sesTenantAttributionEnabled: boolean
 }
 
 /**
@@ -730,19 +727,17 @@ export class EmailService {
             FeedbackForwardingEmailAddress: from.email,
         }
 
-        if (this.sesConfig.sesTenantAttributionEnabled) {
-            // Attributes the send to the team's SES tenant so AWS tracks reputation per team and
-            // its reputation policy can pause one tenant instead of the shared account. `team-<id>`
-            // is the provisioning convention (products/workflows/backend/providers/ses.py and
-            // posthog/management/commands/migrate_ses_tenants.py). Deliberately NOT gated on
-            // isTest: test-panel sends are real over-the-wire SES sends, so leaving them
-            // unattributed would (a) push their bounces onto the shared account's reputation and
-            // (b) let a paused tenant keep sending via "Run test". The isTest skips elsewhere in
-            // this class only shield our internal metrics, a separate concern from SES-side
-            // attribution; test volume is far below the representative volume AWS needs for a
-            // reputation finding.
-            sendEmailParams.TenantName = `team-${result.invocation.teamId}`
-        }
+        // Attributes the send to the team's SES tenant so AWS tracks reputation per team and
+        // its reputation policy can pause one tenant instead of the shared account. `team-<id>`
+        // is the provisioning convention (products/workflows/backend/providers/ses.py and
+        // posthog/management/commands/migrate_ses_tenants.py). Deliberately NOT gated on
+        // isTest: test-panel sends are real over-the-wire SES sends, so leaving them
+        // unattributed would (a) push their bounces onto the shared account's reputation and
+        // (b) let a paused tenant keep sending via "Run test". The isTest skips elsewhere in
+        // this class only shield our internal metrics, a separate concern from SES-side
+        // attribution; test volume is far below the representative volume AWS needs for a
+        // reputation finding.
+        sendEmailParams.TenantName = `team-${result.invocation.teamId}`
 
         // Authoritative tracking-code carrier: a custom MIME header. Header values aren't
         // 256-char-bounded the way SES tag values are, so they safely carry the signed code

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -205,7 +205,6 @@ export class TemplateTester {
                 sesEndpoint: config.SES_ENDPOINT,
                 sesTrackedConfigurationSet: config.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: config.SES_UNTRACKED_CONFIGURATION_SET,
-                sesTenantAttributionEnabled: false,
             },
             undefined as any,
             undefined as any,


### PR DESCRIPTION
## Problem

A deployment that misses one env var silently loses per-team SES reputation isolation: sends carry no tenant name, AWS records no tenant reputation entity, opens no findings, and never auto-pauses an offending team. The shared account absorbs the damage.

Tenant attribution shipped behind `EMAIL_SES_TENANT_ATTRIBUTION_ENABLED` (default `false`) as a rollout gate. It is verified on in production, so the flag's only remaining behavior is that silent off state.

## Changes

- Every SES send now carries `TenantName` (`team-<team id>`), including editor test sends. Cloud behavior is unchanged: both production deployments already run with the flag on.
- The config key and its `sesTenantAttributionEnabled` plumbing are removed (mechanical).

> [!WARNING]
> A deployment whose SES identities lack tenant resource associations now fails those sends instead of sending unattributed. The `migrate_ses_tenants` management command provisions the associations.

A companion PostHog/charts PR removes the now-dead env var from the two deployments. It must merge only after this change deploys; the link follows in a comment once it exists.

## How did you test this code?

- The four touched Jest suites pass locally against the dev stack (parallel and serial configs).
- The "omits TenantName by default" test is deleted rather than inverted: the flag-off behavior no longer exists, and the two remaining cases already assert `TenantName` on regular and test-panel sends.
- Not run: the full CI matrix (draft). `tsc` on the nodejs workspace reports only pre-existing errors from the unbuilt `@posthog/replay-anonymizer` native module, untouched here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no docs reference the flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code via a PostHog Desktop session; the driver's GitHub handle was not verifiable from the session, so the PR is unassigned.
- Skills invoked: /writing-tests, /writing-pr-descriptions, /reviewing-before-pr, /code-review.
- Local review: `hogli review` could not run in this sandbox (no Greptile CLI or API key), so the local pass was the harness fallback review over the branch diff — no findings. The bot review still applies.
- Also ran locally: prettier and eslint on the changed files, `hogli ci:preflight --fix` (0 failures).
- Session origin: an investigation into SES tenant reputation enforcement concluded the rollout flag should go, with attribution always on.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
