### PR TITLE
fix(devbox): name the wrong tailnet as its own failure cause

### DIFF
--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -9,26 +9,38 @@ A devbox is a Coder workspace running the full PostHog stack on an EC2 instance,
 
 ## Prerequisite: tailnet access (the thing people miss)
 
-The devbox control plane lives inside a private VPC reachable only over Tailscale. The ACL that grants the route is [`tailnet-policy.hujson`](https://github.com/PostHog/posthog-cloud-infra/blob/main/tailnet-policy.hujson) in `posthog-cloud-infra`: your email must be in **`group:engineering`**. Without that grant, the Coder control plane (`10.70.0.1:443`) is simply unroutable and _every_ `hogli devbox:*` command dies at the reachability check — not an auth or install problem, and no amount of re-running `devbox:setup` fixes it.
+The devbox control plane lives inside a private VPC reachable only over Tailscale. Two things have to be true, and they fail in ways that look identical at the reachability check — _every_ `hogli devbox:*` command dies there, and it is neither an auth nor an install problem, so no amount of re-running `devbox:setup` fixes it:
 
-If `hogli devbox:doctor` reports the control plane unreachable, the fix is a PR adding the user to `group:engineering` in `tailnet-policy.hujson` (then ask Team DevEx if still blocked). Diagnose this before touching anything else.
+1. **You are signed into the `posthog.com` tailnet.** PostHog has several tailnets — `dev`, `prod-us`, `prod-eu` and `internal` exist for CI runners and subnet routers, and none of them route you to devboxes. Humans want `posthog.com` and nothing else.
+2. **Your email is in `group:engineering`** in [`tailnet-policy.hujson`](https://github.com/PostHog/posthog-cloud-infra/blob/main/tailnet-policy.hujson) (`posthog-cloud-infra`), the ACL that grants the route to the Coder control plane (`10.70.0.1:443`).
 
-### Control plane unreachable with a DNS cause? Check the exit node first
-
-When doctor shows `[ok] Tailscale connected` but fails reachability with a **DNS** cause (`DNS lookup for coder.dev.posthog.dev failed`), that's usually not the grant: the client's split-DNS routes don't cover `dev.posthog.dev`, so the name never reaches the internal resolver.
-The fix is selecting a Tailscale **exit node** — it routes DNS through infra that resolves `*.dev.posthog.dev`.
-Check available exit nodes and select one via the Tailscale menu bar app (Exit Node) or CLI:
+Check the tailnet first — it's cheap, and it's the more common of the two:
 
 ```bash
-tailscale exit-node list                            # list available exit nodes
-tailscale set --exit-node=<name>                    # enable one (use the Name from the list)
+tailscale switch --list                 # the active tailnet is marked; you want posthog.com
+tailscale switch posthog.com            # if you've signed into it before
+tailscale logout && tailscale login     # otherwise — pick posthog.com at the tailnet picker
 # on macOS when `tailscale` isn't on PATH:
-/Applications/Tailscale.app/Contents/MacOS/Tailscale exit-node list
-/Applications/Tailscale.app/Contents/MacOS/Tailscale set --exit-node=<name>
+/Applications/Tailscale.app/Contents/MacOS/Tailscale switch --list
 ```
 
-Do not suggest `/etc/hosts` or `/etc/resolver` workarounds — they hardcode internal ELB IPs that rotate, and the exit node is the supported path.
+Being on the wrong tailnet is sticky and invisible: the picker only appears at first sign-in, so someone who clicked past it a year ago has been on `dev` ever since and was never asked again. In the GUI it's **Add account** → sign in as usual → select `posthog.com`. Suspect this whenever a dev says "it used to work on my other laptop" or is on a new machine.
+
+If the tailnet is right and `hogli devbox:doctor` still reports the control plane unreachable, the fix is a PR adding the user to `group:engineering` in `tailnet-policy.hujson` (then ask Team DevEx if still blocked). Diagnose both of these before touching anything else.
+
+### Control plane unreachable with a DNS cause?
+
+When doctor shows `[ok] Tailscale connected` but fails reachability with a **DNS** cause (`DNS lookup for coder.dev.posthog.dev failed`), the name is never reaching the internal resolver. In order:
+
+1. **Wrong tailnet** (above). The other tailnets have no route to `dev.posthog.dev`, and this is what it looks like. Rule it out first.
+2. **MagicDNS off.** "Use Tailscale DNS" in the client's DNS settings is what points the machine at the internal resolver; without it nothing internal resolves.
+3. **Stale resolver upstream.** MagicDNS on and names still failing, but `tailscale ping <internal-ip>` pongs and the service loads over its raw IP? That's the machine's router/ISP resolver. Adding `8.8.8.8` or `1.1.1.1` to the host's DNS settings has fixed this for several people.
+
 To confirm it's resolution rather than the grant: `dig coder.dev.posthog.dev @10.90.0.2` answering while the system resolver fails proves the name exists and only the resolution path is missing.
+
+**Do not reach for an exit node.** Devboxes are reached as tailnet peers, so an exit node is not required for devbox access — it just routes all of the dev's traffic through infra, which is noticeably slower, and it masks whichever of the three causes above is the real one. Don't suggest `/etc/hosts` or `/etc/resolver` workarounds either: they hardcode internal ELB IPs that rotate.
+
+Full write-up, kept current by Team Cloud Foundations: [wiki.posthog.com/access/vpn](https://wiki.posthog.com/access/vpn#which-tailnet).
 
 ## Workflow
 
@@ -38,7 +50,7 @@ To confirm it's resolution rather than the grant: `dig coder.dev.posthog.dev @10
 hogli devbox:doctor          # read-only: tailnet access, reachability, auth, ssh config, saved setup
 ```
 
-A safe probe — it never prompts or mutates host config (unlike `devbox:setup`). If it flags the control plane unreachable, resolve the tailnet grant before anything else. For more detail: `hogli devbox:list` (your boxes), `hogli devbox:status` (state, template freshness), `hogli devbox:secret:list` (secret names only).
+A safe probe — it never prompts or mutates host config (unlike `devbox:setup`). It names the active tailnet on its own line (`Tailnet is posthog.com (found: …)`) and reports `Cause: wrong_tailnet` when that's the problem — trust that over any other symptom. If it flags the control plane unreachable, resolve the tailnet (and then the ACL grant) before anything else. For more detail: `hogli devbox:list` (your boxes), `hogli devbox:status` (state, template freshness), `hogli devbox:secret:list` (secret names only).
 
 ### 2. One-time local setup — `hogli devbox:setup`
 

--- a/.agents/skills/setting-up-devbox/SKILL.md
+++ b/.agents/skills/setting-up-devbox/SKILL.md
@@ -50,7 +50,7 @@ Full write-up, kept current by Team Cloud Foundations: [wiki.posthog.com/access/
 hogli devbox:doctor          # read-only: tailnet access, reachability, auth, ssh config, saved setup
 ```
 
-A safe probe — it never prompts or mutates host config (unlike `devbox:setup`). It names the active tailnet on its own line (`Tailnet is posthog.com (found: …)`) and reports `Cause: wrong_tailnet` when that's the problem — trust that over any other symptom. If it flags the control plane unreachable, resolve the tailnet (and then the ACL grant) before anything else. For more detail: `hogli devbox:list` (your boxes), `hogli devbox:status` (state, template freshness), `hogli devbox:secret:list` (secret names only).
+A safe probe — it never prompts or mutates host config (unlike `devbox:setup`). It names the active tailnet on its own line (`Tailnet: … (need posthog.com)`) and, when that's the problem, says so outright (`Cause: Signed into the 'dev' tailnet, not 'posthog.com'.`) — trust that over any other symptom. If it flags the control plane unreachable, resolve the tailnet (and then the ACL grant) before anything else. For more detail: `hogli devbox:list` (your boxes), `hogli devbox:status` (state, template freshness), `hogli devbox:secret:list` (secret names only).
 
 ### 2. One-time local setup — `hogli devbox:setup`
 

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -29,6 +29,7 @@ from .coder import (
     DEFAULT_REGION,
     DEFAULT_TEMPLATE,
     DOTFILES_URI_PARAMETER,
+    EXPECTED_TAILNET,
     GIT_EMAIL_PARAMETER,
     GIT_NAME_PARAMETER,
     GIT_SIGNING_KEY_SECRET,
@@ -43,6 +44,7 @@ from .coder import (
     coder_ssh_alias_configured,
     create_task,
     create_workspace,
+    current_tailnet_name,
     delete_user_secret,
     delete_workspace,
     ensure_coder_authenticated,
@@ -113,7 +115,9 @@ _POSTHOG_COMMIT_SIGNING_HANDBOOK_URL = "https://posthog.com/handbook/engineering
 # fails at the reachability check.
 _TAILNET_POLICY_URL = "https://github.com/PostHog/posthog-cloud-infra/blob/main/tailnet-policy.hujson"
 _TAILNET_ACCESS_PREREQ = (
-    "Devbox access needs your email in `group:engineering` in "
+    f"Devbox access needs you on the `{EXPECTED_TAILNET}` tailnet (not dev / "
+    "prod-us / prod-eu / internal — those are for CI runners and subnet "
+    "routers), with your email in `group:engineering` in "
     "posthog-cloud-infra/tailnet-policy.hujson.\n"
     f"    Not granted yet? Add yourself via PR: {_TAILNET_POLICY_URL}"
 )
@@ -735,6 +739,12 @@ def devbox_doctor() -> None:
     click.echo()
 
     _doctor_check("Tailscale connected", tailscale_connected())
+
+    # Being on a per-environment tailnet looks identical to "connected" but
+    # routes nowhere near a devbox, and nothing prompts you about it after the
+    # first sign-in — so name the active tailnet on its own line.
+    tailnet = current_tailnet_name()
+    _doctor_check(f"Tailnet is {EXPECTED_TAILNET} (found: {tailnet or 'unknown'})", tailnet == EXPECTED_TAILNET)
 
     reachable = coder_reachable()
     _doctor_check("Coder control plane reachable", reachable)

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -44,7 +44,6 @@ from .coder import (
     coder_ssh_alias_configured,
     create_task,
     create_workspace,
-    current_tailnet_name,
     delete_user_secret,
     delete_workspace,
     ensure_coder_authenticated,
@@ -88,7 +87,7 @@ from .coder import (
     ssh_replace,
     start_workspace,
     stop_workspace,
-    tailscale_connected,
+    tailscale_state,
     unshare_workspace,
     update_workspace,
     update_workspace_parameters,
@@ -738,13 +737,13 @@ def devbox_doctor() -> None:
     click.echo(f"  Coder URL: {get_coder_url()}")
     click.echo()
 
-    _doctor_check("Tailscale connected", tailscale_connected())
+    connected, tailnet = tailscale_state()
+    _doctor_check("Tailscale connected", connected)
 
     # Being on a per-environment tailnet looks identical to "connected" but
     # routes nowhere near a devbox, and nothing prompts you about it after the
     # first sign-in — so name the active tailnet on its own line.
-    tailnet = current_tailnet_name()
-    _doctor_check(f"Tailnet is {EXPECTED_TAILNET} (found: {tailnet or 'unknown'})", tailnet == EXPECTED_TAILNET)
+    _doctor_check(f"Tailnet: {tailnet or 'unknown'} (need {EXPECTED_TAILNET})", tailnet == EXPECTED_TAILNET)
 
     reachable = coder_reachable()
     _doctor_check("Coder control plane reachable", reachable)

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -366,9 +366,8 @@ def _tailscale_status() -> dict[str, Any] | None:
         return None
 
 
-def tailscale_connected() -> bool:
-    """Check if Tailscale is running and connected."""
-    status = _tailscale_status()
+def _backend_running(status: dict[str, Any] | None) -> bool:
+    """Return whether a `tailscale status --json` blob reports a live backend."""
     return bool(status and status.get("BackendState") == "Running")
 
 
@@ -381,24 +380,20 @@ def _tailnet_name(status: dict[str, Any] | None) -> str | None:
     return name if isinstance(name, str) and name else None
 
 
-def current_tailnet_name() -> str | None:
-    """Return the tailnet the host is signed into, or ``None`` if unknown."""
-    return _tailnet_name(_tailscale_status())
+def tailscale_connected() -> bool:
+    """Check if Tailscale is running and connected."""
+    return _backend_running(_tailscale_status())
 
 
-def tailnet_switch_hint() -> str:
-    """Return the command for moving to the PostHog tailnet.
+def tailscale_state() -> tuple[bool, str | None]:
+    """Return ``(connected, tailnet name)`` from a single `tailscale status` probe.
 
-    On macOS the GUI is how most people signed in, and `tailscale` is often
-    not on PATH at all -- so lead with the app-bundle path there.
+    Bundled because each `_tailscale_status()` call is a subprocess, and the
+    two facts are always reported next to each other. The name is ``None``
+    when Tailscale is down or the blob does not name a tailnet.
     """
-    cli = _MACOS_TAILSCALE_CLI if sys.platform == "darwin" and shutil.which("tailscale") is None else "tailscale"
-    return (
-        f"`{cli} switch {EXPECTED_TAILNET}` if you have signed into it before, "
-        f"otherwise `{cli} logout && {cli} login` and pick {EXPECTED_TAILNET} "
-        "at the tailnet picker (in the GUI: Add account, sign in, select "
-        f"{EXPECTED_TAILNET})."
-    )
+    status = _tailscale_status()
+    return _backend_running(status), _tailnet_name(status)
 
 
 def _tailscale_install_hint() -> str:
@@ -426,6 +421,21 @@ def _tailscale_connect_hint() -> str:
 def _tailscale_cli_missing_on_macos() -> bool:
     """Return whether macOS has the Tailscale app but no CLI on PATH."""
     return sys.platform == "darwin" and shutil.which("tailscale") is None and os.path.isfile(_MACOS_TAILSCALE_CLI)
+
+
+def _tailnet_switch_hint() -> str:
+    """Return the command for moving to the PostHog tailnet.
+
+    On macOS the GUI is how most people signed in, and `tailscale` is often
+    not on PATH at all -- so name the app-bundle CLI there instead.
+    """
+    cli = _MACOS_TAILSCALE_CLI if _tailscale_cli_missing_on_macos() else "tailscale"
+    return (
+        f"`{cli} switch {EXPECTED_TAILNET}` if you have signed into it before, "
+        f"otherwise `{cli} logout && {cli} login` and pick {EXPECTED_TAILNET} "
+        "at the tailnet picker (in the GUI: Add account, sign in, select "
+        f"{EXPECTED_TAILNET})."
+    )
 
 
 def ensure_tailscale_connected(setup_hint: str = RUNTIME_SETUP_HINT) -> None:
@@ -597,7 +607,7 @@ def _diagnose_unreachable_coder() -> CoderReachabilityDiagnosis:
             cause=f"Signed into the '{tailnet_name}' tailnet, not '{EXPECTED_TAILNET}'.",
             next_step=(
                 f"Devboxes only exist on '{EXPECTED_TAILNET}' — the other tailnets are for CI "
-                f"runners and subnet routers. Switch: {tailnet_switch_hint()} "
+                f"runners and subnet routers. Switch: {_tailnet_switch_hint()} "
                 f"Details: {_TAILSCALE_RUNBOOK_URL}"
             ),
             facts=facts,

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -31,7 +31,13 @@ from hogli import telemetry
 from hogli.manifest import load_manifest
 
 _MACOS_TAILSCALE_CLI = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
-_TAILSCALE_RUNBOOK_URL = "https://runbooks.posthog.com/vpn/#tailscale"
+_TAILSCALE_RUNBOOK_URL = "https://wiki.posthog.com/access/vpn#which-tailnet"
+# The only tailnet that routes to devboxes. PostHog also runs per-environment
+# tailnets (dev, prod-us, prod-eu, internal) for CI runners and subnet routers;
+# none of them reach the Coder control plane. Tailscale only asks which tailnet
+# to join at first sign-in, so someone who picked wrong there stays wrong
+# silently and forever -- worth naming as its own diagnosis.
+EXPECTED_TAILNET = "posthog.com"
 DEFAULT_TEMPLATE = "posthog-linux"
 # Newer coder versions added an interactive "Select a preset" prompt to `coder
 # create` that `--yes` does not bypass. Callers must always forward `--preset`
@@ -366,6 +372,35 @@ def tailscale_connected() -> bool:
     return bool(status and status.get("BackendState") == "Running")
 
 
+def _tailnet_name(status: dict[str, Any] | None) -> str | None:
+    """Return the active tailnet's name from a `tailscale status --json` blob."""
+    current_tailnet = (status or {}).get("CurrentTailnet")
+    if not isinstance(current_tailnet, dict):
+        return None
+    name = current_tailnet.get("Name")
+    return name if isinstance(name, str) and name else None
+
+
+def current_tailnet_name() -> str | None:
+    """Return the tailnet the host is signed into, or ``None`` if unknown."""
+    return _tailnet_name(_tailscale_status())
+
+
+def tailnet_switch_hint() -> str:
+    """Return the command for moving to the PostHog tailnet.
+
+    On macOS the GUI is how most people signed in, and `tailscale` is often
+    not on PATH at all -- so lead with the app-bundle path there.
+    """
+    cli = _MACOS_TAILSCALE_CLI if sys.platform == "darwin" and shutil.which("tailscale") is None else "tailscale"
+    return (
+        f"`{cli} switch {EXPECTED_TAILNET}` if you have signed into it before, "
+        f"otherwise `{cli} logout && {cli} login` and pick {EXPECTED_TAILNET} "
+        "at the tailnet picker (in the GUI: Add account, sign in, select "
+        f"{EXPECTED_TAILNET})."
+    )
+
+
 def _tailscale_install_hint() -> str:
     """Return the platform-specific install command for Tailscale.
 
@@ -548,16 +583,25 @@ def _diagnose_unreachable_coder() -> CoderReachabilityDiagnosis:
     status = _tailscale_status()
     tailnet_name: str | None = None
     if status:
-        current_tailnet = status.get("CurrentTailnet")
-        if isinstance(current_tailnet, dict):
-            name = current_tailnet.get("Name")
-            if isinstance(name, str) and name:
-                tailnet_name = name
-                facts.append(f"Tailscale tailnet: {name}")
-        if tailnet_name is None:
-            facts.append("Tailscale tailnet: <unknown>")
+        tailnet_name = _tailnet_name(status)
+        facts.append(f"Tailscale tailnet: {tailnet_name or '<unknown>'}")
     else:
         facts.append("Tailscale status: unavailable")
+
+    # Checked before DNS and TCP because every downstream probe fails the same
+    # way from the wrong tailnet, and their fixes (MagicDNS, the ACL grant)
+    # would all be red herrings.
+    if tailnet_name is not None and tailnet_name != EXPECTED_TAILNET:
+        return CoderReachabilityDiagnosis(
+            code="wrong_tailnet",
+            cause=f"Signed into the '{tailnet_name}' tailnet, not '{EXPECTED_TAILNET}'.",
+            next_step=(
+                f"Devboxes only exist on '{EXPECTED_TAILNET}' — the other tailnets are for CI "
+                f"runners and subnet routers. Switch: {tailnet_switch_hint()} "
+                f"Details: {_TAILSCALE_RUNBOOK_URL}"
+            ),
+            facts=facts,
+        )
 
     resolved_ip = _resolve_host_ip(host)
     if resolved_ip is None:
@@ -566,9 +610,12 @@ def _diagnose_unreachable_coder() -> CoderReachabilityDiagnosis:
             code="dns_lookup_failed",
             cause=f"DNS lookup for {host} failed.",
             next_step=(
-                "MagicDNS may be off or you may be on the wrong tailnet. "
-                "Verify the tailnet name above is PostHog's, then run "
-                "`sudo tailscale up --accept-dns`."
+                "MagicDNS is probably off — turn on 'Use Tailscale DNS' in the "
+                "client, or run `sudo tailscale up --accept-dns`. If it is "
+                "already on, a stale router/ISP resolver is the usual culprit: "
+                "add 8.8.8.8 or 1.1.1.1 to this machine's DNS settings. Do not "
+                "reach for an exit node — devboxes are reached as tailnet peers, "
+                "so it only slows everything down and hides the real cause."
             ),
             facts=facts,
         )
@@ -617,10 +664,10 @@ def _diagnose_blocked_route(
             code="no_subnet_routes_advertised",
             cause="No peer on your tailnet advertises subnet routes.",
             next_step=(
-                "Either you are not on the PostHog tailnet (check the name "
-                "above), or your account has not been added to the Tailscale "
-                f"policy yet. See {_TAILSCALE_RUNBOOK_URL} for the policy "
-                "request flow, then reach out to Team DevEx with the facts below."
+                f"Either you are not on the '{EXPECTED_TAILNET}' tailnet (check "
+                "the name above), or your account has not been added to the "
+                f"Tailscale policy yet. See {_TAILSCALE_RUNBOOK_URL} for both, "
+                "then reach out to Team DevEx with the facts below."
             ),
             facts=facts,
         )

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -604,6 +604,41 @@ class TestDiagnoseUnreachableCoder:
     def _stub_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(coder, "get_coder_url", lambda: "https://coder.example.com")
 
+    def test_wrong_tailnet_dominates_every_other_cause(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A per-env tailnet fails DNS/TCP too, so its fixes would be red herrings."""
+        monkeypatch.setattr(coder, "_tailscale_status", lambda: {"CurrentTailnet": {"Name": "dev"}})
+
+        def must_not_run(*args: object, **kwargs: object) -> object:
+            raise AssertionError("probes should be skipped when the tailnet is wrong")
+
+        monkeypatch.setattr(coder, "_resolve_host_ip", must_not_run)
+        monkeypatch.setattr(coder, "_tcp_reachable", must_not_run)
+
+        diagnosis = coder._diagnose_unreachable_coder()
+        assert diagnosis.code == "wrong_tailnet"
+        assert "'dev'" in diagnosis.cause
+        assert coder.EXPECTED_TAILNET in diagnosis.next_step
+        assert "switch" in diagnosis.next_step
+        assert "Tailscale tailnet: dev" in diagnosis.facts
+
+    def test_unknown_tailnet_name_does_not_claim_wrong_tailnet(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Only accuse the tailnet when we actually read a name — else keep probing."""
+        monkeypatch.setattr(coder, "_tailscale_status", lambda: {"BackendState": "Running"})
+        monkeypatch.setattr(coder, "_resolve_host_ip", lambda host: None)
+
+        diagnosis = coder._diagnose_unreachable_coder()
+        assert diagnosis.code == "dns_lookup_failed"
+        assert "Tailscale tailnet: <unknown>" in diagnosis.facts
+
+    def test_dns_failure_next_step_steers_off_exit_nodes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exit nodes route all traffic through infra and mask the real DNS cause."""
+        monkeypatch.setattr(coder, "_tailscale_status", lambda: {"CurrentTailnet": {"Name": "posthog.com"}})
+        monkeypatch.setattr(coder, "_resolve_host_ip", lambda host: None)
+
+        diagnosis = coder._diagnose_unreachable_coder()
+        assert "exit node" in diagnosis.next_step.lower()
+        assert "1.1.1.1" in diagnosis.next_step
+
     def test_dns_failure_dominates_other_causes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(coder, "_tailscale_status", lambda: {"CurrentTailnet": {"Name": "posthog.com"}})
         monkeypatch.setattr(coder, "_resolve_host_ip", lambda host: None)
@@ -629,11 +664,12 @@ class TestDiagnoseUnreachableCoder:
         assert "HTTPS probe" in diagnosis.cause
         assert "clock" in diagnosis.next_step.lower()
 
-    def test_no_subnet_routers_points_to_wrong_tailnet(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_subnet_routers_points_at_tailnet_or_grant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On the right tailnet with no routes, the missing ACL grant is the suspect."""
         monkeypatch.setattr(
             coder,
             "_tailscale_status",
-            lambda: {"CurrentTailnet": {"Name": "personal.tailnet"}, "Peer": {"k": {"PrimaryRoutes": None}}},
+            lambda: {"CurrentTailnet": {"Name": "posthog.com"}, "Peer": {"k": {"PrimaryRoutes": None}}},
         )
         monkeypatch.setattr(coder, "_resolve_host_ip", lambda host: "10.0.0.1")
         monkeypatch.setattr(coder, "_tcp_reachable", lambda host, port, timeout=3.0: False)

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -630,15 +630,6 @@ class TestDiagnoseUnreachableCoder:
         assert diagnosis.code == "dns_lookup_failed"
         assert "Tailscale tailnet: <unknown>" in diagnosis.facts
 
-    def test_dns_failure_next_step_steers_off_exit_nodes(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Exit nodes route all traffic through infra and mask the real DNS cause."""
-        monkeypatch.setattr(coder, "_tailscale_status", lambda: {"CurrentTailnet": {"Name": "posthog.com"}})
-        monkeypatch.setattr(coder, "_resolve_host_ip", lambda host: None)
-
-        diagnosis = coder._diagnose_unreachable_coder()
-        assert "exit node" in diagnosis.next_step.lower()
-        assert "1.1.1.1" in diagnosis.next_step
-
     def test_dns_failure_dominates_other_causes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(coder, "_tailscale_status", lambda: {"CurrentTailnet": {"Name": "posthog.com"}})
         monkeypatch.setattr(coder, "_resolve_host_ip", lambda host: None)
@@ -652,6 +643,9 @@ class TestDiagnoseUnreachableCoder:
         assert diagnosis.code == "dns_lookup_failed"
         assert "DNS lookup" in diagnosis.cause
         assert "MagicDNS" in diagnosis.next_step
+        # Exit nodes route all traffic through infra and mask the real DNS cause.
+        assert "exit node" in diagnosis.next_step.lower()
+        assert "1.1.1.1" in diagnosis.next_step
         assert "Tailscale tailnet: posthog.com" in diagnosis.facts
 
     def test_tcp_open_signals_tls_or_clock(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

An engineer who is signed into the wrong Tailscale tailnet cannot reach a devbox, and nothing tells them so. PostHog runs several tailnets — `dev`, `prod-us`, `prod-eu` and `internal` are for CI runners and subnet routers, and none of them route to the Coder control plane. Tailscale only asks which tailnet to join at first sign-in, so a wrong pick there is sticky and silent forever.

Every `hogli devbox:*` command then dies at the reachability check reporting a DNS or blocked-route cause, and each of those causes sends the reader somewhere useless: MagicDNS, the `group:engineering` ACL grant, Team DevEx. `devbox:doctor` even prints `[ok] Tailscale connected`, which is true and unhelpful.

The `setting-up-devbox` skill made this worse by prescribing a Tailscale **exit node** as the fix for the DNS symptom. Devboxes are reached as tailnet peers, so an exit node is not needed for devbox access — it routes all of the dev's traffic through infra, which is slower, and it papers over whichever cause is real.

## Changes

- `devbox:doctor` now prints the active tailnet on its own check line — `Tailnet is posthog.com (found: dev)` — so the answer is visible even when the failure is elsewhere.
- A new `wrong_tailnet` diagnosis is returned ahead of the DNS and TCP probes, with the platform-appropriate `tailscale switch` command and the GUI "Add account" route. It short-circuits deliberately: those probes fail the same way from any tailnet, so their fixes would be red herrings. The cause is a stable slug, so it groups in the existing `devbox_failure_cause` telemetry.
- Only fires when a tailnet name was actually read. Unknown name falls through to the existing probes rather than accusing the tailnet.
- The DNS-failure next step now walks MagicDNS → stale router/ISP resolver, and says not to reach for an exit node.
- `setting-up-devbox` skill: the exit-node instruction is replaced by the same ordered check, and the prerequisite section leads with the tailnet before the ACL grant.

## How did you test this code?

Automated only — this agent has no Tailscale client, so no manual devbox run was performed and the doctor output above is from reading the code, not from an observed terminal.

Three new tests in `TestDiagnoseUnreachableCoder`, each covering a regression no existing test did:

- `test_wrong_tailnet_dominates_every_other_cause` — asserts the DNS/TCP probes are never reached from a per-env tailnet (they would otherwise produce a plausible, wrong cause).
- `test_unknown_tailnet_name_does_not_claim_wrong_tailnet` — guards the false-positive direction, where an unreadable status blob would blame the tailnet for an ACL problem.
- `test_dns_failure_next_step_steers_off_exit_nodes` — pins the advice that this PR reverses, so it does not drift back.

One existing test (`test_no_subnet_routers_points_to_wrong_tailnet`) encoded the old behaviour of inferring "wrong tailnet" from missing subnet routes. It is renamed to `test_no_subnet_routers_points_at_tailnet_or_grant` and moved onto `posthog.com`, so it still exercises the no-routes path now that the name check owns that hypothesis.

Ran `pytest hogli_commands/tests/test_devbox.py` in a minimal venv: 329 passed. `test_devbox_setup_runs_explicit_setup_steps` fails there, but it fails identically on a clean `master` checkout in the same venv — an environment gap, not this change. `ruff check` and `ruff format --check` clean on the touched files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The matching wiki page is updated in [PostHog/runbooks#622](https://github.com/PostHog/runbooks/pull/622); the skill links to it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread where an engineer on a replacement laptop could not reach devboxes and had been working around it with an exit node for a week; the root cause turned out to be the tailnet picker. Team Cloud Foundations confirmed in-thread that exit nodes are not needed. The tailnet topology was verified against `docs/TAILSCALE.md` in `posthog-cloud-infra`, which names `posthog.com` as the shared tailnet.

No repo skills were invoked. Scope grew once during the session: the ask was to update the devbox skill, but the same wrong advice was reachable from the CLI, which is what humans actually run — so the diagnosis moved into `coder.py` and the skill now defers to it.

No assignee is set: the requester's GitHub handle was not verifiable in-session, and guessing one would tag the wrong account.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AMVFGJY7Q/p1783347477422179?thread_ts=1783347477.422179&cid=C0AMVFGJY7Q)*
