### PR TITLE
feat(warehouse_sources): add Personio salary bands and cost centers tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -6387,7 +6387,7 @@ Note: Persona's own repo note (products/warehouse_sources/backend/temporal/data_
 
 ## Personio — **thin**
 
-Today (3): `absence_periods`, `attendance_periods`, `persons`
+Today (5): `absence_periods`, `attendance_periods`, `cost_centers`, `persons`, `salary_bands`
 
 Diffed against: <https://developer.personio.de/llms.txt>
 
@@ -6395,7 +6395,8 @@ Diffed against: <https://developer.personio.de/llms.txt>
 - [ ] `GET /v2/absence-types` — lookup resolving the absence type on every absence period already synced (high)
 - [ ] `GET /v2/compensations` — salary, hourly, bonus and recurring compensation - the payroll dataset (high)
 - [ ] `GET /v2/org-units` — department/team hierarchy lookup for grouping persons, absences and attendance (high)
-- [ ] `GET /v2/cost-centers` — cost center lookup for allocating attendance and compensation to finance dimensions (medium)
+- [x] `GET /v2/cost-centers` — cost center lookup for allocating attendance and compensation to finance dimensions (medium)
+- [x] `GET /v2/salary-bands` — salary band ranges (min/max/mid, currency) and the workplaces they apply to (medium)
 - [ ] `GET /v2/legal-entities` — legal entity lookup for multi-entity headcount and payroll splits (medium)
 - [ ] `GET /v2/jobs` — job/position catalog referenced from employments (medium)
 - [ ] `GET /v2/compensations/types` — lookup resolving compensation type IDs on compensation rows (medium)
@@ -6404,7 +6405,7 @@ Diffed against: <https://developer.personio.de/llms.txt>
 - [ ] `GET /v2/recruiting/applications/{id}/stage-transitions` — stage transition history - exactly the state-change data needed for time-in-stage metrics (medium)
 - [ ] `GET /v2/recruiting/candidates` — candidate records joined to applications above (medium)
 
-Note: PERSONIO_ENDPOINTS in products/warehouse_sources/backend/temporal/data_imports/sources/personio/settings.py is a static 3-entry dict (/v2/persons, /v2/absence-periods, /v2/attendance-periods) - no dynamic discovery. The v2 API exposes roughly 20 listable resources, so this is a small fraction, and notably every organizational lookup that would let you group the synced persons and time data (org units, cost centers, legal entities, jobs) is missing. Exact paths confirmed from the individual reference .md pages. Recruiting endpoints are flagged beta by the vendor.
+Note: PERSONIO_ENDPOINTS in products/warehouse_sources/backend/temporal/data_imports/sources/personio/settings.py is a static 5-entry dict (/v2/persons, /v2/absence-periods, /v2/attendance-periods, /v2/salary-bands, /v2/cost-centers) - no dynamic discovery. The v2 API exposes roughly 20 listable resources, so this is still a small fraction, and other organizational lookups that would let you group the synced persons and time data (org units, legal entities, jobs) are still missing. Salary bands and cost centers are dimension lookups with no updated_at/created_at field, so they sync full-refresh only. Exact paths confirmed from the individual reference .md pages. Recruiting endpoints are flagged beta by the vendor.
 
 ## Pexels — gaps
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/personio/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/personio/canonical_descriptions.py
@@ -51,4 +51,24 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "updated_at": "Time at which the attendance period was last updated.",
         },
     },
+    "salary_bands": {
+        "description": "A salary band with its compensation range and the workplaces it applies to.",
+        "docs_url": "https://developer.personio.de/reference/listsalarybands",
+        "columns": {
+            "id": "Unique identifier for the salary band.",
+            "min": "Minimum salary of the band, in major currency units.",
+            "max": "Maximum salary of the band, in major currency units.",
+            "middle": "Midpoint of the band, in major currency units. Null when no midpoint is defined.",
+            "currency": "ISO 4217 three-letter currency code of the band.",
+            "workplaces": "Workplaces the salary band applies to, each carrying a workplace id.",
+        },
+    },
+    "cost_centers": {
+        "description": "A cost center defined in Personio, used to allocate people and time to finance dimensions.",
+        "docs_url": "https://developer.personio.de/reference/listcostcenters",
+        "columns": {
+            "id": "Unique identifier for the cost center.",
+            "name": "The name of the cost center.",
+        },
+    },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/personio/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/personio/settings.py
@@ -54,6 +54,18 @@ PERSONIO_ENDPOINTS: dict[str, PersonioEndpointConfig] = {
         incremental_param="updated_at.gte",
         incremental_fields=list(_UPDATED_AT_INCREMENTAL_FIELDS),
     ),
+    # Salary bands and cost centers are dimension lookups: no updated_at/created_at field, so no
+    # server-side timestamp filter and no partition key — full refresh only.
+    "salary_bands": PersonioEndpointConfig(
+        name="salary_bands",
+        path="/v2/salary-bands",
+        scope="personio:salary-bands:read",
+    ),
+    "cost_centers": PersonioEndpointConfig(
+        name="cost_centers",
+        path="/v2/cost-centers",
+        scope="personio:cost-centers:read",
+    ),
 }
 
 ENDPOINTS = tuple(PERSONIO_ENDPOINTS.keys())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/personio/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/personio/source.py
@@ -66,7 +66,7 @@ class PersonioSource(ResumableSource[PersonioSourceConfig, PersonioResumeConfig]
             label="Personio",
             caption="""Enter your Personio API credentials to pull your Personio HR data into the PostHog Data warehouse.
 
-An admin can create API credentials in Personio under Settings > Integrations > API credentials. Grant the read scopes for the datasets you want to sync (`personio:persons:read`, `personio:absences:read`, `personio:attendances:read`) and whitelist the employee attributes you need — attributes that aren't whitelisted are silently omitted from responses.""",
+An admin can create API credentials in Personio under Settings > Integrations > API credentials. Grant the read scopes for the datasets you want to sync (`personio:persons:read`, `personio:absences:read`, `personio:attendances:read`, `personio:salary-bands:read`, `personio:cost-centers:read`) and whitelist the employee attributes you need — attributes that aren't whitelisted are silently omitted from responses.""",
             iconPath="/static/services/personio.png",
             docsUrl="https://posthog.com/docs/cdp/sources/personio",
             releaseStatus=ReleaseStatus.ALPHA,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/personio/tests/test_personio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/personio/tests/test_personio.py
@@ -273,6 +273,29 @@ class TestGetRows:
         assert "updated_at.gt" not in snapshots[0]["params"]
         assert snapshots[0]["params"]["limit"] == 50
 
+    @pytest.mark.parametrize("endpoint", ["salary_bands", "cost_centers"])
+    @mock.patch(AUTH_SESSION_PATCH)
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_dimension_endpoint_never_sends_timestamp_filter(self, MockSession, MockAuth, endpoint):
+        # salary-bands and cost-centers have no updated_at field, so incremental_param is None. Even
+        # if incremental is requested, the request must go out as a full refresh with no timestamp
+        # param — sending one the API ignores would silently claim a filtered sync.
+        session = MockSession.return_value
+        MockAuth.return_value.post.return_value = _token_response()
+        snapshots = _wire(session, [_response(_page([]))])
+
+        _rows(
+            _source(
+                endpoint,
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 1, 2, tzinfo=UTC),
+            )
+        )
+
+        assert not any(key.startswith("updated_at") for key in snapshots[0]["params"])
+        assert snapshots[0]["params"]["limit"] == 100
+
     @mock.patch(AUTH_SESSION_PATCH)
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_resumes_from_saved_state(self, MockSession, MockAuth):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/personio/tests/test_personio_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/personio/tests/test_personio_source.py
@@ -7,7 +7,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.personio import (
     PersonioSourceConfig,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.personio.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.personio.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.personio.source import PersonioSource
 
 
@@ -49,9 +52,14 @@ class TestPersonioSource:
         schemas = self.source.get_schemas(self.config, self.team_id)
 
         assert {schema.name for schema in schemas} == set(ENDPOINTS)
-        # All shipped endpoints expose a server-side updated_at filter.
-        assert all(schema.supports_incremental for schema in schemas)
-        assert all(schema.supports_append for schema in schemas)
+        # Incremental support tracks the settings catalog: only endpoints with a server-side
+        # updated_at filter expose it. The salary-bands and cost-centers dimension lookups have no
+        # timestamp field, so they must stay full-refresh — marking them incremental would emit an
+        # updated_at param the API ignores while claiming to have filtered.
+        for schema in schemas:
+            expected_incremental = schema.name in INCREMENTAL_FIELDS
+            assert schema.supports_incremental is expected_incremental
+            assert schema.supports_append is expected_incremental
 
     @pytest.mark.parametrize(
         "mock_return, expected_valid, expected_message",


### PR DESCRIPTION
## Problem

The Personio v2 data-warehouse source synced three tables (`persons`, `absence_periods`, `attendance_periods`) but had no table for the salary-bands or cost-centers endpoints the API exposes. A person connecting Personio couldn't pull salary band ranges or cost centers into the warehouse, so they couldn't join people and time data to compensation ranges or finance dimensions.

## Changes

- A person syncing Personio can now select two new tables: **Salary bands** (`/v2/salary-bands`) and **Cost centers** (`/v2/cost-centers`). Each appears in the schema picker with column descriptions from the vendor's API docs.
- Both endpoints have no `updated_at`/`created_at` field, so both sync **full refresh only** — no server-side timestamp filter and no partition key. Incremental and partitioning stay off for them; the existing three tables are unchanged.
- The connection caption now lists the two extra read scopes (`personio:salary-bands:read`, `personio:cost-centers:read`) an admin grants.
- Both tables reuse the existing OAuth2 auth, tracked transport, and `_meta.links.next.href` cursor paginator — no new transport code. (mechanical)
- Updated the source's coverage-gaps appendix: ticked cost-centers, added a ticked salary-bands line. (mechanical)

**Verification against the vendor API:** both endpoints were confirmed to exist on the v2 API we implement, via the official reference (`listsalarybands`, `listcostcenters`) and the `llms.txt` index. No endpoint was skipped — both survived verification and are legitimate warehouse dimension tables.

## How did you test this code?

Automated tests only — I (the agent) could not exercise the live Personio API.

- Extended `test_personio_source.py::test_get_schemas` to tie each table's incremental support to the settings catalog. This catches a regression where the two new dimension tables get marked incremental — which would emit an `updated_at` param the API silently ignores while claiming a filtered sync. The old assertion (`all(... supports_incremental)`) could not express the full-refresh tables.
- Added `test_personio.py::test_dimension_endpoint_never_sends_timestamp_filter` (parameterized over both new endpoints). It catches a regression where the `incremental_param is not None` guard is dropped, so a full-refresh-only endpoint would send a timestamp filter when incremental is requested. No existing test covered an endpoint whose `incremental_param` is `None`.
- The parameterized `test_response_metadata_per_endpoint` now also covers the two new endpoints' name, primary key, sort mode, and no-partitioning automatically.
- Ran the Personio suite and the cross-source version/category invariant suites; all pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The docs "Supported tables" section renders dynamically from `get_schemas` plus the canonical descriptions (the source already sets `lists_tables_without_credentials = True`), so the two new tables appear there without a manual doc edit.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude, via PostHog Desktop). Skills invoked: `/implementing-warehouse-sources` (endpoint/table conventions, full-refresh vs incremental rules) and `/writing-tests` (the test value gate).

Endpoint names came from automated changelog research and were treated as informational only. I verified each against the vendor's official v2 reference before building: both `salary-bands` and `cost-centers` exist on v2, so neither was skipped. Both lack any server-side timestamp filter, so I wired them as full-refresh dimension lookups rather than forcing an incremental cursor the API can't honor.

No customer data, secrets, or session-derived material is in this diff — all sample values in tests are invented, and all descriptions come from the public Personio API docs.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
