### PR TITLE
feat(error-tracking): simplify rule settings

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7913,9 +7913,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-error-tracking--light:
         hash: v1.k794b7964.5ac167271f00184ce6159d0072ce163542658b08419f6e70b5cf6a6ca201a718.X6dKpM6uGw_g_FAwdQ5PukTVcKWGAa77bMOzgw-kiXY
     scenes-app-settings-environment--settings-environment-error-tracking-configuration--dark:
-        hash: v1.k794b7964.033e5499811363c36dee07950ff09f33413e64b81c8522859c85748bc0443e3f.Hz66ItOfiG51KAAT2yidV4lINJmLINi-9_k81Ygdk80
+        hash: v1.k794b7964.3d7a3006130bdc66e1456cb81566e21bb2179f19d17caf91ead7a41ba4be9234.tbIKl_Tlb1T7RBNR3Ic9n51t6kNpTkGsw28sXZHW-Gs
     scenes-app-settings-environment--settings-environment-error-tracking-configuration--light:
-        hash: v1.k794b7964.56f8265ff5de3733a4d00b0dbde7c0fff36ccdc886f713881134159802a13d39.9ArXuAkoxa6dyVQ_uspbjHWKM8YIgCPgCbDUnLHsxso
+        hash: v1.k794b7964.7d62fa47841096cceaa13c9a7cb15c1152b2f929ee030674bc0d97c5bc66c239.GptZ3dbdhoABnDP-dWhaqUCQOTeKYOsMFokkyWuNjwQ
     scenes-app-settings-environment--settings-environment-feature-flags--dark:
         hash: v1.k794b7964.56670f556ffac0360ec521741db9822f4e545e25b45bd8ed4ad012da8885c30a.qj9dLuAFy8v0TwEH-UTymXnlWPe2eu-YjAOpe2zc3Q8
     scenes-app-settings-environment--settings-environment-feature-flags--light:

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -564,13 +564,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['notification', 'alert', 'threshold', 'spike'],
             },
             {
-                id: 'error-tracking-suppression-rules',
-                title: 'Suppression rules',
-                description: 'Filter out exceptions that match the given filters.',
-                component: <SuppressionRules />,
-                keywords: ['filter', 'ignore', 'suppress', 'exception', 'type', 'message'],
-            },
-            {
                 id: 'error-tracking-spike-detection',
                 title: 'Spike detection',
                 component: <SpikeDetectionSettings />,
@@ -584,10 +577,17 @@ export const SETTINGS_MAP: SettingSection[] = [
             },
             {
                 id: 'error-tracking-auto-assignment',
-                title: 'Auto assignment rules',
+                title: 'Assignment rules',
                 description: 'Automatically assign errors to team members based on rules you define.',
                 component: <AssignmentRules />,
-                keywords: ['assign', 'owner', 'team', 'rule', 'routing'],
+                keywords: ['assign', 'auto', 'owner', 'team', 'rule', 'routing'],
+            },
+            {
+                id: 'error-tracking-custom-grouping',
+                title: 'Grouping rules',
+                description: 'Define rules for how errors are grouped together into issues.',
+                component: <GroupingRules />,
+                keywords: ['group', 'custom', 'merge', 'fingerprint', 'dedup'],
             },
             {
                 id: 'error-tracking-severity-rules',
@@ -598,11 +598,11 @@ export const SETTINGS_MAP: SettingSection[] = [
                 keywords: ['severity', 'priority', 'triage', 'critical', 'rule'],
             },
             {
-                id: 'error-tracking-custom-grouping',
-                title: 'Custom grouping rules',
-                description: 'Define rules for how errors are grouped together into issues.',
-                component: <GroupingRules />,
-                keywords: ['group', 'merge', 'fingerprint', 'dedup'],
+                id: 'error-tracking-suppression-rules',
+                title: 'Suppression rules',
+                description: 'Filter out exceptions that match the given filters.',
+                component: <SuppressionRules />,
+                keywords: ['filter', 'ignore', 'suppress', 'exception', 'type', 'message'],
             },
             {
                 id: 'error-tracking-symbol-sets',

--- a/frontend/src/scenes/settings/environment/ErrorTrackingConfigurationMovedBanner.tsx
+++ b/frontend/src/scenes/settings/environment/ErrorTrackingConfigurationMovedBanner.tsx
@@ -7,7 +7,7 @@ export function ErrorTrackingConfigurationMovedBanner(): JSX.Element {
         <LemonBanner type="info">
             <p>
                 <strong>Error tracking configuration has moved.</strong> Configurations for alerting, suppression rules,
-                spike detection, auto assignment, custom grouping, symbol sets, and releases are now on the{' '}
+                spike detection, assignment rules, grouping rules, symbol sets, and releases are now on the{' '}
                 <Link to={urls.errorTrackingConfiguration()}>Error tracking configuration</Link> page.
             </p>
             <p>


### PR DESCRIPTION
## Problem

Error Tracking configuration uses longer rule names and separates suppression rules from the other rule sections.

## Changes

- People now see **Assignment rules** and **Grouping rules** in Error Tracking configuration.
- Assignment, grouping, severity, and suppression rules now appear consecutively.
- Stable setting IDs preserve existing deep links and saved URLs.
- The moved-settings banner now uses the same terms.

| Before | After |
| --- | --- |
| ![Rule settings before](https://raw.githubusercontent.com/PostHog/pr-assets/9270468c91faec149d96cf114bdec6135b904a12/2026/08/606694e1-5d00-44b9-a805-bbdf88b9dc7c.png) | ![Rule settings after](https://raw.githubusercontent.com/PostHog/pr-assets/5074eaad3d646208738bdc98b1cdec649187b98c/2026/08/1faa6657-c91b-4225-8041-7ad36da43cca.png) |

## How did you test this code?

- Rendered the Error Tracking configuration Storybook story and verified all four rule sections appear together.
- Ran `pnpm --filter=@posthog/frontend fix`.
- Ran `hogli ci:preflight --fix`.
- TypeScript checking remains blocked by unrelated generated import and `kea-router` resolution errors.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Companion docs update: https://github.com/PostHog/posthog.com/pull/19764

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi completed the requested UI naming and ordering changes.
- Skills invoked: `/error-tracking`, `/writing-ui-components`, `/writing-user-facing-copy`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.
