### PR TITLE
feat(eng-analytics): measure open to gate and gate to merge legs

### DIFF
--- a/products/engineering_analytics/backend/facade/contracts.py
+++ b/products/engineering_analytics/backend/facade/contracts.py
@@ -17,7 +17,7 @@ with runtime validation on construction, so a mapper that hands back the wrong
 shape fails at the facade boundary instead of producing malformed JSON later.
 
 Provider-specific shapes (GitHub column names, nesting) never reach here — the
-read layer maps them into these types. Reviewers, deploys, and file paths are
+read layer maps them into these types. Reviewers and file paths are
 intentionally absent until the warehouse data that backs them lands.
 """
 
@@ -1111,6 +1111,46 @@ class ReadyToMergeBucket:
     p50_seconds: float | None
 
 
+class DeliveryStage(StrEnum):
+    """A pre-merge leg of a PR's path to production, named for the timestamps that bound it.
+
+    - ``OPEN_TO_GATE``: ``created_at`` to the PR's first merge-queue gate run starting; review,
+      rework, idle time, and the wait for a queue slot stay fused here.
+    - ``GATE_TO_MERGE``: that gate run starting to ``merged_at``.
+
+    The post-merge leg is ``DoraOverview.median_merge_to_deploy_seconds``.
+    """
+
+    OPEN_TO_GATE = "open_to_gate"
+    GATE_TO_MERGE = "gate_to_merge"
+
+
+@dataclass(frozen=True)
+class DeliveryStageTiming:
+    """One leg's timings over the PRs where both of its bounds were observed. ``pr_count`` is
+    that leg's own denominator: a PR that skipped the queue has no gate legs."""
+
+    stage: DeliveryStage
+    median_seconds: float | None
+    p90_seconds: float | None
+    pr_count: int
+
+
+@dataclass(frozen=True)
+class DeliveryPipeline:
+    """Where a change's wall-clock time goes between opening a PR and its merge.
+
+    Bots and drafts excluded, per the locked cycle-time recipe; the merge-queue fields on
+    ``RepoOverview`` count all authors instead. The leg medians do not sum to a cycle-time
+    median: a median of sums is not a sum of medians.
+    """
+
+    merged_pr_count: int
+    # A leg with no observed pair still ships, with a zero count and None timings, so a
+    # consumer renders the whole pipeline rather than a hole.
+    stages: list[DeliveryStageTiming]
+
+
 @dataclass(frozen=True)
 class RepoOverview:
     """Repo-level headline aggregates for the landing page, each with its previous-window twin
@@ -1217,6 +1257,8 @@ class RepoOverview:
     ready_to_merge_series: list[ReadyToMergeBucket]
     # Bucket width of `ready_to_merge_series`, chosen to fit the window: 'hour', 'day', or 'week'.
     ready_to_merge_series_granularity: str
+    # Bots and drafts excluded, unlike the headline counts above.
+    delivery_pipeline: DeliveryPipeline
 
 
 @dataclass(frozen=True)

--- a/products/engineering_analytics/backend/logic/merge_queue.py
+++ b/products/engineering_analytics/backend/logic/merge_queue.py
@@ -34,6 +34,8 @@ A queue that batched several PRs onto one gate branch would break the one-PR ass
 shape above does — batching would need a new shape here, not a new rule at each call site.
 """
 
+from datetime import timedelta
+
 # Both shapes carry the source PR as a ``pr-<number>`` segment; the trailing separator ('/' before
 # Trunk's uuid, '-' before GitHub's sha) is what ends the digit run. ``[0-9]`` rather than ``\d``
 # keeps the pattern backslash-free, so it survives embedding in a HogQL string literal unescaped.
@@ -42,6 +44,12 @@ _SOURCE_PR_PATTERN = "^(?:trunk-merge/|gh-readonly-queue/[^/]+/)pr-([0-9]+)[/-]"
 # The identities a real merge queue acts as. GitHub's native queue pushes gate branches without
 # opening a PR, so only Trunk needs an entry today.
 MERGE_QUEUE_BOT_HANDLES: frozenset[str] = frozenset({"trunk-io[bot]"})
+
+# How far behind a merge population's start the gate-run scan reaches. Gate runs start
+# minutes-to-hours before their merge; dwell beyond this truncates honestly, because the first
+# OBSERVED gate run anchors every gate measure. One bound for every gate read, so two surfaces
+# cannot split the same PR's legs differently.
+GATE_RUN_LOOKBACK = timedelta(days=7)
 
 
 # Both helpers ``ifNull`` their input, and that is load-bearing rather than defensive: a branch or

--- a/products/engineering_analytics/backend/logic/queries/delivery_pipeline.py
+++ b/products/engineering_analytics/backend/logic/queries/delivery_pipeline.py
@@ -1,0 +1,142 @@
+"""Curated query: the pre-merge legs of a PR's path to production.
+
+``created_at`` -> first merge-queue gate run starting -> ``merged_at``.
+
+Nothing records when a PR entered the queue (Trunk keeps only each entry's last transition), so
+the first gate run starting is the earliest queue activity in the data; review, rework, idle,
+and the wait for a slot stay fused in one leg.
+
+The post-merge leg is the DORA lead-time read in ``dora.py``: a deploy timestamp alone cannot
+say which merges a deploy contains. Bots and drafts are excluded (the locked cycle-time recipe),
+unlike the merge-queue overview, which measures the queue over every author.
+"""
+
+from datetime import datetime
+
+from posthog.hogql import ast
+
+from posthog.dataclasses import frozen
+
+from products.engineering_analytics.backend.facade.contracts import DeliveryPipeline, DeliveryStage, DeliveryStageTiming
+from products.engineering_analytics.backend.logic.merge_queue import GATE_RUN_LOOKBACK
+from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource, opt_float
+from products.engineering_analytics.backend.logic.queries._workflow_filters import (
+    date_to_filter_clause,
+    run_started_floor_constant,
+)
+
+_HUMAN_MERGES = "NOT pr.is_bot AND NOT pr.is_draft"
+
+# An outer join lands NULL or the epoch for a missed row depending on ``join_use_nulls``.
+_EPOCH = "toDateTime(0)"
+
+
+def _observed(expr: str) -> str:
+    return f"nullIf(ifNull({expr}, {_EPOCH}), {_EPOCH})"
+
+
+_PIPELINE_SELECT = f"""
+    WITH
+        gate_by_pr AS (
+            SELECT pr_number, min(run_started_at) AS first_gate_at
+            FROM __RUNS_SOURCE__ AS r
+            WHERE r.is_merge_queue AND r.run_started_at >= {{gate_from}}
+            GROUP BY pr_number
+        ),
+        merged AS (
+            SELECT
+                pr.created_at AS opened_at,
+                pr.merged_at AS merged_at,
+                {_observed("g.first_gate_at")} AS raw_gate_at
+            FROM __PR_SOURCE__ AS pr
+            LEFT JOIN gate_by_pr AS g ON g.pr_number = pr.number
+            WHERE pr.merged_at IS NOT NULL AND pr.merged_at >= {{date_from}} AND {_HUMAN_MERGES}
+                __DATE_TO_MERGED__
+        )
+    SELECT
+        count() AS merged_prs,
+        countIf(gate_at IS NOT NULL) AS gate_prs,
+        quantileIf(0.5)(dateDiff('second', opened_at, gate_at), gate_at IS NOT NULL) AS open_to_gate_p50,
+        quantileIf(0.9)(dateDiff('second', opened_at, gate_at), gate_at IS NOT NULL) AS open_to_gate_p90,
+        quantileIf(0.5)(dateDiff('second', gate_at, merged_at), gate_at IS NOT NULL) AS gate_to_merge_p50,
+        quantileIf(0.9)(dateDiff('second', gate_at, merged_at), gate_at IS NOT NULL) AS gate_to_merge_p90
+    FROM (
+        SELECT
+            m.opened_at AS opened_at,
+            m.merged_at AS merged_at,
+            -- A gate run after the merge is the queue bisecting a later failure, not this PR landing.
+            if(m.raw_gate_at <= m.merged_at, m.raw_gate_at, NULL) AS gate_at
+        FROM merged AS m
+    )
+"""
+
+
+@frozen
+class _Timings:
+    median: float | None
+    p90: float | None
+    pr_count: int
+
+
+def _stage(stage: DeliveryStage, timings: _Timings) -> DeliveryStageTiming:
+    return DeliveryStageTiming(
+        stage=stage,
+        median_seconds=timings.median,
+        p90_seconds=timings.p90,
+        pr_count=timings.pr_count,
+    )
+
+
+def _empty() -> DeliveryPipeline:
+    return DeliveryPipeline(
+        merged_pr_count=0,
+        stages=[_stage(stage, _Timings(median=None, p90=None, pr_count=0)) for stage in DeliveryStage],
+    )
+
+
+def query_delivery_pipeline(
+    *,
+    curated: CuratedGitHubSource,
+    date_from: datetime,
+    date_to: datetime | None,
+) -> DeliveryPipeline:
+    """The open -> gate -> merge legs for [date_from, date_to], keyed on merge time."""
+    # A first attempt older than the lookback truncates honestly: the first observed gate run
+    # anchors both legs, the same rule as the merge-queue overview.
+    gate_from = date_from - GATE_RUN_LOOKBACK
+    placeholders: dict[str, ast.Expr] = {
+        "date_from": ast.Constant(value=date_from),
+        "gate_from": ast.Constant(value=gate_from),
+        "run_started_floor": run_started_floor_constant(gate_from),
+    }
+    date_to_merged_clause = date_to_filter_clause(date_to, placeholders, column="pr.merged_at")
+    sql = (
+        _PIPELINE_SELECT.replace("__RUNS_SOURCE__", curated.run_source(started_floor=True))
+        .replace("__PR_SOURCE__", curated.pr_source())
+        .replace("__DATE_TO_MERGED__", date_to_merged_clause)
+    )
+    response = curated.run(sql, query_type="engineering_analytics.delivery_pipeline", placeholders=placeholders)
+    if not response.results:
+        return _empty()
+    (
+        merged_prs,
+        gate_prs,
+        open_to_gate_p50,
+        open_to_gate_p90,
+        gate_to_merge_p50,
+        gate_to_merge_p90,
+    ) = response.results[0]
+    gate_count = int(gate_prs or 0)
+    return DeliveryPipeline(
+        merged_pr_count=int(merged_prs or 0),
+        stages=[
+            _stage(
+                DeliveryStage.OPEN_TO_GATE,
+                _Timings(median=opt_float(open_to_gate_p50), p90=opt_float(open_to_gate_p90), pr_count=gate_count),
+            ),
+            _stage(
+                DeliveryStage.GATE_TO_MERGE,
+                _Timings(median=opt_float(gate_to_merge_p50), p90=opt_float(gate_to_merge_p90), pr_count=gate_count),
+            ),
+        ],
+    )

--- a/products/engineering_analytics/backend/logic/queries/merge_queue_overview.py
+++ b/products/engineering_analytics/backend/logic/queries/merge_queue_overview.py
@@ -12,22 +12,17 @@ table), ``query_merge_queue_trunk_outcomes`` reads the real verdicts instead.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from posthog.hogql import ast
 
-from products.engineering_analytics.backend.logic.merge_queue import gate_attempt_expr
+from products.engineering_analytics.backend.logic.merge_queue import GATE_RUN_LOOKBACK, gate_attempt_expr
 from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource, opt_float
 from products.engineering_analytics.backend.logic.queries._workflow_filters import (
     date_to_filter_clause,
     run_started_floor_constant,
     window_pair_predicates,
 )
-
-# Gate runs start minutes-to-hours before their merge; reach this far behind the previous window so
-# a PR merged just inside it keeps its first attempt. Dwell beyond this truncates honestly: the
-# first observed gate run anchors the measure.
-_GATE_LOOKBACK = timedelta(days=7)
 
 # Three layers so no SELECT reads an alias it defines: the inner select groups gate runs per source
 # PR, the middle names the per-PR measure, the outer splits the current and previous windows on
@@ -213,10 +208,10 @@ def query_merge_queue_overview(
     """Merge-queue landing stats for [date_from, date_to] and [prev_from, date_from], one scan.
 
     The population keys on ``merged_at`` like every merge median; gate runs are scanned from
-    ``prev_from - _GATE_LOOKBACK`` so a merge near the previous window's start keeps its early
+    ``prev_from - GATE_RUN_LOOKBACK`` so a merge near the previous window's start keeps its early
     attempts.
     """
-    gate_from = prev_from - _GATE_LOOKBACK
+    gate_from = prev_from - GATE_RUN_LOOKBACK
     windows = window_pair_predicates("merged_at", date_to=date_to)
     placeholders: dict[str, ast.Expr] = {
         "date_from": ast.Constant(value=date_from),

--- a/products/engineering_analytics/backend/logic/queries/repo_overview.py
+++ b/products/engineering_analytics/backend/logic/queries/repo_overview.py
@@ -40,6 +40,7 @@ from products.engineering_analytics.backend.logic.queries._workflow_filters impo
     run_started_floor_constant,
     window_pair_predicates,
 )
+from products.engineering_analytics.backend.logic.queries.delivery_pipeline import query_delivery_pipeline
 from products.engineering_analytics.backend.logic.queries.merge_queue_overview import (
     query_merge_queue_overview,
     query_merge_queue_trunk_outcomes,
@@ -483,6 +484,7 @@ def query_repo_overview(
     time_to_green = query_time_to_green_window(
         curated=curated, date_from=date_from, date_to=date_to, prev_from=prev_from
     )
+    pipeline = query_delivery_pipeline(curated=curated, date_from=date_from, date_to=date_to)
     costs = _derive_cost_headlines(
         query_workflow_window_costs_with_prev(
             curated=curated, date_from=date_from, date_to=date_to, prev_from=prev_from
@@ -547,4 +549,5 @@ def query_repo_overview(
         open_to_merge_series_granularity=series.granularity,
         ready_to_merge_series=series.ready_to_merge,
         ready_to_merge_series_granularity=series.granularity,
+        delivery_pipeline=pipeline,
     )

--- a/products/engineering_analytics/backend/presentation/serializers/workflows.py
+++ b/products/engineering_analytics/backend/presentation/serializers/workflows.py
@@ -5,6 +5,8 @@ from rest_framework_dataclasses.serializers import DataclassSerializer
 from products.engineering_analytics.backend.facade.contracts import (
     CostPerMergeBucket,
     CurrentBranchHealth,
+    DeliveryPipeline,
+    DeliveryStageTiming,
     MasterFailureGroup,
     OpenToMergeBucket,
     PassRateBucket,
@@ -324,6 +326,50 @@ class ReadyToMergeBucketSerializer(DataclassSerializer):
         }
 
 
+class DeliveryStageTimingSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = DeliveryStageTiming
+        extra_kwargs = {
+            "stage": {
+                "help_text": "Which leg this is: 'open_to_gate' (created_at to the PR's first "
+                "merge-queue gate run starting) or 'gate_to_merge' (that gate run to merged_at). "
+                "The post-merge leg is the DORA endpoint's median_merge_to_deploy_seconds."
+            },
+            "median_seconds": {
+                "help_text": "Median seconds for this leg. Null when no PR in the window has both "
+                "of its bounds observed.",
+                "allow_null": True,
+            },
+            "p90_seconds": {
+                "help_text": "90th-percentile seconds for this leg. Null when not observed.",
+                "allow_null": True,
+            },
+            "pr_count": {
+                "help_text": "PRs behind this leg's figures: those with an observed gate run. A PR "
+                "that skipped the merge queue has no gate legs, so read a median against this "
+                "count, not merged_pr_count."
+            },
+        }
+
+
+class DeliveryPipelineSerializer(DataclassSerializer):
+    stages = DeliveryStageTimingSerializer(
+        many=True,
+        help_text="The legs, ordered open to merge. A leg with nothing observed still appears, "
+        "with a zero pr_count and null timings. The leg medians do not sum to a cycle-time "
+        "median: a median of sums is not a sum of medians.",
+    )
+
+    class Meta:
+        dataclass = DeliveryPipeline
+        extra_kwargs = {
+            "merged_pr_count": {
+                "help_text": "PRs merged in the window with bots and drafts excluded. A narrower "
+                "population than RepoOverview.merged_pr_count, which counts all authors."
+            },
+        }
+
+
 class RepoOverviewSerializer(DataclassSerializer):
     cost_series = CostPerMergeBucketSerializer(
         many=True,
@@ -347,6 +393,10 @@ class RepoOverviewSerializer(DataclassSerializer):
         help_text="Median time-to-merge (p50 open_to_merge_seconds, bots/drafts excluded) per bucket across "
         "the window, oldest first, bucketed by open_to_merge_series_granularity. Empty buckets carry null; "
         "the whole series is empty when include_series=false.",
+    )
+    delivery_pipeline = DeliveryPipelineSerializer(
+        help_text="Where a change's wall-clock time goes on the way to production, over PRs merged "
+        "in the window with bots and drafts excluded."
     )
     ready_to_merge_series = ReadyToMergeBucketSerializer(
         many=True,

--- a/products/engineering_analytics/backend/tests/test_logic_workflows.py
+++ b/products/engineering_analytics/backend/tests/test_logic_workflows.py
@@ -10,6 +10,7 @@ from unittest import mock
 from parameterized import parameterized
 
 from products.engineering_analytics.backend.facade import api
+from products.engineering_analytics.backend.facade.contracts import DeliveryStage
 from products.engineering_analytics.backend.logic import build_workflow_health
 from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource
 from products.engineering_analytics.backend.logic.queries.pr_cost import query_cost_per_merge_series
@@ -278,6 +279,9 @@ class TestWorkflowEndpointsWarehouse(_EndpointsWarehouseMixin, BaseTest):
         assert overview.open_to_merge_series == []
         assert overview.ready_to_merge_series == []
         assert overview.cost_series_granularity == "day"  # the grain the series would have used
+        # No gate runs synced: the gate legs read unobserved, never zero.
+        assert overview.delivery_pipeline.merged_pr_count == 1
+        assert all(leg.median_seconds is None for leg in overview.delivery_pipeline.stages)
 
         with_series = api.get_repo_overview(team=self.team)
         assert len(with_series.cost_series) > 0  # zero-filled spine across the default -30d window
@@ -461,6 +465,67 @@ class TestWorkflowEndpointsWarehouse(_EndpointsWarehouseMixin, BaseTest):
         assert overview.merge_queue_trunk_available is False
         assert overview.merge_queue_failed_or_cancelled_share is None
         assert overview.merge_queue_skip_the_line_count is None
+
+    def test_repo_overview_delivery_pipeline_legs(self) -> None:
+        # Guards the two pre-merge legs end to end: a gate run that only ran after the merge is a
+        # bisection probe, so it carries no leg rather than a negative one.
+        self._create_table(
+            "github_pull_requests",
+            PULL_REQUESTS_COLUMNS,
+            [
+                _pr_row(90, "alice", "closed", 0, _ago(10), merged_at=_ago(4), head_sha="sha90"),
+                _pr_row(91, "bob", "closed", 0, _ago(9), merged_at=_ago(3), head_sha="sha91"),
+                _pr_row(92, "carol", "closed", 0, _ago(8), merged_at=_ago(6), head_sha="sha92"),
+            ],
+        )
+        self._create_table(
+            "github_workflow_runs",
+            WORKFLOW_RUNS_COLUMNS,
+            [
+                _run_row(
+                    9800,
+                    "CI",
+                    "g90",
+                    "completed",
+                    "success",
+                    _ago(5),
+                    _ago(5),
+                    head_branch="trunk-merge/pr-90/aaaa",
+                    actor="trunk-io[bot]",
+                ),
+                _run_row(
+                    9801,
+                    "CI",
+                    "g91",
+                    "completed",
+                    "success",
+                    _ago(4),
+                    _ago(4),
+                    head_branch="trunk-merge/pr-91/bbbb",
+                    actor="trunk-io[bot]",
+                ),
+                # PR 92 merged at -6d; this gate run at -2d is the queue bisecting a later failure.
+                _run_row(
+                    9802,
+                    "CI",
+                    "g92",
+                    "completed",
+                    "success",
+                    _ago(2),
+                    _ago(2),
+                    head_branch="trunk-merge/pr-92/cccc",
+                    actor="trunk-io[bot]",
+                ),
+            ],
+        )
+        pipeline = api.get_repo_overview(team=self.team, include_series=False).delivery_pipeline
+        assert pipeline.merged_pr_count == 3
+        legs = {leg.stage: leg for leg in pipeline.stages}
+        # PR 92's only gate run postdates its merge, so the gate legs see 90 and 91 only.
+        assert legs[DeliveryStage.OPEN_TO_GATE].pr_count == 2
+        assert legs[DeliveryStage.OPEN_TO_GATE].median_seconds == pytest.approx(5 * 86400)
+        assert legs[DeliveryStage.GATE_TO_MERGE].pr_count == 2
+        assert legs[DeliveryStage.GATE_TO_MERGE].median_seconds == pytest.approx(86400)
 
     def test_repo_overview_trunk_queue_outcomes(self) -> None:
         # Guards the Trunk-recorded outcomes: only concluded states enter the share's denominator,

--- a/products/engineering_analytics/backend/tests/test_presentation.py
+++ b/products/engineering_analytics/backend/tests/test_presentation.py
@@ -178,6 +178,20 @@ def _repo_overview() -> contracts.RepoOverview:
         open_to_merge_series_granularity="day",
         ready_to_merge_series=[],
         ready_to_merge_series_granularity="day",
+        delivery_pipeline=contracts.DeliveryPipeline(
+            merged_pr_count=38,
+            stages=[
+                contracts.DeliveryStageTiming(
+                    stage=contracts.DeliveryStage.OPEN_TO_GATE,
+                    median_seconds=58800.0,
+                    p90_seconds=180000.0,
+                    pr_count=36,
+                ),
+                contracts.DeliveryStageTiming(
+                    stage=contracts.DeliveryStage.GATE_TO_MERGE, median_seconds=1920.0, p90_seconds=11280.0, pr_count=36
+                ),
+            ],
+        ),
     )
 
 

--- a/products/engineering_analytics/frontend/generated/api.schemas.ts
+++ b/products/engineering_analytics/frontend/generated/api.schemas.ts
@@ -995,6 +995,45 @@ export interface OpenToMergeBucketApi {
     p50_seconds: number | null
 }
 
+/**
+ * * `open_to_gate` - OPEN_TO_GATE
+ * * `gate_to_merge` - GATE_TO_MERGE
+ */
+export type DeliveryStageTimingStageEnumApi =
+    (typeof DeliveryStageTimingStageEnumApi)[keyof typeof DeliveryStageTimingStageEnumApi]
+
+export const DeliveryStageTimingStageEnumApi = {
+    OpenToGate: 'open_to_gate',
+    GateToMerge: 'gate_to_merge',
+} as const
+
+export interface DeliveryStageTimingApi {
+    /** Which leg this is: 'open_to_gate' (created_at to the PR's first merge-queue gate run starting) or 'gate_to_merge' (that gate run to merged_at). The post-merge leg is the DORA endpoint's median_merge_to_deploy_seconds.
+     *
+     * * `open_to_gate` - OPEN_TO_GATE
+     * * `gate_to_merge` - GATE_TO_MERGE */
+    stage: DeliveryStageTimingStageEnumApi
+    /**
+     * Median seconds for this leg. Null when no PR in the window has both of its bounds observed.
+     * @nullable
+     */
+    median_seconds: number | null
+    /**
+     * 90th-percentile seconds for this leg. Null when not observed.
+     * @nullable
+     */
+    p90_seconds: number | null
+    /** PRs behind this leg's figures: those with an observed gate run. A PR that skipped the merge queue has no gate legs, so read a median against this count, not merged_pr_count. */
+    pr_count: number
+}
+
+export interface DeliveryPipelineApi {
+    /** The legs, ordered open to merge. A leg with nothing observed still appears, with a zero pr_count and null timings. The leg medians do not sum to a cycle-time median: a median of sums is not a sum of medians. */
+    stages: DeliveryStageTimingApi[]
+    /** PRs merged in the window with bots and drafts excluded. A narrower population than RepoOverview.merged_pr_count, which counts all authors. */
+    merged_pr_count: number
+}
+
 export interface ReadyToMergeBucketApi {
     /** Bucket start, aligned to ready_to_merge_series_granularity (top of hour, midnight, or Monday). */
     bucket_start: string
@@ -1014,6 +1053,8 @@ export interface RepoOverviewApi {
     success_rate_series: PassRateBucketApi[]
     /** Median time-to-merge (p50 open_to_merge_seconds, bots/drafts excluded) per bucket across the window, oldest first, bucketed by open_to_merge_series_granularity. Empty buckets carry null; the whole series is empty when include_series=false. */
     open_to_merge_series: OpenToMergeBucketApi[]
+    /** Where a change's wall-clock time goes on the way to production, over PRs merged in the window with bots and drafts excluded. */
+    delivery_pipeline: DeliveryPipelineApi
     /** Median cycle time (p50 per-PR ready_to_merge_seconds, bots/drafts excluded) per bucket across the window, oldest first, bucketed by ready_to_merge_series_granularity. Empty buckets carry null; the whole series is empty when the issue-events table isn't synced or include_series=false, so fall back to open_to_merge_series. */
     ready_to_merge_series: ReadyToMergeBucketApi[]
     /** Workflow runs started in the window, all branches and workflows. */

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.stories.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.stories.tsx
@@ -75,6 +75,13 @@ const OVERVIEW: RepoOverviewApi = {
     open_to_merge_series_granularity: 'day',
     ready_to_merge_series: [],
     ready_to_merge_series_granularity: 'day',
+    delivery_pipeline: {
+        merged_pr_count: 52,
+        stages: [
+            { stage: 'open_to_gate', median_seconds: 16 * 3600 + 18 * 60, p90_seconds: 4 * 86400, pr_count: 39 },
+            { stage: 'gate_to_merge', median_seconds: 30 * 60 + 42, p90_seconds: 3 * 3600 + 8 * 60, pr_count: 39 },
+        ],
+    },
 }
 
 const ACTIVITY: WorkflowRunActivityApi = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27051,6 +27051,45 @@ export namespace Schemas {
     }
 
     /**
+     * * `open_to_gate` - OPEN_TO_GATE
+     * * `gate_to_merge` - GATE_TO_MERGE
+     */
+    export type DeliveryStageTimingStageEnum = typeof DeliveryStageTimingStageEnum[keyof typeof DeliveryStageTimingStageEnum];
+
+
+    export const DeliveryStageTimingStageEnum = {
+      OpenToGate: 'open_to_gate',
+      GateToMerge: 'gate_to_merge',
+    } as const;
+
+    export interface DeliveryStageTiming {
+      /** Which leg this is: 'open_to_gate' (created_at to the PR's first merge-queue gate run starting) or 'gate_to_merge' (that gate run to merged_at). The post-merge leg is the DORA endpoint's median_merge_to_deploy_seconds.
+       *
+       * * `open_to_gate` - OPEN_TO_GATE
+       * * `gate_to_merge` - GATE_TO_MERGE */
+      stage: DeliveryStageTimingStageEnum;
+      /**
+         * Median seconds for this leg. Null when no PR in the window has both of its bounds observed.
+         * @nullable
+         */
+      median_seconds: number | null;
+      /**
+         * 90th-percentile seconds for this leg. Null when not observed.
+         * @nullable
+         */
+      p90_seconds: number | null;
+      /** PRs behind this leg's figures: those with an observed gate run. A PR that skipped the merge queue has no gate legs, so read a median against this count, not merged_pr_count. */
+      pr_count: number;
+    }
+
+    export interface DeliveryPipeline {
+      /** The legs, ordered open to merge. A leg with nothing observed still appears, with a zero pr_count and null timings. The leg medians do not sum to a cycle-time median: a median of sums is not a sum of medians. */
+      stages: DeliveryStageTiming[];
+      /** PRs merged in the window with bots and drafts excluded. A narrower population than RepoOverview.merged_pr_count, which counts all authors. */
+      merged_pr_count: number;
+    }
+
+    /**
      * * `pending` - Pending
      * * `generated` - Generated
      * * `delivered` - Delivered
@@ -73651,6 +73690,8 @@ export namespace Schemas {
       success_rate_series: PassRateBucket[];
       /** Median time-to-merge (p50 open_to_merge_seconds, bots/drafts excluded) per bucket across the window, oldest first, bucketed by open_to_merge_series_granularity. Empty buckets carry null; the whole series is empty when include_series=false. */
       open_to_merge_series: OpenToMergeBucket[];
+      /** Where a change's wall-clock time goes on the way to production, over PRs merged in the window with bots and drafts excluded. */
+      delivery_pipeline: DeliveryPipeline;
       /** Median cycle time (p50 per-PR ready_to_merge_seconds, bots/drafts excluded) per bucket across the window, oldest first, bucketed by ready_to_merge_series_granularity. Empty buckets carry null; the whole series is empty when the issue-events table isn't synced or include_series=false, so fall back to open_to_merge_series. */
       ready_to_merge_series: ReadyToMergeBucket[];
       /** Workflow runs started in the window, all branches and workflows. */


### PR DESCRIPTION
## Problem

- Nobody can see where a change's pre-merge time goes: time-to-merge fuses review, rework, and the queue wait into one number.
- Base of two layers, under [the PR-tab panel](https://github.com/PostHog/posthog/pull/90118). Rebased onto the DORA reads from [the Health tab PR](https://github.com/PostHog/posthog/pull/89744).

## Changes

- Nothing user-visible yet. `RepoOverview` gains `delivery_pipeline` with two legs: open to first gate run, and gate run to merge, bots and drafts excluded.
- The first gate run starting anchors the split. It is the earliest queue activity the data records.
- The post-merge leg stays in the DORA lead time read. A deploy timestamp cannot say what a deploy contains: first-deploy-requested-after-merge picked a pre-merge deploy for 74% of SHA-exact PRs on the connected source.

## How did you test this code?

- `test_repo_overview_delivery_pipeline_legs`: a post-merge bisection gate run carries no leg, never a negative one.
- DORA's containment rule reproduced independently on the connected source: 99.8% agreement with SHA-exact ground truth (n=604), 0-minute median error.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Agent-driven rebase and rework

- Rebased onto master after the DORA tab merged; the deployments layer below closed as redundant.
- The merge-to-live leg, its deploy plumbing, and the end-to-end median were dropped in favor of the DORA reads.
- Skills: /stacking-prs, /improving-drf-endpoints, /writing-tests, /writing-dataclasses, /writing-code-comments, /writing-pr-descriptions.
