### PR TITLE
fix(evals): label eval events with the run's own namespace

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -287,7 +287,8 @@
             "description": "The source that triggered this evaluation.",
             "examples": [
                 "signals-grouping",
-                "sandboxed-agent"
+                "sandboxed-agent",
+                "one-shot"
             ],
             "label": "AI eval source (LLM)"
         },
@@ -4866,7 +4867,8 @@
             "description": "The source that triggered this evaluation.",
             "examples": [
                 "signals-grouping",
-                "sandboxed-agent"
+                "sandboxed-agent",
+                "one-shot"
             ],
             "label": "AI eval source (LLM)"
         },

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2597,7 +2597,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$ai_eval_source": {
             "label": "AI eval source (LLM)",
             "description": "The source that triggered this evaluation.",
-            "examples": ["signals-grouping", "sandboxed-agent"],
+            "examples": ["signals-grouping", "sandboxed-agent", "one-shot"],
         },
         "$ai_evaluation_type": {
             "label": "AI evaluation type (LLM)",

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -111,7 +111,8 @@ class _BaseEvalRun:
     """
 
     trace_namespace = "evals"
-    """Prefix for the experiment name in scorer trace metadata."""
+    """How this run labels itself in PostHog: the experiment-name prefix on every emitted
+    event, and the `$ai_eval_source` on evaluation events. Subclasses set it per run kind."""
 
     def __init__(
         self,
@@ -244,7 +245,12 @@ class _BaseEvalRun:
         if self.posthog_client and result.results:
             try:
                 emit_evaluation_events(
-                    self.posthog_client, self.experiment_id, self.experiment_name, result.results, self.scorer_traces
+                    self.posthog_client,
+                    self.experiment_id,
+                    self.experiment_name,
+                    result.results,
+                    namespace=self.trace_namespace,
+                    scorer_traces=self.scorer_traces,
                 )
                 # Emit $ai_trace root events now that scores are available
                 for eval_result in result.results:
@@ -258,6 +264,7 @@ class _BaseEvalRun:
                             experiment_id=self.experiment_id,
                             experiment_name=self.experiment_name,
                             case_name=case_name,
+                            namespace=self.trace_namespace,
                             prompt=meta["prompt"],
                             duration=meta["duration"],
                             first_timestamp=meta["first_timestamp"],
@@ -427,6 +434,7 @@ class _SandboxedEvalRun(_BaseEvalRun):
                         experiment_name=self.experiment_name,
                         case_name=eval_case.name,
                         parsed=parsed,
+                        namespace=self.trace_namespace,
                     )
                     # Store metadata for emit_trace_root (called after scoring)
                     self.case_trace_meta[eval_case.name] = {

--- a/products/posthog_ai/eval_harness/scorers/tracing.py
+++ b/products/posthog_ai/eval_harness/scorers/tracing.py
@@ -221,7 +221,8 @@ def wrap_scorers(
     experiment_id: str,
     experiment_name: str,
     agent_trace_id_lookup: dict[str, str],
-    trace_namespace: str = "sandboxed-agent",
+    *,
+    trace_namespace: str,
 ) -> tuple[list[Any], dict[tuple[str, str], str]]:
     """Wrap scorers with tracing.
 

--- a/products/posthog_ai/eval_harness/test/test_trace_events.py
+++ b/products/posthog_ai/eval_harness/test/test_trace_events.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from parameterized import parameterized
+from posthoganalytics import Posthog
+
+from products.posthog_ai.eval_harness.base import _SandboxedEvalRun
+from products.posthog_ai.eval_harness.engines.types import CaseResult
+from products.posthog_ai.eval_harness.one_shot import _OneShotEvalRun
+from products.posthog_ai.eval_harness.trace_events import emit_evaluation_events, emit_trace_root
+
+NAMESPACES = [(_SandboxedEvalRun.trace_namespace,), (_OneShotEvalRun.trace_namespace,)]
+
+
+class _CapturingClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def capture(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@parameterized.expand(NAMESPACES)
+def test_evaluation_events_carry_the_run_namespace(namespace: str) -> None:
+    client = _CapturingClient()
+    result = CaseResult(input={"name": "case-1"}, output={}, scores={"a_scorer": 1.0})
+
+    emit_evaluation_events(cast(Posthog, client), "exp-1", "my-suite", [result], namespace=namespace)
+
+    properties = client.calls[0]["properties"]
+    assert properties["$ai_experiment_name"] == f"{namespace}/my-suite"
+    assert properties["$ai_eval_source"] == namespace
+
+
+@parameterized.expand(NAMESPACES)
+def test_trace_root_carries_the_run_namespace(namespace: str) -> None:
+    client = _CapturingClient()
+
+    emit_trace_root(
+        cast(Posthog, client),
+        trace_id="trace-1",
+        experiment_id="exp-1",
+        experiment_name="my-suite",
+        case_name="case-1",
+        namespace=namespace,
+        prompt="hello",
+        duration=1.0,
+        first_timestamp="",
+    )
+
+    properties = client.calls[0]["properties"]
+    assert properties["$ai_experiment_name"] == f"{namespace}/my-suite"
+
+
+def test_the_two_run_kinds_label_themselves_differently() -> None:
+    assert _SandboxedEvalRun.trace_namespace != _OneShotEvalRun.trace_namespace

--- a/products/posthog_ai/eval_harness/trace_events.py
+++ b/products/posthog_ai/eval_harness/trace_events.py
@@ -48,11 +48,12 @@ class TraceEventEmitter:
         experiment_id: str,
         experiment_name: str,
         case_name: str,
+        namespace: str,
     ):
         self._client = client
         self._trace_id = trace_id
         self._experiment_id = experiment_id
-        self._formatted_experiment_name = f"sandboxed-agent/{experiment_name}"
+        self._formatted_experiment_name = f"{namespace}/{experiment_name}"
         self._case_name = case_name
 
     @property
@@ -239,12 +240,14 @@ def emit_trace_events(
     experiment_name: str,
     case_name: str,
     parsed: ParsedLog,
+    *,
+    namespace: str,
 ) -> None:
     """Emit one ``$ai_generation`` per turn, plus ``$ai_span`` events.
 
     Thin wrapper over ``TraceEventEmitter.emit_parsed_events``.
     """
-    TraceEventEmitter(client, trace_id, experiment_id, experiment_name, case_name).emit_parsed_events(parsed)
+    TraceEventEmitter(client, trace_id, experiment_id, experiment_name, case_name, namespace).emit_parsed_events(parsed)
 
 
 def emit_trace_root(
@@ -253,6 +256,8 @@ def emit_trace_root(
     experiment_id: str,
     experiment_name: str,
     case_name: str,
+    *,
+    namespace: str,
     prompt: str,
     duration: float,
     first_timestamp: str,
@@ -262,7 +267,7 @@ def emit_trace_root(
     token_usage: dict[str, int] | None = None,
 ) -> None:
     """Thin wrapper over ``TraceEventEmitter.emit_root``."""
-    TraceEventEmitter(client, trace_id, experiment_id, experiment_name, case_name).emit_root(
+    TraceEventEmitter(client, trace_id, experiment_id, experiment_name, case_name, namespace).emit_root(
         prompt=prompt,
         duration=duration,
         first_timestamp=first_timestamp,
@@ -278,6 +283,8 @@ def emit_evaluation_events(
     experiment_id: str,
     experiment_name: str,
     eval_results: list[CaseResult],
+    *,
+    namespace: str,
     scorer_traces: dict[tuple[str, str], str] | None = None,
 ) -> None:
     """Emit ``$ai_evaluation`` events for each scorer result in each eval case.
@@ -286,7 +293,7 @@ def emit_evaluation_events(
     the scorer's LLM call. If available, ``$ai_trace_id`` on the event
     points to the scorer trace (for inspecting the scorer's reasoning).
     """
-    formatted_name = f"sandboxed-agent/{experiment_name}"
+    formatted_name = f"{namespace}/{experiment_name}"
 
     for result in eval_results:
         case_name = result.input.get("name", "unknown") if isinstance(result.input, dict) else "unknown"
@@ -306,7 +313,7 @@ def emit_evaluation_events(
             trace_id = scorer_trace_id or agent_trace_id
 
             properties: dict[str, Any] = {
-                "$ai_eval_source": "sandboxed-agent",
+                "$ai_eval_source": namespace,
                 "$ai_evaluation_type": "offline",
                 "$ai_experiment_id": experiment_id,
                 "$ai_experiment_name": formatted_name,


### PR DESCRIPTION
## Problem

Every offline eval experiment in `/ai-evals` is labeled `sandboxed-agent/`, including one-shot suites that never start a sandbox.
Browsing the offline experiments list, or filtering evaluation events by `$ai_eval_source`, cannot tell you which harness produced a result.

## Changes

- One-shot suites now file themselves under `one-shot/<suite>` with `$ai_eval_source: one-shot`, so the list names the harness that ran.
- Sandboxed suites emit exactly what they did before, because `_SandboxedEvalRun.trace_namespace` is already `sandboxed-agent`.
- `$ai_eval_source` gains `one-shot` in its taxonomy examples, regenerated into the frontend JSON with `bin/build-taxonomy-json.py`.
- Mechanical: `trace_events.py` takes the run's namespace instead of hardcoding that string in three places, and `wrap_scorers` drops its `trace_namespace="sandboxed-agent"` default so the same mislabel cannot come back through a new caller.

The seam already existed, which is why the diff is small.
`base.py:113` declared `trace_namespace` per run kind and `scorers/tracing.py:240` already honored it for scorer traces, while `trace_events.py` ignored it.
A one-shot run's scorer trace and its own evaluation event therefore disagreed about which harness produced them.

Of the three sites, only `emit_evaluation_events` runs for a one-shot suite today.
`emit_trace_root` needs `agent_trace_id_lookup` and `case_trace_meta`, and both are written only in `_SandboxedEvalRun` (`base.py:416`, `base.py:440`); `emit_trace_events` is called only from `_SandboxedEvalRun` (`base.py:430`).
Those two are threaded anyway so a future one-shot trace path cannot inherit the old label.

> [!NOTE]
> This does not fork experiment history.
> Both the API and the frontend key offline experiments on `$ai_experiment_id` (`offline_evaluations.py:55`, `offlineEvaluationsLogic.ts:502`), and `base.py:137` assigns a fresh UUID per run, so every run is already its own row.
> `$ai_experiment_name` is a display label the list reads with `argMax`.

## How did you test this code?

- New `products/posthog_ai/eval_harness/test/test_trace_events.py` covers the regression this PR fixes: a hardcoded prefix returning to either emitter. Nothing covered `trace_events.py` before, so there was no existing test to extend.
- That guard was checked negatively. Restoring the hardcode failed the two `one-shot` cases and left the `sandboxed-agent` cases green, which is the asymmetry the fix is about.
- `posthog/taxonomy/test/test_event_properties_taxonomy.py` passes, so the regenerated JSON stays in sync with the Python.
- The rest of `products/posthog_ai/eval_harness/test/` passes (261), and repo-wide `mypy` reports the same error set as master, so the keyword-only signatures broke no caller.
- Not run: a real eval. That needs provider credentials and the harness infrastructure, so the emitters are exercised through their public functions instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude authored this PR. It came out of a review question on #83493 about where the Replay Vision golden-dataset eval results should live. That eval is a `SuiteKind.ONE_SHOT` suite, and tracing where its results surface showed every harness run labeling itself `sandboxed-agent` regardless of kind.

Threading the existing `trace_namespace` beats adding a new parameter or a per-suite override. The attribute was already declared per run kind, and already read on the scorer-trace path. The change makes one code path agree with another rather than introducing a second concept.

`_BaseEvalRun` is never instantiated directly and has only the two subclasses, so its `"evals"` default is unreachable and no third code path changes label.

Skills invoked: `/writing-evals`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
