### PR TITLE
fix(visual-review): restore storybook baselines lost in a stale merge

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -4,7 +4,10 @@ on:
         # PRs outside the merge queue run a narrowed visual-regression matrix when the
         # Storybook module graph can safely identify affected stories. Merge-queue runs
         # use the full matrix. To force the full matrix earlier, add the `run-ci-frontend`
-        # label. The `no-ci` label does the opposite: it silences
+        # label. Force it also to give a story back a baseline entry it lost: the narrowed
+        # matrix renders only the stories the diff affects, so a story the diff does not
+        # touch is never captured, and a reviewer has nothing to approve into
+        # `frontend/snapshots.yml`. The `no-ci` label does the opposite: it silences
         # this workflow on a draft entirely (prototypes).
         # No labeled/unlabeled triggers: GitHub cannot filter a label trigger by name,
         # so every unrelated label re-ran the full chromium matrix against a commit CI

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1936,6 +1936,18 @@ snapshots:
         hash: v1.k794b7964.50a5102fcd24dd52bb07a41a78e6685486895d9ed86923b857de67a2bf0cfa25.yhotsOneF2mgB_iFToEVdcMfHQf58lr7yldfNN-ZYbU
     components-sharing--recording-sharing-licensed--light:
         hash: v1.k794b7964.887ed3d23b03515cab22e56f2258a1f1f7be9b7b69c1b5f3e17db17b6c05b4db.XWPlz4WofkRpUrTptzJ_y3K-quE1bDXIBkc2F5gq2wk
+    components-skillpicker--default--dark:
+        hash: v1.k794b7964.42e480d1854fa4e855c514aa6cb4e0adebde88d01cccd1b802b6a2acba0ccfd3.zWHBN45jGiaWgIUoC6ZoTFd9RLQ9LxAZ5x5szvvO2aE
+    components-skillpicker--default--light:
+        hash: v1.k794b7964.cbbe33adfd71b1c432b64dfd92a343c2d562c2e64910d07fff58ff5a4cd926e7.utWGHbQe8EqWV_0Kb54dtyiG1QM_W4-HgVcJ8m6Sys4
+    components-skillpicker--empty--dark:
+        hash: v1.k794b7964.4502f6dbefd7848a18c884a205d5da9ccd1cc1b5ee65717fbbbb8fb07a7202bf.-IXKQW55ul9arMOKU0fHgh1-ppUfSpvYTJLOKg5rwxM
+    components-skillpicker--empty--light:
+        hash: v1.k794b7964.834f1daaa1c90c821674ed0d47d6a8cfe3fe2d92b8c5ba68f2a600383ec439ab.QEFmzIl_TfqoJYnNbyst2sFrixFceJNgdiEDxg3o0v8
+    components-skillpicker--loading--dark:
+        hash: v1.k794b7964.a6c03e74d88d7915ee632eb41078032b6a0ed2b7d2076e3824843ee0504c5184.sPVYxnzC5p8USLUKFktTDgFn9IKoZAr3p8LQ9q2HT1Q
+    components-skillpicker--loading--light:
+        hash: v1.k794b7964.1f11b533447e94851d7036d383a6c200445f7da972d711558cc3f7dba15819ea.hwvMJBLynPWX3xaxY8wXIxncAKZm74pJ_0khYfYWbes
     components-slack-channel-picker--alphabetical--dark:
         hash: v1.k794b7964.c5f45d681dad559cdf8bed1c8e9d31c5dca4d0973e1fbf5d1515ab30c393b554.SYg7auYBsl2kTK9lzMylWzKKRJ9Bf3sT0lwtvlfXx24
     components-slack-channel-picker--alphabetical--light:
@@ -5192,6 +5204,10 @@ snapshots:
         hash: v1.k794b7964.4344045fc1bada8b4f2067de9f83cdb38b5dbe14719e7b4d332c2a7689a5d8cd.NvfJs1mb9VLArjiQdsrspse5hcopmjfyz4HXvwD_MZA
     products-data-modeling-lineage-graph--single-node--light:
         hash: v1.k794b7964.965d630c09110769bac58d2fc162856dc5303d9a98e97995aec4cc48098581da.Gi_VbiOcJVaHaHybXL8911KOWXwBMAGtbHwCIA2HO0E
+    products-mcp-analytics-routingbar--all-variants--dark:
+        hash: v1.k794b7964.769a69526cf676447319f587f24ed0d2670a137098867f8d3ee87ebda3415a70.3FGS0pbxxcrZUSto8SNCNHEkxaFXH6T8shqpdg5zzlQ
+    products-mcp-analytics-routingbar--all-variants--light:
+        hash: v1.k794b7964.7f57dacddb48fbad29a8614127d42d54425501b1f7755423d84316e1e937720e.thYPF2z3eMW5QvSe5SnvYtn35l6UCvUtsyx9EBLeqxk
     products-posthog-ai-composer--default--dark:
         hash: v1.k794b7964.4ccf5eb666de2b3315dc3f142ded80b445748d58ce8ae2d7d154272d7b194b3b.E61uR16UwC5qC1XkQquxMh1z3bonN6IYLdYDyzcorTA
     products-posthog-ai-composer--default--light:
@@ -8436,6 +8452,18 @@ snapshots:
         hash: v1.k794b7964.924843ea467d84943495cc8a3056c6f469da31ea69ed097cb485f6348410f77e.qyTPRNCs1NnpxcMQ3t1SthuCpSr4_HIXQXDtWL-QdwQ
     scenes-other-billing-billinglinegraph--with-marker-at-range-start--light:
         hash: v1.k794b7964.5948fea6ef855d327f6d59f1ed10eb3fd55808540eda078bee5fed552523a4c0.FTXekbDFuL1YE5ad9VyyBtq5lOBiNalah41lHdISQOE
+    scenes-other-billing-desktopusagebreakdown--no-usage--dark:
+        hash: v1.k794b7964.c4a269e9294e2a91457f55f61c92fd7a2be76bd01697be8110a6a521ffe4e259.zVql89Qrf4TpYEZLsF8P0YBEmeSWfjWu3ug_Vn05TNE
+    scenes-other-billing-desktopusagebreakdown--no-usage--light:
+        hash: v1.k794b7964.52c84b283c7c7a66a3dff631676a4f38f2638ae40797d521b026c0af162ae865.EtK9KPsvnlS8w6lGGNaBV5xFWxySGm5viXNk9JWHegA
+    scenes-other-billing-desktopusagebreakdown--resources-unavailable--dark:
+        hash: v1.k794b7964.8dffd1fbfec28d0acf7f1cfacac16498ccefbea6cf0a36fe95b3bff9298a38f9.8OOExOg6aw4wbIPCEB25pSMwoMC4eqFt1KIZiyDD2zE
+    scenes-other-billing-desktopusagebreakdown--resources-unavailable--light:
+        hash: v1.k794b7964.cee76c88340ad14f6123d80e03faa8b0fa30cd8229a8a1f3f882bfdd2f5fbe4a.HoHDeKm6rYX-Sl3uPkZo1mstXYtwF-bMWHMMbcUSAoM
+    scenes-other-billing-desktopusagebreakdown--usage-mix--dark:
+        hash: v1.k794b7964.2c28449c679f7e5e89ec05fd6d681ddebbf9b031102a88ab08cd975e555b919f.YK_K1fOZZ8wYf8qvJlLRXZuKd31GnNaEhiKJOm0hci0
+    scenes-other-billing-desktopusagebreakdown--usage-mix--light:
+        hash: v1.k794b7964.a78b7addf891aa84f730a810d99c8e34c048b49fd8a489e755ed064cb64ebe68.ssx9pdKw8PVqxdqpUcP7LZ-9gNLa11vNHRoy6Uzg94Q
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--dark:
         hash: v1.k794b7964.ce05ab37980f7fc148ea8681fee7b0eeb1f046266e8a7df22fbfc5cc8cefb8e7.hjk8pf9SicO_kBVjVXooUrPaBUj_76AzOPVXuwydGkE
     scenes-other-billing-product--billing-product-inclusion-only-with-addon--light:


### PR DESCRIPTION
## Problem

Three Storybook story files have no baseline entry, and nobody can give them one.

- A stale `snapshots.yml` merge dropped their entries: `SkillPicker`, `RoutingBar`, and `DesktopUsageBreakdown`.
- Every run since classifies their snapshots `new`. The quarantine that followed hides that from the gate and from the run summary, so master reports zero new snapshots while the entries are still missing.
- #89504 made finalize commit a quarantined `new` snapshot that a person approved by identifier. That was the backend half. The entries still need a run that renders the stories, and the narrowed matrix never does.

## Changes

- Nothing looks different. The only source change is a comment.
- The full Storybook suite renders on this PR, because a change to `.github/workflows/ci-storybook.yml` matches a full-run pattern in the story selector. The three stories reach a reviewable run.
- The comment records why someone would force the full matrix, since the lever is otherwise invisible from the selector.
- The payload of this PR is the Visual Review bot commit that follows: approve the `new` snapshots by identifier, finalize, and the approved entries land in `frontend/snapshots.yml` on this branch.
- The quarantine stays until the entries are on master. Lifting it first fails every run until they land.

## How did you test this code?

- `hogli lint:workflows` and `hogli ci:preflight --strict` pass locally.
- The commit path is covered by the tests added in #89504.
- Not run: `hogli review`, because Greptile is not authenticated in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `products/visual_review/README.md` already carries the procedure, from #89504.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-before-pr`.

The session traced the fourteen missing snapshot identifiers to three story files, confirmed none of them appear in `frontend/snapshots.yml`, and read the approve and finalize path from #89504 to check that a per-identifier approval on a quarantined `new` snapshot reaches the baseline commit.

Rejected alternative: touch the three story files instead. Any edit to them risks changing how they render, and the approved hash has to be the one master produces.

Public artifact: everything here comes from this repository and its public CI runs.
