### PR TITLE
fix(replay-vision): never regress the sweep watermark, bound its row wait

### DIFF
--- a/products/replay_vision/backend/temporal/activities/advance_scanner_watermark.py
+++ b/products/replay_vision/backend/temporal/activities/advance_scanner_watermark.py
@@ -1,13 +1,30 @@
+from django.db import OperationalError, connection, transaction
+from django.db.models import Q
+
+import psycopg.errors
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner
 from products.replay_vision.backend.temporal.decorators import track_activity
+from products.replay_vision.backend.temporal.errors import SCANNER_WATERMARK_BUSY_ERROR_TYPE
+from products.replay_vision.backend.temporal.metrics import record_watermark_advance
 from products.replay_vision.backend.temporal.sweep_types import AdvanceScannerWatermarkInputs
 
 
 @activity.defn
 @track_activity()
 def advance_scanner_watermark_activity(inputs: AdvanceScannerWatermarkInputs) -> None:
+    """Advance the sweep keyset; never regress it.
+
+    Concurrent ticks and delayed Temporal retries race on this row, and an unconditional write lets a
+    stale attempt drag the keyset backwards — the next sweep then re-fetches ground a newer tick
+    already covered, and every re-dispatched session burns an insert on UNIQUE(scanner_id, session_id).
+    The WHERE admits only a strictly newer (last_swept_at, last_seen_session_id) keyset, so of N racing
+    writers the newest lands and the rest no-op. Deep-sweep progress rides along only with an admitted
+    fast keyset: a rejected write's deep cursor is as stale as its fast one, and dropping it only makes
+    the deep pass re-walk a window it tolerates re-walking.
+    """
     updates: dict[str, object] = {
         "last_swept_at": inputs.new_last_swept_at,
         "last_seen_session_id": inputs.new_last_seen_session_id,
@@ -15,8 +32,46 @@ def advance_scanner_watermark_activity(inputs: AdvanceScannerWatermarkInputs) ->
     if inputs.new_last_deep_swept_at is not None:
         updates["deep_swept_through"] = inputs.new_last_deep_swept_at
         updates["deep_seen_session_id"] = inputs.new_last_deep_seen_session_id
-    updated = ReplayScanner.objects.filter(pk=inputs.scanner_id).update(**updates)
-    if updated == 0:
+    try:
+        with transaction.atomic():
+            # Bounded like the admission lock: a writer queued behind an open transaction on this row
+            # gives up after 2s and defers to the activity retry instead of camping in Postgres's lock
+            # queue with a connection held. 2s absorbs the row's brief holders (scanner save(),
+            # admission-budget updates), which NOWAIT would turn into a failure on every brush.
+            with connection.cursor() as cursor:
+                cursor.execute("SET LOCAL lock_timeout = '2s'")
+            updated = ReplayScanner.objects.filter(
+                Q(last_swept_at__lt=inputs.new_last_swept_at)
+                | Q(
+                    last_swept_at=inputs.new_last_swept_at,
+                    last_seen_session_id__lt=inputs.new_last_seen_session_id,
+                ),
+                pk=inputs.scanner_id,
+            ).update(**updates)
+    except OperationalError as e:
+        if not isinstance(e.__cause__, psycopg.errors.LockNotAvailable):
+            raise
+        record_watermark_advance("busy")
+        activity.logger.info(
+            "advance_scanner_watermark: row busy; deferring to activity retry",
+            extra={"scanner_id": str(inputs.scanner_id)},
+        )
+        raise ApplicationError(
+            "Scanner watermark row busy; retried with backoff",
+            type=SCANNER_WATERMARK_BUSY_ERROR_TYPE,
+        ) from e
+    if updated:
+        record_watermark_advance("advanced")
+        return
+    if ReplayScanner.objects.filter(pk=inputs.scanner_id).exists():
+        # A newer tick already carried the keyset past this attempt's; dropping the write is the point.
+        record_watermark_advance("superseded")
+        activity.logger.info(
+            "advance_scanner_watermark: superseded by a newer keyset",
+            extra={"scanner_id": str(inputs.scanner_id)},
+        )
+    else:
+        record_watermark_advance("scanner_missing")
         activity.logger.info(
             "advance_scanner_watermark: scanner no longer exists",
             extra={"scanner_id": str(inputs.scanner_id)},

--- a/products/replay_vision/backend/temporal/errors.py
+++ b/products/replay_vision/backend/temporal/errors.py
@@ -8,6 +8,7 @@ __all__ = [
     "INELIGIBLE_SESSION_ERROR_TYPE",
     "SCANNER_ADMISSION_BUSY_ERROR_TYPE",
     "SCANNER_FAILURE_ERROR_TYPE",
+    "SCANNER_WATERMARK_BUSY_ERROR_TYPE",
     "ConsentWithdrawnError",
     "FailureKind",
     "IneligibleSessionError",
@@ -21,6 +22,8 @@ INELIGIBLE_SESSION_ERROR_TYPE = "IneligibleSession"
 SCANNER_FAILURE_ERROR_TYPE = "ScannerFailure"
 # Always retryable: the create activity's backoff spreads contenders that Postgres would otherwise queue.
 SCANNER_ADMISSION_BUSY_ERROR_TYPE = "ScannerAdmissionBusy"
+# Always retryable: a watermark write that lost its brush with the row defers to the activity backoff.
+SCANNER_WATERMARK_BUSY_ERROR_TYPE = "ScannerWatermarkBusy"
 
 
 class _KindedApplicationError(ApplicationError):

--- a/products/replay_vision/backend/temporal/metrics.py
+++ b/products/replay_vision/backend/temporal/metrics.py
@@ -92,6 +92,12 @@ REPLAY_VISION_SCANNER_ADMISSION_BUSY = Counter(
     ["scanner_type"],
 )
 
+REPLAY_VISION_WATERMARK_ADVANCES = Counter(
+    "replay_vision_watermark_advance_total",
+    "Sweep watermark write outcomes: advanced, superseded by a newer keyset, row busy, or scanner missing",
+    ["outcome"],
+)
+
 REPLAY_VISION_SCANNER_LIMIT_REACHED = Counter(
     "replay_vision_scanner_limit_reached_total",
     "Requests refused because a per-scanner credit limit left no room, by the API surface that refused",
@@ -208,6 +214,12 @@ def record_quota_exhausted_skip(scanner_type: str) -> None:
 def record_scanner_admission_busy(scanner_type: str) -> None:
     REPLAY_VISION_SCANNER_ADMISSION_BUSY.labels(scanner_type=scanner_type).inc()
     _otel.record_counter_twin(REPLAY_VISION_SCANNER_ADMISSION_BUSY, 1, {"scanner_type": scanner_type})
+
+
+def record_watermark_advance(outcome: str) -> None:
+    """`outcome` is "advanced", "superseded", "busy", or "scanner_missing"."""
+    REPLAY_VISION_WATERMARK_ADVANCES.labels(outcome=outcome).inc()
+    _otel.record_counter_twin(REPLAY_VISION_WATERMARK_ADVANCES, 1, {"outcome": outcome})
 
 
 def record_scanner_limit_reached(surface: str) -> None:

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime as dt
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -7,6 +8,7 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.db import connections, transaction
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -63,6 +65,7 @@ from products.replay_vision.backend.temporal.constants import (
     SWEEP_READ_BUDGET_BYTES_24H,
     build_process_vision_action_workflow_id,
 )
+from products.replay_vision.backend.temporal.errors import SCANNER_WATERMARK_BUSY_ERROR_TYPE
 from products.replay_vision.backend.temporal.snapshots import BackfillScannerSnapshot
 from products.replay_vision.backend.temporal.sweep_types import (
     AdvanceScannerWatermarkInputs,
@@ -909,6 +912,8 @@ class TestAdvanceScannerWatermarkActivity:
     def test_updates_watermark_and_last_seen(self) -> None:
         scanner = _make_scanner()
         new_watermark = dt.datetime(2026, 5, 1, 12, 0, 0, tzinfo=dt.UTC)
+        # The keyset guard only advances; start the row behind the target.
+        ReplayScanner.objects.filter(pk=scanner.pk).update(last_swept_at=new_watermark - dt.timedelta(days=1))
 
         advance_scanner_watermark_activity(
             AdvanceScannerWatermarkInputs(
@@ -950,7 +955,9 @@ class TestAdvanceScannerWatermarkActivity:
         now = dt.datetime(2026, 5, 1, 12, 0, 0, tzinfo=dt.UTC)
         stamped = now - dt.timedelta(minutes=3)
         scanner = _make_scanner(deep_swept_through=now - dt.timedelta(days=1))
-        ReplayScanner.objects.filter(pk=scanner.pk).update(deep_attempted_at=stamped)
+        ReplayScanner.objects.filter(pk=scanner.pk).update(
+            deep_attempted_at=stamped, last_swept_at=now - dt.timedelta(days=1)
+        )
 
         advance_scanner_watermark_activity(
             AdvanceScannerWatermarkInputs(
@@ -970,6 +977,8 @@ class TestAdvanceScannerWatermarkActivity:
     def test_clears_last_seen_with_empty_string(self) -> None:
         scanner = _make_scanner(last_seen_session_id="stale-id")
         new_watermark = dt.datetime(2026, 5, 1, 12, 0, 0, tzinfo=dt.UTC)
+        # The keyset guard only advances; start the row behind the target.
+        ReplayScanner.objects.filter(pk=scanner.pk).update(last_swept_at=new_watermark - dt.timedelta(days=1))
 
         advance_scanner_watermark_activity(
             AdvanceScannerWatermarkInputs(
@@ -986,6 +995,8 @@ class TestAdvanceScannerWatermarkActivity:
         existing_deep = dt.datetime(2026, 5, 1, 6, 0, 0, tzinfo=dt.UTC)
         scanner = _make_scanner(deep_swept_through=existing_deep)
         new_deep = dt.datetime(2026, 5, 1, 11, 0, 0, tzinfo=dt.UTC)
+        # The keyset guard only advances; start the row behind the target.
+        ReplayScanner.objects.filter(pk=scanner.pk).update(last_swept_at=existing_deep)
 
         advance_scanner_watermark_activity(
             AdvanceScannerWatermarkInputs(
@@ -1020,6 +1031,8 @@ class TestAdvanceScannerWatermarkActivity:
     def test_does_not_bump_scanner_version(self) -> None:
         scanner = _make_scanner()
         original_version = scanner.scanner_version
+        # The keyset guard only advances; start the row behind the target.
+        ReplayScanner.objects.filter(pk=scanner.pk).update(last_swept_at=dt.datetime(2026, 4, 1, tzinfo=dt.UTC))
 
         advance_scanner_watermark_activity(
             AdvanceScannerWatermarkInputs(
@@ -1031,6 +1044,85 @@ class TestAdvanceScannerWatermarkActivity:
 
         scanner.refresh_from_db()
         assert scanner.scanner_version == original_version
+
+    def test_stale_write_never_regresses_the_keyset(self) -> None:
+        # A delayed retry from an older tick must not drag the sweep backwards: the ground it would
+        # re-open was already covered, and every re-dispatched session burns a duplicate-key insert.
+        current = dt.datetime(2026, 5, 2, 12, 0, 0, tzinfo=dt.UTC)
+        scanner = _make_scanner()
+        ReplayScanner.objects.filter(pk=scanner.pk).update(
+            last_swept_at=current, last_seen_session_id="b", deep_swept_through=current
+        )
+
+        advance_scanner_watermark_activity(
+            AdvanceScannerWatermarkInputs(
+                scanner_id=scanner.id,
+                new_last_swept_at=current - dt.timedelta(minutes=35),
+                new_last_seen_session_id="z",
+                # Deep progress rides only with an admitted fast keyset; a stale tick drops both.
+                new_last_deep_swept_at=current + dt.timedelta(hours=1),
+            )
+        )
+
+        scanner.refresh_from_db()
+        assert scanner.last_swept_at == current
+        assert scanner.last_seen_session_id == "b"
+        assert scanner.deep_swept_through == current
+
+    def test_equal_timestamp_advances_only_past_the_session_tiebreaker(self) -> None:
+        current = dt.datetime(2026, 5, 2, 12, 0, 0, tzinfo=dt.UTC)
+        scanner = _make_scanner()
+        ReplayScanner.objects.filter(pk=scanner.pk).update(last_swept_at=current, last_seen_session_id="b")
+
+        advance_scanner_watermark_activity(
+            AdvanceScannerWatermarkInputs(
+                scanner_id=scanner.id, new_last_swept_at=current, new_last_seen_session_id="a"
+            )
+        )
+        scanner.refresh_from_db()
+        assert scanner.last_seen_session_id == "b"
+
+        advance_scanner_watermark_activity(
+            AdvanceScannerWatermarkInputs(
+                scanner_id=scanner.id, new_last_swept_at=current, new_last_seen_session_id="c"
+            )
+        )
+        scanner.refresh_from_db()
+        assert scanner.last_seen_session_id == "c"
+
+    def test_contended_row_fails_fast_as_retryable_busy(self) -> None:
+        # Watermark writers queued behind one open transaction each hold a pooled connection; a held
+        # row must defer to the activity retry within the lock_timeout, not camp in the lock queue.
+        scanner = _make_scanner()
+        target = timezone.now() + dt.timedelta(hours=1)
+        lock_taken = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_scanner_row() -> None:
+            try:
+                with transaction.atomic():
+                    ReplayScanner.objects.select_for_update().filter(pk=scanner.pk).first()
+                    lock_taken.set()
+                    release_lock.wait(timeout=30)
+            finally:
+                connections.close_all()
+
+        holder = threading.Thread(target=hold_scanner_row)
+        holder.start()
+        assert lock_taken.wait(timeout=30)
+        try:
+            with pytest.raises(ApplicationError) as err:
+                advance_scanner_watermark_activity(
+                    AdvanceScannerWatermarkInputs(
+                        scanner_id=scanner.id, new_last_swept_at=target, new_last_seen_session_id=""
+                    )
+                )
+        finally:
+            release_lock.set()
+            holder.join(timeout=30)
+
+        assert err.value.type == SCANNER_WATERMARK_BUSY_ERROR_TYPE
+        assert err.value.non_retryable is False
 
 
 # check_scanner_budget_activity


### PR DESCRIPTION
## Problem

Follow-up to #88861/#88865, which fixed where **admissions** wait. The sweep watermark write has the same shape and is the remaining convoy path — caught live on the prod-us writer this morning (2026-08-27 ~09:00 UTC):

- `advance_scanner_watermark_activity` is an unconditional `UPDATE` on the scanner row. At 09:00 UTC a **62-deep wait queue** of these UPDATEs formed behind one open transaction, all rewriting the same scanner row (`while locking tuple (6560,4) in relation "replay_vision_replayscanner"`), each waiter holding a pooled connection for up to its 30s `start_to_close`.
- The queued writers were carrying `last_swept_at = 08:25:06` — a **35-minute-stale watermark — at 09:00**. Nothing stops a delayed attempt from committing after a newer one, dragging the keyset backwards; the next sweep then re-fetches ground already covered, and every re-dispatched session burns an insert on `UNIQUE(scanner_id, session_id)` (duplicate-key errors on `replay_observation_unique_scanner_session` observed at 08:10 and 08:47 in the same log).
- The same pattern recurred inside the day's big convoy at **13:02–13:12 UTC**: a replay-vision worker holding a long transaction (repeated 59s eventdefinition scans inside it, duplicate-key insert at 13:17) was among the top blockers of a property-definitions-dominated lock wave that pushed pgbouncer-cloud-write from ~130 to **519 server conns in use** and scaled the pods 6→11 — visible on the [pgbouncer pool-shape dashboard (internal), 12:30–15:00 UTC window](https://grafana.prod-us.posthog.dev/d/pgbouncer-pool-shape/pgbouncer-cloud-write-c2b7-pool-shape-and-convoy?from=1787833800000&to=1787842800000). (The second spike in that window, 14:20 UTC, was an unrelated deploy-migration lock dam.)

## Changes

- The write only advances: the `WHERE` admits a strictly newer `(last_swept_at, last_seen_session_id)` keyset, so of N racing writers the newest lands and the rest no-op — a stale attempt whose keyset is already superseded doesn't even take the row lock. Deep-sweep progress rides along only with an admitted fast keyset; a rejected write's deep cursor is as stale as its fast one, and dropping it only makes the deep pass re-walk a window it tolerates re-walking.
- Same contention treatment as the admission lock (#88861): the write runs under `SET LOCAL lock_timeout = '2s'`; a held row maps to a retryable `ScannerWatermarkBusy` `ApplicationError` and defers to the activity's retry (`maximum_attempts=3` on the existing policy) instead of camping in Postgres's lock queue. Other `OperationalError`s re-raise unchanged.
- Outcomes are visible: `replay_vision_watermark_advance_total{outcome=advanced|superseded|busy|scanner_missing}`.

A dropped or refused advance was already the accepted failure mode (scanner deleted → `updated == 0`; activity failure → next 5-minute tick re-derives the keyset and the UNIQUE constraint dedups re-dispatch), so the guard narrows behavior only for writes that would have moved the watermark backwards.

## How did you test this code?

- `test_stale_write_never_regresses_the_keyset`: an older keyset (with a newer deep cursor attached) leaves the row untouched.
- `test_equal_timestamp_advances_only_past_the_session_tiebreaker`: the tuple comparison, both directions.
- `test_contended_row_fails_fast_as_retryable_busy`: a thread holds the row lock; the activity raises retryable `ScannerWatermarkBusy` instead of a raw `OperationalError`.
- Existing watermark tests updated to seed the row behind their target (the guard makes a fresh scanner's now-ish watermark refuse a past-dated advance, which is the point).
- Not run locally: the full replay_vision suite and mypy; CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
