### PR TITLE
feat(desktop): gate GLM 5.3 Flash across model pickers

### DIFF
--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.test.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.test.ts
@@ -1,6 +1,7 @@
 import {
   type CloudTaskConfigOption,
   DEFAULT_GATEWAY_MODEL,
+  GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
 } from "@posthog/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -137,19 +138,23 @@ describe("useCloudTaskConfigOptions", () => {
     });
   });
 
-  it("gates GLM 5.3 independently from GLM 5.2", async () => {
+  it.each([
+    { enabledFlag: GLM53_MODEL_FLAG, model: "zai-org/glm-5.3" },
+    { enabledFlag: GLM53_FLASH_MODEL_FLAG, model: "zai-org/glm-5.3-flash" },
+  ])("gates $model independently", async ({ enabledFlag, model }) => {
     mockUseFeatureFlag.mockImplementation(
-      (flag: string) => flag === GLM53_MODEL_FLAG,
+      (flag: string) => flag === enabledFlag,
     );
     mockGetCloudTaskConfigOptions.mockResolvedValue([
       {
         id: "model",
         name: "Model",
         type: "select",
-        currentValue: "zai-org/glm-5.3",
+        currentValue: model,
         options: [
           { value: "@cf/zai-org/glm-5.2", name: "GLM-5.2" },
           { value: "zai-org/glm-5.3", name: "GLM-5.3" },
+          { value: "zai-org/glm-5.3-flash", name: "GLM-5.3 Flash" },
         ],
         category: "model",
         description: "Choose a model",
@@ -159,9 +164,9 @@ describe("useCloudTaskConfigOptions", () => {
     const result = await renderHook();
     await waitForAssertion(() => {
       const modelOption = getModelConfigOption(result.current.configOptions);
-      expect(modelOption.currentValue).toBe("zai-org/glm-5.3");
+      expect(modelOption.currentValue).toBe(model);
       expect(modelOption.options.map((option) => option.value)).toEqual([
-        "zai-org/glm-5.3",
+        model,
       ]);
     });
   });

--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.ts
@@ -4,8 +4,10 @@ import {
   type CloudTaskConfigOption,
   DEEPSEEK_MODEL_FLAG,
   GLM_MODEL_FLAG,
+  GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
   isDeepseekModelId,
+  isGlm53FlashModelId,
   isGlm53ModelId,
   isGlmModelId,
   isRestrictedModelOption,
@@ -30,6 +32,7 @@ export function useCloudTaskConfigOptions(adapter: Adapter = "claude") {
   const oauthAccessToken = useAuthStore((state) => state.oauthAccessToken);
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
+  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
   const deepseekEnabled = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
   const query = useQuery({
     queryKey: cloudTaskConfigOptionKeys.adapter(adapter),
@@ -40,10 +43,14 @@ export function useCloudTaskConfigOptions(adapter: Adapter = "claude") {
   const configOptions = query.data ?? fallbackOptionsByAdapter[adapter];
   const isHiddenModel = (value: string) =>
     (!glm53Enabled && isGlm53ModelId(value)) ||
-    (!glmEnabled && isGlmModelId(value) && !isGlm53ModelId(value)) ||
+    (!glm53FlashEnabled && isGlm53FlashModelId(value)) ||
+    (!glmEnabled &&
+      isGlmModelId(value) &&
+      !isGlm53ModelId(value) &&
+      !isGlm53FlashModelId(value)) ||
     (!deepseekEnabled && isDeepseekModelId(value));
   const visibleConfigOptions =
-    glmEnabled && glm53Enabled && deepseekEnabled
+    glmEnabled && glm53Enabled && glm53FlashEnabled && deepseekEnabled
       ? configOptions
       : configOptions.map((option) =>
           option.category === "model"

--- a/products/desktop/packages/agent/src/adapters/claude/session/models.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.test.ts
@@ -122,6 +122,13 @@ describe("model capability flags", () => {
       xhighEffort: false,
       mcpInjection: true,
     },
+    {
+      modelId: "zai-org/glm-5.3-flash",
+      oneMContext: false,
+      effort: true,
+      xhighEffort: false,
+      mcpInjection: true,
+    },
   ])(
     "$modelId capability flags",
     ({ modelId, oneMContext, effort, xhighEffort, mcpInjection }) => {
@@ -174,6 +181,7 @@ describe("getEffortOptions", () => {
     ["claude-opus-4-7", ["low", "medium", "high", "xhigh", "max", "ultracode"]],
     ["@cf/zai-org/glm-5.2", ["high", "max"]],
     ["zai-org/glm-5.3", ["high", "max"]],
+    ["zai-org/glm-5.3-flash", ["high", "max"]],
   ])("returns the exact effort levels for %s", (modelId, expected) => {
     expect(getEffortOptions(modelId)?.map((o) => o.value)).toEqual(expected);
   });

--- a/products/desktop/packages/agent/src/adapters/claude/session/models.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.ts
@@ -81,6 +81,7 @@ const MODEL_EFFORT_LEVELS: Readonly<Record<string, readonly EffortLevel[]>> = {
   "claude-fable-5": EXTENDED_EFFORT_LEVELS,
   "@cf/zai-org/glm-5.2": ["high", "max"],
   "zai-org/glm-5.3": ["high", "max"],
+  "zai-org/glm-5.3-flash": ["high", "max"],
 };
 
 export function supportsEffort(modelId: string): boolean {

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
@@ -22,6 +22,7 @@ const PI_MODEL_LABELS: Record<string, string> = {
   "gpt-5.6-luna": "GPT-5.6 Luna",
   "@cf/zai-org/glm-5.2": "GLM-5.2",
   "zai-org/glm-5.3": "GLM-5.3",
+  "zai-org/glm-5.3-flash": "GLM-5.3 Flash",
   "moonshotai/kimi-k3": "Kimi K3",
 };
 

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -37,6 +37,7 @@ describe("formatGatewayModelName", () => {
     [model("moonshotai/kimi-k3", "modal"), "Kimi K3"],
     [model("@cf/zai-org/glm-5.2", "cloudflare"), "GLM-5.2"],
     [model("zai-org/glm-5.3", "baseten"), "GLM-5.3"],
+    [model("zai-org/glm-5.3-flash", "baseten"), "GLM-5.3 Flash"],
     [
       model("deepseek-ai/deepseek-v4-flash-0731", "baseten"),
       "DeepSeek V4 Flash",

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -186,6 +186,10 @@ export function isGlm53ModelId(modelId: string): boolean {
   return modelId.toLowerCase() === "zai-org/glm-5.3";
 }
 
+export function isGlm53FlashModelId(modelId: string): boolean {
+  return modelId.toLowerCase() === "zai-org/glm-5.3-flash";
+}
+
 export function isCloudflareModel(model: GatewayModel): boolean {
   return isCloudflareModelId(model.id) || model.owned_by === "cloudflare";
 }

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -31,6 +31,7 @@ export const DESKTOP_HOME_FLAG = "desktop-home-flag";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";
 export const GLM_MODEL_FLAG = "posthog-code-glm-model";
 export const GLM53_MODEL_FLAG = "posthog-code-glm-53-model";
+export const GLM53_FLASH_MODEL_FLAG = "posthog-code-glm-53-flash-model";
 /** PostHog Desktop: show DeepSeek V4 Flash in the model picker. Off = hidden. */
 export const DEEPSEEK_MODEL_FLAG = "posthog-code-deepseek-model";
 

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -110,6 +110,7 @@ export {
   isCloudflareModel,
   isCloudflareModelId,
   isDeepseekModelId,
+  isGlm53FlashModelId,
   isGlm53ModelId,
   isGlmModelId,
   isModalModel,

--- a/products/desktop/packages/shared/src/reasoning-effort.test.ts
+++ b/products/desktop/packages/shared/src/reasoning-effort.test.ts
@@ -14,6 +14,8 @@ describe("isSupportedReasoningEffort", () => {
     ["claude", "zai-org/glm-5.3", "high", true],
     ["claude", "zai-org/glm-5.3", "max", true],
     ["claude", "zai-org/glm-5.3", "medium", false],
+    ["claude", "zai-org/glm-5.3-flash", "high", true],
+    ["claude", "zai-org/glm-5.3-flash", "medium", false],
     ["claude", "claude-opus-4-8", "minimal", false],
     ["claude", "claude-opus-5", "ultracode", true],
     ["claude", "claude-sonnet-5", "ultracode", true],

--- a/products/desktop/packages/shared/src/reasoning-effort.ts
+++ b/products/desktop/packages/shared/src/reasoning-effort.ts
@@ -38,6 +38,7 @@ const CLAUDE_MODEL_EFFORTS: Readonly<
   "claude-fable-5": EXTENDED_EFFORTS,
   "@cf/zai-org/glm-5.2": ["high", "max"],
   "zai-org/glm-5.3": ["high", "max"],
+  "zai-org/glm-5.3-flash": ["high", "max"],
   "claude-opus-5": EXTENDED_EFFORTS,
 };
 

--- a/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
@@ -1,6 +1,7 @@
 import type { LoopSchemas } from "@posthog/api-client/loops";
 import {
   GLM_MODEL_FLAG,
+  GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
   KIMI_MODEL_FLAG,
 } from "@posthog/shared";
@@ -60,6 +61,7 @@ export function LoopModelFields({
 }: LoopModelFieldsProps) {
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
+  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
   const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
   const configOptions = useLoopModelConfigOptions(adapter);
 
@@ -69,11 +71,20 @@ export function LoopModelFields({
       ...loopModelOptions(adapter, configOptions, {
         glmEnabled,
         glm53Enabled,
+        glm53FlashEnabled,
         kimiEnabled,
         pinnedModel: model,
       }),
     ],
-    [adapter, configOptions, glmEnabled, glm53Enabled, kimiEnabled, model],
+    [
+      adapter,
+      configOptions,
+      glmEnabled,
+      glm53Enabled,
+      glm53FlashEnabled,
+      kimiEnabled,
+      model,
+    ],
   );
 
   const reasoningOptions = useMemo(

--- a/products/desktop/packages/ui/src/features/loops/loopModels.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.test.ts
@@ -114,19 +114,29 @@ describe("loopModelOptions", () => {
     ).toContainEqual({ value: "claude-opus-4-6", label: "claude-opus-4-6" });
   });
 
-  it("gates GLM 5.3 independently from GLM 5.2", () => {
+  it.each([
+    {
+      flags: { glm53Enabled: true },
+      expected: [{ value: "zai-org/glm-5.3", label: "GLM-5.3" }],
+    },
+    {
+      flags: { glm53FlashEnabled: true },
+      expected: [{ value: "zai-org/glm-5.3-flash", label: "GLM-5.3 Flash" }],
+    },
+  ])("gates each GLM 5.3 variant independently", ({ flags, expected }) => {
     const options = modelConfigOption([
       { value: "@cf/zai-org/glm-5.2", name: "GLM-5.2" },
       { value: "zai-org/glm-5.3", name: "GLM-5.3" },
+      { value: "zai-org/glm-5.3-flash", name: "GLM-5.3 Flash" },
     ]);
 
     expect(
       loopModelOptions("claude", options, {
         glmEnabled: false,
-        glm53Enabled: true,
         pinnedModel: "",
+        ...flags,
       }),
-    ).toEqual([{ value: "zai-org/glm-5.3", label: "GLM-5.3" }]);
+    ).toEqual(expected);
   });
 
   it.each<{

--- a/products/desktop/packages/ui/src/features/loops/loopModels.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.ts
@@ -4,6 +4,7 @@ import type { LoopSchemas } from "@posthog/api-client/loops";
 import {
   flattenSelectOptions,
   isDefaultSelectOption,
+  isGlm53FlashModelId,
   isGlm53ModelId,
   isGlmModelId,
   isRestrictedModelOption,
@@ -48,6 +49,7 @@ const FALLBACK_MODEL_OPTIONS: Record<
     { value: "claude-fable-5", label: "Claude Fable 5" },
     { value: "@cf/zai-org/glm-5.2", label: "GLM-5.2" },
     { value: "zai-org/glm-5.3", label: "GLM-5.3" },
+    { value: "zai-org/glm-5.3-flash", label: "GLM-5.3 Flash" },
     { value: "moonshotai/kimi-k3", label: "Kimi K3" },
   ],
   codex: [
@@ -82,11 +84,13 @@ export function loopModelOptions(
   {
     glmEnabled,
     glm53Enabled,
+    glm53FlashEnabled,
     kimiEnabled,
     pinnedModel,
   }: {
     glmEnabled: boolean;
     glm53Enabled?: boolean;
+    glm53FlashEnabled?: boolean;
     kimiEnabled?: boolean;
     pinnedModel: string;
   },
@@ -106,7 +110,11 @@ export function loopModelOptions(
   const options = (served.length > 0 ? served : FALLBACK_MODEL_OPTIONS[adapter])
     .filter(
       (option) =>
-        (isGlm53ModelId(option.value) ? glm53Enabled : glmEnabled) ||
+        (isGlm53FlashModelId(option.value)
+          ? glm53FlashEnabled
+          : isGlm53ModelId(option.value)
+            ? glm53Enabled
+            : glmEnabled) ||
         option.value === pinnedModel ||
         !isGlmModelId(option.value),
     )

--- a/products/desktop/packages/ui/src/features/pi-sessions/usePiModelCatalog.ts
+++ b/products/desktop/packages/ui/src/features/pi-sessions/usePiModelCatalog.ts
@@ -2,6 +2,7 @@ import { useHostTRPC } from "@posthog/host-router/react";
 import {
   DEEPSEEK_MODEL_FLAG,
   GLM_MODEL_FLAG,
+  GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
   getCloudUrlFromRegion,
   KIMI_MODEL_FLAG,
@@ -18,6 +19,7 @@ export function usePiModelCatalog(enabled: boolean) {
   const deepseek = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
   const glm = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53 = useFeatureFlag(GLM53_MODEL_FLAG);
+  const glm53Flash = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
   const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
   const apiHost = useMemo(
     () => (cloudRegion ? getCloudUrlFromRegion(cloudRegion) : null),
@@ -31,6 +33,12 @@ export function usePiModelCatalog(enabled: boolean) {
     }),
     enabled: enabled && apiHost !== null,
     select: (models) =>
-      stripDisabledModels(models, { deepseek, glm, glm53, kimi: kimiEnabled }),
+      stripDisabledModels(models, {
+        deepseek,
+        glm,
+        glm53,
+        glm53Flash,
+        kimi: kimiEnabled,
+      }),
   });
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
@@ -16,6 +16,7 @@ import {
   type Adapter,
   DEEPSEEK_MODEL_FLAG,
   GLM_MODEL_FLAG,
+  GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
   KIMI_MODEL_FLAG,
 } from "@posthog/shared";
@@ -53,12 +54,14 @@ export function ModelSelector({
   const deepseek = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
+  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
   const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
   const modelOption = rawModelOption
     ? stripDisabledModelOption(rawModelOption, {
         deepseek,
         glm: glmEnabled,
         glm53: glm53Enabled,
+        glm53Flash: glm53FlashEnabled,
         kimi: kimiEnabled,
       })
     : rawModelOption;

--- a/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.test.ts
@@ -19,12 +19,14 @@ describe("modelOptionFilters", () => {
     },
     { flag: "glm", id: "@cf/zai-org/glm-5.2", name: "GLM-5.2" },
     { flag: "glm53", id: "zai-org/glm-5.3", name: "GLM-5.3" },
+    { flag: "glm53Flash", id: "zai-org/glm-5.3-flash", name: "GLM-5.3 Flash" },
     { flag: "kimi", id: "moonshotai/kimi-k3", name: "Kimi K3" },
   ];
   const enabledFlags: ModelRolloutFlags = {
     deepseek: true,
     glm: true,
     glm53: true,
+    glm53Flash: true,
     kimi: true,
   };
 

--- a/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.ts
+++ b/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.ts
@@ -1,6 +1,7 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import {
   isDeepseekModelId,
+  isGlm53FlashModelId,
   isGlm53ModelId,
   isGlmModelId,
   isSelectGroup,
@@ -13,6 +14,7 @@ export interface ModelRolloutFlags {
   deepseek: boolean;
   glm: boolean;
   glm53: boolean;
+  glm53Flash: boolean;
   kimi: boolean;
 }
 
@@ -20,7 +22,11 @@ function isModelDisabled(modelId: string, flags: ModelRolloutFlags): boolean {
   return (
     (!flags.deepseek && isDeepseekModelId(modelId)) ||
     (!flags.glm53 && isGlm53ModelId(modelId)) ||
-    (!flags.glm && isGlmModelId(modelId) && !isGlm53ModelId(modelId)) ||
+    (!flags.glm53Flash && isGlm53FlashModelId(modelId)) ||
+    (!flags.glm &&
+      isGlmModelId(modelId) &&
+      !isGlm53ModelId(modelId) &&
+      !isGlm53FlashModelId(modelId)) ||
     (!flags.kimi && isKimiModelId(modelId))
   );
 }

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -18,6 +18,7 @@ import {
   DEEPSEEK_MODEL_FLAG,
   FAST_MODE_FLAG,
   GLM_MODEL_FLAG,
+  GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
   getCloudUrlFromRegion,
   KIMI_MODEL_FLAG,
@@ -61,6 +62,7 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
   const hostClient = useHostTRPCClient();
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
+  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
   const deepseekEnabled = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
   const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
   const fastModeFlagEnabled = useFeatureFlag(FAST_MODE_FLAG);
@@ -118,6 +120,7 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
               deepseek: deepseekEnabled,
               glm: glmEnabled,
               glm53: glm53Enabled,
+              glm53Flash: glm53FlashEnabled,
               kimi: kimiEnabled,
             }),
           )
@@ -246,6 +249,7 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
     hasHydrated,
     glmEnabled,
     glm53Enabled,
+    glm53FlashEnabled,
     deepseekEnabled,
     kimiEnabled,
     fastModeFlagEnabled,


### PR DESCRIPTION
## Problem

PostHog Desktop and mobile users cannot pick GLM 5.3 Flash. The gateway serves it as `zai-org/glm-5.3-flash` after #90292, but the pickers strip every GLM id they do not know behind the GLM 5.2 flag