### PR TITLE
feat(eng-analytics): read github deployments from the warehouse

### DIFF
--- a/products/engineering_analytics/README.md
+++ b/products/engineering_analytics/README.md
@@ -64,7 +64,7 @@ Return shapes are typed contracts whose caveats ride in honest field names (`ope
 ```mermaid
 graph LR
     subgraph "Data in"
-        WH[("warehouse: GitHub source<br/>pull_requests / workflow_runs<br/>workflow_jobs / team_members<br/>issue_events")]
+        WH[("warehouse: GitHub source<br/>pull_requests / workflow_runs<br/>workflow_jobs / team_members<br/>issue_events / deployments")]
         LOGS[("Logs: github-ci-logs<br/>thinned CI failure lines")]
         TRACES[("Traces: per-test CI spans<br/>emitted by Backend and Frontend CI")]
     end

--- a/products/engineering_analytics/SPEC.md
+++ b/products/engineering_analytics/SPEC.md
@@ -44,7 +44,7 @@ graph TB
     end
 
     subgraph Storage
-        WH[("warehouse: GitHub source<br/>pull_requests / workflow_runs<br/>workflow_jobs / team_members<br/>issue_events")]
+        WH[("warehouse: GitHub source<br/>pull_requests / workflow_runs<br/>workflow_jobs / team_members<br/>issue_events / deployments")]
         LOGS[("Logs: github-ci-logs<br/>thinned CI failure lines")]
         TRACES[("Traces: per-test CI spans<br/>from Backend and Frontend CI")]
     end
@@ -155,6 +155,10 @@ Warehouse tables (GitHub source):
 - `github_workflow_runs`: CI runs. Webhook-only (the webhook is the source of truth; history is a deliberate one-off backfill). A settled run never changes, so durations and trends are precise; until settled, `status` / `conclusion` mutate (see the freshness caveat).
 - `github_workflow_jobs`: per-job attempts (runner labels, queue and duration timestamps), the cost substrate. Webhook stream plus a window-limited backfill poll; per-run polling is infeasible at this volume.
 - `github_team_members`: org team membership, the author→team key. Optional at the source; every read that touches it must degrade gracefully when unsynced.
+- `github_deployments` + `github_deployment_statuses`: deploy requests and their state timelines, the substrate for merge-to-production timing.
+  A deployment row records only the request; the first `success` status on it is when the change went live, so the pair is read together and either half missing means no deploy data.
+  `production_environment` is optional in the GitHub API and many repos never set it, so the curated view falls back to the environment's name.
+  Optional, and reads must degrade gracefully when unsynced.
 - `github_issue_events`: immutable issue/PR state transitions, landed raw with every event type kept (a source-side filter would pin the desc-walk watermark). The draft/ready transitions in them back `ready_to_merge_seconds` and the lifecycle timeline. GitHub caps the endpoint's history walk, so rows cover a bounded recent window growing forward from the first sync; optional, and reads must degrade gracefully when unsynced.
 
 Other products read as sources:

--- a/products/engineering_analytics/backend/logic/queries/_curated.py
+++ b/products/engineering_analytics/backend/logic/queries/_curated.py
@@ -33,6 +33,7 @@ from products.engineering_analytics.backend.logic.sources import (
     resolve_trunk_merge_queue_table,
 )
 from products.engineering_analytics.backend.logic.views import (
+    deployments,
     issue_events,
     job_costs,
     pull_requests,
@@ -197,6 +198,18 @@ class CuratedGitHubSource:
         if not self._tables.team_members:
             return None
         return f"({team_members.build_query(self._tables.team_members)})"
+
+    def deployments_source(self) -> str | None:
+        """Curated deployments ``SELECT`` subquery, or None when the optional deployments and
+        deployment-statuses pair isn't synced. Either half missing degrades the same way: without
+        statuses a deployment never says whether it shipped."""
+        if not (self._tables.deployments and self._tables.deployment_statuses):
+            return None
+        query = deployments.build_query(
+            deployments_table=self._tables.deployments,
+            statuses_table=self._tables.deployment_statuses,
+        )
+        return f"({query})"
 
     def issue_events_source(self) -> str | None:
         """Curated PR draft/ready transitions ``SELECT`` subquery, or None when the optional

--- a/products/engineering_analytics/backend/logic/sources.py
+++ b/products/engineering_analytics/backend/logic/sources.py
@@ -53,11 +53,24 @@ TEAM_MEMBERS_SCHEMA = "team_members"
 # Immutable issue/PR events, the substrate for ready-to-merge timing. Optional at the source,
 # so reads must degrade gracefully (no transition data) exactly like workflow_jobs.
 ISSUE_EVENTS_SCHEMA = "issue_events"
+# Deploy requests and the statuses that make them live — the substrate for merge-to-production
+# timing. Only useful as a pair (a deployment alone never says whether it shipped), and optional
+# at the source, so reads degrade gracefully (no deploy stage) exactly like workflow_jobs.
+DEPLOYMENTS_SCHEMA = "deployments"
+DEPLOYMENT_STATUSES_SCHEMA = "deployment_statuses"
 
 # The curated endpoints we resolve per repo. A source's other synced endpoints (issues, commits,
 # teams, …) are irrelevant to the CI/PR read layer and dropped during grouping.
 _CURATED_ENDPOINTS = frozenset(
-    {PULL_REQUESTS_SCHEMA, WORKFLOW_RUNS_SCHEMA, WORKFLOW_JOBS_SCHEMA, TEAM_MEMBERS_SCHEMA, ISSUE_EVENTS_SCHEMA}
+    {
+        PULL_REQUESTS_SCHEMA,
+        WORKFLOW_RUNS_SCHEMA,
+        WORKFLOW_JOBS_SCHEMA,
+        TEAM_MEMBERS_SCHEMA,
+        ISSUE_EVENTS_SCHEMA,
+        DEPLOYMENTS_SCHEMA,
+        DEPLOYMENT_STATUSES_SCHEMA,
+    }
 )
 
 # Resolved names are interpolated into HogQL ``FROM`` clauses. Warehouse table names are
@@ -79,6 +92,10 @@ class GitHubTables:
     team_members: str | None = None
     # Optional: present only once issue events are synced; None means "no transition data".
     issue_events: str | None = None
+    # Optional pair: both are present only once deployments and their statuses are synced. Either
+    # one missing means "no deploy data" — a deployment without its statuses never says it shipped.
+    deployments: str | None = None
+    deployment_statuses: str | None = None
     # Used to scope cross-store reads such as CI traces to the selected source's repository.
     repository: str = ""
 
@@ -148,6 +165,8 @@ def resolve_github_tables(
                 workflow_jobs=tables.get(WORKFLOW_JOBS_SCHEMA),
                 team_members=tables.get(TEAM_MEMBERS_SCHEMA),
                 issue_events=tables.get(ISSUE_EVENTS_SCHEMA),
+                deployments=tables.get(DEPLOYMENTS_SCHEMA),
+                deployment_statuses=tables.get(DEPLOYMENT_STATUSES_SCHEMA),
                 repository=candidate.repository,
             )
     if source_id is not None:

--- a/products/engineering_analytics/backend/logic/views/deployments.py
+++ b/products/engineering_analytics/backend/logic/views/deployments.py
@@ -1,0 +1,38 @@
+"""Curated view over a repo's GitHub deployments, joined to the status that made them live.
+
+A deployment row records only the *request* to deploy a ref; the moment the change is actually
+serving is the first ``success`` status GitHub attaches to it. This builder collapses the pair into
+one row per deployment so consumers read a single "went live at" timestamp, and drops deployments
+that never succeeded — a deploy that failed or is still running never shipped anything.
+
+``is_production`` answers "does this environment serve users" from GitHub's own
+``production_environment`` flag, falling back to the environment's name. The flag is optional in
+the deployment API and many repos never set it, so a name test is the only thing left; consumers
+surface the environments they counted so a mis-classified name is visible rather than silent.
+"""
+
+SUCCESS_STATE = "success"
+
+# `prod`, `production`, and the regional/suffixed forms (`prod-us`, `production_eu`). Deliberately
+# anchored: `preview-pr-123` and `reproduction` must not read as production.
+_PRODUCTION_NAME_PATTERN = "^prod(uction)?([-_.].*)?$"
+
+
+def build_query(*, deployments_table: str, statuses_table: str) -> str:
+    """Curated SELECT over a repo's deployments: one row per deployment that reached ``success``,
+    carrying the request time, the go-live time, and whether the environment serves users."""
+    return f"""
+        SELECT environment, is_production, created_at, succeeded_at
+        FROM (
+            SELECT
+                d.environment AS environment,
+                (d.production_environment
+                    OR match(lower(d.environment), '{_PRODUCTION_NAME_PATTERN}')) AS is_production,
+                parseDateTimeBestEffort(d.created_at) AS created_at,
+                minIf(parseDateTimeBestEffort(s.created_at), s.state = '{SUCCESS_STATE}') AS succeeded_at
+            FROM {deployments_table} AS d
+            LEFT JOIN {statuses_table} AS s ON s.deployment_id = d.id
+            GROUP BY d.id, d.environment, d.production_environment, d.created_at
+        )
+        WHERE created_at IS NOT NULL AND succeeded_at IS NOT NULL
+    """

--- a/products/engineering_analytics/backend/logic/views/source_schema.py
+++ b/products/engineering_analytics/backend/logic/views/source_schema.py
@@ -122,3 +122,25 @@ TRUNK_MERGE_QUEUE_COLUMNS: dict[str, dict[str, str]] = {
     "skip_the_line": {"clickhouse": "Nullable(Bool)", "hogql": "BooleanDatabaseField"},
     "state_changed_at": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
 }
+
+# Deploy requests (``github_deployments``): one row per request to deploy a ref to an environment.
+# ``production_environment`` is optional in the GitHub API and many repos never set it, so the
+# curated view falls back to the environment's name. Same Nullable discipline as above.
+DEPLOYMENTS_COLUMNS: dict[str, dict[str, str]] = {
+    "id": {"clickhouse": "Nullable(Int64)", "hogql": "IntegerDatabaseField"},
+    "sha": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+    "ref": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+    "environment": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+    "production_environment": {"clickhouse": "Nullable(Bool)", "hogql": "BooleanDatabaseField"},
+    "created_at": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+}
+
+# Deploy status transitions (``github_deployment_statuses``): a deployment's state timeline, keyed
+# to its parent by ``deployment_id``. The first ``success`` row is when the change went live.
+DEPLOYMENT_STATUSES_COLUMNS: dict[str, dict[str, str]] = {
+    "id": {"clickhouse": "Nullable(Int64)", "hogql": "IntegerDatabaseField"},
+    "deployment_id": {"clickhouse": "Nullable(Int64)", "hogql": "IntegerDatabaseField"},
+    "state": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+    "environment": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+    "created_at": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
+}

--- a/products/engineering_analytics/backend/tests/_github_fixtures.py
+++ b/products/engineering_analytics/backend/tests/_github_fixtures.py
@@ -4,7 +4,7 @@ import os
 import json
 import zlib
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -16,6 +16,8 @@ import pandas as pd
 from posthog.models.team import Team
 
 from products.engineering_analytics.backend.logic.sources import (
+    DEPLOYMENT_STATUSES_SCHEMA,
+    DEPLOYMENTS_SCHEMA,
     ISSUE_EVENTS_SCHEMA,
     PULL_REQUESTS_SCHEMA,
     WORKFLOW_RUNS_SCHEMA,
@@ -118,28 +120,35 @@ def create_warehouse_table_row(
 
 
 def connect_github_source_without_data(
-    team: Team, *, prefix: str = GITHUB_SOURCE_PREFIX, repository: str = "", include_issue_events: bool = False
+    team: Team,
+    *,
+    prefix: str = GITHUB_SOURCE_PREFIX,
+    repository: str = "",
+    optional_endpoints: Iterable[str] = (),
 ) -> GitHubTables:
     """A GitHub source with pull_requests/workflow_runs schemas over empty ORM tables.
 
     The resolver finds these without touching object storage; pair with a mocked query
-    when only resolution (not real warehouse data) matters. ``include_issue_events``
-    links the optional issue-events schema too, activating the transition reads.
+    when only resolution (not real warehouse data) matters. ``optional_endpoints`` names
+    the extra schemas to link (``ISSUE_EVENTS_SCHEMA``, ``DEPLOYMENTS_SCHEMA``, ...),
+    activating the reads that degrade without them.
     """
     source = create_github_source(team, prefix=prefix, repository=repository)
     pr_table = create_warehouse_table_row(team, name=f"{prefix}github_pull_requests", source=source)
     run_table = create_warehouse_table_row(team, name=f"{prefix}github_workflow_runs", source=source)
     link_schema(team, source, name=PULL_REQUESTS_SCHEMA, table=pr_table)
     link_schema(team, source, name=WORKFLOW_RUNS_SCHEMA, table=run_table)
-    issue_events_table = None
-    if include_issue_events:
-        events_table = create_warehouse_table_row(team, name=f"{prefix}github_issue_events", source=source)
-        link_schema(team, source, name=ISSUE_EVENTS_SCHEMA, table=events_table)
-        issue_events_table = events_table.name
+    optional_tables: dict[str, str] = {}
+    for endpoint in optional_endpoints:
+        table = create_warehouse_table_row(team, name=f"{prefix}github_{endpoint}", source=source)
+        link_schema(team, source, name=endpoint, table=table)
+        optional_tables[endpoint] = table.name
     return GitHubTables(
         pull_requests=pr_table.name,
         workflow_runs=run_table.name,
-        issue_events=issue_events_table,
+        issue_events=optional_tables.get(ISSUE_EVENTS_SCHEMA),
+        deployments=optional_tables.get(DEPLOYMENTS_SCHEMA),
+        deployment_statuses=optional_tables.get(DEPLOYMENT_STATUSES_SCHEMA),
         repository=repository,
     )
 
@@ -225,6 +234,41 @@ def _issue_event_row(
         "event": event,
         "actor": _user(login),
         "issue": f'{{"number": {pr_number}}}',
+        "created_at": created_at,
+    }
+
+
+def _deployment_row(
+    deployment_id: int,
+    environment: str,
+    created_at: str,
+    *,
+    sha: str = "",
+    production_environment: bool = False,
+) -> dict[str, Any]:
+    return {
+        "id": deployment_id,
+        "sha": sha,
+        "ref": sha,
+        "environment": environment,
+        "production_environment": production_environment,
+        "created_at": created_at,
+    }
+
+
+def _deployment_status_row(
+    status_id: int,
+    deployment_id: int,
+    state: str,
+    created_at: str,
+    *,
+    environment: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": status_id,
+        "deployment_id": deployment_id,
+        "state": state,
+        "environment": environment,
         "created_at": created_at,
     }
 

--- a/products/engineering_analytics/backend/tests/test_logic_pull_requests.py
+++ b/products/engineering_analytics/backend/tests/test_logic_pull_requests.py
@@ -11,6 +11,7 @@ from parameterized import parameterized
 
 from products.engineering_analytics.backend.facade import api
 from products.engineering_analytics.backend.facade.contracts import MetricQuality, PRLifecycleEventKind, PRState
+from products.engineering_analytics.backend.logic.sources import ISSUE_EVENTS_SCHEMA
 from products.engineering_analytics.backend.logic.views.source_schema import (
     ISSUE_EVENTS_COLUMNS,
     PULL_REQUESTS_COLUMNS,
@@ -118,7 +119,7 @@ class TestPRLifecycleTransitionsMapping(BaseTest):
 
     def setUp(self) -> None:
         super().setUp()
-        connect_github_source_without_data(self.team, include_issue_events=True)
+        connect_github_source_without_data(self.team, optional_endpoints=[ISSUE_EVENTS_SCHEMA])
 
     def test_interleaves_transitions_with_actor_detail(self) -> None:
         header = _header("merged", merged_at=_dt("2026-01-12T15:00:00"))

--- a/products/engineering_analytics/backend/tests/test_logic_sources.py
+++ b/products/engineering_analytics/backend/tests/test_logic_sources.py
@@ -9,6 +9,8 @@ from posthog.models.team import Team
 from products.engineering_analytics.backend.facade import api
 from products.engineering_analytics.backend.facade.contracts import GitHubSource, GitHubSourceNotConnectedError
 from products.engineering_analytics.backend.logic.sources import (
+    DEPLOYMENT_STATUSES_SCHEMA,
+    DEPLOYMENTS_SCHEMA,
     PULL_REQUESTS_SCHEMA,
     WORKFLOW_JOBS_SCHEMA,
     WORKFLOW_RUNS_SCHEMA,
@@ -69,6 +71,22 @@ class TestResolveGitHubTables(BaseTest):
         assert tables == GitHubTables(
             pull_requests="myprefixgithub_pull_requests", workflow_runs="myprefixgithub_workflow_runs"
         )
+
+    def test_resolves_synced_optional_endpoints(self) -> None:
+        # The optional endpoints reach the resolved tables only if they are listed as curated
+        # endpoints; drop one and every read over it silently degrades to "not synced" instead
+        # of failing loudly.
+        self._connect(
+            prefix="myprefix",
+            schemas=[
+                *self._BOTH_SYNCED,
+                (DEPLOYMENTS_SCHEMA, True, True),
+                (DEPLOYMENT_STATUSES_SCHEMA, True, True),
+            ],
+        )
+        tables = resolve_github_tables(team=self.team)
+        assert tables.deployments == "myprefixgithub_deployments"
+        assert tables.deployment_statuses == "myprefixgithub_deployment_statuses"
 
     def test_repo_scoped_resolution_survives_non_dict_job_inputs(self) -> None:
         # job_inputs is an EncryptedJSONField that can hold any JSON value; the repo-first ordering


### PR DESCRIPTION
## Problem

Engineering analytics can follow a pull request up to the moment it merges and no further, so nobody can see how long a merged change waits before it serves production.

- The GitHub source already syncs `deployments` and `deployment_statuses`, but the read layer never resolved either table.
- SPEC listed deploys as deferred behind an events destination. That is out of date: the warehouse snapshot is enough.

This is the first of three layers. It only makes the tables readable. [The query](https://github.com/PostHog/posthog/pull/90117) and [the UI](https://github.com/PostHog/posthog/pull/90118) sit above it.

## Changes

- Nothing user-visible. This layer adds no surface a person can reach.
- `resolve_github_tables` now returns `deployments` and `deployment_statuses` when a repo has them synced, and `None` otherwise, like the other optional endpoints.
- A curated view collapses each deployment with its first `success` status into one row, and drops deployments that never succeeded. A deploy that failed or is still running shipped nothing.
- `is_production` reads GitHub's `production_environment` flag, falling back to the environment's name. The flag is optional in the deployment API and many repos never set it, so a name test is the only thing left. Consumers surface the environments they counted, which is what makes a wrong guess visible.
- `connect_github_source_without_data` takes `optional_endpoints` instead of one boolean per endpoint. Mechanical, 1 call site.
- SPEC and README record the new source and drop the deferred claim.

## How did you test this code?

- One resolver case in `test_logic_sources.py`. It catches dropping either endpoint from `_CURATED_ENDPOINTS`, which would leave every deploy read silently reporting "not synced" instead of failing.
- The classification rule is not asserted here. It has no observable behavior until the query lands, so its test lives in [the query layer](https://github.com/PostHog/posthog/pull/90117) where a preview environment can be seen not to count.
- The curated view was run against the real connected source before commit. It classified 2 environments as production and 1508 as not, with no false positives among previews, `dev`, or the pypi release environments.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The product docs do not cover the read layer's source list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this layer. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/writing-pr-descriptions`.

The session started from a question about whether PR open to merge queue, queue to merge, and merge to deploy were measurable today. Two of the three turned out not to be, which set the scope: this layer exists because the deploy leg was the only one with data nobody had wired up.

The pair is resolved independently but consumed together, in `deployments_source()`. Enforcing the pairing in the resolver as well would put the same rule in two places, so the resolver stays a faithful mirror of what is synced.

Local review: `hogli review` could not run (not signed in to Greptile), so the harness fallback ran instead. The bot review still applies; the `no-greptile` label is not set.

Public artifact: no customer conversations, tickets, or logs informed this work. The only figures quoted above come from PostHog's own public repository.
