### PR TITLE
fix(clerk): gate organization invitations so a feature-off 404 skips

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
@@ -49,7 +49,13 @@ CLERK_ENDPOINTS: dict[str, ClerkEndpointConfig] = {
         fan_out=ClerkFanOut(parent="users", parent_field="id", query_param="user_id"),
     ),
     "organization_invitations": ClerkEndpointConfig(
-        name="organization_invitations", path="/organization_invitations", is_wrapped_response=True
+        name="organization_invitations",
+        path="/organization_invitations",
+        is_wrapped_response=True,
+        # Clerk answers 404 resource_not_found for the organization invitations list on instances
+        # that don't have Organizations switched on — the same feature-off signal the domains and
+        # OAuth applications endpoints give. Skip zero rows instead of failing the schema every run.
+        gated_feature="Organizations",
     ),
     "organization_domains": ClerkEndpointConfig(
         name="organization_domains", path="/organization_domains", is_wrapped_response=True

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -524,6 +524,8 @@ class TestClerkFeatureGatedEndpoints:
             ("oauth_applications", 404, {"errors": [{"code": "resource_not_found"}]}),
             # Domains feature off: the list endpoint answers the same 404 resource_not_found.
             ("domains", 404, {"errors": [{"code": "resource_not_found"}]}),
+            # Organizations off: the invitations list answers the same 404 resource_not_found.
+            ("organization_invitations", 404, {"errors": [{"code": "resource_not_found"}]}),
         ],
     )
     def test_feature_not_enabled_syncs_no_rows_instead_of_failing(


### PR DESCRIPTION
## Problem

Warehouse customers syncing Clerk on an instance that doesn't have Organizations turned on saw their **entire Clerk source fail on every scheduled run**. Clerk answers `404 resource_not_found` for the `organization_invitations` list when that feature is off, and because the endpoint wasn't gated, that 404 failed the whole schema instead of just skipping the one table — so every other Clerk table stopped syncing too, and each run burned a failed job.

This is the same feature-off signal the `domains`, `oauth_applications`, and Restrictions endpoints already handle by syncing zero rows for the affected table and moving on.

## Changes

- Clerk sources on instances without Organizations now keep syncing the rest of their tables; `organization_invitations` logs a warning and syncs zero rows instead of failing the schema.
- Mechanical: added `gated_feature="Organizations"` to the `organization_invitations` endpoint config, which routes it through the existing `_skip_when_feature_disabled` path (no new code path).

## How did you test this code?

Extended the existing parameterized `test_feature_not_enabled_syncs_no_rows_instead_of_failing` with an `organization_invitations` / 404 `resource_not_found` case — it guards that this endpoint now skips zero rows instead of raising, the regression the fix targets. Couldn't extend a narrower test because this behavior is already covered as a parameter matrix for the sibling endpoints. The negative case (`test_other_errors_still_fail_the_sync`) already asserts a 404 with an unrelated code still fails, so a genuine missing resource isn't swallowed.

Ran the gated-endpoint suite locally: `TestClerkFeatureGatedEndpoints` passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing API or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a batch of data-warehouse sync failure classes. This class showed a Clerk endpoint 404ing on many scheduled runs across a small set of teams — the shape of a gated feature that isn't gated, not a transient blip. Confirmed by comparing against the four sibling endpoints in the same file that already carry `gated_feature` for the identical `resource_not_found` signal, and traced the 404 handling through `_is_feature_disabled` / `_skip_when_feature_disabled`.

Skills invoked: `/writing-tests` (test gate — extended the existing parameterized case rather than adding a new function).

No customer data is included in this change; the test uses synthetic Clerk API response bodies.
