### PR TITLE
feat(notebooks): keep AI questions with answers

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/COMPONENTS.md
+++ b/frontend/src/lib/components/MarkdownNotebook/COMPONENTS.md
@@ -276,7 +276,7 @@ Generated charts and freeform widgets should use an isolated renderer based on t
 ## Reserved tags
 
 Do not reuse the tags of the default registry (`registry.tsx`): `Query`, `Image`, `Divider`, `Embed`, `Latex`, `Python`, `DuckSQL`, `HogQLSQL`, `RecordingPlaylist`, `FeatureFlag`, `Experiment`, `Survey`, `Person`, `Group`, `Cohort`, `Map`.
-The internal AI tag `Prompt` is also reserved (registered by the notebooks scene).
+The internal AI tag `Prompt` is also reserved (registered by the notebooks scene). Its `keepQuestion` boolean prop keeps the submitted question, with the submitting user's name, directly above the generated answer.
 `Image` and `Divider` are special: they serialize back to plain markdown (`![alt](src)` and `---`) rather than component-tag syntax.
 `Comment` is special too: its authorial-note flavor (`text` prop) serializes as a markdown `<!-- … -->` comment, while its discussion flavor (`ref` + `replies` props, a Google Docs-style thread anchored to an inline `<ref id="…">` highlight) serializes as a regular `<Comment … />` tag.
 The lowercase inline tags `<ref>` and `<mention>` are part of the inline grammar, not components — component tags must start with an uppercase letter.

--- a/frontend/src/lib/components/MarkdownNotebook/EditablePromptComponent.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/EditablePromptComponent.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { KeyboardEvent, MutableRefObject, useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconSend, IconTrash } from '@posthog/icons'
+import { IconBookmark, IconBookmarkSolid, IconSend, IconTrash } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { getNotebookStringProp, isPromptComponentNode } from './documentModel'
@@ -37,6 +37,7 @@ export function EditablePromptComponent({
     const handledFocusRequestRef = useRef<number | undefined>(undefined)
     const [isCollapsed, setIsCollapsed] = useState(false)
     const question = getNotebookStringProp(node.props.question) ?? ''
+    const keepQuestion = node.props.keepQuestion === true
     const isEmpty = question.length === 0
     const submitDisabledReason = question.trim()
         ? isAIPromptSubmitDisabled
@@ -115,6 +116,23 @@ export function EditablePromptComponent({
 
     const deletePrompt = (): void => {
         deleteNodeAndFocusAdjacent()
+    }
+
+    const toggleKeepQuestion = (): void => {
+        updateNode(node.id, (currentNode) => {
+            if (!isPromptComponentNode(currentNode)) {
+                return currentNode
+            }
+
+            const nextProps = { ...currentNode.props }
+            if (keepQuestion) {
+                delete nextProps.keepQuestion
+            } else {
+                nextProps.keepQuestion = true
+            }
+
+            return { ...currentNode, props: nextProps }
+        })
     }
 
     const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
@@ -203,6 +221,17 @@ export function EditablePromptComponent({
                             autoFocus={isActive}
                             disabled={mode !== 'edit'}
                             rows={1}
+                        />
+                        <LemonButton
+                            size="xsmall"
+                            icon={keepQuestion ? <IconBookmarkSolid /> : <IconBookmark />}
+                            active={keepQuestion}
+                            tooltip="Keep question with answer"
+                            aria-label="Keep question with answer"
+                            aria-pressed={keepQuestion}
+                            onClick={toggleKeepQuestion}
+                            disabled={mode !== 'edit'}
+                            data-attr="markdown-notebook-ai-keep-question"
                         />
                         <LemonButton
                             type="primary"

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -3959,6 +3959,54 @@ Current AI paragraph`),
         expect(onChange).toHaveBeenLastCalledWith(`${TEST_NOTEBOOK_TITLE_MARKDOWN}\n\nThinking...`)
     })
 
+    it('keeps the named question above the AI response when enabled', () => {
+        const onAskAI = jest.fn()
+        const onChange = jest.fn()
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                value: `${TEST_NOTEBOOK_TITLE_MARKDOWN}\n\n<Prompt question="What is PostHog?" />`,
+                onAskAI,
+                onChange,
+                aiPromptAuthorName: 'Avery',
+                createAIConversationId: () => TEST_AI_CONVERSATION_ID,
+            })
+        )
+        const keepQuestionButton = container.querySelector(
+            '[data-attr="markdown-notebook-ai-keep-question"]'
+        ) as HTMLButtonElement
+
+        expect(keepQuestionButton).toBeInstanceOf(HTMLButtonElement)
+        expect(keepQuestionButton.getAttribute('aria-pressed')).toEqual('false')
+
+        fireEvent.click(keepQuestionButton)
+
+        expect(keepQuestionButton.getAttribute('aria-pressed')).toEqual('true')
+        expect(keepQuestionButton.classList.contains('LemonButton--active')).toBe(true)
+        expect(onChange).toHaveBeenLastCalledWith(
+            `${TEST_NOTEBOOK_TITLE_MARKDOWN}\n\n<Prompt question="What is PostHog?" keepQuestion />`
+        )
+
+        fireEvent.click(keepQuestionButton)
+
+        expect(keepQuestionButton.getAttribute('aria-pressed')).toEqual('false')
+        expect(onChange).toHaveBeenLastCalledWith(
+            `${TEST_NOTEBOOK_TITLE_MARKDOWN}\n\n<Prompt question="What is PostHog?" />`
+        )
+
+        fireEvent.click(keepQuestionButton)
+        fireEvent.click(container.querySelector('[aria-label="Send prompt"]') as HTMLButtonElement)
+
+        const markdownWithResponse = `${TEST_NOTEBOOK_TITLE_MARKDOWN}\n\n**Avery:** What is PostHog?\n\nThinking...`
+        expect(onChange).toHaveBeenLastCalledWith(markdownWithResponse)
+        expect(onAskAI).toHaveBeenCalledWith(
+            expect.objectContaining({
+                conversationId: TEST_AI_CONVERSATION_ID,
+                responseNodeIndex: 2,
+                markdownWithResponse,
+            })
+        )
+    })
+
     it('submits a persisted Ask AI prompt from the prompt textarea', () => {
         const onAskAI = jest.fn()
         const onChange = jest.fn()

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
@@ -241,6 +241,7 @@ export type MarkdownNotebookProps = {
     value: string
     onChange?: (value: string) => void
     onAskAI?: (request: MarkdownNotebookAskAIRequest) => void
+    aiPromptAuthorName?: string
     isAskAIDisabled?: boolean
     createAIConversationId?: () => string
     mode?: NotebookMode
@@ -354,6 +355,17 @@ function createDefaultAIConversationId(): string {
         return window.crypto.randomUUID()
     }
     return makeEmptyParagraph('ai-conversation').id
+}
+
+function makeRetainedAIQuestionNode(authorName: string, question: string, idSeed: string): NotebookTextBlockNode {
+    return {
+        ...makeEmptyParagraph(idSeed),
+        children: [
+            { type: 'text', text: `${authorName.trim() || 'You'}:`, marks: [{ type: 'bold' }] },
+            { type: 'text', text: ' ' },
+            ...plainTextToInlineNodes(question),
+        ],
+    }
 }
 
 /** Below this container width, comment threads render inline instead of in the margin. */
@@ -569,6 +581,7 @@ function MarkdownNotebookEditor({
     value,
     onChange,
     onAskAI,
+    aiPromptAuthorName = 'You',
     isAskAIDisabled: isAIPromptSubmitDisabled = false,
     createAIConversationId = createDefaultAIConversationId,
     mode = 'edit',
@@ -5376,16 +5389,26 @@ function MarkdownNotebookEditor({
         }
 
         let responseNodeIndex = -1
-        const nodesWithResponse = nodes.map((currentNode, index): NotebookBlockNode => {
+        const keepQuestion = currentPromptNode?.props.keepQuestion === true
+        const nodesWithResponse = nodes.flatMap((currentNode, index): NotebookBlockNode[] => {
             if (currentNode.id !== nodeId || !isPromptComponentNode(currentNode)) {
-                return currentNode
+                return [currentNode]
             }
-            responseNodeIndex = index
-            return {
+
+            const responseNode: NotebookTextBlockNode = {
                 id: currentNode.id,
                 type: 'paragraph',
                 children: plainTextToInlineNodes(NOTEBOOK_AI_WRITING_PLACEHOLDER),
             }
+            if (!keepQuestion) {
+                responseNodeIndex = index
+                return [responseNode]
+            }
+
+            responseNodeIndex = index + 1
+            const questionNode = makeRetainedAIQuestionNode(aiPromptAuthorName, query, `ai-question-${currentNode.id}`)
+            questionNode.startsGroup = currentNode.startsGroup
+            return [questionNode, responseNode]
         })
         if (responseNodeIndex === -1) {
             console.error('Prompt node not found for AI submission')

--- a/frontend/src/lib/components/MarkdownNotebook/notebookAI.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/notebookAI.test.ts
@@ -152,15 +152,32 @@ describe('notebookAI', () => {
         })
     })
 
-    it('rebases the streamed AI response range after deleting an earlier generated block', () => {
+    it.each([
+        {
+            change: 'deleting an earlier generated block',
+            previousMarkdown: '# Notebook\n\nFirst paragraph\n\nSecond paragraph\n\nThird paragraph still writing',
+            nextMarkdown: '# Notebook\n\nSecond paragraph\n\nThird paragraph still writing',
+            responseNodeIndex: 3,
+            responseNodeCount: 3,
+            expectedRange: { responseNodeIndex: 2, responseNodeCount: 2 },
+        },
+        {
+            change: 'editing the retained question before the response',
+            previousMarkdown: '# Notebook\n\n**Avery:** What is PostHog?\n\nAnswer still writing',
+            nextMarkdown: '# Notebook\n\n**Avery:** What does PostHog do?\n\nAnswer still writing',
+            responseNodeIndex: 2,
+            responseNodeCount: 1,
+            expectedRange: { responseNodeIndex: 2, responseNodeCount: 1 },
+        },
+    ])('rebases the streamed AI response range after $change', (testCase) => {
         expect(
             rebaseNotebookAIResponseRange(
-                '# Notebook\n\nFirst paragraph\n\nSecond paragraph\n\nThird paragraph still writing',
-                '# Notebook\n\nSecond paragraph\n\nThird paragraph still writing',
-                3,
-                3
+                testCase.previousMarkdown,
+                testCase.nextMarkdown,
+                testCase.responseNodeIndex,
+                testCase.responseNodeCount
             )
-        ).toEqual({ responseNodeIndex: 2, responseNodeCount: 2 })
+        ).toEqual(testCase.expectedRange)
     })
 
     it('replaces the active streamed block when the AI has only written one block so far', () => {

--- a/frontend/src/lib/components/MarkdownNotebook/notebookAI.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/notebookAI.test.ts
@@ -169,6 +169,15 @@ describe('notebookAI', () => {
             responseNodeCount: 1,
             expectedRange: { responseNodeIndex: 2, responseNodeCount: 1 },
         },
+        {
+            change: 'inserting a response-equivalent block before the active response',
+            previousMarkdown: '# Notebook\n\n**Avery:** What is PostHog?\n\nAnswer still writing\n\nAfter the answer',
+            nextMarkdown:
+                '# Notebook\n\n**Avery:** What does PostHog do?\n\nAnswer still writing\n\nAnswer still writing\n\nAfter the answer',
+            responseNodeIndex: 2,
+            responseNodeCount: 1,
+            expectedRange: { responseNodeIndex: 3, responseNodeCount: 1 },
+        },
     ])('rebases the streamed AI response range after $change', (testCase) => {
         expect(
             rebaseNotebookAIResponseRange(

--- a/frontend/src/lib/components/MarkdownNotebook/notebookAI.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/notebookAI.ts
@@ -59,10 +59,27 @@ export function rebaseNotebookAIResponseRange(
         nextDocument.nodes,
         previousStartIndex
     )
+    const nextEndBoundaryIndex = getRebasedNotebookAIResponseEndIndex(
+        previousDocument.nodes,
+        nextDocument.nodes,
+        previousEndIndex,
+        nextStartBoundaryIndex
+    )
+    const latestPossibleResponseStartIndex = Math.max(
+        nextStartBoundaryIndex,
+        nextEndBoundaryIndex - previousRange.deleteCount
+    )
     const previousResponseStartNode = previousDocument.nodes[previousStartIndex]
-    const nextResponseStartIndex = previousResponseStartNode
-        ? getMatchingNodeFingerprintIndex(previousResponseStartNode, nextDocument.nodes, nextStartBoundaryIndex)
-        : null
+    let nextResponseStartIndex: number | null = null
+    if (previousResponseStartNode) {
+        nextResponseStartIndex =
+            getLastMatchingNodeFingerprintIndex(
+                previousResponseStartNode,
+                nextDocument.nodes,
+                nextStartBoundaryIndex,
+                latestPossibleResponseStartIndex
+            ) ?? getMatchingNodeFingerprintIndex(previousResponseStartNode, nextDocument.nodes, nextStartBoundaryIndex)
+    }
     const nextStartIndex = nextResponseStartIndex ?? nextStartBoundaryIndex
     const nextEndIndex = getRebasedNotebookAIResponseEndIndex(
         previousDocument.nodes,
@@ -275,6 +292,22 @@ function getMatchingNodeFingerprintIndex(
 ): number | null {
     const nodeFingerprint = getNodeFingerprint(node)
     for (let index = Math.max(0, startIndex); index < candidateNodes.length; index++) {
+        if (getNodeFingerprint(candidateNodes[index]) === nodeFingerprint) {
+            return index
+        }
+    }
+
+    return null
+}
+
+function getLastMatchingNodeFingerprintIndex(
+    node: NotebookBlockNode,
+    candidateNodes: NotebookBlockNode[],
+    startIndex: number,
+    endIndex: number
+): number | null {
+    const nodeFingerprint = getNodeFingerprint(node)
+    for (let index = Math.min(endIndex, candidateNodes.length - 1); index >= Math.max(0, startIndex); index--) {
         if (getNodeFingerprint(candidateNodes[index]) === nodeFingerprint) {
             return index
         }

--- a/frontend/src/lib/components/MarkdownNotebook/notebookAI.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/notebookAI.ts
@@ -54,11 +54,16 @@ export function rebaseNotebookAIResponseRange(
         previousDocument.nodes.length,
         previousRange.insertionIndex + previousRange.deleteCount
     )
-    const nextStartIndex = getRebasedNotebookAIResponseStartIndex(
+    const nextStartBoundaryIndex = getRebasedNotebookAIResponseStartIndex(
         previousDocument.nodes,
         nextDocument.nodes,
         previousStartIndex
     )
+    const previousResponseStartNode = previousDocument.nodes[previousStartIndex]
+    const nextResponseStartIndex = previousResponseStartNode
+        ? getMatchingNodeFingerprintIndex(previousResponseStartNode, nextDocument.nodes, nextStartBoundaryIndex)
+        : null
+    const nextStartIndex = nextResponseStartIndex ?? nextStartBoundaryIndex
     const nextEndIndex = getRebasedNotebookAIResponseEndIndex(
         previousDocument.nodes,
         nextDocument.nodes,

--- a/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
@@ -29,6 +29,7 @@ import { getInlineText } from 'lib/components/MarkdownNotebook/utils'
 import { uploadFile } from 'lib/hooks/useUploadFiles'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { uuid } from 'lib/utils/dom'
+import { userLogic } from 'scenes/userLogic'
 
 import type { NotebookArtifactContent } from '~/queries/schema/schema-assistant-messages'
 
@@ -89,6 +90,7 @@ export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNot
         markdownRemoteCarets,
     } = useValues(notebookLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { user } = useValues(userLogic)
     const markdownRegistry = useMemo(() => getMarkdownRegistryForFeatureFlags(featureFlags), [featureFlags])
     const hiddenInsertCommandKeys = useMemo(
         () => getHiddenInsertCommandKeysForFeatureFlags(featureFlags),
@@ -686,6 +688,7 @@ export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNot
             <NotebookComponentRunStatusContext.Provider value={resolveComponentRunStatus}>
                 <MarkdownNotebook
                     value={markdownEditorValue}
+                    aiPromptAuthorName={user?.first_name || 'You'}
                     remoteValue={remoteMarkdown}
                     remoteVersion={notebook?.version}
                     mode={isEditable ? 'edit' : 'view'}


### PR DESCRIPTION
## Problem

Notebook users lose the submitted question when Ask AI replaces the prompt with its streamed answer.

This makes generated answers harder to understand after the notebook changes or reloads.

## Changes

- Adds an opt-in save toggle to each Ask AI prompt.
- Keeps the submitter first name and question directly above the streamed answer when enabled.
- Falls back to “You” without persisting an account email.
- Persists the toggle with an open prompt and supports turning it off.
- Keeps existing prompt replacement behavior by default.
- Keeps the streamed response target stable when someone edits the retained question or inserts equivalent content nearby.
- Replaces [#83129](https://github.com/PostHog/posthog/pull/83129) with a new same-repository branch on current `master`.

Toggle enabled before submission:

![Keep question toggle enabled](https://raw.githubusercontent.com/PostHog/pr-assets/3e7ef1985ecb8e5d8a8aca6f6c0713d5926b91b2/2026/08/f7a631fb-3b31-4313-90d9-8fbbe238953a.png)

Question retained after submission:

![Question retained above the answer](https://raw.githubusercontent.com/PostHog/pr-assets/3e7ef1985ecb8e5d8a8aca6f6c0713d5926b91b2/2026/08/3c7e914e-7f88-41dd-be22-6b3cb64a1418.png)

## How did you test this code?

- `hogli test frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts`
- `hogli test frontend/src/lib/components/MarkdownNotebook/notebookAI.test.ts`
- `hogli test frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.test.ts`
- `hogli test frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2RendererUI.test.tsx`
- `pnpm --filter=@posthog/frontend typescript:check`
- `hogli ci:preflight --fix`
- The regressions cover toggle state, retained attribution, answer placement, and streaming after question edits or equivalent block insertion.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the Markdown notebook component guide with the retained-question property.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Codex. A session link is unavailable in this environment.
- Skills: `/github:github`, `/github:gh-address-comments`, `/debugging-ci-failures`, `/reviewing-before-pr`, `/writing-pr-descriptions`, `/writing-tests`, `/writing-ui-components`, and `/running-ci-preflight`.
- The existing public diff was recreated on current `master`; review follow-ups avoid account emails and keep equivalent blocks outside the streamed response range.
- Greptile was not signed in locally, so the full-diff harness fallback found no actionable issues and left the PR bot review enabled.
