### PR TITLE
feat(alerts): fire on absent metrics and score metrics anomalies

### DIFF
--- a/posthog/tasks/alerts/test/test_metrics_alerts.py
+++ b/posthog/tasks/alerts/test/test_metrics_alerts.py
@@ -30,6 +30,11 @@ from products.metrics.backend.facade.testing import seed_metric
 # 08:55 — the 08:00 hourly bucket is still accumulating; 07:00 is the last complete one.
 FROZEN_TIME = dateutil.parser.parse("2026-07-01T08:55:00.000Z")
 
+# A detector drops a series shorter than its own minimum, and the auto-picked bucket size over the
+# default 24h range yields far fewer buckets than that. Pinning the interval is what buys the depth:
+# widening the range instead only coarsens the buckets, leaving the count unchanged.
+DETECTOR_INTERVAL = "minute_15"
+
 
 def _metrics_flag_only(flag: str, *args: Any, **kwargs: Any) -> bool:
     return flag == "metrics"
@@ -86,14 +91,19 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
         self.metric_name = f"queue.depth.{self._testMethodName}"
 
     def create_metrics_insight(
-        self, group_by: Optional[list[str]] = None, clauses: Optional[list[dict[str, Any]]] = None
+        self,
+        group_by: Optional[list[str]] = None,
+        clauses: Optional[list[dict[str, Any]]] = None,
+        interval: Optional[str] = None,
     ) -> dict:
         if clauses is None:
             clause: dict[str, Any] = {"name": "a", "metricName": self.metric_name, "aggregation": "avg"}
             if group_by:
                 clause["groupBy"] = [{"key": key} for key in group_by]
             clauses = [clause]
-        query_dict = {"kind": "MetricsQuery", "clauses": clauses}
+        query_dict: dict[str, Any] = {"kind": "MetricsQuery", "clauses": clauses}
+        if interval:
+            query_dict["interval"] = interval
         return self.dashboard_api.create_insight(data={"name": "metrics insight", "query": query_dict})[1]
 
     def create_alert(
@@ -132,11 +142,12 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
         )
 
     def seed_detector_history(self) -> None:
-        # 19 hourly buckets inside the insight's default 24h window — a windowed detector needs
-        # more history than a threshold check, which only reads the tail. The last bucket sits
-        # well before now so nothing here is read as absent.
-        start = dt.datetime(2026, 6, 30, 12, 30, tzinfo=dt.UTC)
-        points = [(start + dt.timedelta(hours=offset), 10.0 + offset % 2) for offset in range(18)]
+        # Half-hourly samples inside the insight's default 24h window, read back at
+        # DETECTOR_INTERVAL so each one lands in its own bucket. A windowed detector needs more
+        # history than a threshold check, which only reads the tail. The last sample sits well
+        # before now so nothing here is read as absent.
+        start = dt.datetime(2026, 6, 30, 13, 0, tzinfo=dt.UTC)
+        points = [(start + dt.timedelta(minutes=30 * offset), 10.0 + offset % 2) for offset in range(35)]
         points.append((dt.datetime(2026, 7, 1, 6, 30, tzinfo=dt.UTC), 500.0))
         seed_metric(
             team_id=self.team.pk,
@@ -298,7 +309,7 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
         # Metrics is registered in DETECTOR_EXTRACTORS, so the editor preview scores it through
         # the same registry the alert check uses rather than 400ing as an unsupported kind.
         self.seed_detector_history()
-        insight = self.create_metrics_insight()
+        insight = self.create_metrics_insight(interval=DETECTOR_INTERVAL)
         response = self.client.post(
             f"/api/projects/{self.team.id}/alerts/simulate",
             data={
@@ -317,11 +328,12 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
         # End-to-end through the detector branch of the dispatcher. Asserts the path completes and
         # records a check rather than a specific score, so detector tuning can't make it flaky.
         self.seed_detector_history()
-        insight = self.create_metrics_insight()
+        insight = self.create_metrics_insight(interval=DETECTOR_INTERVAL)
+        # No bounds: a detector alert scores the series instead of comparing against one. The
+        # threshold object still has to be present — the serializer rejects a null one.
         alert = self.create_alert(
             insight,
             detector_config={"type": "zscore", "threshold": 0.9, "window": 10},
-            threshold=None,
         )
 
         run_alert_check(alert["id"])
@@ -431,12 +443,6 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
                 {"type": "TrendsAlertConfig", "series_index": 0},
                 {},
                 "not supported",
-            ),
-            (
-                "detector_config_rejected",
-                {"type": "MetricsAlertConfig"},
-                {"detector_config": {"type": "zscore", "threshold": 0.9, "window": 10}},
-                "anomaly detection",
             ),
             (
                 "ongoing_interval_requires_upper_bound",

--- a/posthog/tasks/alerts/test/test_metrics_alerts.py
+++ b/posthog/tasks/alerts/test/test_metrics_alerts.py
@@ -131,6 +131,21 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
             labels=labels or {},
         )
 
+    def seed_detector_history(self) -> None:
+        # 19 hourly buckets inside the insight's default 24h window — a windowed detector needs
+        # more history than a threshold check, which only reads the tail. The last bucket sits
+        # well before now so nothing here is read as absent.
+        start = dt.datetime(2026, 6, 30, 12, 30, tzinfo=dt.UTC)
+        points = [(start + dt.timedelta(hours=offset), 10.0 + offset % 2) for offset in range(18)]
+        points.append((dt.datetime(2026, 7, 1, 6, 30, tzinfo=dt.UTC), 500.0))
+        seed_metric(
+            team_id=self.team.pk,
+            metric_name=self.metric_name,
+            metric_type="gauge",
+            points=points,
+            labels={},
+        )
+
     @parameterized.expand(
         [
             # (name, seeded value, lower, upper, expected_state, expected_message_fragment)
@@ -185,6 +200,37 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
         alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
         assert alert_check.calculated_value == 0
         assert alert_check.error is None
+
+    @parameterized.expand(
+        [
+            # (name, lower, upper, expected_state)
+            ("lower_bound_fires", 10.0, None, AlertState.FIRING),
+            ("upper_bound_stays_quiet", None, 20.0, AlertState.NOT_FIRING),
+        ]
+    )
+    def test_metric_that_stopped_reporting(
+        self,
+        mock_send_breaches: MagicMock,
+        mock_send_errors: MagicMock,
+        mock_feature_enabled: MagicMock,
+        _name: str,
+        lower: Optional[float],
+        upper: Optional[float],
+        expected_state: AlertState,
+    ) -> None:
+        # Healthy at 50 through 05:00, then the emitter dies. The query returns no rows for the
+        # buckets that follow, so left alone the series ends at 50: the lower-bound alert goes
+        # quiet exactly when the metric stopped, and the upper-bound one keeps paging on a
+        # reading hours out of date. Both anchor on an absent bucket instead.
+        self.seed_gauge({3: 50.0, 4: 50.0, 5: 50.0})
+        insight = self.create_metrics_insight()
+        alert = self.create_alert(insight, lower=lower, upper=upper)
+
+        run_alert_check(alert["id"])
+
+        assert AlertConfiguration.objects.get(pk=alert["id"]).state == expected_state
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.calculated_value == 0
 
     def test_group_by_fires_on_any_breaching_series(
         self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock, mock_feature_enabled: MagicMock
@@ -246,10 +292,12 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
         assert response.status_code == 400, response.json()
         assert "not enabled" in str(response.json()).lower()
 
-    def test_simulate_rejects_metrics_insight_with_flag_on(
+    def test_simulate_scores_a_metrics_insight(
         self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock, mock_feature_enabled: MagicMock
     ) -> None:
-        # Metrics has no detector extractor: simulation must 400 cleanly via the registry, not 500.
+        # Metrics is registered in DETECTOR_EXTRACTORS, so the editor preview scores it through
+        # the same registry the alert check uses rather than 400ing as an unsupported kind.
+        self.seed_detector_history()
         insight = self.create_metrics_insight()
         response = self.client.post(
             f"/api/projects/{self.team.id}/alerts/simulate",
@@ -258,8 +306,30 @@ class TestMetricsAlerts(APIBaseTest, ClickhouseTestMixin):
                 "detector_config": {"type": "zscore", "threshold": 0.9, "window": 10},
             },
         )
-        assert response.status_code == 400, response.json()
-        assert "isn't supported for MetricsQuery" in str(response.json())
+        assert response.status_code == 200, response.json()
+        body = response.json()
+        assert body["total_points"] == len(body["data"]) == len(body["scores"])
+        assert body["total_points"] > 0
+
+    def test_detector_alert_check_runs_on_a_metrics_insight(
+        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock, mock_feature_enabled: MagicMock
+    ) -> None:
+        # End-to-end through the detector branch of the dispatcher. Asserts the path completes and
+        # records a check rather than a specific score, so detector tuning can't make it flaky.
+        self.seed_detector_history()
+        insight = self.create_metrics_insight()
+        alert = self.create_alert(
+            insight,
+            detector_config={"type": "zscore", "threshold": 0.9, "window": 10},
+            threshold=None,
+        )
+
+        run_alert_check(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state in (AlertState.FIRING, AlertState.NOT_FIRING)
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.error is None, alert_check.error
 
     @parameterized.expand(
         [

--- a/products/alerts/backend/evaluation/absence.py
+++ b/products/alerts/backend/evaluation/absence.py
@@ -1,0 +1,68 @@
+"""Detecting the buckets a series should have reported and didn't.
+
+Some query runners return one row per bucket that *has data* — a metric that stops
+being emitted simply stops producing rows rather than producing zeroes. A series
+assembled from those rows therefore ends at the last healthy sample, so an alert
+anchored on its tail keeps reading that stale value and goes quiet exactly when the
+thing it watches dies.
+
+This module names the complete buckets missing from the tail of such a series, so an
+extractor can carry them as explicit points instead of letting the series end early.
+
+The reporting cadence is inferred from the series itself, as the smallest gap between
+consecutive observed buckets. That is the bucket width whenever any two adjacent
+buckets reported, and for a metric that only reports every few buckets it reads as the
+sparser cadence — so a sparse metric is judged against its own rhythm rather than the
+grid's. A mean or max would be dragged upwards by interior gaps and under-report
+absence; the minimum cannot be.
+
+Pure Python: no Django, no product imports.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Sequence
+
+# A series that stopped weeks ago would otherwise generate a padded point per bucket for
+# the whole range. Callers only read the tail, so cap the work.
+DEFAULT_MAX_PADDED_BUCKETS = 8
+
+
+def _aware(value: dt.datetime) -> dt.datetime:
+    """Bucket times render in the project timezone; a naive one is read as UTC."""
+    return value.replace(tzinfo=dt.UTC) if value.tzinfo is None else value
+
+
+def absent_trailing_buckets(
+    bucket_times: Sequence[str],
+    now: dt.datetime,
+    *,
+    max_buckets: int = DEFAULT_MAX_PADDED_BUCKETS,
+) -> list[str]:
+    """The complete buckets after the last observed one, in ascending order.
+
+    ``bucket_times`` are ISO 8601 bucket starts, ascending. A bucket counts as missing
+    only once it has closed (``start + cadence <= now``), so the still-accumulating
+    bucket is never reported — it has no value yet, which is not the same as zero.
+
+    Returns ``[]`` when the cadence cannot be inferred (fewer than two observed
+    buckets). Padding on a guessed cadence could invent a breach, so this fails closed.
+    """
+    if len(bucket_times) < 2:
+        return []
+
+    parsed = [_aware(dt.datetime.fromisoformat(value)) for value in bucket_times]
+    now = _aware(now)
+
+    gaps = [later - earlier for earlier, later in zip(parsed, parsed[1:]) if later > earlier]
+    if not gaps:
+        return []
+    cadence = min(gaps)
+
+    absent: list[str] = []
+    bucket = parsed[-1] + cadence
+    while bucket + cadence <= now and len(absent) < max_buckets:
+        absent.append(bucket.isoformat())
+        bucket += cadence
+    return absent

--- a/products/alerts/backend/evaluation/dispatcher.py
+++ b/products/alerts/backend/evaluation/dispatcher.py
@@ -10,7 +10,7 @@ from products.alerts.backend.evaluation.contract import DetectorExtractor, Extra
 from products.alerts.backend.evaluation.detector import TrendsDetectorExtractor, evaluate_with_detector
 from products.alerts.backend.evaluation.funnels import FunnelsExtractor
 from products.alerts.backend.evaluation.hogql import HogQLDetectorExtractor, HogQLExtractor
-from products.alerts.backend.evaluation.metrics import MetricsExtractor
+from products.alerts.backend.evaluation.metrics import MetricsDetectorExtractor, MetricsExtractor
 from products.alerts.backend.evaluation.trends import TrendsExtractor
 from products.alerts.backend.models.alert import AlertConfiguration
 from products.product_analytics.backend.facade.models import Insight
@@ -30,6 +30,7 @@ EXTRACTORS: dict[NodeKind, Extractor] = {
 DETECTOR_EXTRACTORS: dict[NodeKind, DetectorExtractor] = {
     NodeKind.TRENDS_QUERY: TrendsDetectorExtractor(),
     NodeKind.HOG_QL_QUERY: HogQLDetectorExtractor(),
+    NodeKind.METRICS_QUERY: MetricsDetectorExtractor(),
 }
 
 

--- a/products/alerts/backend/evaluation/metrics.py
+++ b/products/alerts/backend/evaluation/metrics.py
@@ -1,21 +1,35 @@
+import datetime as dt
 from typing import Any
+
+from django.utils import timezone
 
 from posthog.schema import InsightThreshold, MetricsAlertConfig, MetricsQuery
 
 from posthog.api.services.query import ExecutionMode
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.event_usage import EventSource
+from posthog.models.team import Team
+from posthog.models.user import User
 
+# Low-level detector sizing primitives, shared with the trends/SQL detector extractors.
+from posthog.tasks.alerts.detector import MAX_DETECTOR_BREAKDOWN_VALUES, _compute_min_samples_for_detector
+
+from products.alerts.backend.evaluation.absence import absent_trailing_buckets
 from products.alerts.backend.evaluation.contract import (
     ComparableSeries,
     ExtractionResult,
     SeriesPoint,
+    SimulationContext,
     zero_sentinel_series,
 )
 from products.alerts.backend.models.alert import AlertConfiguration
 from products.product_analytics.backend.facade.models import Insight
 
 _SUBJECT = "The metric value"
+
+
+def _series_points(row: dict[str, Any]) -> list[SeriesPoint]:
+    return [SeriesPoint(date=point.get("time"), value=point.get("value")) for point in (row.get("points") or [])]
 
 
 def _series_label(row: dict[str, Any]) -> str:
@@ -35,6 +49,13 @@ class MetricsExtractor:
     grid is the union of observed buckets (zero-filled), so the anchor is positional: the last
     observed bucket with ``check_ongoing_interval``, otherwise the one before it, which skips the
     possibly still-accumulating trailing bucket.
+
+    That grid only spans buckets that had samples, so a metric that stops being emitted ends its
+    series at the last healthy value rather than at now. Left alone the anchor would keep reading
+    that value and the alert would go quiet exactly when the emitter died, so closed buckets the
+    series never reported are carried as explicit zeroes — the same reading a metric that never
+    reported at all already gets from ``zero_sentinel_series``. Zero (rather than a gap) is what
+    makes a lower bound fire on a dead metric while leaving an upper bound alone.
     """
 
     def extract(
@@ -71,6 +92,10 @@ class MetricsExtractor:
             calculation_result.result,
             anchor_last_point=check_ongoing_interval,
             is_current_interval=check_ongoing_interval,
+            # Judge absence as of when the result was computed, not wall clock: a cached
+            # result knows nothing about buckets that closed after it ran, and treating
+            # those as unreported would invent a breach out of cache age alone.
+            fresh_as_of=calculation_result.last_refresh or timezone.now(),
         )
         if not series:
             # No observed buckets at all: the metric is genuinely absent, evaluated as 0 so a
@@ -93,15 +118,17 @@ class MetricsExtractor:
         *,
         anchor_last_point: bool,
         is_current_interval: bool,
+        fresh_as_of: dt.datetime,
     ) -> list[ComparableSeries]:
         series: list[ComparableSeries] = []
         for row in results:
             if not isinstance(row, dict):
                 continue
-            raw_points = row.get("points") or []
-            points = [SeriesPoint(date=point.get("time"), value=point.get("value")) for point in raw_points]
+            points = _series_points(row)
             if not points:
                 continue
+            absent = absent_trailing_buckets([point.date for point in points if point.date], fresh_as_of)
+            points.extend(SeriesPoint(date=bucket, value=0.0) for bucket in absent)
             # Anchor on the last observed bucket (ongoing mode) or the one before it. A single-point
             # series anchors on its only point; relative conditions then skip it (no previous point).
             current_index = len(points) - 1 if anchor_last_point else max(0, len(points) - 2)
@@ -114,3 +141,88 @@ class MetricsExtractor:
                 )
             )
         return series
+
+
+class MetricsDetectorExtractor:
+    """Normalize a metrics insight into full series for the anomaly detectors.
+
+    Reads the same result shape as ``MetricsExtractor`` but keeps the whole history
+    instead of an anchor, because the detector scores every point rather than comparing
+    one bucket against a bound.
+
+    History depth comes from the insight's own date range and interval. The metrics
+    runner targets a fixed bucket count, so widening the range alone coarsens the
+    buckets rather than adding samples — pin a finer ``interval`` on the insight to give
+    a wide detector window more to work with. A series shorter than the detector needs
+    is dropped, which the shared scorer reports as uncomputed rather than as "normal".
+
+    Absence padding deliberately does not apply here. Carrying a dead emitter's missed
+    buckets as zeroes (what ``MetricsExtractor`` does, so a lower bound still fires)
+    would read to a detector as a dramatic anomaly. Absence stays a threshold concern
+    with threshold semantics.
+    """
+
+    def extract(
+        self, alert: AlertConfiguration, insight: Insight, query: Any, execution_mode: ExecutionMode
+    ) -> ExtractionResult:
+        MetricsQuery.model_validate(query)
+        if not alert.detector_config:
+            raise ValueError("MetricsDetectorExtractor requires detector_config — dispatcher invariant violated")
+        return self._extract(
+            insight,
+            team=alert.team,
+            user=alert.created_by,
+            detector_config=alert.detector_config,
+            execution_mode=execution_mode,
+        )
+
+    def simulate(self, insight: Insight, query: object, ctx: SimulationContext) -> tuple[ExtractionResult, str | None]:
+        MetricsQuery.model_validate(query)
+        result = self._extract(
+            insight,
+            team=ctx.team,
+            user=ctx.user,
+            detector_config=ctx.detector_config,
+            # Read-only preview: a recent cached result is fine and keeps the editor snappy.
+            execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+        )
+        # The metrics runner resolves its own bucket size and doesn't report it back, so the
+        # chart frames itself from the point timestamps instead of an interval name.
+        return result, None
+
+    def _extract(
+        self,
+        insight: Insight,
+        *,
+        team: Team,
+        user: User | None,
+        detector_config: dict[str, Any],
+        execution_mode: ExecutionMode,
+    ) -> ExtractionResult:
+        calculation_result = calculate_for_query_based_insight(
+            insight,
+            team=team,
+            execution_mode=execution_mode,
+            user=user,
+            analytics_props={"source": EventSource.ALERT},
+        )
+        if calculation_result.result is None:
+            raise RuntimeError(f"No results found for insight with id = {insight.id}")
+
+        rows = [row for row in calculation_result.result if isinstance(row, dict)]
+        # A metrics query with no matching buckets still returns one placeholder series with an
+        # empty point list, so "no rows" is not the only shape an empty result takes.
+        if not any(row.get("points") for row in rows):
+            return ExtractionResult(series=[], subject=_SUBJECT, empty_query_result=True)
+
+        min_points = _compute_min_samples_for_detector(detector_config) + 1
+        series: list[ComparableSeries] = []
+        for row in rows[:MAX_DETECTOR_BREAKDOWN_VALUES]:
+            points = _series_points(row)
+            if len(points) < min_points:
+                continue
+            # current_index is set for contract conformance but unread on this path: the detector
+            # scores the whole series rather than comparing against a single anchor bucket.
+            series.append(ComparableSeries(label=_series_label(row), points=points, current_index=len(points) - 1))
+
+        return ExtractionResult(series=series, is_breakdown=len(series) > 1, subject=_SUBJECT)

--- a/products/alerts/backend/evaluation/test/test_absence.py
+++ b/products/alerts/backend/evaluation/test/test_absence.py
@@ -1,0 +1,62 @@
+import datetime as dt
+
+from unittest import TestCase
+
+from products.alerts.backend.evaluation.absence import absent_trailing_buckets
+
+
+def _at(hour: int, minute: int = 0, offset_hours: int = 0) -> str:
+    tz = dt.timezone(dt.timedelta(hours=offset_hours))
+    return dt.datetime(2026, 7, 1, hour, minute, tzinfo=tz).isoformat()
+
+
+def _now(hour: int, minute: int = 0) -> dt.datetime:
+    return dt.datetime(2026, 7, 1, hour, minute, tzinfo=dt.UTC)
+
+
+class TestAbsentTrailingBuckets(TestCase):
+    def test_reporting_metric_pads_nothing(self) -> None:
+        # 08:00 is still accumulating; 07:00 is the last complete bucket and it has data.
+        self.assertEqual(absent_trailing_buckets([_at(6), _at(7), _at(8)], _now(8, 55)), [])
+
+    def test_stopped_metric_pads_the_complete_buckets_it_missed(self) -> None:
+        # Last sample landed in the 06:00 bucket. 07:00 closed at 08:00 and never reported;
+        # 08:00 does not close until 09:00, so it is not yet missing.
+        self.assertEqual(absent_trailing_buckets([_at(4), _at(5), _at(6)], _now(8, 55)), [_at(7)])
+
+    def test_ongoing_bucket_is_never_padded(self) -> None:
+        # 07:00 closes exactly at 08:00. One second earlier it is still accumulating.
+        self.assertEqual(absent_trailing_buckets([_at(5), _at(6)], _now(7, 59)), [])
+        self.assertEqual(absent_trailing_buckets([_at(5), _at(6)], _now(8, 0)), [_at(7)])
+
+    def test_single_bucket_gives_no_cadence_to_infer_from(self) -> None:
+        # One observed bucket cannot tell us how often this metric reports, so padding
+        # would be guesswork. Fail closed: never invent a breach we cannot justify.
+        self.assertEqual(absent_trailing_buckets([_at(6)], _now(20)), [])
+        self.assertEqual(absent_trailing_buckets([], _now(20)), [])
+
+    def test_cadence_self_calibrates_to_a_sparse_metric(self) -> None:
+        # Reports every 3h. At 08:55 the 09:00 bucket has not even opened, so nothing is late.
+        every_three_hours = [_at(0), _at(3), _at(6)]
+        self.assertEqual(absent_trailing_buckets(every_three_hours, _now(8, 55)), [])
+        # By 12:30 the 09:00 bucket has closed unreported.
+        self.assertEqual(absent_trailing_buckets(every_three_hours, _now(12, 30)), [_at(9)])
+
+    def test_interior_gap_does_not_inflate_the_inferred_cadence(self) -> None:
+        # 08:00 is missing mid-series. The cadence is still hourly (the smallest gap),
+        # not two-hourly — a mean or max would read this as a slower metric and under-report.
+        self.assertEqual(absent_trailing_buckets([_at(6), _at(7), _at(9)], _now(11, 30)), [_at(10)])
+
+    def test_long_dead_metric_is_capped(self) -> None:
+        padded = absent_trailing_buckets([_at(0), _at(1)], _now(23, 59), max_buckets=3)
+        self.assertEqual(padded, [_at(2), _at(3), _at(4)])
+
+    def test_naive_bucket_times_are_read_as_utc(self) -> None:
+        naive = [dt.datetime(2026, 7, 1, 5).isoformat(), dt.datetime(2026, 7, 1, 6).isoformat()]
+        self.assertEqual(absent_trailing_buckets(naive, _now(8, 0)), [_at(7)])
+
+    def test_project_timezone_offset_is_preserved(self) -> None:
+        # HogQL renders bucket times in the project timezone, so the padded buckets must
+        # keep that offset — they are compared against UTC now, and displayed to the user.
+        berlin = [_at(7, offset_hours=2), _at(8, offset_hours=2)]
+        self.assertEqual(absent_trailing_buckets(berlin, _now(8, 0)), [_at(9, offset_hours=2)])


### PR DESCRIPTION
## Problem

An engineer on call with a PostHog metrics alert stops being paged the moment the thing they are watching dies.

- The metrics query runner groups by bucket with no fill, so it returns rows only for buckets that had samples. An emitter that stops producing simply stops producing rows.
- The alert anchors on the tail of that series, which is still the last healthy value. A "queue depth dropped to zero" alert therefore reads the last healthy depth forever and never fires.
- A metric that *never* reported already evaluates as 0 and fires, so the two absence cases disagree with each other today.
- Separately, `MetricsQuery` was absent from `DETECTOR_EXTRACTORS`, so anomaly alerts and the alert-editor preview rejected metrics insights as an unsupported kind. Threshold alerts were the only option, and a threshold is the wrong tool for a metric with a daily shape.

Metrics is in private alpha behind the `metrics` flag, so this reaches only teams already on that flag.

## Changes

- A metric that stops reporting now fires a lower-bound alert instead of going quiet. Closed buckets the series never reported are carried as explicit zeroes.
- An upper-bound alert on that same dead metric now resolves instead of paging on a reading hours out of date. Zero, rather than a gap, is what separates the two.
- Metrics insights can now be alerted on with an anomaly detector, and the alert editor's preview chart scores them. Registering `MetricsDetectorExtractor` in `DETECTOR_EXTRACTORS` unlocks the alert check and the preview through one seam, because `validation.py` already gates both on membership of that registry.
- Absence is judged as of when the result was computed (`InsightResult.last_refresh`), not wall clock. A cached result knows nothing about buckets that closed after it ran, so this stops cache age alone from inventing a breach.
- The reporting cadence is inferred from the series as the smallest gap between observed buckets, so a metric that only reports every few buckets is judged against its own rhythm. A mean or max would be dragged up by interior gaps and under-report absence.
- Mechanical: `_series_points` extracted so both extractors share one row-to-points conversion.

> [!WARNING]
> This changes what an existing alert does. An upper-bound metrics alert that is firing when its emitter dies will now resolve, where before it stayed firing on the stale value. That matches how Prometheus and friends behave — absence resolves the alert, and a separate lower-bound alert covers the outage — but it is a behavior change, not just a bug fix.

Absence padding deliberately does not apply on the detector path. Injecting zeroes for a dead emitter would score as a dramatic anomaly, which is a different alert with different semantics.

## How did you test this code?

The sandbox this was written in has no Postgres, no ClickHouse, and no installed Python dependencies, so **the Django and ClickHouse-backed tests here were written but not executed — CI is their first real run.** What ran locally is listed below.

Ran locally: the 9 pure unit tests in `products/alerts/backend/evaluation/test/test_absence.py`, red before the module existed and green after, plus `ruff check` and `ruff format --check` over both changed trees.

<details>
<summary>Local run</summary>

```
Ran 9 tests in 0.001s

OK
```

</details>

The cadence and completeness logic sits in a pure stdlib module for that reason — the same split `state_machine.py` and `scheduling.py` already use — so the part with the fiddly edge cases is testable at the cheapest rung.

Regressions each group catches that nothing existing did:

- `test_absence.py`: padding a bucket that is still accumulating (fires on every partial bucket); inferring cadence with a mean or max instead of the minimum (under-reports absence on a series with interior gaps); padding from a single observed bucket, where there is no cadence to infer (invents a breach); unbounded padding for a long-dead metric; bucket times that arrive naive or in a non-UTC project timezone.
- `test_metric_that_stopped_reporting`: the bug itself, both bound directions, asserting the evaluated value is 0 in each.
- `test_simulate_scores_a_metrics_insight` replaces the test that asserted metrics had no detector extractor.
- `test_detector_alert_check_runs_on_a_metrics_insight`: the alert-check path, distinct from the preview path. It asserts the check completes and records no error rather than a specific score, so detector tuning cannot make it flaky.

Not checked: any behavior against real ingested metrics, and the alert editor UI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 4.5) in a PostHog cloud task. The ask was to make Metrics usable for on-call, informed by the company's in-flight alerting work: the logs alerting RFC, the shared alerts platform under `products/alerts/backend/`, and the `adding-product-alerting` skill.

The first plan was a product-owned `MetricsAlertConfiguration` with its own Temporal schedule, following the logs adopter. Reading the code ruled that out: metrics threshold alerts already ride the insight-alert path via `MetricsExtractor`, so a second engine would have been a fork rather than an adoption. The two real gaps turned out to be much narrower — a series that ends early, and a missing registry entry.

Absence was first going to key off wall clock; `InsightResult.last_refresh` replaced that once the cached-result false positive became apparent. Cadence inference moved from median to minimum gap after working through a metric that reports every third bucket. Two integration tests were collapsed into one parameterized case under the `/writing-tests` gate.

Skills consulted (read directly, since they are repo-local rather than registered in the session): `adding-product-alerting` and its `adopting-platform-alerting` reference, `writing-tests`, `writing-pr-descriptions`.

Public artifact: nothing here draws on a customer conversation, ticket, or log. Test data is invented and the metric names are the ones the existing test file already generates per test.
