### PR TITLE
chore(semgrep): exclude replay vision migrations from alert state rule

### DIFF
--- a/.semgrep/rules/security/alert-state-must-go-through-state-machine.yaml
+++ b/.semgrep/rules/security/alert-state-must-go-through-state-machine.yaml
@@ -58,6 +58,9 @@ rules:
               - '/products/replay_vision/backend/**/test_*.py'
               # Mutates HogFunction.enabled (delivery plumbing), not an alert.
               - '/products/replay_vision/backend/api/delivery.py'
+              # Migrations mutate historical models from apps.get_model, so they
+              # cannot call the state machine.
+              - '/products/replay_vision/backend/migrations/**'
 
     - id: billing-alert-state-direct-mutation
       patterns:


### PR DESCRIPTION
## Problem

Master's Security workflow fails on every commit, so a red Security run no longer tells anyone whether a real finding landed.

- The `replay-vision-alert-state-direct-mutation` semgrep rule includes every `.py` file under `products/replay_vision/backend`, which sweeps in the migrations directory.
- Migration `0057_closed_beta_launch_reset` disables `ReplayScanner` rows with `scanners.update(enabled=False)`. A scanner is not an alert, so the finding is wrong.
- The rule arrived in #88403 and the next master commit failed. Every Security run since has failed on the same single blocking finding ([example run](https://github.com/PostHog/posthog/actions/runs/33045043931)).

## Changes

- The rule now skips `products/replay_vision/backend/migrations/**`, so Security passes on master again.
- Migrations act on historical models from `apps.get_model`, so they can never route a write through the state machine. The rule cannot hold there.
- The rule's patterns stay unchanged. It still blocks alert lifecycle mutations everywhere else under `products/replay_vision/backend`.
- The sibling `logs` and `billing_alerts` rules share the same include shape, but no migration trips them today, so they stay unchanged.
- No product code changes. The diff is three lines of semgrep path config.

## How did you test this code?

Verified with semgrep 1.175.0 in the sandbox. No manual app testing, and no CI run on this branch yet.

- Before the change, the rule reports 1 blocking finding on `products/replay_vision/backend/migrations/`, matching the CI failure above.
- After the change, the rule reports 0 findings across `products/replay_vision/backend/`.
- A scratch file holding `queryset.update(enabled=False)` outside the migrations directory still trips the rule, so the exclusion stays scoped.
- `hogli ci:preflight` maps nothing in this diff to a known CI failure class.

No test added. The rule's `# ruleid:` fixture in `.semgrep/rules/security/tests/` covers its patterns, and no CI job runs a harness over those fixtures, so a fixture cannot exercise a path exclusion.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread after the DevEx bot reported master red for over six hours. The PostHog Slack app diagnosed the failure from the `semgrep-python` job log, traced the rule to #88403 and the flagged migration to its own earlier PR, then reproduced and fixed it locally.

Skills invoked: `/writing-pr-descriptions`, `/reviewing-before-pr`.

The PR is unassigned because the requester's GitHub handle could not be verified from Slack. Please assign the DRI.

Local review receipt: `hogli review` could not run, as this sandbox has no Greptile CLI and no `GREPTILE_API_KEY`. The `no-greptile` label is deliberately absent, so the PR bot's review still applies.

An alternative fix was a `# nosemgrep` comment on the migration line. The path exclusion won because it also covers the next replay vision migration that touches an `enabled` column.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1787793184208729?thread_ts=1787793184.208729&cid=C0AS64N6DJL)*
