### PR TITLE
fix(team-deletion): delete widget tiles before deleting the team

### DIFF
--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -12,6 +12,7 @@ from posthog.models.async_migration import is_async_migration_complete
 from posthog.temporal.common.client import sync_connect
 
 from products.batch_exports.backend.service import BatchExportServiceScheduleNotFound, batch_export_delete_schedule
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
 logger = structlog.get_logger(__name__)
 
@@ -84,7 +85,6 @@ def _delete_misc_small_tables_for_teams(team_ids: list[int]) -> None:
     """
     from posthog.models.file_system.file_system_view_log import FileSystemViewLog
 
-    from products.dashboards.backend.models.dashboard_tile import DashboardTile
     from products.data_modeling.backend.facade.models import Edge, Node
     from products.early_access_features.backend.models import EarlyAccessFeature
 

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -84,6 +84,7 @@ def _delete_misc_small_tables_for_teams(team_ids: list[int]) -> None:
     """
     from posthog.models.file_system.file_system_view_log import FileSystemViewLog
 
+    from products.dashboards.backend.models.dashboard_tile import DashboardTile
     from products.data_modeling.backend.facade.models import Edge, Node
     from products.early_access_features.backend.models import EarlyAccessFeature
 
@@ -93,6 +94,9 @@ def _delete_misc_small_tables_for_teams(team_ids: list[int]) -> None:
     # DataWarehouseSavedQuery, which has PROTECT on delete.
     _raw_delete_batch(Edge.objects.filter(team_id__in=team_ids))
     _raw_delete_batch(Node.objects.filter(team_id__in=team_ids))
+    # DashboardTile has PROTECT on its widget, which the Team cascade deletes, so tiles go first.
+    # _base_manager because the default manager hides soft-deleted tiles, which protect it too.
+    _raw_delete_batch(DashboardTile._base_manager.filter(team_id__in=team_ids, widget__isnull=False))
     _raw_delete_batch(FileSystemViewLog.objects.filter(team_id__in=team_ids))
     _raw_delete_batch(EarlyAccessFeature.objects.filter(team_id__in=team_ids))
     _raw_delete_batch(error_tracking_fingerprint.objects.filter(team_id__in=team_ids))

--- a/posthog/temporal/tests/delete_teams/test_protected_fk_predelete.py
+++ b/posthog/temporal/tests/delete_teams/test_protected_fk_predelete.py
@@ -1,0 +1,40 @@
+import pytest
+
+from django.db.models.deletion import ProtectedError
+
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+from posthog.models.team.util import _delete_misc_small_tables_for_teams, delete_team_records
+
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
+from products.dashboards.backend.models.dashboard_widget import DashboardWidget
+
+# A plain django_db is enough: PROTECT raises while the cascade is being collected, not at COMMIT,
+# so the rollback-based TestCase sees it.
+pytestmark = [pytest.mark.django_db]
+
+
+def _team_with_widget_on_a_tile(tile_deleted: bool) -> int:
+    _, _, team = Organization.objects.bootstrap(None)
+    dashboard = Dashboard.objects.create(team=team, name="dashboard")
+    widget = DashboardWidget.objects.for_team(team.id).create(team=team, widget_type="usage")
+    DashboardTile.objects.create(dashboard=dashboard, widget=widget, deleted=tile_deleted or None)
+    return team.id
+
+
+def test_team_cascade_is_blocked_by_a_widget_on_a_tile():
+    team_id = _team_with_widget_on_a_tile(tile_deleted=False)
+
+    with pytest.raises(ProtectedError):
+        delete_team_records([team_id])
+
+
+@pytest.mark.parametrize("tile_deleted", [False, True])
+def test_predelete_unblocks_team_deletion(tile_deleted: bool):
+    team_id = _team_with_widget_on_a_tile(tile_deleted=tile_deleted)
+
+    _delete_misc_small_tables_for_teams([team_id])
+    delete_team_records([team_id])
+
+    assert not Team.objects.filter(id=team_id).exists()


### PR DESCRIPTION
## Problem

An organization that uses a dashboard widget cannot be deleted. The deletion workflow fails and the organization stays alive, flagged for deletion, until someone re-drives it by hand.

`DashboardWidget.team` is `CASCADE`, so deleting a team tries to delete its widgets. `DashboardTile.widget` is `PROTECT`, so the tiles refuse. Django's `PROTECT` raises while the cascade is still being collected, even though those tiles sit in the same cascade and would have been deleted moments later. `RESTRICT` is the variant that tolerates this; `PROTECT` does not.

`ProtectedError` is non-retryable in `DELETE_RETRY_POLICY`, so the workflow fails for good rather than retrying.

## Changes

- Delete the widget-bearing tiles in the pre-delete phase, so the cascade never meets a protected row.
- Placed beside the `Edge`/`Node` pre-delete that already guards `DataWarehouseSavedQuery.team`, the other `PROTECT` foreign key on `Team`.
- Reads through `_base_manager`, because the default manager hides soft-deleted tiles and a soft-deleted tile protects its widget just the same.

Nothing user-visible changes. The filter matches tiles by their own `team_id`, which assumes a tile and its widget belong to the same team; a cross-team tile would still block, and would itself be a data bug.

## How did you test this code?

- 3 backend cases added. One locks in that the cascade raises `ProtectedError` without the pre-delete. Two cover the pre-delete clearing the block, parameterized over a live and a soft-deleted tile.
- The soft-deleted case is the one that fails if `_base_manager` is swapped for `objects`. Both directions verified locally.
- A plain `django_db` is enough here, unlike the retired-table pre-delete tests: `PROTECT` raises during collection, not at COMMIT.
- Not run: anything against production data.
- Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/reviewing-before-pr`, `/writing-pr-descriptions`.

Found while sweeping Temporal for stuck deletion workflows after [#83306](https://github.com/PostHog/posthog/pull/83306). One organization failed this way on 2026-08-23. Temporal retention is 7 days with archival off, so earlier occurrences are no longer visible and that count is a floor.

`hogli review` could not run (not signed in to Greptile), so the local pass was a manual read of the diff rather than the bot. The independent review is still the PR bot's. That read changed one line: the test now creates the widget through `objects.for_team(...)` rather than `all_teams`, which AGENTS.md reserves for genuinely cross-team access.

Filtering tiles by `widget__team_id` instead of the tile's own `team_id` would also cover a cross-team tile, at the cost of a join on every batch. The simpler filter matches every other line in this function and the observed failure was same-team.
