### PR TITLE
feat(insights): add performed event breakdown

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/AddBehavioralFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/AddBehavioralFilterButton.tsx
@@ -9,11 +9,13 @@ import { BehavioralPropertyFilter } from '~/types'
 export interface AddBehavioralFilterButtonProps {
     onAdd: (filter: BehavioralPropertyFilter) => void
     'data-attr': string
+    size?: 'xsmall' | 'small' | 'medium'
 }
 
 export function AddBehavioralFilterButton({
     onAdd,
     'data-attr': dataAttr,
+    size,
 }: AddBehavioralFilterButtonProps): JSX.Element {
     return (
         <TaxonomicPopover
@@ -31,6 +33,7 @@ export function AddBehavioralFilterButton({
             placeholder="Performed"
             placeholderClass=""
             icon={<IconPlusSmall />}
+            size={size}
             sideIcon={null}
             data-attr={dataAttr}
         />

--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -1,13 +1,29 @@
 import { useActions, useValues } from 'kea'
 
+import {
+    canAddBehavioralBreakdown,
+    createBehavioralBreakdownSeries,
+} from 'scenes/insights/filters/BreakdownFilter/behavioralBreakdown'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-import { EditorFilterProps } from '~/types'
+import { FEATURE_FLAGS } from '~/lib/constants'
+import { BehavioralPropertyFilter, EditorFilterProps } from '~/types'
 
 export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
-    const { breakdownFilter, display, isTrends, isFunnels } = useValues(insightVizDataLogic(insightProps))
-    const { updateBreakdownFilter, updateDisplay } = useActions(insightVizDataLogic(insightProps))
+    const { breakdownFilter, display, featureFlags, isTrends, isFunnels, querySource } = useValues(
+        insightVizDataLogic(insightProps)
+    )
+    const { updateBreakdownFilter, updateDisplay, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+
+    const addBehavioralBreakdown = canAddBehavioralBreakdown(
+        querySource,
+        !!featureFlags[FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER]
+    )
+        ? (filter: BehavioralPropertyFilter): void => {
+              updateQuerySource({ series: createBehavioralBreakdownSeries(querySource.series[0], filter) })
+          }
+        : undefined
 
     return (
         <>
@@ -19,6 +35,7 @@ export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
                 isFunnels={isFunnels}
                 updateBreakdownFilter={updateBreakdownFilter}
                 updateDisplay={updateDisplay}
+                onAddBehavioralBreakdown={addBehavioralBreakdown}
                 showLabel={false}
                 showInlineOptions
             />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.test.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom'
 import { cleanup, configure, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { FEATURE_FLAGS } from '~/lib/constants'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildTrendsQuery, renderInsightPage } from '~/test/insight-testing'
 
@@ -34,6 +35,16 @@ describe('TaxonomicBreakdownFilter', () => {
             renderInsightPage({ query: buildTrendsQuery() })
             const button = await waitForBreakdownButton()
             expect(button).toHaveAttribute('aria-disabled', 'false')
+            expect(screen.queryByTestId('add-behavioral-breakdown-button')).not.toBeInTheDocument()
+        })
+
+        it('renders the Performed breakdown when its feature is enabled', async () => {
+            renderInsightPage({
+                query: buildTrendsQuery(),
+                featureFlags: { [FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER]: true },
+            })
+            await waitForBreakdownButton()
+            expect(screen.getByTestId('add-behavioral-breakdown-button')).toHaveTextContent('Performed')
         })
     })
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react'
 
 import { IconGear, IconPencil } from '@posthog/icons'
 
+import { AddBehavioralFilterButton } from 'lib/components/PropertyFilters/components/AddBehavioralFilterButton'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Link } from 'lib/lemon-ui/Link'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -12,7 +13,7 @@ import { LemonButton } from '~/lib/lemon-ui/LemonButton'
 import { LemonLabel } from '~/lib/lemon-ui/LemonLabel'
 import { Popover } from '~/lib/lemon-ui/Popover'
 import { BreakdownFilter } from '~/queries/schema/schema-general'
-import { ChartDisplayType, InsightLogicProps } from '~/types'
+import { BehavioralPropertyFilter, ChartDisplayType, InsightLogicProps } from '~/types'
 
 import { EditableBreakdownTag } from './BreakdownTag'
 import { GlobalBreakdownOptionsMenu } from './GlobalBreakdownOptionsMenu'
@@ -31,6 +32,7 @@ export interface TaxonomicBreakdownFilterProps {
     disabledReason?: string
     updateBreakdownFilter: (breakdownFilter: BreakdownFilter) => void
     updateDisplay: (display: ChartDisplayType | undefined) => void
+    onAddBehavioralBreakdown?: (filter: BehavioralPropertyFilter) => void
     showLabel?: boolean
     showInlineOptions?: boolean
     disablePropertyInfo?: boolean
@@ -46,6 +48,7 @@ export function TaxonomicBreakdownFilter({
     disabledReason,
     updateBreakdownFilter,
     updateDisplay,
+    onAddBehavioralBreakdown,
     showLabel = true,
     showInlineOptions = false,
     disablePropertyInfo,
@@ -163,6 +166,13 @@ export function TaxonomicBreakdownFilter({
                     disabledReasonInteractive={!!composedDisabledReason}
                     size={size}
                 />
+                {onAddBehavioralBreakdown && (
+                    <AddBehavioralFilterButton
+                        onAdd={onAddBehavioralBreakdown}
+                        data-attr="add-behavioral-breakdown-button"
+                        size={size}
+                    />
+                )}
             </div>
             {showInlineOptions && isMultipleBreakdownsEnabled && hasGlobalBreakdownOptions && (
                 <div className="mt-2 border-t pt-2">

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/behavioralBreakdown.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/behavioralBreakdown.test.ts
@@ -1,0 +1,92 @@
+import { InsightQueryNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import {
+    BehavioralEventType,
+    BehavioralPropertyFilter,
+    ChartDisplayType,
+    PropertyFilterType,
+    PropertyOperator,
+    TimeUnitType,
+} from '~/types'
+
+import { canAddBehavioralBreakdown, createBehavioralBreakdownSeries } from './behavioralBreakdown'
+
+const behavioralFilter: BehavioralPropertyFilter = {
+    type: PropertyFilterType.Behavioral,
+    value: BehavioralEventType.PerformEvent,
+    key: 'signed_up',
+    event_type: 'events' as const,
+    time_value: 30,
+    time_interval: TimeUnitType.Day,
+}
+
+const query: TrendsQuery = {
+    kind: NodeKind.TrendsQuery,
+    series: [
+        {
+            kind: NodeKind.EventsNode,
+            event: 'uploaded_file',
+            properties: [
+                {
+                    type: PropertyFilterType.Event,
+                    key: 'file_type',
+                    value: 'csv',
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        },
+    ],
+}
+
+describe('behavioralBreakdown', () => {
+    it('creates complementary performed and did not perform series without dropping existing filters', () => {
+        const existingProperties = query.series[0].properties ?? []
+
+        expect(createBehavioralBreakdownSeries(query.series[0], behavioralFilter)).toEqual([
+            {
+                ...query.series[0],
+                custom_name: 'Performed',
+                properties: [...existingProperties, behavioralFilter],
+            },
+            {
+                ...query.series[0],
+                custom_name: 'Did not perform',
+                properties: [...existingProperties, { ...behavioralFilter, negation: true }],
+            },
+        ])
+    })
+
+    it.each<[string, InsightQueryNode, boolean]>([
+        ['the feature is disabled', query, false],
+        ['a breakdown already exists', { ...query, breakdownFilter: { breakdown: '$browser' } }, true],
+        ['there are multiple series', { ...query, series: [...query.series, ...query.series] }, true],
+        ['formula mode is active', { ...query, trendsFilter: { formula: 'A' } }, true],
+        [
+            'the display only supports one series',
+            { ...query, trendsFilter: { display: ChartDisplayType.BoldNumber } },
+            true,
+        ],
+        [
+            'the series comes from the data warehouse',
+            {
+                ...query,
+                series: [
+                    {
+                        kind: NodeKind.DataWarehouseNode,
+                        id: 'orders',
+                        table_name: 'orders',
+                        id_field: 'id',
+                        timestamp_field: 'created_at',
+                        distinct_id_field: 'user_id',
+                    },
+                ],
+            },
+            true,
+        ],
+    ])('does not offer a behavioral breakdown when %s', (_name, candidate, featureEnabled) => {
+        expect(canAddBehavioralBreakdown(candidate, featureEnabled)).toBe(false)
+    })
+
+    it('offers a behavioral breakdown for a single event series', () => {
+        expect(canAddBehavioralBreakdown(query, true)).toBe(true)
+    })
+})

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/behavioralBreakdown.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/behavioralBreakdown.ts
@@ -1,0 +1,41 @@
+import { SINGLE_SERIES_DISPLAY_TYPES } from 'lib/constants'
+
+import { InsightQueryNode, TrendsQuery, TrendsQuerySeriesNode } from '~/queries/schema/schema-general'
+import { hasBreakdownFilter, isActionsNode, isEventsNode, isTrendsQuery } from '~/queries/utils'
+import { BehavioralPropertyFilter } from '~/types'
+
+export function canAddBehavioralBreakdown(
+    query: InsightQueryNode | null | undefined,
+    featureEnabled: boolean
+): query is TrendsQuery {
+    if (!featureEnabled || !isTrendsQuery(query)) {
+        return false
+    }
+
+    const { breakdownFilter, series, trendsFilter } = query
+    return (
+        series.length === 1 &&
+        (isEventsNode(series[0]) || isActionsNode(series[0])) &&
+        !hasBreakdownFilter(breakdownFilter) &&
+        !trendsFilter?.formula &&
+        !trendsFilter?.formulas?.length &&
+        !trendsFilter?.formulaNodes?.length &&
+        (!trendsFilter?.display || !SINGLE_SERIES_DISPLAY_TYPES.includes(trendsFilter.display))
+    )
+}
+
+export function createBehavioralBreakdownSeries(
+    series: TrendsQuerySeriesNode,
+    filter: BehavioralPropertyFilter
+): TrendsQuerySeriesNode[] {
+    const properties = [...(series.properties ?? []), filter]
+
+    return [
+        { ...series, custom_name: 'Performed', properties },
+        {
+            ...series,
+            custom_name: 'Did not perform',
+            properties: [...(series.properties ?? []), { ...filter, negation: true }],
+        },
+    ]
+}


### PR DESCRIPTION
## Problem

People can filter a trend series by past behavior, but they cannot compare performers with non-performers in one action.

## Changes

- The Breakdown panel now shows a Performed shortcut for eligible trends behind the existing behavioral filter flag.
- Selecting an event or action creates matching Performed and Did not perform series.
- Both series preserve the original series filters and use the same behavioral criterion.
- The shortcut stays hidden when splitting would conflict with the current query or display.

Screenshot unavailable: local Storybook did not render the full insight editor in this sandbox.

## How did you test this code?

- Added unit coverage for complementary series, preserved filters, and unsupported query shapes.
- Added editor coverage for the feature-gated Performed shortcut.
- Ran the affected Jest suites, the frontend TypeScript check, frontend formatting, and CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The existing feature flag still limits this workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi. Invoked `/writing-ui-components`, `/placing-product-frontend-code`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.