### PR TITLE
fix(ingestion): key the feed-order sentinel on the Kafka message key

### DIFF
--- a/nodejs/src/ingestion/api/feed-order-sentinel.test.ts
+++ b/nodejs/src/ingestion/api/feed-order-sentinel.test.ts
@@ -7,9 +7,9 @@ function msg(offset: number, overrides: Partial<SerializedKafkaMessage> = {}): S
         partition: 0,
         offset,
         timestamp: 0,
-        key: null,
+        key: 't:a',
         value: null,
-        headers: { token: 't', distinct_id: 'a' },
+        headers: {},
         ...overrides,
     }
 }
@@ -42,21 +42,18 @@ describe('FeedOrderSentinel', () => {
         expect(sentinel.check([msg(40)], 'c2', false)).toEqual({ outOfOrder: 1, replayed: 0 })
     })
 
-    it('tracks keys independently across partitions and distinct_ids', () => {
+    it('tracks keys independently across partitions and Kafka keys', () => {
         const sentinel = new FeedOrderSentinel()
-        sentinel.check(
-            [msg(10), msg(10, { partition: 1 }), msg(10, { headers: { token: 't', distinct_id: 'b' } })],
-            'c1',
-            false
-        )
+        sentinel.check([msg(10), msg(10, { partition: 1 }), msg(10, { key: 't:b' })], 'c1', false)
         // Same offsets again on other keys don't interfere; only 'a' on partition 0 regresses.
         expect(sentinel.check([msg(9)], 'c1', false)).toEqual({ outOfOrder: 1, replayed: 0 })
         expect(sentinel.check([msg(11, { partition: 1 })], 'c1', false)).toEqual({ outOfOrder: 0, replayed: 0 })
     })
 
-    it('skips messages without routing headers', () => {
+    it.each([null, ''])('skips unkeyed messages even when routing headers are present (key: %j)', (key) => {
         const sentinel = new FeedOrderSentinel()
-        const result = sentinel.check([msg(5, { headers: {} }), msg(1, { headers: {} })], 'c1', false)
+        const headers = { token: 't', distinct_id: 'a' }
+        const result = sentinel.check([msg(5, { key, headers }), msg(1, { key, headers })], 'c1', false)
         expect(result).toEqual({ outOfOrder: 0, replayed: 0 })
         expect(sentinel.size).toBe(0)
     })
@@ -64,8 +61,8 @@ describe('FeedOrderSentinel', () => {
     it('evicts the least-recently-seen key at capacity and rebaselines it silently', () => {
         const sentinel = new FeedOrderSentinel(2)
         sentinel.check([msg(10)], 'c1', false)
-        sentinel.check([msg(10, { headers: { token: 't', distinct_id: 'b' } })], 'c1', false)
-        sentinel.check([msg(10, { headers: { token: 't', distinct_id: 'c' } })], 'c1', false)
+        sentinel.check([msg(10, { key: 't:b' })], 'c1', false)
+        sentinel.check([msg(10, { key: 't:c' })], 'c1', false)
         expect(sentinel.size).toBe(2)
         // 'a' was evicted: its regression rebaselines instead of firing.
         expect(sentinel.check([msg(5)], 'c1', false)).toEqual({ outOfOrder: 0, replayed: 0 })

--- a/nodejs/src/ingestion/api/feed-order-sentinel.ts
+++ b/nodejs/src/ingestion/api/feed-order-sentinel.ts
@@ -62,14 +62,12 @@ export class FeedOrderSentinel {
         const result: FeedOrderCheckResult = { outOfOrder: 0, replayed: 0 }
 
         for (const message of messages) {
-            const token = message.headers['token']
-            const distinctId = message.headers['distinct_id']
-            if (!token || !distinctId) {
-                // No routing key: the consumer routes these individually under a
+            if (!message.key) {
+                // Unkeyed: the consumer routes these individually under a
                 // synthetic unique key, so there is no per-key order to check.
                 continue
             }
-            const key = `${message.topic}/${message.partition}/${token}:${distinctId}`
+            const key = `${message.topic}/${message.partition}/${message.key}`
 
             const entry = this.entries.get(key)
             if (entry && entry.consumerId === consumerId) {

--- a/rust/ingestion-consumer/README.md
+++ b/rust/ingestion-consumer/README.md
@@ -25,7 +25,7 @@ The rebalance metrics from the consumer context stay on regardless, and the `con
 The worker-side check lives in `nodejs/src/ingestion/api/feed-order-sentinel.ts`, fed by the `consumer_id` (process incarnation) and `replay` fields the transport stamps on every `/ingest` request.
 It measures the invariant at its end point: the worker's grouping stage processes each key strictly in feed order, so "fed in offset order per key" is "processed in order per key".
 Rebalances reset all baselines (`ingestion_consumer_rebalances_total{event}` counts them), so partition handoffs don't fire false positives.
-Null-key messages (e.g. overflow rerouting) are excluded from the consumer-side key checks: the producer deliberately spreads such a routing key across partitions, forfeiting per-key order, so offsets from different partitions are not comparable and there is no invariant to check. The worker-side check is unaffected — it scopes keys per partition, an invariant that holds for all traffic.
+Null-key messages (e.g. overflow rerouting) are excluded from both checks: the producer deliberately forfeits per-key order for them, and the consumer routes each one individually rather than pinning it, so there is no invariant to check on either side.
 
 ## Debug API
 


### PR DESCRIPTION
## Problem

- Operators watching the ingestion consumer dashboard see `ingestion_api_out_of_order_messages_total` climb on the overflow lane once #90282 is deployed there, at roughly the rate of null-key traffic.
- The worker-side feed-order sentinel keys on the `token` and `distinct_id` headers. Null-key messages still carry those headers, so the sentinel tracks them as keyed.
- The consumer now routes null-key messages individually with no pin, so two such messages for one distinct id on one partition can reach a worker out of offset order. The sentinel counts that as a violation, but no per-key promise exists for them.

## Changes

- The feed-order sentinel keys on `topic/partition/<Kafka key>` and skips messages whose key is null or empty. The out-of-order metric now means the same thing on both sides of the transport.
- The consumer README states that null-key messages are excluded from both checks.
- Mechanical: the sentinel test helper builds keyed messages with no headers.

> [!NOTE]
> Depends on #90282 for the metric to stay flat in production. On its own it only stops counting null-key traffic.

## How did you test this code?

- `feed-order-sentinel.test.ts` gains one parameterized case: a null or empty key with routing headers present is skipped and tracks no state. It catches a regression back to header-based keying, which no existing case did since the old helper had both headers and a null key.
- Not run: the full nodejs suite. Only the sentinel test, eslint, tsc, and prettier ran locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The consumer README paragraph on null-key handling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) in VS Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The change followed a prod-US Grafana check after deploying #90282 to overflow: consumer-side key-order violations stayed at zero while the worker-side counter tracked the null-key rate. The alternative, grouping null-key messages by headers again in the consumer, was rejected because it reintroduces the distinct id notion #90282 removes.
