### PR TITLE
fix(desktop): reject clone path symlink escapes

### DIFF
--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -183,6 +183,80 @@ describe("clone_repo", () => {
 
     expect(result.isError).toBe(true);
     expect(existsSync(keptCheckout)).toBe(true);
+  });
+
+  it("rejects an owner directory that escapes through a symlink", async () => {
+    const externalPath = path.join(cwd, "external");
+    await mkdir(path.join(cwd, "repos"), { recursive: true });
+    await mkdir(externalPath);
+    await symlink(externalPath, path.join(cwd, "repos", "PostHog"));
+
+    const result = await cloneRepoTool.handler(
+      { cwd, token: "test-token" },
+      { repo: "PostHog/posthog" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(path.join(externalPath, "posthog"))).toBe(false);
+  });
+
+  it("rejects a clone root symlink", async () => {
+    const externalPath = path.join(cwd, "external");
+    await mkdir(externalPath);
+    await symlink(externalPath, path.join(cwd, "repos"));
+
+    const result = await cloneRepoTool.handler(
+      { cwd, token: "test-token" },
+      { repo: "PostHog/posthog" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(path.join(externalPath, "PostHog"))).toBe(false);
+  });
+
+  it("rejects an existing target that escapes through a symlink", async () => {
+    const externalPath = path.join(cwd, "external");
+    await mkdir(path.join(cwd, "repos", "PostHog"), { recursive: true });
+    await mkdir(externalPath);
+    await symlink(externalPath, targetPath);
+
+    const result = await cloneRepoTool.handler(
+      { cwd, token: "test-token" },
+      { repo: "PostHog/posthog" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(path.join(externalPath, ".git"))).toBe(false);
+  });
+
+  it("does not follow an existing target symlink within the clone root", async () => {
+    const linkedPath = path.join(cwd, "repos", "Other", "keep");
+    const workPath = path.join(linkedPath, "work-in-progress.md");
+    await mkdir(linkedPath, { recursive: true });
+    await writeFile(workPath, "unsaved edits\n");
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await symlink(linkedPath, targetPath);
+
+    const result = await cloneRepoTool.handler(
+      { cwd, token: "test-token" },
+      { repo: "PostHog/posthog" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(workPath)).toBe(true);
+  });
+
+  it("reports filesystem setup failures separately", async () => {
+    await writeFile(path.join(cwd, "repos"), "not a directory\n");
+
+    const result = await cloneRepoTool.handler(
+      { cwd, token: "test-token" },
+      { repo: "PostHog/posthog" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("couldn't prepare");
+    expect(result.content[0].text).not.toContain("escapes");
   });
 
   // Regression: a reuse-path failure used to fail every subsequent call for

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/clone-repo.ts
@@ -73,6 +73,71 @@ export function cloneRoot(cwd: string): string {
     : path.join(cwd, "repos");
 }
 
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+class ClonePathEscapeError extends Error {}
+
+async function rejectSymlink(
+  targetPath: string,
+  allowMissing = false,
+): Promise<void> {
+  try {
+    const stats = await fsPromises.lstat(targetPath);
+    if (stats.isSymbolicLink()) {
+      throw new ClonePathEscapeError();
+    }
+  } catch (error) {
+    if (allowMissing && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function cloneTargetPath(
+  root: string,
+  owner: string,
+  repo: string,
+): Promise<string> {
+  await fsPromises.mkdir(root, { recursive: true });
+  await rejectSymlink(root);
+  const resolvedRoot = await fsPromises.realpath(root);
+  if (process.env.IS_SANDBOX === "1" && resolvedRoot !== CLOUD_CLONE_ROOT) {
+    throw new ClonePathEscapeError();
+  }
+
+  const ownerPath = path.join(root, owner);
+  await fsPromises.mkdir(ownerPath, { recursive: true });
+  await rejectSymlink(ownerPath);
+  const resolvedOwner = await fsPromises.realpath(ownerPath);
+  if (!isWithin(resolvedRoot, resolvedOwner)) {
+    throw new ClonePathEscapeError();
+  }
+
+  const targetPath = path.join(ownerPath, repo);
+  await rejectSymlink(targetPath, true);
+  try {
+    const resolvedTarget = await fsPromises.realpath(targetPath);
+    if (!isWithin(resolvedRoot, resolvedTarget)) {
+      throw new ClonePathEscapeError();
+    }
+    return targetPath;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return targetPath;
+    }
+    throw error;
+  }
+}
+
 function withCloneLock(
   targetPath: string,
   task: () => Promise<LocalToolResult>,
@@ -130,7 +195,23 @@ export const cloneRepoTool = defineLocalTool({
     }
     const slug = `${parsed.owner}/${parsed.repo}`;
     const repoName = parsed.repo;
-    const targetPath = path.join(cloneRoot(ctx.cwd), slug);
+    let targetPath: string;
+    try {
+      targetPath = await cloneTargetPath(
+        cloneRoot(ctx.cwd),
+        parsed.owner,
+        parsed.repo,
+      );
+    } catch (error) {
+      if (error instanceof ClonePathEscapeError) {
+        return fail("clone_repo: repository path escapes the clone root.");
+      }
+      return fail(
+        `clone_repo couldn't prepare the repository path: ${redact(
+          error instanceof Error ? error.message : String(error),
+        )}`,
+      );
+    }
     const cloneUrl = `${GITHUB_BASE_URL}${slug}.git`;
 
     const git = (gitArgs: string[], cwd?: string): Promise<GitExecResult> =>


### PR DESCRIPTION
## Problem

A replaced clone directory could redirect a cloud checkout outside the snapshotted workspace.

## Changes

`clone_repo` now resolves its root, owner, and existing target before use and rejects paths that escape through symlinks.


