### PR TITLE
feat(desktop): request gateway write scope

### DIFF
--- a/products/desktop/packages/shared/src/oauth.test.ts
+++ b/products/desktop/packages/shared/src/oauth.test.ts
@@ -20,26 +20,31 @@ describe("OAUTH_SCOPES guard", () => {
       fingerprint,
     }).toMatchInlineSnapshot(`
       {
-        "fingerprint": -237404099,
-        "scopeCount": 206,
-        "scopeVersion": 7,
+        "fingerprint": 1415029434,
+        "scopeCount": 207,
+        "scopeVersion": 8,
       }
     `);
   });
 
   // Structural guards that catch drift cheaply, independent of the exact list.
   // OAUTH_SCOPES must mirror OAUTH_SCOPES_SUPPORTED in the API's generated
-  // services/mcp/src/lib/oauth-scopes.generated.ts (plus llm_gateway:read); this
-  // repo can't assert cross-repo equality, so these check the shape invariants.
+  // services/mcp/src/lib/oauth-scopes.generated.ts (plus the privileged gateway
+  // scopes); this repo can't assert cross-repo equality, so these check the shape invariants.
   it("contains no duplicate scopes", () => {
     expect(OAUTH_SCOPES.length).toBe(new Set(OAUTH_SCOPES).size);
   });
 
-  it("includes the privileged llm_gateway:read scope exactly once, kept last", () => {
-    expect(
-      OAUTH_SCOPES.filter((scope) => scope === "llm_gateway:read"),
-    ).toHaveLength(1);
-    expect(OAUTH_SCOPES.at(-1)).toBe("llm_gateway:read");
+  it("includes each privileged gateway scope exactly once, kept last", () => {
+    for (const scope of ["llm_gateway:read", "llm_gateway:write"]) {
+      expect(
+        OAUTH_SCOPES.filter((candidate) => candidate === scope),
+      ).toHaveLength(1);
+    }
+    expect(OAUTH_SCOPES.slice(-2)).toEqual([
+      "llm_gateway:read",
+      "llm_gateway:write",
+    ]);
   });
 
   it("only contains well-formed scope strings", () => {

--- a/products/desktop/packages/shared/src/oauth.ts
+++ b/products/desktop/packages/shared/src/oauth.ts
@@ -6,10 +6,11 @@ export const POSTHOG_DEV_CLIENT_ID = "DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ";
 
 // Explicit scopes instead of "*". Mirrors scopes_supported at
 // /.well-known/oauth-authorization-server (OAUTH_SCOPES_SUPPORTED in the API's
-// services/mcp/src/lib/oauth-scopes.generated.ts), plus privileged llm_gateway:read
-// which the advertised set excludes. The LLM gateway requires that scope; it is
-// granted only because this app's OAuth ceiling is seeded to
-// ["@default", "llm_gateway:read"] in US + EU.
+// services/mcp/src/lib/oauth-scopes.generated.ts), plus the privileged
+// llm_gateway:read/write scopes, which the advertised set excludes. The gateway
+// requires read access for inference, and spend limit changes require write access.
+// Before a build requests both, this app's OAuth ceiling must be seeded in US + EU to
+// ["@default", "llm_gateway:read", "llm_gateway:write"].
 //
 // That generated file also exports OAUTH_SCOPES_HIDDEN (batch_import_support,
 // query_performance, wizard_session). Never copy those in: they are staff-only
@@ -19,11 +20,11 @@ export const POSTHOG_DEV_CLIENT_ID = "DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ";
 // Deploy-order guardrail: NEVER ship a non-"*" OAUTH_SCOPES set (or bump
 // OAUTH_SCOPE_VERSION off a build that still requests "*") until that ceiling is
 // seeded in both regions. A non-empty ceiling rejects scope=* at /authorize, and
-// an empty/unseeded ceiling rejects privileged llm_gateway:read. #3411 shipped
+// an empty/unseeded ceiling rejects the privileged gateway scopes. #3411 shipped
 // the explicit list bundled with loops without seeding; prod login broke and was
 // reverted in #3668. Keep this comment when regenerating the list.
 //
-// Regenerate from the live advertised list + llm_gateway:read last; bump
+// Regenerate from the live advertised list + llm_gateway:read/write last; bump
 // OAUTH_SCOPE_VERSION whenever the set changes so installs re-authorize.
 export const OAUTH_SCOPES = [
   "openid",
@@ -231,10 +232,11 @@ export const OAUTH_SCOPES = [
   "web_analytics:write",
   "webhook:read",
   "webhook:write",
-  // Privileged: embedded agent model calls go through PostHog's LLM gateway
-  // (gateway.{region}.posthog.com), which requires this scope. Not in the
-  // advertised set above; granted via this app's seeded ceiling.
+  // Privileged: model calls need read access, and spend limit changes need write
+  // access. Neither appears in the advertised set above. The app ceiling must
+  // grant both before this scope list ships.
   "llm_gateway:read",
+  "llm_gateway:write",
 ];
 
 // v6: the server grew the `canvas` scope (PostHog/posthog#73874). On apps with a seeded
@@ -244,7 +246,8 @@ export const OAUTH_SCOPES = [
 // applies to every future server-side scope addition the app relies on, even when
 // OAUTH_SCOPES itself is unchanged.
 // v7: "*" replaced with the explicit list above.
-export const OAUTH_SCOPE_VERSION = 7;
+// v8: added llm_gateway:write so spend limit changes can use a separate write permission.
+export const OAUTH_SCOPE_VERSION = 8;
 
 // Token refresh settings
 export const TOKEN_REFRESH_BUFFER_MS = 30 * 60 * 1000; // 30 minutes before expiry


### PR DESCRIPTION
## Problem

Desktop OAuth tokens can read from the gateway, but they cannot change a user's spend limit.
The backend endpoint in [#87671](https://github.com/PostHog/posthog/pull/87671) requires `llm_gateway:write` for set and clear operations.

## Changes

- Desktop requests the privileged `llm_gateway:write` scope alongside its existing read scope.
- Scope version 8 forces existing installations to authorize the expanded scope set once.
- Tests pin the scope count, fingerprint, ordering, and uniqueness.

> [!WARNING]
> Keep this PR in draft until [#87671](https://github.com/PostHog/posthog/pull/87671) reaches production and US and EU OAuth ceilings grant `llm_gateway:write`.

### Before

```mermaid
flowchart LR
    A[Desktop OAuth grant] --> B[Gateway read scope]
    B --> C[Read spend limit]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C phBlue;
```

### After

```mermaid
flowchart LR
    A[Desktop OAuth grant] --> B[Gateway read and write scopes]
    B --> C[Read, set, or clear spend limit]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C phBlue;
```

No UI layout changes, so there are no screenshots.

## How did you test this code?

- The shared Desktop package type check passed.
- All shared-package tests passed, including the OAuth scope guard.
- Desktop Biome checks passed.
- The OAuth application ceilings were not changed or verified from this environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The source comment records the OAuth ceiling and release-order requirement.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi split this release-dependent Desktop change from the backend PR after the coupling gate required separate deploys.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/reviewing-before-pr`.

The local Greptile CLI was unavailable. A fallback diff review found no code issue and retained the explicit rollout blocker.