### PR TITLE
fix(replay): bill every recording regardless of reported source and sdk

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -940,7 +940,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web'
+     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 0
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
@@ -987,7 +987,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web'
+     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 0
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
@@ -1045,7 +1045,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile'
+     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 1
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
@@ -1069,7 +1069,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile'
+     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 1
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
@@ -1092,11 +1092,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
-             AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios',
-                                                               'posthog-android',
-                                                               'posthog-react-native',
-                                                               'posthog-flutter'))
+     HAVING ifNull(argMinMerge(snapshot_source), '') == 'mobile'
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -1092,7 +1092,7 @@
      WHERE min_first_timestamp >= '2022-01-10 00:00:00'
        AND min_first_timestamp < '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), '') == 'mobile'
+     HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 1
      AND max(is_deleted) = 0)
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1179,19 +1179,32 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
     def test_usage_report_replay(self) -> None:
         _setup_replay_data(self.team.pk, include_mobile_replay=False)
 
+        # `$snapshot_source` reaches ClickHouse unvalidated, so anything that is not mobile has to
+        # land on the web meter. An equality on 'web' here would bill this session under neither.
+        timestamp = now() - relativedelta(hours=12)
+        produce_replay_summary(
+            team_id=self.team.pk,
+            session_id="unrecognized-snapshot-source",
+            distinct_id=str(uuid4()),
+            first_timestamp=timestamp,
+            last_timestamp=timestamp + timedelta(seconds=1),
+            snapshot_source="not-a-real-source",
+            size=10,
+        )
+
         period = get_previous_day()
 
         all_reports = _get_all_usage_data_as_team_rows(period.start, period.end)
         report = _get_team_report(all_reports, self.team)
 
-        assert report.recording_count_in_period == 5
+        assert report.recording_count_in_period == 6
         assert report.mobile_recording_count_in_period == 0
         assert report.zero_duration_recording_count_in_period == 0
 
         org_reports: dict[str, OrgReport] = {}
         _add_team_report_to_org_reports(org_reports, self.team, report, period.start)
 
-        assert org_reports[str(self.organization.id)].recording_count_in_period == 5
+        assert org_reports[str(self.organization.id)].recording_count_in_period == 6
         assert org_reports[str(self.organization.id)].mobile_recording_count_in_period == 0
         assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 0
 
@@ -1228,13 +1241,14 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
         # but we do split them out of the daily usage since that field is used
         assert report.recording_count_in_period == 5
         assert report.mobile_recording_count_in_period == 1
-        assert report.mobile_billable_recording_count_in_period == 0
+        # Reports no library at all, and still bills: the client decides what to send here.
+        assert report.mobile_billable_recording_count_in_period == 1
         org_reports: dict[str, OrgReport] = {}
         _add_team_report_to_org_reports(org_reports, self.team, report, period.start)
 
         assert org_reports[str(self.organization.id)].recording_count_in_period == 5
         assert org_reports[str(self.organization.id)].mobile_recording_count_in_period == 1
-        assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 0
+        assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 1
 
     @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay_with_billable_mobile(self) -> None:
@@ -1276,17 +1290,49 @@ class TestReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyT
         all_reports = _get_all_usage_data_as_team_rows(period.start, period.end)
         report = _get_team_report(all_reports, self.team)
 
-        # Regular mobile recordings (non-billable) + billable ones
         assert report.recording_count_in_period == 5  # web recordings
-        assert report.mobile_recording_count_in_period == 4  # 1 non-billable + 2 billable + 1 from _setup_replay_data
-        assert report.mobile_billable_recording_count_in_period == 2  # iOS and Android recordings
+        assert report.mobile_recording_count_in_period == 4
+        # All four bill, the one naming a library we do not ship included: `$lib` is whatever the
+        # caller sent, so letting it decide leaves a session no meter charges for.
+        assert report.mobile_billable_recording_count_in_period == 4
 
         org_reports: dict[str, OrgReport] = {}
         _add_team_report_to_org_reports(org_reports, self.team, report, period.start)
 
         assert org_reports[str(self.organization.id)].recording_count_in_period == 5
         assert org_reports[str(self.organization.id)].mobile_recording_count_in_period == 4
-        assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 2
+        assert org_reports[str(self.organization.id)].mobile_billable_recording_count_in_period == 4
+
+    @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
+    def test_usage_report_replay_bills_every_recording_exactly_once(self) -> None:
+        # `$snapshot_source` and `$lib` arrive from the client and are never validated, so the two
+        # billed meters have to partition every recording between them. A combination that matched
+        # neither would be a recording anyone could ask for and not be charged for.
+        crafted = [
+            ("plain-web", "web", "web"),
+            ("mobile-shipped-sdk", "mobile", "posthog-ios"),
+            ("mobile-unshipped-sdk", "mobile", "posthog-unity"),
+            ("mobile-invented-sdk", "mobile", "not-a-real-sdk"),
+            ("invented-source", "not-a-real-source", "web"),
+        ]
+        timestamp = now() - relativedelta(hours=12)
+        for session_id, snapshot_source, snapshot_library in crafted:
+            produce_replay_summary(
+                team_id=self.team.pk,
+                session_id=session_id,
+                distinct_id=str(uuid4()),
+                first_timestamp=timestamp,
+                last_timestamp=timestamp + timedelta(seconds=1),
+                snapshot_source=snapshot_source,
+                snapshot_library=snapshot_library,
+                size=10,
+            )
+
+        period = get_previous_day()
+        report = _get_team_report(_get_all_usage_data_as_team_rows(period.start, period.end), self.team)
+
+        billed = report.recording_count_in_period + report.mobile_billable_recording_count_in_period
+        assert billed == len(crafted)
 
     @also_test_with_materialized_columns(event_properties=["$lib", "$exception_values"], verify_no_jsonextract=False)
     def test_usage_report_replay_excludes_deleted_recordings(self) -> None:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1080,7 +1080,7 @@ def get_teams_with_recording_count_in_period(
                 FROM session_replay_events
                 WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
                 GROUP BY session_id
-                HAVING ifNull(argMinMerge(snapshot_source), 'web') == %(snapshot_source)s
+                HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == %(want_mobile)s
                 AND max(is_deleted) = 0
             )
             WHERE session_id NOT IN (
@@ -1100,7 +1100,9 @@ def get_teams_with_recording_count_in_period(
                 "previous_begin": previous_begin,
                 "begin": begin,
                 "end": end,
-                "snapshot_source": snapshot_source,
+                # Web is the catch-all, not an equality on 'web'. `$snapshot_source` is client-supplied
+                # and unvalidated, so the two meters have to partition every session between them.
+                "want_mobile": 1 if snapshot_source == "mobile" else 0,
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
@@ -1183,6 +1185,7 @@ def get_teams_with_zero_duration_recording_count_in_period(begin: datetime, end:
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, end: datetime) -> list[tuple[int, int]]:
+    """Mobile recordings in the period; the client-reported SDK does not affect billing."""
     previous_begin = begin - (end - begin)
 
     with tags_context(product=Product.MOBILE_REPLAY, feature=Feature.USAGE_REPORT):
@@ -1194,8 +1197,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
                 FROM session_replay_events
                 WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
                 GROUP BY session_id
-                HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
-                AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'))
+                HAVING ifNull(argMinMerge(snapshot_source), '') == 'mobile'
                 AND max(is_deleted) = 0
             )
             WHERE session_id NOT IN (
@@ -2335,7 +2337,7 @@ def get_teams_with_recording_bytes_in_period(
                 FROM session_replay_events
                 WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
                 GROUP BY session_id
-                HAVING ifNull(argMinMerge(snapshot_source), 'web') == %(snapshot_source)s
+                HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == %(want_mobile)s
                 AND max(is_deleted) = 0
             )
             WHERE session_id NOT IN (
@@ -2355,7 +2357,9 @@ def get_teams_with_recording_bytes_in_period(
                 "previous_begin": previous_begin,
                 "begin": begin,
                 "end": end,
-                "snapshot_source": snapshot_source,
+                # Web is the catch-all, not an equality on 'web'. `$snapshot_source` is client-supplied
+                # and unvalidated, so the two meters have to partition every session between them.
+                "want_mobile": 1 if snapshot_source == "mobile" else 0,
             },
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1197,7 +1197,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
                 FROM session_replay_events
                 WHERE min_first_timestamp >= %(begin)s AND min_first_timestamp < %(end)s
                 GROUP BY session_id
-                HAVING ifNull(argMinMerge(snapshot_source), '') == 'mobile'
+                HAVING (ifNull(argMinMerge(snapshot_source), 'web') == 'mobile') == 1
                 AND max(is_deleted) = 0
             )
             WHERE session_id NOT IN (


### PR DESCRIPTION
## Problem

Some session replay recordings are ingested, stored and played back, but charged by neither billing meter.

- Billing splits replay into two meters: web counts sessions where `$snapshot_source` equals `web`, mobile counts sessions where it equals `mobile` and `$lib` names one of four SDKs.
- Both properties come from the client. Capture types `$snapshot_source` as arbitrary JSON and defaults `$lib` to `"unknown"`, and neither is checked against a known set anywhere on the path into ClickHouse.
- A session outside those two shapes matches neither meter, so nothing charges for it.
- The population is not empty. Mobile SDKs we ship but did not list, posthog-unity, posthog-kmp and posthog-java, land there today, as do two community SDKs.

## Changes

Every non-deleted session now lands on exactly one meter, whatever the client sends.

| Session | Now | With this PR |
|---|---|---|
| `source=web`, ordinary web `$lib` | web | web |
| `source` and `$lib` both absent | web, via `ifNull` | web |
| `source=web`, mobile-looking `$lib` | web | web |
| `source=mobile`, `$lib` in the four listed SDKs | mobile | mobile |
| **`source=mobile`, `$lib` outside those four** | **neither** | **mobile** |
| `source` set to an unrecognised value | neither | web |

- Teams on mobile SDKs outside the four listed ones start being charged for replay, at mobile rates. Row five is the only one that moves, so nobody else sees a change.
- The web meter counts every session that is not mobile, rather than only sessions that say `web`.
- The mobile meter counts every session that says mobile, whatever `$lib` reports.
- `mobile_recording_count_in_period` is unchanged. It is a reporting number, not a billed one.
- Nothing is charged twice, before or after. The old meters were already disjoint, so the defect only ever undercounted.

> [!NOTE]
> `recording_count_in_period` and `mobile_billable_recording_count_in_period` are the keys assumed to drive charging. That assumption is not verified here, because the billing service lives in another repo. Worth confirming before this merges.

The snapshot file is mechanical, regenerated from the three query edits.

## How did you test this code?

`test_usage_report_replay_bills_every_recording_exactly_once` writes five recordings across the shapes a client can send, then asserts the two meters between them count five. Against master it fails with `assert 2 == 5`: three of the five went uncharged.

Two existing tests changed their expected counts, from 0 to 1 and from 2 to 4. They cover the same fact from the other side, that a mobile recording is charged whatever SDK it names.

Not checked: which keys the billing service consumes, per the note above. Nothing was tested manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by @TueHaulund. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/clickhouse-query`, `/toolbox-access`.

The gap surfaced while reviewing a separate PR that mirrors these predicates into a new usage stream. Read-only queries against both production clusters built the table above: no session reports a source outside `web`, `mobile` and null today, and the sessions falling between the meters do so through the SDK list rather than the source.

An earlier draft made the source the catch-all but kept the SDK list. That still left a session naming an unrecognised SDK uncharged, so the list came out of the billed query instead. A variant that moved those sessions onto the web meter was rejected because mobile is the correct bucket for them.
