### PR TITLE
fix(signals): label the scout detail link to its skill

### DIFF
--- a/products/signals/frontend/inbox/components/config/scouts/ScoutDetailHeader.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutDetailHeader.tsx
@@ -131,14 +131,15 @@ export function ScoutDetailHeader({
                         })
                     }
                 >
-                    <Tooltip title="Open the skill that defines what this scout does">
+                    <Tooltip title="A scout is defined by its skill: editable instructions for what it watches and reports.">
                         <LemonButton
                             type="secondary"
                             size="small"
                             icon={<IconExternal />}
                             to={urls.skill(config.skill_name)}
-                            aria-label={`Open the ${config.skill_name} skill`}
-                        />
+                        >
+                            View skill
+                        </LemonButton>
                     </Tooltip>
                 </span>
                 <ScoutEnabledSwitch config={config} onUpdate={updateScoutConfig} updating={updating} />


### PR DESCRIPTION
## Problem

On the scout detail page in the Signals inbox, the link to the skill that defines the scout is a bare external-link icon.
Users cannot tell that the scout's editable definition is one click away.
A scout is defined by its skill, and the page showed no words about that relationship.

## Changes

- The skill link in the scout detail header now reads "View skill" next to the external-link icon.
- Its tooltip now explains the relationship: "A scout is defined by its skill: editable instructions for what it watches and reports."
- "Edit skill" reads truer for custom scouts but nudges edits to canonical ones, so the label is "View skill"; flipping it is a one-word change.
- Mechanical: the visible label replaces the aria-label; the link target and analytics capture are unchanged.
- No screenshot: copy only, no logic touched. The button renders like the labeled "Run now" button beside it.

## How did you test this code?

- No jest test renders this header, and none referenced the old tooltip or aria-label, so no test changes.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) left the diff unchanged.
- Not run: the repo-wide TypeScript check and a browser render of the page.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no doc references this button or its tooltip.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5) authored the change in [this session](https://claude.ai/code/session_01EztVa97HewBMNkhbGuocU9).
- Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions, /code-review.
- Local review: Greptile sign-in was unavailable in this session, so the harness /code-review fallback ran with no findings; the bot review still applies.
- The session's one open decision was the "View" vs "Edit" label, recorded in Changes.
