### PR TITLE
chore(posthog-ai): let the experiments audit discover its notebook tool

### DIFF
--- a/products/posthog_ai/skills/auditing-experiments-flags/SKILL.md
+++ b/products/posthog_ai/skills/auditing-experiments-flags/SKILL.md
@@ -35,7 +35,7 @@ When the user asks for a comprehensive audit of both experiments and flags:
 1. Fetch all experiments via `experiment-list` and all flags via `feature-flag-get-all`.
 2. Run all experiment checks and all flag checks.
 3. Apply [recurring patterns](./references/synthesis-patterns.md) to identify patterns across multiple findings.
-4. If there are more than 5 entities with findings, output as a notebook artifact via `notebooks-create` for easier navigation. Otherwise report inline.
+4. If there are more than 5 entities with findings, write them to a notebook for easier navigation, using available notebook creation tools in the tool list. Otherwise report inline.
 
 ## Output format
 

--- a/products/posthog_ai/skills/auditing-experiments-flags/SKILL.md
+++ b/products/posthog_ai/skills/auditing-experiments-flags/SKILL.md
@@ -35,7 +35,7 @@ When the user asks for a comprehensive audit of both experiments and flags:
 1. Fetch all experiments via `experiment-list` and all flags via `feature-flag-get-all`.
 2. Run all experiment checks and all flag checks.
 3. Apply [recurring patterns](./references/synthesis-patterns.md) to identify patterns across multiple findings.
-4. If there are more than 5 entities with findings, write them to a notebook for easier navigation, using available notebook creation tools in the tool list. Otherwise report inline.
+4. If there are more than 5 entities with findings, write them to a notebook for easier navigation. Otherwise report inline. Create the notebook from the project's own notebook tools. Run `search notebooks?-` to load them and read the titles.
 
 ## Output format
 


### PR DESCRIPTION
## Problem

A person who asks for a comprehensive experiments and flags audit gets a wall of inline findings instead of a navigable notebook, on every project where a feature flag swapped the notebook tools.

The full-audit step named `notebooks-create`, so a flagged agent calls a tool it cannot see and falls back to inline output. That is the case the step exists to avoid. It triggers past 5 entities with findings, which is when inline output stops being readable.

Companion to #90002 and #90011, which fix the same defect in the signals scout and its authoring guide.

## Changes

- The step now tells the agent to run `search notebooks?-`, load the notebook tools, and read the titles.
- The step names no tool. Naming one is what went stale, and naming both replacements would go stale again when either retires.
- The regex is `notebooks?-`, not `notebooks-`, so it also matches `notebook-edit`.

Nothing changes in the product UI. This PR edits one line of an agent-facing skill.

> [!NOTE]
> Discovery is a workaround. The real defect is that `products/notebooks/mcp/tools.yaml` gates the notebook tools on `revamped-py-notebooks`, a flag that now resolves to `is_sql_v2_enabled` and gates cell execution instead. Markdown notebooks are already the app's default, and legacy documents convert on render. Fixing that gating would let one tool name replace this discovery step.

## How did you test this code?

- `hogli lint:skills` and `hogli build:skills` pass. The four warnings sit in other files and predate this branch.
- Not checked: a live audit run against a flagged project. The change is guidance prose, and no test asserts skill wording.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) produced the change. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`.

An earlier revision told the agent to use "available notebook creation tools in the tool list". That restated what the agent already had, and it gave no discriminator, so the agent could land on `accounts-notebooks-create`. The step now names the discovery command.

The sibling PR #90002 still names its tools. The two notebook surfaces there need different call sequences, and that skill carries a recipe for each.

The `skip-agent-review` label is applied: the diff is one line of prose.

**Public artifact:** the diff carries no customer, session, or operational data.
