### PR TITLE
feat(warehouse_sources): add Smartsheet report_columns and report_scope tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -7684,10 +7684,12 @@ Note: The public smartreach.io/api_docs page only documents campaigns + prospect
 
 ## Smartsheet — **thin**
 
-Today (6): `contacts`, `reports`, `sheets`, `templates`, `users`, `workspaces`
+Today (8): `contacts`, `report_columns`, `report_scope`, `reports`, `sheets`, `templates`, `users`, `workspaces`
 
 Diffed against: <https://developers.smartsheet.com/sitemap.xml>
 
+- [x] `GET /reports/{reportId}/columns` — the columns of every report (title, type, index), fanned out across all reports (announced Jul-09-2026)
+- [x] `GET /reports/{reportId}/scope` — each report's source sheets and workspaces, fanned out across all reports (announced Jul-09-2026)
 - [ ] `GET /sheets/{sheetId} (rows + cells)` — the actual row/cell data inside every sheet - today only sheet metadata is synced, so no sheet content is queryable (high)
 - [ ] `GET /sheets/{sheetId}/columns` — lookup resolving the column ids that every cell references, including picklist options (high)
 - [ ] `GET /events (list-events, list-filtered-events)` — the org-wide activity event stream - who changed what and when (high)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/canonical_descriptions.py
@@ -80,4 +80,29 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "type": "The type of object the template creates (e.g. sheet).",
         },
     },
+    "report_columns": {
+        "description": "A column in a report — one per report the account can access, fanned out across every report.",
+        "docs_url": "https://developers.smartsheet.com/api/smartsheet/openapi/reports/listreportcolumns",
+        "columns": {
+            "reportId": "Identifier of the report this column belongs to.",
+            "virtualId": "The virtual ID of the report column, unique within its report.",
+            "title": "The column's title.",
+            "type": "The column type (e.g. TEXT_NUMBER, DATE, CONTACT_LIST, CHECKBOX).",
+            "systemColumnType": "The system column type, if any (e.g. CREATED_BY, MODIFIED_DATE, AUTO_NUMBER).",
+            "index": "Zero-based position of the column within the report.",
+            "primary": "Whether this is the report's primary column.",
+            "sheetNameColumn": "Whether this is the special sheet-name column identifying each row's source sheet.",
+            "hidden": "Whether the column is hidden.",
+            "width": "Display width of the column, in pixels.",
+        },
+    },
+    "report_scope": {
+        "description": "The scope of a report — its source sheets and source workspaces, fanned out across every report.",
+        "docs_url": "https://developers.smartsheet.com/api/smartsheet/openapi/reports/getreportscope",
+        "columns": {
+            "reportId": "Identifier of the report this scope entry belongs to.",
+            "assetType": "The kind of source asset, either 'sheet' or 'workspace'.",
+            "assetId": "Identifier of the source asset, according to its assetType.",
+        },
+    },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/settings.py
@@ -1,17 +1,28 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    DependentEndpointConfig,
+)
 from products.warehouse_sources.backend.types import IncrementalField
 
-# Smartsheet's list endpoints all share the same offset-based pagination envelope
-# ({pageNumber, pageSize, totalPages, totalCount, data: [...]}). We model each as a
-# top-level resource and full-refresh it on every sync.
+# Smartsheet's account-level list endpoints share the same page-based envelope
+# ({pageNumber, pageSize, totalPages, totalCount, data: [...]}). We model each as a top-level
+# resource and full-refresh it on every sync.
 #
-# Incremental sync is intentionally not enabled. Although `List Sheets` / `List Reports`
-# document a `modifiedSince` server-side filter, these list endpoints expose no stable
-# `sort` parameter, so we cannot guarantee the ascending ordering the pipeline relies on
-# to advance an incremental watermark safely across resumed syncs. The payloads here are
-# small (account-level metadata listings), so a full refresh is cheap and correct.
+# The report child endpoints (report_columns / report_scope) are different: they fan out from
+# each report and page by token (`lastKey` / `maxItems`) rather than page number — see smartsheet.py.
+#
+# Incremental sync is intentionally not enabled anywhere. Although `List Sheets` / `List Reports`
+# document a `modifiedSince` server-side filter, these list endpoints expose no stable `sort`
+# parameter, so we cannot guarantee the ascending ordering the pipeline relies on to advance an
+# incremental watermark safely across resumed syncs. The report child endpoints expose no
+# timestamp filter at all. The payloads here are small (account-level metadata and per-report
+# structure), so a full refresh is cheap and correct.
+
+# The report child endpoints page by token; `maxItems` default and minimum is 100. The `reports`
+# parent walk keeps the same 100-row page size the top-level `reports` endpoint uses.
+PAGE_SIZE = 100
 
 
 @dataclass
@@ -19,10 +30,30 @@ class SmartsheetEndpointConfig:
     name: str
     path: str
     incremental_fields: list[IncrementalField]
-    primary_key: str = "id"
+    primary_key: str | list[str] = "id"
     # A stable creation-date field used for datetime partitioning. Only set it where the
     # list response is documented to return it on every row.
     partition_key: Optional[str] = None
+    # Fan-out plumbing for the report child endpoints. `default_incremental_field` and
+    # `page_size` satisfy the shared dependent-resource builder's endpoint protocol; both stay
+    # at their defaults because these endpoints are full refresh.
+    default_incremental_field: Optional[str] = None
+    page_size: int = PAGE_SIZE
+    fanout: Optional[DependentEndpointConfig] = None
+
+
+# The parent-report id injected into each report child row (via include_from_parent), used as the
+# leading component of the child's composite key. Report-scoped ids repeat across reports, so the
+# report id is what makes each key unique table-wide.
+_REPORT_PARENT_FANOUT = DependentEndpointConfig(
+    parent_name="reports",
+    resolve_param="report_id",
+    resolve_field="id",
+    include_from_parent=["id"],
+    parent_field_renames={"id": "reportId"},
+    parent_params={"pageSize": PAGE_SIZE},
+    child_params={"maxItems": PAGE_SIZE},
+)
 
 
 SMARTSHEET_ENDPOINTS: dict[str, SmartsheetEndpointConfig] = {
@@ -57,6 +88,24 @@ SMARTSHEET_ENDPOINTS: dict[str, SmartsheetEndpointConfig] = {
         name="templates",
         path="/templates",
         incremental_fields=[],
+    ),
+    "report_columns": SmartsheetEndpointConfig(
+        name="report_columns",
+        path="/reports/{report_id}/columns",
+        incremental_fields=[],
+        # `virtualId` addresses a report column (GET /reports/{reportId}/columns/{columnVirtualId})
+        # but is unique only within its report, so the parent report id leads the key.
+        primary_key=["reportId", "virtualId"],
+        fanout=_REPORT_PARENT_FANOUT,
+    ),
+    "report_scope": SmartsheetEndpointConfig(
+        name="report_scope",
+        path="/reports/{report_id}/scope",
+        incremental_fields=[],
+        # A scope row is one source sheet or workspace of a report; assetId is unique only within
+        # its assetType, so the key spans the report id, the asset type, and the asset id.
+        primary_key=["reportId", "assetType", "assetId"],
+        fanout=_REPORT_PARENT_FANOUT,
     ),
 }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/settings.py
@@ -25,7 +25,9 @@ from products.warehouse_sources.backend.types import IncrementalField
 PAGE_SIZE = 100
 
 
-@dataclass
+# Mutable so instances satisfy the shared FanoutEndpointLike protocol, which declares settable
+# attributes; a frozen dataclass would fail that structural check.
+@dataclass(frozen=False)
 class SmartsheetEndpointConfig:
     name: str
     path: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/smartsheet.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/smartsheet.py
@@ -1,22 +1,30 @@
 import dataclasses
-from typing import Any, Optional
+from collections.abc import Iterable
+from typing import Any, Optional, cast
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
     RESTAPIConfig,
     rest_api_resource,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout import (
+    build_dependent_resource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
     PageNumberPaginator,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import ClientConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
-from products.warehouse_sources.backend.temporal.data_imports.sources.smartsheet.settings import SMARTSHEET_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.smartsheet.settings import (
+    PAGE_SIZE,
+    SMARTSHEET_ENDPOINTS,
+    SmartsheetEndpointConfig,
+)
 
 SMARTSHEET_BASE_URL = "https://api.smartsheet.com/2.0"
-# Smartsheet list endpoints page with `page` (1-based) and `pageSize` (max 100).
-PAGE_SIZE = 100
 
 
 @dataclasses.dataclass
@@ -31,6 +39,66 @@ def _non_secret_headers() -> dict[str, str]:
     return {"Accept": "application/json"}
 
 
+def _client_config(access_token: str) -> ClientConfig:
+    return {
+        "base_url": SMARTSHEET_BASE_URL,
+        "headers": _non_secret_headers(),
+        "auth": {"type": "bearer", "token": access_token},
+    }
+
+
+def _primary_keys(config: SmartsheetEndpointConfig) -> list[str]:
+    return config.primary_key if isinstance(config.primary_key, list) else [config.primary_key]
+
+
+def _report_fanout_source(
+    access_token: str,
+    endpoint: str,
+    config: SmartsheetEndpointConfig,
+    team_id: int,
+    job_id: str,
+) -> SourceResponse:
+    """Fan out from each report to its per-report structure (columns or scope).
+
+    The `reports` parent walks the account's reports page-by-page; each child request resolves a
+    report id into its path and pages by token (`lastKey`) until Smartsheet omits the key. These
+    endpoints carry no timestamp, so the child full-refreshes and resume is not wired.
+    """
+    assert config.fanout is not None
+    dependent_resource = cast(
+        Iterable[Any],
+        build_dependent_resource(
+            endpoint_configs=SMARTSHEET_ENDPOINTS,
+            child_endpoint=endpoint,
+            fanout=config.fanout,
+            client_config=_client_config(access_token),
+            path_format_values={},
+            team_id=team_id,
+            job_id=job_id,
+            db_incremental_field_last_value=None,
+            # Parent uses `pageSize`, child uses `maxItems`; both are supplied through the fan-out
+            # config's parent_params / child_params rather than a shared page-size param.
+            page_size_param=None,
+            parent_endpoint_extra={
+                "paginator": PageNumberPaginator(base_page=1, page_param="page", total_path="totalPages"),
+                "data_selector": "data",
+            },
+            child_endpoint_extra={
+                "paginator": JSONResponseCursorPaginator(cursor_path="lastKey", cursor_param="lastKey"),
+                "data_selector": "data",
+            },
+        ),
+    )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: dependent_resource,
+        primary_keys=_primary_keys(config),
+        partition_count=1,
+        partition_size=1,
+    )
+
+
 def smartsheet_source(
     access_token: str,
     endpoint: str,
@@ -41,14 +109,15 @@ def smartsheet_source(
 ) -> SourceResponse:
     config = SMARTSHEET_ENDPOINTS[endpoint]
 
+    if config.fanout is not None:
+        return _report_fanout_source(access_token, endpoint, config, team_id, job_id)
+
+    client_config = _client_config(access_token)
+    # Smartsheet returns the grand total of PAGES in `totalPages`; stop after the last one.
+    client_config["paginator"] = PageNumberPaginator(base_page=1, page_param="page", total_path="totalPages")
+
     rest_config: RESTAPIConfig = {
-        "client": {
-            "base_url": SMARTSHEET_BASE_URL,
-            "headers": _non_secret_headers(),
-            "auth": {"type": "bearer", "token": access_token},
-            # Smartsheet returns the grand total of PAGES in `totalPages`; stop after the last one.
-            "paginator": PageNumberPaginator(base_page=1, page_param="page", total_path="totalPages"),
-        },
+        "client": client_config,
         # Per-resource settings are fully specified below, so no shared defaults are needed.
         "resource_defaults": {},
         "resources": [
@@ -87,7 +156,7 @@ def smartsheet_source(
     return SourceResponse(
         name=endpoint,
         items=lambda: resource,
-        primary_keys=[config.primary_key],
+        primary_keys=_primary_keys(config),
         partition_count=1,
         partition_size=1,
         partition_mode="datetime" if config.partition_key else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/tests/test_smartsheet.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/smartsheet/tests/test_smartsheet.py
@@ -6,6 +6,10 @@ from unittest import mock
 
 from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
+    JSONResponseCursorPaginator,
+    PageNumberPaginator,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.smartsheet.settings import (
     ENDPOINTS,
     SMARTSHEET_ENDPOINTS,
@@ -16,6 +20,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.smartsheet
     smartsheet_source,
     validate_credentials,
 )
+
+# Endpoints that fan out from each report (parent id injected, token pagination).
+FANOUT_ENDPOINTS = [name for name, config in SMARTSHEET_ENDPOINTS.items() if config.fanout]
 
 # RESTClient builds its session via make_tracked_session in the rest_client module.
 CLIENT_SESSION_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
@@ -137,8 +144,9 @@ class TestSmartsheetSourceResponse:
         config = SMARTSHEET_ENDPOINTS[endpoint]
         response = _source(endpoint, _make_manager())
 
+        expected_keys = config.primary_key if isinstance(config.primary_key, list) else [config.primary_key]
         assert response.name == endpoint
-        assert response.primary_keys == [config.primary_key]
+        assert response.primary_keys == expected_keys
         assert response.sort_mode == "asc"
         if config.partition_key:
             assert response.partition_mode == "datetime"
@@ -182,3 +190,78 @@ class TestValidateCredentials:
     def test_validate_credentials_swallows_exceptions(self, mock_session) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
         assert validate_credentials("token") is False
+
+
+class _FakeDltResource:
+    """Stand-in for a dlt resource that applies add_map and iterates its rows."""
+
+    def __init__(self, name: str, rows: list[dict[str, Any]]) -> None:
+        self.name = name
+        self._rows = rows
+
+    def add_map(self, mapper):
+        self._rows = [mapper(dict(row)) for row in self._rows]
+        return self
+
+    def __iter__(self):
+        # Yield rows as a single page — the source iterates pages, matching the real engine.
+        yield self._rows
+
+
+class TestReportFanout:
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources"
+    )
+    def test_report_columns_row_carries_renamed_parent_id(self, mock_rest_api_resources) -> None:
+        mock_rest_api_resources.return_value = [
+            _FakeDltResource("reports", [{"id": 999}]),
+            _FakeDltResource("report_columns", [{"virtualId": 1, "title": "Status", "_reports_id": 999}]),
+        ]
+
+        response = _source("report_columns", _make_manager())
+        rows = _rows(response)
+
+        # The parent report id is injected and renamed to `reportId`, which leads the key so the
+        # per-report `virtualId` stays unique table-wide.
+        assert rows == [{"virtualId": 1, "title": "Status", "reportId": 999}]
+        assert response.primary_keys == ["reportId", "virtualId"]
+        assert response.partition_mode is None
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources"
+    )
+    def test_report_scope_row_carries_renamed_parent_id(self, mock_rest_api_resources) -> None:
+        mock_rest_api_resources.return_value = [
+            _FakeDltResource("reports", [{"id": 999}]),
+            _FakeDltResource("report_scope", [{"assetType": "sheet", "assetId": 42, "_reports_id": 999}]),
+        ]
+
+        response = _source("report_scope", _make_manager())
+        rows = _rows(response)
+
+        assert rows == [{"assetType": "sheet", "assetId": 42, "reportId": 999}]
+        assert response.primary_keys == ["reportId", "assetType", "assetId"]
+        assert response.partition_mode is None
+
+    @pytest.mark.parametrize("endpoint", FANOUT_ENDPOINTS)
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.smartsheet.smartsheet.build_dependent_resource"
+    )
+    def test_fanout_wires_two_paginators_and_no_watermark(self, mock_build, endpoint) -> None:
+        mock_build.return_value = iter([])
+
+        _source(endpoint, _make_manager())
+
+        kwargs = mock_build.call_args.kwargs
+        # Parent and child page differently, so no shared page-size param is used.
+        assert kwargs["page_size_param"] is None
+        parent_paginator = kwargs["parent_endpoint_extra"]["paginator"]
+        child_paginator = kwargs["child_endpoint_extra"]["paginator"]
+        assert isinstance(parent_paginator, PageNumberPaginator)
+        assert isinstance(child_paginator, JSONResponseCursorPaginator)
+        # The child pages by Smartsheet's `lastKey` token, not by page number.
+        assert child_paginator.cursor_param == "lastKey"
+        assert kwargs["parent_endpoint_extra"]["data_selector"] == "data"
+        assert kwargs["child_endpoint_extra"]["data_selector"] == "data"
+        # These endpoints have no timestamp filter, so they always full-refresh.
+        assert kwargs["db_incremental_field_last_value"] is None


### PR DESCRIPTION
## Problem

The Smartsheet data-warehouse source synced only account-level list metadata (sheets, reports, workspaces, users, contacts, templates). It had no table for a report's *structure*, so you could see that a report exists but not which columns it has or which sheets and workspaces feed it. Smartsheet's July 2026 API changelog added dedicated read endpoints for exactly that, and we had no table for either.

## Changes

Two new selectable Smartsheet tables, each fanned out across every report the account can access:

- **`report_columns`** — a row per column in each report (`title`, `type`, `index`, `virtualId`, and so on), from `GET /reports/{reportId}/columns`. Keyed on `[reportId, virtualId]`.
- **`report_scope`** — a row per source sheet or workspace that feeds each report (`assetType`, `assetId`), from `GET /reports/{reportId}/scope`. Keyed on `[reportId, assetType, assetId]`.

Both endpoints are children of the existing `reports` list: the sync walks reports page-by-page, then for each report pages its child endpoint by Smartsheet's token pagination (`lastKey` / `maxItems`) until the key is omitted. They're wired through the shared dependent-resource builder with a per-endpoint cursor paginator, so the parent keeps its page-number pagination while the children use the token cursor. The parent report id is injected into every child row and renamed to `reportId`, which leads each composite key — the report-scoped ids (`virtualId`, `assetId`) repeat across reports, so the report id is what keeps a key unique table-wide.

Both are **full refresh only**: neither endpoint exposes a server-side timestamp filter, so there is no stable cursor to sync incrementally against. Canonical column descriptions for both tables are documented from the API reference, so they render in the public "Supported tables" docs and feed the semantic layer without an LLM pass.

Mechanical: the shared `_client_config` / `_primary_keys` helpers factor out construction now used by both the top-level and fan-out paths; `PAGE_SIZE` moved into `settings.py` as the single source. The coverage appendix ticks both endpoints for this source.

### Endpoints verified, none skipped

Both endpoints in the request were checked against the official Smartsheet API reference before building and both exist on API 2.0 (announced Jul-09-2026): `GET /reports/{reportId}/columns` ("returns a paginated list of the columns in a report") and `GET /reports/{reportId}/scope` ("lists a report's scope — its source sheets and source workspaces"). Nothing was skipped.

## How did you test this code?

Automated only — I could not exercise the live Smartsheet API (no account/token in this environment). Added and ran unit tests in `smartsheet/tests/test_smartsheet.py`:

- Fan-out row shaping for both tables: the parent report id is injected and renamed to `reportId`, and the composite primary keys are `[reportId, virtualId]` / `[reportId, assetType, assetId]`.
- Fan-out wiring: the parent uses a page-number paginator and the child a `lastKey` cursor paginator, the child selects the `data` envelope, and no incremental watermark is passed (full refresh).

The existing per-endpoint metadata test now also covers both new endpoints (name, keys, no partition). Ran the source-catalog, source-version, and source-category invariant suites — all green. Token-pagination termination (stop when `lastKey` is absent) is covered by the shared `JSONResponseCursorPaginator` tests, so it isn't re-asserted here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The "Supported tables" section on posthog.com is generated from the source's schema catalog and canonical descriptions, so both new tables appear there automatically once this ships. No in-repo doc file to change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude) via the PostHog Desktop cloud-task flow. Skills invoked: `/implementing-warehouse-sources` (endpoint verification, fan-out and pagination conventions, test expectations), and the PR-writing and pre-PR-review guidance. `hogli review` was not available in this environment, so the local Greptile pass was skipped; the Greptile bot will still run on the PR.

Design decisions along the way: the two endpoints turned out to be fan-out children with **token** pagination, unlike the source's existing page-numbered top-level endpoints — so rather than the source's single-resource path, they route through the shared dependent-resource builder with a per-endpoint cursor paginator (the same shape `fillout` uses). Resume is deliberately not wired for the fan-out children: fan-out resume state is ambiguous and these payloads are small, so a full refresh with replace disposition is simpler and safe.

Public-artifact note: all sample data in the tests is invented (fake integer ids); no customer data, tokens, or session material is present in the diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
