### PR TITLE
ci(tasks): resolve latest hogland CLI release, reuse the deployer app

### DIFF
--- a/.github/workflows/cd-tasks-golden-snapshot.yml
+++ b/.github/workflows/cd-tasks-golden-snapshot.yml
@@ -335,40 +335,55 @@ jobs:
               id: hogland-token
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               with:
-                  app-id: ${{ secrets.GH_APP_HOGLAND_CLI_APP_ID }}
-                  private-key: ${{ secrets.GH_APP_HOGLAND_CLI_PRIVATE_KEY }}
+                  app-id: ${{ secrets.GH_APP_HOGLAND_DEPLOYER_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_HOGLAND_DEPLOYER_PRIVATE_KEY }}
                   owner: PostHog
                   repositories: hogland
+                  # Read-only: this token only checks out hogland to build the
+                  # CLI. The deployer app may hold write; scope the minted token
+                  # down so a bake can never push to hogland.
+                  permission-contents: read
 
-            # Build the CLI from a released, immutable tag, never a moving branch
-            # like main — a rebuilt CLI must be reproducible across bakes. Require
-            # at least v1.5.0-cli: every flag and JSON field the bake/smoke scripts
-            # use (notably --kind) exists from that tag; older tags predate them.
-            - name: Require a pinned hogland CLI tag
+            # Resolve the latest published hogland CLI release (a v*-cli tag) at
+            # runtime rather than pinning a var. Released tags are immutable and
+            # reviewed — we never build from a moving branch like main. The bake
+            # relies on flags/fields (notably --kind) that exist from v1.5.0-cli,
+            # so guard that the resolved tag is at least that. Needs the hogland
+            # token (private repo), so it runs after the mint step.
+            - name: Resolve latest hogland CLI release
               if: env.skip != 'true'
+              id: cli-ref
               env:
-                  CLI_REF: ${{ vars.HOGLAND_CLI_REF }}
+                  GH_TOKEN: ${{ steps.hogland-token.outputs.token }}
               run: |
                   set -euo pipefail
                   MIN_CLI_VERSION=1.5.0
-                  if [[ ! "$CLI_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-cli$ ]]; then
-                      echo "::error::HOGLAND_CLI_REF must be a released vX.Y.Z-cli tag (got '${CLI_REF:-<unset>}'); a moving branch like main is not allowed"
+                  ref=$(gh api --paginate repos/PostHog/hogland/releases \
+                      --jq 'map(select(.tag_name | endswith("-cli"))) | sort_by(.created_at) | last | .tag_name // empty')
+                  if [[ -z "$ref" ]]; then
+                      echo "::error::no published v*-cli release found in PostHog/hogland"
                       exit 1
                   fi
-                  cli_version="${CLI_REF#v}"
+                  if [[ ! "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-cli$ ]]; then
+                      echo "::error::resolved CLI release '$ref' is not a vX.Y.Z-cli tag"
+                      exit 1
+                  fi
+                  cli_version="${ref#v}"
                   cli_version="${cli_version%-cli}"
                   lowest=$(printf '%s\n%s\n' "$MIN_CLI_VERSION" "$cli_version" | sort -V | head -1)
                   if [[ "$cli_version" != "$MIN_CLI_VERSION" && "$lowest" != "$MIN_CLI_VERSION" ]]; then
-                      echo "::error::HOGLAND_CLI_REF ${CLI_REF} is below the minimum v${MIN_CLI_VERSION}-cli; the bake relies on flags/fields introduced there"
+                      echo "::error::latest hogland CLI release ${ref} is below the minimum v${MIN_CLI_VERSION}-cli"
                       exit 1
                   fi
+                  echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+                  echo "::notice::building hogland CLI from ${ref}"
 
             - name: Check out hogland CLI source
               if: env.skip != 'true'
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: PostHog/hogland
-                  ref: ${{ vars.HOGLAND_CLI_REF }}
+                  ref: ${{ steps.cli-ref.outputs.ref }}
                   token: ${{ steps.hogland-token.outputs.token }}
                   path: hogland-src
 

--- a/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
+++ b/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
@@ -125,9 +125,10 @@ For **each** cluster the workflow targets (dev, then prod-us):
   - `HOG_TASKS_GOLDEN_PROD_ENABLED=true` — second arm for prod-targeting
     clusters. The prod-us leg stays a no-op until this is set, so it does not
     fail nightly before its own principal + TrustMapping exist.
-  - `HOGLAND_CLI_REF` (**required**) — the `PostHog/hogland` ref to build the CLI
-    from. Must be a released `v*-cli` tag; the workflow fails if it is unset or
-    not a `*-cli` tag (a moving branch like `main` is not reproducible).
+  - No `HOGLAND_CLI_REF` variable. The workflow resolves the latest published
+    `v*-cli` release of `PostHog/hogland` at runtime and builds the CLI from that
+    tag (never `main`), guarding that it is at least `v1.5.0-cli`. The CLI only
+    orchestrates the bake, so its version does not change the golden's contents.
   - The quiet-window guard's rollout workflow is **per cluster**, hardcoded in the
     bake matrix (dev: `deploy.yml`, prod-us: `promote-to-prod.yml`) — not a shared
     var, because the two clusters roll out through different workflows. The guard
@@ -138,9 +139,12 @@ For **each** cluster the workflow targets (dev, then prod-us):
     cluster means adding its rollout workflow file to the matrix.
   - `TS_HOGLAND_CI_CLIENT_ID`, `TS_HOGLAND_CI_AUDIENCE` — shared with
     `hogbox-preview-env.yml`; already present if preview is provisioned.
-- **Secrets** — a GitHub App with read access to `PostHog/hogland` (for the CLI
-  checkout), exposed as `GH_APP_HOGLAND_CLI_APP_ID` +
-  `GH_APP_HOGLAND_CLI_PRIVATE_KEY`. See `/managing-github-actions-secrets`.
+- **Secrets** — the `GH_APP_HOGLAND_DEPLOYER` GitHub App (org secrets
+  `GH_APP_HOGLAND_DEPLOYER_APP_ID` + `GH_APP_HOGLAND_DEPLOYER_PRIVATE_KEY`),
+  reused for the CLI checkout of `PostHog/hogland`. The minted token is scoped
+  to `contents: read` (`permission-contents: read`), so even though the deployer
+  app may hold write, a bake can never push to hogland. See
+  `/managing-github-actions-secrets`.
 
 ## Running it
 


### PR DESCRIPTION
## Problem

The tasks golden-snapshot bake needed two pieces of standing config that were more friction than they were worth:

- A `HOGLAND_CLI_REF` repo variable pinning the exact `v*-cli` tag to build the CLI from — which meant a manual bump every time hogland shipped a new CLI, and a bake that silently no-op'd if it was unset.
- A bespoke `GH_APP_HOGLAND_CLI` GitHub App for the CLI checkout, when the org already has `GH_APP_HOGLAND_DEPLOYER` with access to `PostHog/hogland`.

## Changes

- The bake resolves the **latest published `v*-cli` release** of `PostHog/hogland` at runtime (via the releases API, using the checkout token), instead of reading `HOGLAND_CLI_REF`. It still guards the resolved tag is a real `vX.Y.Z-cli` tag and at least `v1.5.0-cli`, and never builds from a moving branch like `main`. The CLI only orchestrates the bake (create/snapshot/alias), so its version doesn't change the golden's contents — pinning bought little.
- The `HOGLAND_CLI_REF` variable is gone.
- The CLI checkout reuses **`GH_APP_HOGLAND_DEPLOYER`** (`GH_APP_HOGLAND_DEPLOYER_APP_ID` / `_PRIVATE_KEY`) instead of a new `GH_APP_HOGLAND_CLI` app.
- The minted token is scoped to `permission-contents: read`, so even though the deployer app may hold write, a bake can never push to hogland.
- Runbook updated to match.

## How did you test this code?

I am an agent (Claude Code), work by Tom Owers. YAML parses (`yaml.safe_load`). The bake itself only runs on `master` when `HOG_TASKS_GOLDEN_ENABLED=true`, so the real end-to-end check is the first armed dev run. The releases resolve (`gh api repos/PostHog/hogland/releases … endswith("-cli") … last`) matches how the workflow already resolves the latest `@posthog/agent` version.

## 🤖 Agent context

Agent-authored (Claude Code), authored by Tom Owers. Two simplifications requested while arming the dev bake: use the latest CLI release instead of a pinned var, and reuse the existing hogland deployer app rather than mint a new one. The token is deliberately down-scoped to `contents: read` since the checkout only reads.
