### PR TITLE
fix(custom): explain when a base URL includes an HTTP method

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -529,11 +529,26 @@ def validate_manifest_urls(manifest: dict[str, Any], team_id: int) -> tuple[bool
     return True, None
 
 
+_HTTP_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"})
+
+
+def _has_leading_http_method(url: str) -> bool:
+    """True when a URL starts with an HTTP verb, e.g. a "POST https://..." pasted from API docs.
+    urlparse then reads no host, so the URL is rejected for a missing hostname it plainly has."""
+    head, _, rest = url.strip().partition(" ")
+    return bool(rest) and head.upper() in _HTTP_METHODS
+
+
 def _check_url(url: str, team_id: int) -> tuple[bool, str | None]:
     # `_url_hostname` mirrors the real connect host (backslash/whitespace-normalized) so the
     # validator can't be fooled into vetting a different host than the request reaches.
     hostname = _url_hostname(url)
     if not hostname:
+        if _has_leading_http_method(url):
+            return (
+                False,
+                "Remove the HTTP method from the URL and enter just the address (for example, https://api.example.com).",
+            )
         return False, f"URL {url!r} is missing a hostname"
     if is_cloud() and urlparse(url).scheme != "https":
         return False, f"URL {url!r} must use https:// on PostHog Cloud"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -316,6 +316,14 @@ class TestValidateManifestUrls(SimpleTestCase):
         ok, err = validate_manifest_urls(manifest, team_id=999)
         assert not ok, err
 
+    def test_rejects_base_url_with_http_method_prefix(self):
+        # A user who pastes "POST https://..." from API docs used to get an unhelpful
+        # "missing a hostname" — the message must instead tell them to drop the method.
+        manifest = _minimal_manifest(base_url="POST https://api.example.com/v1")
+        ok, err = validate_manifest_urls(manifest, team_id=999)
+        assert not ok
+        assert "Remove the HTTP method" in (err or "")
+
     @override_settings(CLOUD_DEPLOYMENT="US")
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.custom.source._is_host_safe",


### PR DESCRIPTION
## Problem

A user setting up a custom REST source who pasted an HTTP method in front of the base URL (for example a "POST https://..." copied from API docs) saw "is missing a hostname" in the wizard. The URL plainly has a hostname, so the message pointed at the wrong problem and gave no way forward.

Once a method prefix is present, urlparse reads no host, so validation rejects the URL for a missing hostname.

## Changes

- The wizard now tells the user to remove the HTTP method and enter just the address when the base URL starts with a verb.
- `_check_url` detects a leading HTTP method (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`) before the generic "missing a hostname" path.
- A genuinely malformed URL with no method still gets the existing message. No change to the SSRF host-safety checks.

## How did you test this code?

- Added `test_rejects_base_url_with_http_method_prefix` to `TestValidateManifestUrls`. It catches a regression where a method-prefixed base URL again returns the unhelpful "missing a hostname" string.
- Ran `TestValidateManifestUrls` locally: passing.
- Not run: the OAuth2 integration suites in the same file, because they need a Postgres this sandbox does not have.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged failed data-warehouse source-creation errors and fixed the custom-source base URL case. Authored with Claude Code. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

The triggering error string originates from a user-entered URL, so it is treated as sensitive; the test asserts on a fixed example host and a stable substring, not a customer value.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
