### PR TITLE
chore(devex): skip test reporting when no test ran

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -19,7 +19,8 @@
 #   auto-commit (handle-snapshots), posthog-github-action telemetry (including the
 #   capture-test-selection job — turbo-discover still emits its telemetry outputs to
 #   stay apples-to-apples, they just have no consumer here),
-#   --store-durations write, test-selection verdict, Trunk flaky-test quarantine
+#   --store-durations write, test-selection verdict (so the guard skipping it when both
+#   test matrices were skipped has nothing to mirror), Trunk flaky-test quarantine
 #   gate (canonical runs per-shard analytics-uploader steps that post to the
 #   external Trunk service; the upload is best-effort and a local "Fail on test
 #   failure" step owns the pass/fail verdict. The shadow strips all of it — no
@@ -41,7 +42,9 @@
 #   changes confined to it (script deps, the reporter's availability guard, emission secret
 #   plumbing such as dual-project tokens, the JUnit-artifact download pattern, re-run attempt
 #   handling — including the attempt-suffixed junit artifact names canonical uploads so the
-#   reporter can pair re-run recoveries with attempt-1 failures) need no depot bump.
+#   reporter can pair re-run recoveries with attempt-1 failures, and the guard that skips the
+#   job when both test matrices were skipped, with the needs: entries that feed it) need no
+#   depot bump.
 # - mirror-schema-cache: canonical's master run copies the migrated schema dump out of the
 #   migrated-schema artifact into GitHub Actions Cache, so fork PRs (which run without
 #   secrets and cannot authenticate to Depot Cache) prime instead of migrating from scratch.

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3843,8 +3843,15 @@ jobs:
     test-selection-verdict:
         needs: [django, turbo-tests, changes, turbo-discover]
         name: Test selection verdict
-        # changes is skipped on no-ci drafts — no tests ran, nothing to verdict.
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.changes.result != 'skipped' }}
+        # The verdict scores the selection against the JUnit a run produced, so it needs
+        # a test job to have run. changes is skipped on no-ci drafts. Both matrices are
+        # skipped on a draft whose selection was untrusted, which defers to the ready run
+        # — there is no selection to score and no JUnit to score it against. The decision
+        # itself is still recorded, by capture-test-selection.
+        if: >-
+            !cancelled() && github.event_name == 'pull_request' &&
+            needs.changes.result != 'skipped' &&
+            (needs.django.result != 'skipped' || needs.turbo-tests.result != 'skipped')
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:
@@ -4008,7 +4015,9 @@ jobs:
 
     report-test-timings:
         name: Report per-test traces
-        needs: [django_tests]
+        # django and turbo-tests are here for their results only; django_tests already
+        # waits for both, so this adds no wall time.
+        needs: [django_tests, django, turbo-tests]
         runs-on: ubuntu-latest
         continue-on-error: true
         timeout-minutes: 10
@@ -4016,9 +4025,13 @@ jobs:
         # flake proof the test-health queue reads, and the shards a re-run re-executed upload under
         # attempt-suffixed artifact names so only they are emitted for the new attempt.
         # Master pushes and all in-repo PRs. Skip forks (no secrets access).
+        # Both matrices skipped means no JUnit was uploaded, so there are no traces to
+        # emit. This job sits on the tail of the run, so skipping it takes its whole
+        # duration off the wall of a draft that ran no tests.
         if: >-
             !cancelled() &&
             github.repository == 'PostHog/posthog' &&
+            (needs.django.result != 'skipped' || needs.turbo-tests.result != 'skipped') &&
             (
             (github.event_name != 'pull_request' && github.ref == 'refs/heads/master') ||
             (github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Problem

Backend CI keeps a draft PR waiting about a minute at the end of a run that executed no tests at all.

A draft whose test selection cannot be trusted skips both the Django and the product matrices and defers to the ready-for-review run. Two reporting jobs do not know that and run anyway.

- `report-test-timings` downloads no JUnit and emits no traces. It sits after the `Django Tests Pass` gate, so its whole duration lands on the wall.
- `test-selection-verdict` regenerates a selection and scores it against JUnit that does not exist. That costs about two minutes of runner time.

[This run](https://github.com/PostHog/posthog/actions/runs/33008467049) is the shape: 5m45 wall, and the traces job is the last minute of it.

## Changes

- Backend CI now ends about a minute earlier on a draft that ran no tests.
- `report-test-timings` and `test-selection-verdict` skip when both matrices were skipped.
- The selection decision is still recorded. `capture-test-selection` reports the mode and the skip reason, and already gates on an empty mode.
- Mechanical: `django` and `turbo-tests` join the `needs` of `report-test-timings` for their results. `django_tests` already waits for both, so this adds no wall time.
- Mechanical: the Depot shadow strips both jobs, so only its header note changes.

Nothing in the product looks different. This changes CI wiring only.

Before, on a draft that ran no tests:

```mermaid
flowchart LR
    D[Django matrix<br/>skipped] --> G{{Django Tests Pass}}
    P[Product matrix<br/>skipped] --> G
    D --> V[Test selection verdict<br/>runs]
    P --> V
    G --> T[Report per-test traces<br/>runs]
    T --> E[Run ends]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D,P phGray;
    class G phBlue;
    class V,T phRed;
    class E phYellow;
```

After:

```mermaid
flowchart LR
    D[Django matrix<br/>skipped] --> G{{Django Tests Pass}}
    P[Product matrix<br/>skipped] --> G
    D --> V[Test selection verdict<br/>skipped]
    P --> V
    G --> T[Report per-test traces<br/>skipped]
    G --> E[Run ends]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D,P,V,T phGray;
    class G phBlue;
    class E phYellow;
```

## How did you test this code?

No test covers a workflow condition, so this PR is its own two-stage check.

- As a draft, both matrices skip, so both reporting jobs must show as skipped and the run must end at the gate.
- Marking it ready runs the matrices, so both jobs must run and report as they do today.

Local linters pass, including the Depot shadow-drift check. `actionlint` reports no finding that master does not already report.

Not run: nothing here can be exercised outside GitHub Actions.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code. Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`, `/reviewing-before-pr`, `/babysit-pr`.

The session started from a wider list of waste in draft runs and dropped two candidates after checking the repo. Caching the OpenAPI gate fails because generation is not a pure function of the source tree: it is not idempotent across environments, and an enum added in one product renames another product's generated enum, so the key would cover the whole tree and miss on every backend PR. Gating the migration replay on the `migrations` paths filter fails because `uv.lock` is already part of the migration set, since a dependency bump can carry third-party migrations. Both jobs were left alone.

`hogli review` could not run, because the Greptile CLI is absent from this environment. The local pass was the harness fallback (`/code-review`) over the branch diff, and it reported no finding. The independent review is still the PR bot's.
