### PR TITLE
feat(tasks): serve a PostHog preview from dev-stack cloud runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
   - Frontend: `pnpm --filter=@posthog/frontend build`
   - Start dev: `./bin/start` or `hogli start` (interactive TUI). Detached mode: `hogli up -d` paired with `hogli wait` / `hogli down`
     - Cloud task VMs (prebaked dev-stack image): run `bootstrap-dev-stack` first (restores compose host aliases, starts dockerd), then `uv sync`, `source .venv/bin/activate`, `hogli start -y -d`, and `hogli wait` (the detached start returns while the stack is still booting; `hogli wait` blocks until every process is ready) — always detached: the sandbox has no TTY, and phrocs under a pseudo-TTY balloons in memory until OOM-killed
+    - Cloud task VMs: on user-created runs the backend may already be starting the stack; check `curl -sf localhost:8010/_health` and `/tmp/posthog-preview/status.json` before running `hogli start`
     - Cloud task VMs, frontend work: `pnpm install --frozen-lockfile --prefer-offline` links from the prebaked pnpm store, and Playwright Chromium is preinstalled; product/Storybook builds still run from source
 - OpenAPI/types: `hogli build:openapi` (regenerate after changing serializers/viewsets)
 - LSP: Pyright is configured against the flox venv. Prefer LSP (`goToDefinition`, `findReferences`, `hover`) over grep when navigating or refactoring Python code.

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -330,6 +330,40 @@ the dockerd warmup overlaps the repo clone and the environment is usually
 ready by the agent's first command. Running `bootstrap-dev-stack` again is still the right first
 step — it is the synchronization point, blocking until the warmup completes.
 
+##### Preview URL
+
+A user-created cloud run on `PostHog/PostHog` that booted the dev-stack image can also serve
+that stack back to the person who started it, so they can click through a change instead of
+reading the diff. Gated on the `tasks-dev-stack-preview` flag, per organization.
+
+Once the branch is checked out, the workflow starts the stack in the background
+(`start_dev_stack_preview`) and then waits for it (`wait_dev_stack_preview`) without holding
+the agent up. The in-sandbox script (`start-dev-stack-preview.sh`) runs `pnpm install`, `uv sync`,
+`hogli start -y -d`, `hogli wait`, and `setup_dev --no-data`, then reports `starting`, `ready`, or
+`failed` in `/tmp/posthog-preview/status.json`, which the wait activity polls. A crashed or unready
+dev-stack process fails the preview instead of publishing a half-working one, and each click on the
+link re-probes Django and Vite inside the sandbox before redirecting. Startup peaks around 19 GB, so
+these runs default to 32 GB rather than the standard VM memory size; cores stay at the VM default,
+and a per-task `sandbox_resources` override still wins. The launcher starts with a scrubbed
+environment (`env -i`, fixed PATH), so the stack and its containers never inherit the run's
+GitHub token or personal API key. Relaunching is safe: the script takes an `flock` and reports
+`ready` straight away when the stack is already serving.
+
+A Modal tunnel cannot reach the 127.0.0.1 listeners the dev compose stack publishes, and a
+two-origin setup breaks ES module loading, so the script puts one host-network Caddy container on
+port 8020 in front of both Django (8010) and Vite (8234). It serves `/_metrics` a 404, because
+that endpoint is unauthenticated under `DEBUG`.
+
+When the stack answers, the run's state gets a `dev_stack_preview` entry and the link is emitted
+as a progress step (and posted on the pull request, when there is one). The link always points at
+PostHog: `GET /api/projects/{team}/tasks/{task}/runs/{run}/preview/` checks the caller's access,
+mints a fresh Modal connect token per click, and redirects. No sandbox host or token is ever
+stored on the run. A preview that fails or takes too long is reported and the run carries on
+without it.
+
+Known limit for v1: the dev stack runs with `DEBUG=1`, so a server error renders Django's debug
+page inside the preview.
+
 Restricted runs can use the VM runtime only when `tasks-modal-network-allowlist` is also enabled.
 The network flag interlock runs before state overrides, image-builder routing, custom-image routing,
 and the VM rollout flag. A trusted `use_modal_vm_sandbox` state value cannot bypass it.

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -21,7 +21,7 @@ import hashlib
 import logging
 from collections.abc import Collection, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -71,6 +71,8 @@ from products.tasks.backend.constants import (
     ANALYSIS_TARGET_RUN_ID_STATE_KEY,
     ANALYSIS_TARGET_TASK_ID_STATE_KEY,
     CI_STATUSES as CI_STATUSES,  # re-exported for presentation
+    DEV_STACK_PREVIEW_PORT,
+    DEV_STACK_PREVIEW_STATE_KEY,
     MAX_CUSTOM_IMAGES_PER_TEAM,
     MAX_CUSTOM_IMAGES_PER_USER,
     PI_CLOUD_RUNTIME_FEATURE_FLAG,
@@ -236,6 +238,8 @@ __all__ = [
     "sync_task_run_session",
     "get_task_run_detail",
     "get_task_run_sandbox_connection",
+    "resolve_task_run_preview_redirect",
+    "task_run_preview_ready",
     "get_task_run_living_artifact",
     "capture_relay_command_telemetry",
     "get_task_run_stream_info",
@@ -496,6 +500,7 @@ def _task_run_detail_to_dto(run: TaskRun, *, include_agent_state: bool = False) 
         created_at=run.created_at,
         updated_at=run.updated_at,
         completed_at=run.completed_at,
+        preview_available=task_run_preview_ready(run.state),
     )
 
 
@@ -2125,6 +2130,7 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
         "sandbox_url",
         "sandbox_connect_token",
         "sandbox_jwt_kid",
+        DEV_STACK_PREVIEW_STATE_KEY,
         "sandbox_cpu_cores",
         "sandbox_memory_gb",
         "sandbox_ttl_seconds",
@@ -4178,6 +4184,96 @@ def get_task_run_sandbox_connection(
         sandbox_connect_token=transport_token,
         connection_token=connection_token,
         sandbox_token_param=token_param,
+    )
+
+
+TaskRunPreviewOutcome = Literal["ready", "not_ready", "ended", "unavailable"]
+
+
+@frozen
+class TaskRunPreviewRedirect:
+    outcome: TaskRunPreviewOutcome
+    redirect_url: str | None = field(default=None, repr=False)
+
+
+_PREVIEW_NOT_READY = TaskRunPreviewRedirect(outcome="not_ready")
+_PREVIEW_ENDED = TaskRunPreviewRedirect(outcome="ended")
+_PREVIEW_UNAVAILABLE = TaskRunPreviewRedirect(outcome="unavailable")
+_PREVIEW_HEALTH_PROBE = (
+    "curl -sf --max-time 5 http://localhost:8010/_health >/dev/null"
+    f" && curl -sf --max-time 5 http://127.0.0.1:{DEV_STACK_PREVIEW_PORT}/@vite/client >/dev/null"
+)
+_PREVIEW_HEALTH_PROBE_TIMEOUT_SECONDS = 20
+
+
+def task_run_preview_ready(state: dict | None) -> bool:
+    run_state = state or {}
+    preview = run_state.get(DEV_STACK_PREVIEW_STATE_KEY)
+    if not isinstance(preview, dict):
+        return False
+    port = preview.get("port")
+    if isinstance(port, bool) or port != DEV_STACK_PREVIEW_PORT:
+        return False
+    sandbox_id = run_state.get("sandbox_id")
+    return bool(sandbox_id) and preview.get("sandbox_id") == sandbox_id
+
+
+def resolve_task_run_preview_redirect(
+    run_id: str | UUID, task_id: str | UUID, team_id: int, *, user_id: int
+) -> TaskRunPreviewRedirect | None:
+    from products.tasks.backend.exceptions import (
+        SandboxNotFoundError,  # noqa: PLC0415 — keep temporalio off the api import path
+    )
+    from products.tasks.backend.logic.services.sandbox import (  # noqa: PLC0415 — keeps the sandbox providers off the api import path
+        get_sandbox_class,
+    )
+
+    run = _get_visible_run(run_id, task_id, team_id)
+    if run is None:
+        return None
+
+    state = run.state if isinstance(run.state, dict) else {}
+    if not task_run_preview_ready(state):
+        return _PREVIEW_NOT_READY
+    sandbox_id = state["sandbox_id"]
+
+    try:
+        sandbox = get_sandbox_class().get_by_id(str(sandbox_id))
+        running = sandbox.is_running()
+    except SandboxNotFoundError:
+        return _PREVIEW_ENDED
+    except Exception:
+        logger.exception("task_run_preview_sandbox_lookup_failed", extra={"run_id": str(run.id)})
+        return _PREVIEW_UNAVAILABLE
+
+    if not running:
+        return _PREVIEW_ENDED
+
+    try:
+        probe = sandbox.execute(_PREVIEW_HEALTH_PROBE, timeout_seconds=_PREVIEW_HEALTH_PROBE_TIMEOUT_SECONDS)
+    except SandboxNotFoundError:
+        return _PREVIEW_ENDED
+    except Exception:
+        logger.exception("task_run_preview_health_probe_failed", extra={"run_id": str(run.id)})
+        return _PREVIEW_UNAVAILABLE
+    if probe.exit_code != 0:
+        return _PREVIEW_UNAVAILABLE
+
+    try:
+        credentials = sandbox.create_preview_connect_credentials(
+            port=DEV_STACK_PREVIEW_PORT, user_metadata={"user_id": user_id, "team_id": team_id}
+        )
+    except SandboxNotFoundError:
+        return _PREVIEW_ENDED
+    except Exception:
+        logger.exception("task_run_preview_token_mint_failed", extra={"run_id": str(run.id)})
+        return _PREVIEW_UNAVAILABLE
+
+    if not credentials.token:
+        return _PREVIEW_UNAVAILABLE
+    return TaskRunPreviewRedirect(
+        outcome="ready",
+        redirect_url=f"{credentials.url.rstrip('/')}/?_modal_connect_token={credentials.token}",
     )
 
 

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -572,6 +572,7 @@ class TaskRunDetailDTO:
     created_at: datetime | None = None
     updated_at: datetime | None = None
     completed_at: datetime | None = None
+    preview_available: bool = False
 
 
 @dataclass(frozen=True)

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -443,6 +443,14 @@ class TaskRunDetailSerializer(DataclassSerializer):
         required=False,
         help_text="Configured reasoning effort for this run when the selected model supports it.",
     )
+    preview_available = serializers.BooleanField(
+        required=False,
+        help_text=(
+            "True when this run's sandbox serves a dev stack preview, so clients can offer the "
+            "preview link. Open it through the run's `preview/` endpoint, which mints a fresh "
+            "access token on every request."
+        ),
+    )
 
     class Meta:
         dataclass = TaskRunDetailDTO
@@ -465,6 +473,7 @@ class TaskRunDetailSerializer(DataclassSerializer):
             "created_at",
             "updated_at",
             "completed_at",
+            "preview_available",
         ]
 
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.utils.html import escape
 
 import pydantic
 import requests as http_requests
@@ -1377,6 +1378,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         "artifacts_presign",
         "artifacts_download",
         "artifacts_download_by_id",
+        "preview",
     )
     _VISIBILITY_ONLY_ACTIONS = ("analyze",)
 
@@ -2257,6 +2259,59 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if url is None:
             raise NotFound()
         return HttpResponseRedirect(url)
+
+    def _preview_unavailable_page(self, outcome: str, task_id: str) -> HttpResponse:
+        if outcome == "ended":
+            heading = "This preview has ended"
+            body = "Rerun the task to start a new one."
+        elif outcome == "unavailable":
+            heading = "This preview isn't reachable right now"
+            body = "Try again in a moment."
+        else:
+            heading = "This preview isn't ready yet"
+            body = "PostHog is still starting in the sandbox. Refresh this page in a moment."
+        task_url = escape(absolute_uri(f"/project/{self.team_id}/tasks/{task_id}"))
+        html = (
+            '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">'
+            f"<title>{escape(heading)}</title></head>"
+            '<body style="font-family: system-ui, sans-serif; margin: 3rem auto; max-width: 32rem; padding: 0 1rem;">'
+            f'<h1 style="font-size: 1.25rem;">{escape(heading)}</h1>'
+            f"<p>{escape(body)}</p>"
+            f'<p><a href="{task_url}">Back to the task</a></p>'
+            "</body></html>"
+        )
+        response = HttpResponse(html, content_type="text/html; charset=utf-8")
+        response["Cache-Control"] = "no-store"
+        return response
+
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(description="HTML page explaining that the preview is not ready yet or has ended"),
+            302: OpenApiResponse(description="Redirect to the sandbox preview with a freshly minted access token"),
+            404: OpenApiResponse(description="Task run not found"),
+        },
+        summary="Open the dev stack preview for a task run",
+        description=(
+            "Redirects to the PostHog dev stack running inside this run's sandbox. A fresh sandbox "
+            "access token is minted on every request and carried only in the redirect target, so it "
+            "is never persisted or returned in a response body. When the run has no preview, or its "
+            "sandbox has stopped, this renders a short HTML page instead."
+        ),
+    )
+    @action(detail=True, methods=["get"], url_path="preview", required_scopes=["task:read"])
+    def preview(self, request, pk=None, **kwargs):
+        task_id = self._ensure_task_accessible()
+        redirect = tasks_facade.resolve_task_run_preview_redirect(
+            pk, task_id, self.team_id, user_id=cast(User, request.user).id
+        )
+        if redirect is None:
+            raise NotFound()
+        if redirect.outcome == "ready" and redirect.redirect_url:
+            response = HttpResponseRedirect(redirect.redirect_url)
+            response["Cache-Control"] = "no-store"
+            return response
+        return self._preview_unavailable_page(redirect.outcome, task_id)
 
     def _peer_messaging_gate(self, task_id: str) -> Response | None:
         """Server-side authorization for the peers endpoints. Tool gating in the

--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -46,8 +46,10 @@ from .process_task.activities import (
     send_permission_denial_guidance,
     send_permission_response_to_sandbox,
     start_agent_server,
+    start_dev_stack_preview,
     track_workflow_event,
     update_task_run_status,
+    wait_dev_stack_preview,
 )
 from .process_task.activities.feature_flags import is_slack_app_agent_design_enabled_for_task_activity
 from .process_task.activities.get_pr_babysit_snapshot import get_pr_babysit_snapshot
@@ -107,6 +109,8 @@ ACTIVITIES = [
     enforce_self_driving_run_quota,
     track_workflow_event,
     post_slack_update,
+    start_dev_stack_preview,
+    wait_dev_stack_preview,
     update_task_run_status,
     get_pr_context,
     get_pr_babysit_snapshot,

--- a/products/tasks/backend/temporal/process_task/activities/__init__.py
+++ b/products/tasks/backend/temporal/process_task/activities/__init__.py
@@ -71,6 +71,14 @@ from .start_agent_server import (
     mark_repo_ready,
     start_agent_server,
 )
+from .start_dev_stack_preview import (
+    StartDevStackPreviewInput,
+    StartDevStackPreviewOutput,
+    WaitDevStackPreviewInput,
+    WaitDevStackPreviewOutput,
+    start_dev_stack_preview,
+    wait_dev_stack_preview,
+)
 from .track_workflow_event import TrackWorkflowEventInput, track_workflow_event
 from .update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
 
@@ -93,6 +101,10 @@ __all__ = [
     "InjectFreshTokensOnResumeInput",
     "InvalidateResumeSnapshotInput",
     "PostSlackUpdateInput",
+    "StartDevStackPreviewInput",
+    "StartDevStackPreviewOutput",
+    "WaitDevStackPreviewInput",
+    "WaitDevStackPreviewOutput",
     "PrepareSandboxForRepositoryInput",
     "PrepareSandboxForRepositoryOutput",
     "ReadSandboxLogsInput",
@@ -137,6 +149,8 @@ __all__ = [
     "restore_sandbox_connection_state",
     "invalidate_resume_snapshot",
     "post_slack_update",
+    "start_dev_stack_preview",
+    "wait_dev_stack_preview",
     "prepare_sandbox_for_repository",
     "read_sandbox_logs",
     "refresh_sandbox_credentials",

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -17,6 +17,8 @@ from products.tasks.backend.constants import (
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
+    DEV_STACK_IMAGE_NAME,
+    DEV_STACK_PREVIEW_FEATURE_FLAG,
     HOGLAND_SANDBOX_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     OVERLAP_CLONE_BOOT_FEATURE_FLAG,
@@ -145,6 +147,7 @@ class TaskProcessingContext:
     # workflow start and persisted into TaskRun.state at provision time, so activities
     # and out-of-band consumers route deterministically for the run's whole life.
     sandbox_backend: str = "modal"
+    dev_stack_preview_enabled: bool = False
 
     @property
     def mode(self) -> str:
@@ -703,6 +706,47 @@ def _is_desktop_workspace_warm_enabled(
     return enabled
 
 
+def _is_dev_stack_preview_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    origin_product: str | None,
+    use_modal_vm_sandbox: bool,
+    custom_image_name: str | None,
+    repository: str | None,
+) -> bool:
+    if (
+        not use_modal_vm_sandbox
+        or custom_image_name != DEV_STACK_IMAGE_NAME
+        or origin_product != Task.OriginProduct.USER_CREATED
+        or (repository or "").casefold() != "posthog/posthog"
+    ):
+        return False
+
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                DEV_STACK_PREVIEW_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("dev_stack_preview_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context(
+        "dev_stack_preview_flag_checked",
+        run_id=run_id,
+        dev_stack_preview_enabled=enabled,
+    )
+    return enabled
+
+
 def _is_modal_network_allowlist_enabled(
     *,
     distinct_id: str,
@@ -1255,6 +1299,20 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         f"sandbox_backend: {sandbox_backend} for this task run",
     )
 
+    dev_stack_preview_enabled = _is_dev_stack_preview_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        origin_product=task.origin_product,
+        use_modal_vm_sandbox=use_modal_vm_sandbox,
+        custom_image_name=custom_image_name,
+        repository=run_repository,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"dev_stack_preview_enabled: {dev_stack_preview_enabled} for this task run",
+    )
     pr_authorship_mode = get_pr_authorship_mode(task, state)
     user_github_integration_id = None
     if not (is_slack_interaction_state(state) and pr_authorship_mode.value == "user"):
@@ -1327,6 +1385,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         continue_as_new_history_threshold=settings.TASKS_CONTINUE_AS_NEW_HISTORY_THRESHOLD,
         interactive_max_run_duration_seconds=interactive_max_run_duration_seconds,
         sandbox_backend=sandbox_backend,
+        dev_stack_preview_enabled=dev_stack_preview_enabled,
         # v1 scopes peer messaging to Pi runs; the flag check is skipped elsewhere
         # so ACP runs never even evaluate it.
         peer_messaging_enabled=task.runtime == Task.Runtime.PI

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -61,6 +61,7 @@ from products.tasks.backend.logic.services.sandbox import (
     sandbox_repo_path,
     workload_for_origin_product,
 )
+from products.tasks.backend.logic.services.sandbox_config import DEV_STACK_PREVIEW_MEMORY_GB
 from products.tasks.backend.logic.services.sandbox_usage import (
     measure_sandbox_billed_cpu_usage,
     measure_sandbox_cpu_usage,
@@ -735,6 +736,13 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         )
 
 
+def _dev_stack_preview_resources(ctx: TaskProcessingContext) -> dict[str, float | int]:
+    overrides = ctx.sandbox_resource_overrides()
+    if ctx.dev_stack_preview_enabled:
+        overrides.setdefault("memory_gb", DEV_STACK_PREVIEW_MEMORY_GB)
+    return overrides
+
+
 @asyncify
 def _create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> CreateSandboxForRepositoryOutput:
     ctx = input.context
@@ -761,6 +769,7 @@ def _create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cr
         # The VM template bakes in Docker (and forces the VM runtime), so the agent
         # can run nested containers; the default template has neither.
         use_vm_sandbox = ctx.use_modal_vm_sandbox
+        resource_overrides = _dev_stack_preview_resources(ctx)
         config = SandboxConfig(
             name=prepared.sandbox_name,
             template=SandboxTemplate.VM_BASE if use_vm_sandbox else SandboxTemplate.DEFAULT_BASE,
@@ -774,7 +783,7 @@ def _create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cr
             snapshot_source=prepared.snapshot_source,
             metadata=_build_sandbox_tags(ctx, prepared, use_vm_sandbox),
             vm_runtime=use_vm_sandbox,
-            **ctx.sandbox_resource_overrides(),
+            **resource_overrides,
         )
 
         # Request a small slice and let the box burst up to the configured size. Burstable by

--- a/products/tasks/backend/temporal/process_task/activities/start_dev_stack_preview.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_dev_stack_preview.py
@@ -1,0 +1,318 @@
+import json
+import time
+import shlex
+import asyncio
+from pathlib import Path
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.utils import timezone
+
+import structlog
+from temporalio import activity
+
+from posthog.dataclasses import frozen
+from posthog.temporal.common.utils import asyncify, close_db_connections
+from posthog.utils import absolute_uri
+
+from products.tasks.backend.constants import DEV_STACK_PREVIEW_PORT, DEV_STACK_PREVIEW_STATE_KEY
+from products.tasks.backend.logic.services.sandbox import (
+    Sandbox,
+    SandboxBase,
+    redact_sandbox_command,
+    sandbox_repo_path,
+)
+from products.tasks.backend.metrics import DEV_STACK_PREVIEW_BOOT_SECONDS, DEV_STACK_PREVIEW_TOTAL
+from products.tasks.backend.models import TaskRun
+from products.tasks.backend.temporal.observability import emit_agent_log, emit_progress, log_activity_execution
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+
+logger = structlog.get_logger(__name__)
+
+SCRIPT_LOCAL_PATH = Path("products/tasks/backend/sandbox/images/start-dev-stack-preview.sh")
+SCRIPT_SANDBOX_PATH = "/tmp/start-dev-stack-preview.sh"
+STATE_DIR = "/tmp/posthog-preview"
+STATUS_FILE = f"{STATE_DIR}/status.json"
+LOCK_FILE = f"{STATE_DIR}/lock"
+LOG_FILE = f"{STATE_DIR}/start.log"
+
+LAUNCH_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin"
+LAUNCH_HOME = "/root"
+
+BAKE_MANIFEST_PATH = "/opt/posthog/dev-stack-bake.json"
+
+STEP_TIMEOUT_SECONDS = 30
+LAUNCH_TIMEOUT_SECONDS = 30
+POLL_TIMEOUT_SECONDS = 30
+POLL_INTERVAL_SECONDS = 10
+READY_TIMEOUT_SECONDS = 12 * 60
+
+PROGRESS_STEP = "preview"
+PROGRESS_GROUP = "setup"
+
+_LOG_TAIL_CHARS = 1_500
+
+
+@frozen
+class StartDevStackPreviewInput:
+    context: TaskProcessingContext
+    sandbox_id: str
+    repository: str
+
+
+@frozen
+class StartDevStackPreviewOutput:
+    started: bool
+    attached: bool = False
+    reason: str | None = None
+
+
+@frozen
+class WaitDevStackPreviewInput:
+    context: TaskProcessingContext
+    sandbox_id: str
+
+
+@frozen
+class WaitDevStackPreviewOutput:
+    ready: bool
+    boot_seconds: float | None = None
+    reason: str | None = None
+
+
+@frozen
+class PreviewStatus:
+    state: str
+    error: str | None = None
+
+
+def preview_url(*, team_id: int, task_id: str, run_id: str) -> str:
+    return absolute_uri(f"/api/projects/{team_id}/tasks/{task_id}/runs/{run_id}/preview/")
+
+
+def _preview_host(url: str) -> str | None:
+    parsed = urlparse(url)
+    return parsed.netloc or None
+
+
+def _launch_command(*, host: str, repo_path: str) -> str:
+    return (
+        f"/usr/bin/env -i "
+        f"HOME={shlex.quote(LAUNCH_HOME)} "
+        f"PATH={shlex.quote(LAUNCH_PATH)} "
+        f"MODAL_HOST={shlex.quote(host)} "
+        f"PREVIEW_PORT={shlex.quote(str(DEV_STACK_PREVIEW_PORT))} "
+        f"REPO_PATH={shlex.quote(repo_path)} "
+        f"setsid /bin/bash {shlex.quote(SCRIPT_SANDBOX_PATH)} "
+        f">>{shlex.quote(LOG_FILE)} 2>&1 </dev/null &"
+    )
+
+
+def _already_previewing(run_id: str, sandbox_id: str) -> bool:
+    run = TaskRun.objects.filter(id=run_id).values_list("state", flat=True).first()
+    state = run if isinstance(run, dict) else {}
+    preview = state.get(DEV_STACK_PREVIEW_STATE_KEY)
+    return isinstance(preview, dict) and preview.get("sandbox_id") == sandbox_id
+
+
+@asyncify
+def _launch_preview(input: StartDevStackPreviewInput) -> StartDevStackPreviewOutput:
+    ctx = input.context
+    if _already_previewing(ctx.run_id, input.sandbox_id):
+        return StartDevStackPreviewOutput(started=False, reason="already_ready")
+
+    sandbox: SandboxBase = Sandbox.get_by_id(input.sandbox_id)
+
+    manifest = sandbox.execute(f"test -f {shlex.quote(BAKE_MANIFEST_PATH)}", timeout_seconds=STEP_TIMEOUT_SECONDS)
+    if manifest.exit_code != 0:
+        return StartDevStackPreviewOutput(started=False, reason="not_dev_stack_image")
+
+    credentials = sandbox.create_preview_connect_credentials(
+        port=DEV_STACK_PREVIEW_PORT,
+        user_metadata={"run_id": ctx.run_id, "team_id": ctx.team_id},
+    )
+    host = _preview_host(credentials.url)
+    if not host:
+        return StartDevStackPreviewOutput(started=False, reason="no_preview_host")
+
+    prepared = sandbox.execute(f"mkdir -p {shlex.quote(STATE_DIR)}", timeout_seconds=STEP_TIMEOUT_SECONDS)
+    if prepared.exit_code != 0:
+        return StartDevStackPreviewOutput(started=False, reason=f"prepare_exit_{prepared.exit_code}")
+
+    lock = sandbox.execute(f"flock -n {shlex.quote(LOCK_FILE)} true", timeout_seconds=STEP_TIMEOUT_SECONDS)
+    if lock.exit_code != 0:
+        return StartDevStackPreviewOutput(started=True, attached=True)
+
+    script = (Path(settings.BASE_DIR) / SCRIPT_LOCAL_PATH).read_text()
+    uploaded = sandbox.write_file(SCRIPT_SANDBOX_PATH, script.encode(), timeout_seconds=STEP_TIMEOUT_SECONDS)
+    if uploaded.exit_code != 0:
+        return StartDevStackPreviewOutput(started=False, reason=f"upload_exit_{uploaded.exit_code}")
+
+    result = sandbox.execute(
+        _launch_command(host=host, repo_path=sandbox_repo_path(input.repository)),
+        timeout_seconds=LAUNCH_TIMEOUT_SECONDS,
+    )
+    if result.exit_code != 0:
+        return StartDevStackPreviewOutput(started=False, reason=f"launch_exit_{result.exit_code}")
+    return StartDevStackPreviewOutput(started=True)
+
+
+@asyncify
+def _resolve_sandbox(sandbox_id: str) -> SandboxBase:
+    return Sandbox.get_by_id(sandbox_id)
+
+
+@asyncify
+def _read_status(sandbox: SandboxBase) -> PreviewStatus | None:
+    result = sandbox.execute(f"cat {shlex.quote(STATUS_FILE)} 2>/dev/null", timeout_seconds=POLL_TIMEOUT_SECONDS)
+    if result.exit_code != 0 or not result.stdout.strip():
+        return None
+    try:
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    state = payload.get("state")
+    error = payload.get("error")
+    if not isinstance(state, str):
+        return None
+    return PreviewStatus(state=state, error=error if isinstance(error, str) else None)
+
+
+@asyncify
+def _read_log_tail(sandbox: SandboxBase) -> str:
+    try:
+        result = sandbox.execute(f"tail -c {_LOG_TAIL_CHARS} {shlex.quote(LOG_FILE)} 2>/dev/null", timeout_seconds=30)
+    except Exception:
+        return ""
+    return redact_sandbox_command(result.stdout.strip())[:_LOG_TAIL_CHARS]
+
+
+@asyncify
+def _stamp_preview_ready(run_id: str, sandbox_id: str, ready_at: str) -> None:
+    def _mutator(state: dict) -> None:
+        existing = state.get(DEV_STACK_PREVIEW_STATE_KEY)
+        preview = dict(existing) if isinstance(existing, dict) else {}
+        preview.update({"port": DEV_STACK_PREVIEW_PORT, "sandbox_id": sandbox_id, "ready_at": ready_at})
+        state[DEV_STACK_PREVIEW_STATE_KEY] = preview
+
+    TaskRun.mutate_state_atomic(run_id, _mutator)
+
+
+@asyncify
+def _emit_preview_progress(*, run_id: str, status: str, label: str, detail: str | None = None) -> None:
+    emit_progress(
+        run_id=run_id,
+        step=PROGRESS_STEP,
+        status=status,
+        label=label,
+        group=f"{PROGRESS_GROUP}:{run_id}",
+        detail=detail,
+    )
+
+
+@asyncify
+def _emit_preview_warning(run_id: str, message: str) -> None:
+    emit_agent_log(run_id, "warn", message)
+
+
+@activity.defn
+@close_db_connections
+async def start_dev_stack_preview(input: StartDevStackPreviewInput) -> StartDevStackPreviewOutput:
+    ctx = input.context
+    with log_activity_execution("start_dev_stack_preview", sandbox_id=input.sandbox_id, **ctx.to_log_context()):
+        if not ctx.dev_stack_preview_enabled:
+            return StartDevStackPreviewOutput(started=False, reason="disabled")
+
+        try:
+            output = await _launch_preview(input)
+        except Exception:
+            logger.warning("dev_stack_preview_launch_failed", run_id=ctx.run_id, exc_info=True)
+            DEV_STACK_PREVIEW_TOTAL.labels(outcome="launch_failed").inc()
+            raise
+
+        if not output.started:
+            logger.info("dev_stack_preview_not_started", run_id=ctx.run_id, reason=output.reason)
+            return output
+
+        DEV_STACK_PREVIEW_TOTAL.labels(outcome="attached" if output.attached else "started").inc()
+        await _emit_preview_progress(run_id=ctx.run_id, status="in_progress", label="Starting PostHog preview")
+        return output
+
+
+async def _await_ready(sandbox: SandboxBase, run_id: str) -> tuple[PreviewStatus | None, float]:
+    started_at = time.monotonic()
+    deadline = started_at + READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        activity.heartbeat()
+        try:
+            status = await _read_status(sandbox)
+        except Exception:
+            logger.warning("dev_stack_preview_status_read_failed", run_id=run_id, exc_info=True)
+            status = None
+        if status is not None and status.state in ("ready", "failed"):
+            return status, time.monotonic() - started_at
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    return None, time.monotonic() - started_at
+
+
+@activity.defn
+@close_db_connections
+async def wait_dev_stack_preview(input: WaitDevStackPreviewInput) -> WaitDevStackPreviewOutput:
+    ctx = input.context
+    with log_activity_execution("wait_dev_stack_preview", sandbox_id=input.sandbox_id, **ctx.to_log_context()):
+        if not ctx.dev_stack_preview_enabled:
+            return WaitDevStackPreviewOutput(ready=False, reason="disabled")
+
+        try:
+            return await _wait_for_preview(input)
+        except asyncio.CancelledError:
+            DEV_STACK_PREVIEW_TOTAL.labels(outcome="cancelled").inc()
+            raise
+
+
+async def _wait_for_preview(input: WaitDevStackPreviewInput) -> WaitDevStackPreviewOutput:
+    ctx = input.context
+    try:
+        sandbox = await _resolve_sandbox(input.sandbox_id)
+    except Exception:
+        logger.warning("dev_stack_preview_sandbox_unavailable", run_id=ctx.run_id, exc_info=True)
+        DEV_STACK_PREVIEW_TOTAL.labels(outcome="failed").inc()
+        await _emit_preview_progress(run_id=ctx.run_id, status="failed", label="Preview didn't start")
+        return WaitDevStackPreviewOutput(ready=False, reason="sandbox_unavailable")
+
+    status, elapsed = await _await_ready(sandbox, ctx.run_id)
+
+    if status is not None and status.state == "ready":
+        DEV_STACK_PREVIEW_BOOT_SECONDS.observe(elapsed)
+        try:
+            await _stamp_preview_ready(ctx.run_id, input.sandbox_id, timezone.now().isoformat())
+        except Exception:
+            logger.warning("dev_stack_preview_state_write_failed", run_id=ctx.run_id, exc_info=True)
+            DEV_STACK_PREVIEW_TOTAL.labels(outcome="failed").inc()
+            await _emit_preview_progress(run_id=ctx.run_id, status="failed", label="Preview didn't start")
+            return WaitDevStackPreviewOutput(ready=False, boot_seconds=elapsed, reason="state_write_failed")
+        DEV_STACK_PREVIEW_TOTAL.labels(outcome="ready").inc()
+        await _emit_preview_progress(
+            run_id=ctx.run_id,
+            status="completed",
+            label="Preview ready",
+            detail=preview_url(team_id=ctx.team_id, task_id=ctx.task_id, run_id=ctx.run_id),
+        )
+        return WaitDevStackPreviewOutput(ready=True, boot_seconds=elapsed)
+
+    timed_out = status is None
+    DEV_STACK_PREVIEW_TOTAL.labels(outcome="timed_out" if timed_out else "failed").inc()
+    await _emit_preview_progress(run_id=ctx.run_id, status="failed", label="Preview didn't start")
+    tail = await _read_log_tail(sandbox)
+    detail = (status.error if status is not None and status.error else "") or "timed out"
+    await _emit_preview_warning(
+        ctx.run_id,
+        f"The PostHog preview did not start ({detail}). The task continues without it." + (f"\n{tail}" if tail else ""),
+    )
+    return WaitDevStackPreviewOutput(
+        ready=False,
+        boot_seconds=elapsed,
+        reason="timed_out" if timed_out else "failed",
+    )

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -15,6 +15,7 @@ from products.tasks.backend.constants import (
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
+    DEV_STACK_IMAGE_NAME,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
     PR_BABYSIT_SNAPSHOT_FEATURE_FLAG,
     RTK_DISABLED_FEATURE_FLAG,
@@ -36,6 +37,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_burstable_sandbox_resources_enabled,
     _is_continue_as_new_enabled,
     _is_desktop_workspace_warm_enabled,
+    _is_dev_stack_preview_enabled,
     _is_pr_babysit_snapshot_enabled,
     _is_rtk_enabled,
     _is_sandbox_event_ingest_enabled,
@@ -125,6 +127,54 @@ def test_desktop_workspace_warm_flag_fails_closed():
             )
             is False
         )
+
+
+def _preview_gate(
+    *,
+    origin_product: str = Task.OriginProduct.USER_CREATED,
+    use_modal_vm_sandbox: bool = True,
+    custom_image_name: str | None = DEV_STACK_IMAGE_NAME,
+    repository: str | None = "PostHog/PostHog",
+) -> bool:
+    return _is_dev_stack_preview_enabled(
+        distinct_id="distinct-id",
+        organization_id="organization-id",
+        run_id="run-id",
+        origin_product=origin_product,
+        use_modal_vm_sandbox=use_modal_vm_sandbox,
+        custom_image_name=custom_image_name,
+        repository=repository,
+    )
+
+
+@pytest.mark.parametrize(
+    "flag_value,overrides,expected",
+    [
+        (True, {}, True),
+        (False, {}, False),
+        (None, {}, False),
+        (True, {"origin_product": Task.OriginProduct.ONBOARDING}, False),
+        (True, {"use_modal_vm_sandbox": False}, False),
+        (True, {"custom_image_name": "posthog-sandbox-custom-abc"}, False),
+        (True, {"custom_image_name": None}, False),
+        (True, {"repository": "posthog/posthog-js"}, False),
+        (True, {"repository": None}, False),
+    ],
+)
+def test_dev_stack_preview_needs_the_flag_and_the_right_shape_of_run(flag_value, overrides, expected):
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+        return_value=flag_value,
+    ):
+        assert _preview_gate(**overrides) is expected
+
+
+def test_dev_stack_preview_flag_fails_closed():
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+        side_effect=RuntimeError("flag service failed"),
+    ):
+        assert _preview_gate() is False
 
 
 @pytest.mark.requires_secrets

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -22,6 +22,7 @@ from products.tasks.backend.temporal.process_task.activities.provision_sandbox i
     CreateSandboxForRepositoryInput,
     CreateSandboxForRepositoryOutput,
     PrepareSandboxForRepositoryOutput,
+    _dev_stack_preview_resources,
     _prepare_posthog_desktop_cloud_task,
     _prewarmed_resume_needs_fresh_agent,
     _sandbox_image_kind,
@@ -46,6 +47,27 @@ def _context_for_desktop_bootstrap(
         custom_image_name=image_name,
         desktop_workspace_warm_enabled=warm_enabled,
     )
+
+
+@pytest.mark.parametrize(
+    "preview_enabled, state, expected",
+    [
+        (False, {}, {}),
+        (True, {}, {"memory_gb": 32.0}),
+        (True, {"sandbox_memory_gb": 48}, {"memory_gb": 48.0}),
+        (
+            True,
+            {"sandbox_cpu_cores": 4, "sandbox_memory_gb": 48},
+            {"cpu_cores": 4.0, "memory_gb": 48.0},
+        ),
+    ],
+)
+def test_dev_stack_preview_sizes_the_sandbox_without_overriding_the_task(preview_enabled, state, expected):
+    context = _context_for_desktop_bootstrap()
+    context.dev_stack_preview_enabled = preview_enabled
+    context.state = state
+
+    assert _dev_stack_preview_resources(context) == expected
 
 
 def test_prepares_desktop_workspace_for_posthog_dev_stack_task(mocker):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_dev_stack_preview.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_dev_stack_preview.py
@@ -1,0 +1,280 @@
+import asyncio
+
+import pytest
+from unittest.mock import MagicMock
+
+from django.test import override_settings
+
+from asgiref.sync import async_to_sync
+
+from products.tasks.backend.constants import DEV_STACK_PREVIEW_PORT, DEV_STACK_PREVIEW_STATE_KEY
+from products.tasks.backend.logic.services.sandbox import AgentServerResult, ExecutionResult
+from products.tasks.backend.metrics import DEV_STACK_PREVIEW_TOTAL
+from products.tasks.backend.models import TaskRun
+from products.tasks.backend.temporal.process_task.activities.start_dev_stack_preview import (
+    StartDevStackPreviewInput,
+    WaitDevStackPreviewInput,
+    start_dev_stack_preview,
+    wait_dev_stack_preview,
+)
+
+MODULE = "products.tasks.backend.temporal.process_task.activities.start_dev_stack_preview"
+SITE_URL = "https://us.posthog.example"
+SANDBOX_HOST = "abc-8020.modal.host"
+LOG_TAIL_WITH_A_SECRET = "hogli start failed POSTHOG_TASK_RUN_SESSION_TOKEN=super-secret-value"
+
+
+def _sandbox(
+    mocker,
+    *,
+    manifest_exit_code=0,
+    prepare_exit_code=0,
+    lock_exit_code=0,
+    upload_exit_code=0,
+    launch_exit_code=0,
+    status_payload=None,
+    on_status_read=None,
+):
+    sandbox = MagicMock()
+    sandbox.create_preview_connect_credentials.return_value = AgentServerResult(
+        url=f"https://{SANDBOX_HOST}", token="connect-token"
+    )
+    sandbox.write_file.return_value = ExecutionResult(stdout="", stderr="", exit_code=upload_exit_code)
+
+    def _execute(command, timeout_seconds=None):
+        if command.startswith("test -f"):
+            return ExecutionResult(stdout="", stderr="", exit_code=manifest_exit_code)
+        if command.startswith("mkdir "):
+            return ExecutionResult(stdout="", stderr="", exit_code=prepare_exit_code)
+        if command.startswith("flock "):
+            return ExecutionResult(stdout="", stderr="", exit_code=lock_exit_code)
+        if command.startswith("cat "):
+            if on_status_read is not None:
+                on_status_read()
+            return ExecutionResult(stdout=status_payload or "", stderr="", exit_code=0)
+        if command.startswith("tail "):
+            return ExecutionResult(stdout=LOG_TAIL_WITH_A_SECRET, stderr="", exit_code=0)
+        return ExecutionResult(stdout="", stderr="", exit_code=launch_exit_code)
+
+    sandbox.execute.side_effect = _execute
+    mocker.patch(f"{MODULE}.Sandbox.get_by_id", return_value=sandbox)
+    return sandbox
+
+
+def _enabled(context):
+    context.dev_stack_preview_enabled = True
+    context.repository = "PostHog/posthog"
+    return context
+
+
+def _start(context, activity_environment):
+    return async_to_sync(activity_environment.run)(
+        start_dev_stack_preview,
+        StartDevStackPreviewInput(context=context, sandbox_id="sandbox-1", repository="PostHog/posthog"),
+    )
+
+
+def _wait(context, activity_environment):
+    return async_to_sync(activity_environment.run)(
+        wait_dev_stack_preview,
+        WaitDevStackPreviewInput(context=context, sandbox_id="sandbox-1"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def fast_polling(mocker):
+    mocker.patch(f"{MODULE}.POLL_INTERVAL_SECONDS", 0)
+    mocker.patch(f"{MODULE}.READY_TIMEOUT_SECONDS", 0.05)
+
+
+@pytest.fixture(autouse=True)
+def agent_log(mocker):
+    return mocker.patch(f"{MODULE}.emit_agent_log")
+
+
+@pytest.fixture
+def progress(mocker):
+    return mocker.patch(f"{MODULE}.emit_progress")
+
+
+def _outcome_count(outcome):
+    return DEV_STACK_PREVIEW_TOTAL.labels(outcome=outcome)._value.get()
+
+
+@pytest.mark.django_db
+def test_start_is_skipped_when_the_run_has_no_preview(task_context, activity_environment, mocker, progress):
+    sandbox = _sandbox(mocker)
+
+    output = _start(task_context, activity_environment)
+
+    assert output.started is False
+    assert output.reason == "disabled"
+    sandbox.execute.assert_not_called()
+    progress.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_start_is_skipped_when_the_sandbox_is_not_the_dev_stack_image(
+    task_context, activity_environment, mocker, progress
+):
+    sandbox = _sandbox(mocker, manifest_exit_code=1)
+
+    output = _start(_enabled(task_context), activity_environment)
+
+    assert output.started is False
+    assert output.reason == "not_dev_stack_image"
+    sandbox.create_preview_connect_credentials.assert_not_called()
+    progress.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "failure, expected_reason",
+    [
+        ({"prepare_exit_code": 5}, "prepare_exit_5"),
+        ({"upload_exit_code": 3}, "upload_exit_3"),
+        ({"launch_exit_code": 7}, "launch_exit_7"),
+    ],
+)
+def test_start_reports_step_failures_without_launching(
+    task_context, activity_environment, mocker, progress, failure, expected_reason
+):
+    sandbox = _sandbox(mocker, **failure)
+
+    output = _start(_enabled(task_context), activity_environment)
+
+    assert output.started is False
+    assert output.reason == expected_reason
+    if "launch_exit_code" not in failure:
+        assert not any(call.args[0].startswith("/usr/bin/env") for call in sandbox.execute.call_args_list)
+    progress.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_start_raises_provider_errors_so_temporal_retries(task_context, activity_environment, mocker, progress):
+    mocker.patch(f"{MODULE}.Sandbox.get_by_id", side_effect=RuntimeError("sandbox gone"))
+    before = _outcome_count("launch_failed")
+
+    with pytest.raises(RuntimeError):
+        _start(_enabled(task_context), activity_environment)
+
+    assert _outcome_count("launch_failed") == before + 1
+    progress.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_start_attaches_to_a_launch_already_in_progress(task_context, activity_environment, mocker, progress):
+    sandbox = _sandbox(mocker, lock_exit_code=1)
+    before = {outcome: _outcome_count(outcome) for outcome in ("started", "attached")}
+
+    output = _start(_enabled(task_context), activity_environment)
+
+    assert output.started is True
+    assert output.attached is True
+    sandbox.write_file.assert_not_called()
+    assert not any(call.args[0].startswith("/usr/bin/env") for call in sandbox.execute.call_args_list)
+    assert _outcome_count("attached") == before["attached"] + 1
+    assert _outcome_count("started") == before["started"]
+    assert progress.call_args.kwargs["status"] == "in_progress"
+
+
+@pytest.mark.django_db
+def test_start_launches_the_stack_against_the_minted_preview_host(task_context, activity_environment, mocker, progress):
+    sandbox = _sandbox(mocker)
+
+    output = _start(_enabled(task_context), activity_environment)
+
+    assert output.started is True
+    sandbox.create_preview_connect_credentials.assert_called_once()
+    assert sandbox.create_preview_connect_credentials.call_args.kwargs["port"] == DEV_STACK_PREVIEW_PORT
+    assert sandbox.write_file.call_args.args[0] == "/tmp/start-dev-stack-preview.sh"
+    launch_command = sandbox.execute.call_args.args[0]
+    assert launch_command.startswith("/usr/bin/env -i ")
+    assert "HOME=/root" in launch_command
+    assert "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin" in launch_command
+    assert f"MODAL_HOST={SANDBOX_HOST}" in launch_command
+    assert f"PREVIEW_PORT={DEV_STACK_PREVIEW_PORT}" in launch_command
+    assert "REPO_PATH=/tmp/workspace/repos/posthog/posthog" in launch_command
+    assert progress.call_args.kwargs["status"] == "in_progress"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_start_skips_a_sandbox_that_already_serves_a_preview(
+    task_context, test_task_run, activity_environment, mocker, progress
+):
+    TaskRun.update_state_atomic(
+        test_task_run.id,
+        updates={DEV_STACK_PREVIEW_STATE_KEY: {"port": DEV_STACK_PREVIEW_PORT, "sandbox_id": "sandbox-1"}},
+    )
+    sandbox = _sandbox(mocker)
+
+    output = _start(_enabled(task_context), activity_environment)
+
+    assert output.started is False
+    assert output.reason == "already_ready"
+    sandbox.execute.assert_not_called()
+    progress.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(SITE_URL=SITE_URL)
+def test_wait_stamps_the_preview_and_links_it_through_posthog(
+    task_context, test_task_run, activity_environment, mocker, progress
+):
+    _sandbox(mocker, status_payload='{"state": "ready"}')
+
+    output = _wait(_enabled(task_context), activity_environment)
+
+    assert output.ready is True
+    test_task_run.refresh_from_db()
+    preview = test_task_run.state[DEV_STACK_PREVIEW_STATE_KEY]
+    assert preview["port"] == DEV_STACK_PREVIEW_PORT
+    assert preview["sandbox_id"] == "sandbox-1"
+    assert preview["ready_at"]
+    detail = progress.call_args.kwargs["detail"]
+    assert progress.call_args.kwargs["status"] == "completed"
+    assert (
+        detail
+        == f"{SITE_URL}/api/projects/{task_context.team_id}/tasks/{task_context.task_id}/runs/{task_context.run_id}/preview/"
+    )
+    assert "modal.host" not in detail
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status_payload, expected_reason",
+    [
+        ("", "timed_out"),
+        ('{"state": "starting"}', "timed_out"),
+        ('{"state": "failed", "error": "hogli start failed"}', "failed"),
+    ],
+)
+def test_wait_reports_a_failed_preview_without_failing_the_run(
+    task_context, test_task_run, activity_environment, mocker, progress, agent_log, status_payload, expected_reason
+):
+    _sandbox(mocker, status_payload=status_payload)
+
+    output = _wait(_enabled(task_context), activity_environment)
+
+    assert output.ready is False
+    assert output.reason == expected_reason
+    test_task_run.refresh_from_db()
+    assert DEV_STACK_PREVIEW_STATE_KEY not in (test_task_run.state or {})
+    assert progress.call_args.kwargs["status"] == "failed"
+    warning = agent_log.call_args.args[2]
+    assert "super-secret-value" not in warning
+    assert "POSTHOG_TASK_RUN_SESSION_TOKEN=<redacted>" in warning
+
+
+@pytest.mark.django_db
+def test_wait_records_a_cancelled_boot(task_context, test_task_run, activity_environment, mocker, progress):
+    mocker.patch(f"{MODULE}.READY_TIMEOUT_SECONDS", 60)
+    _sandbox(mocker, status_payload='{"state": "starting"}', on_status_read=activity_environment.cancel)
+    before = _outcome_count("cancelled")
+
+    with pytest.raises(asyncio.CancelledError):
+        _wait(_enabled(task_context), activity_environment)
+
+    assert _outcome_count("cancelled") == before + 1
+    test_task_run.refresh_from_db()
+    assert DEV_STACK_PREVIEW_STATE_KEY not in (test_task_run.state or {})

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -128,6 +128,12 @@ from .activities.start_agent_server import (
     mark_repo_ready,
     start_agent_server,
 )
+from .activities.start_dev_stack_preview import (
+    StartDevStackPreviewInput,
+    WaitDevStackPreviewInput,
+    start_dev_stack_preview,
+    wait_dev_stack_preview,
+)
 from .activities.track_workflow_event import SANDBOX_DEADLINE_EVENT, TrackWorkflowEventInput, track_workflow_event
 from .activities.update_task_run_status import (
     SANDBOX_GONE_STATE_KEY,
@@ -353,6 +359,8 @@ _PATCH_ID_AGENT_READY_AFTER_PRIMARY_CLONE = "tasks-agent-ready-after-primary-clo
 # that non-idempotent work one attempt with a budget larger than its inner 10-minute cap.
 _DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT = timedelta(minutes=20)
 
+_DEV_STACK_PREVIEW_WAIT_TIMEOUT = timedelta(minutes=15)
+
 # #60923 dropped the redundant slack post that ran immediately after sandbox
 # provisioning — between `_get_sandbox_for_repository` and the agent-start
 # progress emit. Pre-rollout histories scheduled a `post_slack_update` activity
@@ -400,6 +408,8 @@ _PATCH_ID_SNAPSHOT_BEFORE_CI_FOLLOW_UP = "tasks-snapshot-before-ci-follow-up"
 # terminalization poll_for_turn callers rely on. Same cleanup lifecycle as above.
 _PATCH_ID_FOLLOWUP_FAILURE_KEEPS_RUN = "tasks-followup-failure-keeps-run"
 
+_PATCH_ID_DEV_STACK_PREVIEW = "tasks-dev-stack-preview"
+
 # `Task.OriginProduct.ONBOARDING`, mirrored as a literal so workflow code stays free of
 # Django model imports.
 _ONBOARDING_ORIGIN_PRODUCT = "onboarding"
@@ -427,6 +437,10 @@ def _run_lifecycle_bounds_enabled() -> bool:
     return workflow.patched(_PATCH_ID_RUN_LIFECYCLE_BOUNDS)
 
 
+def _dev_stack_preview_enabled() -> bool:
+    return workflow.in_workflow() and workflow.patched(_PATCH_ID_DEV_STACK_PREVIEW)
+
+
 @temporalio.workflow.defn(name="process-task")
 class ProcessTaskWorkflow(PostHogWorkflow):
     def __init__(self) -> None:
@@ -439,6 +453,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         self._sandbox_connect_token: Optional[str] = None
         self._sandbox_jwt_kid: Optional[str] = None
         self._resume_snapshot_invalidated = False
+        self._preview_progress_open: bool = False
         self._task_completed: bool = False
         self._completion_status: str = "completed"
         self._completion_error: Optional[str] = None
@@ -964,6 +979,54 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         await self._emit_progress("pr", "completed", "Opened pull request", "setup", detail=pr_url)
         await self._emit_progress("ci", "in_progress", "Keeping CI green", "setup")
 
+    def _start_dev_stack_preview(self, sandbox_id: str) -> "asyncio.Task[None] | None":
+        repository = self.context.repository
+        if not repository:
+            return None
+        return asyncio.ensure_future(self._run_dev_stack_preview(sandbox_id, repository))
+
+    async def _run_dev_stack_preview(self, sandbox_id: str, repository: str) -> None:
+        try:
+            output = await workflow.execute_activity(
+                start_dev_stack_preview,
+                StartDevStackPreviewInput(
+                    context=self.context,
+                    sandbox_id=sandbox_id,
+                    repository=repository,
+                ),
+                start_to_close_timeout=timedelta(minutes=3),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+        except Exception:
+            workflow.logger.warning(
+                "Could not start the dev stack preview",
+                extra={"run_id": self.context.run_id, "sandbox_id": sandbox_id},
+            )
+            return
+        if not output.started:
+            return
+        self._preview_progress_open = True
+        try:
+            await workflow.execute_activity(
+                wait_dev_stack_preview,
+                WaitDevStackPreviewInput(context=self.context, sandbox_id=sandbox_id),
+                start_to_close_timeout=_DEV_STACK_PREVIEW_WAIT_TIMEOUT,
+                heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        except Exception:
+            workflow.logger.warning(
+                "Gave up waiting for the dev stack preview",
+                extra={"run_id": self.context.run_id, "sandbox_id": sandbox_id},
+            )
+        self._preview_progress_open = False
+
+    async def _close_dev_stack_preview_progress(self) -> None:
+        if not self._preview_progress_open:
+            return
+        self._preview_progress_open = False
+        await self._emit_progress("preview", "failed", "Preview didn't start", "setup")
+
     async def _should_run_babysit_follow_up(self) -> CIFollowUpDecision:
         self._pending_babysit = None
         snapshot = await workflow.execute_activity(
@@ -1054,6 +1117,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         self._prewarmed = input.prewarmed
         credential_refresh_task: asyncio.Task[None] | None = None
         permission_response_task: asyncio.Task[None] | None = None
+        preview_task: asyncio.Task[None] | None = None
         try:
             self._context = await self._get_task_processing_context(input)
             self._posthog_mcp_scopes = input.posthog_mcp_scopes
@@ -1104,6 +1168,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     self._run_credential_refresh_until_sandbox_gone(sandbox_id)
                 )
 
+            if self.context.dev_stack_preview_enabled and _dev_stack_preview_enabled():
+                preview_task = self._start_dev_stack_preview(sandbox_id)
+
             # A continuation already delivered the first user message in a prior execution.
             if input.resumed_sandbox is None and input.initial_message is not None:
                 self._pending_followups.append(input.initial_message)
@@ -1127,7 +1194,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                         },
                     )
                     # Stop the background loops but leave the sandbox for the next execution.
-                    for task in (relay_task, credential_refresh_task, permission_response_task):
+                    for task in (
+                        relay_task,
+                        credential_refresh_task,
+                        permission_response_task,
+                        preview_task,
+                    ):
                         if task is not None:
                             await self._cancel_relay(task)
                     workflow.continue_as_new(self._build_resumed_input(input, sandbox_id))
@@ -1211,6 +1283,10 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                             rotation_reason = rotation.reason
                         if rotated_sandbox_id:
                             sandbox_id = rotated_sandbox_id
+                            if self.context.dev_stack_preview_enabled and _dev_stack_preview_enabled():
+                                if preview_task is not None:
+                                    await self._cancel_relay(preview_task)
+                                preview_task = self._start_dev_stack_preview(sandbox_id)
                             await self._emit_progress(
                                 step="sandbox_deadline",
                                 status="completed",
@@ -1515,6 +1591,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     await self._cancel_relay(credential_refresh_task)
                 if permission_response_task is not None:
                     await self._cancel_relay(permission_response_task)
+                if preview_task is not None:
+                    await self._cancel_relay(preview_task)
+                await self._close_dev_stack_preview_progress()
 
                 cleanup_sandbox_id = sandbox_id or self._sandbox_id_for_cleanup
                 if cleanup_sandbox_id:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -40,6 +40,8 @@ from posthog.utils import absolute_uri
 from products.posthog_ai.backend.models.assistant import Conversation
 from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.tasks.backend.access import DesktopAccessResolutionError
+from products.tasks.backend.constants import DEV_STACK_PREVIEW_PORT
+from products.tasks.backend.exceptions import SandboxNotFoundError
 from products.tasks.backend.facade import (
     access as tasks_access,
     api as tasks_facade,
@@ -5434,6 +5436,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
                     "analysis_target_repository": "attacker/attacker",
                     "analysis_target_custom_image_id": "img-attacker",
                     "analysis_target_custom_image_name": "attacker-image",
+                    "dev_stack_preview": {"port": 8080, "sandbox_id": "sb-real"},
                     "scratch": "ok",
                 }
             },
@@ -5443,6 +5446,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         run.refresh_from_db()
         assert run.state["github_credential_source"] == "caller_token"
         assert run.state["pr_authorship_mode"] == "user"
+        assert "dev_stack_preview" not in run.state
         assert run.state["sandbox_id"] == "sb-real"
         assert run.state["sandbox_cpu_cores"] == 2
         assert run.state["sandbox_memory_gb"] == 8
@@ -14185,3 +14189,160 @@ class TestTaskAnalysisInsightReporting(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.analysis_run.refresh_from_db()
         self.assertEqual(len(self.analysis_run.state["task_analysis_insights"]), 1)
+
+
+class TestTaskRunPreviewAPI(BaseTaskAPITest):
+    SANDBOX_CLASS_TARGET = "products.tasks.backend.logic.services.sandbox.get_sandbox_class"
+
+    def _preview_url(self, task: Task, run: TaskRun) -> str:
+        return f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/preview/"
+
+    def _create_run(self, task: Task, state: dict, team: Team | None = None) -> TaskRun:
+        return TaskRun.objects.create(
+            task=task,
+            team=team or self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            state=state,
+        )
+
+    def _ready_state(self) -> dict:
+        return {
+            "sandbox_id": "sandbox-1",
+            "dev_stack_preview": {
+                "port": DEV_STACK_PREVIEW_PORT,
+                "sandbox_id": "sandbox-1",
+                "ready_at": "2026-01-01T00:00:00+00:00",
+            },
+        }
+
+    def _patch_sandbox_class(self, sandbox: MagicMock) -> Any:
+        sandbox_class = MagicMock()
+        sandbox_class.get_by_id.return_value = sandbox
+        return patch(self.SANDBOX_CLASS_TARGET, return_value=sandbox_class)
+
+    def test_preview_redirects_with_a_freshly_minted_token(self):
+        task = self.create_task()
+        run = self._create_run(task, self._ready_state())
+        sandbox = MagicMock()
+        sandbox.is_running.return_value = True
+        sandbox.execute.return_value = MagicMock(exit_code=0)
+        sandbox.create_preview_connect_credentials.return_value = MagicMock(
+            url="https://preview-abc.modal.host", token="connect-token-xyz"
+        )
+
+        with self._patch_sandbox_class(sandbox):
+            response = self.client.get(self._preview_url(task, run))
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("/_health", sandbox.execute.call_args.args[0])
+        self.assertIn("/@vite/client", sandbox.execute.call_args.args[0])
+        self.assertEqual(response["Location"], "https://preview-abc.modal.host/?_modal_connect_token=connect-token-xyz")
+        self.assertEqual(response.content, b"")
+        sandbox.create_preview_connect_credentials.assert_called_once_with(
+            port=DEV_STACK_PREVIEW_PORT, user_metadata={"user_id": self.user.id, "team_id": self.team.id}
+        )
+
+    def test_preview_without_a_recorded_preview_never_reaches_the_sandbox(self):
+        task = self.create_task()
+        run = self._create_run(task, {"sandbox_id": "sandbox-1"})
+
+        with patch(self.SANDBOX_CLASS_TARGET) as mock_get_sandbox_class:
+            response = self.client.get(self._preview_url(task, run))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/html", response["Content-Type"])
+        self.assertIn("ready yet", response.content.decode())
+        self.assertIn(f"/project/{self.team.id}/tasks/{task.id}", response.content.decode())
+        mock_get_sandbox_class.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                "sandbox_not_found",
+                SandboxNotFoundError("sandbox gone", {}, cause=RuntimeError("gone"), capture=False),
+                None,
+                0,
+                "This preview has ended",
+            ),
+            ("not_running", None, False, 0, "This preview has ended"),
+            ("lookup_raises", RuntimeError("modal is down"), None, 0, "isn&#x27;t reachable right now"),
+            ("stack_dead_in_a_live_sandbox", None, True, 22, "isn&#x27;t reachable right now"),
+        ]
+    )
+    def test_preview_separates_an_ended_sandbox_from_a_bad_moment(
+        self, _name, lookup_error, is_running, probe_exit_code, expected
+    ):
+        task = self.create_task()
+        run = self._create_run(task, self._ready_state())
+        sandbox_class = MagicMock()
+        if lookup_error is not None:
+            sandbox_class.get_by_id.side_effect = lookup_error
+        else:
+            sandbox = MagicMock()
+            sandbox.is_running.return_value = is_running
+            sandbox.execute.return_value = MagicMock(exit_code=probe_exit_code)
+            sandbox_class.get_by_id.return_value = sandbox
+
+        with patch(self.SANDBOX_CLASS_TARGET, return_value=sandbox_class):
+            response = self.client.get(self._preview_url(task, run))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/html", response["Content-Type"])
+        self.assertIn(expected, response.content.decode())
+
+    def test_preview_on_another_teams_run_is_not_found(self):
+        other_org = Organization.objects.create(name="Other Preview Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Preview Team")
+        other_task = Task.objects.create(
+            team=other_team,
+            title="Other Team Task",
+            description="Description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        other_run = self._create_run(other_task, self._ready_state(), team=other_team)
+
+        with patch(self.SANDBOX_CLASS_TARGET) as mock_get_sandbox_class:
+            response = self.client.get(self._preview_url(other_task, other_run))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        mock_get_sandbox_class.assert_not_called()
+
+    def test_preview_requires_authentication(self):
+        task = self.create_task()
+        run = self._create_run(task, self._ready_state())
+        self.client.force_authenticate(None)
+
+        response = self.client.get(self._preview_url(task, run))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_run_detail_reports_whether_a_preview_is_available(self):
+        task = self.create_task()
+        without_preview = self._create_run(task, {"sandbox_id": "sandbox-1"})
+        with_preview = self._create_run(task, self._ready_state())
+
+        base_url = f"/api/projects/@current/tasks/{task.id}/runs"
+        self.assertFalse(self.client.get(f"{base_url}/{without_preview.id}/").json()["preview_available"])
+        self.assertTrue(self.client.get(f"{base_url}/{with_preview.id}/").json()["preview_available"])
+
+    @parameterized.expand(
+        [
+            ("other_port", {"port": 8080}),
+            ("rotated_sandbox", {"sandbox_id": "sandbox-2"}),
+        ]
+    )
+    def test_preview_state_that_does_not_match_the_run_is_not_ready(self, _name, override):
+        task = self.create_task()
+        state = self._ready_state()
+        state["dev_stack_preview"].update(override)
+        run = self._create_run(task, state)
+
+        with patch(self.SANDBOX_CLASS_TARGET) as mock_get_sandbox_class:
+            response = self.client.get(self._preview_url(task, run))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("ready yet", response.content.decode())
+        mock_get_sandbox_class.assert_not_called()
+        self.assertFalse(
+            self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/").json()["preview_available"]
+        )

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1656,6 +1656,8 @@ export interface TaskRunDetailDTOApi {
     updated_at?: string | null
     /** @nullable */
     completed_at?: string | null
+    /** True when this run's sandbox serves a dev stack preview, so clients can offer the preview link. Open it through the run's `preview/` endpoint, which mints a fresh access token on every request. */
+    preview_available?: boolean
 }
 
 export interface SlackThreadReferenceDTOApi {

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -2153,6 +2153,26 @@ export const tasksRunsPeersMessageCreate = async (
     )
 }
 
+export const getTasksRunsPreviewRetrieveUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/preview/`
+}
+
+/**
+ * Redirects to the PostHog dev stack running inside this run's sandbox. A fresh sandbox access token is minted on every request and carried only in the redirect target, so it is never persisted or returned in a response body. When the run has no preview, or its sandbox has stopped, this renders a short HTML page instead.
+ * @summary Open the dev stack preview for a task run
+ */
+export const tasksRunsPreviewRetrieve = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTasksRunsPreviewRetrieveUrl(projectId, taskId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getTasksRunsRelayMessageCreateUrl = (projectId: string, taskId: string, id: string) => {
     return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/relay_message/`
 }

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -614,6 +614,9 @@ tools:
     tasks-runs-peers-retrieve:
         operation: tasks_runs_peers_retrieve
         enabled: false
+    tasks-runs-preview-retrieve:
+        operation: tasks_runs_preview_retrieve
+        enabled: false
     tasks-runs-relay-message-create:
         operation: tasks_runs_relay_message_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -56588,6 +56588,8 @@ export namespace Schemas {
       updated_at?: string | null;
       /** @nullable */
       completed_at?: string | null;
+      /** True when this run's sandbox serves a dev stack preview, so clients can offer the preview link. Open it through the run's `preview/` endpoint, which mints a fresh access token on every request. */
+      preview_available?: boolean;
     }
 
     export interface SlackThreadReferenceDTO {


### PR DESCRIPTION
## Problem

A person who starts a cloud run from PostHog Code on the `posthog/posthog` repo cannot see the app the agent changed. The sandbox already boots from the prebaked `posthog-dev-stack` VM image, which carries a migrated dev stack, but nothing starts it or exposes it.

## Changes

- The run's progress card gets a "Preview ready" step with a link. Clicking it opens the PostHog app running inside the sandbox on the run's branch.
- The link points at a new team-scoped endpoint, `GET /api/projects/{team}/tasks/{task}/runs/{run}/preview/`. It mints a Modal connect token for the sandbox's proxy port on every click and redirects. No token is stored, logged, or returned in JSON.
- A backend activity starts the stack after checkout, beside the agent, behind flag `tasks-dev-stack-preview` and only for user-created runs on the dev-stack image. The stack runs with the run's credentials scrubbed from its environment.
- Preview runs default to 32 GB (startup peaks near 19 GB; VM memory is pinned). A per-task override still wins.
- The endpoint only mints for the fixed preview port on the sandbox the preview was stamped on. `dev_stack_preview` is a protected run state key, so the run PATCH API cannot point the preview at another port, and a rotated sandbox reads as not ready until its own stack is up.
- The launcher reports ready only when both Django and Vite answer, so a dead Vite shows "Preview didn't start" instead of a blank page.
- Clicking the link re-probes Django and Vite inside the sandbox. A stack that died in a live sandbox shows the "isn't reachable right now" page instead of a bare 502.
- Preview startup does not delay the agent's first message: start and wait run in one background task, cancelled at continue-as-new, rotation and teardown. Provider errors during start retry once, and a retry that finds the launcher already running attaches to it.
- The `posthog_tasks_dev_stack_preview_total` metric records `started`, `attached`, `ready`, `failed`, `timed_out`, `cancelled` and `launch_failed`, so started minus terminal outcomes stays meaningful.
- Mechanical: regenerated OpenAPI types, handbook and AGENTS.md notes.

Builds on #89975 (connect credentials, launcher script, constants and metrics). The PR comment that carries the same link follows in #88672.

## How did you test this code?

- Unit tests in `test_start_dev_stack_preview.py` cover the launcher lock attach path, provider errors propagating for retry, upload failures short-circuiting the launch, and the `cancelled` outcome on activity cancellation. `TestTaskRunPreviewAPI` covers the redirect health probe failing in a live sandbox.
- Live cloud run on the `posthog-dev-stack` image with the unsplit branch: `hogli wait` reported 39 processes ready in 1m36s and the preview stamped ready 2m13s after launch. Stopping the proxy container turned the redirect into `unavailable`; starting it again restored the redirect.
- Not checked: continue-as-new and sandbox rotation against the background preview task on a live run.
