### PR TITLE
fix(signals): raise inbox ranking dag run-pod memory to 16Gi

### DIFF
--- a/products/signals/dags/inbox_ranking/dataset/dag.py
+++ b/products/signals/dags/inbox_ranking/dataset/dag.py
@@ -887,7 +887,22 @@ inbox_ranking_dataset_job = dagster.define_asset_job(
     # The seven label streams run sequentially and each may take its full 600s query timeout, so an
     # hour left a slow-but-valid pass no room for the join, the S3 writes, or an asset retry — and
     # the label windows only grow, since they accumulate from LABELS_EPOCH.
-    tags={**owner_tags, "dagster/max_runtime": str(3 * 60 * 60)},
+    tags={
+        **owner_tags,
+        "dagster/max_runtime": str(3 * 60 * 60),
+        # The state, embeddings, signal-embeddings and labels assets execute as parallel subprocesses
+        # in one run pod, and the embeddings snapshot holds a 1536-float vector per live report, so
+        # the pod's peak memory grows with the inventory. The default 8Gi limit is what a run gets
+        # without this tag, and the peak crossed it (OOMKilled) once the inventory grew enough.
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"memory": "8Gi"},
+                    "limits": {"memory": "16Gi"},
+                }
+            }
+        },
+    },
 )
 
 

--- a/products/signals/dags/inbox_ranking/training/dag.py
+++ b/products/signals/dags/inbox_ranking/training/dag.py
@@ -375,7 +375,22 @@ inbox_ranking_training_job = dagster.define_asset_job(
     name="inbox_ranking_training_job",
     selection=[EXAMPLES_TABLE, "inbox_ranking_model_candidate", "inbox_ranking_model_champion"],
     partitions_def=partition_def,
-    tags={**owner_tags, "dagster/max_runtime": str(2 * 60 * 60)},
+    tags={
+        **owner_tags,
+        "dagster/max_runtime": str(2 * 60 * 60),
+        # The examples asset holds every snapshot of the lookback window in pandas at once (state
+        # plus labels per day) before the per-head builders run, so the peak grows with the
+        # lookback and the inventory. Sized like the dataset job rather than left at the 8Gi
+        # default so growth surfaces as a slow run, not an OOMKilled pod.
+        "dagster-k8s/config": {
+            "container_config": {
+                "resources": {
+                    "requests": {"memory": "8Gi"},
+                    "limits": {"memory": "16Gi"},
+                }
+            }
+        },
+    },
 )
 
 


### PR DESCRIPTION
## Problem

- The inbox ranking dataset job on prod-us was OOMKilled on its 2026-08-27 run (partition 2026-08-26), the first failure in three weeks: [run a8e6c2ed](https://posthog.dagster.cloud/prod-us/runs/a8e6c2ed-118e-49c3-9519-a18be1f53e82).
- The first scheduled run of the new training job (#85876) then failed because that day's state and labels snapshots do not exist: [run 59049d6d](https://posthog.dagster.cloud/prod-us/runs/59049d6d-f276-4f8e-8417-ac3884e06dad).
- Run pods get an 8Gi limit unless the job sets `dagster-k8s/config`, and the dataset pods peaked between 4 and 7 GiB over the previous week.
- The state, embeddings and labels assets run as parallel subprocesses in one pod, and the embeddings snapshot carries a 1536-float vector per live report, so the peak grows with the inventory.

## Changes

- `inbox_ranking_dataset_job` and `inbox_ranking_training_job` now request 8Gi and cap at 16Gi, the same shape as `customer_archetype_job`.
- Nothing user-visible changes and no dag logic changes.

## How did you test this code?

- Ran `products/signals/dags/inbox_ranking/tests/` locally (definitions resolve with the new tags).
- Not run: `posthog/dags/tests/test_slack_alerts.py`, which needs a local `test_dagster` database.
- Not verified: the peak memory of a full training run, which has not completed on prod yet. 16Gi is the same ceiling the dataset job gets and the nodes are 32 GiB.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) diagnosed the failed runs from Dagster Cloud and VictoriaMetrics pod memory, then wrote the tag change. Skills invoked: `/phs inbox-ranking`, `/writing-code-comments`, `/writing-pr-descriptions`.

https://claude.ai/code/session_01YYumH1ar4MdTzJFqNDqaem
