### PR TITLE
fix(skills): stop reporting every skill load failure as "not found"

### DIFF
--- a/products/skills/frontend/LLMSkillScene.tsx
+++ b/products/skills/frontend/LLMSkillScene.tsx
@@ -81,6 +81,8 @@ export function LLMSkillScene(): JSX.Element {
         downloadingZip,
         isSkillFormDirty,
         nextVersion,
+        skillName,
+        skillLoadErrorStatus,
     } = useValues(llmSkillLogic)
     const { searchParams } = useValues(router)
 
@@ -93,11 +95,8 @@ export function LLMSkillScene(): JSX.Element {
         loadMoreVersions,
         downloadSkill,
         cancelEditing,
+        loadSkill,
     } = useActions(llmSkillLogic)
-
-    if (isSkillMissing) {
-        return <NotFound object="skill" />
-    }
 
     if (shouldDisplaySkeleton) {
         return (
@@ -106,6 +105,37 @@ export function LLMSkillScene(): JSX.Element {
                 <LemonSkeleton active className="h-4 w-full" />
                 <LemonSkeleton active className="h-4 w-3/5" />
             </div>
+        )
+    }
+
+    if (skillLoadErrorStatus !== null) {
+        return (
+            <LemonBanner type="error" action={{ children: 'Try again', onClick: loadSkill }}>
+                {skillLoadErrorStatus === 403
+                    ? "You don't have access to this skill. Ask an admin of your organization to give you access."
+                    : "Couldn't load this skill. Try again, and if it keeps happening contact support."}
+            </LemonBanner>
+        )
+    }
+
+    if (isSkillMissing) {
+        return (
+            <NotFound
+                object="skill"
+                caption={
+                    searchParams.version ? (
+                        <>
+                            This skill has no version {searchParams.version}.{' '}
+                            <Link to={urls.skill(skillName)}>View the latest version</Link>, or{' '}
+                            <Link to={urls.skills()}>browse all skills</Link>.
+                        </>
+                    ) : (
+                        <>
+                            Check the skill name in the URL, or <Link to={urls.skills()}>browse all skills</Link>.
+                        </>
+                    )
+                }
+            />
         )
     }
 

--- a/products/skills/frontend/LLMSkillScene.tsx
+++ b/products/skills/frontend/LLMSkillScene.tsx
@@ -16,6 +16,7 @@ import {
 import { LemonBanner, LemonButton, LemonSelect, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { AccessDenied } from 'lib/components/AccessDenied'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
 import { NotFound } from 'lib/components/NotFound'
 import { dayjs } from 'lib/dayjs'
@@ -82,7 +83,9 @@ export function LLMSkillScene(): JSX.Element {
         isSkillFormDirty,
         nextVersion,
         skillName,
-        skillLoadErrorStatus,
+        selectedVersion,
+        isSkillAccessDenied,
+        hasSkillLoadError,
     } = useValues(llmSkillLogic)
     const { searchParams } = useValues(router)
 
@@ -108,12 +111,14 @@ export function LLMSkillScene(): JSX.Element {
         )
     }
 
-    if (skillLoadErrorStatus !== null) {
+    if (isSkillAccessDenied) {
+        return <AccessDenied object="skill" />
+    }
+
+    if (hasSkillLoadError) {
         return (
             <LemonBanner type="error" action={{ children: 'Try again', onClick: loadSkill }}>
-                {skillLoadErrorStatus === 403
-                    ? "You don't have access to this skill. Ask an admin of your organization to give you access."
-                    : "Couldn't load this skill. Try again, and if it keeps happening contact support."}
+                Couldn't load this skill. Try again, and if it keeps happening contact support.
             </LemonBanner>
         )
     }
@@ -123,10 +128,12 @@ export function LLMSkillScene(): JSX.Element {
             <NotFound
                 object="skill"
                 caption={
-                    searchParams.version ? (
+                    // The resolve endpoint returns the same 404 for a missing skill and a missing
+                    // version, so the caption can only name what the URL asks for.
+                    selectedVersion !== null ? (
                         <>
-                            This skill has no version {searchParams.version}.{' '}
-                            <Link to={urls.skill(skillName)}>View the latest version</Link>, or{' '}
+                            This link points to version {selectedVersion}.{' '}
+                            <Link to={urls.skill(skillName)}>Try the latest version</Link>, or{' '}
                             <Link to={urls.skills()}>browse all skills</Link>.
                         </>
                     ) : (

--- a/products/skills/frontend/llmSkillLogic.test.ts
+++ b/products/skills/frontend/llmSkillLogic.test.ts
@@ -312,4 +312,35 @@ describe('llmSkillLogic', () => {
             )
         })
     })
+
+    describe('load failures', () => {
+        let logic: ReturnType<typeof llmSkillLogic.build>
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            initKeaTests()
+            mockFilesRetrieve.mockResolvedValue(MOCK_FILE)
+        })
+
+        afterEach(() => {
+            logic?.unmount()
+        })
+
+        // Only a 404 proves the skill isn't there. Treating every failure as "not found" tells a user
+        // who lacks access, or who hit a server error, that a skill they may well own does not exist.
+        it.each([
+            [404, true, null],
+            [403, false, 403],
+            [500, false, 500],
+        ])('reports a %i as missing=%s', async (status, missing, errorStatus) => {
+            mockResolve.mockRejectedValue(new ApiError('Request failed', status))
+
+            logic = llmSkillLogic({ skillName: 'my-test-skill' })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadSkillFailure'])
+
+            expect(logic.values.isSkillMissing).toBe(missing)
+            expect(logic.values.skillLoadErrorStatus).toBe(errorStatus)
+        })
+    })
 })

--- a/products/skills/frontend/llmSkillLogic.test.ts
+++ b/products/skills/frontend/llmSkillLogic.test.ts
@@ -355,9 +355,15 @@ describe('llmSkillLogic', () => {
             expect(logic.values.hasSkillLoadError).toBe(expected.loadError)
             expect(logic.values.breadcrumbs.at(-1)?.name).toBe('my-test-skill')
 
+            mockResolve.mockResolvedValue(resolveResponse(mockSkill))
+            mockFilesRetrieve.mockResolvedValue(MOCK_FILE)
             logic.actions.loadSkill()
             expect(logic.values.hasSkillLoadError).toBe(false)
-            await expectLogic(logic).toDispatchActions(['loadSkillFailure'])
+            await expectLogic(logic).toDispatchActions(['loadSkillSuccess'])
+
+            expect(logic.values.isSkillMissing).toBe(false)
+            expect(logic.values.isSkillAccessDenied).toBe(false)
+            expect(logic.values.hasSkillLoadError).toBe(false)
         })
     })
 })

--- a/products/skills/frontend/llmSkillLogic.test.ts
+++ b/products/skills/frontend/llmSkillLogic.test.ts
@@ -2,7 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
-import { ApiError } from '~/lib/api-error'
+import { ApiError, NetworkError } from '~/lib/api-error'
 import { initKeaTests } from '~/test/init'
 
 import {
@@ -319,28 +319,45 @@ describe('llmSkillLogic', () => {
         beforeEach(() => {
             jest.clearAllMocks()
             initKeaTests()
-            mockFilesRetrieve.mockResolvedValue(MOCK_FILE)
         })
 
         afterEach(() => {
             logic?.unmount()
         })
 
-        // Only a 404 proves the skill isn't there. Treating every failure as "not found" tells a user
-        // who lacks access, or who hit a server error, that a skill they may well own does not exist.
         it.each([
-            [404, true, null],
-            [403, false, 403],
-            [500, false, 500],
-        ])('reports a %i as missing=%s', async (status, missing, errorStatus) => {
-            mockResolve.mockRejectedValue(new ApiError('Request failed', status))
+            ['a 404', new ApiError('Not found', 404), { missing: true, accessDenied: false, loadError: false }],
+            [
+                'a permission-denied 403',
+                new ApiError('Forbidden', 403, undefined, { code: 'permission_denied' }),
+                { missing: false, accessDenied: true, loadError: false },
+            ],
+            [
+                'a 403 that is not about object access',
+                new ApiError('Forbidden', 403),
+                { missing: false, accessDenied: false, loadError: true },
+            ],
+            ['a 500', new ApiError('Server error', 500), { missing: false, accessDenied: false, loadError: true }],
+            [
+                'a dropped connection',
+                new NetworkError('network'),
+                { missing: false, accessDenied: false, loadError: true },
+            ],
+        ])('resolves %s to its own state', async (_label, error, expected) => {
+            mockResolve.mockRejectedValue(error)
 
             logic = llmSkillLogic({ skillName: 'my-test-skill' })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadSkillFailure'])
 
-            expect(logic.values.isSkillMissing).toBe(missing)
-            expect(logic.values.skillLoadErrorStatus).toBe(errorStatus)
+            expect(logic.values.isSkillMissing).toBe(expected.missing)
+            expect(logic.values.isSkillAccessDenied).toBe(expected.accessDenied)
+            expect(logic.values.hasSkillLoadError).toBe(expected.loadError)
+            expect(logic.values.breadcrumbs.at(-1)?.name).toBe('my-test-skill')
+
+            logic.actions.loadSkill()
+            expect(logic.values.hasSkillLoadError).toBe(false)
+            await expectLogic(logic).toDispatchActions(['loadSkillFailure'])
         })
     })
 })

--- a/products/skills/frontend/llmSkillLogic.ts
+++ b/products/skills/frontend/llmSkillLogic.ts
@@ -17,6 +17,7 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
 
 import { ApiConfig, ApiError } from '~/lib/api'
+import { isAccessDeniedError } from '~/lib/api-error'
 import { lemonToast } from '~/lib/lemon-ui/LemonToast/LemonToast'
 import { urls } from '~/scenes/urls'
 import { Breadcrumb } from '~/types'
@@ -124,6 +125,12 @@ export interface PublishConflict {
     latestVersion: number | null
 }
 
+export interface SkillLoadError {
+    /** Undefined when the request never reached the server: a `NetworkError` carries no status. */
+    status: number | undefined
+    code: string | null
+}
+
 // Sorted by path so a reorder that ends up byte-identical on the server is not presented as a change.
 function sortSkillFilesByPath(files: SkillFormFileValues[]): SkillFormFileValues[] {
     return [...files].sort((a, b) => a.path.localeCompare(b.path))
@@ -202,12 +209,14 @@ export interface llmSkillLogicValues {
     }>
     downloadingZip: boolean
     fileContentsLoading: boolean
+    hasSkillLoadError: boolean
     isDiffVisible: boolean
     isEditMode: boolean
     isHistoricalVersion: boolean
     isNewSkill: boolean
     isOutlineExpanded: boolean
     isPublishReviewOpen: boolean
+    isSkillAccessDenied: boolean
     isSkillFormDirty: boolean
     isSkillFormSubmitting: boolean
     isSkillFormValid: boolean
@@ -220,6 +229,7 @@ export interface llmSkillLogicValues {
     ownersEditing: boolean
     publishConflict: PublishConflict | null
     savingOwners: boolean
+    selectedVersion: number | null
     shouldDisplaySkeleton: boolean
     showSkillFormErrors: boolean
     skill: ResolvedLLMSkill | SkillFormValues | null
@@ -234,8 +244,7 @@ export interface llmSkillLogicValues {
     skillFormTouched: boolean
     skillFormTouches: Record<string, boolean>
     skillFormValidationErrors: DeepPartialMap<SkillFormValues, ValidationErrorType>
-    skillLoadErrorStatus: number | null
-    skillLoadStatus: number | null
+    skillLoadError: SkillLoadError | null
     skillLoading: boolean
     skillName: string
     skillOwners: readonly UserBasicApi[]
@@ -391,12 +400,14 @@ export interface llmSkillLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         isNewSkill: (arg: any) => boolean
         skillName: (arg: SkillLogicProps) => string
-        skillLoadErrorStatus: (skillLoadStatus: number | null) => number | null
+        selectedVersion: (arg: SkillLogicProps) => number | null
+        isSkillAccessDenied: (skillLoadError: any) => boolean
+        hasSkillLoadError: (skillLoadError: any, isSkillAccessDenied: any) => boolean
         isSkillMissing: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
             skillLoading: boolean,
             skillFetched: boolean,
-            skillLoadErrorStatus: number | null
+            skillLoadError: any
         ) => boolean
         shouldDisplaySkeleton: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
@@ -407,7 +418,7 @@ export interface llmSkillLogicMeta {
         isHistoricalVersion: (skill: ResolvedLLMSkill | SkillFormValues | null) => boolean
         breadcrumbs: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
-            skillName: any,
+            skillName: string,
             searchParams: Record<string, any>
         ) => Breadcrumb[]
         isViewMode: (mode: SkillMode, arg: any) => boolean
@@ -487,12 +498,15 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
                 loadSkillFailure: () => true,
             },
         ],
-        skillLoadStatus: [
-            null as number | null,
+        skillLoadError: [
+            null as SkillLoadError | null,
             {
                 loadSkill: () => null,
                 loadSkillSuccess: () => null,
-                loadSkillFailure: (_, { errorObject }) => errorObject?.status ?? null,
+                loadSkillFailure: (_, { errorObject }) => ({
+                    status: errorObject?.status,
+                    code: errorObject?.code ?? null,
+                }),
             },
         ],
         versionsLoading: [
@@ -767,23 +781,38 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
             (props: SkillLogicProps): string => props.skillName,
         ],
 
-        // A 404 is the only failure that proves the skill isn't there. Every other status (no access,
-        // server error, network drop) leaves the question open, so it gets its own state rather than
-        // telling the user a skill they may well own does not exist.
-        skillLoadErrorStatus: [
-            (s) => [s.skillLoadStatus],
-            (skillLoadStatus: number | null): number | null =>
-                skillLoadStatus !== null && skillLoadStatus !== 404 ? skillLoadStatus : null,
+        selectedVersion: [
+            () => [(_: unknown, props: SkillLogicProps) => props],
+            (props: SkillLogicProps): number | null => props.selectedVersion ?? null,
         ],
 
+        isSkillAccessDenied: [
+            (s) => [s.skillLoadError],
+            (skillLoadError: SkillLoadError | null): boolean =>
+                skillLoadError !== null && isAccessDeniedError(skillLoadError),
+        ],
+
+        hasSkillLoadError: [
+            (s) => [s.skillLoadError, s.isSkillAccessDenied],
+            (skillLoadError: SkillLoadError | null, isSkillAccessDenied: boolean): boolean =>
+                skillLoadError !== null && skillLoadError.status !== 404 && !isSkillAccessDenied,
+        ],
+
+        // A 404 is the only failure that proves the skill isn't there. Every other failure (no access,
+        // a server error, a request that never left the browser) leaves the question open, so it gets
+        // its own state rather than telling the user a skill they may well own does not exist.
         isSkillMissing: [
-            (s) => [s.skill, s.skillLoading, s.skillFetched, s.skillLoadErrorStatus],
+            (s) => [s.skill, s.skillLoading, s.skillFetched, s.skillLoadError],
             (
                 skill: ResolvedLLMSkill | SkillFormValues | null,
                 skillLoading: boolean,
                 skillFetched: boolean,
-                skillLoadErrorStatus: number | null
-            ) => skillFetched && !skillLoading && skill === null && skillLoadErrorStatus === null,
+                skillLoadError: SkillLoadError | null
+            ) =>
+                skillFetched &&
+                !skillLoading &&
+                skill === null &&
+                (skillLoadError === null || skillLoadError.status === 404),
         ],
 
         shouldDisplaySkeleton: [

--- a/products/skills/frontend/llmSkillLogic.ts
+++ b/products/skills/frontend/llmSkillLogic.ts
@@ -401,13 +401,13 @@ export interface llmSkillLogicMeta {
         isNewSkill: (arg: any) => boolean
         skillName: (arg: SkillLogicProps) => string
         selectedVersion: (arg: SkillLogicProps) => number | null
-        isSkillAccessDenied: (skillLoadError: any) => boolean
-        hasSkillLoadError: (skillLoadError: any, isSkillAccessDenied: any) => boolean
+        isSkillAccessDenied: (skillLoadError: SkillLoadError | null) => boolean
+        hasSkillLoadError: (skillLoadError: SkillLoadError | null, isSkillAccessDenied: boolean) => boolean
         isSkillMissing: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
             skillLoading: boolean,
             skillFetched: boolean,
-            skillLoadError: any
+            skillLoadError: SkillLoadError | null
         ) => boolean
         shouldDisplaySkeleton: (
             skill: ResolvedLLMSkill | SkillFormValues | null,

--- a/products/skills/frontend/llmSkillLogic.ts
+++ b/products/skills/frontend/llmSkillLogic.ts
@@ -234,7 +234,10 @@ export interface llmSkillLogicValues {
     skillFormTouched: boolean
     skillFormTouches: Record<string, boolean>
     skillFormValidationErrors: DeepPartialMap<SkillFormValues, ValidationErrorType>
+    skillLoadErrorStatus: number | null
+    skillLoadStatus: number | null
     skillLoading: boolean
+    skillName: string
     skillOwners: readonly UserBasicApi[]
     versionDescription: string
     versions: LLMSkillVersionSummaryApi[]
@@ -387,10 +390,13 @@ export interface llmSkillLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
         isNewSkill: (arg: any) => boolean
+        skillName: (arg: SkillLogicProps) => string
+        skillLoadErrorStatus: (skillLoadStatus: number | null) => number | null
         isSkillMissing: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
             skillLoading: boolean,
-            skillFetched: boolean
+            skillFetched: boolean,
+            skillLoadErrorStatus: number | null
         ) => boolean
         shouldDisplaySkeleton: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
@@ -401,6 +407,7 @@ export interface llmSkillLogicMeta {
         isHistoricalVersion: (skill: ResolvedLLMSkill | SkillFormValues | null) => boolean
         breadcrumbs: (
             skill: ResolvedLLMSkill | SkillFormValues | null,
+            skillName: any,
             searchParams: Record<string, any>
         ) => Breadcrumb[]
         isViewMode: (mode: SkillMode, arg: any) => boolean
@@ -478,6 +485,14 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
             {
                 loadSkillSuccess: () => true,
                 loadSkillFailure: () => true,
+            },
+        ],
+        skillLoadStatus: [
+            null as number | null,
+            {
+                loadSkill: () => null,
+                loadSkillSuccess: () => null,
+                loadSkillFailure: (_, { errorObject }) => errorObject?.status ?? null,
             },
         ],
         versionsLoading: [
@@ -747,10 +762,28 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
     selectors({
         isNewSkill: [() => [(_, props) => props], (props) => props.skillName === 'new'],
 
+        skillName: [
+            () => [(_: unknown, props: SkillLogicProps) => props],
+            (props: SkillLogicProps): string => props.skillName,
+        ],
+
+        // A 404 is the only failure that proves the skill isn't there. Every other status (no access,
+        // server error, network drop) leaves the question open, so it gets its own state rather than
+        // telling the user a skill they may well own does not exist.
+        skillLoadErrorStatus: [
+            (s) => [s.skillLoadStatus],
+            (skillLoadStatus: number | null): number | null =>
+                skillLoadStatus !== null && skillLoadStatus !== 404 ? skillLoadStatus : null,
+        ],
+
         isSkillMissing: [
-            (s) => [s.skill, s.skillLoading, s.skillFetched],
-            (skill: ResolvedLLMSkill | SkillFormValues | null, skillLoading: boolean, skillFetched: boolean) =>
-                skillFetched && !skillLoading && skill === null,
+            (s) => [s.skill, s.skillLoading, s.skillFetched, s.skillLoadErrorStatus],
+            (
+                skill: ResolvedLLMSkill | SkillFormValues | null,
+                skillLoading: boolean,
+                skillFetched: boolean,
+                skillLoadErrorStatus: number | null
+            ) => skillFetched && !skillLoading && skill === null && skillLoadErrorStatus === null,
         ],
 
         shouldDisplaySkeleton: [
@@ -769,8 +802,12 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
         ],
 
         breadcrumbs: [
-            (s) => [s.skill, router.selectors.searchParams],
-            (skill: LLMSkillApi | SkillFormValues | null, searchParams: Record<string, any>): Breadcrumb[] => [
+            (s) => [s.skill, s.skillName, router.selectors.searchParams],
+            (
+                skill: LLMSkillApi | SkillFormValues | null,
+                skillName: string,
+                searchParams: Record<string, any>
+            ): Breadcrumb[] => [
                 {
                     name: 'Skills',
                     path: combineUrl(urls.skills(), searchParams).url,
@@ -782,7 +819,9 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
                             ? isSkill(skill)
                                 ? `${skill.name} v${skill.version}`
                                 : skill.name || 'New skill'
-                            : 'New skill',
+                            : skillName === 'new'
+                              ? 'New skill'
+                              : skillName,
                     key: 'Skill',
                 },
             ],


### PR DESCRIPTION
## Problem

Opening a skill page renders "Skill not found" whenever the load doesn't produce a skill, regardless of why. `isSkillMissing` was `skillFetched && !skillLoading && skill === null`, and `skillFetched` flips true on failure as well as success, so a 403, a 500, or a dropped request all land on the 404 page.

That leaves a user who lacks access, or who hit a server error, told that a skill they may well own does not exist. There is no retry and no link onward, so the page is a dead end. The breadcrumb made it stranger: it fell through to "New skill", so the header read "Skills / New skill" above a "Skill not found" body.

Skill URLs are name-keyed and can carry a pinned `?version=N`, and the app emits absolute copyable links to them, so people do arrive at these pages from stale links. `not_found_shown` with `object: 'skill'` fires steadily rather than in bursts, so this state is reached regularly, though by a very small share of the people who open a skills page.

## Changes

- A skill that fails to load for any reason other than a 404 now shows a retryable error instead of "Skill not found". A user who lacks access is told that, and a server error offers "Try again".
- The "Skill not found" page now says what to do next: it links to the skills list, and a request pinned to a missing `?version=N` also links to the skill's latest version.
- The breadcrumb shows the skill name from the URL instead of "New skill" when a skill doesn't load.
- Branches now run in resolution order (loading, then error, then not-found), per the resolution-states rule in `/writing-ui-components`. Mechanical: the not-found branch moved below the skeleton branch, which changes nothing, since it was already gated on the fetch having finished.

Not addressed here: why the stale links exist. There is an unverified lead that skills are read on the parent team in one place but linked into the child environment, which would 404 systematically on multi-environment projects. That needs confirming against a real multi-environment project and is a separate change.

## How did you test this code?

Automated, in `products/skills/frontend/llmSkillLogic.test.ts`: three `it.each` cases assert that a 404 sets `isSkillMissing`, and that a 403 and a 500 instead set `skillLoadErrorStatus` and leave `isSkillMissing` false. That is the regression this PR fixes, and no existing test covered skill load failures at all, which is why it is a new nested `describe` rather than a case on an existing test. The full file passes (11 tests).

Ran `kea-typegen` for the changed logic and `pnpm --filter=@posthog/frontend fix`. `typescript:check` reports no errors in `products/skills`.

Not verified in a browser, so there is no screenshot. This sandbox has no built `@posthog/quill` workspace, so the app and Storybook don't start and the repo-wide typecheck reports pre-existing module-resolution failures unrelated to these files. The three rendered states are worth a human eye before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no docs describe this state.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from the Slack thread linked below. A scheduled session-summary digest surfaced a user landing on a skill not-found page and leaving; checking that session's events confirmed a real 404 on the skill resolve endpoint, and reading the logic turned up the wider defect that every other failure status renders the same page.

The copy fix and the status gate were considered separately. Shipping only a friendlier 404 caption was rejected: it would have made the misleading case worse by dressing up a 403 as a polished "not found". The status gate is deliberately conservative, so a null skill with no recorded failure status still renders not-found exactly as before, and only an explicit non-404 failure takes the new path.

Skills invoked: `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-tests`.

The investigation drew on session recordings and analytics from PostHog's own workspace. Nothing from it reaches this PR: no session, recording, person, organization, or skill name from that data appears here, and no figures from those queries are quoted. The test fixture reuses the file's existing invented skill.

A person directed this work in Slack; their GitHub handle was not verified in that session, so the PR is left unassigned rather than assigned to a guessed account.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1787745658994919?thread_ts=1787745658.994919&cid=C0BLK2ZEUSH)*
