### PR TITLE
chore(ci): drop product analytics from the joined-mode safeguard allowlist

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -2208,7 +2208,7 @@ jobs:
                     if [[ "${{ matrix.compat }}" == "true" ]]; then
                         full_targets="$CLICKHOUSE_COMPAT_PYTEST_TARGETS"
                     elif [[ "${{ matrix.person-on-events }}" == "true" ]]; then
-                        full_targets="./posthog/clickhouse/ ./posthog/queries/ ./products/product_analytics/backend/tests/api/ ./posthog/api/test/dashboards/test_dashboard.py ee/clickhouse/"
+                        full_targets="./posthog/clickhouse/ ./posthog/queries/ ./posthog/api/test/dashboards/test_dashboard.py ee/clickhouse/"
                         full_ignores+=(--ignore=posthog/hogql_queries --ignore=posthog/hogql)
                     fi
                     # shellcheck disable=SC2086

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -837,7 +837,6 @@ const DJANGO_SEGMENTS = {
         include: [
             'posthog/clickhouse/',
             'posthog/queries/',
-            'products/product_analytics/backend/tests/api/',
             'posthog/api/test/dashboards/test_dashboard.py',
             'ee/clickhouse/',
         ],

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -112,6 +112,20 @@ test('the backend test selector routes files with the same partition', () => {
     assert.deepEqual(sorted([...ignored, ...claimedFromCore]), sorted(DJANGO_SEGMENTS.Core.exclude))
 })
 
+// CorePOE re-runs a slice of Core under the legacy joined person mode, and Core
+// runs the same files under the customer-default mode. A CorePOE path outside
+// Core's pool therefore runs in the legacy mode only, so a regression under the
+// mode customers use goes uncaught. Product tests belong in the product's own
+// turbo lane, which is where that path would otherwise be reaching for coverage.
+test("the safeguard allowlist stays inside Core's pool", () => {
+    for (const prefix of DJANGO_SEGMENTS.CorePOE.include) {
+        assert.ok(
+            DJANGO_SEGMENTS.Core.include.some((include) => prefix.startsWith(include)),
+            `${prefix} is in CorePOE but not under any Core include, so it never runs in the default person mode`
+        )
+    }
+})
+
 // Isolation is the claim that a product can be tested without the Django suite.
 // A product that ships the contract-check script but no turbo.json of its own
 // leaves the task on the root definition, whose inputs are its whole backend,

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -117,11 +117,16 @@ test('the backend test selector routes files with the same partition', () => {
 // Core's pool therefore runs in the legacy mode only, so a regression under the
 // mode customers use goes uncaught. Product tests belong in the product's own
 // turbo lane, which is where that path would otherwise be reaching for coverage.
+// An include Core also ignores is no better than one it never listed, so both
+// halves have to hold. A Core ignore NESTED inside a CorePOE path needs no check:
+// CorePOE's ignores are Core's plus its own, so that subtree is out of both legs.
 test("the safeguard allowlist stays inside Core's pool", () => {
     for (const prefix of DJANGO_SEGMENTS.CorePOE.include) {
+        const included = DJANGO_SEGMENTS.Core.include.some((include) => prefix.startsWith(include))
+        const excluded = DJANGO_SEGMENTS.Core.exclude.some((exclude) => prefix.startsWith(exclude))
         assert.ok(
-            DJANGO_SEGMENTS.Core.include.some((include) => prefix.startsWith(include)),
-            `${prefix} is in CorePOE but not under any Core include, so it never runs in the default person mode`
+            included && !excluded,
+            `${prefix} is in CorePOE but Core does not run it, so it never runs in the default person mode`
         )
     }
 })

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3258,7 +3258,7 @@ jobs:
                     if [[ "${{ matrix.compat }}" == "true" ]]; then
                         full_targets="$CLICKHOUSE_COMPAT_PYTEST_TARGETS"
                     elif [[ "${{ matrix.person-on-events }}" == "true" ]]; then
-                        full_targets="./posthog/clickhouse/ ./posthog/queries/ ./products/product_analytics/backend/tests/api/ ./posthog/api/test/dashboards/test_dashboard.py ee/clickhouse/"
+                        full_targets="./posthog/clickhouse/ ./posthog/queries/ ./posthog/api/test/dashboards/test_dashboard.py ee/clickhouse/"
                         full_ignores+=(--ignore=posthog/hogql_queries --ignore=posthog/hogql)
                     fi
                     # shellcheck disable=SC2086

--- a/posthog/test/repo_invariants/test_pytest_module_collisions.py
+++ b/posthog/test/repo_invariants/test_pytest_module_collisions.py
@@ -65,7 +65,6 @@ CI_SESSIONS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
         (
             "posthog/clickhouse",
             "posthog/queries",
-            "products/product_analytics/backend/tests/api",
             "posthog/api/test/dashboards",
             "ee/clickhouse",
         ),

--- a/tools/snob_backend_test_selection_shadow.py
+++ b/tools/snob_backend_test_selection_shadow.py
@@ -605,7 +605,6 @@ _POE_PREFIXES = (
     "posthog/clickhouse/",
     "posthog/queries/",
     "ee/clickhouse/",
-    "products/product_analytics/backend/tests/api/",
 )
 _CORE_IGNORED_PREFIXES = ("posthog/dags/", "common/hogvm/python/test/", "posthog/test/repo_invariants/")
 


### PR DESCRIPTION
## Problem

Product analytics' insight API tests get no CI coverage under the person mode customers run, and pay for a duplicate run of the mode they already cover.

- The `CorePOE` leg re-runs a slice of Core with `PERSON_ON_EVENTS_V2_ENABLED=false`, guarding the legacy joined mode. Core runs the same files with it on, the customer default.
- `products/product_analytics/backend/tests/api/` sits in that allowlist, but Core's targets are `posthog ee/`, so nothing runs those files with the default on.
- The product turbo lane already runs them. It sets no person-mode env, so it takes the `False` default: the same joined mode, on the same ClickHouse image, and it checks snapshots, which the safeguard leg does not (it passes `--snapshot-update`).

The path entered the allowlist when the insight API tests moved into the product in [#86647](https://github.com/PostHog/posthog/pull/86647), and the mode it selects flipped under [#87770](https://github.com/PostHog/posthog/pull/87770).

## Changes

- Product analytics keeps identical coverage. Its API tests run in the product lane as before, and stop running a second time in the joined-mode safeguard on merge queue and master.
- Removes the path from the four copies of the allowlist: both workflow files, `turbo-discover.js`'s segment table, the backend test selector, and the pytest module-collision sessions. Existing tests pin those copies to each other.
- Adds a guard so this cannot recur: every `CorePOE` path must sit under a `Core` include. A path outside Core's pool runs in the legacy mode only, which is what went unnoticed here.

Not fixed here: no product's own tests run under the default person mode, because product jobs never set the env. That is repo-wide, not specific to product analytics, and flipping a product lane's default means regenerating its snapshots.

## How did you test this code?

- The guard test fails on the pre-change tree with `products/product_analytics/backend/tests/api/ is in CorePOE but not under any Core include`, and passes after. No existing test caught it: the other four assert the copies agree, and they agreed while wrong.
- Ran locally: `node --test .github/scripts/turbo-discover.test.js`, `pytest posthog/test/repo_invariants/test_pytest_module_collisions.py tools/test_snob_backend_test_selection_shadow.py`, `hogli lint:workflows`.
- Not checked: the real `CorePOE` leg, which runs on merge queue and master only. The claim that the product lane covers the same mode rests on reading the two job definitions, not on a run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (PostHog Desktop). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/authoring-ci-workflows`, `/writing-pr-descriptions`.
- The task started as "add a person-on-events dimension to the product matrix, then drop the path", planned before [#87770](https://github.com/PostHog/posthog/pull/87770) inverted the leg's meaning. Reading the merged workflow showed the dimension would duplicate what the product lane already does, so only the removal remains.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
