### PR TITLE
feat(desktop): offer the ASD-STE100 skill in cost management

### DIFF
--- a/products/desktop/packages/core/src/billing/leanSkills.ts
+++ b/products/desktop/packages/core/src/billing/leanSkills.ts
@@ -12,6 +12,12 @@
  * system prompt. Its authors measured the same text as a skill folder at
  * -0.5%, so no one-click install can deliver it. Adopting it means shipping
  * the rules in the prompt every harness appends, which is its own change.
+ *
+ * Simplified Technical English is the weakest cost case here and sits last for
+ * that reason. Nobody has measured it, and its saving is indirect: text a model
+ * cannot misread is text it does not act on wrongly and then redo. It is a
+ * clarity tool first, so a rewrite that has to keep a hedge can come out longer
+ * than it went in. It earns its slot on rework, not on tokens.
  */
 
 export interface LeanSkill {
@@ -108,6 +114,22 @@ export const LEAN_SKILLS: readonly LeanSkill[] = [
     // The repository is MIT with several runtime directories carved out under
     // BSL-1.1. Only the MIT-covered skills directory is fetched.
     license: "MIT (skills directory)",
+  },
+  {
+    name: "Simplified Technical English",
+    source: "danyuchn/asd-ste100-skill",
+    ref: "d5ce157870cf9c41efd1d6e836706a2be3c7b9da",
+    skillId: "asd-ste100",
+    summary:
+      "Rewrites text an agent has to read so it carries one meaning, not two.",
+    approach:
+      'ASD-STE100, the controlled English that aerospace maintenance manuals are written in, aimed at the text a model parses with nobody nearby to ask what it meant: tool descriptions, error messages, prompts. One instruction per sentence, active voice, no phrasal verbs, twenty words for an instruction. It leaves hedges where it finds them, so "may have failed" does not become "failed", and it names the rules it cannot check without ASD\'s licensed dictionary rather than implying it checked them.',
+    example: {
+      ask: "Tightening a tool description",
+      without: "Perform an inspection of the filter.",
+      with: "Inspect the filter.",
+    },
+    license: "MIT",
   },
 ];
 

--- a/products/desktop/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.test.ts
@@ -77,6 +77,27 @@ describe("findSkillDirPrefix", () => {
   it("returns null when absent", () => {
     expect(findSkillDirPrefix({}, "commit")).toBeNull();
   });
+
+  // A repository that is one skill has no directory named after it, so the
+  // archive root is the skill directory.
+  it("falls back to the archive root when it declares the skill id", () => {
+    const entries = {
+      "asd-ste100-skill-HEAD/SKILL.md": strToU8("---\nname: asd-ste100\n---\n"),
+      "asd-ste100-skill-HEAD/references/writing-rules.md": strToU8("x"),
+    };
+
+    expect(findSkillDirPrefix(entries, "asd-ste100")).toBe(
+      "asd-ste100-skill-HEAD/",
+    );
+  });
+
+  it("leaves a root skill alone when it declares a different id", () => {
+    const entries = {
+      "repo-HEAD/SKILL.md": strToU8("---\nname: something-else\n---\n"),
+    };
+
+    expect(findSkillDirPrefix(entries, "asd-ste100")).toBeNull();
+  });
 });
 
 describe("collectSkillFiles", () => {

--- a/products/desktop/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -4,6 +4,7 @@ import { isIgnoredSkillPath, SKILL_EXISTS_MARKER } from "@posthog/shared";
 import type { Unzipped } from "fflate";
 import { injectable } from "inversify";
 import { unzipAsync } from "../posthog-plugin/extract-zip";
+import { parseSkillFrontmatter } from "../skills/parse-skill-frontmatter";
 import { getUserSkillsDir, isProbablyText } from "../skills/skill-discovery";
 import { validateSkillDirName } from "../skills/skills";
 import {
@@ -69,7 +70,8 @@ async function writeInstalledState(state: InstalledSkillsFile): Promise<void> {
 
 /**
  * Finds the archive prefix of the directory named `skillId` that contains a
- * SKILL.md, e.g. "repo-HEAD/skills/commit/". Prefers the shallowest match.
+ * SKILL.md, e.g. "repo-HEAD/skills/commit/". Prefers the shallowest match, and
+ * falls back to a repository that is itself one skill.
  */
 export function findSkillDirPrefix(
   entries: Unzipped,
@@ -80,8 +82,32 @@ export function findSkillDirPrefix(
     .filter((key) => key.endsWith(suffix))
     .sort((a, b) => a.split("/").length - b.split("/").length);
   const match = matches[0];
-  if (!match) return null;
-  return match.slice(0, match.length - "SKILL.md".length);
+  if (match) return match.slice(0, match.length - "SKILL.md".length);
+  return findRootSkillPrefix(entries, skillId);
+}
+
+/**
+ * The prefix for a repository that holds one skill rather than a collection of
+ * them: its SKILL.md sits at the top level, so no directory is named after the
+ * skill for the search above to find. codeload still wraps the tree in a single
+ * "<repo>-<ref>/" directory, which is the prefix to install from.
+ *
+ * The name the SKILL.md declares has to be the one being asked for. Without
+ * that check, asking a repository for a skill it does not have would install
+ * whichever single skill sat at its root under the requested name.
+ */
+function findRootSkillPrefix(
+  entries: Unzipped,
+  skillId: string,
+): string | null {
+  for (const [key, bytes] of Object.entries(entries)) {
+    const segments = key.split("/");
+    if (segments.length !== 2 || segments[1] !== "SKILL.md") continue;
+    const frontmatter = parseSkillFrontmatter(new TextDecoder().decode(bytes));
+    if (frontmatter?.name !== skillId) continue;
+    return `${segments[0]}/`;
+  }
+  return null;
 }
 
 /** Rejects zip entries that would escape the install directory (zip-slip). */


### PR DESCRIPTION
## Problem

- Cost management offers three skills to install in one click. ASD-STE100 is not one of them.
- That skill rewrites text an agent has to parse — tool descriptions, error messages, prompts — so it reads one way. A misread instruction costs a re-run.
- Listing it would not have been enough. The installer searches the archive for `<skillId>/SKILL.md`, and this repository keeps its SKILL.md at the top level, so the Install button would have thrown "Skill was not found".
- That limit hits every single-skill repository, including one a user finds through marketplace search.

## Changes

- Recommendations gains a fourth entry, "Simplified Technical English". Install and uninstall behave like the other three.
- The installer falls back to the archive root when no directory carries the skill's name.
- The root SKILL.md has to declare the id being asked for. Without that check, asking a repository for a skill it lacks would install its root skill under the wrong name.
- The entry states no measured saving, because the project publishes none. Inventing one would break the registry's rule that every figure names who measured it.
- It sits last, and the registry doc records why.
- No UI code changed. The row and the dialog are the existing components rendering a fourth data entry.

![the new entry's dialog](https://raw.githubusercontent.com/PostHog/pr-assets/1cf9ccb7e8471d44be9b7bf817bb9419f4c32f48/2026/08/5eb8b09b-8567-4b06-929a-d1f2873f6e8c.png)

> [!NOTE]
> This is the weakest fit in a section titled "Ways to spend less on your runs", and that is worth a second opinion before it ships. The other three change how the agent works by default. This one runs when someone asks it to rewrite something, so installing it moves no number on its own. Its own worked example comes out longer, 28 words to 31, because it keeps a hedge the original had. Listing it in the skills marketplace instead would be a smaller change than this one.

## How did you test this code?

- Two cases lock the new fallback in both directions: a root SKILL.md that declares the id resolves to the archive root, one that declares a different id still returns null. The second is the one that matters, since a loose fallback would mis-install.
- Ran the real archive at the pinned commit through `findSkillDirPrefix` and `collectSkillFiles`. The prefix resolves to `asd-ste100-skill-d5ce157.../`, and the install collects SKILL.md, README.md, LICENSE, `examples/` and `references/`. That check needed the network, so it was a throwaway and is not committed.
- Not run: the desktop app. The screenshot above comes from Storybook, with the dialog story pointed at the new entry.
- The `workspace-server` suite reports 100 failures in this sandbox that this change does not cause. A clean tree gives the same 100; this adds 2 passing tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested in Slack by Paul D'Ambra. The PR is unassigned because his GitHub handle was not confirmed in the thread, so it needs assigning rather than triaging as autonomous work.

Authored by the PostHog Slack app. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The ask read as a one-line data change. Downloading the repository's real archive showed `findSkillDirPrefix` could not resolve it, which is where most of this diff went. Reading the upstream README and SKILL.md turned up no cost or token claim anywhere, so the entry carries no trial block, and the reservation above is recorded in the registry doc rather than left for a reviewer to notice.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1787742840832139?thread_ts=1787742840.832139&cid=C0ACRAMJUAG)*
