### PR TITLE
fix(evals): show which tool an agent called in eval traces

### DIFF
--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -14,6 +14,7 @@ from .config import AgentArtifacts, BaseEvalCase, SandboxedEvalCase
 from .engines.base import EvalEngine
 from .engines.types import CaseHooks, CaseSpec, ExperimentResult, ExperimentSpec, SpanKind
 from .harness.kernel_sandboxes import reclaim_kernels
+from .log_parser import describe_tool_use
 from .log_sink import append_case_scores, build_case_dir, write_case_logs
 from .runner import AgentNeverRanError, EvalCaseResult, agent_never_ran, run_eval_case
 from .scorers import ExitCodeZero, wrap_scorers
@@ -47,6 +48,7 @@ def _log_conversation_spans(hooks: CaseHooks, parsed: ParsedLog) -> None:
         content = msg.get("content", "")
 
         # Anthropic format: content can be a string or list of content blocks
+        tool_calls: list[dict[str, Any]] = []
         if isinstance(content, list):
             # Render content blocks for display
             parts: list[str] = []
@@ -57,7 +59,12 @@ def _log_conversation_spans(hooks: CaseHooks, parsed: ParsedLog) -> None:
                 if block_type == "text":
                     parts.append(block.get("text", ""))
                 elif block_type == "tool_use":
-                    parts.append(f"[tool_use: {block.get('name', '?')}]")
+                    block_input = block.get("input")
+                    tool, tool_input = describe_tool_use(
+                        block.get("name"), block_input if isinstance(block_input, dict) else {}
+                    )
+                    tool_calls.append({"tool": tool, "input": tool_input})
+                    parts.append(f"[tool_use: {tool or '?'}]")
                 elif block_type == "tool_result":
                     result_text = str(block.get("content", ""))[:500]
                     is_error = block.get("is_error", False)
@@ -69,12 +76,13 @@ def _log_conversation_spans(hooks: CaseHooks, parsed: ParsedLog) -> None:
 
         span_type: SpanKind
         if role == "assistant":
-            # Check if this message contains tool_use blocks
-            has_tool_use = isinstance(content, list) and any(
-                isinstance(b, dict) and b.get("type") == "tool_use" for b in content
-            )
-            span_type = "function" if has_tool_use else "llm"
-            name = "tool_call" if has_tool_use else "agent"
+            span_type = "function" if tool_calls else "llm"
+            # Naming the span after the resolved tool keeps the trace tree scannable;
+            # every single-exec call would otherwise read as an undifferentiated "exec".
+            if len(tool_calls) == 1:
+                name = f"tool_call: {tool_calls[0]['tool']}"
+            else:
+                name = "tool_call" if tool_calls else "agent"
         elif role == "user":
             has_tool_result = isinstance(content, list) and any(
                 isinstance(b, dict) and b.get("type") == "tool_result" for b in content
@@ -89,7 +97,12 @@ def _log_conversation_spans(hooks: CaseHooks, parsed: ParsedLog) -> None:
             if role == "user":
                 span.log(input=display_content)
             elif role == "assistant":
-                span.log(output=display_content)
+                # Logged untruncated: the arguments are the only record of what the
+                # agent asked for, and a query payload is easy to cut short.
+                if tool_calls:
+                    span.log(input=tool_calls, output=display_content)
+                else:
+                    span.log(output=display_content)
             else:
                 span.log(metadata={"message": display_content})
 

--- a/products/posthog_ai/eval_harness/log_parser.py
+++ b/products/posthog_ai/eval_harness/log_parser.py
@@ -47,6 +47,24 @@ def normalize_tool_name(name: str | None) -> str:
     return name
 
 
+def describe_tool_use(name: str | None, tool_input: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Resolve a raw ``tool_use`` name and input to the tool the agent actually invoked.
+
+    Single-exec mode routes every PostHog tool through one ``exec`` call, so the raw
+    name says ``exec`` for all of them and only the command string tells them apart.
+    Falls back to the normalized raw name for command shapes that wrap no inner tool
+    (``search``, ``tools``, ``schema``).
+    """
+    normalized = normalize_tool_name(name)
+    if normalized == EXEC_TOOL_NAME:
+        command = tool_input.get("command", "")
+        if isinstance(command, str):
+            unwrapped = _parse_exec_command(command)
+            if unwrapped is not None:
+                return unwrapped
+    return (normalized, tool_input)
+
+
 class ToolCall(BaseModel):
     model_config = ConfigDict(frozen=True)
 

--- a/products/posthog_ai/eval_harness/test/test_sandboxed_harness_output.py
+++ b/products/posthog_ai/eval_harness/test/test_sandboxed_harness_output.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import sys
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import pytest
 from unittest.mock import MagicMock
 
 from products.posthog_ai.eval_harness import base
-from products.posthog_ai.eval_harness.engines.types import AggregateScore, EvalSummary
+from products.posthog_ai.eval_harness.acp_log import GenerationDescriptor, ParsedLog
+from products.posthog_ai.eval_harness.engines.types import AggregateScore, EvalSummary, NullCaseHooks
 from products.posthog_ai.eval_harness.harness.reporting import ProgressReporter, SuiteRunResult
 from products.posthog_ai.eval_harness.harness.transcript import RunTranscript
 from products.posthog_ai.eval_harness.scorers import ExitCodeZero
@@ -111,6 +116,69 @@ async def test_reporter_output_is_labeled_and_reserves_pass_for_the_run(
     assert "Braintrust: https://experiments.example/e" in output
     assert f"Agent logs: {tmp_path}" in output
     assert output.count("PASS") == 1
+
+
+def test_tool_call_spans_carry_the_resolved_tool_and_its_arguments() -> None:
+    trends_query = {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}
+    parsed = ParsedLog(
+        generations=[
+            GenerationDescriptor(
+                output_content=[
+                    {
+                        "type": "tool_use",
+                        "id": "1",
+                        "name": "mcp__posthog__exec",
+                        "input": {"command": f"call query-trends {json.dumps(trends_query)}"},
+                    }
+                ],
+            )
+        ]
+    )
+
+    spans = _collect_spans(parsed)
+
+    assert spans == [("tool_call: query-trends", [{"tool": "query-trends", "input": trends_query}])]
+
+
+def test_exec_commands_wrapping_no_inner_tool_stay_under_the_raw_name() -> None:
+    parsed = ParsedLog(
+        generations=[
+            GenerationDescriptor(
+                output_content=[
+                    {
+                        "type": "tool_use",
+                        "id": "1",
+                        "name": "mcp__posthog__exec",
+                        "input": {"command": "schema query-trends series"},
+                    }
+                ],
+            )
+        ]
+    )
+
+    spans = _collect_spans(parsed)
+
+    assert spans == [("tool_call: exec", [{"tool": "exec", "input": {"command": "schema query-trends series"}}])]
+
+
+def _collect_spans(parsed: ParsedLog) -> list[tuple[str, Any]]:
+    collected: list[tuple[str, Any]] = []
+
+    class _Span:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def log(self, *, input: Any = None, output: Any = None, metadata: Any = None) -> None:
+            if input is not None:
+                collected.append((self.name, input))
+
+    class _Hooks(NullCaseHooks):
+        @contextmanager
+        def start_span(self, name: str, kind: Any) -> Iterator[_Span]:
+            yield _Span(name)
+
+    base._log_conversation_spans(_Hooks(), parsed)
+    return collected
 
 
 def test_sandboxed_eval_run_adds_exit_code_scorer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Anyone reading a sandboxed eval trace in Braintrust cannot tell which PostHog tool the agent used. Every tool call renders as `mcp__posthog__exec` with a null input.

- The PostHog MCP has one entry point, so `exec` is the only tool name the agent ever emits. The tool it actually called lives in the `command` argument.
- `_log_conversation_spans` rendered `[tool_use: <name>]` and dropped `block["input"]`.
- Assistant spans logged `output` only, so the span carried no input field at all.

This blocks any work that turns on tool choice, such as measuring whether the agent answers a trends question with `query-trends` or with `execute-sql`.

## Changes

- A trace now names the tool: a span reads `tool_call: query-trends` instead of `tool_call`.
- The span carries the call arguments, logged untruncated. A `TrendsQuery` payload is easy to cut short, and the arguments are the only record of what the agent asked for.
- `describe_tool_use` in `log_parser.py` resolves a raw `tool_use` to the tool behind it. It reuses the existing `normalize_tool_name` and `_parse_exec_command`, so the trace and the scorers now read the log the same way.
- Commands that wrap no inner tool (`search`, `tools`, `schema`) stay under the raw `exec` name. A span reading `tool_call: exec` is a schema probe, not a tool call.

No product code changes. This affects eval traces only.

> [!NOTE]
> `LastToolCallNot` has a matching blind spot, which this PR makes visible rather than fixes. A run whose last successful call is a `schema` probe scores as a pass, because the scorer sees `exec` and `exec` is in no forbidden set.

## How did you test this code?

Two tests in `test_sandboxed_harness_output.py`. `_log_conversation_spans` had no coverage, which is how the null input shipped.

- The first catches a regression that drops `input` from the span, or stops resolving the inner tool. Either one silently empties every trace again.
- The second pins the `search`/`tools`/`schema` fallback, so that gap stays deliberate.

Ran `_log_conversation_spans` over a real agent log from a previous `eval_trends` run and read the spans back:

<details>
<summary>Spans from <code>trends_pageview_default</code></summary>

```
tool_call: ToolSearch    -> [{"tool": "ToolSearch", ...}]
tool_call                -> [{"tool": "read-data-schema", ...}, {"tool": "__info__:query-trends", ...}]
tool_call                -> [{"tool": "exec", "input": {"command": "schema query-trends series", ...
tool_call: query-trends  -> [{"tool": "query-trends", "input": {"kind": "TrendsQuery", "series": [...]
```

</details>

In the Braintrust UI this now renders the tool name in the trace span list and also the tool call information in the input field rather than just `null` like before.

<img width="927" height="966" alt="Screenshot 2026-08-27 at 11 58 27" src="https://github.com/user-attachments/assets/aea672b6-00ca-4856-9219-70a54089d12b" />

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.5) via PostHog Desktop. Skills invoked: `/writing-tests` for the test gate, `/writing-pr-descriptions` for this body.

The session started on unrelated `query_cache_store_result_failed` noise in local eval runs, then moved to why Braintrust traces were unreadable. Two options were weighed for the span name: keep the literal `mcp__posthog__exec`, or resolve the inner tool. Resolving won because the literal name is the one part of the call that carries no information, and `log_parser` already had the unwrapping the scorers depend on. Reusing it keeps one definition of "which tool ran" instead of two that can drift.

Public artifact: the diff is harness code and an invented `TrendsQuery` fixture. Nothing from the session context reached the code, the tests, or this description.
