### PR TITLE
fix(ingestion): stop blocking merges on the remaining warning acks

### DIFF
--- a/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
@@ -5,7 +5,7 @@ import { InternalPerson } from '~/types'
 
 import { PersonContext } from './person-context'
 import { PersonMergeService } from './person-merge-service'
-import { createDefaultSyncMergeMode } from './person-merge-types'
+import { PersonMergeResult, createDefaultSyncMergeMode } from './person-merge-types'
 
 describe('PersonMergeService', () => {
     let teamCounter = 1000
@@ -26,30 +26,69 @@ describe('PersonMergeService', () => {
         }
     }
 
+    let teamId: number
+    let queueMessages: jest.Mock
+
+    beforeEach(() => {
+        teamId = teamCounter++
+        queueMessages = jest.fn().mockResolvedValue(undefined)
+    })
+
+    function service(targetDistinctId: string): PersonMergeService {
+        const context = new PersonContext(
+            { uuid: 'event-uuid', event: '$identify', distinct_id: targetDistinctId, properties: {} } as any,
+            { id: teamId } as any,
+            targetDistinctId,
+            DateTime.now(),
+            true,
+            { queueMessages } as any,
+            {} as any,
+            0,
+            createDefaultSyncMergeMode(),
+            false,
+            false
+        )
+        return new PersonMergeService(context)
+    }
+
+    describe('merge with an illegal distinct id', () => {
+        it.each([
+            ['target', 'null', 'user'],
+            ['source', 'user', 'null'],
+        ])(
+            'returns before the %s warning is acked and hands the ack back as kafkaAck',
+            async (_side, mergeIntoDistinctId, otherPersonDistinctId) => {
+                let ackWarning!: () => void
+                queueMessages.mockReturnValue(new Promise<void>((resolve) => (ackWarning = resolve)))
+
+                const result = await service(mergeIntoDistinctId).merge(
+                    otherPersonDistinctId,
+                    mergeIntoDistinctId,
+                    teamId,
+                    DateTime.now()
+                )
+
+                expect(result).toMatchObject({ success: true, person: undefined, needsPersonUpdate: true })
+                if (!result.success) {
+                    throw new Error('unreachable')
+                }
+                expect(queueMessages).toHaveBeenCalledWith(INGESTION_WARNINGS_OUTPUT, [{ value: expect.any(Buffer) }])
+
+                let acked = false
+                void result.kafkaAck.then(() => (acked = true))
+                await Promise.resolve()
+                expect(acked).toBe(false)
+
+                ackWarning()
+                await result.kafkaAck
+                expect(acked).toBe(true)
+            }
+        )
+    })
+
     describe('mergePeople with an already identified source', () => {
-        let teamId: number
-        let queueMessages: jest.Mock
-
-        beforeEach(() => {
-            teamId = teamCounter++
-            queueMessages = jest.fn().mockResolvedValue(undefined)
-        })
-
-        function refuseMerge(targetDistinctId: string) {
-            const context = new PersonContext(
-                { uuid: 'event-uuid', event: '$identify', distinct_id: targetDistinctId, properties: {} } as any,
-                { id: teamId } as any,
-                targetDistinctId,
-                DateTime.now(),
-                true,
-                { queueMessages } as any,
-                {} as any,
-                0,
-                createDefaultSyncMergeMode(),
-                false,
-                false
-            )
-            return new PersonMergeService(context).mergePeople({
+        function refuseMerge(targetDistinctId: string): Promise<PersonMergeResult> {
+            return service(targetDistinctId).mergePeople({
                 mergeInto: person('target-uuid', true, teamId),
                 mergeIntoDistinctId: targetDistinctId,
                 otherPerson: person('source-uuid', true, teamId),

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -163,7 +163,7 @@ export class PersonMergeService {
                 // The counter is the rollout's drop-rate signal; the warning is debounced by
                 // the standard limiter so a long-held claim cannot flood the warnings topic.
                 mergeClaimDroppedCounter.labels({ call: this.context.event.event }).inc()
-                await emitIngestionWarning(this.context.outputs, this.context.team.id, {
+                const warningAck = emitIngestionWarning(this.context.outputs, this.context.team.id, {
                     type: 'merge_race_condition',
                     details: {
                         distinctId: this.context.distinctId,
@@ -174,12 +174,12 @@ export class PersonMergeService {
                         targetPersonDistinctId: this.context.distinctId,
                     },
                     pipelineStep: 'person-merge',
-                })
+                }).then(() => undefined)
                 logger.warn('🤔', 'merge dropped: person claimed by a concurrent lifecycle operation', {
                     team_id: this.context.team.id,
                     distinctId: this.context.distinctId,
                 })
-                return mergeSuccess(undefined, Promise.resolve(), true)
+                return mergeSuccess(undefined, warningAck, true)
             }
             captureException(e, {
                 tags: { team_id: this.context.team.id, pipeline_step: 'processPersonsStep' },
@@ -218,7 +218,7 @@ export class PersonMergeService {
             return mergeSuccess(undefined, Promise.resolve(), true)
         }
         if (isDistinctIdIllegal(mergeIntoDistinctId)) {
-            await emitIngestionWarning(this.context.outputs, teamId, {
+            const warningAck = emitIngestionWarning(this.context.outputs, teamId, {
                 type: 'cannot_merge_with_illegal_distinct_id',
                 details: {
                     illegalDistinctId: mergeIntoDistinctId,
@@ -228,11 +228,11 @@ export class PersonMergeService {
                 },
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
-            })
-            return mergeSuccess(undefined, Promise.resolve(), true)
+            }).then(() => undefined)
+            return mergeSuccess(undefined, warningAck, true)
         }
         if (isDistinctIdIllegal(otherPersonDistinctId)) {
-            await emitIngestionWarning(this.context.outputs, teamId, {
+            const warningAck = emitIngestionWarning(this.context.outputs, teamId, {
                 type: 'cannot_merge_with_illegal_distinct_id',
                 details: {
                     illegalDistinctId: otherPersonDistinctId,
@@ -242,8 +242,8 @@ export class PersonMergeService {
                 },
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
-            })
-            return mergeSuccess(undefined, Promise.resolve(), true)
+            }).then(() => undefined)
+            return mergeSuccess(undefined, warningAck, true)
         }
 
         const result = await promiseRetry(
@@ -513,19 +513,24 @@ export class PersonMergeService {
         const mergeSources: InternalPerson[] = []
         const seenSourceIds = new Set<string>([target.id])
         const missingPairs: MergeFoldPair[] = []
+        // Warning produces are awaited at batch end through the result's kafkaAck,
+        // not here, so a plan full of refused pairs does not serialize round-trips.
+        const warningAcks: Promise<boolean>[] = []
         for (const pair of pairsToFold) {
             if (isDistinctIdIllegal(pair.anonDistinctId)) {
-                await emitIngestionWarning(this.context.outputs, teamId, {
-                    type: 'cannot_merge_with_illegal_distinct_id',
-                    details: {
-                        illegalDistinctId: pair.anonDistinctId,
-                        otherDistinctId: plan.targetDistinctId,
-                        distinctId: plan.targetDistinctId,
-                        eventUuid: pair.eventUuid,
-                    },
-                    pipelineStep: 'person-merge',
-                    alwaysSend: true,
-                })
+                warningAcks.push(
+                    emitIngestionWarning(this.context.outputs, teamId, {
+                        type: 'cannot_merge_with_illegal_distinct_id',
+                        details: {
+                            illegalDistinctId: pair.anonDistinctId,
+                            otherDistinctId: plan.targetDistinctId,
+                            distinctId: plan.targetDistinctId,
+                            eventUuid: pair.eventUuid,
+                        },
+                        pipelineStep: 'person-merge',
+                        alwaysSend: true,
+                    })
+                )
                 continue
             }
             const source = sourceByDistinctId.get(pair.anonDistinctId)
@@ -539,29 +544,32 @@ export class PersonMergeService {
             if (source.is_identified) {
                 // $identify never merges an already-identified source. One
                 // warning per folded pair (pairs are deduped), not per event.
-                await emitIngestionWarning(this.context.outputs, teamId, {
-                    type: 'cannot_merge_already_identified',
-                    details: {
-                        sourcePersonDistinctId: pair.anonDistinctId,
-                        targetPersonDistinctId: plan.targetDistinctId,
-                        distinctId: plan.targetDistinctId,
-                        eventUuid: pair.eventUuid,
-                        personId: target.uuid,
-                        otherPersonId: source.uuid,
-                    },
-                    pipelineStep: 'person-merge',
-                    alwaysSend: true,
-                })
+                warningAcks.push(
+                    emitIngestionWarning(this.context.outputs, teamId, {
+                        type: 'cannot_merge_already_identified',
+                        details: {
+                            sourcePersonDistinctId: pair.anonDistinctId,
+                            targetPersonDistinctId: plan.targetDistinctId,
+                            distinctId: plan.targetDistinctId,
+                            eventUuid: pair.eventUuid,
+                            personId: target.uuid,
+                            otherPersonId: source.uuid,
+                        },
+                        pipelineStep: 'person-merge',
+                        alwaysSend: true,
+                    })
+                )
                 continue
             }
             seenSourceIds.add(source.id)
             mergeSources.push(source)
         }
+        const warningsAck = Promise.all(warningAcks).then(() => undefined)
 
         if (mergeSources.length === 0 && missingPairs.length === 0) {
             plan.status = 'executed'
             plan.mergedPerson = target
-            return mergeSuccess(target, Promise.resolve(), true)
+            return mergeSuccess(target, warningsAck, true)
         }
 
         // Sequential property precedence: each pair merges source properties
@@ -677,7 +685,7 @@ export class PersonMergeService {
         mergeFoldExecutedCounter.inc()
         mergeFoldSizeHistogram.observe(plan.pairs.length)
 
-        const kafkaAck = this.context.produceMessages(kafkaMessages)
+        const kafkaAck = Promise.all([this.context.produceMessages(kafkaMessages), warningsAck]).then(() => undefined)
         for (const source of mergeSources) {
             // Same fire-and-forget contract as executeTransaction.
             void this.context.producePersonMergeEvent(source, mergedPerson).catch(() => {})
@@ -761,7 +769,7 @@ export class PersonMergeService {
 
         // Handle specific error types
         if (result.error instanceof PersonMergeRaceConditionError) {
-            await emitIngestionWarning(this.context.outputs, this.context.team.id, {
+            const warningAck = emitIngestionWarning(this.context.outputs, this.context.team.id, {
                 type: 'merge_race_condition',
                 details: {
                     sourcePersonDistinctId: otherPersonDistinctId,
@@ -773,11 +781,11 @@ export class PersonMergeService {
                 },
                 pipelineStep: 'person-merge',
                 alwaysSend: true,
-            })
+            }).then(() => undefined)
             logger.warn('🤔', 'merge race condition detected, too many concurrent merges', {
                 team_id: this.context.team.id,
             })
-            return mergeSuccess(mergeInto, Promise.resolve(), true)
+            return mergeSuccess(mergeInto, warningAck, true)
         }
 
         // For other errors (PersonMergeLimitExceededError, etc.), return the error result


### PR DESCRIPTION
## Problem

- A team that steadily sends `$identify` or `$create_alias` events with an illegal distinct_id (such as `null` or `undefined`) slows the ingestion lane for its own events.
- Each refused or dropped merge awaited the Kafka ack of its ingestion warning before returning the event.
- Events for one distinct_id run sequentially, so a hot key was capped at about one event per produce round-trip.
- #88730 fixed this for the `cannot_merge_already_identified` warning. Six other warning sites in the merge path still awaited.

## Changes

- Refused and dropped merges no longer wait for their warning to be acked. The warning produce flows back as the merge's `kafkaAck`, which the pipeline awaits at batch end like every other person write.
- This covers the illegal distinct_id checks, both `merge_race_condition` paths, and the folded merge path.
- The folded merge collects one ack per refused pair and joins them with its own produce ack, so a plan full of refused pairs no longer serializes round-trips.
- Nothing user-visible changes. Every refused merge still produces its warning.
- Not changed: the warning in `person-create-service.ts`, which throws right after, and the three flush-time warnings in `batch-writing-person-store.ts`, which run at batch end already.

## How did you test this code?

- New `it.each` in `person-merge-service.test.ts` drives `merge()` with an illegal target and an illegal source distinct_id through the real `emitIngestionWarning` with a fake warning output.
- `merge()` returns while the warning ack is still pending and hands that ack back as `kafkaAck`. Fails on the old code, which hangs on the await.
- The existing setup was moved into a shared helper so the #88730 cases and the new cases share it.
- The race-condition and folded-merge sites need a fake person store to reach, so they have no dedicated test. The change there follows the same pattern.
- Not run: the ClickHouse-backed person state suites, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) swept the ingestion code for awaited warning emitters after #88730, classified each site by whether it sat on the per-event lane, and applied the #88730 pattern to the six merge-path sites at the human's direction. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/reviewing-before-pr`. No local Greptile review ran (CLI not installed), so the bot review applies. The test data is invented and carries no customer material.
