### PR TITLE
fix(desktop): stop pinned models from drifting to a floating sdk alias

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.clear.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.clear.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POSTHOG_METHODS, POSTHOG_NOTIFICATIONS } from "../../acp-extensions";
 import { Pushable } from "../../utils/streams";
 import { getSessionJsonlPath } from "./session/jsonl-hydration";
+import { FALLBACK_MODEL } from "./session/models";
 
 type InitResult = {
   result: "success";
@@ -94,7 +95,11 @@ function makeAgent(): { agent: Agent; client: ClientMocks } {
   return { agent, client };
 }
 
-function installFakeSession(agent: Agent, sessionId: string) {
+function installFakeSession(
+  agent: Agent,
+  sessionId: string,
+  overrides: Partial<{ modelId: string; fallbackModel: string }> = {},
+) {
   const oldQuery = makeQueryHandle();
   const input = new Pushable();
   const endSpy = vi.spyOn(input, "end");
@@ -108,6 +113,7 @@ function installFakeSession(agent: Agent, sessionId: string) {
       cwd: "/tmp/repo",
       permissionMode: "bypassPermissions",
       model: "claude-sonnet-4-6",
+      fallbackModel: overrides.fallbackModel ?? FALLBACK_MODEL,
       mcpServers: {
         posthog: { type: "http", url: "https://posthog" },
         "posthog-code-tools": {
@@ -147,7 +153,7 @@ function installFakeSession(agent: Agent, sessionId: string) {
     notificationHistory: [] as unknown[],
     taskRunId: "run-1",
     lastContextWindowSize: 200_000,
-    modelId: "claude-sonnet-4-6",
+    modelId: overrides.modelId ?? "claude-sonnet-4-6",
     taskState: new Map(),
   };
 
@@ -270,6 +276,31 @@ describe("ClaudeAcpAgent /clear", () => {
       used: 0,
       size: 200_000,
     });
+  });
+
+  it("re-roots /clear on a pinned live model without colliding with its own fallback model", async () => {
+    const { agent } = makeAgent();
+    installFakeSession(agent, "s-model", { modelId: "claude-opus-4-8" });
+
+    await agent.prompt({
+      sessionId: "s-model",
+      prompt: [{ type: "text", text: "/clear" }],
+    });
+
+    expect(lastQueryCall.options?.model).toBe("claude-opus-4-8");
+    expect(lastQueryCall.options?.fallbackModel).toBeUndefined();
+  });
+
+  it("preserves a caller-configured fallback model across /clear", async () => {
+    const { agent } = makeAgent();
+    installFakeSession(agent, "s-model", { fallbackModel: "claude-fable-5" });
+
+    await agent.prompt({
+      sessionId: "s-model",
+      prompt: [{ type: "text", text: "/clear" }],
+    });
+
+    expect(lastQueryCall.options?.fallbackModel).toBe("claude-fable-5");
   });
 
   it("clears when the host prepends hidden context ahead of the /clear, as cloud resumes do", async () => {

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -5,6 +5,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POSTHOG_METHODS } from "../../acp-extensions";
 import { Pushable } from "../../utils/streams";
+import { FALLBACK_MODEL } from "./session/models";
 
 type InitResult = {
   result: "success";
@@ -111,7 +112,7 @@ function findUpdate(
 function installFakeSession(
   agent: Agent,
   sessionId: string,
-  overrides: Partial<{ modelId: string }> = {},
+  overrides: Partial<{ modelId: string; fallbackModel: string }> = {},
 ) {
   const oldQuery = makeQueryHandle();
   const input = new Pushable();
@@ -135,6 +136,7 @@ function installFakeSession(
       sessionId,
       cwd: "/tmp/repo",
       model: "claude-sonnet-4-6",
+      fallbackModel: overrides.fallbackModel ?? FALLBACK_MODEL,
       mcpServers: {
         posthog: { type: "http", url: "https://old" },
         "posthog-code-tools": {
@@ -630,19 +632,22 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
     {
       name: "re-roots the new query on the live session model",
       modelId: "claude-fable-5",
-      expected: "claude-fable-5",
+      expectedModel: "claude-fable-5",
+      expectedFallback: FALLBACK_MODEL,
     },
     {
-      name: "maps the live session model to its SDK alias",
+      name: "drops the fallback model once the live model is the fallback model itself",
       modelId: "claude-opus-4-8",
-      expected: "opus",
+      expectedModel: "claude-opus-4-8",
+      expectedFallback: undefined,
     },
     {
       name: "keeps the creation-time model when the session has no modelId",
       modelId: undefined,
-      expected: "claude-sonnet-4-6",
+      expectedModel: "claude-sonnet-4-6",
+      expectedFallback: FALLBACK_MODEL,
     },
-  ])("$name", async ({ modelId, expected }) => {
+  ])("$name", async ({ modelId, expectedModel, expectedFallback }) => {
     const { agent } = makeAgent();
     installFakeSession(agent, "s-model", { modelId });
 
@@ -650,7 +655,19 @@ describe("ClaudeAcpAgent.extMethod refresh_session", () => {
       mcpServers: freshMcpServers,
     });
 
-    expect(lastQueryCall.options?.model).toBe(expected);
+    expect(lastQueryCall.options?.model).toBe(expectedModel);
+    expect(lastQueryCall.options?.fallbackModel).toBe(expectedFallback);
+  });
+
+  it("preserves a caller-configured fallback model across refresh", async () => {
+    const { agent } = makeAgent();
+    installFakeSession(agent, "s-model", { fallbackModel: "claude-fable-5" });
+
+    await agent.extMethod(POSTHOG_METHODS.REFRESH_SESSION, {
+      mcpServers: freshMcpServers,
+    });
+
+    expect(lastQueryCall.options?.fallbackModel).toBe("claude-fable-5");
   });
 
   it("rebuilds a FRESH in-process local-tools server across refresh", async () => {

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -336,7 +336,7 @@ describe("ClaudeAcpAgent session creation", () => {
       name: "pins the default model explicitly when resuming without meta.model",
       sessionId: "0197a000-0000-7000-8000-000000000002",
       model: undefined,
-      expectedSetModel: "opus",
+      expectedSetModel: "claude-opus-4-8",
       expectedCurrentValue: "claude-opus-4-8",
     },
   ])(
@@ -412,13 +412,9 @@ describe("ClaudeAcpAgent session creation", () => {
     },
   );
 
-  // New sessions pass the model to the SDK at spawn, never via setModel. The
-  // Codex-model row guards the desync that surfaced as "picked gpt-5.5, session
-  // ran Opus": a non-Anthropic id on the Claude adapter must fall back to the
-  // default AND warn rather than silently masquerade as a deliberate Opus run.
   it.each([
     {
-      name: "uses the gateway default and never calls setModel without a requested model",
+      name: "pins the gateway default explicitly at spawn so it never rides the floating SDK alias",
       model: undefined,
       expectsWarn: false,
     },
@@ -437,7 +433,9 @@ describe("ClaudeAcpAgent session creation", () => {
       _meta: { taskRunId: "run-new", ...(model ? { model } : {}) },
     });
 
-    expect(createdQueries[0].setModel).not.toHaveBeenCalled();
+    expect(createdQueries[0].setModel).toHaveBeenCalledWith(
+      DEFAULT_GATEWAY_MODEL,
+    );
     expect(getModelConfigOption(response)?.currentValue).toBe(
       DEFAULT_GATEWAY_MODEL,
     );

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.side-question.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.side-question.test.ts
@@ -5,6 +5,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POSTHOG_METHODS } from "../../acp-extensions";
 import { Pushable } from "../../utils/streams";
+import { FALLBACK_MODEL } from "./session/models";
 
 type SdkMessage =
   | { type: "assistant"; message: { content: unknown[] } }
@@ -53,7 +54,11 @@ function makeAgent(): Agent {
 function installFakeSession(
   agent: Agent,
   sessionId: string,
-  overrides: Partial<{ modelId: string; sdkSessionId: string }> = {},
+  overrides: Partial<{
+    modelId: string;
+    sdkSessionId: string;
+    fallbackModel: string;
+  }> = {},
 ) {
   const abortController = new AbortController();
   const input = new Pushable();
@@ -69,6 +74,7 @@ function installFakeSession(
       sessionId,
       cwd: "/tmp/repo",
       model: "claude-sonnet-4-6",
+      fallbackModel: overrides.fallbackModel ?? FALLBACK_MODEL,
       mcpServers: {
         posthog: { type: "http", url: "https://example" },
       },
@@ -201,7 +207,23 @@ describe("ClaudeAcpAgent.extMethod side_question", () => {
 
     await agent.extMethod(POSTHOG_METHODS.SIDE_QUESTION, { question: "hm?" });
 
-    expect(lastQueryCall.options?.model).toContain("opus");
+    expect(lastQueryCall.options?.model).toBe("claude-opus-4-8");
+    expect(lastQueryCall.options?.fallbackModel).toBeUndefined();
+  });
+
+  it("preserves a caller-configured fallback model for the side question", async () => {
+    const agent = makeAgent();
+    installFakeSession(agent, "s-fallback", {
+      fallbackModel: "claude-fable-5",
+    });
+    nextQueryMessages = [
+      assistantText("yes"),
+      { type: "result", subtype: "success" },
+    ];
+
+    await agent.extMethod(POSTHOG_METHODS.SIDE_QUESTION, { question: "hm?" });
+
+    expect(lastQueryCall.options?.fallbackModel).toBe("claude-fable-5");
   });
 
   it("surfaces an error result subtype as a RequestError", async () => {

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -126,16 +126,15 @@ import {
   CONTEXT_WINDOW_1M_BETA,
   CONTEXT_WINDOW_200K_TOKENS,
   DEFAULT_EFFORT,
-  DEFAULT_MODEL,
   fastModeStateEnabled,
   getContextWindowOptions,
   getEffortOptions,
+  rerootedModelOptions,
   resolveEffortForModel,
   resolveModelPreference,
   supports1MContext,
   supportsFastMode,
   supportsMcpInjection,
-  toSdkModelId,
 } from "./session/models";
 import {
   buildSessionOptions,
@@ -1857,7 +1856,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         abortController: newAbortController,
         // `rest.model` is the creation-time value; the user may have switched
         // models since, so re-root the new Query on the live session model.
-        ...(session.modelId && { model: toSdkModelId(session.modelId) }),
+        ...rerootedModelOptions(session.modelId, rest.fallbackModel),
       };
 
       const newInput = new Pushable<SDKUserMessage>();
@@ -2081,9 +2080,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         abortController,
         // `rest.model` is the creation-time value; the user may have
         // switched models since, so answer on the live session model.
-        ...(this.session.modelId && {
-          model: toSdkModelId(this.session.modelId),
-        }),
+        ...rerootedModelOptions(this.session.modelId, rest.fallbackModel),
       };
 
       const oneShot = query({
@@ -2193,7 +2190,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         abortController: newAbortController,
         // `rest.model` is the creation-time value; the user may have switched
         // models since, so re-root the new Query on the live session model.
-        ...(prev.modelId && { model: toSdkModelId(prev.modelId) }),
+        ...rerootedModelOptions(prev.modelId, rest.fallbackModel),
       };
 
       const newInput = new Pushable<SDKUserMessage>();
@@ -2363,8 +2360,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         },
       });
     } else if (params.configId === "model") {
-      const sdkModelId = toSdkModelId(resolvedValue);
-      await this.session.query.setModel(sdkModelId);
+      await this.session.query.setModel(resolvedValue);
       this.session.modelId = resolvedValue;
       this.session.lastContextWindowSize =
         this.getContextWindowForModel(resolvedValue);
@@ -2924,14 +2920,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         ? CONTEXT_WINDOW_200K_TOKENS
         : this.getContextWindowForModel(resolvedModelId);
 
-    const resolvedSdkModel = toSdkModelId(resolvedModelId);
-
-    // New sessions start with options.model = DEFAULT_MODEL, so only a
-    // non-default pick needs a setModel call. Resumed sessions always need
-    // it: the SDK does not carry the model across resume and would silently
-    // run its default otherwise.
-    if (isResume || resolvedSdkModel !== DEFAULT_MODEL) {
-      await this.session.query.setModel(resolvedSdkModel);
+    if (isResume || resolvedModelId !== options.model) {
+      await this.session.query.setModel(resolvedModelId);
     }
 
     // Keep thinking enabled by default for effort-capable models (see

--- a/products/desktop/packages/agent/src/adapters/claude/session/models.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.test.ts
@@ -2,44 +2,60 @@ import { isDefaultSelectOption, selectOptionDocsUrl } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_EFFORT,
+  FALLBACK_MODEL,
   getContextWindowOptions,
   getEffortOptions,
+  rerootedModelOptions,
   resolveEffortForModel,
+  resolveFallbackModel,
   resolveModelPreference,
   supports1MContext,
   supportsEffort,
   supportsMcpInjection,
   supportsXhighEffort,
-  toSdkModelId,
 } from "./models";
 
-describe("toSdkModelId", () => {
-  it("maps known gateway IDs to SDK aliases", () => {
-    expect(toSdkModelId("claude-opus-4-7")).toBe("opus");
-    expect(toSdkModelId("claude-opus-4-8")).toBe("opus");
-    expect(toSdkModelId("claude-sonnet-4-6")).toBe("sonnet");
+describe("resolveFallbackModel", () => {
+  it("recommends the fallback model when it differs from the live model", () => {
+    expect(resolveFallbackModel("claude-sonnet-5")).toBe(FALLBACK_MODEL);
   });
 
-  it("passes unknown IDs through unchanged", () => {
-    expect(toSdkModelId("custom-model")).toBe("custom-model");
+  it("omits the fallback when the live model already is the fallback model", () => {
+    expect(resolveFallbackModel(FALLBACK_MODEL)).toBeUndefined();
+  });
+});
+
+describe("rerootedModelOptions", () => {
+  it("returns no override when there is no live modelId", () => {
+    expect(rerootedModelOptions(undefined)).toEqual({});
   });
 
-  it("passes claude-fable-5 through unchanged (no SDK alias)", () => {
-    expect(toSdkModelId("claude-fable-5")).toBe("claude-fable-5");
+  it("re-roots on the pinned gateway model id, unaliased", () => {
+    expect(rerootedModelOptions("claude-sonnet-5")).toEqual({
+      model: "claude-sonnet-5",
+      fallbackModel: FALLBACK_MODEL,
+    });
   });
 
-  it("passes claude-sonnet-5 through unchanged (no SDK alias)", () => {
-    expect(toSdkModelId("claude-sonnet-5")).toBe("claude-sonnet-5");
+  it("omits the fallback model when the live model is the fallback model itself", () => {
+    expect(rerootedModelOptions(FALLBACK_MODEL)).toEqual({
+      model: FALLBACK_MODEL,
+      fallbackModel: undefined,
+    });
   });
 
-  it("passes claude-opus-5 through unchanged (no SDK alias)", () => {
-    expect(toSdkModelId("claude-opus-5")).toBe("claude-opus-5");
+  it("preserves a caller-configured fallback model instead of the computed default", () => {
+    expect(rerootedModelOptions("claude-sonnet-5", "claude-fable-5")).toEqual({
+      model: "claude-sonnet-5",
+      fallbackModel: "claude-fable-5",
+    });
   });
 
-  it("passes deprecated gateway IDs through unchanged", () => {
-    expect(toSdkModelId("claude-opus-4-6")).toBe("claude-opus-4-6");
-    expect(toSdkModelId("claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
-    expect(toSdkModelId("claude-haiku-4-5")).toBe("claude-haiku-4-5");
+  it("falls back to the computed default when the caller's fallback now equals the live model", () => {
+    expect(rerootedModelOptions("claude-sonnet-5", "claude-sonnet-5")).toEqual({
+      model: "claude-sonnet-5",
+      fallbackModel: FALLBACK_MODEL,
+    });
   });
 });
 

--- a/products/desktop/packages/agent/src/adapters/claude/session/models.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.ts
@@ -19,14 +19,22 @@ export const FALLBACK_MODEL = "claude-opus-4-8";
 // shape, so effort-capable models default to high to keep thinking enabled.
 export const DEFAULT_EFFORT: EffortLevel = "high";
 
-const GATEWAY_TO_SDK_MODEL: Record<string, string> = {
-  "claude-opus-4-7": "opus",
-  "claude-opus-4-8": "opus",
-  "claude-sonnet-4-6": "sonnet",
-};
+export function resolveFallbackModel(modelId: string): string | undefined {
+  return modelId === FALLBACK_MODEL ? undefined : FALLBACK_MODEL;
+}
 
-export function toSdkModelId(modelId: string): string {
-  return GATEWAY_TO_SDK_MODEL[modelId] ?? modelId;
+export function rerootedModelOptions(
+  modelId: string | undefined,
+  existingFallbackModel?: string,
+):
+  | { model: string; fallbackModel: string | undefined }
+  | Record<string, never> {
+  if (!modelId) return {};
+  const fallbackModel =
+    existingFallbackModel && existingFallbackModel !== modelId
+      ? existingFallbackModel
+      : resolveFallbackModel(modelId);
+  return { model: modelId, fallbackModel };
 }
 
 const MODELS_WITH_1M_CONTEXT = new Set([

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -44,7 +44,7 @@ import { type CodeExecutionMode, toSdkPermissionMode } from "../tools";
 import type { EffortLevel } from "../types";
 import { buildAppendedInstructions } from "./instructions";
 import { loadUserClaudeJsonMcpServers } from "./mcp-config";
-import { DEFAULT_MODEL, FALLBACK_MODEL } from "./models";
+import { DEFAULT_MODEL, resolveFallbackModel } from "./models";
 import { createRtkRewriteHook, resolveRtkPrefix } from "./rtk";
 import type { SettingsManager } from "./settings";
 
@@ -599,8 +599,10 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     options.model = DEFAULT_MODEL;
   }
 
-  if (!options.fallbackModel && options.model !== FALLBACK_MODEL) {
-    options.fallbackModel = FALLBACK_MODEL;
+  if (!options.fallbackModel) {
+    options.fallbackModel = resolveFallbackModel(
+      options.model ?? DEFAULT_MODEL,
+    );
   }
 
   if (params.additionalDirectories) {


### PR DESCRIPTION
## Problem

A live session pinned to a specific model (e.g. Opus 4.8) silently ran a different model version after `/clear`, an MCP session refresh, a cloud sandbox retry, or even on a brand-new session start.

The picked model id was collapsed to a floating SDK alias (`opus`) before reaching the agent SDK, so the actual version served depended on whatever that alias currently resolved to, not the version the person picked.

## Changes

- `toSdkModelId` no longer maps `claude-opus-4-7`, `claude-opus-4-8`, and `claude-sonnet-4-6` to the bare `opus`/`sonnet` aliases. A pinned model now reaches the SDK exactly as selected, the same way newer models already did.
- Removed the now-empty `GATEWAY_TO_SDK_MODEL` lookup and the `toSdkModelId` wrapper; call sites use the model id directly.
- Added `rerootedModelOptions`/`resolveFallbackModel` so the SDK's `fallbackModel` option never equals the live `model` option at spawn, which the SDK rejects. Used at the three places that re-root a live session onto a fresh SDK query: `/clear`, `refresh_session`, and side questions.
- A new session now always pins its resolved model explicitly via `setModel` right after spawn, comparing against the actual spawn value instead of a derived default. Previously a session on the default model kept running on the floating alias from spawn, since the spawn value and the derived default were (wrongly) treated as equivalent.
- `options.ts`'s own fallback-model guard now reuses `resolveFallbackModel` instead of duplicating the same check.

