### PR TITLE
fix(charts): prevent duplicate time labels collapsing points

### DIFF
--- a/frontend/src/scenes/retention/retentionGraphLogic.test.ts
+++ b/frontend/src/scenes/retention/retentionGraphLogic.test.ts
@@ -32,7 +32,7 @@ const breakdownQuery: RetentionQuery = {
 
 const breakdownRows = [
     cohortRow('2024-01-01T00:00:00Z', 'Chrome'),
-    cohortRow('2024-01-02T00:00:00Z', 'Chrome'),
+    cohortRow('2025-01-01T00:00:00Z', 'Chrome'),
     cohortRow('2024-01-01T00:00:00Z', BREAKDOWN_OTHER_STRING_LABEL),
 ]
 
@@ -102,6 +102,7 @@ describe('retentionGraphLogic', () => {
             ['Chrome', 'Chrome'],
             [BREAKDOWN_OTHER_DISPLAY, BREAKDOWN_OTHER_STRING_LABEL],
         ])
+        expect(logic.values.xAxisLabels).toEqual(['2024-01-01T00:00:00.000Z', '2025-01-01T00:00:00.000Z'])
     })
 
     it('per-cohort series keep rawBreakdownValue unset when filtered to one breakdown value', async () => {

--- a/frontend/src/scenes/retention/retentionGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionGraphLogic.ts
@@ -408,13 +408,7 @@ export const retentionGraphLogic = kea<retentionGraphLogicType>([
 
                 // When an interval is selected, show cohort dates on x-axis
                 if (selectedInterval !== null && selectedInterval !== undefined) {
-                    const formatCohortLabel = (cohort: ProcessedRetentionPayload): string => {
-                        if (cohort.date) {
-                            return period === 'Hour' ? cohort.date.format('MMM D, h A') : cohort.date.format('MMM D')
-                        }
-                        return cohort.label
-                    }
-                    return filteredResults.map(formatCohortLabel)
+                    return [...new Set(filteredResults.map((cohort) => cohort.date?.toISOString() ?? cohort.label))]
                 }
 
                 const unit = dateOptionPlurals[period || 'Day']

--- a/frontend/src/scenes/web-analytics/pagePerformanceLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/pagePerformanceLogic.test.ts
@@ -185,10 +185,10 @@ describe('pagePerformanceLogic', () => {
                 comparedWindow
             )
 
-            expect(mergePagePerformanceSeries(human, crawler, 'day')).toEqual([
-                { label: 'Aug 3', visitors: 50, google: 20, llm: 3, crawls: 0 },
-                { label: 'Aug 4', visitors: 0, google: 0, llm: 0, crawls: 700 },
-                { label: 'Aug 5', visitors: 40, google: 10, llm: 2, crawls: 0 },
+            expect(mergePagePerformanceSeries(human, crawler)).toEqual([
+                { label: '2026-08-03T05:00:00.000Z', visitors: 50, google: 20, llm: 3, crawls: 0 },
+                { label: '2026-08-04T05:00:00.000Z', visitors: 0, google: 0, llm: 0, crawls: 700 },
+                { label: '2026-08-05T05:00:00.000Z', visitors: 40, google: 10, llm: 2, crawls: 0 },
             ])
         })
 

--- a/frontend/src/scenes/web-analytics/pagePerformanceLogic.ts
+++ b/frontend/src/scenes/web-analytics/pagePerformanceLogic.ts
@@ -309,8 +309,7 @@ export const parsePagePerformanceOverviewResponse = (
 /** Aligns the human and crawler series onto one bucket axis — either query can miss a bucket entirely. */
 export const mergePagePerformanceSeries = (
     human: ParsedOverviewResponse,
-    crawler: ParsedOverviewResponse,
-    bucketSize: PagePerformanceBucket
+    crawler: ParsedOverviewResponse
 ): OverviewSeriesPoint[] => {
     const byBucket = new Map<number, OverviewSeriesPoint>()
 
@@ -321,7 +320,7 @@ export const mergePagePerformanceSeries = (
             return existing
         }
         const point: OverviewSeriesPoint = {
-            label: formatBucketLabel(bucket, bucketSize),
+            label: bucket.toISOString(),
             visitors: 0,
             google: 0,
             llm: 0,
@@ -375,16 +374,6 @@ const BUCKET_HOGQL_FN: Record<PagePerformanceBucket, string> = {
     day: 'toStartOfDay',
     week: 'toStartOfWeek',
 }
-
-const BUCKET_LABEL_FORMAT: Record<PagePerformanceBucket, string> = {
-    hour: 'MMM D, HH:mm',
-    day: 'MMM D',
-    week: 'MMM D',
-}
-
-// The bucket is parsed with `dayjs.tz(..., timezone)`, so it already carries the target offset.
-const formatBucketLabel = (bucket: dayjs.Dayjs, bucketSize: PagePerformanceBucket): string =>
-    bucket.format(BUCKET_LABEL_FORMAT[bucketSize])
 
 export interface MetricCellValue {
     current: number
@@ -1248,7 +1237,7 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
                         performQuery(overviewNode(values.overviewCrawlerQuery), { signal }),
                     ])
                     breakpoint()
-                    const { window: dateWindow, bucketSize } = values
+                    const { window: dateWindow } = values
                     const human = parsePagePerformanceOverviewResponse(
                         humanResponse.columns,
                         humanResponse.results,
@@ -1271,7 +1260,7 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
                             crawlsPrevious: crawler.totals.crawls_previous ?? 0,
                             pages: human.totals.pages ?? 0,
                         },
-                        mergePagePerformanceSeries(human, crawler, bucketSize)
+                        mergePagePerformanceSeries(human, crawler)
                     )
                 } catch (error) {
                     if (isCancellation(error)) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitHistoryChart.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitHistoryChart.tsx
@@ -7,7 +7,7 @@ import { getColorVar } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
 
 import { getBucketOption, RateLimitHistoryBucket } from './rateLimitConfigLogic'
-import { buildRateLimitBarChartConfig, formatBucketLabel, getBucketTimeline } from './RateLimitSimulationChart'
+import { buildRateLimitBarChartConfig, getBucketTimeline } from './RateLimitSimulationChart'
 
 function fillHistoryBuckets(history: RateLimitHistoryBucket[], bucketMinutes: number): RateLimitHistoryBucket[] {
     const bucketMs = getBucketOption(bucketMinutes).minutes * 60_000
@@ -44,7 +44,7 @@ export function RateLimitHistoryChart({
 
         return {
             isEmpty: recorded.every((c) => c === 0) && dropped.every((c) => c === 0) && bypassed.every((c) => c === 0),
-            labels: filled.map((b) => formatBucketLabel(b.bucket, bucketMinutes)),
+            labels: filled.map((b) => b.bucket),
             series: [
                 { key: 'recorded', label: 'Recorded', data: recorded },
                 { key: 'dropped', label: 'Dropped', data: dropped, color: getColorVar('danger') },
@@ -54,7 +54,7 @@ export function RateLimitHistoryChart({
     }, [history, bucketMinutes])
 
     const theme = useChartTheme()
-    const config = useChartConfig(() => buildRateLimitBarChartConfig('stacked'), [])
+    const config = useChartConfig(() => buildRateLimitBarChartConfig('stacked', bucketMinutes), [bucketMinutes])
 
     if (isEmpty) {
         return (

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.test.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render } from '@testing-library/react'
+
+import { TimeSeriesBarChart } from '@posthog/quill-charts'
+
+import { dayjs } from 'lib/dayjs'
+
+import { RateLimitSimulationChart } from './RateLimitSimulationChart'
+
+jest.mock('@posthog/quill-charts', () => ({
+    ...jest.requireActual('@posthog/quill-charts'),
+    TimeSeriesBarChart: jest.fn(() => <div data-testid="rate-limit-chart" />),
+}))
+
+jest.mock('lib/charts/hooks', () => ({
+    useChartTheme: () => ({ colors: ['#000'] }),
+    useChartConfig: (buildConfig: () => unknown) => buildConfig(),
+}))
+
+const mockTimeSeriesBarChart = jest.mocked(TimeSeriesBarChart)
+
+describe('RateLimitSimulationChart', () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2024-11-03T08:00:00.000Z'))
+        mockTimeSeriesBarChart.mockClear()
+    })
+
+    afterEach(() => {
+        cleanup()
+        jest.useRealTimers()
+    })
+
+    it('keeps ISO labels distinct across a repeated local hour', () => {
+        render(<RateLimitSimulationChart volume={[]} rateLimit={null} bucketMinutes={60} />)
+
+        const labels = mockTimeSeriesBarChart.mock.calls[0][0].labels
+        const repeatedHourLabels = labels.filter(
+            (label) => dayjs(label).tz('America/New_York').format('MMM D, HH:mm') === 'Nov 3, 01:00'
+        )
+
+        expect(repeatedHourLabels).toEqual(['2024-11-03T05:00:00.000Z', '2024-11-03T06:00:00.000Z'])
+        expect(new Set(labels).size).toBe(labels.length)
+    })
+})

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from 'react'
 
-import { type Series, TimeSeriesBarChart, type TimeSeriesBarChartConfig } from '@posthog/quill-charts'
+import {
+    type Series,
+    type TimeInterval,
+    TimeSeriesBarChart,
+    type TimeSeriesBarChartConfig,
+} from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { getColorVar } from 'lib/colors'
@@ -45,6 +50,16 @@ function fillBuckets(volume: ExceptionVolumeBucket[], bucketMinutes: number): Ex
     }))
 }
 
+function bucketInterval(bucketMinutes: number): TimeInterval {
+    if (bucketMinutes >= 1440) {
+        return 'day'
+    }
+    if (bucketMinutes >= 60) {
+        return 'hour'
+    }
+    return 'minute'
+}
+
 /** Shared config for the rate limit bar charts: hidden bucket ticks, stacked bars, default tooltip
  *  with a total row. */
 export function buildRateLimitBarChartConfig(
@@ -55,7 +70,7 @@ export function buildRateLimitBarChartConfig(
         xAxis: {
             hide: true,
             timezone: dayjs.tz.guess(),
-            interval: bucketMinutes >= 1440 ? 'day' : bucketMinutes >= 60 ? 'hour' : 'minute',
+            interval: bucketInterval(bucketMinutes),
         },
         showAxisLines: { x: false, y: true },
         barLayout,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSimulationChart.tsx
@@ -45,21 +45,18 @@ function fillBuckets(volume: ExceptionVolumeBucket[], bucketMinutes: number): Ex
     }))
 }
 
-export function formatBucketLabel(iso: string, bucketMinutes: number): string {
-    const ts = dayjs(iso)
-    if (bucketMinutes >= 1440) {
-        return ts.format('MMM D')
-    }
-    return ts.format('MMM D, HH:mm')
-}
-
 /** Shared config for the rate limit bar charts: hidden bucket ticks, stacked bars, default tooltip
  *  with a total row. */
 export function buildRateLimitBarChartConfig(
-    barLayout: NonNullable<TimeSeriesBarChartConfig['barLayout']>
+    barLayout: NonNullable<TimeSeriesBarChartConfig['barLayout']>,
+    bucketMinutes: number
 ): TimeSeriesBarChartConfig {
     return {
-        xAxis: { hide: true },
+        xAxis: {
+            hide: true,
+            timezone: dayjs.tz.guess(),
+            interval: bucketMinutes >= 1440 ? 'day' : bucketMinutes >= 60 ? 'hour' : 'minute',
+        },
         showAxisLines: { x: false, y: true },
         barLayout,
         legend: { show: false },
@@ -85,7 +82,7 @@ export function RateLimitSimulationChart({
 
     const { labels, series } = useMemo(() => {
         const filled = fillBuckets(volume, bucketMinutes)
-        const labels = filled.map((b) => formatBucketLabel(b.bucket, bucketMinutes))
+        const labels = filled.map((b) => b.bucket)
         const counts = filled.map((b) => b.count)
 
         if (!hasLimit || rateLimit === null) {
@@ -111,7 +108,7 @@ export function RateLimitSimulationChart({
 
     const theme = useChartTheme()
     const config = useChartConfig<TimeSeriesBarChartConfig>(() => {
-        const base = buildRateLimitBarChartConfig(hasLimit ? 'stacked' : 'grouped')
+        const base = buildRateLimitBarChartConfig(hasLimit ? 'stacked' : 'grouped', bucketMinutes)
         if (!hasLimit || rateLimit === null) {
             return base
         }

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -60,6 +60,7 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
         filteredTrendSeries,
         labelGroupType,
         shouldShowMeanPerBreakdown,
+        timezone,
         xAxisLabels,
         getRetentionColor,
     } = useValues(retentionGraphLogic(insightProps))
@@ -151,8 +152,17 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
     const goalLines = retentionFilter?.goalLines ?? EMPTY_GOAL_LINES
 
     const barConfig = useChartConfig(
-        () => buildRetentionBarChartConfig({ isPercentage, goalLines, series, tooltip: INSIGHT_TOOLTIP_CONFIG }),
-        [isPercentage, goalLines, series]
+        () =>
+            buildRetentionBarChartConfig({
+                isPercentage,
+                goalLines,
+                series,
+                tooltip: INSIGHT_TOOLTIP_CONFIG,
+                isIntervalView,
+                period,
+                timezone,
+            }),
+        [isPercentage, goalLines, series, isIntervalView, period, timezone]
     )
 
     if (filteredTrendSeries.length === 0 && hasValidBreakdown) {

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -63,6 +63,7 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
         labelGroupType,
         shouldShowMeanPerBreakdown,
         showTrendLines,
+        timezone,
         xAxisLabels,
         getRetentionColor,
     } = useValues(retentionGraphLogic(insightProps))
@@ -162,10 +163,13 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
                 showTrendLines,
                 series,
                 tooltip: INSIGHT_TOOLTIP_CONFIG,
+                isIntervalView,
+                period,
+                timezone,
             }),
             curve: chartStyleCurve(retentionFilter?.chartStyle),
         }),
-        [isPercentage, goalLines, showTrendLines, series, retentionFilter?.chartStyle]
+        [isPercentage, goalLines, showTrendLines, series, isIntervalView, period, timezone, retentionFilter?.chartStyle]
     )
 
     if (filteredTrendSeries.length === 0 && hasValidBreakdown) {

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
@@ -167,6 +167,20 @@ describe('retentionChartTransforms', () => {
         })
     })
 
+    it.each([
+        ['line', buildRetentionLineChartConfig],
+        ['bar', buildRetentionBarChartConfig],
+    ])('formats %s interval-view dates in the team timezone', (_name, buildConfig) => {
+        const config = buildConfig({
+            isPercentage: true,
+            series: [],
+            isIntervalView: true,
+            period: 'Day',
+            timezone: 'America/Chicago',
+        })
+        expect(config.xAxis).toEqual({ interval: 'day', timezone: 'America/Chicago' })
+    })
+
     describe('buildRetentionLineChartConfig', () => {
         const baseSeries: Series<RetentionSeriesMeta>[] = buildRetentionSeries(
             [makeEntry({ index: 0 }), makeEntry({ index: 1 })],

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
@@ -3,8 +3,10 @@ import type {
     Series,
     TimeSeriesBarChartConfig,
     TimeSeriesLineChartConfig,
+    TimeInterval,
     TooltipConfig,
     TrendLineConfig,
+    XAxisConfig,
     YAxisConfig,
 } from '@posthog/quill-charts'
 
@@ -91,6 +93,9 @@ export interface BuildRetentionChartConfigOpts {
     showTrendLines?: boolean
     series: Series<RetentionSeriesMeta>[]
     tooltip?: TooltipConfig
+    isIntervalView?: boolean
+    period?: string
+    timezone?: string
 }
 
 function buildTrendLines(
@@ -107,8 +112,21 @@ function buildGoalLines(goalLines: GoalLineLike[] | null | undefined): GoalLineC
     return schemaGoalLinesToConfigs(goalLines)
 }
 
+const TIME_INTERVAL_BY_RETENTION_PERIOD: Record<string, TimeInterval> = {
+    Hour: 'hour',
+    Day: 'day',
+    Week: 'week',
+    Month: 'month',
+}
+
+function buildXAxis(opts: BuildRetentionChartConfigOpts): XAxisConfig | undefined {
+    const interval = opts.period ? TIME_INTERVAL_BY_RETENTION_PERIOD[opts.period] : undefined
+    return opts.isIntervalView && interval && opts.timezone ? { interval, timezone: opts.timezone } : undefined
+}
+
 export function buildRetentionLineChartConfig(opts: BuildRetentionChartConfigOpts): TimeSeriesLineChartConfig {
     return {
+        xAxis: buildXAxis(opts),
         yAxis: {
             format: opts.isPercentage ? 'percentage' : 'numeric',
             scale: 'linear',
@@ -124,6 +142,7 @@ export function buildRetentionBarChartConfig(
     opts: BuildRetentionChartConfigOpts
 ): TimeSeriesBarChartConfig & { yAxis?: YAxisConfig } {
     return {
+        xAxis: buildXAxis(opts),
         yAxis: {
             format: opts.isPercentage ? 'percentage' : 'numeric',
             scale: 'linear',


### PR DESCRIPTION
## Problem

Charts can collapse separate time buckets when two timestamps share the same formatted date label.

The time scale uses labels as keys, so repeated labels can move points onto the wrong position.

## Changes

- Rate-limit, page-performance, and retention charts now keep raw ISO timestamps as scale keys.
- Retention charts format timestamps with the insight interval and team timezone.
- No screenshots: ordinary ranges look unchanged. The fix affects charts only when display labels repeat.

## How did you test this code?

- Jest covers cross-year labels, repeated breakdown dates, and interval timezone configuration.
- Frontend lint and formatting passed.
- The full frontend type check exceeded the environment memory limit after local packages built.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The chart guide already requires unique ISO labels.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenAI Codex used PostHog MCP and repository tools. It invoked `/querying-posthog-data`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The change fixes the shared label failure mode across existing callers. The diff uses repository-owned fixtures and contains no external session material.