### PR TITLE
fix(ci): retry pnpm setup for product tests

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -814,6 +814,8 @@ jobs:
             # available on Depot), so setup-python keeps the bot PAT.
             - parallel:
                   - name: Install pnpm dependencies
+                    id: pnpm_install_first_attempt
+                    continue-on-error: true
                     uses: ./.depot/actions/pnpm-install
                     with:
                         install-command: pnpm install --frozen-lockfile --filter=@posthog/root
@@ -827,6 +829,11 @@ jobs:
                     with:
                         toolchain: 1.91.1
                         components: cargo
+            - name: Retry pnpm dependency installation
+              if: steps.pnpm_install_first_attempt.outcome == 'failure'
+              uses: ./.depot/actions/pnpm-install
+              with:
+                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -781,6 +781,8 @@ jobs:
 
             - parallel:
                   - name: Install pnpm dependencies
+                    id: pnpm_install_first_attempt
+                    continue-on-error: true
                     uses: ./.github/actions/pnpm-install
                     with:
                         install-command: pnpm install --frozen-lockfile --filter=@posthog/root
@@ -797,6 +799,13 @@ jobs:
                     with:
                         toolchain: 1.91.1
                         components: cargo
+
+            - name: Retry pnpm dependency installation
+              if: steps.pnpm_install_first_attempt.outcome == 'failure'
+              uses: ./.github/actions/pnpm-install
+              with:
+                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install uv
               id: setup-uv


### PR DESCRIPTION
🤖 Robot-authored pull request.

## Problem

A transient GitHub Actions setup error can fail one product-test shard before its tests start.

The [failed product-test job](https://github.com/PostHog/posthog/actions/runs/33018425931/job/98343574489) completed Node and pnpm setup, then the GitHub Actions runner failed while it merged step state.

## Changes

- Product-test jobs now allow the first pnpm setup attempt to fail.
- A failed first attempt retries once outside the parallel setup block.
- A failed retry still fails the job.
- The Depot shadow workflow has the same behavior.

Depot retries support shell steps only. This explicit second action also retries failures between composite action steps.

## How did you test this code?

- `hogli lint:workflows` passed for all workflow checks.
- Actionlint 1.7.12 passed against the flattened backend workflow.
- `hogli ci:preflight --fix` passed, including the Depot shadow drift check.
- No manual CI run was done.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The workflow files describe the retry behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent investigated the public CI failure and found that the product tests never started. Other product shards and later runs passed with the same code.

Skills invoked: `/investigating-ci-failures`, `/authoring-ci-workflows`, `/reviewing-before-pr`, and `/writing-pr-descriptions`.

`hogli review` could not run because the Greptile CLI is unavailable. The fallback review found no issues, so the PR keeps the normal bot review enabled.

Public artifact check: the code, commit, and description use public repository and CI data only.


