### PR TITLE
fix(ui): open disabled reason tooltips on click

### DIFF
--- a/frontend/src/lib/components/Account/ProjectCombobox.tsx
+++ b/frontend/src/lib/components/Account/ProjectCombobox.tsx
@@ -191,7 +191,9 @@ export function ProjectCombobox(): JSX.Element | null {
                             tooltip="Create a new project"
                             tooltipPlacement="right"
                             className="shrink-0"
-                            disabled={!!projectCreationForbiddenReason}
+                            disabledReasons={
+                                projectCreationForbiddenReason ? { [projectCreationForbiddenReason]: true } : undefined
+                            }
                         >
                             <IconPlusSmall className="text-tertiary" />
                             New project

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -301,6 +301,8 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         arrowOffset={tooltipArrowOffset}
                         docLink={tooltipDocLink}
                         visible={tooltipForceMount}
+                        // A click on a blocked button must surface the reason, since hover is unavailable on touch
+                        openOnClick={!!disabledReason}
                         interactive={disabledReasonInteractive}
                         closeDelayMs={disabledReasonInteractive ? INTERACTIVE_CLOSE_DELAY_MS : undefined}
                     >

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
@@ -292,6 +292,11 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
     const effectiveVariant = forceVariant ? variant : context?.variantContext || variant
     let effectiveDisabled = disabledReasons ? Object.values(disabledReasons).some((value) => value) : disabled
     const externalAriaDisabled = rest['aria-disabled']
+
+    // If there are disabled reasons which are true, render them, otherwise render the tooltip
+    const tooltipTitle = disabledReasons && effectiveDisabled ? renderDisabledReasons(disabledReasons) : tooltip
+    const hasTooltip = !!(tooltipTitle || tooltipDocLink)
+
     let buttonComponent: JSX.Element = React.createElement(
         'button',
         {
@@ -309,7 +314,9 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
                     inert,
                     truncate,
                     className,
-                })
+                }),
+                // A disabled button swallows pointer events, so let the tooltip wrapper span receive them
+                hasTooltip && effectiveDisabled && 'pointer-events-none'
             ),
             ref,
             disabled: effectiveDisabled,
@@ -323,13 +330,7 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
         children
     )
 
-    // If there are disabled reasons which are true, render them, otherwise render the tooltip
-    const tooltipTitle =
-        disabledReasons && Object.values(disabledReasons).some(Boolean)
-            ? renderDisabledReasons(disabledReasons)
-            : tooltip
-
-    if (tooltipTitle || tooltipDocLink) {
+    if (hasTooltip) {
         const tooltipChild = effectiveDisabled ? (
             <span className="inline-flex w-fit">{buttonComponent}</span>
         ) : (
@@ -344,6 +345,7 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement, ButtonPrimitiveProp
                 docLink={tooltipDocLink}
                 visible={tooltipVisible}
                 interactive={tooltipInteractive}
+                openOnClick={!!effectiveDisabled}
             >
                 {tooltipChild}
             </Tooltip>


### PR DESCRIPTION
## Problem

Clicking a button that is disabled for a reason doesn't open the relevant tooltip. The reason appears only after hovering.

## Changes

- A click on a button disabled with a reason now opens the reason tooltip immediately. Hover behavior is unchanged.
- `LemonButton` passes the existing `openOnClick` Tooltip prop when `disabledReason` is set.
- `ButtonPrimitive` does the same when disabled. Its natively disabled button also gets `pointer-events-none`, so the tooltip wrapper span receives the click.
- The disabled "New project" row in the project combobox now shows the forbidden reason through `disabledReasons` instead of a generic tooltip.

No static visual change - the tooltip is the existing one, now also shown on click.

## How did you test this code?

- Existing jest suites for Tooltip (`openOnClick` cases) and LemonButton cover the wiring. No new tests: the behavior is the Tooltip prop's existing contract.
- Manual, local dev, as a member without project-creation permission: clicking the disabled "New project" row in the project switcher and the disabled "Save" in org settings opens the reason tooltip. Hover still works. Enabled buttons with tooltips are unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
