### PR TITLE
feat(warehouse_sources): add HiBob employee time-off calendars table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -3896,10 +3896,11 @@ Note: learn.hex.tech renders the reference client-side from Docusaurus; the oper
 
 ## HiBob — **thin**
 
-Today (2): `employees`, `tasks`
+Today (3): `employees`, `tasks`, `time_off_calendars`
 
 Diffed against: <https://apidocs.hibob.com/reference/get_tasks>
 
+- [x] `POST /timeoff/calendars/employees/search` — the holiday calendar resolved per employee (employment override or site default); fans out over employee ids, full refresh (medium)
 - [ ] `GET /bulk/people/lifecycle` — employee lifecycle state transitions (hire, promotion, termination) — the core HR history table (high)
 - [ ] `GET /bulk/people/employment` — employment history rows per employee (contract, manager, site changes) rather than only current state (high)
 - [ ] `GET /bulk/people/salaries` — compensation history, the headline HR analytics dataset (high)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/canonical_descriptions.py
@@ -43,4 +43,15 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "listName": "Name of the task list the task belongs to.",
         },
     },
+    "time_off_calendars": {
+        "description": "The holiday calendar that applies to each employee, resolved from their employment override or their site default.",
+        "docs_url": "https://apidocs.hibob.com/reference/post_timeoff-calendars-employees-search",
+        "columns": {
+            "employeeId": "Identifier of the employee the calendar is resolved for.",
+            "calendarId": "Identifier of the resolved holiday calendar, or null when no calendar applies.",
+            "calendarName": "Display name of the resolved holiday calendar, or null when no calendar applies.",
+            "source": "How the calendar was resolved: employment (an employment override), site (the site default), or none.",
+            "siteId": "Identifier of the employee's site, or null when they have no site.",
+        },
+    },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/hibob.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/hibob.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterator
+from typing import Any
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
     Endpoint,
@@ -8,9 +11,18 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     SinglePagePaginator,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.settings import HIBOB_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.hibob.settings import (
+    HIBOB_ENDPOINTS,
+    TIME_OFF_CALENDARS,
+)
 
 HIBOB_BASE_URL = "https://api.hibob.com"
+
+# HiBob rejects more than 5000 employee ids in one calendar search (400 tooManyEmployeeIds).
+EMPLOYEE_ID_BATCH_SIZE = 5000
+# Max page size the calendars search accepts.
+CALENDAR_PAGE_LIMIT = 1000
+REQUEST_TIMEOUT_SECONDS = 30
 
 
 def validate_credentials(service_user_id: str, service_user_token: str) -> tuple[bool, str | None]:
@@ -32,6 +44,69 @@ def validate_credentials(service_user_id: str, service_user_token: str) -> tuple
         session.close()
 
 
+def _leaf_key(key: str) -> str:
+    """HiBob returns calendar fields under JSON-pointer keys (e.g. `/employeeCalendar/employeeId`).
+    Keep only the leaf segment so columns are clean; a flat key is returned unchanged."""
+    return key.rsplit("/", 1)[-1] if "/" in key else key
+
+
+def _iter_employee_ids(session: Any) -> Iterator[str]:
+    employees_config = HIBOB_ENDPOINTS["employees"]
+    response = session.post(
+        f"{HIBOB_BASE_URL}{employees_config.path}",
+        json=employees_config.body,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    for employee in response.json().get(employees_config.data_key, []):
+        employee_id = employee.get("id")
+        if employee_id is not None:
+            # HiBob ids exceed JS safe-integer range, so send them back as strings.
+            yield str(employee_id)
+
+
+def _search_employee_calendars(session: Any, path: str, employee_ids: list[str]) -> Iterator[list[dict[str, Any]]]:
+    cursor: str | None = None
+    while True:
+        body: dict[str, Any] = {
+            "filters": [
+                {"fieldId": "/employeeCalendar/employeeId", "operator": "equals", "values": employee_ids},
+            ],
+            "limit": CALENDAR_PAGE_LIMIT,
+        }
+        if cursor:
+            body["cursor"] = cursor
+
+        response = session.post(f"{HIBOB_BASE_URL}{path}", json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        data = response.json()
+
+        items = data.get("items", [])
+        if items:
+            yield [{_leaf_key(key): value for key, value in item.items()} for item in items]
+
+        cursor = (data.get("response_metadata") or {}).get("next_cursor")
+        if not cursor:
+            break
+
+
+def _time_off_calendars_rows(
+    service_user_id: str, service_user_token: str, path: str
+) -> Iterator[list[dict[str, Any]]]:
+    # The search resolves the holiday calendar for a supplied set of employee ids, so fan out over
+    # every employee. Repeated 401/403s trip HiBob's WAF, so auth errors fail loud (raise_for_status)
+    # rather than retry — the tracked session only retries 429/5xx.
+    session = make_tracked_session(redact_values=(service_user_token,))
+    session.auth = (service_user_id, service_user_token)
+    try:
+        employee_ids = list(_iter_employee_ids(session))
+        for start in range(0, len(employee_ids), EMPLOYEE_ID_BATCH_SIZE):
+            batch = employee_ids[start : start + EMPLOYEE_ID_BATCH_SIZE]
+            yield from _search_employee_calendars(session, path, batch)
+    finally:
+        session.close()
+
+
 def hibob_source(
     service_user_id: str,
     service_user_token: str,
@@ -40,6 +115,16 @@ def hibob_source(
     job_id: str,
 ) -> SourceResponse:
     config = HIBOB_ENDPOINTS[endpoint]
+
+    if endpoint == TIME_OFF_CALENDARS:
+        return SourceResponse(
+            name=endpoint,
+            items=lambda: _time_off_calendars_rows(service_user_id, service_user_token, config.path),
+            primary_keys=[config.primary_key],
+            partition_count=1,
+            partition_size=1,
+            sort_mode="asc",
+        )
 
     # Basic auth carries the token; supplying it via the framework auth config redacts the
     # token from any raised error. Repeated 401/403s trip HiBob's WAF, so auth errors must

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/settings.py
@@ -16,6 +16,12 @@ class HiBobEndpointConfig:
     primary_key: str = "id"
 
 
+# Name of the employee time-off calendars stream. It fans out over employee ids
+# (the search endpoint resolves the holiday calendar per employee), so it needs
+# bespoke transport rather than the shared single-page path — routed by name in
+# hibob.py.
+TIME_OFF_CALENDARS = "time_off_calendars"
+
 # HiBob has no updated-at filter on employees (Airbyte is full-refresh only and
 # Fivetran re-imports most tables every sync), so every stream is an honest
 # full refresh. The time off changes endpoint has a `since` param but its rows
@@ -34,6 +40,14 @@ HIBOB_ENDPOINTS: dict[str, HiBobEndpointConfig] = {
         name="tasks",
         path="/v1/tasks",
         data_key="tasks",
+    ),
+    TIME_OFF_CALENDARS: HiBobEndpointConfig(
+        name=TIME_OFF_CALENDARS,
+        path="/v1/timeoff/calendars/employees/search",
+        data_key="items",
+        method="POST",
+        # One resolved calendar per employee, so the employee id is table-wide unique.
+        primary_key="employeeId",
     ),
 }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/tests/test_hibob.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hibob/tests/test_hibob.py
@@ -139,6 +139,103 @@ class TestGetRows:
         assert session.send.call_count == 1
 
 
+class TestTimeOffCalendars:
+    """The calendars stream fans out over employee ids (POST search), so it hand-rolls its own
+    session.post calls rather than riding the shared rest_client."""
+
+    def _people_then_calendars(self, session, calendar_pages: list[Response], employees=None):
+        employees = employees if employees is not None else [{"id": "e1"}, {"id": "e2"}]
+        session.post.side_effect = [_response({"employees": employees}), *calendar_pages]
+
+    @mock.patch(HIBOB_SESSION_PATCH)
+    def test_fans_out_employee_ids_and_normalizes_pointer_keys(self, mock_make_session):
+        session = mock_make_session.return_value
+        self._people_then_calendars(
+            session,
+            [
+                _response(
+                    {
+                        "items": [
+                            {
+                                "/employeeCalendar/employeeId": "e1",
+                                "/employeeCalendar/calendarId": "c1",
+                                "/employeeCalendar/calendarName": "UK",
+                                "/employeeCalendar/source": "site",
+                                "/employeeCalendar/siteId": "s1",
+                            },
+                            {
+                                "/employeeCalendar/employeeId": "e2",
+                                "/employeeCalendar/calendarId": None,
+                                "/employeeCalendar/source": "none",
+                                "/employeeCalendar/siteId": None,
+                            },
+                        ],
+                        "response_metadata": {"next_cursor": None},
+                    }
+                )
+            ],
+        )
+
+        rows = _rows(hibob_source("service-id", "token", "time_off_calendars", team_id=1, job_id="j"))
+
+        assert rows == [
+            {"employeeId": "e1", "calendarId": "c1", "calendarName": "UK", "source": "site", "siteId": "s1"},
+            {"employeeId": "e2", "calendarId": None, "source": "none", "siteId": None},
+        ]
+        search_call = session.post.call_args_list[1]
+        assert search_call.args[0] == "https://api.hibob.com/v1/timeoff/calendars/employees/search"
+        assert search_call.kwargs["json"]["filters"] == [
+            {"fieldId": "/employeeCalendar/employeeId", "operator": "equals", "values": ["e1", "e2"]}
+        ]
+
+    @mock.patch(HIBOB_SESSION_PATCH)
+    def test_follows_cursor_until_exhausted(self, mock_make_session):
+        session = mock_make_session.return_value
+        self._people_then_calendars(
+            session,
+            [
+                _response(
+                    {"items": [{"/employeeCalendar/employeeId": "e1"}], "response_metadata": {"next_cursor": "n"}}
+                ),
+                _response(
+                    {"items": [{"/employeeCalendar/employeeId": "e2"}], "response_metadata": {"next_cursor": None}}
+                ),
+            ],
+            employees=[{"id": "e1"}],
+        )
+
+        rows = _rows(hibob_source("service-id", "token", "time_off_calendars", team_id=1, job_id="j"))
+
+        assert [row["employeeId"] for row in rows] == ["e1", "e2"]
+        assert session.post.call_count == 3  # people/search + two cursor pages
+        assert session.post.call_args_list[2].kwargs["json"]["cursor"] == "n"
+
+    @mock.patch(HIBOB_SESSION_PATCH)
+    def test_splits_employee_ids_into_batches_of_5000(self, mock_make_session):
+        session = mock_make_session.return_value
+        empty_page = {"items": [], "response_metadata": {"next_cursor": None}}
+        self._people_then_calendars(
+            session,
+            [_response(empty_page), _response(empty_page)],
+            employees=[{"id": str(i)} for i in range(5001)],
+        )
+
+        _rows(hibob_source("service-id", "token", "time_off_calendars", team_id=1, job_id="j"))
+
+        assert session.post.call_count == 3  # people/search + two batched searches
+        assert len(session.post.call_args_list[1].kwargs["json"]["filters"][0]["values"]) == 5000
+        assert len(session.post.call_args_list[2].kwargs["json"]["filters"][0]["values"]) == 1
+
+    @mock.patch(HIBOB_SESSION_PATCH)
+    def test_auth_error_fails_loud(self, mock_make_session):
+        session = mock_make_session.return_value
+        # Repeated 401s trip HiBob's WAF, so the fan-out must raise rather than swallow the failure.
+        session.post.side_effect = [_response({"error": "unauthorized"}, status=401)]
+
+        with pytest.raises(Exception):
+            _rows(hibob_source("service-id", "token", "time_off_calendars", team_id=1, job_id="j"))
+
+
 class TestHiBobSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     @mock.patch(CLIENT_SESSION_PATCH)


### PR DESCRIPTION
## Problem

The HiBob (Bob) data-warehouse source syncs only `employees` and `tasks`. HiBob's changelog announced two new API areas, and this source had no table for either. Customers who connect Bob could not pull the holiday calendar that applies to each employee into PostHog.

## Changes

- Adds a `time_off_calendars` table to the HiBob source. Once synced, it holds one row per employee — `employeeId`, `calendarId`, `calendarName`, `source` (employment override, site default, or none), and `siteId` — so you can see and join which holiday calendar each person follows.
- The stream fans out over every employee id (read from `/v1/people/search`), batched at HiBob's 5000-id-per-request limit, and follows the search endpoint's cursor pagination. It is full refresh: the endpoint exposes no timestamp usable as an incremental watermark. _(mechanical)_
- HiBob returns calendar fields under JSON-pointer keys like `/employeeCalendar/employeeId`; these are flattened to leaf column names (`employeeId`). _(mechanical)_
- Adds canonical column descriptions for the new table and ticks the endpoint in `COVERAGE_GAPS_APPENDIX.md`. _(mechanical)_

**Endpoint verification.** Both announced endpoints were checked against HiBob's official API reference before building:

- `time-off-calendars` → `POST /timeoff/calendars/employees/search` ("Find employee calendars"). Real, returns HR data — **implemented**.
- `skills` (Bob Skills API) → **skipped**. It is a push/sync management surface: every operation is over *API-origin* skills (`POST /skills` create, `PATCH /skills` update, `PATCH /skills/archive`, `POST /skills/search`, plus `GET /skills/proficiency-levels` reference metadata). There is no endpoint to read an employee's actual skill assignments, so a warehouse table would be empty for any customer not pushing skills in through the API — nothing to sync.

No source form fields changed, so generated configs and schema types are untouched. `get_schemas` still does no I/O (the fan-out runs only at sync time), so the source stays safe for public-docs table listing.

## How did you test this code?

Automated only — this environment has no HiBob account, so the live API was not called and no manual sync was run. The fan-out request/response shape was verified against HiBob's published API reference.

Added four transport tests in `test_hibob.py` (`TestTimeOffCalendars`), each catching a regression no existing test did:

- key normalization + the search filter body shape — catches a broken JSON-pointer flatten or a malformed `filters` payload the API would 400 on;
- cursor pagination termination — catches an infinite loop or dropped pages;
- the 5000-id batch split — catches the `tooManyEmployeeIds` cause;
- fail-loud on a 401 — catches a silent auth failure that would trip HiBob's WAF.

The existing parameterized `test_response_metadata_per_endpoint` now also covers the new endpoint's `SourceResponse` metadata. All HiBob tests pass locally; CI reports authoritative counts.

`hogli review` (local Greptile) could not run — the Greptile CLI is not installed in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The HiBob source doc's Supported tables section is generated from the source's schema catalog, so the new table appears without a manual doc edit.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (`claude-opus-4-8`). Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-pr-descriptions`.

The source list came from automated changelog research, so each endpoint was re-verified against HiBob's official API reference. `skills` was dropped after that check showed it is a write/management API with no readable employee-skills data. `time_off_calendars` needed bespoke transport — the source's other endpoints are single-page reads, but this one requires fanning out employee ids into a POST search — so it is routed by name to a hand-rolled iterator that still rides the tracked session, rather than the shared single-page path.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
