### PR TITLE
fix(insights): handle trend results without action metadata

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7681,9 +7681,9 @@ snapshots:
     scenes-app-posthog-ai-tools--dangerous-operation-pending-approval-long-content--light:
         hash: v1.k794b7964.6557ac5b0fac9d1f226f12f944e08240e2913aef7d527c4b53a2017d6a7231aa.v61UHKqXj02ZfvDPrQtC2qsl4vPe0oPd98gpiaaQ_2Y
     scenes-app-posthog-ai-tools--multi-visualization-in-thread--dark:
-        hash: v1.k794b7964.e278289eb9de180c2b31995845077f34f05ee7bf66659add563eb8d7d7dc8592.uQvjAfNevwR7QvhINeSqaoNJKg0AUpWj3PY-P_ajaWg
+        hash: v1.k794b7964.6becd54faf97831df4f4a778c5e8de44acd297727ab9c1def058323cd071be33.PqDN2G62zNR4yAmnMU-xdjNsPU82m7BmBuYCveOsw6E
     scenes-app-posthog-ai-tools--multi-visualization-in-thread--light:
-        hash: v1.k794b7964.d6abb413fd77e00eb11393b237f4eeac0edc21baed3d33f727bc910d3c3c4536.0h8RhpILbz2mY4QxRc05ZsRPAIwEctZYFunYAmQscNc
+        hash: v1.k794b7964.7bd16ac554b0ef6a0f9abf8e8e7d5bc460369c2b0c3dd778776e4bf63ec97bc0.94NsDXj_srsigHAu8uGEMBlarn0ZQnIfJnyADZELmkM
     scenes-app-posthog-ai-tools--notebook-artifact-markdown-only--dark:
         hash: v1.k794b7964.153ef583b440b6078bd4d7c0fda71f34388699df02b964f464f82754b883f2d2.Th0lXC3c1DSCIyk2A7Di_YHPboZhWXtudWM0qHA5934
     scenes-app-posthog-ai-tools--notebook-artifact-markdown-only--light:

--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -44,6 +44,10 @@ describe('getDisplayNameFromEntityFilter()', () => {
             expect(getDisplayNameFromEntityFilter(filter, isCustom)).toEqual(expected)
         })
     })
+
+    it('returns null when a result has no action', () => {
+        expect(getDisplayNameFromEntityFilter(undefined)).toBeNull()
+    })
 })
 
 const createEventsNode = (id?: Entity['id'], name?: string, custom_name?: string): EventsNode => {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -69,9 +69,9 @@ import {
 
 import { insightLogic } from './insightLogic'
 
-export const isAllEventsEntityFilter = (filter: EntityFilter | ActionFilter | null): boolean => {
+export const isAllEventsEntityFilter = (filter: EntityFilter | ActionFilter | null | undefined): boolean => {
     return (
-        filter !== null &&
+        filter != null &&
         filter.type === EntityTypes.EVENTS &&
         filter.id === null &&
         (!filter.name || filter.name === 'All events')
@@ -98,7 +98,7 @@ export const formatEventName = (name: string | undefined | null): string | undef
 }
 
 export const getDisplayNameFromEntityFilter = (
-    filter: EntityFilter | ActionFilter | null,
+    filter: EntityFilter | ActionFilter | null | undefined,
     isCustom = true
 ): string | null => {
     // Make sure names aren't blank strings


### PR DESCRIPTION
## Problem

Trend charts can crash when a query result omits optional action metadata.

## Changes

- Trend charts now use the raw series label when action metadata is absent.
- The shared label helper accepts missing filters, so all chart displays use the same fallback.
- This fix has no expected visual change when action metadata is present.

## How did you test this code?

- The focused Jest suite passed and guards the missing-action crash.
- Frontend lint and formatting passed.
- The full frontend type check exited with status 137 in this environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change fixes existing chart rendering behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used PostHog MCP and repository tools. Skills used: `investigating-error-issue`, `querying-posthog-data`, `writing-tests`, `writing-pr-descriptions`, `reviewing-before-pr`, and `writing-simplified-technical-english`.

The Greptile CLI was unavailable. The fallback review found no issues. The diff contains no event payloads or project data.
