### PR TITLE
feat(warehouse-sources): promote Plain and Intercom sources to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
@@ -98,8 +98,7 @@ class IntercomSource(SimpleSource[IntercomSourceConfig], OAuthMixin):
                     ),
                 ],
             ),
-            featureFlag="dwh_intercom",
-            releaseStatus=ReleaseStatus.BETA,
+            releaseStatus=ReleaseStatus.GA,
         )
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plain/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plain/source.py
@@ -46,8 +46,7 @@ class PlainSource(SimpleSource[PlainSourceConfig]):
             name=SchemaExternalDataSourceType.PLAIN,
             category=DataWarehouseSourceCategory.CUSTOMER_SUPPORT,
             label="Plain",
-            releaseStatus=ReleaseStatus.ALPHA,
-            featureFlag="dwh_plain",
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Plain API key to automatically pull your Plain customer support data into the PostHog Data warehouse.
 
 You can create an API key in your [Plain workspace settings](https://app.plain.com/settings/api-keys).


### PR DESCRIPTION
## Problem

Teams browsing the data warehouse connector catalog saw Plain behind an Alpha label and Intercom behind a Beta label, and both were gated to feature-flagged users. Each source now meets the bar for general availability, so both should be visible and connectable for every team.

- Plain: live 3.4 months with a 0.0% import error rate over the last 7 days (bar: 100 teams or 3 months live, and under 2.5% errors).
- Intercom: live 3.6 months with a 0.2% import error rate over the last 7 days (same bar).

## Changes

- Every team can now find and connect Plain and Intercom without a feature flag.
- Plain's `releaseStatus` moves from `ALPHA` to `GA`; Intercom's moves from `BETA` to `GA`.
- Both sources drop their `featureFlag` (`dwh_plain`, `dwh_intercom`). No GA source in the tree carries a feature flag, so removing them matches the release-to-all convention for GA.

No connector behavior, schema, or sync logic changed.

## How did you test this code?

`ruff check` passes on both changed files. No tests assert these release-status or feature-flag values, so none needed updating. The change is a two-field edit per source with no runtime logic.

Not run: the backend test suites, as the change is limited to declarative source config.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Promotion of two warehouse sources' release status. Skills invoked: `/implementing-warehouse-sources` (confirmed where `releaseStatus` lives and the GA convention that GA sources drop their `featureFlag` — verified no GA source retains one, and Supabase's test asserts `featureFlag is None`) and `/writing-pr-descriptions`. Ruled out duplicate open PRs by searching each source name plus "releaseStatus"/"promote" and listing the maintainer's own open PRs; none promote these sources.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
