### PR TITLE
fix(logs): mask klog headers so patterns survive past midnight

### DIFF
--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -11,6 +11,16 @@ describe('log-pattern-mask', () => {
             ['timestamp iso Z', 'started at 2026-08-24T10:20:45.123Z ok', 'started at <TIMESTAMP> ok'],
             ['timestamp space comma millis', 'at 2026-08-24 10:20:45,123 done', 'at <TIMESTAMP> done'],
             ['timestamp offset', 'at 2026-08-24T10:20:45+02:00 done', 'at <TIMESTAMP> done'],
+            [
+                'klogtime info',
+                'I0827 11:39:40.307946 1 proxier.go:1484] reloading',
+                'I<KLOGTIME> <N> proxier.go:<N>] reloading',
+            ],
+            [
+                'klogtime error without micros',
+                'E0827 11:39:40 1 sync.go:12] failed',
+                'E<KLOGTIME> <N> sync.go:<N>] failed',
+            ],
             ['uuid', 'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 failed', 'request <UUID> failed'],
             ['email', 'user alice@example.com rejected', 'user <EMAIL> rejected'],
             ['hex0x', 'fault at 0xdeadBEEF handler', 'fault at <HEX> handler'],
@@ -34,6 +44,16 @@ describe('log-pattern-mask', () => {
                 'dial capture.posthog.svc.cluster.local failed',
                 'dial <HOST> failed',
             ],
+            [
+                'klog header is not shredded by num, so the date cannot survive as a literal',
+                'I0827 11:39:40.307946 1 sync.go:12] ok',
+                'I<KLOGTIME> <N> sync.go:<N>] ok',
+            ],
+            [
+                'a count followed by a time of day is not claimed as klogtime',
+                'processed 1234 12:34:56 rows',
+                'processed <N> <N>:<N>:<N> rows',
+            ],
         ])('ordering: %s', (_name, input, expected) => {
             expect(maskString(input).masked).toEqual(expected)
         })
@@ -47,9 +67,26 @@ describe('log-pattern-mask', () => {
         })
 
         it('counts fires per rule', () => {
-            const { ruleFires } = maskString('a@example.com b@example.com via api.example.net from 10.0.0.1 in 12ms')
-            const byName = Object.fromEntries(MASK_RULES.map((rule, i) => [rule.name, ruleFires[i]]))
-            expect(byName).toEqual({ timestamp: 0, uuid: 0, email: 2, host: 1, hex0x: 0, hex: 0, ipv4: 1, num: 1 })
+            const { ruleFires } = maskString(
+                'I0827 11:39:40.3 a@example.com b@example.com via api.example.net from 10.0.0.1 in 12ms'
+            )
+            // Summed rather than keyed by assignment: klogtime is four rules, one per severity
+            // letter, so an overwriting fold would report only the last one's fires.
+            const byName = MASK_RULES.reduce<Record<string, number>>(
+                (acc, rule, i) => ({ ...acc, [rule.name]: (acc[rule.name] ?? 0) + ruleFires[i] }),
+                {}
+            )
+            expect(byName).toEqual({
+                timestamp: 0,
+                klogtime: 1,
+                uuid: 0,
+                email: 2,
+                host: 1,
+                hex0x: 0,
+                hex: 0,
+                ipv4: 1,
+                num: 1,
+            })
         })
     })
 
@@ -150,7 +187,7 @@ describe('log-pattern-mask', () => {
                 .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
-            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 2, digest: 'cf5d13fd81dbf547' })
+            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 3, digest: 'e902e3a7060f935f' })
         })
     })
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -21,6 +21,8 @@ describe('log-pattern-mask', () => {
                 'E0827 11:39:40 1 sync.go:12] failed',
                 'E<KLOGTIME> <N> sync.go:<N>] failed',
             ],
+            ['klogtime warning severity', 'W0101 00:00:00 rotating', 'W<KLOGTIME> rotating'],
+            ['klogtime at the MMDD upper bound', 'F1231 23:59:59 shutdown', 'F<KLOGTIME> shutdown'],
             ['uuid', 'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 failed', 'request <UUID> failed'],
             ['email', 'user alice@example.com rejected', 'user <EMAIL> rejected'],
             ['hex0x', 'fault at 0xdeadBEEF handler', 'fault at <HEX> handler'],
@@ -55,6 +57,27 @@ describe('log-pattern-mask', () => {
                 'processed <N> <N>:<N>:<N> rows',
             ],
         ])('ordering: %s', (_name, input, expected) => {
+            expect(maskString(input).masked).toEqual(expected)
+        })
+
+        // The klog rule reaches text `\b\d+` cannot, so each guard is asserted from the negative
+        // side too: a near-miss must fall through to `num` and keep its digits, which is what stops
+        // two unrelated messages from collapsing onto one pattern.
+        it.each([
+            ['month 00', 'E0027 10:20:30 x', 'E0027 <N>:<N>:<N> x'],
+            ['month 13', 'E1327 10:20:30 x', 'E1327 <N>:<N>:<N> x'],
+            ['day 00', 'E0800 10:20:30 x', 'E0800 <N>:<N>:<N> x'],
+            ['day 32', 'E0832 10:20:30 x', 'E0832 <N>:<N>:<N> x'],
+            ['a year, not an MMDD', 'E2024 10:20:30 x', 'E2024 <N>:<N>:<N> x'],
+            ['lowercase severity letter', 'e0827 11:39:40 x', 'e0827 <N>:<N>:<N> x'],
+            ['severity letter outside IWEF', 'D0827 11:39:40 x', 'D0827 <N>:<N>:<N> x'],
+            ['no word boundary before the letter', 'foobarI0827 11:39:40 x', 'foobarI0827 <N>:<N>:<N> x'],
+            ['three date digits', 'I082 11:39:40 x', 'I082 <N>:<N>:<N> x'],
+            ['five date digits', 'I08277 11:39:40 x', 'I08277 <N>:<N>:<N> x'],
+            ['time without seconds', 'I0827 11:39 x', 'I0827 <N>:<N> x'],
+            ['two spaces between date and time', 'I0827  11:39:40 x', 'I0827  <N>:<N>:<N> x'],
+            ['no time at all', 'I0827 sync failed', 'I0827 sync failed'],
+        ])('klogtime does not claim %s', (_name, input, expected) => {
             expect(maskString(input).masked).toEqual(expected)
         })
 
@@ -187,7 +210,7 @@ describe('log-pattern-mask', () => {
                 .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
-            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 3, digest: 'e902e3a7060f935f' })
+            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 3, digest: '599889a916d04e14' })
         })
     })
 

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -31,10 +31,19 @@ export const MASK_RULES: readonly MaskRule[] = [
     //
     // The letter also guards the match. Without it, `\d{4} \d{2}:\d{2}:\d{2}` would claim any count
     // followed by a time of day.
-    { name: 'klogtime', pattern: '\\bI\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'I<KLOGTIME>' },
-    { name: 'klogtime', pattern: '\\bW\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'W<KLOGTIME>' },
-    { name: 'klogtime', pattern: '\\bE\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'E<KLOGTIME>' },
-    { name: 'klogtime', pattern: '\\bF\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'F<KLOGTIME>' },
+    //
+    // The date is spelled out as a real MMDD rather than `\d{4}`, because the letter alone is a weak
+    // guard: the rule reaches text that `\b\d+` cannot (there is no boundary between the letter and
+    // the digits), so a bare `\d{4}` masks any letter-prefixed 4-digit token that happens to precede
+    // a time — collapsing `E2024 10:20:30` and `E2025 10:20:30`, which are distinct today. A month of
+    // 01-12 and a day of 01-31 rejects those while accepting every date klog can print. The match
+    // cannot be anchored to the line start instead: Kubernetes CRI lines carry a container prefix
+    // ("<time> stderr F I0827 ..."), so the header is mid-string in the most common real source.
+    ...(['I', 'W', 'E', 'F'] as const).map((letter) => ({
+        name: 'klogtime' as const,
+        pattern: `\\b${letter}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\\d|3[01]) \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?`,
+        replacement: `${letter}<KLOGTIME>`,
+    })),
     {
         name: 'uuid',
         pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -2,9 +2,9 @@ import { createTrackedRE2 } from '~/common/utils/tracked-re2'
 
 import { parseLogBodyForIngestion } from './log-body-parse'
 
-export const PATTERN_VERSION = 2
+export const PATTERN_VERSION = 3
 
-export type MaskRuleName = 'timestamp' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
+export type MaskRuleName = 'timestamp' | 'klogtime' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
 export type MaskRule = {
     name: MaskRuleName
@@ -18,6 +18,23 @@ export const MASK_RULES: readonly MaskRule[] = [
         pattern: '\\b\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:[.,]\\d+)?(?:Z|[+-]\\d{2}:?\\d{2})?',
         replacement: '<TIMESTAMP>',
     },
+    // klog / glog headers ("I0827 11:39:40.307946") carry no year and no separators, so the
+    // timestamp rule above misses them and `\b\d+` cannot reach the date either — there is no word
+    // boundary between the severity letter and the digits, so the date survives as a literal and
+    // the pattern changes every midnight.
+    //
+    // One rule per severity letter, rather than one rule with a lookbehind. The letter is content,
+    // not a variable, so it has to survive into the output; replacements are constant strings, so
+    // the only way to keep it is to consume it and write it back. Lookbehind and backreferences are
+    // both unavailable — RE2 lacks the first, and the rule-fire attribution in MASK_COMBINED_RE
+    // indexes capture groups positionally, so a rule may not add one.
+    //
+    // The letter also guards the match. Without it, `\d{4} \d{2}:\d{2}:\d{2}` would claim any count
+    // followed by a time of day.
+    { name: 'klogtime', pattern: '\\bI\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'I<KLOGTIME>' },
+    { name: 'klogtime', pattern: '\\bW\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'W<KLOGTIME>' },
+    { name: 'klogtime', pattern: '\\bE\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'E<KLOGTIME>' },
+    { name: 'klogtime', pattern: '\\bF\\d{4} \\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?', replacement: 'F<KLOGTIME>' },
     {
         name: 'uuid',
         pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',


### PR DESCRIPTION
## Problem

A klog or glog line masks to a pattern that changes every midnight, so no two days ever agree on its identity.

The header is `I0827 11:39:40.307946` — a severity letter, then `MMDD`, then the time. No year, no separators. The `timestamp` rule needs an ISO date, so it misses. `\b\d+` cannot reach the date either, because there is no word boundary between a letter and a digit, so `I0827` survives into the pattern as a literal.

Every Kubernetes component logs this way — kube-proxy, kubelet, controller-manager.

The effect on pattern-anchored detection is total rather than partial:

- No klog pattern can ever build a baseline. A baseline needs weeks of samples for one identity; a klog identity lasts a day.
- New-pattern detection would fire on every klog shape, every day, forever. They are absent from the baseline by construction.

## Changes

- klog headers now mask to `I<KLOGTIME>`, keeping the severity letter and collapsing the date and time. The same log line mines to the same pattern tomorrow.
- `PATTERN_VERSION` moves 2 → 3, so the change is a clean identity boundary rather than a silent re-shaping.
- Four rules, one per severity letter, rather than one rule with a lookbehind. Three constraints force this. The consumer masks under RE2, which has no lookbehind. Replacements are constant strings, so a capture group and backreference cannot carry the letter through either. And `MASK_COMBINED_RE` attributes rule fires by capture-group index, so a rule that adds a group would silently misattribute every rule after it. Consuming the letter and writing it back is the only form that satisfies all three, and the existing RE2 ratchet test enforces exactly those constraints.
- The letter also guards the match: without it, `\d{4} \d{2}:\d{2}:\d{2}` would claim any count followed by a time of day. `processed 1234 12:34:56 rows` has a test.
- Mechanical: the fires-per-rule test built its map with `Object.fromEntries`, which keeps only the last entry for a repeated key, so four rules sharing the name `klogtime` would have under-reported. Now a summing fold.

Drain3 already solves this at read time with `(?<=\b[IWEF])\d{4} \d{2}:\d{2}:\d{2}`, including the reasoning for keeping the letter outside the mask. This ports that behavior to the consumer, where the stamped pattern is the identity.

## How did you test this code?

Extended the existing parameterized suites rather than adding standalone tests, since each case is a variation of behavior already covered:

- Two cases in the rule table: an info header with microseconds, and an error header without them.
- Two cases in the ordering table: that `num` cannot shred the header, and that a bare count followed by a time of day is not claimed. The second is the regression the severity letter exists to prevent.
- The fires-per-rule and `PATTERN_VERSION` ratchet expectations were updated for the new rule set.

510 tests pass across `nodejs/src/logs/`. The RE2 ratchet independently confirms each of the four rules compiles and uses no lookaround, backreference, or capture group.

<details>
<summary>Masking cost, measured locally against a synthetic corpus</summary>

Comparing the 8-rule and 12-rule combined regexes, microseconds per call:

```
input                           chars   8-rule µs  12-rule µs     delta
klog line (the target)            114        5.11        3.62      -29%
ordinary prose log                 98        1.85        2.02        9%
json body                          98        1.99        2.14        8%
ADVERSARIAL all digits           4096      251.71      257.38        2%
ADVERSARIAL I + digits           4096        6.65        6.57       -1%
ADVERSARIAL klog near-miss       4095     1017.96     1062.73        4%
ADVERSARIAL I repeated           4096        6.44        6.44        0%
ADVERSARIAL nested-ish alt       4095      865.81      268.16      -69%
ADVERSARIAL hex runs             4080      352.13      363.21        3%
```

Faster on the lines it targets, because one match replaces four. RE2 is a linear-time automaton, so adversarial input cannot trigger backtracking, and length is separately bounded by the input cap. The slowest row is match-callback bound rather than backtracking bound, and predates this change.

</details>

Not checked: no run against production bodies, and no change to the read-time miner, which already handles this format.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this, directed by the assignee. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Found while reading a masked pattern and asking why a timestamp had become a run of `<N>` placeholders. The `<N>` run was the visible symptom; the surviving date was the actual defect.

Three other divergences between the consumer and the read-time miner were considered and rejected in the same pass, because measurement showed each was worth approximately nothing once a single dominant tenant was excluded from the sample: a longer message-key list, an `error_message` key, and one level of nesting for JSON message extraction. This one is different in kind — a correctness defect in pattern identity rather than a coverage preference — so it is the only one here.

Timing matters for the version bump. Stamped patterns began flowing today, and nothing consumes them yet, so the boundary is close to free now and gets more expensive once a rollup starts accumulating history against version 2.
