### PR TITLE
fix(phai): give the conversation summarizer a cacheable fixed prefix

### DIFF
--- a/ee/hogai/utils/conversation_summarizer/prompts.py
+++ b/ee/hogai/utils/conversation_summarizer/prompts.py
@@ -3,7 +3,7 @@ You are PostHog AI, the friendly and knowledgeable AI agent of PostHog.
 You are tasked with summarizing conversations.
 """.strip()
 
-USER_PROMPT = """
+SUMMARIZATION_INSTRUCTION_PROMPT = """
 Create a comprehensive summary of the conversation to date, ensuring you capture the user’s specific requests and your prior responses.
 This summary should be thorough in capturing research concepts, key insights, and relevant data that would be essential for continuing product management work without losing context.
 
@@ -77,4 +77,8 @@ Here's an example of how your output must be structured:
 Please provide a comprehensive, accurate summary of the conversation so far following the provided structure.
 
 **CRITICAL**: keep important details
+""".strip()
+
+FINAL_TURN_PROMPT = """
+Summarize the conversation above, following the structure in your instructions.
 """.strip()

--- a/ee/hogai/utils/conversation_summarizer/summarizer.py
+++ b/ee/hogai/utils/conversation_summarizer/summarizer.py
@@ -3,15 +3,16 @@ import datetime
 from abc import abstractmethod
 from collections.abc import Sequence
 
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import BaseMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from posthog.models import Team, User
 
 from ee.hogai.llm import MaxChatAnthropic
+from ee.hogai.utils.anthropic import add_cache_control
 
-from .prompts import SYSTEM_PROMPT, USER_PROMPT
+from .prompts import FINAL_TURN_PROMPT, SUMMARIZATION_INSTRUCTION_PROMPT, SYSTEM_PROMPT
 
 
 class ConversationSummarizer:
@@ -31,11 +32,21 @@ class ConversationSummarizer:
     def _get_model(self): ...
 
     def _construct_messages(self, messages: Sequence[BaseMessage]):
+        # The summarization instruction carries no per-conversation data, so it leads the prompt to
+        # keep the fixed prefix contiguous and identical between calls. Everything that changes per
+        # call follows it: the project context `MaxChatMixin` appends to the system block, then the
+        # conversation itself.
         return (
-            ChatPromptTemplate.from_messages([("system", SYSTEM_PROMPT)])
+            ChatPromptTemplate.from_messages([self._construct_system_message()])
             + messages
-            + ChatPromptTemplate.from_messages([("user", USER_PROMPT)])
+            # The conversation can end with an assistant message, which the Anthropic API rejects as
+            # a prefill. This turn keeps the request ending on a user message, and repeats the task
+            # after a conversation that can reach the full 400k-token window.
+            + ChatPromptTemplate.from_messages([("user", FINAL_TURN_PROMPT)])
         )
+
+    def _construct_system_message(self) -> BaseMessage:
+        return SystemMessage(content=f"{SYSTEM_PROMPT}\n\n{SUMMARIZATION_INSTRUCTION_PROMPT}")
 
     def _parse_xml_tags(self, message: str) -> str:
         """
@@ -80,8 +91,17 @@ class AnthropicConversationSummarizer(ConversationSummarizer):
             billable=True,
         )
 
+    def _construct_system_message(self) -> BaseMessage:
+        # The 1h TTL outlives the 5m one between compactions, which are minutes to hours apart.
+        return add_cache_control(super()._construct_system_message(), ttl="1h")
+
     def _construct_messages(self, messages: Sequence[BaseMessage]):
-        """Removes cache_control headers."""
+        """Removes cache_control headers, so the only breakpoint is the one on the fixed prefix.
+
+        The agent marks the last message of the conversation it hands over, which would make
+        Anthropic write a cache entry for a ~400k-token prefix that no later call can read, because
+        each compaction sends a conversation only it has.
+        """
         messages_without_cache: list[BaseMessage] = []
         for message in messages:
             if isinstance(message.content, list):

--- a/ee/hogai/utils/conversation_summarizer/test/test_nodes.py
+++ b/ee/hogai/utils/conversation_summarizer/test/test_nodes.py
@@ -9,6 +9,7 @@ from langchain_core.messages import (
 from parameterized import parameterized
 
 from ee.hogai.utils.conversation_summarizer import AnthropicConversationSummarizer
+from ee.hogai.utils.conversation_summarizer.prompts import SUMMARIZATION_INSTRUCTION_PROMPT
 
 
 class TestAnthropicConversationSummarizer(BaseTest):
@@ -175,3 +176,33 @@ class TestAnthropicConversationSummarizer(BaseTest):
         result = self.summarizer._construct_messages([])
         # Should return prompt template with just system and user prompts
         self.assertEqual(len(result.messages), 2)
+
+    def test_only_cache_breakpoint_is_the_fixed_prefix(self):
+        messages = self.summarizer._construct_messages(
+            [
+                LangchainHumanMessage(content=[{"type": "text", "text": "Hello"}]),
+                LangchainAIMessage(content=[{"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}}]),
+            ]
+        ).format_messages()
+
+        cached = [
+            (message, block)
+            for message in messages
+            for block in (message.content if isinstance(message.content, list) else [])
+            if isinstance(block, dict) and "cache_control" in block
+        ]
+        self.assertEqual(len(cached), 1)
+        cached_message, cached_block = cached[0]
+        self.assertIs(cached_message, messages[0])
+        self.assertIn(SUMMARIZATION_INSTRUCTION_PROMPT, cached_block["text"])
+
+    @parameterized.expand(
+        [
+            ("conversation_ends_with_assistant_message", LangchainAIMessage(content="Done")),
+            ("conversation_ends_with_human_message", LangchainHumanMessage(content="Thanks")),
+        ]
+    )
+    def test_request_ends_on_a_user_turn(self, name, last_message):
+        messages = self.summarizer._construct_messages([last_message]).format_messages()
+
+        self.assertIsInstance(messages[-1], LangchainHumanMessage)

--- a/ee/hogai/utils/conversation_summarizer/test/test_nodes.py
+++ b/ee/hogai/utils/conversation_summarizer/test/test_nodes.py
@@ -195,6 +195,7 @@ class TestAnthropicConversationSummarizer(BaseTest):
         cached_message, cached_block = cached[0]
         self.assertIs(cached_message, messages[0])
         self.assertIn(SUMMARIZATION_INSTRUCTION_PROMPT, cached_block["text"])
+        self.assertEqual(cached_block["cache_control"], {"type": "ephemeral", "ttl": "1h"})
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Every conversation compaction pays full input price for its prompt, because the summarizer has no cacheable prefix to read. The workflow records no cache reads at all.

The prompt was assembled with the fixed content split across both ends:

1. `SYSTEM_PROMPT` in front, 118 characters.
2. The project and user context `MaxChatMixin` appends, which varies per project and per conversation.
3. The conversation, up to the full 400k-token window, unique to one compaction.
4. `USER_PROMPT`, the actual summarization instruction, 3,158 characters, as the final user turn.

The only content identical between calls sat in position 1, so a cache breakpoint anywhere in that prompt had almost nothing in front of it.

## Changes

- The summarization instruction now leads the prompt inside the system block, so the fixed prefix is contiguous and byte-identical between calls at 3,278 characters instead of 118. Everything that varies follows it.
- That prefix carries the single cache breakpoint, at a 1 hour TTL, which outlives the 5 minute TTL between compactions.
- A short trailing user turn keeps the request ending on a user message. This also removes a latent 400: Anthropic rejects a final assistant turn as a prefill, and the handed-over conversation can end with one.
- Inherited breakpoints are still stripped. The agent marks the last message of the conversation it hands over, and honoring that mark would make Anthropic write a cache entry for a ~400k-token prefix that no later call can read.
- Mechanical: `USER_PROMPT` becomes `SUMMARIZATION_INSTRUCTION_PROMPT`, since it no longer renders as a user message.

> [!NOTE]
> This makes the prefix cacheable in shape, and it is the precondition for any caching on this path, but it is not by itself a large saving. At roughly 900 tokens the prefix sits near Anthropic's minimum cacheable prefix for Sonnet-class models, so cache reads may still report zero until it grows. The conversation body stays at full price either way, because each compaction sends a conversation only it has. Reading the agent's own cached prefix for that body needs the tools block, system block and thinking config to match the agent's, which is a larger change and wants an eval.

No user-visible change. The summary content and the compaction trigger are untouched.

## How did you test this code?

`ee/hogai/utils/conversation_summarizer/test/test_nodes.py` passes locally against Postgres and ClickHouse.

Two tests were added, both aimed at regressions the existing cases could not catch:

- `test_only_cache_breakpoint_is_the_fixed_prefix` fails if the breakpoint moves off the fixed prefix or onto a conversation message. The second case is the expensive one, because it writes a cache entry for the whole conversation at a 25% surcharge with no later read.
- `test_request_ends_on_a_user_turn` fails if the trailing turn is dropped, which would send a prefill and 400 whenever the conversation ends with an assistant message.

The existing `_construct_messages` cases still assert breakpoint stripping and content preservation, and they were left unchanged.

Not run: the wider backend suites, and no request was made against the Anthropic API, so the cache-read rate after this change is not measured here. The cache accounting for this workflow is visible in AI observability under `ai_product = posthog_ai` and `$ai_span_name = MaxChatAnthropic`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app from a thread about an inbox report on this workflow's cache usage.
- Skills invoked: `/claude-api` (for the prompt caching rules: render order, per-model minimum cacheable prefix, and the invalidation hierarchy), `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- An earlier attempt at this report, #86697, put the breakpoint on the last conversation message instead. Nearly every conversation is summarized exactly once, so that placement would have bought a cache-write surcharge on almost every call and very few reads. This PR keeps the stripping that prevents that, and moves the prefix instead.
- The prompt is public repository content and carries no session material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1787623443464769?thread_ts=1787623443.464769&cid=C0BLK2ZEUSH)*
