### PR TITLE
chore(signals): Instead of providing the specific notebook tool (will be deprecated soon), lets ask the scout to use the one available after a tool-search

### DIFF
--- a/products/signals/skills/authoring-scouts/references/scout-patterns.md
+++ b/products/signals/skills/authoring-scouts/references/scout-patterns.md
@@ -613,8 +613,11 @@ These compose into any pattern above:
   Your body carries the ownership map only; the shared discipline is already in the harness prompt (check the fleet before investigating, search the scratchpad by entity rather than by your own prefix, and author anyway when your angle is materially new — citing the sibling's report id).
   So don't spend body lines re-teaching "check what siblings found" or "don't duplicate": name what's yours and what isn't, and let the prompt handle the rest.
 - **Run-budget discipline** — the sandbox kills a run after a fixed budget, so an expensive scout should name its budget at the top of the body and query economically: one combined SQL returning several metrics beats several queries, cap tool calls and items per run, and prefer a fast shallower pass that completes over a thorough one that times out and posts nothing.
-- **Notebook write-up behind a rich finding.** When a finding carries real analysis (charts, a multi-step investigation, several supporting queries), write it up in a notebook with `notebooks-create` and link the URL from the finding description, rather than cramming everything into the report prose.
+- **Notebook write-up behind a rich finding.** When a finding carries real analysis (charts, a multi-step investigation, several supporting queries), write it up in a notebook and link the URL from the finding description, rather than cramming everything into the report prose.
   The inbox entry stays scannable; the depth is one click away.
+  Tell your scout to use the notebook tools available in its tool list, instead of naming one in the body.
+  A feature flag swaps the notebook surface, so different projects expose different notebook tools, and a body that hardcodes one breaks on the projects that get the other.
+  The two surfaces also want different write-up procedures — `signals-scout-anomaly-detection`'s `references/report-contract.md` carries the recipe for each.
 
 ## Picking and combining
 

--- a/products/signals/skills/authoring-scouts/references/scout-patterns.md
+++ b/products/signals/skills/authoring-scouts/references/scout-patterns.md
@@ -615,7 +615,8 @@ These compose into any pattern above:
 - **Run-budget discipline** — the sandbox kills a run after a fixed budget, so an expensive scout should name its budget at the top of the body and query economically: one combined SQL returning several metrics beats several queries, cap tool calls and items per run, and prefer a fast shallower pass that completes over a thorough one that times out and posts nothing.
 - **Notebook write-up behind a rich finding.** When a finding carries real analysis (charts, a multi-step investigation, several supporting queries), write it up in a notebook and link the URL from the finding description, rather than cramming everything into the report prose.
   The inbox entry stays scannable; the depth is one click away.
-  Tell your scout to use the notebook tools available in its tool list, instead of naming one in the body.
+  Tell your scout to create the notebook from the project's own notebook tools, and to run `search notebooks?-` to load them and read the titles.
+  Name the discovery command in the body, never a tool.
   A feature flag swaps the notebook surface, so different projects expose different notebook tools, and a body that hardcodes one breaks on the projects that get the other.
   The two surfaces also want different write-up procedures — `signals-scout-anomaly-detection`'s `references/report-contract.md` carries the recipe for each.
 


### PR DESCRIPTION
## Problem

Someone writing a new scout copies a pattern that names `notebooks-create`, and their scout then posts a rich finding with no write-up on every project where a feature flag swapped that tool away. The reader gets report prose instead of the charts and the supporting queries.

The flag exposes either `notebooks-create-markdown` plus `notebooks-add-cell`, or `notebooks-create`. A scout sees one surface, never both. The "notebook write-up behind a rich finding" pattern in `scout-patterns.md` named the second one as if it were the only one.

Companion to #90002 and #90012, which fix the same defect in the anomaly scout and the experiments audit.

## Changes

- The pattern now tells an author to write a discovery command into the scout body: run `search notebooks?-`, load the notebook tools, and read the titles.
- The pattern says to name the command and never a tool.
- The pattern says what breaks otherwise. A hardcoded tool name fails on the projects that get the other surface.
- The pattern points at `signals-scout-anomaly-detection`'s report contract for the per-surface write-up recipe.

Nothing changes in the product UI. This PR edits five lines of an agent-facing skill.

> [!NOTE]
> Discovery is a workaround. The real defect is that `products/notebooks/mcp/tools.yaml` gates the notebook tools on `revamped-py-notebooks`, a flag that now resolves to `is_sql_v2_enabled` and gates cell execution instead. Markdown notebooks are already the app's default, and legacy documents convert on render. Fixing that gating would let one tool name replace this discovery step.

## How did you test this code?

- `hogli lint:skills` passes. The four warnings it prints are pre-existing and sit in other files.
- Not checked: a live scout-authoring session. The change is guidance prose, and no test asserts skill wording.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) produced the change. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`.

The defect came out of an audit of which notebook MCP tools the flag retires. #90002 fixes the scout that hits this at runtime. This PR fixes the guide that would keep reproducing it in new scouts.

An earlier revision told the author to point the scout at its tool list. That named no command, so the instruction restated what the scout already had.

The `skip-agent-review` label is applied: the diff is five lines of prose in one reference file. `hogli review` is unavailable on this machine, because Greptile is not signed in.

**Public artifact:** the diff carries only tool names read from this repository. It carries no customer, session, or operational data.
