### PR TITLE
fix(metabase): show a clear error when the instance URL redirects

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
@@ -30,6 +30,14 @@ REQUEST_TIMEOUT_SECONDS = 60
 
 HOST_NOT_ALLOWED_ERROR = "Metabase host is not allowed"
 
+# Returned when the Instance URL responds with a 3xx. We refuse to follow redirects (an off-host
+# 3xx is an SSRF vector), so a redirecting URL can never be probed. The raw HOST_NOT_ALLOWED_ERROR
+# told the user nothing they could act on; this points them at the canonical instance URL.
+REDIRECT_NOT_FOLLOWED_ERROR = (
+    "Your Metabase instance redirected the connection, which PostHog doesn't follow. "
+    "Enter the direct https:// URL of your Metabase instance, then reconnect."
+)
+
 # Stable substring matched by MetabaseSource.get_non_retryable_errors when the session endpoint
 # returns a 2xx that isn't JSON (the Instance URL isn't a Metabase API).
 SESSION_RESPONSE_NOT_JSON_ERROR = "Metabase session response was not valid JSON"
@@ -237,7 +245,7 @@ def validate_credentials(
         return False, _connection_error_message(e)
 
     if response.is_redirect or response.is_permanent_redirect:
-        return False, HOST_NOT_ALLOWED_ERROR
+        return False, REDIRECT_NOT_FOLLOWED_ERROR
     if response.status_code == 200:
         return True, None
     if response.status_code == 401:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
@@ -220,7 +220,7 @@ class TestValidateCredentials:
         with self._patch_session(_response(status_code=302)) as patched:
             valid, msg = validate_credentials("https://x.metabaseapp.com", _api_key_auth())
             assert valid is False
-            assert msg == metabase_module.HOST_NOT_ALLOWED_ERROR
+            assert msg == metabase_module.REDIRECT_NOT_FOLLOWED_ERROR
             assert patched.return_value.get.call_args.kwargs["allow_redirects"] is False
 
     def test_blocks_unsafe_host(self):


### PR DESCRIPTION
## Problem

A user connecting Metabase whose Instance URL responds with a redirect saw only "Metabase host is not allowed" in the source wizard. The message named no cause and no next step, so there was nothing to act on.

Credential validation refuses to follow redirects on purpose: an off-host 3xx is an SSRF vector. But that refusal surfaced as the raw internal string.

## Changes

- The wizard now tells the user their instance redirected the connection and to enter the direct instance URL, then reconnect.
- The redirect branch in `validate_credentials` returns a new `REDIRECT_NOT_FOLLOWED_ERROR` instead of the terse `HOST_NOT_ALLOWED_ERROR`.
- `HOST_NOT_ALLOWED_ERROR` stays for the host-safety fallback and the sync-time guard, so no other path changes.

## How did you test this code?

- Extended `test_rejects_redirect_response` to assert the redirect branch returns the new message. It catches a regression where a redirect again surfaces the terse, non-actionable string.
- Ran the metabase unit suite (`test_metabase.py`) locally: passing.
- Not run: the database-backed source suites, because this sandbox has no Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged failed data-warehouse source-creation errors and fixed the Metabase redirect case. Authored with Claude Code. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

The error string this fix replaces originates from a user-entered host, so it is treated as sensitive and is not reproduced here; the test asserts on a stable module constant, not a customer value.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
