### PR TITLE
feat(mcp-store): share new MCP connections with every agent by default

### DIFF
--- a/products/desktop/packages/api-client/src/mcp-gateway.ts
+++ b/products/desktop/packages/api-client/src/mcp-gateway.ts
@@ -216,11 +216,15 @@ export interface McpGatewayMemberSummary {
 
 /**
  * Gateway options accepted by install_custom / install_template. Credentials
- * are always personal to the installer; agents reach them through grants.
+ * are always personal to the installer; every built-in agent is granted the
+ * connection automatically when the installer may manage agent access.
  */
 export interface McpGatewayInstallSharingOptions {
   /** Whether the server starts enabled for the whole team. */
   team_enabled?: boolean;
-  /** Service accounts to grant the server to at install time, when team settings allow it. */
-  agent_ids?: string[];
+  /**
+   * How far the automatic agent grants reach. Defaults to "personal" on the
+   * backend; sending any value requires permission to manage agent access.
+   */
+  agent_scope?: McpAgentGrantScope;
 }

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.test.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.test.ts
@@ -30,7 +30,7 @@ describe("canSubmitGatewayServer", () => {
 describe("buildGatewayInstallRequest", () => {
   it("builds an oauth install with admin team options", () => {
     const request = buildGatewayInstallRequest(
-      values({ description: "  Wiki tools  ", agentIds: ["svc-1"] }),
+      values({ description: "  Wiki tools  ", agentScope: "personal" }),
       { isAdmin: true, canManageAgentAccess: true },
     );
     expect(request).toEqual({
@@ -39,7 +39,7 @@ describe("buildGatewayInstallRequest", () => {
       description: "Wiki tools",
       auth_type: "oauth",
       team_enabled: true,
-      agent_ids: ["svc-1"],
+      agent_scope: "personal",
     });
   });
 
@@ -66,20 +66,20 @@ describe("buildGatewayInstallRequest", () => {
     expect(withCreds.client_secret).toBe("secret");
   });
 
-  it("lets permitted members share with agents without team enablement", () => {
-    const request = buildGatewayInstallRequest(
-      values({ agentIds: ["svc-1"] }),
-      { isAdmin: false, canManageAgentAccess: true },
-    );
+  it("lets permitted members pick the agent scope without team enablement", () => {
+    const request = buildGatewayInstallRequest(values({ agentScope: "team" }), {
+      isAdmin: false,
+      canManageAgentAccess: true,
+    });
     expect(request.team_enabled).toBeUndefined();
-    expect(request.agent_ids).toEqual(["svc-1"]);
+    expect(request.agent_scope).toBe("team");
   });
 
-  it("omits agent grants when team settings make them admin-only", () => {
-    const request = buildGatewayInstallRequest(
-      values({ agentIds: ["svc-1"] }),
-      { isAdmin: false, canManageAgentAccess: false },
-    );
-    expect(request.agent_ids).toBeUndefined();
+  it("omits the agent scope when team settings make agent access admin-only", () => {
+    const request = buildGatewayInstallRequest(values({ agentScope: "team" }), {
+      isAdmin: false,
+      canManageAgentAccess: false,
+    });
+    expect(request.agent_scope).toBeUndefined();
   });
 });

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
@@ -27,7 +27,7 @@ export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
   clientId: "",
   clientSecret: "",
   teamEnabled: true,
-  agentScope: "team",
+  agentScope: "personal",
 };
 
 export function canSubmitGatewayServer(

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
@@ -1,4 +1,5 @@
 import type {
+  McpAgentGrantScope,
   McpAuthType,
   McpGatewayInstallSharingOptions,
 } from "@posthog/api-client/posthog-client";
@@ -12,9 +13,9 @@ export interface GatewayAddServerValues {
   apiKey: string;
   clientId: string;
   clientSecret: string;
-  /** Team sharing options are admin-only; agentIds follows the team setting. */
+  /** Team sharing options are admin-only; agentScope follows the team setting. */
   teamEnabled: boolean;
-  agentIds: string[];
+  agentScope: McpAgentGrantScope;
 }
 
 export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
@@ -26,7 +27,7 @@ export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
   clientId: "",
   clientSecret: "",
   teamEnabled: true,
-  agentIds: [],
+  agentScope: "team",
 };
 
 export function canSubmitGatewayServer(
@@ -48,8 +49,8 @@ export interface GatewayInstallRequest extends McpGatewayInstallSharingOptions {
 /**
  * install_custom payload for registering a server with the gateway. The
  * credential is always personal to the installer. Team-wide options are
- * attached only for admins; agent grants are attached whenever the team
- * allows this member to manage agent access.
+ * attached only for admins; the agent grant scope is attached whenever the
+ * team allows this member to manage agent access.
  */
 export function buildGatewayInstallRequest(
   values: GatewayAddServerValues,
@@ -70,8 +71,6 @@ export function buildGatewayInstallRequest(
       ? { client_secret: values.clientSecret.trim() }
       : {}),
     ...(options.isAdmin ? { team_enabled: values.teamEnabled } : {}),
-    ...(options.canManageAgentAccess && values.agentIds.length
-      ? { agent_ids: values.agentIds }
-      : {}),
+    ...(options.canManageAgentAccess ? { agent_scope: values.agentScope } : {}),
   };
 }

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/McpGatewayView.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/McpGatewayView.tsx
@@ -13,7 +13,6 @@ import {
 } from "@posthog/ui/features/mcp-gateway/gatewayRoute";
 import { useGatewayConfig } from "@posthog/ui/features/mcp-gateway/hooks/useGatewayConfig";
 import { useGatewayServers } from "@posthog/ui/features/mcp-gateway/hooks/useGatewayServers";
-import { useServiceAccounts } from "@posthog/ui/features/mcp-gateway/hooks/useServiceAccounts";
 import { DotPatternBackground } from "@posthog/ui/primitives/DotPatternBackground";
 import { Box, Flex, ScrollArea } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
@@ -35,7 +34,6 @@ export function McpGatewayView() {
     useGatewayConfig();
   const canAddServers = isAdmin || allowCustomServers;
   const gateway = useGatewayServers();
-  const serviceAccounts = useServiceAccounts();
 
   // Refresh gateway state when the window regains focus — connections and
   // policies can change from the web app or another teammate meanwhile.
@@ -68,7 +66,6 @@ export function McpGatewayView() {
           <GatewayAddServer
             isAdmin={isAdmin}
             canManageAgentAccess={canManageAgentAccess}
-            accounts={serviceAccounts.accounts}
             onNavigate={setRoute}
           />
         );

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/AgentScopeToggle.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/AgentScopeToggle.tsx
@@ -9,12 +9,12 @@ import {
 const OPTIONS: { id: McpAgentGrantScope; label: string; hint: string }[] = [
   {
     id: "personal",
-    label: "Just my agents",
+    label: "Only me",
     hint: "The agent uses your connection only when it runs for you.",
   },
   {
     id: "team",
-    label: "All team agents",
+    label: "Everyone in this project",
     hint: "The agent uses your connection for every run in this project, including runs nobody started. Teammates can't use the connection directly, but agents act through it on their runs too.",
   },
 ];
@@ -36,7 +36,7 @@ export function AgentScopeToggle({
     <TooltipProvider>
       <div
         role="radiogroup"
-        aria-label="Which runs use your connection"
+        aria-label="Who can use this connection"
         className="inline-flex items-stretch overflow-hidden rounded-md border border-gray-5 bg-gray-2"
       >
         {OPTIONS.map((option, index) => {

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.test.tsx
@@ -1,4 +1,3 @@
-import type { McpServiceAccount } from "@posthog/api-client/posthog-client";
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -15,29 +14,11 @@ vi.mock(
 
 import { GatewayAddServer } from "./GatewayAddServer";
 
-const account = {
-  id: "agent-1",
-  name: "Support agent",
-  description: "",
-  handle: "support-agent",
-  status: "active",
-  token_mask: "",
-  server_ids: [],
-  last_active_at: null,
-  created_at: "2026-07-23T12:00:00Z",
-  updated_at: "2026-07-23T12:00:00Z",
-} as McpServiceAccount;
-
 describe("GatewayAddServer", () => {
   it("keeps team and agent sharing without offering shared credentials", () => {
     render(
       <Theme>
-        <GatewayAddServer
-          isAdmin
-          canManageAgentAccess
-          accounts={[account]}
-          onNavigate={vi.fn()}
-        />
+        <GatewayAddServer isAdmin canManageAgentAccess onNavigate={vi.fn()} />
       </Theme>,
     );
 
@@ -45,7 +26,8 @@ describe("GatewayAddServer", () => {
       screen.getByText("Enabled for your organization"),
     ).toBeInTheDocument();
     expect(screen.getByText("Share with agents")).toBeInTheDocument();
-    expect(screen.getByText(account.name)).toBeInTheDocument();
+    expect(screen.getByText("All team agents")).toBeInTheDocument();
+    expect(screen.getByText("Just my agents")).toBeInTheDocument();
     expect(screen.queryByText("One shared credential")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Allow personal connections"),

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.test.tsx
@@ -25,9 +25,11 @@ describe("GatewayAddServer", () => {
     expect(
       screen.getByText("Enabled for your organization"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Share with agents")).toBeInTheDocument();
-    expect(screen.getByText("All team agents")).toBeInTheDocument();
-    expect(screen.getByText("Just my agents")).toBeInTheDocument();
+    expect(
+      screen.getByText("Who can use this connection?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Everyone in this project")).toBeInTheDocument();
+    expect(screen.getByText("Only me")).toBeInTheDocument();
     expect(screen.queryByText("One shared credential")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Allow personal connections"),

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -252,11 +252,13 @@ export function GatewayAddServer({
               {canManageAgentAccess && (
                 <div className="flex items-center justify-between gap-3 rounded-md border border-gray-5 bg-gray-2 p-3">
                   <div>
-                    <div className="font-medium text-sm">Share with agents</div>
+                    <div className="font-medium text-sm">
+                      Who can use this connection?
+                    </div>
                     <div className="text-[13px] text-gray-11">
                       {values.agentScope === "team"
-                        ? "Agents use this connection on every run in this project."
-                        : "Agents use this connection only on your runs."}
+                        ? "Anyone in this project can use this connection through agents."
+                        : "Only you can use this connection through agents."}
                     </div>
                   </div>
                   <AgentScopeToggle

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -255,8 +255,8 @@ export function GatewayAddServer({
                     <div className="font-medium text-sm">Share with agents</div>
                     <div className="text-[13px] text-gray-11">
                       {values.agentScope === "team"
-                        ? "PostHog agents can use your connection for every run in this project."
-                        : "PostHog agents can use your connection only on runs for you."}
+                        ? "Agents use this connection on every run in this project."
+                        : "Agents use this connection only on your runs."}
                     </div>
                   </div>
                   <AgentScopeToggle

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -257,8 +257,8 @@ export function GatewayAddServer({
                     </div>
                     <div className="text-[13px] text-gray-11">
                       {values.agentScope === "team"
-                        ? "Anyone in this project can use this connection through agents."
-                        : "Only you can use this connection through agents."}
+                        ? "Anyone in this project can use this connection"
+                        : "Only you can use this connection"}
                     </div>
                   </div>
                   <AgentScopeToggle

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -1,5 +1,4 @@
 import { ArrowLeft, CaretRight, Check } from "@phosphor-icons/react";
-import type { McpServiceAccount } from "@posthog/api-client/posthog-client";
 import {
   buildGatewayInstallRequest,
   canSubmitGatewayServer,
@@ -7,7 +6,7 @@ import {
   type GatewayAddServerValues,
 } from "@posthog/core/mcp-gateway/gatewayAddServer";
 import { isValidMcpUrl } from "@posthog/core/mcp-servers/customServerForm";
-import { RobotAvatar } from "@posthog/ui/features/mcp-gateway/components/parts/avatars";
+import { AgentScopeToggle } from "@posthog/ui/features/mcp-gateway/components/parts/AgentScopeToggle";
 import type { GatewayRoute } from "@posthog/ui/features/mcp-gateway/gatewayRoute";
 import { useRegisterGatewayServer } from "@posthog/ui/features/mcp-gateway/hooks/useRegisterGatewayServer";
 import {
@@ -26,7 +25,6 @@ import { type FormEvent, useState } from "react";
 interface GatewayAddServerProps {
   isAdmin: boolean;
   canManageAgentAccess: boolean;
-  accounts: McpServiceAccount[];
   onNavigate: (route: GatewayRoute) => void;
 }
 
@@ -34,7 +32,6 @@ interface GatewayAddServerProps {
 export function GatewayAddServer({
   isAdmin,
   canManageAgentAccess,
-  accounts,
   onNavigate,
 }: GatewayAddServerProps) {
   const [values, setValues] = useState<GatewayAddServerValues>(
@@ -235,8 +232,8 @@ export function GatewayAddServer({
           <>
             <SectionHeader label="Sharing" />
             <Text color="gray" className="text-[13px]">
-              Once the server authenticates, you'll be able to configure tool
-              approvals for each agent.
+              Once the server authenticates, you can configure tool approvals
+              for each agent on the server page.
             </Text>
             <Flex direction="column" gap="3">
               {isAdmin && (
@@ -253,60 +250,20 @@ export function GatewayAddServer({
               )}
 
               {canManageAgentAccess && (
-                <Flex direction="column" gap="2">
-                  <Text className="font-medium text-base">
-                    Share with agents
-                  </Text>
-                  <div className="overflow-hidden rounded border border-gray-5 bg-gray-2">
-                    {accounts.map((account) => {
-                      const on = values.agentIds.includes(account.id);
-                      return (
-                        <Flex
-                          key={account.id}
-                          align="center"
-                          gap="3"
-                          className="border-gray-5 border-b px-3 py-2 last:border-b-0"
-                        >
-                          <RobotAvatar />
-                          <Flex direction="column" className="min-w-0 flex-1">
-                            <Text truncate className="font-medium text-sm">
-                              {account.name}
-                            </Text>
-                            <Text
-                              color="gray"
-                              truncate
-                              className="font-mono text-xs"
-                            >
-                              {account.handle}
-                            </Text>
-                          </Flex>
-                          <Switch
-                            size="1"
-                            checked={on}
-                            onCheckedChange={(checked) =>
-                              set(
-                                "agentIds",
-                                checked
-                                  ? [...values.agentIds, account.id]
-                                  : values.agentIds.filter(
-                                      (id) => id !== account.id,
-                                    ),
-                              )
-                            }
-                          />
-                        </Flex>
-                      );
-                    })}
-                    {accounts.length === 0 && (
-                      <Text
-                        color="gray"
-                        className="block px-3 py-3 text-[13px] italic"
-                      >
-                        No agents yet — create one under Team &amp; agents.
-                      </Text>
-                    )}
+                <div className="flex items-center justify-between gap-3 rounded-md border border-gray-5 bg-gray-2 p-3">
+                  <div>
+                    <div className="font-medium text-sm">Share with agents</div>
+                    <div className="text-[13px] text-gray-11">
+                      {values.agentScope === "team"
+                        ? "PostHog agents can use your connection for every run in this project."
+                        : "PostHog agents can use your connection only on runs for you."}
+                    </div>
                   </div>
-                </Flex>
+                  <AgentScopeToggle
+                    value={values.agentScope}
+                    onChange={(agentScope) => set("agentScope", agentScope)}
+                  />
+                </div>
               )}
             </Flex>
           </>

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayServerDetail.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayServerDetail.test.tsx
@@ -289,14 +289,16 @@ describe("GatewayServerDetail", () => {
     // one toggle renders: the caller's own.
     expect(
       screen.getAllByRole("radiogroup", {
-        name: "Which runs use your connection",
+        name: "Who can use this connection",
       }),
     ).toHaveLength(1);
     expect(
       screen.getByText(/shared to the team by Grace Hopper/),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("radio", { name: "All team agents" }));
+    await user.click(
+      screen.getByRole("radio", { name: "Everyone in this project" }),
+    );
 
     expect(mocks.setAgentAccess).toHaveBeenCalledWith({
       accountId: "sa-1",

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GiveAccessDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GiveAccessDialog.test.tsx
@@ -219,7 +219,9 @@ describe("GiveAccessDialog", () => {
 
     screen.getByRole("combobox").focus();
     await user.keyboard("{ArrowDown}{Enter}");
-    await user.click(screen.getByRole("radio", { name: "All team agents" }));
+    await user.click(
+      screen.getByRole("radio", { name: "Everyone in this project" }),
+    );
     await user.click(screen.getByRole("button", { name: "Share access" }));
 
     expect(onGrant).toHaveBeenCalledWith(

--- a/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useGatewayConfig.ts
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useGatewayConfig.ts
@@ -37,9 +37,12 @@ export function useGatewayConfig() {
     allowMemberAgentAccess: config?.allow_member_agent_access ?? true,
     /** Whether untouched (row-less) catalog servers are enabled for the team. */
     defaultServersEnabled: config?.default_servers_enabled ?? true,
+    // Default to false until config loads (or if the request fails): an
+    // unconfirmed member must not send agent_scope, which the backend rejects
+    // with 403 when they can't manage agent access.
     canManageAgentAccess:
       (config?.is_admin ?? false) ||
-      (config?.allow_member_agent_access ?? true),
+      (config?.allow_member_agent_access ?? false),
     updateSettings: updateSettingsMutation.mutate,
   };
 }

--- a/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useGatewayServers.ts
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useGatewayServers.ts
@@ -61,6 +61,9 @@ export function useGatewayServers() {
 
   const invalidateServers = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: gatewayKeys.servers });
+    // Connecting grants the built-in agents automatically and disconnecting
+    // unbinds those grants, so the agents' server lists change too.
+    queryClient.invalidateQueries({ queryKey: gatewayKeys.accounts });
     // Connections are installation rows, so the legacy surfaces change too.
     queryClient.invalidateQueries({ queryKey: mcpKeys.installations });
   }, [queryClient]);

--- a/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useRegisterGatewayServer.ts
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useRegisterGatewayServer.ts
@@ -78,6 +78,7 @@ export function useRegisterGatewayServer() {
           });
           queryClient.invalidateQueries({ queryKey: gatewayKeys.servers });
         }
+        queryClient.invalidateQueries({ queryKey: gatewayKeys.accounts });
         queryClient.invalidateQueries({ queryKey: mcpKeys.installations });
       },
       onError: (error: Error) =>

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -37,7 +37,7 @@ The gateway experience has these pages and workflows:
   Users with permission can add a hosted custom server and choose OAuth or API key authentication.
   Admins can set its team availability.
   Every connection is shared with the built-in PostHog agents automatically when the connecting user may manage agent access (admins always, members while team settings allow it).
-  The add-server form picks how far that share reaches: only the user's own runs, or every agent run in the project.
+  The add-server form picks how far that share reaches: only the user's own runs (the default), or every agent run in the project.
   Connecting a catalog server shares it for the user's own runs; the server page widens it to the team or revokes it.
   Connecting starts the appropriate authorization flow, while an existing connection opens its configuration.
 - **Server details**: Manage a personal connection by enabling, reconnecting, disconnecting, or removing it.

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -35,7 +35,10 @@ The gateway experience has these pages and workflows:
 
 - **MCP servers**: Browse the catalog, search by server details, filter by category, and see connection status.
   Users with permission can add a hosted custom server and choose OAuth or API key authentication.
-  Admins can set its team availability, and eligible users can grant initial agent access.
+  Admins can set its team availability.
+  Every connection is shared with the built-in PostHog agents automatically when the connecting user may manage agent access (admins always, members while team settings allow it).
+  The add-server form picks how far that share reaches: only the user's own runs, or every agent run in the project.
+  Connecting a catalog server shares it for the user's own runs; the server page widens it to the team or revokes it.
   Connecting starts the appropriate authorization flow, while an existing connection opens its configuration.
 - **Server details**: Manage a personal connection by enabling, reconnecting, disconnecting, or removing it.
   Admins can also manage team and member access.

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -52,13 +52,14 @@ from ..agents import sync_built_in_agents
 from ..facade.api import resolve_member_tool_states
 from ..gateway import link_installation_to_gateway, members_can_manage_agent_access, server_disabled_reason
 from ..models import (
+    AGENT_GRANT_SCOPE_CHOICES,
     APPROVAL_STATES,
+    MCPGatewayServer,
     MCPMemberServerRevocation,
     MCPOAuthState,
     MCPServerInstallation,
     MCPServerInstallationTool,
     MCPServerTemplate,
-    MCPServiceAccount,
     MCPServiceAccountServerAccess,
     MCPToolPolicy,
     SensitiveConfig,
@@ -394,7 +395,10 @@ class InstallCustomSerializer(serializers.Serializer):
         choices=["personal", "shared"],
         required=False,
         default="personal",
-        help_text="'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.",
+        help_text=(
+            "'personal' is per-user; 'shared' makes the credential available to project members. "
+            "PostHog agents get access to the connection automatically; see agent_scope."
+        ),
     )
     # Team-wide install options remain admin-only. Agent grants follow the
     # team's allow_member_agent_access setting.
@@ -403,13 +407,14 @@ class InstallCustomSerializer(serializers.Serializer):
         default=True,
         help_text="Whether the server starts enabled for the whole team. Non-default values are admin-only.",
     )
-    agent_ids = serializers.ListField(
-        child=serializers.UUIDField(),
+    agent_scope = serializers.ChoiceField(
+        choices=AGENT_GRANT_SCOPE_CHOICES,
         required=False,
-        default=list,
         help_text=(
-            "Service accounts to share the server with at install time. "
-            "Available to members when team settings allow member-managed agent access."
+            "How far the automatic agent grants for this connection reach. 'personal' (the default) lets "
+            "PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. "
+            "Grants are created when the caller may manage agent access: project admins always, members "
+            "when team settings allow it. Sending a value without that permission is rejected."
         ),
     )
     return_path = serializers.CharField(
@@ -440,7 +445,10 @@ class InstallTemplateSerializer(serializers.Serializer):
         choices=["personal", "shared"],
         required=False,
         default="personal",
-        help_text="'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.",
+        help_text=(
+            "'personal' is per-user; 'shared' makes the credential available to project members. "
+            "PostHog agents get access to the connection automatically; see agent_scope."
+        ),
     )
     # Team-wide install options remain admin-only. Agent grants follow the
     # team's allow_member_agent_access setting.
@@ -449,13 +457,14 @@ class InstallTemplateSerializer(serializers.Serializer):
         default=True,
         help_text="Whether the server starts enabled for the whole team. Non-default values are admin-only.",
     )
-    agent_ids = serializers.ListField(
-        child=serializers.UUIDField(),
+    agent_scope = serializers.ChoiceField(
+        choices=AGENT_GRANT_SCOPE_CHOICES,
         required=False,
-        default=list,
         help_text=(
-            "Service accounts to share the server with at install time. "
-            "Available to members when team settings allow member-managed agent access."
+            "How far the automatic agent grants for this connection reach. 'personal' (the default) lets "
+            "PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. "
+            "Grants are created when the caller may manage agent access: project admins always, members "
+            "when team settings allow it. Sending a value without that permission is rejected."
         ),
     )
     return_path = serializers.CharField(
@@ -877,65 +886,23 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
     def _wants_team_gateway_options(data: dict) -> bool:
         return not data.get("team_enabled", True)
 
-    def _install_target_owner_id(self, data: dict) -> int | None:
-        """Owner of the connection this install flow would end up delegating.
-
-        A personal install is keyed on the caller, so it is always the caller's.
-        A shared install reuses a row keyed on (team, url) that another member
-        may own, and there is no such row yet when the install creates one.
-        """
-        user_id = cast(User, self.request.user).id
-        if data.get("scope", "personal") != "shared":
-            return user_id
-        url = (data.get("url") or "").strip()
-        template_id = data.get("template_id")
-        if not url and template_id:
-            template = MCPServerTemplate.objects.filter(id=template_id, is_active=True).first()
-            url = template.url if template is not None else ""
-        if not url:
-            return user_id
-        existing = MCPServerInstallation.objects.filter(team_id=self.team_id, url=url, scope="shared").first()
-        return existing.user_id if existing is not None else user_id
+    def _can_manage_agent_access(self) -> bool:
+        return self._is_project_admin() or members_can_manage_agent_access(self.team_id)
 
     def _validate_gateway_options(self, data: dict) -> None:
-        """Validate team-level options and agent grants before creating rows."""
+        """Validate team-level options and the agent grant scope before creating rows."""
         if self._wants_team_gateway_options(data) and not self._is_project_admin():
             raise PermissionDenied("Only project admins can set team availability.")
-
-        agent_ids = set(data.get("agent_ids") or [])
-        if not agent_ids:
-            return
-        if not self._is_project_admin() and not members_can_manage_agent_access(self.team_id):
+        if data.get("agent_scope") is not None and not self._can_manage_agent_access():
             raise PermissionDenied("Only project admins can share servers with agents in this project.")
-
-        built_in_agent_ids = {account.id for account in sync_built_in_agents(self.team)}
-        if not agent_ids.issubset(built_in_agent_ids):
-            raise serializers.ValidationError({"agent_ids": "Select only the PostHog agents listed for this project."})
-
-        # Rejected here rather than while applying the grants: by then the
-        # install has already written the gateway rows and the credential, and
-        # a 4xx would leave that half-finished install behind.
-        if self._install_target_owner_id(data) != cast(User, self.request.user).id:
-            raise serializers.ValidationError(
-                {"agent_ids": "You can only share a connection you set up yourself with an agent."}
-            )
 
     def _apply_gateway_options(self, installation: MCPServerInstallation, data: dict) -> None:
         """Register the installation with the gateway and apply install-time
-        team options (enablement, personal connections, agent shares).
+        team options (enablement, agent shares).
 
         Called only once the install is persisted for good; `_validate_gateway_options`
-        has already gated team options and agent grants.
+        has already gated team options and the agent scope.
         """
-        agent_ids = set(data.get("agent_ids") or [])
-        accounts_by_id = {
-            account.id: account for account in MCPServiceAccount.objects.for_team(self.team_id).filter(id__in=agent_ids)
-        }
-        if agent_ids != set(accounts_by_id):
-            raise serializers.ValidationError(
-                {"agent_ids": "One or more selected PostHog agents are no longer available. Refresh and try again."}
-            )
-
         user = cast(User, self.request.user)
         server = link_installation_to_gateway(installation, created_by=user)
 
@@ -945,8 +912,28 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
                 server.is_team_enabled = team_enabled
                 server.save(update_fields=["is_team_enabled", "updated_at"])
 
-        for account in accounts_by_id.values():
-            MCPServiceAccountServerAccess.objects.for_team(self.team_id).update_or_create(
+        # A grant lends the granter's own connection, so a shared install that
+        # reused another member's row lends nothing.
+        if installation.user_id == user.id and self._can_manage_agent_access():
+            self._grant_built_in_agents(installation, server, user, data.get("agent_scope"))
+
+    def _grant_built_in_agents(
+        self,
+        installation: MCPServerInstallation,
+        server: MCPGatewayServer,
+        user: User,
+        agent_scope: str | None,
+    ) -> None:
+        """Share the connection with every built-in agent. A connection is shared
+        with agents by default; the scope decides how far that share reaches.
+
+        Reconnecting binds the fresh credential to grants that already exist,
+        because deleting a connection nulls their installation rather than
+        removing them. Such a grant keeps its scope unless the request names one,
+        so a reconnect that omits `agent_scope` never demotes a team share.
+        """
+        for account in sync_built_in_agents(self.team):
+            access, created = MCPServiceAccountServerAccess.objects.for_team(self.team_id).get_or_create(
                 service_account=account,
                 gateway_server=server,
                 user=user,
@@ -954,8 +941,20 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
                     "team_id": self.team_id,
                     "installation": installation,
                     "granted_by": user,
+                    "scope": agent_scope or "personal",
                 },
             )
+            if created:
+                continue
+            update_fields: list[str] = []
+            if access.installation_id != installation.id:
+                access.installation = installation
+                update_fields.append("installation")
+            if agent_scope is not None and access.scope != agent_scope:
+                access.scope = agent_scope
+                update_fields.append("scope")
+            if update_fields:
+                access.save(update_fields=update_fields)
 
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -1239,10 +1239,19 @@ class TestMCPServiceAccountAPI(APIBaseTest):
         assert create_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
         assert delete_response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
+    @parameterized.expand([("default_scope", None, "personal"), ("team_scope", "team", "team")])
     @ALLOW_URL
-    def test_member_can_delegate_a_personal_credential_during_install(self, _mock_is_url_allowed) -> None:
+    def test_install_shares_the_connection_with_every_built_in_agent(
+        self, _label, agent_scope, expected_scope, _mock_is_url_allowed
+    ) -> None:
         self._make_member()
         accounts = sync_built_in_agents(self.team)
+        legacy_account = MCPServiceAccount.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            name="Legacy custom agent",
+            handle="svc-legacy-custom-agent",
+            token_hash="legacy-custom-agent-token-hash",
+        )
         install_url = "https://mcp.personal-agent-grant.example.com/mcp"
 
         response = self.client.post(
@@ -1253,7 +1262,7 @@ class TestMCPServiceAccountAPI(APIBaseTest):
                 "auth_type": "api_key",
                 "api_key": "secret",
                 "scope": "personal",
-                "agent_ids": [str(account.id) for account in accounts],
+                **({"agent_scope": agent_scope} if agent_scope else {}),
             },
             format="json",
         )
@@ -1261,62 +1270,85 @@ class TestMCPServiceAccountAPI(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED
         installation = MCPServerInstallation.objects.get(team=self.team, url=install_url)
         accesses = MCPServiceAccountServerAccess.objects.for_team(self.team.id).filter(
-            service_account__in=accounts,
-            gateway_server=installation.gateway_server,
+            gateway_server=installation.gateway_server
         )
-        access_rows = set(accesses.values_list("service_account_id", "installation_id"))
-        assert installation.scope == "personal"
-        assert access_rows == {(account.id, installation.id) for account in accounts}
+        access_rows = set(accesses.values_list("service_account_id", "installation_id", "user_id", "scope"))
+        assert access_rows == {(account.id, installation.id, self.user.id, expected_scope) for account in accounts}
+        assert not accesses.filter(service_account=legacy_account).exists()
 
     @ALLOW_URL
-    def test_install_rejects_member_agent_grant_when_team_setting_is_off(self, _mock_is_url_allowed) -> None:
+    def test_install_skips_agent_grants_for_member_when_team_setting_is_off(self, _mock_is_url_allowed) -> None:
         self._make_member()
         TeamMCPGatewayConfig.objects.for_team(self.team.id).create(team=self.team, allow_member_agent_access=False)
-        account = sync_built_in_agents(self.team)[0]
+        sync_built_in_agents(self.team)
         install_url = "https://mcp.restricted-agent-grant.example.com/mcp"
+        data = {
+            "name": "Restricted grant",
+            "url": install_url,
+            "auth_type": "api_key",
+            "api_key": "secret",
+            "scope": "personal",
+        }
 
+        explicit_response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/install_custom/",
+            data={**data, "agent_scope": "personal"},
+            format="json",
+        )
         response = self.client.post(
             f"/api/environments/{self.team.id}/mcp_server_installations/install_custom/",
-            data={
-                "name": "Restricted grant",
-                "url": install_url,
-                "auth_type": "api_key",
-                "api_key": "secret",
-                "scope": "personal",
-                "agent_ids": [str(account.id)],
-            },
+            data=data,
             format="json",
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert not MCPServerInstallation.objects.filter(team=self.team, url=install_url).exists()
+        assert explicit_response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_201_CREATED
+        installation = MCPServerInstallation.objects.get(team=self.team, url=install_url)
+        assert not (
+            MCPServiceAccountServerAccess.objects.for_team(self.team.id)
+            .filter(gateway_server=installation.gateway_server)
+            .exists()
+        )
 
     @ALLOW_URL
-    def test_install_rejects_hidden_legacy_service_account(self, _mock_is_url_allowed) -> None:
-        self._make_admin()
-        legacy_account = MCPServiceAccount.objects.for_team(self.team.id).create(
-            team_id=self.team.id,
-            name="Legacy custom agent",
-            handle="svc-legacy-custom-agent",
-            token_hash="legacy-custom-agent-token-hash",
+    def test_reconnect_rebinds_existing_agent_grants_and_keeps_their_scope(self, _mock_is_url_allowed) -> None:
+        self._make_member()
+        accounts = sync_built_in_agents(self.team)
+        install_url = "https://mcp.reconnect-agent-grant.example.com/mcp"
+        data = {
+            "name": "Reconnect grant",
+            "url": install_url,
+            "auth_type": "api_key",
+            "api_key": "secret",
+            "scope": "personal",
+        }
+        first_response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/install_custom/",
+            data={**data, "agent_scope": "team"},
+            format="json",
         )
-        install_url = "https://mcp.legacy-agent-grant.example.com/mcp"
+        assert first_response.status_code == status.HTTP_201_CREATED
+        first_installation_id = first_response.json()["id"]
+        delete_response = self.client.delete(
+            f"/api/environments/{self.team.id}/mcp_server_installations/{first_installation_id}/"
+        )
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/mcp_server_installations/install_custom/",
-            data={
-                "name": "Legacy grant",
-                "url": install_url,
-                "auth_type": "api_key",
-                "api_key": "secret",
-                "scope": "shared",
-                "agent_ids": [str(legacy_account.id)],
-            },
+            data=data,
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert not MCPServerInstallation.objects.filter(team=self.team, url=install_url).exists()
+        assert response.status_code == status.HTTP_201_CREATED
+        installation = MCPServerInstallation.objects.get(team=self.team, url=install_url)
+        assert str(installation.id) != first_installation_id
+        accesses = MCPServiceAccountServerAccess.objects.for_team(self.team.id).filter(
+            gateway_server=installation.gateway_server
+        )
+        assert set(accesses.values_list("service_account_id", "installation_id", "scope")) == {
+            (account.id, installation.id, "team") for account in accounts
+        }
 
     def test_member_can_delegate_their_credential_and_control_agent_tools_by_default(self) -> None:
         self._make_member()

--- a/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
@@ -2,10 +2,10 @@ import { useActions, useValues } from 'kea'
 
 import {
     LemonButton,
-    LemonCheckbox,
     LemonCollapse,
     LemonInput,
     LemonModal,
+    LemonSegmentedButton,
     LemonSelect,
     LemonSwitch,
 } from '@posthog/lemon-ui'
@@ -14,6 +14,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { InstallCustomAuthTypeEnumApi } from '../generated/api.schemas'
 import { isValidMcpUrl } from './gatewayAddServer'
+import { AGENT_GRANT_SCOPE_OPTIONS } from './gatewayUtils'
 import { mcpGatewayLogic } from './mcpGatewayLogic'
 
 const AUTH_TYPE_OPTIONS = [
@@ -29,8 +30,6 @@ export function GatewayAddServerModal(): JSX.Element | null {
         addingServer,
         canManageAgentAccess,
         isAdmin,
-        serviceAccounts,
-        serviceAccountsLoading,
     } = useValues(mcpGatewayLogic)
     const { closeAddServerModal, setAddServerFormValue, submitAddServer } = useActions(mcpGatewayLogic)
 
@@ -43,14 +42,6 @@ export function GatewayAddServerModal(): JSX.Element | null {
             closeAddServerModal()
         }
     }
-    const setAgentSelected = (accountId: string, selected: boolean): void => {
-        setAddServerFormValue(
-            'agentIds',
-            selected
-                ? [...addServerForm.agentIds, accountId]
-                : addServerForm.agentIds.filter((candidate) => candidate !== accountId)
-        )
-    }
     const urlError =
         addServerForm.url.trim() && !isValidMcpUrl(addServerForm.url)
             ? 'Enter a full URL, like https://mcp.example.com/mcp.'
@@ -61,7 +52,7 @@ export function GatewayAddServerModal(): JSX.Element | null {
             isOpen
             onClose={closeModal}
             title="Add MCP server"
-            description="Connect a remote MCP server, then choose who and which agents can use it."
+            description="Connect a remote MCP server and choose how far to share it."
             width={640}
             footer={
                 <div className="flex items-center justify-end gap-2">
@@ -218,29 +209,22 @@ export function GatewayAddServerModal(): JSX.Element | null {
                 )}
 
                 {canManageAgentAccess && (
-                    <LemonField.Pure label="Share with agents (optional)">
-                        <div className="flex flex-col gap-2 rounded border p-3">
-                            {serviceAccountsLoading ? (
-                                <span className="text-sm text-secondary">Loading agents…</span>
-                            ) : serviceAccounts.length === 0 ? (
-                                <span className="text-sm text-secondary">No PostHog agents are available.</span>
-                            ) : (
-                                serviceAccounts.map((account) => (
-                                    <LemonCheckbox
-                                        key={account.id}
-                                        checked={addServerForm.agentIds.includes(account.id)}
-                                        onChange={(checked) => setAgentSelected(account.id, checked)}
-                                        label={
-                                            <span>
-                                                <span className="font-medium">{account.name}</span>
-                                                <span className="ml-2 text-xs text-secondary">{account.handle}</span>
-                                            </span>
-                                        }
-                                    />
-                                ))
-                            )}
+                    <div className="flex items-center justify-between gap-4 rounded border p-3">
+                        <div>
+                            <div className="font-semibold">Share with agents</div>
+                            <div className="text-sm text-secondary">
+                                {addServerForm.agentScope === 'team'
+                                    ? 'PostHog agents can use your connection for every run in this project. You can change this or revoke access on the server page.'
+                                    : 'PostHog agents can use your connection only on runs for you. You can change this or revoke access on the server page.'}
+                            </div>
                         </div>
-                    </LemonField.Pure>
+                        <LemonSegmentedButton
+                            size="small"
+                            value={addServerForm.agentScope}
+                            options={AGENT_GRANT_SCOPE_OPTIONS}
+                            onChange={(agentScope) => setAddServerFormValue('agentScope', agentScope)}
+                        />
+                    </div>
                 )}
             </form>
         </LemonModal>

--- a/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
@@ -211,11 +211,11 @@ export function GatewayAddServerModal(): JSX.Element | null {
                 {canManageAgentAccess && (
                     <div className="flex items-center justify-between gap-4 rounded border p-3">
                         <div>
-                            <div className="font-semibold">Share with agents</div>
+                            <div className="font-semibold">Who can use this connection?</div>
                             <div className="text-sm text-secondary">
                                 {addServerForm.agentScope === 'team'
-                                    ? 'Agents use this connection on every run in this project.'
-                                    : 'Agents use this connection only on your runs.'}
+                                    ? 'Anyone in this project can use this connection through agents.'
+                                    : 'Only you can use this connection through agents.'}
                             </div>
                         </div>
                         <LemonSegmentedButton

--- a/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
@@ -214,8 +214,8 @@ export function GatewayAddServerModal(): JSX.Element | null {
                             <div className="font-semibold">Who can use this connection?</div>
                             <div className="text-sm text-secondary">
                                 {addServerForm.agentScope === 'team'
-                                    ? 'Anyone in this project can use this connection through agents.'
-                                    : 'Only you can use this connection through agents.'}
+                                    ? 'Anyone in this project can use this connection'
+                                    : 'Only you can use this connection'}
                             </div>
                         </div>
                         <LemonSegmentedButton

--- a/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayAddServerModal.tsx
@@ -214,8 +214,8 @@ export function GatewayAddServerModal(): JSX.Element | null {
                             <div className="font-semibold">Share with agents</div>
                             <div className="text-sm text-secondary">
                                 {addServerForm.agentScope === 'team'
-                                    ? 'PostHog agents can use your connection for every run in this project. You can change this or revoke access on the server page.'
-                                    : 'PostHog agents can use your connection only on runs for you. You can change this or revoke access on the server page.'}
+                                    ? 'Agents use this connection on every run in this project.'
+                                    : 'Agents use this connection only on your runs.'}
                             </div>
                         </div>
                         <LemonSegmentedButton

--- a/products/mcp_store/frontend/gateway/gatewayAddServer.test.ts
+++ b/products/mcp_store/frontend/gateway/gatewayAddServer.test.ts
@@ -45,7 +45,7 @@ describe('gatewayAddServer', () => {
                     description: '  Company knowledge  ',
                     clientId: '  client-id  ',
                     clientSecret: '  client-secret  ',
-                    agentIds: ['agent-1'],
+                    agentScope: 'personal',
                 }),
                 { isAdmin: true, canManageAgentAccess: true }
             )
@@ -57,13 +57,13 @@ describe('gatewayAddServer', () => {
             client_id: 'client-id',
             client_secret: 'client-secret',
             team_enabled: true,
-            agent_ids: ['agent-1'],
+            agent_scope: 'personal',
         })
     })
 
     it('omits team and agent sharing fields when a member cannot manage them', () => {
         expect(
-            buildGatewayInstallRequest(values({ teamEnabled: false, agentIds: ['agent-1'] }), {
+            buildGatewayInstallRequest(values({ teamEnabled: false, agentScope: 'team' }), {
                 isAdmin: false,
                 canManageAgentAccess: false,
             })
@@ -75,9 +75,9 @@ describe('gatewayAddServer', () => {
         })
     })
 
-    it('lets a permitted member share with agents without sending team enablement', () => {
+    it('lets a permitted member pick the agent scope without sending team enablement', () => {
         expect(
-            buildGatewayInstallRequest(values({ teamEnabled: false, agentIds: ['agent-1'] }), {
+            buildGatewayInstallRequest(values({ teamEnabled: false, agentScope: 'team' }), {
                 isAdmin: false,
                 canManageAgentAccess: true,
             })
@@ -86,7 +86,7 @@ describe('gatewayAddServer', () => {
             url: 'https://mcp.example.com/sse',
             description: '',
             auth_type: 'oauth',
-            agent_ids: ['agent-1'],
+            agent_scope: 'team',
         })
     })
 

--- a/products/mcp_store/frontend/gateway/gatewayAddServer.ts
+++ b/products/mcp_store/frontend/gateway/gatewayAddServer.ts
@@ -1,4 +1,4 @@
-import type { InstallCustomApi } from '../generated/api.schemas'
+import type { InstallCustomApi, MCPAgentGrantScopeEnumApi } from '../generated/api.schemas'
 
 export interface GatewayAddServerValues {
     name: string
@@ -9,7 +9,7 @@ export interface GatewayAddServerValues {
     clientId: string
     clientSecret: string
     teamEnabled: boolean
-    agentIds: string[]
+    agentScope: MCPAgentGrantScopeEnumApi
 }
 
 export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
@@ -21,7 +21,7 @@ export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
     clientId: '',
     clientSecret: '',
     teamEnabled: true,
-    agentIds: [],
+    agentScope: 'team',
 }
 
 export function isValidMcpUrl(url: string): boolean {
@@ -58,6 +58,6 @@ export function buildGatewayInstallRequest(
             ? { client_secret: values.clientSecret.trim() }
             : {}),
         ...(options.isAdmin ? { team_enabled: values.teamEnabled } : {}),
-        ...(options.canManageAgentAccess && values.agentIds.length ? { agent_ids: values.agentIds } : {}),
+        ...(options.canManageAgentAccess ? { agent_scope: values.agentScope } : {}),
     }
 }

--- a/products/mcp_store/frontend/gateway/gatewayAddServer.ts
+++ b/products/mcp_store/frontend/gateway/gatewayAddServer.ts
@@ -21,7 +21,7 @@ export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
     clientId: '',
     clientSecret: '',
     teamEnabled: true,
-    agentScope: 'team',
+    agentScope: 'personal',
 }
 
 export function isValidMcpUrl(url: string): boolean {

--- a/products/mcp_store/frontend/gateway/gatewayUtils.tsx
+++ b/products/mcp_store/frontend/gateway/gatewayUtils.tsx
@@ -45,12 +45,12 @@ export function credentialOwnerLabel(owner: UserBasicApi, grantScope: string): s
 export const AGENT_GRANT_SCOPE_OPTIONS: { value: MCPAgentGrantScopeEnumApi; label: string; tooltip: string }[] = [
     {
         value: 'personal',
-        label: 'Just my agents',
+        label: 'Only me',
         tooltip: 'The agent uses your connection only when it runs for you.',
     },
     {
         value: 'team',
-        label: 'All team agents',
+        label: 'Everyone in this project',
         tooltip:
             "The agent uses your connection for every run in this project, including runs nobody started. Teammates can't use the connection directly, but agents act through it on their runs too.",
     },

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
@@ -378,16 +378,16 @@ describe('mcpGatewayLogic', () => {
         )
     })
 
-    it('adds a custom server with team and agent sharing in one guarded request', async () => {
+    it('adds a custom server with team sharing and every agent selected by default', async () => {
         const pendingInstall = deferred<Awaited<ReturnType<typeof mcpServerInstallationsInstallCustomCreate>>>()
         mockInstallCustom.mockReturnValue(pendingInstall.promise)
         logic.actions.loadServiceAccountsSuccess([serviceAccount()])
         logic.actions.openAddServerModal()
+        expect(logic.values.addServerForm.agentIds).toEqual(['scout-id'])
         logic.actions.setAddServerFormValue('name', '  Custom server  ')
         logic.actions.setAddServerFormValue('url', ' https://mcp.example.com/mcp ')
         logic.actions.setAddServerFormValue('authType', 'api_key')
         logic.actions.setAddServerFormValue('apiKey', 'secret-key')
-        logic.actions.setAddServerFormValue('agentIds', ['scout-id'])
 
         logic.actions.submitAddServer()
         logic.actions.submitAddServer()

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
@@ -378,7 +378,7 @@ describe('mcpGatewayLogic', () => {
         )
     })
 
-    it('adds a custom server shared with the team and with every agent by default', async () => {
+    it("adds a custom server shared with the team and with every agent for the user's own runs by default", async () => {
         const pendingInstall = deferred<Awaited<ReturnType<typeof mcpServerInstallationsInstallCustomCreate>>>()
         mockInstallCustom.mockReturnValue(pendingInstall.promise)
         logic.actions.openAddServerModal()
@@ -401,7 +401,7 @@ describe('mcpGatewayLogic', () => {
                 api_key: 'secret-key',
                 scope: 'personal',
                 team_enabled: true,
-                agent_scope: 'team',
+                agent_scope: 'personal',
             })
         )
 

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
@@ -378,12 +378,10 @@ describe('mcpGatewayLogic', () => {
         )
     })
 
-    it('adds a custom server with team sharing and every agent selected by default', async () => {
+    it('adds a custom server shared with the team and with every agent by default', async () => {
         const pendingInstall = deferred<Awaited<ReturnType<typeof mcpServerInstallationsInstallCustomCreate>>>()
         mockInstallCustom.mockReturnValue(pendingInstall.promise)
-        logic.actions.loadServiceAccountsSuccess([serviceAccount()])
         logic.actions.openAddServerModal()
-        expect(logic.values.addServerForm.agentIds).toEqual(['scout-id'])
         logic.actions.setAddServerFormValue('name', '  Custom server  ')
         logic.actions.setAddServerFormValue('url', ' https://mcp.example.com/mcp ')
         logic.actions.setAddServerFormValue('authType', 'api_key')
@@ -403,7 +401,7 @@ describe('mcpGatewayLogic', () => {
                 api_key: 'secret-key',
                 scope: 'personal',
                 team_enabled: true,
-                agent_ids: ['scout-id'],
+                agent_scope: 'team',
             })
         )
 

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
@@ -1233,6 +1233,15 @@ export const mcpGatewayLogic = kea<mcpGatewayLogicType>([
     }),
 
     listeners(({ actions, cache, values }) => ({
+        openAddServerModal: () => {
+            if (!values.canManageAgentAccess) {
+                return
+            }
+            actions.setAddServerFormValue(
+                'agentIds',
+                values.serviceAccounts.map((account) => account.id)
+            )
+        },
         setAddServerFormValue: ({ field, value }) => {
             if (field !== 'authType') {
                 return

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
@@ -1233,15 +1233,6 @@ export const mcpGatewayLogic = kea<mcpGatewayLogicType>([
     }),
 
     listeners(({ actions, cache, values }) => ({
-        openAddServerModal: () => {
-            if (!values.canManageAgentAccess) {
-                return
-            }
-            actions.setAddServerFormValue(
-                'agentIds',
-                values.serviceAccounts.map((account) => account.id)
-            )
-        },
         setAddServerFormValue: ({ field, value }) => {
             if (field !== 'authType') {
                 return
@@ -1455,6 +1446,7 @@ export const mcpGatewayLogic = kea<mcpGatewayLogicType>([
                 }
                 actions.closeConnectionModal()
                 actions.refreshServersAfterConnection()
+                actions.loadServiceAccounts()
                 lemonToast.success(`Connected to ${server.name}`)
             } catch (error: unknown) {
                 actions.loadServers()

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
@@ -437,7 +437,7 @@ export interface mcpGatewayLogicActions {
         value: GatewayAddServerValues[keyof GatewayAddServerValues]
     ) => {
         field: keyof GatewayAddServerValues
-        value: boolean | string | string[]
+        value: boolean | string
     }
     setAgentServerAccess: (
         accountId: string,

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -1102,15 +1102,18 @@ export interface InstallCustomApi {
     client_secret?: string
     install_source?: InstallSourceEnumApi
     posthog_code_callback_url?: string
-    /** 'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.
+    /** 'personal' is per-user; 'shared' makes the credential available to project members. PostHog agents get access to the connection automatically; see agent_scope.
      *
      * * `personal` - personal
      * * `shared` - shared */
     scope?: MCPInstallationScopeEnumApi
     /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
     team_enabled?: boolean
-    /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
-    agent_ids?: string[]
+    /** How far the automatic agent grants for this connection reach. 'personal' (the default) lets PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. Grants are created when the caller may manage agent access: project admins always, members when team settings allow it. Sending a value without that permission is rejected.
+     *
+     * * `personal` - Personal
+     * * `team` - Team */
+    agent_scope?: MCPAgentGrantScopeEnumApi
     /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
     return_path?: string
 }
@@ -1124,15 +1127,18 @@ export interface InstallTemplateApi {
     api_key?: string
     install_source?: InstallSourceEnumApi
     posthog_code_callback_url?: string
-    /** 'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.
+    /** 'personal' is per-user; 'shared' makes the credential available to project members. PostHog agents get access to the connection automatically; see agent_scope.
      *
      * * `personal` - personal
      * * `shared` - shared */
     scope?: MCPInstallationScopeEnumApi
     /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
     team_enabled?: boolean
-    /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
-    agent_ids?: string[]
+    /** How far the automatic agent grants for this connection reach. 'personal' (the default) lets PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. Grants are created when the caller may manage agent access: project admins always, members when team settings allow it. Sending a value without that permission is rejected.
+     *
+     * * `personal` - Personal
+     * * `team` - Team */
+    agent_scope?: MCPAgentGrantScopeEnumApi
     /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
     return_path?: string
 }

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -513,17 +513,18 @@ export const McpServerInstallationsInstallCustomCreateBody = /* @__PURE__ */ zod
         .describe('\* `personal` - personal\n\* `shared` - shared')
         .default(mcpServerInstallationsInstallCustomCreateBodyScopeDefault)
         .describe(
-            "'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.\n\n\* `personal` - personal\n\* `shared` - shared"
+            "'personal' is per-user; 'shared' makes the credential available to project members. PostHog agents get access to the connection automatically; see agent_scope.\n\n\* `personal` - personal\n\* `shared` - shared"
         ),
     team_enabled: zod
         .boolean()
         .default(mcpServerInstallationsInstallCustomCreateBodyTeamEnabledDefault)
         .describe('Whether the server starts enabled for the whole team. Non-default values are admin-only.'),
-    agent_ids: zod
-        .array(zod.uuid())
+    agent_scope: zod
+        .enum(['personal', 'team'])
+        .describe('\* `personal` - Personal\n\* `team` - Team')
         .optional()
         .describe(
-            'Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access.'
+            "How far the automatic agent grants for this connection reach. 'personal' (the default) lets PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. Grants are created when the caller may manage agent access: project admins always, members when team settings allow it. Sending a value without that permission is rejected.\n\n\* `personal` - Personal\n\* `team` - Team"
         ),
     return_path: zod
         .string()
@@ -553,17 +554,18 @@ export const McpServerInstallationsInstallTemplateCreateBody = /* @__PURE__ */ z
         .describe('\* `personal` - personal\n\* `shared` - shared')
         .default(mcpServerInstallationsInstallTemplateCreateBodyScopeDefault)
         .describe(
-            "'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.\n\n\* `personal` - personal\n\* `shared` - shared"
+            "'personal' is per-user; 'shared' makes the credential available to project members. PostHog agents get access to the connection automatically; see agent_scope.\n\n\* `personal` - personal\n\* `shared` - shared"
         ),
     team_enabled: zod
         .boolean()
         .default(mcpServerInstallationsInstallTemplateCreateBodyTeamEnabledDefault)
         .describe('Whether the server starts enabled for the whole team. Non-default values are admin-only.'),
-    agent_ids: zod
-        .array(zod.uuid())
+    agent_scope: zod
+        .enum(['personal', 'team'])
+        .describe('\* `personal` - Personal\n\* `team` - Team')
         .optional()
         .describe(
-            'Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access.'
+            "How far the automatic agent grants for this connection reach. 'personal' (the default) lets PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. Grants are created when the caller may manage agent access: project admins always, members when team settings allow it. Sending a value without that permission is rejected.\n\n\* `personal` - Personal\n\* `team` - Team"
         ),
     return_path: zod
         .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -45711,15 +45711,18 @@ export namespace Schemas {
       client_secret?: string;
       install_source?: InstallSourceEnum;
       posthog_code_callback_url?: string;
-      /** 'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.
+      /** 'personal' is per-user; 'shared' makes the credential available to project members. PostHog agents get access to the connection automatically; see agent_scope.
        *
        * * `personal` - personal
        * * `shared` - shared */
       scope?: MCPInstallationScopeEnum;
       /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
       team_enabled?: boolean;
-      /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
-      agent_ids?: string[];
+      /** How far the automatic agent grants for this connection reach. 'personal' (the default) lets PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. Grants are created when the caller may manage agent access: project admins always, members when team settings allow it. Sending a value without that permission is rejected.
+       *
+       * * `personal` - Personal
+       * * `team` - Team */
+      agent_scope?: MCPAgentGrantScopeEnum;
       /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
       return_path?: string;
     }
@@ -45729,15 +45732,18 @@ export namespace Schemas {
       api_key?: string;
       install_source?: InstallSourceEnum;
       posthog_code_callback_url?: string;
-      /** 'personal' is per-user; 'shared' makes the credential available to project members. Agent access is granted separately.
+      /** 'personal' is per-user; 'shared' makes the credential available to project members. PostHog agents get access to the connection automatically; see agent_scope.
        *
        * * `personal` - personal
        * * `shared` - shared */
       scope?: MCPInstallationScopeEnum;
       /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
       team_enabled?: boolean;
-      /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
-      agent_ids?: string[];
+      /** How far the automatic agent grants for this connection reach. 'personal' (the default) lets PostHog agents use it only on runs for you; 'team' lets every agent run in the project use it. Grants are created when the caller may manage agent access: project admins always, members when team settings allow it. Sending a value without that permission is rejected.
+       *
+       * * `personal` - Personal
+       * * `team` - Team */
+      agent_scope?: MCPAgentGrantScopeEnum;
       /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
       return_path?: string;
     }


### PR DESCRIPTION
## Problem

- A person who adds an MCP server in the web app or Desktop sees a checklist of agents to share it with, while the "Share access with an agent" modal on the server page asks a different question: just my agents, or all team agents.
- A person who connects a recommended server shares it with no agent, so PostHog agents cannot use it until that person finds the server page and grants access by hand.
- The result is two flows that disagree, and a default that leaves agents without access.

## Changes

- The add-server form on web and Desktop replaces the agent checklist with one question, "Who can use this connection?", and a toggle: "Only me" or "Everyone in this project". The default is "Only me".
- The same two labels replace "Just my agents" and "All team agents" in the share-access modal and in the access lists on the server and agent pages, on web and Desktop.
- Every new connection is shared with all built-in PostHog agents automatically, on every install path: custom API key, custom OAuth, catalog API key, catalog OAuth.
- Connecting a recommended server shares it for the person's own runs only. The server page widens it to the team or revokes it.
- The Agents list on the server page now shows grants right after connecting, and the person can revoke them there.
- Members get the automatic grants only while team settings let members manage agent access. Project admins always get them.
- A member without that permission gets no grants, and a request that names an `agent_scope` gets a 403.
- Reconnecting a server after a disconnect rebinds the existing grants to the new credential and keeps their scope, so a reconnect never demotes a team share.
- API: `install_custom` and `install_template` accept `agent_scope` (`personal` or `team`) instead of `agent_ids`. An omitted value means personal.
- Mechanical: regenerated OpenAPI types for the web app and the MCP service, the Desktop api-client mirror, and the README.

No screenshots: the local dev stack was not running during this work. The visible change is the toggle row in the add-server form, replacing the agent checklist.

This PR carries `skip-desktop-backend-check`, so the desktop and backend halves ship together. They are safe in either order. A Desktop build that sends `agent_scope` to the old backend gets the old behaviour: the field is ignored and no agent grants are created. An older Desktop build that sends `agent_ids` to the new backend gets grants at the default personal scope. Neither order breaks an install.

## How did you test this code?

- Backend, `TestMCPServiceAccountAPI` in `products/mcp_store/backend/test/test_api.py`, three tests replace the `agent_ids` delegation tests:
  - install grants every built-in agent at the requested scope (personal by default, team when named) and skips legacy accounts.
  - a member with the team setting off gets no grants, and a 403 when naming a scope.
  - a reconnect rebinds grants to the new credential and keeps team scope.
- Web Jest: `gatewayAddServer.test.ts` and `mcpGatewayLogic.test.ts` now assert the `agent_scope` request shape and the personal default.
- Desktop Vitest: the core request builder, the add-server form render, and the scope toggle in the give-access dialog and the server detail page (new labels).
- Not done: no browser pass of either UI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/mcp_store/README.md` describes the automatic sharing and the scope choice.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5), [session](https://claude.ai/code/session_01Go2VjviGWefkyv7ocxc2SB).
- Skills invoked: `/improving-drf-endpoints`, `/adopting-generated-api-types`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/posthog-desktop`, `/writing-pr-descriptions`.
- The first commit only preselected every agent in the old checklist. The driver then asked for the scope toggle plus automatic grants, and the checklist went away.
- The toggle default started as team and moved to personal at the driver's direction, so custom and recommended servers start with the same reach.
- A PostHog Desktop session rebased the branch onto master and added the guard that keeps a member from sending `agent_scope` before the gateway config loads.
- A later PostHog Desktop session rebased onto master again to clear a conflict in the add-server test, kept both sides of it, and regenerated the kea types for the form.

https://claude.ai/code/session_01Go2VjviGWefkyv7ocxc2SB


