### PR TITLE
feat(workflows): roll out email sending rate limit to everyone

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -559,7 +559,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS: 'web-analytics-tooltip-comparison-labels', // owner: @lricoy #team-web-analytics
     WORKFLOW_AI_TASK_ACTION: 'workflow-ai-task-action', // owner: @mayteio #team-workflows
     WORKFLOWS_DELAY_UNTIL_DATE: 'workflows-delay-until-date', // owner: @dmarchuk #team-workflows
-    WORKFLOWS_EMAIL_RATE_LIMIT: 'workflows-email-rate-limit', // owner: #team-workflows
     WORKFLOWS_EMAIL_REPUTATION: 'workflows-email-reputation', // owner: #team-workflows
     WORKFLOWS_EMAIL_SENDER_ROTATION: 'workflows-email-sender-rotation', // owner: @arthurdedeus #team-workflows
     WORKFLOWS_INCIDENT_REPLAY: 'workflows-incident-replay', // owner: #team-workflows

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -190,10 +190,6 @@ DRAFT_CONTENT_FIELDS = (
     "variables",
 )
 
-# Server-side rollout gate for email sending rate limits. Key shared with FEATURE_FLAGS in
-# frontend/src/lib/constants.tsx, where the same flag hides the editor control.
-EMAIL_SENDING_RATE_LIMIT_FLAG = "workflows-email-rate-limit"
-
 
 # Compiled from the author's filters rather than written by them, and only present once a condition has
 # been through validation. Comparing them would make an unchanged condition look edited.
@@ -2441,29 +2437,6 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
     def validate(self, data):
         instance = cast(Optional[HogFlow], self.instance)
         is_draft = self.context.get("is_draft")
-
-        # New adoption of the email sending rate limit is flag-gated server-side: the UI hides the
-        # control behind the same flag, but API and MCP callers write workflows directly. Only new
-        # adoption is policed — resubmitting the stored or draft-staged value and clearing to null
-        # always pass, so a flag dial-down can't brick saves or publishes of workflows that already
-        # carry a limit. Uses the same fail-closed flag evaluation as gated templates.
-        if "email_sending_rate_limit" in data:
-            # Nested use (the `configuration` override on test invocations) never binds
-            # self.instance — the flow arrives via context, same as in to_internal_value — so
-            # resolve it here too or a test run echoing a stored limit would fail the gate.
-            gate_instance = instance or cast(Optional[HogFlow], self.context.get("instance"))
-            new_value = data["email_sending_rate_limit"]
-            existing_values = [gate_instance.email_sending_rate_limit if gate_instance else None]
-            if gate_instance is not None and isinstance(gate_instance.draft, dict):
-                existing_values.append(gate_instance.draft.get("email_sending_rate_limit"))
-            if new_value is not None and new_value not in existing_values:
-                # Outside a request (internal re-saves, direct construction) there is no team
-                # to evaluate the flag against.
-                get_team = self.context.get("get_team")
-                if get_team is not None and not gated_template_enabled(EMAIL_SENDING_RATE_LIMIT_FLAG, get_team()):
-                    raise serializers.ValidationError(
-                        {"email_sending_rate_limit": "Email sending rate limits are not enabled for this project."}
-                    )
 
         # Reject duplicate action ids on any client-submitted actions array (create/update/graph), on
         # every path - not just the surgical /graph endpoint where validate_graph enforces it. Secret

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -181,11 +181,10 @@ class TestHogFlowAPI(APIBaseTest):
     def test_email_sending_rate_limit_round_trip(self):
         flow_id = self._create_simple_flow()
 
-        with patch("products.workflows.backend.api.hog_flow.gated_template_enabled", return_value=True):
-            response = self.client.patch(
-                f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
-                {"email_sending_rate_limit": {"count": 250, "period": "hour"}},
-            )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"email_sending_rate_limit": {"count": 250, "period": "hour"}},
+        )
         assert response.status_code == 200, response.json()
         assert response.json()["email_sending_rate_limit"] == {"count": 250, "period": "hour"}
         assert HogFlow.objects.get(id=flow_id).email_sending_rate_limit == {"count": 250, "period": "hour"}
@@ -207,35 +206,11 @@ class TestHogFlowAPI(APIBaseTest):
     def test_email_sending_rate_limit_rejects_invalid_values(self, _name, value):
         flow_id = self._create_simple_flow()
 
-        with patch("products.workflows.backend.api.hog_flow.gated_template_enabled", return_value=True):
-            response = self.client.patch(
-                f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
-                {"email_sending_rate_limit": value},
-            )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}",
+            {"email_sending_rate_limit": value},
+        )
         assert response.status_code == 400, response.json()
-
-    def test_email_sending_rate_limit_gated_on_feature_flag(self):
-        # The UI hides the control behind the flag, but API callers hit the serializer directly —
-        # without the server-side gate any team could adopt the feature before its rollout.
-        flow_id = self._create_simple_flow()
-        url = f"/api/projects/{self.team.id}/hog_flows/{flow_id}"
-        value = {"email_sending_rate_limit": {"count": 100, "period": "minute"}}
-
-        with patch("products.workflows.backend.api.hog_flow.gated_template_enabled", return_value=False) as mock_gate:
-            response = self.client.patch(url, value)
-        assert response.status_code == 400, response.json()
-        assert mock_gate.call_args.args[0] == "workflows-email-rate-limit"
-
-        with patch("products.workflows.backend.api.hog_flow.gated_template_enabled", return_value=True):
-            response = self.client.patch(url, value)
-        assert response.status_code == 200, response.json()
-
-        # A flag dial-down must not brick saves that resubmit the stored value, nor block clearing.
-        with patch("products.workflows.backend.api.hog_flow.gated_template_enabled", return_value=False):
-            response = self.client.patch(url, value)
-            assert response.status_code == 200, response.json()
-            response = self.client.patch(url, {"email_sending_rate_limit": None})
-            assert response.status_code == 200, response.json()
 
     @parameterized.expand(
         [

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -983,7 +983,6 @@ function ConversionGoalSection(): JSX.Element {
 function SendingRateLimitSection(): JSX.Element | null {
     const { setWorkflowValue } = useActions(workflowLogic)
     const { workflow } = useValues(workflowLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const rateLimit = workflow.email_sending_rate_limit ?? null
     // Mirror the count locally so clearing the field doesn't snap back to the committed value
@@ -992,12 +991,6 @@ function SendingRateLimitSection(): JSX.Element | null {
     useEffect(() => {
         setDisplayCount(rateLimit?.count)
     }, [rateLimit?.count])
-
-    // Flag-gated rollout, but a workflow that already carries a limit keeps the section after a
-    // flag dial-down so the limit stays visible and removable.
-    if (!featureFlags[FEATURE_FLAGS.WORKFLOWS_EMAIL_RATE_LIMIT] && !rateLimit) {
-        return null
-    }
 
     const hasEmailAction = workflow.actions.some((action) => action.type === 'function_email')
     // Stay visible while a limit is set even without an email step, so it can still be removed.


### PR DESCRIPTION
## Problem

The per-workflow email sending rate limit shipped in #87647 behind the `workflows-email-rate-limit` flag, so most teams cannot cap how fast a workflow sends email. The rollout is done and the gate now only blocks adoption of a deliverability protection.

## Changes

- Every workflow with an email step now shows the "Email sending rate limit" control in the trigger panel.
- The API and MCP accept `email_sending_rate_limit` writes for all projects; the serializer's flag gate is removed.
- Mechanical: the `WORKFLOWS_EMAIL_RATE_LIMIT` constant is removed from `FEATURE_FLAGS`.

Nothing looks different from the flagged-on state; the control from #87647 is unchanged and only appears for more users.

> [!NOTE]
> The `workflows-email-rate-limit` flag in the PostHog project can be archived once this deploys.

## How did you test this code?

- `pytest products/workflows/backend/api/test/test_hog_flow.py -k email_sending_rate_limit` passes locally.
- The gate test is deleted because the gated behavior no longer exists; the round-trip and invalid-value tests keep their coverage and now run without flag patches.
- Frontend typecheck reports only one error, which exists on master (`ComposerModePicker.tsx`); this diff adds none.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`. The session removed the flag gating from #87647 at the driver's request; no design decisions beyond deleting the gate and its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
