### PR TITLE
fix(tasks): clear merged reports from pull requests

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1111,11 +1111,11 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
             task_id=str(self.task.id),
         )
 
-    def _post_pr_webhook(self, action: str, merged: bool):
+    def _post_pr_webhook(self, action: str, merged: bool, pr_url: str = "https://github.com/posthog/posthog/pull/42"):
         payload = {
             "action": action,
             "pull_request": {
-                "html_url": "https://github.com/posthog/posthog/pull/42",
+                "html_url": pr_url,
                 "merged": merged,
             },
         }
@@ -1169,6 +1169,10 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, expected_status)
+        if merged:
+            self.task_run.refresh_from_db()
+            assert self.task_run.output is not None
+            self.assertIs(self.task_run.output.get("pr_merged"), True)
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
@@ -1183,6 +1187,114 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @parameterized.expand(
+        [
+            ("merged", True, SignalReport.Status.RESOLVED),
+            ("closed", False, SignalReport.Status.SUPPRESSED),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_event_transitions_report_when_pr_is_bound_to_another_task(
+        self, _name, merged, expected_status, _mock_capture, mock_get_secret
+    ):
+        mock_get_secret.return_value = self.webhook_secret
+        pr_url = "https://github.com/posthog/posthog/pull/42"
+        self.task_run.state = {}
+        self.task_run.save(update_fields=["state"])
+        review_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review task",
+            description="Review the implementation",
+            origin_product=Task.OriginProduct.REVIEW_HOG,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=review_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"verified_pr_urls": [pr_url]},
+            output={"pr_url": pr_url},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=merged)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, expected_status)
+        if merged:
+            self.task_run.refresh_from_db()
+            assert self.task_run.output is not None
+            self.assertIs(self.task_run.output.get("pr_merged"), True)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_event_does_not_transition_report_for_older_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/99"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_implementation_pr_takes_priority_over_newer_discussion_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        discussion_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Discuss report",
+            description="Discuss the signal report",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=discussion_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/99"},
+        )
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(self.report.id),
+            product="signals",
+            type="discussion",
+            task_id=str(discussion_task.id),
+        )
+
+        response = self._post_pr_webhook(
+            action="closed", merged=False, pr_url="https://github.com/posthog/posthog/pull/99"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_url_variants_match_the_webhook_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self.task_run.output = {"pr_url": "https://www.github.com/PostHog/PostHog/pull/42/files?diff=split"}
+        self.task_run.save(update_fields=["output"])
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.task_run.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.RESOLVED)
+        assert self.task_run.output is not None
+        self.assertIs(self.task_run.output.get("pr_merged"), True)
 
 
 class TestExternalPRWebhook(TestCase):
@@ -1505,6 +1617,68 @@ class TestFindTaskRun(TestCase):
         )
         result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
+
+    @parameterized.expand([("branch", False), ("signed_head_branch", True)])
+    def test_branch_fallback_prefers_newest_run_even_when_it_is_terminal(self, _name, signed_head_branch):
+        branch_fields = (
+            {
+                "branch": "master",
+                "output": {"head_branches": [{"repository": "posthog/posthog", "branch": "feature/shared-branch"}]},
+            }
+            if signed_head_branch
+            else {"branch": "feature/shared-branch"}
+        )
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            **branch_fields,
+        )
+        review_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review task",
+            description="Review the implementation",
+            origin_product=Task.OriginProduct.REVIEW_HOG,
+            repository="posthog/posthog",
+        )
+        newest_run = TaskRun.objects.create(
+            task=review_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            **branch_fields,
+        )
+
+        result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
+
+        self.assertEqual(result, newest_run)
+
+    @parameterized.expand([("branch", False), ("signed_head_branch", True)])
+    def test_branch_fallback_prefers_newest_run_with_same_status_rank(self, _name, signed_head_branch):
+        branch_fields = (
+            {
+                "branch": "master",
+                "output": {"head_branches": [{"repository": "posthog/posthog", "branch": "feature/shared-branch"}]},
+            }
+            if signed_head_branch
+            else {"branch": "feature/shared-branch"}
+        )
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            **branch_fields,
+        )
+        newest_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.QUEUED,
+            **branch_fields,
+        )
+
+        result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
+
+        self.assertEqual(result, newest_run)
 
     def test_finds_by_signed_commit_head_branch(self):
         task_run = TaskRun.objects.create(

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1280,11 +1280,18 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
 
+    @parameterized.expand(
+        [
+            ("trailing_slash", "https://github.com/posthog/posthog/pull/42/"),
+            ("www_host", "https://www.github.com/posthog/posthog/pull/42"),
+            ("www_host_trailing_slash", "https://www.github.com/posthog/posthog/pull/42/"),
+        ]
+    )
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
-    def test_pr_url_variants_match_the_webhook_pr(self, _mock_capture, mock_get_secret):
+    def test_pr_url_variants_match_the_webhook_pr(self, _name, stored_pr_url, _mock_capture, mock_get_secret):
         mock_get_secret.return_value = self.webhook_secret
-        self.task_run.output = {"pr_url": "https://www.github.com/PostHog/PostHog/pull/42/files?diff=split"}
+        self.task_run.output = {"pr_url": stored_pr_url}
         self.task_run.save(update_fields=["output"])
 
         response = self._post_pr_webhook(action="closed", merged=True)

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -921,6 +921,26 @@ def _pull_request_identity(pr_url: str) -> tuple[str, int] | None:
     return parsed.repository.lower(), parsed.number
 
 
+def _pr_url_lookup_values(pr_url: str) -> list[str]:
+    """The ``output.pr_url`` strings that can stand for ``pr_url``.
+
+    ``output.pr_url`` is caller-supplied: the agent server PATCHes it onto the run, so it can hold
+    a valid but noncanonical form of the URL GitHub sends as ``html_url``. The variants are
+    enumerated rather than matched with a prefix or a normalizing scan so the lookup stays on the
+    partial index ``task_run_output_pr_url_idx``. A prefix match cannot use that index, and this
+    lookup runs on every closed-PR delivery, including the many for PRs no run ever opened.
+    """
+    parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+    if parsed is None:
+        return [pr_url]
+    values = {pr_url}
+    for host in ("github.com", "www.github.com"):
+        for repository in (parsed.repository, parsed.repository.lower()):
+            base = f"https://{host}/{repository}/pull/{parsed.number}"
+            values.update((base, f"{base}/"))
+    return sorted(values)
+
+
 def _signal_reports_for_pr_runs(pr_url: str, runs: list[TaskRun]) -> list[SignalReport]:
     if not runs:
         return []
@@ -960,29 +980,10 @@ def _transition_signal_reports_for_pr(
     Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
     5xx responses and we've already acknowledged the PR event.
     """
-    run_candidates = TaskRun.objects.filter(output__pr_url=pr_url)
+    run_candidates = TaskRun.objects.filter(output__pr_url__in=_pr_url_lookup_values(pr_url))
     if team_ids:
         run_candidates = run_candidates.filter(team_id__in=team_ids)
-    candidate_runs = list(run_candidates)
-    reports = _signal_reports_for_pr_runs(pr_url, candidate_runs)
-
-    if not reports:
-        parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
-        if parsed is None:
-            return
-        pr_path = f"{parsed.owner}/{parsed.repo}/pull/{parsed.number}"
-        normalized_candidates = TaskRun.objects.filter(
-            Q(output__pr_url__istartswith=f"https://github.com/{pr_path}")
-            | Q(output__pr_url__istartswith=f"https://www.github.com/{pr_path}")
-        )
-        if team_ids:
-            normalized_candidates = normalized_candidates.filter(team_id__in=team_ids)
-        candidate_runs = [
-            run
-            for run in normalized_candidates
-            if _pull_request_identity((run.output or {}).get("pr_url", "")) == _pull_request_identity(pr_url)
-        ]
-        reports = _signal_reports_for_pr_runs(pr_url, candidate_runs)
+    reports = _signal_reports_for_pr_runs(pr_url, list(run_candidates))
 
     if record_merge and reports:
         report_task_runs = SignalReport.associated_task_runs_for_reports(

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -15,6 +15,7 @@ import posthoganalytics
 from social_django.models import UserSocialAuth
 
 from posthog.event_usage import groups
+from posthog.models.github_integration_base import GitHubIntegrationBase
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.integration import Integration
 from posthog.models.organization import OrganizationMembership
@@ -22,6 +23,7 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 
+from products.signals.backend.implementation_pr import fetch_implementation_pr_state_for_reports
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
 from products.tasks.backend.constants import PR_LOOP_ENABLED_STATE_KEY
@@ -113,6 +115,7 @@ def find_task_run(
                 branch=branch,
                 state__wizard_head_branch__isnull=True,
             )
+            .order_by("-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -129,6 +132,7 @@ def find_task_run(
                 output__head_branches__contains=[head_branch],
                 state__wizard_head_branch__isnull=True,
             )
+            .order_by("-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -236,9 +240,8 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
 
     branch = pull_request.get("head", {}).get("ref")
     repository_full_name = (payload.get("repository") or {}).get("full_name")
-    task_run = find_task_run(
-        pr_url=pr_url, branch=branch, repository=repository_full_name, team_ids=_task_run_scope_team_ids(payload)
-    )
+    scoped_team_ids = _task_run_scope_team_ids(payload)
+    task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name, team_ids=scoped_team_ids)
     claimed_pr_urls = (
         read_pr_urls(task_run.output if isinstance(task_run.output, dict) else {}) if task_run is not None else []
     )
@@ -286,27 +289,29 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         event_uuid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{pr_url}:{analytics_event}"))
         _capture_pr_event(payload, task_run, analytics_event, event_uuid)
 
-    if task_run and action == "closed" and merged:
+    if action == "closed" and merged:
         # Only trust the merge for the run that actually claims this PR URL. The pr_url backstop
         # above already covers branch-matched internal PRs, so requiring equality here keeps a
         # same-branch webhook for a different PR from marking this run's PR as merged.
-        if pr_url in claimed_pr_urls:
+        if task_run and pr_url in claimed_pr_urls:
             _record_run_pr_merged(task_run)
-        # Ungated on the pr_url match above: unlike the run-bookkeeping calls, this keys off
-        # task_id (reports_for_task_filter), not output.pr_url, so the same-branch trust rule
-        # doesn't apply — a merged PR resolves its report.
-        _transition_signal_reports_for_task(
-            task_run.task_id, pr_url, SignalReport.Status.RESOLVED, "github_pr_webhook_signal_report_resolved"
+        _transition_signal_reports_for_pr(
+            pr_url,
+            SignalReport.Status.RESOLVED,
+            "github_pr_webhook_signal_report_resolved",
+            scoped_team_ids or ([task_run.team_id] if task_run else None),
+            record_merge=True,
         )
 
-    if task_run and action == "closed" and not merged:
+    if action == "closed" and not merged:
         # Same trust rule as the merge branch: only the run that claims this PR URL.
-        if pr_url in claimed_pr_urls:
+        if task_run and pr_url in claimed_pr_urls:
             _cancel_wizard_run_on_close(task_run)
-        # Ungated for the same reason as the merge branch's resolve call: a closed-unmerged PR
-        # archives (suppresses) its report so it leaves the inbox instead of lingering.
-        _transition_signal_reports_for_task(
-            task_run.task_id, pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
+        _transition_signal_reports_for_pr(
+            pr_url,
+            SignalReport.Status.SUPPRESSED,
+            "github_pr_webhook_signal_report_archived",
+            scoped_team_ids or ([task_run.team_id] if task_run else None),
         )
 
     return HttpResponse(status=200)
@@ -909,18 +914,19 @@ def _resolve_external_team(payload: dict) -> Team | None:
     return Team.objects.filter(pk=team_ids[0]).first()
 
 
-def _transition_signal_reports_for_task(
-    task_id: uuid.UUID, pr_url: str, target_status: SignalReport.Status, success_log_event: str
-) -> None:
-    """Transition signal reports linked to a task's PR to ``target_status``.
+def _pull_request_identity(pr_url: str) -> tuple[str, int] | None:
+    parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+    if parsed is None:
+        return None
+    return parsed.repository.lower(), parsed.number
 
-    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
-    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
-    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
-    5xx responses and we've already acknowledged the PR event.
-    """
-    reports = (
-        SignalReport.objects.filter(SignalReport.reports_for_task_filter(task_id))
+
+def _signal_reports_for_pr_runs(pr_url: str, runs: list[TaskRun]) -> list[SignalReport]:
+    if not runs:
+        return []
+
+    reports = list(
+        SignalReport.objects.filter(SignalReport.reports_for_task_ids_filter({run.task_id for run in runs}))
         .exclude(
             status__in=[
                 SignalReport.Status.RESOLVED,
@@ -930,6 +936,68 @@ def _transition_signal_reports_for_task(
         )
         .distinct()
     )
+    pr_identity = _pull_request_identity(pr_url)
+    surfaced_prs = fetch_implementation_pr_state_for_reports([str(report.id) for report in reports])
+    return [
+        report
+        for report in reports
+        if (surfaced_pr := surfaced_prs.get(str(report.id))) and _pull_request_identity(surfaced_pr.url) == pr_identity
+    ]
+
+
+def _transition_signal_reports_for_pr(
+    pr_url: str,
+    target_status: SignalReport.Status,
+    success_log_event: str,
+    team_ids: list[int] | None,
+    *,
+    record_merge: bool = False,
+) -> None:
+    """Transition signal reports whose surfaced implementation PR matches ``pr_url``.
+
+    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
+    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
+    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
+    5xx responses and we've already acknowledged the PR event.
+    """
+    run_candidates = TaskRun.objects.filter(output__pr_url=pr_url)
+    if team_ids:
+        run_candidates = run_candidates.filter(team_id__in=team_ids)
+    candidate_runs = list(run_candidates)
+    reports = _signal_reports_for_pr_runs(pr_url, candidate_runs)
+
+    if not reports:
+        parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+        if parsed is None:
+            return
+        pr_path = f"{parsed.owner}/{parsed.repo}/pull/{parsed.number}"
+        normalized_candidates = TaskRun.objects.filter(
+            Q(output__pr_url__istartswith=f"https://github.com/{pr_path}")
+            | Q(output__pr_url__istartswith=f"https://www.github.com/{pr_path}")
+        )
+        if team_ids:
+            normalized_candidates = normalized_candidates.filter(team_id__in=team_ids)
+        candidate_runs = [
+            run
+            for run in normalized_candidates
+            if _pull_request_identity((run.output or {}).get("pr_url", "")) == _pull_request_identity(pr_url)
+        ]
+        reports = _signal_reports_for_pr_runs(pr_url, candidate_runs)
+
+    if record_merge and reports:
+        report_task_runs = SignalReport.associated_task_runs_for_reports(
+            report_ids=[str(report.id) for report in reports]
+        )
+        associated_task_ids = {run.task_id for runs in report_task_runs.values() for run in runs}
+        surfaced_runs = (
+            TaskRun.objects.filter(task_id__in=associated_task_ids, output__pr_url__isnull=False)
+            .exclude(output__pr_url="")
+            .order_by("task_id", "-created_at", "-id")
+            .distinct("task_id")
+        )
+        for run in surfaced_runs:
+            if _pull_request_identity((run.output or {}).get("pr_url", "")) == _pull_request_identity(pr_url):
+                _record_run_pr_merged(run)
 
     for report in reports:
         try:
@@ -946,6 +1014,5 @@ def _transition_signal_reports_for_task(
         logger.info(
             success_log_event,
             report_id=str(report.id),
-            task_id=str(task_id),
             pr_url=pr_url,
         )


### PR DESCRIPTION
## Problem

A self-driving report whose implementation PR has already merged stays in the Inbox Pull requests tab, with an Open badge, until someone dismisses it by hand.

**Why:** One code path flips the report's status, and it keys off the task run the webhook attributed the PR to. Several runs share a head branch, so the webhook often binds to the code-review run instead of the implementation run, and the report never transitions.

Closes #88140
Supersedes #88195

## Changes

- A report leaves the Pull requests tab when its surfaced PR closes, whichever run the webhook attributed the PR to. A merged PR resolves the report, an unmerged PR suppresses it.
- The card's Open badge clears on merge, because the merge flag now lands on the run the report surfaces.
- The lookup keys on the PR the inbox surfaces, so a report holding both an implementation PR and a newer discussion PR still follows the implementation one.
- The lookup matches a fixed list of URL forms (`www.`, trailing slash, repository casing) and stays on the `task_run_output_pr_url_idx` index. A prefix match cannot use that index and would read every PR-bearing run on every closed-PR delivery.
- The branch fallback in `find_task_run` gains an `-id` tie-breaker. Mechanical: the model already orders by `-created_at`, so only runs created in the same instant change.

> [!NOTE]
> This clears reports from the tab on the next `closed` webhook. Reports whose PR merged before this ships get no further webhook, so the backlog needs the reconciler #88140 lists as a follow-up.

**Before**

```mermaid
flowchart LR
    Hook[GitHub closed webhook] --> Run[Attributed task run]
    Run --> Report[Reports linked to that task]
    Report --> Stale[Wrong attribution leaves report ready]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Hook phRed;
    class Run,Report phBlue;
    class Stale phYellow;
```

**After**

```mermaid
flowchart LR
    Hook[GitHub closed webhook] --> Runs[Runs with the same PR identity]
    Runs --> Surface[Canonical surfaced PR]
    Surface --> Outcome[Resolve or suppress report]
    Surface --> Merge[Record merge on surfaced run]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Hook phRed;
    class Runs,Surface phBlue;
    class Outcome,Merge phYellow;
```

No screenshot: nothing renders differently. The card leaves the tab because its status changes.

## How did you test this code?

New cases in `products/tasks/backend/tests/test_webhooks.py`, each naming a regression:

- A closed webhook attributed to a different run still transitions the report. This is the bug.
- A report with an implementation PR and a newer discussion PR ignores the discussion PR's close.
- A run storing a `www.` or trailing-slash URL form still matches the webhook PR.
- The branch fallback picks the newest run, including a terminal one.

The whole file runs against Postgres locally.

Verified the index claim with `EXPLAIN` on a local Postgres:

<details>
<summary>Plans for both lookup forms</summary>

```text
-- fixed URL list (this PR)
Bitmap Index Scan on task_run_output_pr_url_idx
  Index Cond: ((output -> 'pr_url') = ANY (...))

-- prefix match
Bitmap Index Scan on task_run_output_pr_url_idx
  Recheck Cond: ((output -> 'pr_url') IS NOT NULL)
  Filter: (upper((output -> 'pr_url')::text) ~~ '"HTTPS://GITHUB.COM/...%')
```

The prefix form reads every run that carries a PR URL, then filters in memory.

</details>

Not checked: behavior against production data.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This changes internal webhook bookkeeping only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex rebased and revised #88195, which @BaconMan1168 authored, after automated review. Claude Code then reviewed the result, ran the suite against Postgres, and replaced the prefix URL match with the indexed fixed list.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
