### PR TITLE
feat(warehouse_sources): add Float rate cards and currencies tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -3120,19 +3120,19 @@ Note: The Flexmail public API is contact-management only - it exposes no campaig
 
 ## FloatApp — gaps
 
-Today (18): `accounts`, `clients`, `deleted_logged_time`, `deleted_tasks`, `deleted_timeoffs`, `departments`, `holidays`, `logged_time`, `milestones`, `people`, `phases`, `project_tasks`, `projects`, `roles`, `status`, `tasks`, `timeoff_types`, `timeoffs`
+Today (20): `accounts`, `clients`, `currencies`, `deleted_logged_time`, `deleted_tasks`, `deleted_timeoffs`, `departments`, `holidays`, `logged_time`, `milestones`, `people`, `phases`, `project_tasks`, `projects`, `rate_cards`, `roles`, `status`, `tasks`, `timeoff_types`, `timeoffs`
 
 Diffed against: <https://developer.float.com/swagger-api-v3.yaml>
 
 - [ ] `/project-stages` — lookup table resolving the stage IDs carried on the projects we already sync (high)
-- [ ] `/rate-cards` — lookup for the rate card IDs on people/projects; required to turn logged hours into billable value (high)
+- [x] `/rate-cards` — lookup for the rate card IDs on people/projects; required to turn logged hours into billable value (high)
 - [ ] `/reports/people` — Float's headline utilization/capacity report per person, pre-aggregated (high)
 - [ ] `/reports/projects` — per-project scheduled vs logged vs billable breakdown (medium)
 - [ ] `/project-expenses` — non-labor project cost, needed for true project margin alongside logged_time (medium)
 - [ ] `/public-holidays` — region public holidays; distinct from the team /holidays table already synced, needed for correct capacity math (medium)
-- [ ] `/currencies` — lookup for currency codes on rate cards and project budgets (low)
+- [x] `/currencies` — lookup for currency codes on rate cards and project budgets (low)
 
-Note: Machine-readable OpenAPI at /swagger-api-v3.yaml enumerates 26 resources; PostHog covers 18. /project-templates was excluded as config.
+Note: Machine-readable OpenAPI at /swagger-api-v3.yaml enumerates 26 resources; PostHog covers 20. /project-templates was excluded as config.
 
 ## Flowlu — **thin**
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/canonical_descriptions.py
@@ -200,6 +200,27 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "end_date": "The holiday's end date.",
         },
     },
+    "rate_cards": {
+        "description": "A rate card defining bill rates by role, applied to projects to turn scheduled hours into billable value.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "rate_card_id": "Unique identifier for the rate card.",
+            "name": "The rate card's name.",
+            "currency_code": "ISO 4217 currency the card's rates are expressed in; defaults to the company currency.",
+            "roles": "The per-role bill rates, each pairing a role_id with its bill_rate.",
+            "client_ids": "The ids of the clients this rate card applies to.",
+        },
+    },
+    "currencies": {
+        "description": "A currency the workspace bills in, with its exchange rate against the company's base currency.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "currency_id": "Unique identifier for the currency entry.",
+            "source_currency": "The company's base currency (ISO 4217); set automatically.",
+            "target_currency": "The billing currency (ISO 4217, e.g. CAD); fixed after creation.",
+            "fx_rate": "The exchange rate from the source currency to the target currency.",
+        },
+    },
     "deleted_tasks": {
         "description": "Tombstone log of deleted allocations (tasks), for reconciling deletions since a cursor.",
         "docs_url": _DOCS_URL,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/float_app.posthog.com.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/float_app.posthog.com.md
@@ -16,8 +16,9 @@ import AlphaRelease from "../\_snippets/alpha-release.mdx"
 
 [Float](https://www.float.com/) is a resource-management and team-scheduling platform for capacity
 planning. This source syncs your people, accounts, clients, departments, projects, phases,
-allocations, milestones, logged time, time off, and holidays into the PostHog data warehouse so you
-can join scheduling and capacity data with your product and revenue data.
+allocations, milestones, logged time, time off, holidays, rate cards, and currencies into the
+PostHog data warehouse so you can join scheduling and capacity data with your product and revenue
+data.
 
 ## Prerequisites
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/float_app/settings.py
@@ -57,6 +57,8 @@ FLOAT_ENDPOINTS: dict[str, FloatEndpointConfig] = {
     "status": FloatEndpointConfig(name="status", path="/status", primary_keys=["status_id"]),
     "roles": FloatEndpointConfig(name="roles", path="/roles", primary_keys=["id"]),
     "holidays": FloatEndpointConfig(name="holidays", path="/holidays", primary_keys=["holiday_id"]),
+    "rate_cards": FloatEndpointConfig(name="rate_cards", path="/rate-cards", primary_keys=["rate_card_id"]),
+    "currencies": FloatEndpointConfig(name="currencies", path="/currencies", primary_keys=["currency_id"]),
     # Delete Log endpoints — cursor pagination, append-only tombstones. Niche, so off by default.
     "deleted_tasks": FloatEndpointConfig(
         name="deleted_tasks",


### PR DESCRIPTION
## Problem

Float users syncing their resource-management data into the PostHog warehouse had no way to pull rate cards or currencies. Both are needed to turn scheduled and logged hours into billable value: rate cards hold the per-role bill rates, and currencies hold the exchange rates that convert those rates into a project's billing currency. Float shipped both as generally-available API endpoints (`/currencies` in June 2026, `/rate-cards` in July 2026), and the source's own coverage-gap notes listed both as missing.

## Changes

- Float now offers `rate_cards` and `currencies` as syncable tables in the source's schema picker.
- Both are page-paginated, full-refresh, top-level list resources, wired exactly like the existing Float core endpoints — two entries in `FLOAT_ENDPOINTS` (`settings.py`) with primary keys `rate_card_id` and `currency_id`.
- Neither sets a partition key: Float does not document a stable `created` timestamp on either resource, and an absent partition column would fail the write.
- Added canonical column descriptions for both tables from Float's documented field lists, so the AI agent and public docs describe them without per-team LLM enrichment.
- Mechanical: ticked the two boxes in `COVERAGE_GAPS_APPENDIX.md`, updated the source's coverage count, and extended the doc intro sentence.

Verified before building that both endpoints exist and are GA on Float's official API reference and changelog — neither was skipped.

## How did you test this code?

The source's existing parametrized tests iterate `ENDPOINTS`, so they now assert the two new tables are full-refresh with the mapped primary keys and are published in the documentation catalog. `hogli test .../float_app/tests/` passes 27 tests. No new transport branch was added — both endpoints reuse the page paginator that existing tests already cover — so no new test was written.

Not run against the live Float API: this environment has no Float token. Endpoint existence, paths, and field lists were confirmed from Float's public API reference and changelog.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude, via the PostHog Desktop cloud-task harness) from a changelog-research task flagging the two missing endpoints. The task's detection notes were treated as untrusted informational input; each endpoint was independently verified against Float's official API reference and changelog before building.

Skills invoked: `/implementing-warehouse-sources`, `/writing-pr-descriptions`, `/reviewing-before-pr`, `/writing-tests`.

Local review: Greptile CLI was unavailable in the sandbox, so the harness `/code-review` fallback ran over the branch diff instead — the independent Greptile pass still runs as the PR bot. The fallback found no issues on this config-only diff.

Public artifact: no customer data or session-private material is present; all content is derived from Float's public API documentation.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
