### PR TITLE
fix(usage): report analytics usage from the ingestion API server

### DIFF
--- a/nodejs/src/common/usage-ingestion/index.test.ts
+++ b/nodejs/src/common/usage-ingestion/index.test.ts
@@ -1,0 +1,23 @@
+import { createEventUsageBatchFactory } from './index'
+
+describe('createEventUsageBatchFactory', () => {
+    const config = {
+        USAGE_INGESTION_ADDR: 'localhost:7143',
+        USAGE_INGESTION_TLS: false,
+        USAGE_INGESTION_TIMEOUT_MS: 5_000,
+        USAGE_INGESTION_MAX_BATCH_SIZE: 500,
+        USAGE_INGESTION_REPORT_TEAMS: '2,4',
+    }
+
+    // A batch that accepts nothing reports nothing, and that silence reads the same as a
+    // working collector with no traffic. Both halves of the config have to reach the batch,
+    // or a deployment looks enabled and bills nobody.
+    it.each([
+        ['bills a listed team when the address and the team list are both set', config, true],
+        ['bills nothing when the address is empty', { ...config, USAGE_INGESTION_ADDR: '' }, false],
+        ['bills nothing when the team list is empty', { ...config, USAGE_INGESTION_REPORT_TEAMS: '' }, false],
+        ['bills nothing for a team outside the list', { ...config, USAGE_INGESTION_REPORT_TEAMS: '4' }, false],
+    ])('%s', (_name, usageConfig, billed) => {
+        expect(createEventUsageBatchFactory(usageConfig, 'events')().accepts(2)).toBe(billed)
+    })
+})

--- a/nodejs/src/common/usage-ingestion/index.ts
+++ b/nodejs/src/common/usage-ingestion/index.ts
@@ -3,6 +3,7 @@ import { buildIntegerMatcher } from '~/common/config/config'
 import { ValueMatcher } from '~/types'
 
 import { UsageIngestionClient } from './client'
+import { UsageRecordBatch } from './usage-record-batch'
 
 export type UsageIngestionConfig = Pick<
     CommonConfig,
@@ -40,4 +41,18 @@ export function createUsageIngestionClient(
         timeoutMs: config.USAGE_INGESTION_TIMEOUT_MS,
         maxBatchSize: config.USAGE_INGESTION_MAX_BATCH_SIZE,
     })
+}
+
+/**
+ * The batch every event pipeline bills through. Shared so a new pipeline host cannot
+ * half-wire it: a client built without an address reports nothing, and that silence is
+ * indistinguishable from a working collector with no traffic.
+ */
+export function createEventUsageBatchFactory(
+    config: UsageIngestionConfig,
+    site: UsageReportSite
+): () => UsageRecordBatch {
+    const client = createUsageIngestionClient(config, site)
+    const isTeamEnabled = usageReportTeamMatcher(config)
+    return () => new UsageRecordBatch(client, { unit: 'events', isTeamEnabled })
 }

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -26,8 +26,7 @@ import {
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { PersonRepository } from '~/common/persons/repositories/person-repository'
 import { instrumentFn } from '~/common/tracing/tracing-utils'
-import { UsageIngestionConfig, createUsageIngestionClient, usageReportTeamMatcher } from '~/common/usage-ingestion'
-import { UsageRecordBatch } from '~/common/usage-ingestion/usage-record-batch'
+import { UsageIngestionConfig, createEventUsageBatchFactory } from '~/common/usage-ingestion'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import {
     EventIngestionRestrictionManager,
@@ -314,7 +313,7 @@ export class IngestionConsumer {
                 EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS: this.config.EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS,
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
-            createEventUsageBatch: this.createEventUsageBatch(),
+            createEventUsageBatch: createEventUsageBatchFactory(this.config, 'events'),
         }
         const joinedPipelineDeps: JoinedIngestionPipelineDeps = {
             personsStore: this.personsStore,
@@ -398,12 +397,6 @@ export class IngestionConsumer {
         }
 
         return new HealthCheckResultOk()
-    }
-
-    private createEventUsageBatch(): () => UsageRecordBatch {
-        const client = createUsageIngestionClient(this.config, 'events')
-        const isTeamEnabled = usageReportTeamMatcher(this.config)
-        return () => new UsageRecordBatch(client, { unit: 'events', isTeamEnabled })
     }
 
     private runInstrumented<T>(name: string, func: () => Promise<T>): Promise<T> {

--- a/nodejs/src/ingestion/pipelines/ai/pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ai/pipeline.ts
@@ -92,7 +92,7 @@ export interface AiIngestionPipelineConfig {
     topHog: TopHogRegistry
     aiBlobStore: BlobStore | null
     aiBlobOffloadConfig: OffloadAiBlobsConfig
-    createEventUsageBatch?: () => UsageRecordBatch
+    createEventUsageBatch: () => UsageRecordBatch
 }
 
 interface AiIngestionPipelineInput {
@@ -140,7 +140,7 @@ export function createAiIngestionPipeline<
         topHog,
         aiBlobStore,
         aiBlobOffloadConfig,
-        createEventUsageBatch = () => new UsageRecordBatch(null, { unit: 'events', isTeamEnabled: () => false }),
+        createEventUsageBatch,
     } = config
 
     return (

--- a/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
@@ -83,7 +83,7 @@ export interface JoinedIngestionPipelineConfig {
      * (`ingestion_api_batch_capacity_rejections_total`).
      */
     concurrentBatches: number
-    createEventUsageBatch?: () => UsageRecordBatch
+    createEventUsageBatch: () => UsageRecordBatch
 }
 
 export interface JoinedIngestionPipelineDeps {
@@ -132,7 +132,7 @@ export function createJoinedIngestionPipeline<
         outputs,
         perDistinctIdOptions,
         concurrentBatches,
-        createEventUsageBatch = () => new UsageRecordBatch(null, { unit: 'events', isTeamEnabled: () => false }),
+        createEventUsageBatch,
     } = config
 
     const {

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.test.ts
@@ -8,6 +8,7 @@ import { KafkaConsumer } from '~/common/kafka/consumer/consumer-v1'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '~/common/outputs/single-ingestion-output'
 import { PersonReadRepository } from '~/common/persons/repositories/person-repository'
+import { UsageRecordBatch } from '~/common/usage-ingestion/usage-record-batch'
 import { parseJSON } from '~/common/utils/json-parse'
 import { UUIDT } from '~/common/utils/utils'
 import { IngestionTestInfra, createIngestionTestInfra } from '~/tests/helpers/ingestion-e2e'
@@ -196,6 +197,7 @@ describe('ErrorTrackingConsumer', () => {
             cookielessManager: infra.cookielessManager,
             redisPool: infra.redisPool,
             personRepository: createMockPersonRepository(),
+            createEventUsageBatch: () => new UsageRecordBatch(null, { unit: 'events', isTeamEnabled: () => false }),
         }
         const consumer = new ErrorTrackingConsumer(config, deps)
         // Replace Kafka consumer with mock to avoid actual connections

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
@@ -84,7 +84,7 @@ export interface ErrorTrackingConsumerDeps {
     cookielessManager: CookielessManager
     redisPool: GenericPool<Redis>
     personRepository: PersonReadRepository
-    createEventUsageBatch?: () => UsageRecordBatch
+    createEventUsageBatch: () => UsageRecordBatch
 }
 
 // Batch processing status - useful for tracking failures (batch sizes already tracked by KafkaConsumer)

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.test.ts
@@ -7,6 +7,7 @@ import { TophogOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '~/common/outputs/single-ingestion-output'
 import { PersonReadRepository } from '~/common/persons/repositories/person-repository'
+import { UsageRecordBatch } from '~/common/usage-ingestion/usage-record-batch'
 import { EventIngestionRestrictionManager, RestrictionType } from '~/common/utils/event-ingestion-restrictions'
 import { parseJSON } from '~/common/utils/json-parse'
 import { PromiseScheduler } from '~/common/utils/promise-scheduler'
@@ -320,6 +321,7 @@ describe('ErrorTrackingPipeline', () => {
             overflowMode: 'disabled',
             preservePartitionLocality: false,
             topHog: mockTopHog,
+            createEventUsageBatch: () => new UsageRecordBatch(null, { unit: 'events', isTeamEnabled: () => false }),
         }
     })
 

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.ts
@@ -102,7 +102,7 @@ export interface ErrorTrackingPipelineConfig {
     overflowLaneTTLRefreshService?: OverflowRedirectService
     /** TopHog registry for metrics. */
     topHog: TopHogRegistry
-    createEventUsageBatch?: () => UsageRecordBatch
+    createEventUsageBatch: () => UsageRecordBatch
 }
 
 /**
@@ -146,7 +146,7 @@ export function createErrorTrackingPipeline(config: ErrorTrackingPipelineConfig)
         overflowRedirectService,
         overflowLaneTTLRefreshService,
         topHog,
-        createEventUsageBatch = () => new UsageRecordBatch(null, { unit: 'events', isTeamEnabled: () => false }),
+        createEventUsageBatch,
     } = config
 
     const preCymbal = newCommonIngestionPipeline<ErrorTrackingPipelineInput, { message: Message }, OverflowOutput>({

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -18,6 +18,7 @@ import { PersonHogClient } from '~/common/personhog/client'
 import { createIdentityClients } from '~/common/personhog/identity-clients'
 import { PersonHogPersonWriteRepository } from '~/common/personhog/personhog-person-write-repository'
 import { PostgresPersonRepository } from '~/common/persons/repositories/postgres-person-repository'
+import { UsageIngestionConfig, createEventUsageBatchFactory } from '~/common/usage-ingestion'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { createRedisPoolFromConfig } from '~/common/utils/db/redis'
 import { EventIngestionRestrictionManagerComponent } from '~/common/utils/event-ingestion-restrictions'
@@ -113,6 +114,7 @@ export type IngestionApiServerConfig = BaseServerConfig &
     RedisConnectionsConfig &
     KafkaConsumerBaseConfig &
     PersonHogConfig &
+    UsageIngestionConfig &
     Pick<
         CommonConfig,
         | 'LOG_LEVEL'
@@ -480,6 +482,7 @@ export class IngestionApiServer implements NodeServer {
                 EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS: this.config.EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS,
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
+            createEventUsageBatch: createEventUsageBatchFactory(this.config, 'events'),
         }
         const eventFilterManagerStarted = await new EventFilterManagerComponent(this.postgres).start()
         const featureFlagCalledDedupService = createFeatureFlagCalledDedupService(


### PR DESCRIPTION
## Problem

Analytics usage records never appear from the split ingestion deployment, and setting `USAGE_INGESTION_REPORT_TEAMS` on it changes nothing.

The Rust consumer streams batches to the Node ingestion API server. That server builds the analytics pipeline without a usage batch, so the pipeline falls back to a default with a null client and a team matcher fixed to `false`. Its config type does not carry the usage settings either, so the env vars were never read.

The old all-in-one `IngestionConsumer` wires it correctly, which is why CDP and the consumer path work.

## Changes

- The ingestion API server now reports usage, so a team in `USAGE_INGESTION_REPORT_TEAMS` bills from the split deployment.
- `createEventUsageBatch` is required on all three pipeline configs. The default it replaces disabled billing for any host that forgot it, and reported nothing to say so.
- Mechanical: `createEventUsageBatchFactory` moves to `common/usage-ingestion` so both hosts build the batch the same way.

## How did you test this code?

New `index.test.ts` covers the factory: it bills a listed team only when the address and the team list are both set. Nothing covered that, and a silent disable is exactly the bug here.

The wiring itself is now a type error rather than a test. Making the field required is what caught the missing config on the API server in the first place.

Not run: `ingestion-api-server.test.ts` and the `ml-mirror-image-fetch` suites, which fail locally on unbuilt `@posthog/hogvm` and `@posthog/replay-anonymizer` workspace packages. Both fail the same way on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. Found while debugging why dev reported no analytics usage after the env var was set.
