### PR TITLE
fix(cohorts): unwrap single-element list values for single-value operators

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -373,7 +373,9 @@ def _coerce_stored_filter_values(filters: Any) -> Any:
         key: _coerce_stored_filter_values(value) if key in ("properties", "values") else value
         for key, value in filters.items()
     }
-    if coerced.get("type") in SINGLE_VALUE_FILTER_TYPES:
+    # An is_set/is_not_set filter stores no value key, and validate_filters serializes with
+    # exclude_none, so writing `value: None` here would make an unchanged filter compare unequal.
+    if coerced.get("type") in SINGLE_VALUE_FILTER_TYPES and "value" in coerced:
         coerced["value"] = _single_value_operator_value(coerced.get("operator"), coerced.get("value"))
     return coerced
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -78,7 +78,7 @@ from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.utils import earliest_timestamp_func
 from posthog.models.person.util import get_person_by_uuid, validate_person_uuids_exist
-from posthog.models.property.property import Property
+from posthog.models.property.property import STRING_PREFIX_SUFFIX_OPERATORS, Property
 from posthog.models.property.relative_date import determine_parsed_date_for_property_matching
 from posthog.models.team.team import DEPRECATED_ATTRS, Team
 from posthog.models.utils import UUIDT
@@ -326,18 +326,15 @@ class CohortFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
 # Keep in sync with OperatorType in posthog/models/property/property.py
 DATE_OPERATORS = ("is_date_after", "is_date_before")
 
-# Operators that compare against exactly one string. A multi-value list is meaningful for
+# Operators that compare against exactly one value. A multi-value list is meaningful for
 # `icontains`/`not_icontains` in HogQL, which turns it into multiSearchAnyCaseInsensitive, so
-# only the single-element case is unwrapped here. See _single_value_operator_value.
+# only the single-element case is unwrapped here.
 SINGLE_VALUE_STRING_OPERATORS = (
     "icontains",
     "not_icontains",
     "is_date_after",
     "is_date_before",
-    "startswith",
-    "not_startswith",
-    "endswith",
-    "not_endswith",
+    *STRING_PREFIX_SUFFIX_OPERATORS,
 )
 
 
@@ -350,7 +347,10 @@ def _single_value_operator_value(operator: str | None, value: Any) -> Any:
     the unwrapped string is what both readers already agree on.
     """
     if operator in SINGLE_VALUE_STRING_OPERATORS and isinstance(value, list) and len(value) == 1:
-        return value[0]
+        # Only a string element unwraps. A `[None]` value would otherwise become `None` and fail
+        # the missing-value check below, which rejects a payload that saved before.
+        if isinstance(value[0], str):
+            return value[0]
     return value
 
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -326,6 +326,33 @@ class CohortFilter(FilterBytecodeMixin, BaseModel, extra="forbid"):
 # Keep in sync with OperatorType in posthog/models/property/property.py
 DATE_OPERATORS = ("is_date_after", "is_date_before")
 
+# Operators that compare against exactly one string. A multi-value list is meaningful for
+# `icontains`/`not_icontains` in HogQL, which turns it into multiSearchAnyCaseInsensitive, so
+# only the single-element case is unwrapped here. See _single_value_operator_value.
+SINGLE_VALUE_STRING_OPERATORS = (
+    "icontains",
+    "not_icontains",
+    "is_date_after",
+    "is_date_before",
+    "startswith",
+    "not_startswith",
+    "endswith",
+    "not_endswith",
+)
+
+
+def _single_value_operator_value(operator: str | None, value: Any) -> Any:
+    """Unwrap `["x"]` to `"x"` for operators that compare against one string.
+
+    The two cohort readers disagree about a single-element list. HogQL unwraps it
+    (posthog/hogql/property.py), so the cohort lists the person, while the Rust flag evaluator
+    stringifies it and searches for the literal text `["x"]`, so the flag never matches. Storing
+    the unwrapped string is what both readers already agree on.
+    """
+    if operator in SINGLE_VALUE_STRING_OPERATORS and isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value
+
 
 class PersonValueValidationMixin(BaseModel):
     """Shared value/operator presence and date-value validation for the person and
@@ -335,6 +362,12 @@ class PersonValueValidationMixin(BaseModel):
 
     operator: str | None = None  # accept any legacy operator
     value: Any | None = None  # mostly likely it's list[str], str, or None
+
+    @model_validator(mode="after")
+    def _coerce_single_value_list(self):
+        # Runs before the date check below so that check sees the unwrapped value.
+        self.value = _single_value_operator_value(self.operator, self.value)
+        return self
 
     @model_validator(mode="after")
     def _missing_keys_check(self):

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -329,13 +329,15 @@ DATE_OPERATORS = ("is_date_after", "is_date_before")
 # Operators that compare against exactly one value. A multi-value list is meaningful for
 # `icontains`/`not_icontains` in HogQL, which turns it into multiSearchAnyCaseInsensitive, so
 # only the single-element case is unwrapped here.
-SINGLE_VALUE_STRING_OPERATORS = (
+SINGLE_VALUE_OPERATORS = (
     "icontains",
     "not_icontains",
-    "is_date_after",
-    "is_date_before",
     *STRING_PREFIX_SUFFIX_OPERATORS,
+    *DATE_OPERATORS,
 )
+
+# Filter variants that inherit PersonValueValidationMixin, and so store an unwrapped value.
+SINGLE_VALUE_FILTER_TYPES = ("person", "person_metadata")
 
 
 def _single_value_operator_value(operator: str | None, value: Any) -> Any:
@@ -346,12 +348,34 @@ def _single_value_operator_value(operator: str | None, value: Any) -> Any:
     stringifies it and searches for the literal text `["x"]`, so the flag never matches. Storing
     the unwrapped string is what both readers already agree on.
     """
-    if operator in SINGLE_VALUE_STRING_OPERATORS and isinstance(value, list) and len(value) == 1:
-        # Only a string element unwraps. A `[None]` value would otherwise become `None` and fail
-        # the missing-value check below, which rejects a payload that saved before.
+    if operator in SINGLE_VALUE_OPERATORS and isinstance(value, list) and len(value) == 1:
+        # Unwrapping `[None]` gives `None`, which the missing-value check below rejects. That
+        # payload saves today, so leave a non-string element wrapped.
         if isinstance(value[0], str):
             return value[0]
     return value
+
+
+def _coerce_stored_filter_values(filters: Any) -> Any:
+    """Apply the single-value unwrap to a stored filters dict, without re-running validation.
+
+    `update()` compares the incoming filters against the stored ones to decide whether the
+    criteria changed. Incoming filters have already been unwrapped by `validate_filters`, so a row
+    written before the unwrap existed would compare unequal on a save that touched no criteria,
+    and a static cohort holding such a value would become uneditable.
+    """
+    if isinstance(filters, list):
+        return [_coerce_stored_filter_values(item) for item in filters]
+    if not isinstance(filters, dict):
+        return filters
+
+    coerced = {
+        key: _coerce_stored_filter_values(value) if key in ("properties", "values") else value
+        for key, value in filters.items()
+    }
+    if coerced.get("type") in SINGLE_VALUE_FILTER_TYPES:
+        coerced["value"] = _single_value_operator_value(coerced.get("operator"), coerced.get("value"))
+    return coerced
 
 
 class PersonValueValidationMixin(BaseModel):
@@ -364,7 +388,7 @@ class PersonValueValidationMixin(BaseModel):
     value: Any | None = None  # mostly likely it's list[str], str, or None
 
     @model_validator(mode="after")
-    def _coerce_single_value_list(self):
+    def _coerce_single_value_list(self) -> "PersonValueValidationMixin":
         # Runs before the date check below so that check sees the unwrapped value.
         self.value = _single_value_operator_value(self.operator, self.value)
         return self
@@ -1301,7 +1325,9 @@ class CohortSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerializ
     def update(self, cohort: Cohort, validated_data: dict, *args: Any, **kwargs: Any) -> Cohort:  # type: ignore
         request = self.context["request"]
         existing_has_criteria = cohort_filters_have_values(cohort.filters)
-        filters_changed = "filters" in validated_data and validated_data.get("filters") != cohort.filters
+        filters_changed = "filters" in validated_data and validated_data.get("filters") != _coerce_stored_filter_values(
+            cohort.filters
+        )
 
         create_in_folder = validated_data.pop("_create_in_folder", None)
         if create_in_folder is not None:

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -3747,17 +3747,24 @@ email@example.org,
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
+    @parameterized.expand(
+        [
+            ("holding_legacy_single_element_list", "icontains", "@example.com"),
+            ("with_is_set_filter_without_value_key", "is_set", None),
+        ]
+    )
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
-    def test_rename_static_cohort_holding_single_element_list_value(
-        self, patch_calculate_cohort, patch_capture
+    def test_rename_static_cohort_with_unchanged_criteria(
+        self, _name: str, operator: str, value: str | None, patch_calculate_cohort, patch_capture
     ) -> None:
-        person_filter = {"key": "email", "type": "person", "operator": "icontains", "value": "@example.com"}
+        person_filter = {"key": "email", "type": "person", "operator": operator, "value": value}
         stored_filters = CohortFilters.model_validate(
             {"properties": {"type": "OR", "values": [person_filter]}}, context={"team": self.team}
         ).model_dump(exclude_none=True)
-        # A row written before the unwrap shipped. HogQL builds the same bytecode either way.
-        stored_filters["properties"]["values"][0]["value"] = ["@example.com"]
+        if value is not None:
+            # A row written before the unwrap shipped. HogQL builds the same bytecode either way.
+            stored_filters["properties"]["values"][0]["value"] = [value]
         static_cohort = Cohort.objects.create(
             team=self.team,
             name="static cohort",
@@ -3776,6 +3783,9 @@ email@example.org,
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         static_cohort.refresh_from_db()
         self.assertEqual(static_cohort.name, "renamed static cohort")
+        assert static_cohort.filters is not None
+        # The save also repairs a legacy list in place: the persisted value is the unwrapped scalar.
+        self.assertEqual(static_cohort.filters["properties"]["values"][0].get("value"), value)
 
     @parameterized.expand([("with_filters", True), ("without_filters", False)])
     @patch("posthog.api.cohort.report_user_action")
@@ -4424,24 +4434,32 @@ email@example.org,
 
     @parameterized.expand(
         [
-            ("icontains_single_list", "icontains", ["@example.com"], "@example.com"),
-            ("not_icontains_single_list", "not_icontains", ["@example.com"], "@example.com"),
-            ("starts_with_single_list", "starts_with", ["admin"], "admin"),
-            ("not_starts_with_single_list", "not_starts_with", ["admin"], "admin"),
-            ("ends_with_single_list", "ends_with", [".com"], ".com"),
-            ("not_ends_with_single_list", "not_ends_with", [".com"], ".com"),
-            ("is_date_after_single_list", "is_date_after", ["-7d"], "-7d"),
-            ("is_date_before_single_list", "is_date_before", ["-7d"], "-7d"),
-            ("icontains_multi_list_kept", "icontains", ["@a.com", "@b.com"], ["@a.com", "@b.com"]),
-            ("icontains_plain_string_kept", "icontains", "@example.com", "@example.com"),
-            ("icontains_empty_list_kept", "icontains", [], []),
-            ("icontains_non_string_element_kept", "icontains", [None], [None]),
-            ("exact_single_list_kept", "exact", ["admin"], ["admin"]),
+            ("icontains_single_list", "person", "email", "icontains", ["@example.com"], "@example.com"),
+            ("not_icontains_single_list", "person", "email", "not_icontains", ["@example.com"], "@example.com"),
+            ("starts_with_single_list", "person", "email", "starts_with", ["admin"], "admin"),
+            ("not_starts_with_single_list", "person", "email", "not_starts_with", ["admin"], "admin"),
+            ("ends_with_single_list", "person", "email", "ends_with", [".com"], ".com"),
+            ("not_ends_with_single_list", "person", "email", "not_ends_with", [".com"], ".com"),
+            ("is_date_after_single_list", "person", "email", "is_date_after", ["-7d"], "-7d"),
+            ("is_date_before_single_list", "person", "email", "is_date_before", ["-7d"], "-7d"),
+            (
+                "person_metadata_single_list",
+                "person_metadata",
+                "created_at",
+                "is_date_after",
+                ["2024-01-01"],
+                "2024-01-01",
+            ),
+            ("icontains_multi_list_kept", "person", "email", "icontains", ["@a.com", "@b.com"], ["@a.com", "@b.com"]),
+            ("icontains_plain_string_kept", "person", "email", "icontains", "@example.com", "@example.com"),
+            ("icontains_empty_list_kept", "person", "email", "icontains", [], []),
+            ("icontains_non_string_element_kept", "person", "email", "icontains", [None], [None]),
+            ("exact_single_list_kept", "person", "email", "exact", ["admin"], ["admin"]),
         ]
     )
     @patch("posthog.api.cohort.report_user_action")
     def test_cohort_single_value_operator_unwraps_single_element_list(
-        self, _name, operator, value, expected, patch_capture
+        self, _name, filter_type, key, operator, value, expected, patch_capture
     ):
         response = self.client.post(
             f"/api/projects/{self.team.id}/cohorts",
@@ -4450,7 +4468,7 @@ email@example.org,
                 "filters": {
                     "properties": {
                         "type": "OR",
-                        "values": [{"key": "email", "type": "person", "operator": operator, "value": value}],
+                        "values": [{"key": key, "type": filter_type, "operator": operator, "value": value}],
                     }
                 },
             },

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -4396,10 +4396,15 @@ email@example.org,
         [
             ("icontains_single_list", "icontains", ["@example.com"], "@example.com"),
             ("not_icontains_single_list", "not_icontains", ["@example.com"], "@example.com"),
-            ("startswith_single_list", "startswith", ["admin"], "admin"),
-            ("endswith_single_list", "endswith", [".com"], ".com"),
+            ("starts_with_single_list", "starts_with", ["admin"], "admin"),
+            ("not_starts_with_single_list", "not_starts_with", ["admin"], "admin"),
+            ("ends_with_single_list", "ends_with", [".com"], ".com"),
+            ("not_ends_with_single_list", "not_ends_with", [".com"], ".com"),
+            ("is_date_after_single_list", "is_date_after", ["-7d"], "-7d"),
             ("icontains_multi_list_kept", "icontains", ["@a.com", "@b.com"], ["@a.com", "@b.com"]),
             ("icontains_plain_string_kept", "icontains", "@example.com", "@example.com"),
+            ("icontains_empty_list_kept", "icontains", [], []),
+            ("icontains_non_string_element_kept", "icontains", [None], [None]),
             ("exact_single_list_kept", "exact", ["admin"], ["admin"]),
         ]
     )
@@ -4421,6 +4426,7 @@ email@example.org,
         )
         self.assertEqual(response.status_code, 201, response.json())
         cohort = Cohort.objects.get(pk=response.json()["id"])
+        assert cohort.filters is not None
         self.assertEqual(cohort.filters["properties"]["values"][0]["value"], expected)
 
     @patch("posthog.api.cohort.report_user_action")

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -3747,6 +3747,36 @@ email@example.org,
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
+    @patch("posthog.api.cohort.report_user_action")
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
+    def test_rename_static_cohort_holding_single_element_list_value(
+        self, patch_calculate_cohort, patch_capture
+    ) -> None:
+        person_filter = {"key": "email", "type": "person", "operator": "icontains", "value": "@example.com"}
+        stored_filters = CohortFilters.model_validate(
+            {"properties": {"type": "OR", "values": [person_filter]}}, context={"team": self.team}
+        ).model_dump(exclude_none=True)
+        # A row written before the unwrap shipped. HogQL builds the same bytecode either way.
+        stored_filters["properties"]["values"][0]["value"] = ["@example.com"]
+        static_cohort = Cohort.objects.create(
+            team=self.team,
+            name="static cohort",
+            is_static=True,
+            filters=stored_filters,
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/cohorts/{static_cohort.pk}",
+            data={
+                "name": "renamed static cohort",
+                "filters": stored_filters,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        static_cohort.refresh_from_db()
+        self.assertEqual(static_cohort.name, "renamed static cohort")
+
     @parameterized.expand([("with_filters", True), ("without_filters", False)])
     @patch("posthog.api.cohort.report_user_action")
     @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
@@ -4401,6 +4431,7 @@ email@example.org,
             ("ends_with_single_list", "ends_with", [".com"], ".com"),
             ("not_ends_with_single_list", "not_ends_with", [".com"], ".com"),
             ("is_date_after_single_list", "is_date_after", ["-7d"], "-7d"),
+            ("is_date_before_single_list", "is_date_before", ["-7d"], "-7d"),
             ("icontains_multi_list_kept", "icontains", ["@a.com", "@b.com"], ["@a.com", "@b.com"]),
             ("icontains_plain_string_kept", "icontains", "@example.com", "@example.com"),
             ("icontains_empty_list_kept", "icontains", [], []),

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -4392,6 +4392,37 @@ email@example.org,
         self.assertEqual(response.status_code, 201, response.json())
         self.assertNotEqual(response.json()["id"], None)
 
+    @parameterized.expand(
+        [
+            ("icontains_single_list", "icontains", ["@example.com"], "@example.com"),
+            ("not_icontains_single_list", "not_icontains", ["@example.com"], "@example.com"),
+            ("startswith_single_list", "startswith", ["admin"], "admin"),
+            ("endswith_single_list", "endswith", [".com"], ".com"),
+            ("icontains_multi_list_kept", "icontains", ["@a.com", "@b.com"], ["@a.com", "@b.com"]),
+            ("icontains_plain_string_kept", "icontains", "@example.com", "@example.com"),
+            ("exact_single_list_kept", "exact", ["admin"], ["admin"]),
+        ]
+    )
+    @patch("posthog.api.cohort.report_user_action")
+    def test_cohort_single_value_operator_unwraps_single_element_list(
+        self, _name, operator, value, expected, patch_capture
+    ):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": f"cohort with {operator}",
+                "filters": {
+                    "properties": {
+                        "type": "OR",
+                        "values": [{"key": "email", "type": "person", "operator": operator, "value": value}],
+                    }
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 201, response.json())
+        cohort = Cohort.objects.get(pk=response.json()["id"])
+        self.assertEqual(cohort.filters["properties"]["values"][0]["value"], expected)
+
     @patch("posthog.api.cohort.report_user_action")
     def test_cohort_property_validation_cohort_filter(self, patch_capture):
         # First create a cohort to reference


### PR DESCRIPTION
## Problem

A cohort can list a person while a feature flag rolled out to that same cohort reaches nobody. The flag looks live, the audience sits on screen, and nothing errors.

The two cohort readers disagree about a single-element list value, such as `email icontains ["@example.com"]`:

- HogQL unwraps the list and matches, so the cohort page lists the person ([property.py](https://github.com/PostHog/posthog/blob/master/posthog/hogql/property.py#L585-L594)).
- The Rust flag evaluator stringifies it and searches for the literal text `["@example.com"]`, so the flag never matches.

`PersonValueValidationMixin.value` is typed `Any`, so the API stores whichever shape a caller sends. API and agent callers send the list form.

## Changes

- A cohort saved with `email icontains ["@example.com"]` now stores `"@example.com"`, so both readers agree and the flag matches the people the cohort lists.
- `_single_value_operator_value` unwraps a single-element list for operators that compare against one string.
- A `mode="after"` validator on `PersonValueValidationMixin` applies it before the date check, so that check sees the unwrapped value.
- Renaming a static cohort that already stores the list form keeps working. `update()` decides whether the criteria changed by comparing the incoming filters, which are unwrapped, against the stored ones, so it unwraps the stored side too.

Coercion, not rejection: the list form already works on the HogQL side, so rejecting it would break saves on cohorts that read correctly today, including edits to an unrelated field.

Two shapes stay untouched, because both are meaningful:

- A multi-element list under `icontains`, which HogQL turns into `multiSearchAnyCaseInsensitive`.
- Any list under `exact`, which takes lists as normal input.

This repairs a cohort on its next write. It does not repair stored cohorts that nobody edits, and it does not change flag evaluation. Nothing user-visible changes beyond the stored value, and no UI changes.

## How did you test this code?

Parameterized cases in `test_cohort_single_value_operator_unwraps_single_element_list` assert what the API persists. They catch two regressions no existing test covered: the single-element list reaching storage unwrapped, and the multi-element and `exact` shapes surviving untouched.

`test_rename_static_cohort_holding_single_element_list_value` renames a static cohort whose stored value is a single-element list. It fails without the comparison fix, because the save is rejected as a criteria edit.

Not tested: flag evaluation against a coerced cohort. That path is Rust and unchanged here.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-pr-descriptions`.

The work started from a support ticket about a flag not applying to a cohort, and from a linked self-driving report proposing three read-side fixes in Rust and Python. Reading the generated MCP cohort tool showed the same `Any` reaching the tool schema as `zod.unknown()`, so a caller is never told the expected shape. This PR closes the write path only. The three read-side fixes stay open, so existing broken cohorts still fail flag evaluation.

Coercion was chosen over rejecting the list or tightening the type, because both would break saves on cohorts that work today, and the count of affected stored cohorts is unknown.

No customer data, ticket content, or session material appears in this PR. The test fixtures use `@example.com`.

