### PR TITLE
feat(tasks): report why a steer was declined

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -2880,7 +2880,49 @@ describe("AgentServer HTTP Mode", () => {
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toMatchObject({
-        result: { stopReason: "steer_declined", steered: false },
+        result: {
+          stopReason: "steer_declined",
+          steered: false,
+          reason: "startup_turn",
+        },
+      });
+      expect(prompt).not.toHaveBeenCalled();
+    }, 20000);
+
+    it("declines steering when the sandbox has no turn to fold it into", async () => {
+      const s = createServer();
+      await s.start();
+      const prompt = vi.fn();
+      const serverInternals = s as unknown as {
+        session: { clientConnection: { prompt: typeof prompt } };
+      };
+      serverInternals.session.clientConnection.prompt = prompt;
+
+      const response = await fetch(`http://localhost:${port}/command`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${createToken()}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "steer-while-idle",
+          method: "user_message",
+          params: {
+            content: "status?",
+            messageId: "steer-while-idle",
+            steer: true,
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        result: {
+          stopReason: "steer_declined",
+          steered: false,
+          reason: "no_active_turn",
+        },
       });
       expect(prompt).not.toHaveBeenCalled();
     }, 20000);
@@ -2923,7 +2965,11 @@ describe("AgentServer HTTP Mode", () => {
 
       const steerResponse = await send("steer-during-first-turn", true);
       await expect(steerResponse.json()).resolves.toMatchObject({
-        result: { stopReason: "steer_declined", steered: false },
+        result: {
+          stopReason: "steer_declined",
+          steered: false,
+          reason: "startup_turn",
+        },
       });
       expect(prompt).toHaveBeenCalledOnce();
 
@@ -3023,7 +3069,11 @@ describe("AgentServer HTTP Mode", () => {
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toMatchObject({
-        result: { stopReason: "steer_declined", steered: false },
+        result: {
+          stopReason: "steer_declined",
+          steered: false,
+          reason: "adapter_rejected",
+        },
       });
       expect(prompt).toHaveBeenCalledTimes(1);
       expect(prompt.mock.calls[0]?.[0]).toEqual(

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -391,6 +391,11 @@ function getTaskRunStateString(
   return typeof value === "string" ? value : null;
 }
 
+type SteerDeclineReason =
+  | "startup_turn"
+  | "no_active_turn"
+  | "adapter_rejected";
+
 /** Which delivery routes a Slack run has, as resolved by the backend from flags and Slack scopes. */
 type SlackArtifactDelivery = "none" | "message" | "canvas_file";
 
@@ -1308,10 +1313,10 @@ export class AgentServer {
           };
 
           if (params.steer === true) {
-            if (
-              this.activeOwnedTurnCount > 0 &&
-              this.activeStartupTurnCount === 0
-            ) {
+            let declineReason: SteerDeclineReason = "no_active_turn";
+            if (this.activeStartupTurnCount > 0) {
+              declineReason = "startup_turn";
+            } else if (this.activeOwnedTurnCount > 0) {
               const result = await commandSession.clientConnection.prompt({
                 sessionId: commandSession.acpSessionId,
                 prompt,
@@ -1326,10 +1331,12 @@ export class AgentServer {
                 resolveDelivery(outcome);
                 return outcome;
               }
+              declineReason = "adapter_rejected";
             }
             const outcome = {
               stopReason: "steer_declined",
               steered: false,
+              reason: declineReason,
             };
             resolveDelivery(outcome);
             return outcome;

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -96,6 +96,8 @@ DENIAL_BRAKE_CONSUMED_REQUEST_ID_KEY = "followup_denial_brake_request_id"
 SEND_FOLLOWUP_MAX_ATTEMPTS = 3
 SEND_FOLLOWUP_HEARTBEAT_INTERVAL_SECONDS = 15
 STEER_DECLINED_OUTCOME = "steer_declined"
+STEER_DECLINE_REASON_UNREPORTED = "unreported"
+STEER_DECLINE_REASON_ACTOR_MISMATCH = "actor_mismatch"
 
 
 @dataclass
@@ -275,6 +277,16 @@ def _is_steer_declined(result_data: dict[str, Any] | None) -> bool:
     return isinstance(result, dict) and result.get("steered") is False
 
 
+def _steer_decline_reason(result_data: dict[str, Any] | None) -> str:
+    if not isinstance(result_data, dict):
+        return STEER_DECLINE_REASON_UNREPORTED
+    result = result_data.get("result")
+    if not isinstance(result, dict):
+        return STEER_DECLINE_REASON_UNREPORTED
+    reason = result.get("reason")
+    return reason if isinstance(reason, str) and reason else STEER_DECLINE_REASON_UNREPORTED
+
+
 def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
     peer_message_id = peer_message_id_from_context(input.context)
     try:
@@ -334,6 +346,11 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
                 actor_user_id=input.actor_user_id,
                 resolved_user_id=actor_user.id if actor_user is not None else None,
                 bound_user_id=bound_user_id,
+            )
+            logger.info(
+                "send_followup_steer_declined",
+                run_id=input.run_id,
+                reason=STEER_DECLINE_REASON_ACTOR_MISMATCH,
             )
             return STEER_DECLINED_OUTCOME
 
@@ -439,7 +456,11 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
             logger.info("send_followup_steered", run_id=input.run_id)
             return None
         if input.steer and _is_steer_declined(result.data):
-            logger.info("send_followup_steer_declined", run_id=input.run_id)
+            logger.info(
+                "send_followup_steer_declined",
+                run_id=input.run_id,
+                reason=_steer_decline_reason(result.data),
+            )
             return STEER_DECLINED_OUTCOME
         _write_turn_complete(input.run_id, _get_stop_reason(result.data), run_uses_dedicated_stream(task_run.state))
         logger.info("send_followup_delivered", run_id=input.run_id)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
@@ -3,9 +3,13 @@ import json
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
+from parameterized import parameterized
+
 from products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox import (
+    STEER_DECLINE_REASON_UNREPORTED,
     SendFollowupToSandboxInput,
     _get_stop_reason,
+    _steer_decline_reason,
     _write_turn_complete,
     send_followup_to_sandbox,
 )
@@ -22,6 +26,23 @@ class TestGetStopReason(BaseTest):
 
     def test_defaults_to_end_turn_when_result_is_not_a_dict(self):
         self.assertEqual(_get_stop_reason({"result": "ok"}), "end_turn")
+
+
+class TestSteerDeclineReason(BaseTest):
+    @parameterized.expand(
+        [
+            ("startup_turn", {"result": {"steered": False, "reason": "startup_turn"}}, "startup_turn"),
+            ("no_active_turn", {"result": {"steered": False, "reason": "no_active_turn"}}, "no_active_turn"),
+            ("adapter_rejected", {"result": {"steered": False, "reason": "adapter_rejected"}}, "adapter_rejected"),
+            ("older_sandbox_omits_reason", {"result": {"steered": False}}, STEER_DECLINE_REASON_UNREPORTED),
+            ("reason_outside_result", {"reason": "startup_turn"}, STEER_DECLINE_REASON_UNREPORTED),
+            ("result_is_not_a_dict", {"result": "steer_declined"}, STEER_DECLINE_REASON_UNREPORTED),
+            ("empty_reason", {"result": {"reason": ""}}, STEER_DECLINE_REASON_UNREPORTED),
+            ("no_data", None, STEER_DECLINE_REASON_UNREPORTED),
+        ]
+    )
+    def test_reads_reason_from_command_result(self, _name, data, expected):
+        self.assertEqual(_steer_decline_reason(data), expected)
 
 
 class TestWriteTurnComplete(BaseTest):


### PR DESCRIPTION
## Problem

- A large share of mid-turn steers on cloud runs are declined, and the run logs cannot say which of those are a deliberate block and which are a defect.
- One log line, `send_followup_steer_declined`, covers every decline and carries no reason.
- The sandbox refuses a steer down three different paths, and all three produce the identical line.
- The actor-mismatch gate returns the same declined outcome and never logs that line, so a decline rate misses it.
- Someone reading the decline rate cannot act on it. Narrowing the startup block, tightening the client's view of the running turn, and chasing an adapter refusal are three different fixes.

## Changes

- The dashboard's decline rate can now be split by cause, so a change to one path is visible on its own.
- The sandbox names the reason on the declined outcome, and the activity logs it as `reason`.

| Reason | When the sandbox reports it | What it implies |
| --- | --- | --- |
| `startup_turn` | The initial, resume, or prewarmed first turn is running | The steer gate refuses by design, from #83092 |
| `no_active_turn` | The sandbox has no turn to fold the message into | The client believes a turn is still running |
| `adapter_rejected` | A turn is running, and the runtime refused the injection | The runtime could not reach the live turn |
| `actor_mismatch` | The backend's identity gate rejected the sender | Credentials, not turn state |
| `unreported` | A sandbox image that predates this field | Clears once the base image ships |



