### PR TITLE
feat(error-tracking): remove severity feature flag gates

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6417,13 +6417,13 @@ snapshots:
     scenes-app-errortracking--list-page--light:
         hash: v1.k794b7964.ec828bd049bcf02367910abb18539201ef5f6447b602a75891a64d45d743c4f5.RAArjfFKQhB64bx3ypvlJdCR3svO5Yify4gANdrDJ94
     scenes-app-errortracking--list-page-with-ingestion-warning--dark:
-        hash: v1.k794b7964.a2671ce13fc32c39579ab419634c7c77d034372dd473ee24ee05e26bcfe8be56.Z2FlqVo9HNn0jHgCPaFQ-UdDH75h9_Wm3HUPk-VSav4
+        hash: v1.k794b7964.97ebfc5cbd8a42f9812b6ae0af9d00cec4ba9ca7f46107868182a390024faab3.ooOBXcc0lMvw3a8ZbdAY85MWZUswPFAuGCXQoj6_5ig
     scenes-app-errortracking--list-page-with-ingestion-warning--light:
-        hash: v1.k794b7964.fc094917ab619f645401504337c6eed08254baf12433126b71a74241c499ad98.zuuZ0RWxU2OZDmwDZY1Usfd9fyV_qZq8t_romWDeQqA
+        hash: v1.k794b7964.7b9f01e55b78170fce3391e35155eb18d06792895ba3258d414de3d1dbc0d4b5.c16uU0LYiIhXwjauAVxLiRe89gjPabGtgzW6nQ64oe0
     scenes-app-errortracking--list-page-with-source-maps-banner--dark:
-        hash: v1.k794b7964.b4b51ded4a19da613650179d957e7ecce0fd6a3600cde4137322b5f44bf0ab99.ILobhTAx6Pev1QH9aJBVB7402wksWls0nqrzQXEc1dk
+        hash: v1.k794b7964.c8aff38ce4732c22ffb12634a8a88a7608eab6b35f19136a093c7a76c8b6dfb0.X7tIrVh7xeTeQGkJpJ6deLOaEofLRqPGo8tDDkffOrU
     scenes-app-errortracking--list-page-with-source-maps-banner--light:
-        hash: v1.k794b7964.1f1efabaa301aa1fb6df35608b4f0ceb04758b16bd0cb5c5b683d38e9372209d.v4lJX3wKzX7RGn4ckCTmgnfmWGaWaokyfojnXS0_Dlo
+        hash: v1.k794b7964.4ad3aec35d102e36ebf1fe44363d5880aebe5196dd996cac8c0c478c1e12dd97.8LV-zlkk75MYmXUmoW91uF77ffyKKwP6X8omwnj0JLQ
     scenes-app-errortracking-linkedreports--fix-proposed--dark:
         hash: v1.k794b7964.1b50022f8fafb4684dacd255b966bd2969f79e84d5c7c7daeb68291772a1e36d.9uyjrwufsjMCFx9c7cjsoIyabB3A4ZBnPSVUouM0RZE
     scenes-app-errortracking-linkedreports--fix-proposed--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4949,9 +4949,9 @@ snapshots:
     products-dashboards-add-insight-to-dashboard-modal--with-more-insight-types--light:
         hash: v1.k794b7964.6c001db5555f48832f11ae8d9dcc535dff4e22044bb6dfce15db3a2a522f1fa9.GQCxp64JkEqDCNEeSD6gPtc5rwlzjHFJ-QnZu4lRips
     products-dashboards-dashboard-widgets-overview--all-widget-types--dark:
-        hash: v1.k794b7964.27ab8862dbf358dc2df0893273abcafe7006824040c987dfc4cf5d0c9a80195b.BkMUYotGDlaTPnWgagssWf_ncly914WbuPPwE-hphjs
+        hash: v1.k794b7964.a77dcd14bd2d8b53539d53c1079930dbf93a2ef8c2b5513a41c9038501fed92f.VZCGHoQ9tMl1HV8egdsDQfJHa0DuwuGgM6oSIl-XS6M
     products-dashboards-dashboard-widgets-overview--all-widget-types--light:
-        hash: v1.k794b7964.51bbf943e0b71a1288c60cb614d891527a5d7f158dcdfbd56fbc259bb3e3e22a.iCf_qZPuEOIvfqIGh5iOCBWGzrUAVdHm3xe_XNNNO3c
+        hash: v1.k794b7964.b5c0cfe90d2779c6b04aa18ba5c59e8e3167641cfc0427ef0e2e8298ec3c0c99.R9OUnlu8GQ9lJJF1390FEnYntECugVcViH0G4H8H_Zo
     products-dashboards-dashboard-widgets-widget-types-activity-recent-events--default--dark:
         hash: v1.k794b7964.c69d28ef03335511de9b7dd75d5ad1c0458272d5d8f340083cdb86acc3b3c888.KB3MNhE9xEjVSl9hmVpz2jLC0IAmOTvaVZBmrl3pNKs
     products-dashboards-dashboard-widgets-widget-types-activity-recent-events--default--light:
@@ -4969,9 +4969,9 @@ snapshots:
     products-dashboards-dashboard-widgets-widget-types-activity-recent-events--tile-filters-read-only--light:
         hash: v1.k794b7964.355b2fe7000461fbb2fb166e627e8f9b4f39631649ff62fd9966c69fa990f94e.GcjA3-hBC1df2mGFD0d6crjPeEbeOnwEZLOICsPTp6Y
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--default--dark:
-        hash: v1.k794b7964.77b0c690ee3199858b4f196d73c32fbd944079ef7e3e76c8727aba4c3d27225c.tuLjkbo2ZpMG9HZaTRmsJh6F3oxbNGPKL6PJ7DZkFMY
+        hash: v1.k794b7964.0c5e48132f055382561335fea973ddf546cf7216ce997c00e4c5d871838bbb1f.ALpVMICEU6x_cD5zCzaVXJBuqGqjWXHVTivfn-jrmik
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--default--light:
-        hash: v1.k794b7964.5aa1d315ee65b9129ab2a8ae1b0b4e81e2c41e49d7379b66ecd23fdc0b28b962.ejXifLgq55lPUx_QsVZSaZCBxxNUCTpX_Y0pWVw-13o
+        hash: v1.k794b7964.c31adcd884aca83bfe569fa9798ad0ad646399a4b948bada221a9181660d29fa.32fhpDGIwvoq0ASzzWq53IBdtqumn-p73n9WIpELcdg
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--empty--dark:
         hash: v1.k794b7964.3ec20b929e310ec6a4e3f3f1bdf66a3a1c1a3662a731ead330d76352fff7200e.elsn8w_XZ815pzyLLkZEn18o19B0b4YHppPMWSXurpA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--empty--light:
@@ -4985,9 +4985,9 @@ snapshots:
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--setup-unavailable--light:
         hash: v1.k794b7964.f39bc70d65f2d61b5861441fdb195b0ba9dc97d223a80c1af5d3683fe71351c6.6iCfN2igi-y8qUByF2SbVJVClwnKPWMoDdulEK7PNlg
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--dark:
-        hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
+        hash: v1.k794b7964.7aa75cb68efd2fdb961a6cd8529f3b1fd533967dd2d847ea23da6de24b201399.Uj1sl90pvQFCxoh8UEEPCUnKpCgbcPQhYllhyoR36h8
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
-        hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
+        hash: v1.k794b7964.500f6d858f4bbc00e4b2fdc7586d1934d470d9564fcf2cce9b8e8e9ea64843c0.Hv-Pm6nrOvuvFA4r2uQIWOlSE5BKipuUefN04RD6DbE
     ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
     :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
     ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -321,7 +321,6 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_RATE_LIMITING_PER_ISSUE: 'error-tracking-rate-limiting-per-issue', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RECOMMENDATIONS: 'error-tracking-recommendations', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RELATED_ISSUES: 'error-tracking-related-issues', // owner: #team-error-tracking
-    ERROR_TRACKING_SEVERITY_RULES: 'error-tracking-severity-rules', // owner: #team-error-tracking
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_BEHAVIOR_COMPARISON: 'experiment-behavior-comparison', // owner: @mp-hog #team-experiments

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -594,7 +594,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: 'Severity rules',
                 description: 'Set the initial severity of new issues based on rules you define.',
                 component: <SeverityRules />,
-                flag: 'ERROR_TRACKING_SEVERITY_RULES',
                 keywords: ['severity', 'priority', 'triage', 'critical', 'rule'],
             },
             {

--- a/products/error_tracking/frontend/ErrorTracking.stories.tsx
+++ b/products/error_tracking/frontend/ErrorTracking.stories.tsx
@@ -365,9 +365,7 @@ const meta: Meta = {
 export default meta
 
 type Story = StoryObj<{}>
-export const ListPage: Story = {
-    parameters: { featureFlags: [FEATURE_FLAGS.ERROR_TRACKING_SEVERITY_RULES] },
-}
+export const ListPage: Story = {}
 
 // An unresolved source maps recommendation renders the wizard banner above the
 // issue list without the sticky filters bar overlapping its bottom edge
@@ -483,18 +481,12 @@ export const ListPageWithIngestionWarning: Story = {
 }
 export const GroupPage: Story = {
     name: 'Issue scene',
-    parameters: {
-        pageUrl: urls.errorTrackingIssue(ISSUE_ID),
-        featureFlags: [FEATURE_FLAGS.ERROR_TRACKING_SEVERITY_RULES],
-    },
+    parameters: { pageUrl: urls.errorTrackingIssue(ISSUE_ID) },
 }
 
 export const GroupPageManyAssignees: Story = {
     name: 'Issue scene with many assignees',
-    parameters: {
-        pageUrl: urls.errorTrackingIssue(ISSUE_ID),
-        featureFlags: [FEATURE_FLAGS.ERROR_TRACKING_SEVERITY_RULES],
-    },
+    parameters: { pageUrl: urls.errorTrackingIssue(ISSUE_ID) },
     decorators: [
         mswDecorator({
             get: {

--- a/products/error_tracking/frontend/components/ErrorTrackingIssueList/ErrorTrackingIssueList.test.tsx
+++ b/products/error_tracking/frontend/components/ErrorTrackingIssueList/ErrorTrackingIssueList.test.tsx
@@ -3,9 +3,6 @@ import '@testing-library/jest-dom'
 import { cleanup, render, screen } from '@testing-library/react'
 import { Provider } from 'kea'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
@@ -68,27 +65,14 @@ describe('ErrorTrackingIssueListRow', () => {
         )
     })
 
-    it.each([
-        ['disabled', false, false],
-        ['enabled', true, true],
-    ])('shows severity only when the feature flag is %s', (_label, enabled, expectedVisible) => {
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags(
-            enabled ? [FEATURE_FLAGS.ERROR_TRACKING_SEVERITY_RULES] : [],
-            enabled ? { [FEATURE_FLAGS.ERROR_TRACKING_SEVERITY_RULES]: true } : {}
-        )
-
+    it('shows severity', () => {
         render(
             <Provider>
                 <ErrorTrackingIssueListRow issue={ISSUE} />
             </Provider>
         )
 
-        if (expectedVisible) {
-            expect(screen.getByText('High')).toBeInTheDocument()
-        } else {
-            expect(screen.queryByText('High')).not.toBeInTheDocument()
-        }
+        expect(screen.getByText('High')).toBeInTheDocument()
     })
 })
 

--- a/products/error_tracking/frontend/components/ErrorTrackingIssueList/ErrorTrackingIssueList.tsx
+++ b/products/error_tracking/frontend/components/ErrorTrackingIssueList/ErrorTrackingIssueList.tsx
@@ -6,7 +6,6 @@ import { Link } from '@posthog/lemon-ui'
 
 import { getRuntimeFromLib } from 'lib/components/Errors/utils'
 import { TZLabel } from 'lib/components/TZLabel'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 import { urls } from 'scenes/urls'
@@ -65,7 +64,6 @@ export function ErrorTrackingIssueListRow({
 }): JSX.Element {
     const { updateIssueAssignee, updateIssueSeverity, updateIssueStatus } = useActions(issueActionsLogic)
     const { severityUpdateInFlightIds } = useValues(issueActionsLogic)
-    const hasSeverityRules = useFeatureFlag('ERROR_TRACKING_SEVERITY_RULES')
     const runtime = getRuntimeFromLib(issue.library)
     const sparklineKey = issue.id ?? 'issue-unknown'
     const sparklineData = useSparklineData(issue.aggregations, ERROR_TRACKING_LISTING_RESOLUTION)
@@ -116,20 +114,16 @@ export function ErrorTrackingIssueListRow({
                         <StatusIndicator status={issue.status} size="small" />
                     )}
                     <CustomSeparator />
-                    {hasSeverityRules ? (
-                        <>
-                            {canMutateIssues ? (
-                                <IssueSeveritySelect
-                                    severity={issue.severity}
-                                    onChange={(severity) => updateIssueSeverity(issue.id, severity)}
-                                    loading={severityUpdateInFlightIds.includes(issue.id)}
-                                />
-                            ) : (
-                                <IssueSeverityTag severity={issue.severity} />
-                            )}
-                            <CustomSeparator />
-                        </>
-                    ) : null}
+                    {canMutateIssues ? (
+                        <IssueSeveritySelect
+                            severity={issue.severity}
+                            onChange={(severity) => updateIssueSeverity(issue.id, severity)}
+                            loading={severityUpdateInFlightIds.includes(issue.id)}
+                        />
+                    ) : (
+                        <IssueSeverityTag severity={issue.severity} />
+                    )}
+                    <CustomSeparator />
                     {canMutateIssues ? (
                         <QuillAssigneeSelect
                             assignee={issue.assignee}

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -6,7 +6,6 @@ import { LemonCheckbox, Link } from '@posthog/lemon-ui'
 
 import { ErrorTrackingRuntime } from 'lib/components/Errors/types'
 import { getRuntimeFromLib } from 'lib/components/Errors/utils'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Button, ButtonGroup, SelectTriggerIcon } from 'lib/ui/quill'
 import { Params } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -72,8 +71,6 @@ export const IssueListTitleColumn = (props: {
     const { updateIssueAssignee, updateIssueSeverity, updateIssueStatus } = useActions(issueActionsLogic)
     const { severityUpdateInFlightIds } = useValues(issueActionsLogic)
     const { dateRange, filterGroup, filterTestAccounts, searchQuery } = useValues(issueFiltersLogic)
-    const hasSeverityRules = useFeatureFlag('ERROR_TRACKING_SEVERITY_RULES')
-
     const checked = selectedIssueIds.includes(record.id)
     const runtime = getRuntimeFromLib(record.library)
 
@@ -127,7 +124,6 @@ export const IssueListTitleColumn = (props: {
                 )}
                 <IssueMetadata
                     record={record}
-                    showSeverity={hasSeverityRules}
                     severityLoading={severityUpdateInFlightIds.includes(record.id)}
                     onStatusChange={(status) => updateIssueStatus(record.id, status)}
                     onSeverityChange={(severity) => updateIssueSeverity(record.id, severity)}
@@ -168,14 +164,12 @@ const IssueTitle = ({
 
 const IssueMetadata = ({
     record,
-    showSeverity,
     severityLoading,
     onStatusChange,
     onSeverityChange,
     onAssigneeChange,
 }: {
     record: ErrorTrackingIssue
-    showSeverity: boolean
     severityLoading: boolean
     onStatusChange: (status: ErrorTrackingIssue['status']) => void
     onSeverityChange: (severity: NonNullable<ErrorTrackingIssue['severity']> | null) => void
@@ -184,9 +178,7 @@ const IssueMetadata = ({
     <div className="my-1 flex h-6 items-center text-secondary">
         <ButtonGroup>
             <IssueStatusSelect status={record.status} onChange={onStatusChange} />
-            {showSeverity ? (
-                <IssueSeveritySelect severity={record.severity} onChange={onSeverityChange} loading={severityLoading} />
-            ) : null}
+            <IssueSeveritySelect severity={record.severity} onChange={onSeverityChange} loading={severityLoading} />
             <QuillAssigneeSelect assignee={record.assignee} onChange={onAssigneeChange}>
                 {(anyAssignee) => (
                     <Button variant="outline" size="sm">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -64,7 +64,6 @@ export function ErrorTrackingIssueScene(): JSX.Element {
     const isMobile = isWindowLessThan('md')
     const sceneMenuBarEnabled = useFeatureFlag('SCENE_MENU_BAR')
     const hasIssueSplitting = useFeatureFlag('ERROR_TRACKING_ISSUE_SPLITTING')
-    const hasSeverityRules = useFeatureFlag('ERROR_TRACKING_SEVERITY_RULES')
 
     useAttachedContext(
         issueIdValid ? [{ type: 'error_tracking_issue', key: issueId, label: issue?.name ?? undefined }] : null
@@ -152,14 +151,12 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                         onChange={updateStatus}
                                                         size="default"
                                                     />
-                                                    {hasSeverityRules ? (
-                                                        <IssueSeveritySelect
-                                                            severity={issue.severity}
-                                                            onChange={updateSeverity}
-                                                            loading={severityUpdateInFlightIds.includes(issue.id)}
-                                                            size="default"
-                                                        />
-                                                    ) : null}
+                                                    <IssueSeveritySelect
+                                                        severity={issue.severity}
+                                                        onChange={updateSeverity}
+                                                        loading={severityUpdateInFlightIds.includes(issue.id)}
+                                                        size="default"
+                                                    />
                                                     <IssueAssigneeSelect
                                                         assignee={issue.assignee}
                                                         onChange={updateAssignee}
@@ -198,14 +195,12 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                 onChange={updateStatus}
                                                 size="default"
                                             />
-                                            {hasSeverityRules ? (
-                                                <IssueSeveritySelect
-                                                    severity={issue.severity}
-                                                    onChange={updateSeverity}
-                                                    loading={severityUpdateInFlightIds.includes(issue.id)}
-                                                    size="default"
-                                                />
-                                            ) : null}
+                                            <IssueSeveritySelect
+                                                severity={issue.severity}
+                                                onChange={updateSeverity}
+                                                loading={severityUpdateInFlightIds.includes(issue.id)}
+                                                size="default"
+                                            />
                                             <IssueAssigneeSelect
                                                 assignee={issue.assignee}
                                                 onChange={updateAssignee}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesFilters.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesFilters.tsx
@@ -1,5 +1,3 @@
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-
 import { ErrorFilters } from 'products/error_tracking/frontend/components/IssueFilters'
 import { ErrorTrackingQuickFilters } from 'products/error_tracking/frontend/components/IssueFilters/QuickFilters'
 import {
@@ -8,8 +6,6 @@ import {
 } from 'products/error_tracking/frontend/components/IssueQueryOptions/IssueQueryOptions'
 
 export function IssuesFilters(): JSX.Element {
-    const hasSeverityRules = useFeatureFlag('ERROR_TRACKING_SEVERITY_RULES')
-
     return (
         <ErrorFilters.Root>
             <div className="flex flex-col gap-2">
@@ -18,7 +14,7 @@ export function IssuesFilters(): JSX.Element {
                         <ReloadIssuesButton />
                         <ErrorFilters.DateRange />
                         <ErrorFilters.Status />
-                        {hasSeverityRules ? <ErrorFilters.Severity /> : null}
+                        <ErrorFilters.Severity />
                         <ErrorFilters.Assignee />
                         <ErrorFilters.InternalAccounts />
                     </div>


### PR DESCRIPTION
## Summary
- show severity controls and filters without a feature flag
- expose severity rule settings to all projects
- remove the retired feature flag constant and story configuration

## Stack
- Based on https://github.com/PostHog/posthog/pull/89193

## Tests
- `pnpm exec oxfmt --check <changed files>`
- `pnpm exec oxlint --quiet <changed files>`
- `pnpm --filter @posthog/frontend jest --runInBand products/error_tracking/frontend/components/ErrorTrackingIssueList/ErrorTrackingIssueList.test.tsx`