### PR TITLE
perf(nodejs): run the ingestion e2e suite concurrently

### DIFF
--- a/nodejs/src/common/outputs/ingestion-outputs.test.ts
+++ b/nodejs/src/common/outputs/ingestion-outputs.test.ts
@@ -133,6 +133,21 @@ describe('IngestionOutputs', () => {
             expect(failures).toEqual(['events'])
         })
 
+        it('accepts a topic that is missing from metadata only briefly', async () => {
+            const producer = createMockProducer()
+            producer.checkTopicExists.mockRejectedValueOnce(new Error('Topic not found')).mockResolvedValue(undefined)
+            const outputs = new IngestionOutputs({
+                events: new SingleIngestionOutput('events', 'events', producer, 'test'),
+                ai_events: new SingleIngestionOutput('ai_events', 'ai_events', producer, 'test'),
+            })
+
+            const failures = await outputs.checkTopics(10000, 3, 0)
+
+            expect(failures).toEqual([])
+            // Only the output that failed is retried, not the whole set.
+            expect(producer.checkTopicExists).toHaveBeenCalledTimes(3)
+        })
+
         it('checks same topic separately on different producers', async () => {
             const mskProducer = createMockProducer()
             const wsProducer = createMockProducer()

--- a/nodejs/src/common/outputs/ingestion-outputs.test.ts
+++ b/nodejs/src/common/outputs/ingestion-outputs.test.ts
@@ -131,11 +131,34 @@ describe('IngestionOutputs', () => {
             const failures = await outputs.checkTopics()
 
             expect(failures).toEqual(['events'])
+            // Pins the far boundary: three checks, not two and not four.
+            expect(producer.checkTopicExists).toHaveBeenCalledTimes(3)
         })
 
-        it('accepts a topic that is missing from metadata only briefly', async () => {
+        it.each([
+            ['recovers on the second check', 1, 2],
+            ['recovers on the last permitted check', 2, 3],
+        ])(
+            'accepts a topic missing from metadata only briefly, and %s',
+            async (_label, failuresBefore, expectedChecks) => {
+                const producer = createMockProducer()
+                for (let i = 0; i < failuresBefore; i++) {
+                    producer.checkTopicExists.mockRejectedValueOnce(new Error('Topic not found'))
+                }
+                const outputs = new IngestionOutputs({
+                    events: new SingleIngestionOutput('events', 'events', producer, 'test'),
+                })
+
+                const failures = await outputs.checkTopics(10000, 3, 0)
+
+                expect(failures).toEqual([])
+                expect(producer.checkTopicExists).toHaveBeenCalledTimes(expectedChecks)
+            }
+        )
+
+        it('retries only the output that failed, not the whole set', async () => {
             const producer = createMockProducer()
-            producer.checkTopicExists.mockRejectedValueOnce(new Error('Topic not found')).mockResolvedValue(undefined)
+            producer.checkTopicExists.mockRejectedValueOnce(new Error('Topic not found'))
             const outputs = new IngestionOutputs({
                 events: new SingleIngestionOutput('events', 'events', producer, 'test'),
                 ai_events: new SingleIngestionOutput('ai_events', 'ai_events', producer, 'test'),
@@ -144,7 +167,7 @@ describe('IngestionOutputs', () => {
             const failures = await outputs.checkTopics(10000, 3, 0)
 
             expect(failures).toEqual([])
-            // Only the output that failed is retried, not the whole set.
+            // Two outputs on the first attempt, then only the failed one.
             expect(producer.checkTopicExists).toHaveBeenCalledTimes(3)
         })
 

--- a/nodejs/src/common/outputs/ingestion-outputs.ts
+++ b/nodejs/src/common/outputs/ingestion-outputs.ts
@@ -1,5 +1,6 @@
 import { MessageKey } from '~/common/kafka/producer'
 import { logger } from '~/common/utils/logger'
+import { delay } from '~/common/utils/utils'
 
 import { IngestionOutput } from './ingestion-output'
 import { IngestionOutputMessage } from './types'
@@ -48,22 +49,45 @@ export class IngestionOutputs<O extends string> {
     /**
      * Check that all non-empty topics exist on their brokers.
      *
+     * Retries the failing subset, because a topic can be briefly absent from broker
+     * metadata while it still exists: during a controller failover or leader election,
+     * or in the window just after another client created it. Only a topic that stays
+     * absent across every attempt is treated as missing, which keeps the startup gate
+     * fatal for a genuinely absent topic.
+     *
      * @param timeoutMs - Timeout for each topic metadata check.
-     * @returns Output names whose topics failed the check.
+     * @param attempts - How many times to check before reporting failure.
+     * @param retryDelayMs - Wait between attempts.
+     * @returns Output names whose topics failed every attempt.
      */
-    async checkTopics(timeoutMs = 10000): Promise<string[]> {
-        const failures: string[] = []
-        for (const outputName in this.outputs) {
-            try {
-                await this.outputs[outputName].checkTopicExists(timeoutMs)
-            } catch {
-                failures.push(outputName)
+    async checkTopics(timeoutMs = 10000, attempts = 3, retryDelayMs = 500): Promise<string[]> {
+        let pending = Object.keys(this.outputs) as O[]
+
+        for (let attempt = 1; ; attempt++) {
+            const failures: O[] = []
+            for (const outputName of pending) {
+                try {
+                    await this.outputs[outputName].checkTopicExists(timeoutMs)
+                } catch {
+                    failures.push(outputName)
+                }
             }
+
+            if (failures.length === 0) {
+                return []
+            }
+            if (attempt >= attempts) {
+                logger.error('🔴', `Topic check failed for outputs: ${failures.join(', ')}`)
+                return failures
+            }
+
+            logger.warn(
+                '🟡',
+                `Topic check failed for outputs: ${failures.join(', ')}. Retrying (${attempt}/${attempts - 1}).`
+            )
+            pending = failures
+            await delay(retryDelayMs)
         }
-        if (failures.length > 0) {
-            logger.error('🔴', `Topic check failed for outputs: ${failures.join(', ')}`)
-        }
-        return failures
     }
 }
 

--- a/nodejs/tests/helpers/ingestion-e2e.ts
+++ b/nodejs/tests/helpers/ingestion-e2e.ts
@@ -502,7 +502,7 @@ export function createTestWithTeamIngester<T extends IngesterLike>(
         config: TeamIngesterTestConfig = {},
         testFn: (ctx: TeamIngesterTestContext<T>) => Promise<void>
     ) => {
-        test(name, async () => {
+        test.concurrent(name, async () => {
             const infra = await createIngestionTestInfra({
                 ...baseConfig,
                 ...config.pluginServerConfig,

--- a/nodejs/tests/ingestion/ingestion-e2e.test.ts
+++ b/nodejs/tests/ingestion/ingestion-e2e.test.ts
@@ -1,4 +1,3 @@
-// Serial until the startup topic check tolerates a transient metadata gap (see the follow-up PR).
 import { DateTime } from 'luxon'
 
 import { createHogTransformerService } from '~/cdp/hog-transformations/hog-transformer.service'


### PR DESCRIPTION
## Problem

`ingestion-e2e` is the biggest suite left on the nodejs serial lane: 119s for 152 tests that run one after another. The tests are almost entirely idle, waiting on the ClickHouse Kafka engine to flush, so overlapping them would recover most of that.

Running them concurrently fails first. Each test builds its own `KafkaProducerWrapper`, so concurrency churns a producer per test through the broker, and `IngestionConsumer.start()` gates on a single `getMetadata` call per output topic. One absent metadata response fails the test with `Output topic verification failed for: ...`, naming a different subset of topics each time.

## Changes

- `checkTopics` retries only the outputs that failed, three attempts 500ms apart. A topic absent across every attempt still fails the gate, which `src/ingestion/config.ts` relies on for `INGESTION_OUTPUT_FLAG_EVALUATIONS_TOPIC`.
- A failed attempt logs at warn with the outputs and the attempt number, so a recurrence shows how long the gap lasted.
- The shared `tests/helpers/ingestion-e2e.ts` harness runs its tests with `test.concurrent`. Five e2e suites share it.
- `ingestion-e2e` moves to the parallel lane. It kept its reset removals from #89152, so this is a rename.
- Nothing user-visible changes.

| | master | here |
| --- | --- | --- |
| serial lane | 348s, 17 suites | 243s, 16 suites |
| parallel lane | 81s, 10885 tests | 89s, 11037 tests |
| both lanes | 429s | 332s |
| `ingestion-e2e` alone | 119s | 28s |

> [!NOTE]
> `checkTopics` is production code. A genuinely missing topic now fails consumer startup after about a second rather than immediately.

## How did you test this code?

One unit test: a topic that fails the first check and passes the second leaves no failures, and only the failed output is re-checked. The suite previously covered single-shot success and permanent failure only.

Both lanes ran in full on this branch, with no failing tests. `ingestion-e2e` passed in 28s. The only failing suites are the five `recording-rasterizer` ones, on a missing local dist, which fail with this branch reverted too.

The causal link between the retry and the pass is weaker than the timings suggest, and worth a reviewer's judgment:

<details>
<summary>What the retry was and was not observed doing</summary>

The retry did not fire for any `ingestion-e2e` output in the passing run. It fired only for the two deliberately-rejecting mocks in `ingestion-outputs.test.ts`. So the suite passing here is not direct evidence that the retry rescued it.

The failure was never reproduced on demand. It was diagnosed by elimination: setup coverage (all 13 output topics are created), metadata contention (600 cold checks across 20 concurrent producers, 0 failures in 132ms), a suite deleting shared topics, and a broker restart were each ruled out.

One observation does not fit a pure metadata gap. The failure also appears under `--runInBand`, where a single process runs all 16 serial files in order, and it hits the second `describe.each` arm rather than the first. That points at producer accumulation within a long-lived process, which the retry would mask rather than fix.

</details>

Not checked: CI hardware. Local timings come from one machine that also runs the dev stack, so the ratios hold rather than the absolute numbers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Skills invoked: `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`.

Split out of #89152 at the reviewer's request, so the production change and the concurrency that needs it are reviewed apart from the test moves. #89152 has since merged, so this now targets master directly. The retry count and delay are fixed rather than configurable, pending evidence the window exceeds a second.
