### PR TITLE
fix(desktop): show project switcher on consent screen

### DIFF
--- a/products/desktop/packages/ui/src/features/consent/ConsentScreen.test.tsx
+++ b/products/desktop/packages/ui/src/features/consent/ConsentScreen.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-hotkeys-hook", () => ({ useHotkeys: vi.fn() }));
+
+vi.mock("@posthog/ui/features/auth/useAuthMutations", () => ({
+  useLogoutMutation: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@posthog/ui/features/auth/useOrgRole", () => ({
+  useIsOrgAdmin: () => ({ isAdmin: false }),
+}));
+
+vi.mock("@posthog/ui/features/settings/SettingsDialog", () => ({
+  openSettingsDialog: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/sidebar/components/ProjectSwitcher", () => ({
+  ProjectSwitcher: () => <button type="button">Example project</button>,
+}));
+
+vi.mock("@posthog/ui/primitives/FullScreenLayout", () => ({
+  FullScreenLayout: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("./ConsentPanel", () => ({
+  ConsentPanel: () => <div>Consent requirements</div>,
+}));
+
+vi.mock("./useOrgConsent", () => ({
+  useOrgConsent: () => ({
+    status: "resolved",
+    organizationId: "org-id",
+    needsAiConsent: false,
+    needsBetaTerms: true,
+    satisfied: false,
+  }),
+}));
+
+import { ConsentScreen } from "./ConsentScreen";
+
+describe("ConsentScreen", () => {
+  it("keeps the selected project switcher available while consent blocks the app", () => {
+    render(<ConsentScreen />);
+
+    expect(
+      screen.getByRole("button", { name: "Example project" }),
+    ).toBeVisible();
+    expect(screen.getByText("Consent requirements")).toBeVisible();
+  });
+});

--- a/products/desktop/packages/ui/src/features/consent/ConsentScreen.tsx
+++ b/products/desktop/packages/ui/src/features/consent/ConsentScreen.tsx
@@ -4,6 +4,7 @@ import { useLogoutMutation } from "@posthog/ui/features/auth/useAuthMutations";
 import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { openSettingsDialog } from "@posthog/ui/features/settings/SettingsDialog";
+import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/ProjectSwitcher";
 import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
 import type { ReactNode } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -62,12 +63,19 @@ export function ConsentScreen({
   return (
     <>
       <FullScreenLayout footerLeft={footerLeft} footerRight={footerRight}>
-        <div className="flex h-full items-center justify-center overflow-y-auto px-8 py-16">
-          {consent.status === "error" ? (
-            <ConsentErrorContent onRetry={consent.retry} />
-          ) : consent.status === "resolved" ? (
-            <ConsentPanel consent={consent} isAdmin={isAdmin === true} />
-          ) : null}
+        <div className="flex h-full flex-col overflow-y-auto px-8 pt-12 pb-16">
+          <div className="flex shrink-0 justify-end">
+            <div className="w-64 max-w-full">
+              <ProjectSwitcher />
+            </div>
+          </div>
+          <div className="flex min-h-0 flex-1 items-center justify-center py-8">
+            {consent.status === "error" ? (
+              <ConsentErrorContent onRetry={consent.retry} />
+            ) : consent.status === "resolved" ? (
+              <ConsentPanel consent={consent} isAdmin={isAdmin === true} />
+            ) : null}
+          </div>
         </div>
       </FullScreenLayout>
       {settingsDialog}


### PR DESCRIPTION
## Problem

People blocked by organization consent cannot switch to another project or organization, so they can get stuck on the consent screen.

## Changes

- The consent screen now shows the project and organization menu at the top.
- The menu trigger shows the selected project.
- The layout keeps the consent panel centered and scrollable.

![consent-project-switcher](https://raw.githubusercontent.com/PostHog/pr-assets/c95aab0ac497b9c08cfd38774aec1a650b05e4b6/2026/08/c3b1f81c-266a-4ec6-8194-da1c10d7a5b6.png)

## How did you test this code?

- Added a component test that fails if the consent gate hides the selected project switcher.
- Ran the consent screen and consent panel tests.
- Ran the `@posthog/ui` TypeScript check and `hogli ci:preflight --strict`.
- Rendered the gate in Storybook at 1440x900 and confirmed the selected project appears in the top menu trigger.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The existing docs do not describe the consent gate layout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI's coding agent used repository file, shell, test, and signed commit tools.
- Invoked `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/reviewing-before-pr`, and `/writing-simplified-technical-english`.
- Greptile was unavailable. The fallback review found no issues.
- The test uses invented project and organization identifiers.