### PR TITLE
chore(ci): retry the binstall lookups that 504

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -451,7 +451,15 @@ jobs:
               # --force: Swatinem/rust-cache restores ~/.cargo/.crates2.json but not the
               # binary itself, so without --force binstall can short-circuit ("already
               # installed") and leave no `cargo nextest` binary.
-              run: cargo binstall --no-confirm --force cargo-nextest@0.9.140
+              # The release lookup goes to api.github.com, which 504s, so retry. Compiling
+              # is not a fallback: nextest refuses a source build without --locked, and
+              # binstall does not pass it, so the fallback burns three minutes and fails.
+              run: |
+                  for attempt in 1 2 3; do
+                      cargo binstall --no-confirm --force --disable-strategies compile cargo-nextest@0.9.140 && exit 0
+                      sleep $((attempt * 10))
+                  done
+                  exit 1
 
             - name: Run cargo test
               env:
@@ -830,7 +838,13 @@ jobs:
               # (which records cargo-shear as installed) but not the binary itself, so
               # without --force binstall short-circuits ("already installed") and the
               # next step fails with `error: no such command: shear`.
-              run: cargo binstall --no-confirm --force cargo-shear@1.1.12
+              # Retried for the same api.github.com 504 the nextest install hits.
+              run: |
+                  for attempt in 1 2 3; do
+                      cargo binstall --no-confirm --force cargo-shear@1.1.12 && exit 0
+                      sleep $((attempt * 10))
+                  done
+                  exit 1
 
             - name: Run cargo shear
               run: cargo shear


### PR DESCRIPTION
## Problem

Rust CI goes red when `api.github.com` 504s on the nextest release lookup. Not specific to any PR: [the run that prompted this](https://github.com/PostHog/posthog/actions/runs/33053059967/job/98453341403) hit it on a one-file change.

The source fallback cannot save it. nextest 0.9.140 refuses to build without `--locked`, binstall does not pass it, so the fallback compiles for three minutes and then fails on a `compile_error!`.

## Changes

- Both binstall installs retry three times with a growing sleep.
- The nextest install stops falling back to a source build, so a failed lookup fails in seconds instead of three minutes.

## How did you test this code?

`bin/hogli lint:workflows` passes. actionlint is not installed in this environment, so it went unchecked.

The retry itself cannot be tested locally: it only fires on a 504 from GitHub.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills: `/authoring-ci-workflows`, `/writing-pr-descriptions`.
