### PR TITLE
fix(insights): run the SQLBoxPlot edit story in both browsers again

### DIFF
--- a/frontend/src/scenes/insights/stories/SQLBoxPlot.stories.tsx
+++ b/frontend/src/scenes/insights/stories/SQLBoxPlot.stories.tsx
@@ -78,12 +78,15 @@ export default meta
 export const GroupedSeries: Story = createInsightStory(__sqlBoxPlot as any)
 
 export const EditOptions: Story = {
-    // The play function raises an unhandled error event under webkit, which fails the story there.
-    // No story opts into webkit snapshots, so nothing is lost by skipping it. See issue #90191.
-    tags: ['test-skip-webkit'],
     render: createInsightStory(__sqlBoxPlot as any, 'edit'),
     parameters: {
         ...meta.parameters,
+        // Edit mode mounts the SQL editor, so Monaco starts and asks for its web worker at
+        // /static/monacoEditorWorker.js. Storybook does not serve that file, and Monaco reports the
+        // failed load as an uncaught error. Storybook fails a story when an error like that lands
+        // while the play function runs, which makes the result depend on how fast the browser is.
+        // The error says nothing about the box plot settings this story asserts. See issue #90191.
+        test: { dangerouslyIgnoreUnhandledErrors: true },
         testOptions: {
             ...meta.parameters?.testOptions,
             waitForSelector: '[data-attr="box-plot-minColumn"]',


### PR DESCRIPTION
## Problem

The Storybook check on master went red on one story, `Scenes-App/Insights/SQLBoxPlot` → `EditOptions`. The layer below ([#90192](https://github.com/PostHog/posthog/pull/90192)) stopped the bleeding by skipping the story under webkit. This layer fixes the cause and puts the story back in both browsers.

The story is not webkit-specific. It is a race, and chromium reproduces it locally.

- Edit mode mounts the SQL editor, so Monaco starts and requests `/static/monacoEditorWorker.js`.
- Storybook maps `/static` to `frontend/public`, but the workers are built into `frontend/dist`, so the request 404s.
- Monaco rethrows the worker's error `Event`, which prints as `[object Event]`.
- Storybook only collects unhandled errors while a play function runs, and fails the story if it collects any.
- Chromium in CI finishes playing before the error arrives. Webkit is slower and does not.

Refs #90191

## Changes

- The story runs under webkit again, so a chromium-only regression in it can no longer hide.
- `EditOptions` sets `parameters.test.dangerouslyIgnoreUnhandledErrors`, which stops Storybook from failing the story on errors that have nothing to do with what it asserts.
- The `test-skip-webkit` tag from the layer below is removed.

The play function still asserts the box plot settings panel opens, and chromium still captures the snapshot. What the story no longer does is fail on Monaco's startup noise.

The narrower alternatives do not work. A plain `element.click()` instead of `userEvent.click` still fails under webkit, and serving Monaco's workers removes this error but leaves a second one (`Canceled`, from Monaco's cancellation path) that fails the story on its own.

> [!NOTE]
> No Storybook story has a working Monaco or HogQL parser worker, for the `frontend/public` vs `frontend/dist` reason above. That is a real gap, it is written up in #90191, and it is not this PR: fixing it does not fix this story.

## How did you test this code?

Ran the test-runner against a local Storybook build, in both browsers, on the exact committed diff:

<details><summary>webkit and chromium, after the change</summary>

```
$ pnpm --filter=@posthog/storybook test:visual:ci:update --browsers webkit -- frontend/src/scenes/insights/stories/SQLBoxPlot.stories.tsx
    GroupedSeries
      ✓ smoke-test (458 ms)
    EditOptions
      ✓ play-test (7107 ms)
Tests:       2 passed, 2 total

$ pnpm --filter=@posthog/storybook test:visual:ci:update --browsers chromium -- frontend/src/scenes/insights/stories/SQLBoxPlot.stories.tsx
    GroupedSeries
      ✓ smoke-test (7524 ms)
    EditOptions
      ✓ play-test (7049 ms)
Tests:       2 passed, 2 total
Snapshots:   2 written, 2 passed, 4 total
```

Before the change, on master, `EditOptions` failed in webkit and also in chromium locally.

</details>

No new tests. The regression this catches is the story itself, which already exists.

Not checked: the rest of the Storybook suite. Only this story file ran locally, so the full shard result comes from CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app, continuing from the request that produced [#90192](https://github.com/PostHog/posthog/pull/90192).

The diagnosis needed a local Storybook build, which needed two unbuilt workspace packages first (`@posthog/quill` for `tokens.scoped.css`, `@posthog/hogvm` for `HogRepl.tsx`). A Playwright script then read the `unhandledErrorsWhilePlaying` channel payload and the render-phase timeline, which is what identified the two errors and showed chromium winning the race rather than behaving differently. Three candidate fixes were built and measured against both browsers before this one was chosen; the comparison table is in #90191.

Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1787839448892549?thread_ts=1787839448.892549&cid=C0AS64N6DJL)*
