### PR TITLE
chore(mcp-analytics): use distributed ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,19 +63,6 @@ posthog/temporal/data_modeling/run_workflow.py @PostHog/team-data-modeling
 # Dev sandbox provides important protection in local dev
 bin/dev-sandbox* @PostHog/team-security
 
-# MCP Analytics relies on a cross-repo event contract with no shared type boundary.
-# Producers can change without failing product consumers, so team review gates both ends.
-products/mcp_analytics/** @PostHog/team-mcp-analytics
-posthog/temporal/mcp_analytics/** @PostHog/team-mcp-analytics
-services/mcp/src/hono/analytics.ts @PostHog/team-mcp-analytics
-services/mcp/src/lib/posthog/analytics.ts @PostHog/team-mcp-analytics
-services/mcp/tests/hono/analytics.test.ts @PostHog/team-mcp-analytics
-services/mcp/tests/unit/posthog/analytics.test.ts @PostHog/team-mcp-analytics
-services/mcp/src/generated/mcp_analytics/** @PostHog/team-mcp-analytics
-services/mcp/src/tools/generated/mcp_analytics.ts @PostHog/team-mcp-analytics
-docs/published/docs/mcp-analytics/** @PostHog/team-mcp-analytics
-bin/inject_mcp_intents.py @PostHog/team-mcp-analytics
-
 # The MCP store catalog is a fleet-wide trust decision, not ordinary code: a merged entry
 # becomes (probe permitting) an active server template in every environment on the next
 # deploy — installable by all tenants and feeding tool results into their LLM agents. The

--- a/docs/published/docs/mcp-analytics/owners.yaml
+++ b/docs/published/docs/mcp-analytics/owners.yaml
@@ -1,0 +1,3 @@
+version: 1
+owners:
+    - team-mcp-analytics

--- a/owners.yaml
+++ b/owners.yaml
@@ -53,6 +53,8 @@ rules:
           - '/nodejs/bin/'
           - '/rust/bin/'
       owners: team-devex
+    - match: '/bin/inject_mcp_intents.py'
+      owners: team-mcp-analytics
     - match: '/.agents/skills/manage-dashboard-widgets/'
       owners: team-analytics-platform
     - match: '/.claude/'

--- a/services/mcp/src/owners.yaml
+++ b/services/mcp/src/owners.yaml
@@ -2,6 +2,12 @@ version: 1
 owners: []
 rules:
     - match:
+          - '/generated/mcp_analytics/'
+          - '/hono/analytics.ts'
+          - '/lib/posthog/analytics.ts'
+          - '/tools/generated/mcp_analytics.ts'
+      owners: team-mcp-analytics
+    - match:
           - '/generated/ai_observability/'
           - '/tools/aiObservability/'
           - '/tools/generated/ai_observability.ts'

--- a/services/mcp/tests/owners.yaml
+++ b/services/mcp/tests/owners.yaml
@@ -1,0 +1,7 @@
+version: 1
+owners: []
+rules:
+    - match:
+          - '/hono/analytics.test.ts'
+          - '/unit/posthog/analytics.test.ts'
+      owners: team-mcp-analytics


### PR DESCRIPTION
## Problem

[#89712](https://github.com/PostHog/posthog/pull/89712) made MCP Analytics review blocking when the team only needs ownership notifications.

The product and Temporal paths already use distributed ownership, but the remaining domain surfaces had no team owner.

## Changes

- Remove the MCP Analytics rules from CODEOWNERS, restoring non-blocking merges.
- Route telemetry, generated bindings, tests, docs, and local tooling to `team-mcp-analytics` through distributed ownership.
- Keep the existing `product.yaml` and Temporal ownership unchanged.
- This change affects review routing only; it has no user-visible effect.

## How did you test this code?

- Ran the ownership resolver against every covered path and representative shared paths.
- Ran the GitHub-faithful CODEOWNERS matcher to confirm the blocking rules are gone.
- Ran `./bin/hogli owners:lint` and the ownership resolver test suite.
- Ran `hogli ci:preflight --fix` and the strict pre-push check.
- Not completed: `owners:fmt` hits an unrelated equivalence assertion in existing Node ingestion ownership.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is required because this change only affects review routing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this correction with the `/establishing-code-ownership`, `/running-ci-preflight`, and `/writing-pr-descriptions` skills.
