### PR TITLE
fix(desktop): only show task cost for user-created tasks

### DIFF
--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -697,7 +697,11 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
           <PromptInput
             sessionId={taskId}
             toolbarEndSlot={
-              <ContextUsageIndicator usage={contextUsage} taskId={taskId} />
+              <ContextUsageIndicator
+                usage={contextUsage}
+                taskId={taskId}
+                originProduct={task.origin_product}
+              />
             }
             taskId={taskId}
             repoPath={repoPath}

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -78,6 +78,7 @@ describe("ContextUsageIndicator", () => {
           <ContextUsageIndicator
             usage={usage(overrides as Partial<ContextUsage>)}
             taskId="task-1"
+            originProduct={costEnabled ? "user_created" : undefined}
           />
         </Theme>,
       );
@@ -91,17 +92,42 @@ describe("ContextUsageIndicator", () => {
     enableCost(true);
     render(
       <Theme>
-        <ContextUsageIndicator usage={usage()} taskId="task-1" />
+        <ContextUsageIndicator
+          usage={usage()}
+          taskId="task-1"
+          originProduct="user_created"
+        />
       </Theme>,
     );
     expect(screen.getByText("$0.42")).toBeInTheDocument();
+  });
+
+  it("hides the cost for a task from another product", () => {
+    enableCost(true);
+    const { container } = render(
+      <Theme>
+        <ContextUsageIndicator
+          usage={usage()}
+          taskId="task-1"
+          originProduct="slack"
+        />
+      </Theme>,
+    );
+    expect(screen.queryByText("$0.42")).not.toBeInTheDocument();
+    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
+      "Context usage: 25%",
+    );
   });
 
   it("keeps the cost in the popover while the visible flag is off", () => {
     enableCost();
     render(
       <Theme>
-        <ContextUsageIndicator usage={usage()} taskId="task-1" />
+        <ContextUsageIndicator
+          usage={usage()}
+          taskId="task-1"
+          originProduct="user_created"
+        />
       </Theme>,
     );
     expect(screen.queryByText("$0.42")).not.toBeInTheDocument();

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -24,16 +24,23 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 interface ContextUsageIndicatorProps {
   usage: ContextUsage | null;
   taskId?: string;
+  originProduct?: string;
   focused?: boolean;
 }
 
 export function ContextUsageIndicator({
   usage,
   taskId,
+  originProduct,
   focused = true,
 }: ContextUsageIndicatorProps) {
+  const costEnabled = originProduct === "user_created";
   const costVisible = useFeatureFlag(TASK_COST_VISIBLE_FLAG);
-  const { data: taskUsage } = useTaskUsage(taskId, focused);
+  const { data: fetchedTaskUsage } = useTaskUsage(
+    taskId,
+    costEnabled && focused,
+  );
+  const taskUsage = costEnabled ? fetchedTaskUsage : undefined;
 
   if (!usage) return null;
 

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -933,6 +933,7 @@ export function SessionView({
                             <ContextUsageIndicator
                               usage={contextUsage}
                               taskId={taskId}
+                              originProduct={task?.origin_product}
                               focused={isActiveSession !== false}
                             />
                           }


### PR DESCRIPTION
## Problem

PostHog Desktop shows task cost for work filed by Slack, PostHog AI, self-driving agents, and other products.

Those tasks keep their source in `origin_product`, which the Desktop UI already receives with the task.

## Changes

- Desktop shows task cost only when `origin_product` is `user_created`.
- Sourced tasks keep the context usage indicator without the cost text or cost details.
- Desktop skips the usage request for sourced tasks.
- The task usage API, billing logic, and generated API types stay unchanged.

No screenshot: the changed state removes the existing cost from sourced tasks. The local app was not run.

## How did you test this code?

- The UI component test covers a Slack task with cached usage and verifies that no cost appears.
- The Desktop UI test suite passes.
- The full Desktop typecheck passes.
- Biome reports no issues in the changed files. The full-tree check reports existing warnings in other files.

Manual testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes an existing Desktop display rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop and pi updated this PR. Skills invoked: `/posthog-desktop`, `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/improving-drf-endpoints`, and `/writing-pr-descriptions`.

The initial approach changed the backend response contract. The final approach keeps the API stable and uses task metadata already available in the UI.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*