### PR TITLE
fix(max): stop clipping the top of capability badges

### DIFF
--- a/frontend/src/scenes/max/components/CapabilityBadges.tsx
+++ b/frontend/src/scenes/max/components/CapabilityBadges.tsx
@@ -49,7 +49,7 @@ export function CapabilityBadges({
     return (
         <div
             className={cn(
-                'flex flex-wrap items-center justify-center gap-1.5 max-w-[500px] px-3',
+                'flex flex-wrap items-center justify-center gap-1.5 max-w-[500px] px-3 pt-[2px]',
                 COLORFUL_ICONS,
                 className
             )}


### PR DESCRIPTION
## Problem

On the PostHog AI home screen, the top edge of the first row of suggestion buttons is visually cut off. The badge row sits flush against its container, so the button borders clip.

## Changes

- The top row of capability suggestion buttons is no longer clipped — the row now has 2px of top padding.

## How did you test this code?

Not manually verified in a running app. The change is a single Tailwind class (`pt-[2px]`) on the badge row container.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread reporting the clipped top row, with the exact container and class specified. Change made with the PostHog Slack app; no skills beyond the repo conventions were needed for a one-class edit.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787839234752209?thread_ts=1787839234.752209&cid=C09SK2PAGKF)*
