### PR TITLE
fix(insights): make agent-built charts readable by default

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2176,7 +2176,7 @@
                     "type": "string"
                 },
                 "displayType": {
-                    "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                    "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                     "enum": ["auto", "line", "bar", "area"],
                     "type": "string"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2176,7 +2176,7 @@
                     "type": "string"
                 },
                 "displayType": {
-                    "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                    "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                     "enum": ["auto", "line", "bar", "area"],
                     "type": "string"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2176,7 +2176,7 @@
                     "type": "string"
                 },
                 "displayType": {
-                    "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                    "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                     "enum": ["auto", "line", "bar", "area"],
                     "type": "string"
                 },

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -1812,10 +1812,9 @@ export interface AssistantDataVisualizationAxisDisplaySettings {
     /** Which Y axis this numeric series should use. Use `right` for a secondary Y axis. */
     yAxisPosition?: 'left' | 'right'
     /**
-     * Override how this series renders, independent of the chart-level `display` type.
-     * Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the
-     * secondary axis (`yAxisPosition: "right"`) — e.g. counts as `bar` left, a rate as `line` right.
-     * Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.
+     * Override how this series renders, independent of the chart-level `display` type. `auto` (the default)
+     * suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series
+     * in another unit on the secondary axis (`yAxisPosition: "right"`).
      */
     displayType?: 'auto' | 'line' | 'bar' | 'area'
     /** Draw a linear trend line for this series. Only meaningful for line, bar, and area charts. */

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -1813,8 +1813,12 @@ export interface AssistantDataVisualizationAxisDisplaySettings {
     yAxisPosition?: 'left' | 'right'
     /**
      * Override how this individual series is rendered, independent of the chart-level `display` type.
-     * Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`.
-     * `auto` follows the chart-level display type.
+     * `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely
+     * unless you have a specific reason to override.
+     * Only mix series types when a series is on a genuinely different scale or unit from the others AND you
+     * pin it to the secondary axis with `yAxisPosition: "right"` — e.g. counts as `bar` on the left axis with
+     * a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated
+     * measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.
      */
     displayType?: 'auto' | 'line' | 'bar' | 'area'
     /** Draw a linear trend line for this series. Only meaningful for line, bar, and area charts. */

--- a/frontend/src/queries/schema/schema-assistant-queries.ts
+++ b/frontend/src/queries/schema/schema-assistant-queries.ts
@@ -1812,13 +1812,10 @@ export interface AssistantDataVisualizationAxisDisplaySettings {
     /** Which Y axis this numeric series should use. Use `right` for a secondary Y axis. */
     yAxisPosition?: 'left' | 'right'
     /**
-     * Override how this individual series is rendered, independent of the chart-level `display` type.
-     * `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely
-     * unless you have a specific reason to override.
-     * Only mix series types when a series is on a genuinely different scale or unit from the others AND you
-     * pin it to the secondary axis with `yAxisPosition: "right"` — e.g. counts as `bar` on the left axis with
-     * a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated
-     * measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.
+     * Override how this series renders, independent of the chart-level `display` type.
+     * Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the
+     * secondary axis (`yAxisPosition: "right"`) — e.g. counts as `bar` left, a rate as `line` right.
+     * Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.
      */
     displayType?: 'auto' | 'line' | 'bar' | 'area'
     /** Draw a linear trend line for this series. Only meaningful for line, bar, and area charts. */

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -463,9 +463,15 @@ class AssistantDataVisualizationAxisDisplaySettings(BaseModel):
         default=None,
         description=(
             "Override how this individual series is rendered, independent of the"
-            " chart-level `display` type. Use this to mix series types — e.g. plot one"
-            " series as `bar` and overlay another as `line`. `auto` follows the"
-            " chart-level display type."
+            " chart-level `display` type. `auto` (the default) follows the chart-level"
+            " display type — prefer it, and omit this field entirely unless you have a"
+            " specific reason to override. Only mix series types when a series is on a"
+            " genuinely different scale or unit from the others AND you pin it to the"
+            ' secondary axis with `yAxisPosition: "right"` — e.g. counts as `bar` on'
+            " the left axis with a conversion rate as `line` on the right. Series"
+            " sharing a unit should share one type, and unrelated measures belong in"
+            " separate insights: a mixed bar/line chart on a single shared axis is"
+            " unreadable."
         ),
     )
     label: str | None = Field(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -462,15 +462,11 @@ class AssistantDataVisualizationAxisDisplaySettings(BaseModel):
     displayType: DisplayType | None = Field(
         default=None,
         description=(
-            "Override how this individual series is rendered, independent of the"
-            " chart-level `display` type. `auto` (the default) follows the chart-level"
-            " display type — prefer it, and omit this field entirely unless you have a"
-            " specific reason to override. Only mix series types when a series is on a"
-            " genuinely different scale or unit from the others AND you pin it to the"
-            ' secondary axis with `yAxisPosition: "right"` — e.g. counts as `bar` on'
-            " the left axis with a conversion rate as `line` on the right. Series"
-            " sharing a unit should share one type, and unrelated measures belong in"
-            " separate insights: a mixed bar/line chart on a single shared axis is"
+            "Override how this series renders, independent of the chart-level `display`"
+            " type. Prefer the `auto` default: omit this unless one series is on a"
+            " different scale or unit AND sits on the secondary axis (`yAxisPosition:"
+            ' "right"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise'
+            " use one type, or separate insights. A bar/line mix on one shared axis is"
             " unreadable."
         ),
     )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -463,11 +463,9 @@ class AssistantDataVisualizationAxisDisplaySettings(BaseModel):
         default=None,
         description=(
             "Override how this series renders, independent of the chart-level `display`"
-            " type. Prefer the `auto` default: omit this unless one series is on a"
-            " different scale or unit AND sits on the secondary axis (`yAxisPosition:"
-            ' "right"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise'
-            " use one type, or separate insights. A bar/line mix on one shared axis is"
-            " unreadable."
+            " type. `auto` (the default) suits most charts. Mix types for a line that"
+            " annotates bars (rolling average, target), or for a series in another unit"
+            ' on the secondary axis (`yAxisPosition: "right"`).'
         ),
     )
     label: str | None = Field(

--- a/products/product_analytics/skills/choosing-chart-display/SKILL.md
+++ b/products/product_analytics/skills/choosing-chart-display/SKILL.md
@@ -1,130 +1,74 @@
 ---
 name: choosing-chart-display
 description: >
-  Pick the chart type and display settings for an insight so it is actually readable:
-  the `display` / `ChartDisplayType` choice plus legend, series count, secondary axis,
-  stacking, and value labels. Use whenever creating or updating an insight with
-  `insight-create` or `insight-update`, for both TrendsQuery (`trendsFilter`) and SQL
-  insights (`DataVisualizationNode`, `chartSettings`), or when the user says a chart is
-  "unreadable", "cluttered", "spaghetti", "hard to read", "the wrong chart type", or
-  asks for a bar / line / pie / stacked / area / scatter chart, a second y-axis, or a
-  legend. Covers when NOT to mix bar and line series, how many series one chart can
-  carry, and which settings need turning on explicitly because they default to off. For
-  y-axis units and number formatting use `formatting-insight-axes`; for the
-  line-vs-slope question use `choosing-trend-or-slope-view`.
+  Pick the chart type and display settings so an insight is readable: `display` /
+  `ChartDisplayType`, legend, series count, secondary axis, stacking, value labels.
+  Use when creating or updating an insight (`insight-create`, `insight-update`) for
+  TrendsQuery or SQL (`DataVisualizationNode`) insights, or when a chart is called
+  unreadable, cluttered, spaghetti, or the wrong chart type. For y-axis units see
+  `formatting-insight-axes`; for line-vs-slope see `choosing-trend-or-slope-view`.
 ---
 
 # Choosing a chart display
 
-A query that returns the right numbers still fails if the chart is unreadable.
-Pick the display deliberately.
-Most defaults are tuned for the simplest case, not for the chart you are actually building.
+Defaults are tuned for the simplest case, not the chart you are building.
 
-## 1. Pick one chart type
+## Pick one chart type
 
-| The result is...                          | Use                                                     |
-| ----------------------------------------- | ------------------------------------------------------- |
-| A measure over time                       | `ActionsLineGraph` (the trends default)                 |
-| A measure over time, part-of-whole        | `ActionsAreaGraph` or `ActionsStackedBar`               |
-| Categories compared against each other    | `ActionsBar` (SQL) / `ActionsBarValue` (trends)         |
-| Proportions of a single total, few slices | `ActionsPie`                                            |
-| One number                                | `BoldNumber`, or `Metric` for trends with a change pill |
-| Two measures related, one point per row   | `ScatterPlot`                                           |
-| Rows a reader needs to scan or copy       | `ActionsTable`                                          |
+| The result is...                       | Use                                                |
+| -------------------------------------- | -------------------------------------------------- |
+| A measure over time                    | `ActionsLineGraph` (the trends default)            |
+| A measure over time, part-of-whole     | `ActionsAreaGraph` or `ActionsStackedBar`          |
+| Categories compared against each other | `ActionsBar` (SQL) / `ActionsBarValue` (trends)    |
+| Proportions of one total, few slices   | `ActionsPie`                                       |
+| One number                             | `BoldNumber`, or trends `Metric` for a change pill |
+| Two measures, one point per row        | `ScatterPlot`                                      |
+| Rows to scan or copy                   | `ActionsTable`                                     |
 
 Two traps:
 
-- **SQL insights default to `ActionsTable` when `display` is omitted.**
-  A time series left at the default renders as a wall of rows.
-  Set `display` explicitly.
-- **Trends `ActionsBar` is a time-series bar chart**, one bar per interval.
-  For "top N countries" you want `ActionsBarValue`, which bars the totals.
+- SQL insights render as `ActionsTable` when `display` is omitted, so a time series left at the default is a wall of rows.
+- Trends `ActionsBar` is a time-series bar chart, one bar per interval. "Top N countries" wants `ActionsBarValue`.
 
-## 2. Do not mix bar and line series
+## Do not mix bar and line series
 
-One chart, one series type.
-The per-series override (`chartSettings.yAxis[].settings.display.displayType`) defaults to `auto`, which follows the chart-level `display`.
-Leave it there.
+One chart, one series type. Leave `yAxis[].settings.display.displayType` at `auto`.
 
-The single case that justifies a mix:
-one series is on a genuinely different scale or unit, and you pin it to the secondary axis.
+The only exception: a series on a different scale or unit, pinned to the secondary axis.
 
 ```json
-{
-  "yAxis": [
-    { "column": "signups", "settings": { "display": { "displayType": "bar", "yAxisPosition": "left" } } },
-    { "column": "conversion_rate", "settings": { "display": { "displayType": "line", "yAxisPosition": "right" } } }
-  ],
-  "leftYAxisSettings": { "label": "Signups" },
-  "rightYAxisSettings": { "label": "Conversion rate" },
-  "showLegend": true
-}
+{ "column": "conversion_rate", "settings": { "display": { "displayType": "line", "yAxisPosition": "right" } } }
 ```
 
-If the series share a unit, use one type.
-If they are unrelated, use two insights.
-A bar/line mix on a single shared axis is noise: the reader cannot compare across shapes, and nothing in the chart explains why they differ.
+Label both axes when you do (`leftYAxisSettings.label`, `rightYAxisSettings.label`).
+Series sharing a unit share one type; unrelated measures belong in separate insights.
 
-Whenever you use a secondary axis, label both axes.
-Without `leftYAxisSettings.label` and `rightYAxisSettings.label` the reader cannot tell which series reads against which scale.
+## Turn the legend on for more than one series
 
-## 3. Turn the legend on when more than one series renders
+SQL charts default to `showLegend: false`, leaving a multi-series chart readable only by hovering.
+Set `showLegend: true` whenever several `yAxis` columns or a `seriesBreakdownColumn` render.
+This is the most common miss, because nothing about writing the query prompts it.
 
-SQL charts default to `showLegend: false`.
-A multi-series chart without a legend is only decipherable by hovering each line.
+## Cap the series count
 
-Set `showLegend: true` whenever the chart renders more than one series.
-That means either several `yAxis` columns, or a `seriesBreakdownColumn`, which splits one column into many.
-A single unbroken series does not need one.
+Past about six series a line chart reads as spaghetti.
+Keep a top N with an `Other` row, split into several insights, or switch to `ActionsTable`.
 
-This is the most common readability miss, because nothing about writing the query prompts you to think about it.
+## Settings that usually hurt
 
-## 4. Cap the series count
+- `showValuesOnSeries` — fine on a few bars, unreadable on a dense time series.
+- `trendLine` — only when the trend is the point.
+- Log scale (`leftYAxisSettings.scale`, `trendsFilter.yAxisScaleType`) — only for series spanning orders of magnitude.
+- `stackBars100` — hides absolute movement, so pair it with a volume chart.
+- Bar charts need `leftYAxisSettings.startAtZero`; a truncated bar axis misstates the ratio between bars.
 
-Six series on a line chart is about the limit.
-Past that the colors stop being distinguishable and it reads as spaghetti.
+## Field locations
 
-When a breakdown returns more:
-
-- Rank in SQL and keep the top N, folding the rest into an `Other` row, or
-- Split into several insights along a meaningful cut, or
-- Switch to `ActionsTable` if the reader genuinely needs every row.
-
-Do not solve it by shrinking the chart or leaning on the tooltip.
-
-## 5. Settings that usually make things worse
-
-- `showValuesOnSeries` is fine for a handful of bars and unreadable on a dense time series where every point gets a label.
-  Leave it off for time series.
-- `trendLine` earns its place only when the trend is the point.
-  On a series that is already visibly trending it adds a line that says nothing new.
-- Logarithmic scale (`leftYAxisSettings.scale: "logarithmic"`, or `trendsFilter.yAxisScaleType: "log10"`) suits series that genuinely span orders of magnitude.
-  Otherwise it flattens the change the chart exists to show.
-- `stackBars100` suits parts that really do sum to a meaningful whole.
-  It hides absolute movement, so pair it with a volume chart when that matters.
-
-## 6. Axis baselines
-
-Bar charts must start at zero.
-A truncated bar axis misstates the ratio between bars, which is the whole point of bars.
-Set `leftYAxisSettings.startAtZero: true` where the data allows.
-
-Line charts may start off zero when the interesting variation sits in a small band high above it.
-Say so in the insight description when they do.
-
-## 7. Field locations
-
-The same decisions live in different places per insight kind:
-
-| Decision        | TrendsQuery (`trendsFilter`)      | SQL (`chartSettings`)                      |
-| --------------- | --------------------------------- | ------------------------------------------ |
-| Chart type      | `display`                         | `display` (on the `DataVisualizationNode`) |
-| Legend          | `showLegend`                      | `showLegend`                               |
-| Value labels    | `showValuesOnSeries`              | `showValuesOnSeries`                       |
-| Second y-axis   | `showMultipleYAxes`               | `yAxis[].settings.display.yAxisPosition`   |
-| Per-series type | not available, one type per chart | `yAxis[].settings.display.displayType`     |
-| Log scale       | `yAxisScaleType`                  | `leftYAxisSettings.scale`                  |
-| Axis label      | `xAxisLabel` / `yAxisLabel`       | `xAxisLabel` / `leftYAxisSettings.label`   |
-
-Units and number formatting are a separate decision.
-See `formatting-insight-axes`.
+| Decision        | Trends (`trendsFilter`)           | SQL (`chartSettings`)                    |
+| --------------- | --------------------------------- | ---------------------------------------- |
+| Chart type      | `display`                         | `display` (on the node)                  |
+| Legend          | `showLegend`                      | `showLegend`                             |
+| Second y-axis   | `showMultipleYAxes`               | `yAxis[].settings.display.yAxisPosition` |
+| Per-series type | not available, one type per chart | `yAxis[].settings.display.displayType`   |
+| Log scale       | `yAxisScaleType`                  | `leftYAxisSettings.scale`                |
+| Axis label      | `xAxisLabel` / `yAxisLabel`       | `xAxisLabel` / `leftYAxisSettings.label` |

--- a/products/product_analytics/skills/choosing-chart-display/SKILL.md
+++ b/products/product_analytics/skills/choosing-chart-display/SKILL.md
@@ -32,8 +32,8 @@ Two traps:
 
 `auto` for `yAxis[].settings.display.displayType` suits most charts. Two mixes read well:
 
-- A line that annotates the bars in the same unit: rolling average, target, cumulative.
-- A series in a different unit or scale, pinned to the secondary axis. Label both axes (`leftYAxisSettings.label`, `rightYAxisSettings.label`).
+- A line that annotates the bars in the same unit and scale: a rolling average or a target.
+- A series in a different unit or scale, pinned to the secondary axis: another unit, or a cumulative total that outgrows the bars. Label both axes (`leftYAxisSettings.label`, `rightYAxisSettings.label`).
 
 ```json
 { "column": "conversion_rate", "settings": { "display": { "displayType": "line", "yAxisPosition": "right" } } }

--- a/products/product_analytics/skills/choosing-chart-display/SKILL.md
+++ b/products/product_analytics/skills/choosing-chart-display/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: choosing-chart-display
+description: >
+  Pick the chart type and display settings for an insight so it is actually readable:
+  the `display` / `ChartDisplayType` choice plus legend, series count, secondary axis,
+  stacking, and value labels. Use whenever creating or updating an insight with
+  `insight-create` or `insight-update`, for both TrendsQuery (`trendsFilter`) and SQL
+  insights (`DataVisualizationNode`, `chartSettings`), or when the user says a chart is
+  "unreadable", "cluttered", "spaghetti", "hard to read", "the wrong chart type", or
+  asks for a bar / line / pie / stacked / area / scatter chart, a second y-axis, or a
+  legend. Covers when NOT to mix bar and line series, how many series one chart can
+  carry, and which settings need turning on explicitly because they default to off. For
+  y-axis units and number formatting use `formatting-insight-axes`; for the
+  line-vs-slope question use `choosing-trend-or-slope-view`.
+---
+
+# Choosing a chart display
+
+A query that returns the right numbers still fails if the chart is unreadable.
+Pick the display deliberately.
+Most defaults are tuned for the simplest case, not for the chart you are actually building.
+
+## 1. Pick one chart type
+
+| The result is...                          | Use                                                     |
+| ----------------------------------------- | ------------------------------------------------------- |
+| A measure over time                       | `ActionsLineGraph` (the trends default)                 |
+| A measure over time, part-of-whole        | `ActionsAreaGraph` or `ActionsStackedBar`               |
+| Categories compared against each other    | `ActionsBar` (SQL) / `ActionsBarValue` (trends)         |
+| Proportions of a single total, few slices | `ActionsPie`                                            |
+| One number                                | `BoldNumber`, or `Metric` for trends with a change pill |
+| Two measures related, one point per row   | `ScatterPlot`                                           |
+| Rows a reader needs to scan or copy       | `ActionsTable`                                          |
+
+Two traps:
+
+- **SQL insights default to `ActionsTable` when `display` is omitted.**
+  A time series left at the default renders as a wall of rows.
+  Set `display` explicitly.
+- **Trends `ActionsBar` is a time-series bar chart**, one bar per interval.
+  For "top N countries" you want `ActionsBarValue`, which bars the totals.
+
+## 2. Do not mix bar and line series
+
+One chart, one series type.
+The per-series override (`chartSettings.yAxis[].settings.display.displayType`) defaults to `auto`, which follows the chart-level `display`.
+Leave it there.
+
+The single case that justifies a mix:
+one series is on a genuinely different scale or unit, and you pin it to the secondary axis.
+
+```json
+{
+  "yAxis": [
+    { "column": "signups", "settings": { "display": { "displayType": "bar", "yAxisPosition": "left" } } },
+    { "column": "conversion_rate", "settings": { "display": { "displayType": "line", "yAxisPosition": "right" } } }
+  ],
+  "leftYAxisSettings": { "label": "Signups" },
+  "rightYAxisSettings": { "label": "Conversion rate" },
+  "showLegend": true
+}
+```
+
+If the series share a unit, use one type.
+If they are unrelated, use two insights.
+A bar/line mix on a single shared axis is noise: the reader cannot compare across shapes, and nothing in the chart explains why they differ.
+
+Whenever you use a secondary axis, label both axes.
+Without `leftYAxisSettings.label` and `rightYAxisSettings.label` the reader cannot tell which series reads against which scale.
+
+## 3. Turn the legend on when more than one series renders
+
+SQL charts default to `showLegend: false`.
+A multi-series chart without a legend is only decipherable by hovering each line.
+
+Set `showLegend: true` whenever the chart renders more than one series.
+That means either several `yAxis` columns, or a `seriesBreakdownColumn`, which splits one column into many.
+A single unbroken series does not need one.
+
+This is the most common readability miss, because nothing about writing the query prompts you to think about it.
+
+## 4. Cap the series count
+
+Six series on a line chart is about the limit.
+Past that the colors stop being distinguishable and it reads as spaghetti.
+
+When a breakdown returns more:
+
+- Rank in SQL and keep the top N, folding the rest into an `Other` row, or
+- Split into several insights along a meaningful cut, or
+- Switch to `ActionsTable` if the reader genuinely needs every row.
+
+Do not solve it by shrinking the chart or leaning on the tooltip.
+
+## 5. Settings that usually make things worse
+
+- `showValuesOnSeries` is fine for a handful of bars and unreadable on a dense time series where every point gets a label.
+  Leave it off for time series.
+- `trendLine` earns its place only when the trend is the point.
+  On a series that is already visibly trending it adds a line that says nothing new.
+- Logarithmic scale (`leftYAxisSettings.scale: "logarithmic"`, or `trendsFilter.yAxisScaleType: "log10"`) suits series that genuinely span orders of magnitude.
+  Otherwise it flattens the change the chart exists to show.
+- `stackBars100` suits parts that really do sum to a meaningful whole.
+  It hides absolute movement, so pair it with a volume chart when that matters.
+
+## 6. Axis baselines
+
+Bar charts must start at zero.
+A truncated bar axis misstates the ratio between bars, which is the whole point of bars.
+Set `leftYAxisSettings.startAtZero: true` where the data allows.
+
+Line charts may start off zero when the interesting variation sits in a small band high above it.
+Say so in the insight description when they do.
+
+## 7. Field locations
+
+The same decisions live in different places per insight kind:
+
+| Decision        | TrendsQuery (`trendsFilter`)      | SQL (`chartSettings`)                      |
+| --------------- | --------------------------------- | ------------------------------------------ |
+| Chart type      | `display`                         | `display` (on the `DataVisualizationNode`) |
+| Legend          | `showLegend`                      | `showLegend`                               |
+| Value labels    | `showValuesOnSeries`              | `showValuesOnSeries`                       |
+| Second y-axis   | `showMultipleYAxes`               | `yAxis[].settings.display.yAxisPosition`   |
+| Per-series type | not available, one type per chart | `yAxis[].settings.display.displayType`     |
+| Log scale       | `yAxisScaleType`                  | `leftYAxisSettings.scale`                  |
+| Axis label      | `xAxisLabel` / `yAxisLabel`       | `xAxisLabel` / `leftYAxisSettings.label`   |
+
+Units and number formatting are a separate decision.
+See `formatting-insight-axes`.

--- a/products/product_analytics/skills/choosing-chart-display/SKILL.md
+++ b/products/product_analytics/skills/choosing-chart-display/SKILL.md
@@ -13,15 +13,15 @@ Defaults are tuned for the simplest case, not the chart you are building.
 
 ## Pick one chart type
 
-| The result is...                       | Use                                                |
-| -------------------------------------- | -------------------------------------------------- |
-| A measure over time                    | `ActionsLineGraph` (the trends default)            |
-| A measure over time, part-of-whole     | `ActionsAreaGraph` or `ActionsStackedBar`          |
-| Categories compared against each other | `ActionsBar` (SQL) / `ActionsBarValue` (trends)    |
-| Proportions of one total, few slices   | `ActionsPie`                                       |
-| One number                             | `BoldNumber`, or trends `Metric` for a change pill |
-| Two measures, one point per row        | `ScatterPlot`                                      |
-| Rows to scan or copy                   | `ActionsTable`                                     |
+| The result is...                       | Use                                                                                |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| A measure over time                    | `ActionsLineGraph` (the trends default)                                            |
+| A measure over time, part-of-whole     | `ActionsStackedBar` (area stacks only on trends with `showPercentStackView: true`) |
+| Categories compared against each other | `ActionsBar` (SQL) / `ActionsBarValue` (trends)                                    |
+| Proportions of one total, few slices   | `ActionsPie`                                                                       |
+| One number                             | `BoldNumber`, or trends `Metric` for a change pill                                 |
+| Two measures, one point per row        | `ScatterPlot`                                                                      |
+| Rows to scan or copy                   | `ActionsTable`                                                                     |
 
 Two traps:
 
@@ -44,7 +44,7 @@ Unrelated measures sharing one axis read better as separate insights.
 ## Turn the legend on for more than one series
 
 SQL charts default to `showLegend: false`, leaving a multi-series chart readable only by hovering.
-Set `showLegend: true` whenever several `yAxis` columns or a `seriesBreakdownColumn` render.
+Set `showLegend: true` for `ActionsPie` (slices show values, names only on hover) and whenever several `yAxis` columns or a `seriesBreakdownColumn` render.
 This is the most common miss, because nothing about writing the query prompts it.
 
 ## Cap the series count
@@ -56,17 +56,17 @@ Keep a top N with an `Other` row, split into several insights, or switch to `Act
 
 - `showValuesOnSeries`: fine on a few bars, unreadable on a dense time series.
 - `trendLine`: only when the trend is the point.
-- Log scale (`leftYAxisSettings.scale`, `trendsFilter.yAxisScaleType`): only for series spanning orders of magnitude.
+- Log scale (`leftYAxisSettings.scale` / `rightYAxisSettings.scale`, `trendsFilter.yAxisScaleType`): only for series spanning orders of magnitude.
 - `stackBars100`: hides absolute movement, so pair it with a volume chart.
 - Bar charts need `leftYAxisSettings.startAtZero`; a truncated bar axis misstates the ratio between bars.
 
 ## Field locations
 
-| Decision        | Trends (`trendsFilter`)           | SQL (`chartSettings`)                    |
-| --------------- | --------------------------------- | ---------------------------------------- |
-| Chart type      | `display`                         | `display` (on the node)                  |
-| Legend          | `showLegend`                      | `showLegend`                             |
-| Second y-axis   | `showMultipleYAxes`               | `yAxis[].settings.display.yAxisPosition` |
-| Per-series type | not available, one type per chart | `yAxis[].settings.display.displayType`   |
-| Log scale       | `yAxisScaleType`                  | `leftYAxisSettings.scale`                |
-| Axis label      | `xAxisLabel` / `yAxisLabel`       | `xAxisLabel` / `leftYAxisSettings.label` |
+| Decision        | Trends (`trendsFilter`)           | SQL (`chartSettings`)                                  |
+| --------------- | --------------------------------- | ------------------------------------------------------ |
+| Chart type      | `display`                         | `display` (on the node)                                |
+| Legend          | `showLegend`                      | `showLegend`                                           |
+| Second y-axis   | `showMultipleYAxes`               | `yAxis[].settings.display.yAxisPosition`               |
+| Per-series type | not available, one type per chart | `yAxis[].settings.display.displayType`                 |
+| Log scale       | `yAxisScaleType`                  | `leftYAxisSettings.scale` / `rightYAxisSettings.scale` |
+| Axis label      | `xAxisLabel` / `yAxisLabel`       | `xAxisLabel` / `leftYAxisSettings.label`               |

--- a/products/product_analytics/skills/choosing-chart-display/SKILL.md
+++ b/products/product_analytics/skills/choosing-chart-display/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: choosing-chart-display
 description: >
-  Pick the chart type and display settings so an insight is readable: `display` /
-  `ChartDisplayType`, legend, series count, secondary axis, stacking, value labels.
-  Use when creating or updating an insight (`insight-create`, `insight-update`) for
-  TrendsQuery or SQL (`DataVisualizationNode`) insights, or when a chart is called
-  unreadable, cluttered, spaghetti, or the wrong chart type. For y-axis units see
-  `formatting-insight-axes`; for line-vs-slope see `choosing-trend-or-slope-view`.
+  Chart type and display settings for a readable insight: `display`, legend, series
+  count, secondary axis, stacking. Use when creating or updating a trends or SQL insight
+  (`insight-create`, `insight-update`), or when a chart is unreadable, cluttered, or the
+  wrong type. Units: `formatting-insight-axes`. Line vs slope: `choosing-trend-or-slope-view`.
 ---
 
 # Choosing a chart display
@@ -30,18 +28,18 @@ Two traps:
 - SQL insights render as `ActionsTable` when `display` is omitted, so a time series left at the default is a wall of rows.
 - Trends `ActionsBar` is a time-series bar chart, one bar per interval. "Top N countries" wants `ActionsBarValue`.
 
-## Do not mix bar and line series
+## Mix bar and line when it adds meaning
 
-One chart, one series type. Leave `yAxis[].settings.display.displayType` at `auto`.
+`auto` for `yAxis[].settings.display.displayType` suits most charts. Two mixes read well:
 
-The only exception: a series on a different scale or unit, pinned to the secondary axis.
+- A line that annotates the bars in the same unit: rolling average, target, cumulative.
+- A series in a different unit or scale, pinned to the secondary axis. Label both axes (`leftYAxisSettings.label`, `rightYAxisSettings.label`).
 
 ```json
 { "column": "conversion_rate", "settings": { "display": { "displayType": "line", "yAxisPosition": "right" } } }
 ```
 
-Label both axes when you do (`leftYAxisSettings.label`, `rightYAxisSettings.label`).
-Series sharing a unit share one type; unrelated measures belong in separate insights.
+Unrelated measures sharing one axis read better as separate insights.
 
 ## Turn the legend on for more than one series
 
@@ -56,10 +54,10 @@ Keep a top N with an `Other` row, split into several insights, or switch to `Act
 
 ## Settings that usually hurt
 
-- `showValuesOnSeries` — fine on a few bars, unreadable on a dense time series.
-- `trendLine` — only when the trend is the point.
-- Log scale (`leftYAxisSettings.scale`, `trendsFilter.yAxisScaleType`) — only for series spanning orders of magnitude.
-- `stackBars100` — hides absolute movement, so pair it with a volume chart.
+- `showValuesOnSeries`: fine on a few bars, unreadable on a dense time series.
+- `trendLine`: only when the trend is the point.
+- Log scale (`leftYAxisSettings.scale`, `trendsFilter.yAxisScaleType`): only for series spanning orders of magnitude.
+- `stackBars100`: hides absolute movement, so pair it with a volume chart.
 - Bar charts need `leftYAxisSettings.startAtZero`; a truncated bar axis misstates the ratio between bars.
 
 ## Field locations

--- a/products/product_analytics/skills/choosing-trend-or-slope-view/SKILL.md
+++ b/products/product_analytics/skills/choosing-trend-or-slope-view/SKILL.md
@@ -9,7 +9,7 @@ description: >
   "slopegraph". Two readings of "change" need different charts: the whole trend
   (a line, every interval) versus just the two endpoints (a slope, start vs
   end). Ask which they want, then render it. Not for choosing a saved insight
-  ChartDisplayType in the insight editor.
+  ChartDisplayType in the insight editor — that is `choosing-chart-display`.
 ---
 
 # Choosing a trend line vs a slope view

--- a/products/product_analytics/skills/formatting-insight-axes/SKILL.md
+++ b/products/product_analytics/skills/formatting-insight-axes/SKILL.md
@@ -25,8 +25,7 @@ The two insight kinds configure it in different places:
   `settings.formatting` (see [SQL insights](#sql-insights-datavisualizationnode))
 
 This page is only about **units**.
-The chart type itself (line vs bar vs pie, how many series one chart can carry, the legend, a secondary axis) is `choosing-chart-display`.
-On a SQL insight both live in the same nested object, `settings.formatting` next to `settings.display`, so it is easy to set one and never consider the other.
+Chart type, legend, series count, and a secondary axis are `choosing-chart-display` — on a SQL insight they sit in the same nested object, `settings.display` next to `settings.formatting`.
 
 ## The anti-pattern
 

--- a/products/product_analytics/skills/formatting-insight-axes/SKILL.md
+++ b/products/product_analytics/skills/formatting-insight-axes/SKILL.md
@@ -24,6 +24,10 @@ The two insight kinds configure it in different places:
 - **SQL insights** (`DataVisualizationNode`) — per-column
   `settings.formatting` (see [SQL insights](#sql-insights-datavisualizationnode))
 
+This page is only about **units**.
+The chart type itself (line vs bar vs pie, how many series one chart can carry, the legend, a secondary axis) is `choosing-chart-display`.
+On a SQL insight both live in the same nested object, `settings.formatting` next to `settings.display`, so it is easy to set one and never consider the other.
+
 ## The anti-pattern
 
 If you are reaching for any of these, stop and pick a format below first:

--- a/products/product_analytics/skills/formatting-insight-axes/SKILL.md
+++ b/products/product_analytics/skills/formatting-insight-axes/SKILL.md
@@ -25,7 +25,8 @@ The two insight kinds configure it in different places:
   `settings.formatting` (see [SQL insights](#sql-insights-datavisualizationnode))
 
 This page is only about **units**.
-Chart type, legend, series count, and a secondary axis are `choosing-chart-display` — on a SQL insight they sit in the same nested object, `settings.display` next to `settings.formatting`.
+Chart type, legend, series count, and a secondary axis are `choosing-chart-display`.
+Two of its SQL settings — per-series type (`displayType`) and secondary-axis side (`yAxisPosition`) — sit in `settings.display`, next to the `settings.formatting` this page covers; chart type is `display` on the node and the legend is `chartSettings.showLegend`.
 
 ## The anti-pattern
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -54,7 +54,7 @@ const AssistantDataVisualizationAxisDisplaySettings = z.object({
     displayType: z
         .enum(['auto', 'line', 'bar', 'area'])
         .describe(
-            'Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.'
+            'Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: "right"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.'
         )
         .optional(),
     label: z

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -54,7 +54,7 @@ const AssistantDataVisualizationAxisDisplaySettings = z.object({
     displayType: z
         .enum(['auto', 'line', 'bar', 'area'])
         .describe(
-            'Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: "right"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.'
+            'Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: "right"`).'
         )
         .optional(),
     label: z

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -54,7 +54,7 @@ const AssistantDataVisualizationAxisDisplaySettings = z.object({
     displayType: z
         .enum(['auto', 'line', 'bar', 'area'])
         .describe(
-            'Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: "right"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.'
+            'Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: "right"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.'
         )
         .optional(),
     label: z

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
@@ -181,7 +181,7 @@
                                                             "type": "string"
                                                         },
                                                         "displayType": {
-                                                            "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                                                            "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                                                             "enum": ["auto", "line", "bar", "area"],
                                                             "type": "string"
                                                         },
@@ -254,7 +254,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },
@@ -359,7 +359,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
@@ -181,7 +181,7 @@
                                                             "type": "string"
                                                         },
                                                         "displayType": {
-                                                            "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                                                            "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                                                             "enum": ["auto", "line", "bar", "area"],
                                                             "type": "string"
                                                         },
@@ -254,7 +254,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },
@@ -359,7 +359,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
@@ -181,7 +181,7 @@
                                                             "type": "string"
                                                         },
                                                         "displayType": {
-                                                            "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                                                            "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                                                             "enum": ["auto", "line", "bar", "area"],
                                                             "type": "string"
                                                         },
@@ -254,7 +254,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },
@@ -359,7 +359,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
@@ -192,7 +192,7 @@
                                                             "type": "string"
                                                         },
                                                         "displayType": {
-                                                            "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                                                            "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                                                             "enum": ["auto", "line", "bar", "area"],
                                                             "type": "string"
                                                         },
@@ -265,7 +265,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },
@@ -370,7 +370,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. Use this to mix series types — e.g. plot one series as `bar` and overlay another as `line`. `auto` follows the chart-level display type.",
+                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
@@ -192,7 +192,7 @@
                                                             "type": "string"
                                                         },
                                                         "displayType": {
-                                                            "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                                                            "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                                                             "enum": ["auto", "line", "bar", "area"],
                                                             "type": "string"
                                                         },
@@ -265,7 +265,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },
@@ -370,7 +370,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this individual series is rendered, independent of the chart-level `display` type. `auto` (the default) follows the chart-level display type — prefer it, and omit this field entirely unless you have a specific reason to override. Only mix series types when a series is on a genuinely different scale or unit from the others AND you pin it to the secondary axis with `yAxisPosition: \"right\"` — e.g. counts as `bar` on the left axis with a conversion rate as `line` on the right. Series sharing a unit should share one type, and unrelated measures belong in separate insights: a mixed bar/line chart on a single shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
@@ -192,7 +192,7 @@
                                                             "type": "string"
                                                         },
                                                         "displayType": {
-                                                            "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                                                            "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                                                             "enum": ["auto", "line", "bar", "area"],
                                                             "type": "string"
                                                         },
@@ -265,7 +265,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },
@@ -370,7 +370,7 @@
                                                                 "type": "string"
                                                             },
                                                             "displayType": {
-                                                                "description": "Override how this series renders, independent of the chart-level `display` type. Prefer the `auto` default: omit this unless one series is on a different scale or unit AND sits on the secondary axis (`yAxisPosition: \"right\"`) — e.g. counts as `bar` left, a rate as `line` right. Otherwise use one type, or separate insights. A bar/line mix on one shared axis is unreadable.",
+                                                                "description": "Override how this series renders, independent of the chart-level `display` type. `auto` (the default) suits most charts. Mix types for a line that annotates bars (rolling average, target), or for a series in another unit on the secondary axis (`yAxisPosition: \"right\"`).",
                                                                 "enum": ["auto", "line", "bar", "area"],
                                                                 "type": "string"
                                                             },


### PR DESCRIPTION
## Problem

Charts that agents build come out unreadable more often than they should: bar and line series mixed on one shared axis, a dozen lines with no legend, a time series left rendering as a table.

The schema nudged them there. `displayType` described itself as an invitation, "Use this to mix series types", and said nothing about the `auto` default or when a mix helps. No skill covered chart type, legend, or series count: `formatting-insight-axes` handles units only and `choosing-trend-or-slope-view` disclaims the question.

## Changes

- Agents now leave `displayType` at `auto` unless a mix adds meaning: a line that annotates bars (rolling average, target), or a series in another unit on the secondary axis. The description names those two cases and stops.
- New skill `choosing-chart-display` holds the best practices the schema cannot: chart type per result shape, the legend (SQL charts default to off), a series cap, and the settings that usually hurt.
- `formatting-insight-axes` and `choosing-trend-or-slope-view` cross-link to it.
- Both always-loaded surfaces stay small: the description is 270 characters (230 before this PR) and the skill frontmatter is 348.
- Mechanical: `schema.json`, `schema.py`, and the `services/mcp` generated tool and snapshots are codegen from the one docstring.

The docstring reaches the MCP `insight-create` / `insight-update` schemas and the in-app assistant's SQL tool, which share this type.

> [!NOTE]
> The guidance is a nudge, not a rule. It names when a mix reads well and forbids nothing, so an agent asked for bars with a rolling average still builds one chart.

## How did you test this code?

- Schema files regenerated with `schema:build:json`, `bin/build-schema-python.sh`, and `hogli build:openapi`; the only churn is the changed description.
- `services/mcp` `tests/unit/tool-schema-snapshots.test.ts` regenerated and passing.
- `hogli lint:skills`, markdownlint on the touched skills, `oxfmt --check`, and `hogli ci:preflight --strict` on push, all clean.
- No new tests: a docstring and a skill have no behavior to regression-test. No manual testing applies.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Opened by the PostHog Slack app (Claude Code) after a question about why agent-built insights so often mix bars and lines. The diagnosis came from reading the live tool schema over MCP and querying saved insights: the mixing was SQL-only and concentrated among charts that set `displayType` at all, which pointed at the field description. The same query surfaced the legend gap, which justified a skill.

A later Claude Code session addressed the Codex review. The first version banned every same-axis mix, which also blocked bars with a rolling average, so the wording now names the two mixes that read well instead. That session also cut both always-loaded surfaces further.

Skills invoked: `writing-skills`, `writing-code-comments`, `writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1787847849528979)*
