### PR TITLE
fix(signals): stop the scout roster reporting an error when it unmounts mid-load

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/scannerScoutLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerScoutLogic.ts
@@ -148,9 +148,9 @@ export interface scannerScoutLogicActions {
         configId: string
         surface: import('products/signals/frontend/inbox/inboxAnalytics').ScoutSurface
     } // scoutFleetLogic
-    loadScoutConfigs: () => any // scoutFleetLogic
+    loadScoutConfigs: (_?: void | undefined) => void // scoutFleetLogic
     loadScoutMetadata: () => any // scoutFleetLogic
-    loadScoutRuns: () => any // scoutFleetLogic
+    loadScoutRuns: (_?: void | undefined) => void // scoutFleetLogic
     runScoutNow: (configId: string) => {
         configId: string
     } // scoutFleetLogic

--- a/products/signals/frontend/inbox/logics/inboxOnboardingLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxOnboardingLogic.ts
@@ -306,7 +306,7 @@ export interface inboxOnboardingLogicValues {
 export interface inboxOnboardingLogicActions {
     loadPullsCount: () => any // reportListLogic
     loadReportsCount: () => any // reportListLogic
-    loadScoutConfigs: () => any // scoutFleetLogic
+    loadScoutConfigs: (_?: void | undefined) => void // scoutFleetLogic
     loadSourceConfigs: () => any // signalSourcesLogic
     checkWizardSession: () => {
         value: true

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -230,6 +230,22 @@ describe('scoutFleetLogic', () => {
         expect(logic.values.scoutConfigs).toBeNull()
     })
 
+    // The roster mounts from short-lived components, so an unmount mid-request is routine. The
+    // loader reconciles against `values.scoutConfigs`, and that read throws once the reducer branch
+    // leaves the store — a silent error report from a page the user has already left.
+    it('reports nothing when the roster unmounts while its config request is in flight', async () => {
+        const request = deferred<SignalScoutConfigApi[]>()
+        mockSignalsScoutConfigList.mockReturnValueOnce(request.promise)
+
+        logic.actions.loadScoutConfigs()
+        logic.unmount()
+        request.resolve([BASE_CONFIG])
+        // Drain the microtasks the loader resumes on, so the assertion sees its full continuation.
+        await new Promise(setImmediate)
+
+        expect(posthog.captureException).not.toHaveBeenCalled()
+    })
+
     // The 500 row is the point of this case: a guard wide enough to swallow it would leave a real
     // scout-configs outage looking identical to a project the user simply cannot reach.
     it.each([

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -255,7 +255,7 @@ export interface scoutFleetLogicActions {
         fleetFindingsSummary: FleetFindingsSummaryApi | null
         payload?: any
     }
-    loadRunsWindow: () => any
+    loadRunsWindow: (_: void) => void
     loadRunsWindowFailure: (
         error: string,
         errorObject?: any
@@ -268,15 +268,15 @@ export interface scoutFleetLogicActions {
             complete: boolean
             runs: SignalScoutRunSummary[]
         },
-        payload?: any
+        payload?: void
     ) => {
         runsWindow: {
             complete: boolean
             runs: SignalScoutRunSummary[]
         }
-        payload?: any
+        payload?: void
     }
-    loadScoutConfigs: () => any
+    loadScoutConfigs: (_: void) => void
     loadScoutConfigsFailure: (
         error: string,
         errorObject?: any
@@ -286,10 +286,10 @@ export interface scoutFleetLogicActions {
     }
     loadScoutConfigsSuccess: (
         scoutConfigs: SignalScoutConfigApi[] | null,
-        payload?: any
+        payload?: void
     ) => {
         scoutConfigs: SignalScoutConfigApi[] | null
-        payload?: any
+        payload?: void
     }
     loadScoutMetadata: () => any
     loadScoutMetadataFailure: (
@@ -306,7 +306,7 @@ export interface scoutFleetLogicActions {
         scoutMetadata: ScoutMetadataApi | null
         payload?: any
     }
-    loadScoutRuns: () => any
+    loadScoutRuns: (_: void) => void
     loadScoutRunsFailure: (
         error: string,
         errorObject?: any
@@ -316,10 +316,10 @@ export interface scoutFleetLogicActions {
     }
     loadScoutRunsSuccess: (
         scoutRuns: SignalScoutRunSummary[],
-        payload?: any
+        payload?: void
     ) => {
         scoutRuns: SignalScoutRunSummary[]
-        payload?: any
+        payload?: void
     }
     patchScoutConfigLocally: (
         configId: string,
@@ -489,7 +489,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
         scoutConfigs: [
             null as SignalScoutConfig[] | null,
             {
-                loadScoutConfigs: async (_, breakpoint) => {
+                loadScoutConfigs: async (_: void, breakpoint) => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return null
@@ -560,7 +560,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
         scoutRuns: [
             [] as SignalScoutRunSummary[],
             {
-                loadScoutRuns: async (_, breakpoint) => {
+                loadScoutRuns: async (_: void, breakpoint) => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return values.scoutRuns
@@ -583,7 +583,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                 complete: boolean
             },
             {
-                loadRunsWindow: async (_, breakpoint) => {
+                loadRunsWindow: async (_: void, breakpoint) => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return values.runsWindow

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -489,13 +489,17 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
         scoutConfigs: [
             null as SignalScoutConfig[] | null,
             {
-                loadScoutConfigs: async () => {
+                loadScoutConfigs: async (_, breakpoint) => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return null
                     }
                     try {
                         const configs = await signalsScoutConfigList(String(teamId))
+                        // The breakpoint must run before the `values` read below. The roster mounts from
+                        // short-lived components, so the logic can unmount while this request is in
+                        // flight. The reducer branch is then gone from the store, and the read throws.
+                        breakpoint()
                         // The 60s poll refetches all configs every cycle. Reconcile against the previous
                         // list so an unchanged fleet keeps the same references — otherwise the whole
                         // roster re-renders on every poll even when nothing changed.
@@ -556,7 +560,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
         scoutRuns: [
             [] as SignalScoutRunSummary[],
             {
-                loadScoutRuns: async () => {
+                loadScoutRuns: async (_, breakpoint) => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return values.scoutRuns
@@ -564,6 +568,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                     const runs = await signalsScoutRunsRecentPerScout(String(teamId), {
                         per_scout_limit: SCOUT_RUNS_PER_SCOUT,
                     })
+                    breakpoint()
                     // Reuse prior references for unchanged runs so the 60s poll doesn't churn every
                     // run's identity and needlessly re-render the memoized run/emission rows. Live
                     // (running/queued) runs are never reused: their rows show a wall-clock duration
@@ -578,7 +583,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                 complete: boolean
             },
             {
-                loadRunsWindow: async () => {
+                loadRunsWindow: async (_, breakpoint) => {
                     const teamId = teamLogic.values.currentTeamId
                     if (!teamId) {
                         return values.runsWindow
@@ -597,6 +602,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                             date_from: windowStart,
                             date_to: cursor,
                         })
+                        breakpoint()
                         for (const run of pageRuns) {
                             // `date_to` is exclusive, so a boundary row can reappear on the next
                             // page — dedupe by run_id to be safe.


### PR DESCRIPTION
## Problem

Anyone who opens the Self-driving Inbox and navigates away within a second or two silently files an error against the project. Nothing renders wrong and no toast appears, so the only visible effect is noise in Error tracking — a `[KEA] Can not find path "scenes.inbox.logics.scoutFleetLogic" in the store.` issue that has been reported once per affected session since it appeared a few days ago.

`scoutFleetLogic` has three loaders that read `values` after an await, to reconcile object identity against the previous poll so an unchanged fleet keeps stable references. The roster is mounted by short-lived components that swap out as flags and onboarding resolve, so an unmount mid-request is routine. When it happens the reducer branch is already gone from the store, the `values` read throws, and the failure path reports it.

## Changes

- The Inbox no longer files an error when a person leaves it while the scout roster is still loading. Nothing else about the page changes.
- Mechanical: `loadScoutConfigs`, `loadScoutRuns`, and `loadRunsWindow` take the loaders' `breakpoint` argument and call it after each await. This is the same guard [#84013](https://github.com/PostHog/posthog/pull/84013) applies to `visionQuotaLogic` and `dashboardTemplatesLogic`; that PR predates this logic's regression, so it does not cover it.

`loadScoutConfigs` was the only one reported, because it is the loader that runs unconditionally on mount. The other two read `values` after an await in exactly the same way and only escape reports because they run on the Scouts tab, so they are guarded here too rather than left to surface later.

## How did you test this code?

`scoutFleetLogic.test.ts` gains one case: trigger the config load, unmount, then resolve the request. It asserts nothing is reported. Verified it discriminates — the case fails on the unpatched loader (`captureException` called once) and passes with the breakpoint in place. No existing case covered this: the nearest one unmounts *before* the request starts, never mid-flight.

Also ran, locally: the full `scoutFleetLogic` suite (27 cases), oxlint, and oxfmt. `tsgo` reports no errors in the changed files; the failures it does report are pre-existing missing-module errors from the unbuilt nested `@posthog/quill` workspace.

Not done: `hogli ci:preflight` and `hogli review` could not run in this environment (no Python env for the `hogli` entrypoint), so the local Greptile pass was skipped and CI is the first reviewer. No manual browser testing — the change removes an error report and has no visual surface.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1787749269312709?thread_ts=1787749269.312709&cid=C0BLK2ZEUSH) asking whether two issues flagged by a Replay Vision scanner were real and worth fixing. This is the half that was.

The scanner's headline claim was a "client request failure on inbox load". That did not hold up: the flagged session has no exception events at all. Reading Error tracking for the Inbox route instead surfaced this kea issue, which is a real regression with a first-seen date, and a spiky `signals/reports` 500 that two open PRs already attribute to shared database-pool saturation rather than signals code — so no change is proposed for it here.

Skills invoked: `/writing-tests` (to gate whether the new case earned its place) and the repo's kea and PR-description conventions.

Public artifact: the diff, the test data, and this description carry no session material. The test reuses the file's existing `BASE_CONFIG` fixture.
