### PR TITLE
fix(desktop): keep cloud clones inside resume snapshots

### DIFF
--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.test.ts
@@ -10,7 +10,9 @@ vi.mock("../../../utils/github-token", () => ({
   resolveGithubToken: vi.fn(() => undefined),
 }));
 
-const { cloneRepoTool, GITHUB_AUTH_CONFIG_KEY } = await import("./clone-repo");
+const { cloneRepoTool, cloneRoot, GITHUB_AUTH_CONFIG_KEY } = await import(
+  "./clone-repo"
+);
 
 const REPO_URL = "https://github.com/PostHog/posthog.git";
 
@@ -19,6 +21,7 @@ describe("clone_repo", () => {
   let sourcePath: string;
   let targetPath: string;
   let previousConfigGlobal: string | undefined;
+  let previousIsSandbox: string | undefined;
 
   async function git(args: string[], repoPath: string): Promise<string> {
     const result = await execGit(args, { cwd: repoPath });
@@ -29,6 +32,8 @@ describe("clone_repo", () => {
   }
 
   beforeEach(async () => {
+    previousIsSandbox = process.env.IS_SANDBOX;
+    delete process.env.IS_SANDBOX;
     cwd = await mkdtemp(path.join(tmpdir(), "posthog-code-clone-tool-"));
     sourcePath = path.join(cwd, "source");
     targetPath = path.join(cwd, "repos", "PostHog", "posthog");
@@ -61,12 +66,23 @@ describe("clone_repo", () => {
   });
 
   afterEach(async () => {
+    if (previousIsSandbox === undefined) {
+      delete process.env.IS_SANDBOX;
+    } else {
+      process.env.IS_SANDBOX = previousIsSandbox;
+    }
     if (previousConfigGlobal === undefined) {
       delete process.env.GIT_CONFIG_GLOBAL;
     } else {
       process.env.GIT_CONFIG_GLOBAL = previousConfigGlobal;
     }
     await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("uses the snapshotted repository root in cloud sandboxes", () => {
+    process.env.IS_SANDBOX = "1";
+
+    expect(cloneRoot("/tmp/another-directory")).toBe("/tmp/workspace/repos");
   });
 
   it("clones one commit of the requested branch, without tags or a token in origin", async () => {

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.ts
@@ -13,6 +13,7 @@ import { defineLocalTool, type LocalToolResult } from "../registry";
 
 const GIT_TIMEOUT_MS = 10 * 60 * 1000;
 const GITHUB_BASE_URL = "https://github.com/";
+const CLOUD_CLONE_ROOT = "/tmp/workspace/repos";
 
 /**
  * Scoping the auth header to github.com is what keeps the token from being
@@ -65,6 +66,12 @@ function gitEnv(token: string | undefined): Record<string, string> {
  * cloning into.
  */
 const inFlight = new Map<string, Promise<LocalToolResult>>();
+
+export function cloneRoot(cwd: string): string {
+  return process.env.IS_SANDBOX === "1"
+    ? CLOUD_CLONE_ROOT
+    : path.join(cwd, "repos");
+}
 
 function withCloneLock(
   targetPath: string,
@@ -123,7 +130,7 @@ export const cloneRepoTool = defineLocalTool({
     }
     const slug = `${parsed.owner}/${parsed.repo}`;
     const repoName = parsed.repo;
-    const targetPath = path.join(ctx.cwd, "repos", slug);
+    const targetPath = path.join(cloneRoot(ctx.cwd), slug);
     const cloneUrl = `${GITHUB_BASE_URL}${slug}.git`;
 
     const git = (gitArgs: string[], cwd?: string): Promise<GitExecResult> =>


### PR DESCRIPTION
## Problem

Cloud clone destinations could follow a session cwd outside the snapshotted workspace, risking unpushed changes on resume.

## Changes

Cloud `clone_repo` calls now always use `/tmp/workspace/repos`. Local sessions keep their current clone root.


