### PR TITLE
fix(event-definitions): left join the enterprise table instead of full outer

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -78,8 +78,16 @@ def create_event_definitions_sql(
     # split this query's load across hundreds of fingerprints and none of them looks expensive.
     selected_fields = sorted(event_definition_fields)
 
+    # LEFT, not FULL OUTER. The two return the same rows here, on two independent grounds:
+    # `eventdefinition_ptr_id` is the child's primary key and a validated NOT NULL foreign key, so an
+    # enterprise row without a base row cannot be committed; and even if one existed, the scope
+    # filter below reads base-table columns, so that row's `COALESCE(project_id, team_id)` would be
+    # NULL and it would be filtered out regardless of join type.
+    # The join type does change the plan. A full join can be neither a nested loop nor a filter
+    # pushed into the scan, which leaves a sequential scan of the whole table available to the
+    # planner — and it picked that plan in production once statistics shifted.
     enterprise_join = (
-        "FULL OUTER JOIN ee_enterpriseeventdefinition ON posthog_eventdefinition.id=ee_enterpriseeventdefinition.eventdefinition_ptr_id"
+        "LEFT JOIN ee_enterpriseeventdefinition ON posthog_eventdefinition.id=ee_enterpriseeventdefinition.eventdefinition_ptr_id"
         if is_enterprise
         else ""
     )

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -660,6 +660,11 @@ class TestCreateEventDefinitionsSql(SimpleTestCase):
         columns = [column.strip() for column in select_clause.split(",")]
         assert columns == sorted(columns)
 
+    def test_joins_the_enterprise_table_with_a_left_join(self):
+        sql = create_event_definitions_sql(EventDefinitionType.EVENT, is_enterprise=True)
+        assert "LEFT JOIN ee_enterpriseeventdefinition" in sql
+        assert "FULL OUTER JOIN" not in sql
+
 
 class TestEventDefinitionExcludeStale(APIBaseTest):
     """Stale filter tests need real wall-clock times so the Postgres NOW() comparison


### PR DESCRIPTION
## Problem

The event definitions list query can make Postgres read every row of `posthog_eventdefinition`, a table with over 100 million rows. It backs every event picker, so a bad plan there burns CPU on the writer that every team on the cluster shares.

The query joins the enterprise table with `FULL OUTER JOIN`. That single word is what leaves the bad plan available:

- The project scope filter, `COALESCE(project_id, team_id) = X`, is not strict, so Postgres cannot demote the full join to a left join.
- A full join can be neither a nested loop nor a filter pushed into the scan. The planner is left free to sequential-scan the whole table, and it took that plan in production once statistics shifted.
- Only some parameter combinations are affected. `event_type=event` and `event_type=event_posthog` add a strict `name NOT LIKE` clause, which restores the demotion. The default list call carries no such clause.

## Changes

The list query seeks `event_definition_proj_uniq` instead of reading the table. Same rows, same order, same columns.

- `FULL OUTER JOIN` becomes `LEFT JOIN`, which removes the scan-everything plan from the planner's search space.
- A comment records why the two are equivalent here, so the next person to read that line does not have to re-derive it.

### Why the two joins return the same rows

A full join keeps enterprise rows that have no base row; a left join drops them. So the change is only safe if such rows cannot reach this result set. Two independent reasons say they cannot.

**They cannot exist.** `eventdefinition_ptr_id` is the child table's primary key and a foreign key to `posthog_eventdefinition`, and the constraint is validated (`convalidated = t`) with `NO ACTION` on delete. Inserting an enterprise row with no base row fails:

```
ERROR: insert or update on table "ee_enterpriseeventdefinition" violates foreign key
       constraint "ee_enterpriseeventde_eventdefinition_ptr__5b4562bd_fk_posthog_e"
```

**Even if one existed, this query could not return it.** The enterprise table has no `team_id` or `project_id` column — in Django multi-table inheritance those live only on the parent. So the unqualified `COALESCE(project_id, team_id)` in the `WHERE` clause always reads base-table columns. On the enterprise-only side of a full join those are NULL, `COALESCE(NULL, NULL) = X` is NULL, and the row is filtered out before the join type can matter.

This one does not depend on the foreign key holding, which is why it is the argument worth trusting.

## How did you test this code?

One new test, `test_joins_the_enterprise_table_with_a_left_join`. It guards a plan invariant, not a behavioral one — no behavioral test can distinguish the two joins here, which is the whole point of the section above. It runs with no database.

The behavioral risk of this change is the opposite direction: a join that drops base rows with no enterprise child. That is already covered, and covered hard. Flipping this line to `INNER JOIN` locally fails **23 existing tests** in `posthog/api/test/test_event_definition.py`, including `test_list_event_definitions`, the search-ordering cases, and the whole `TestEventDefinitionExcludeStale` class. The reverse case — enterprise rows appearing — is covered by `ee/api/test/test_event_definition.py::test_list_event_definitions`, whose fixtures are all enterprise rows.

<details>
<summary>Row-equivalence check against a real orphan</summary>

Run against a scratch database cloned from the dev schema. The foreign key is `DEFERRABLE INITIALLY DEFERRED`, so an orphan can be created inside a transaction and queried before the constraint is checked at commit — no trigger surgery, and the production constraint state is left intact.

Fixtures: a base row with an enterprise child, a base row without one, a legacy row (`project_id IS NULL`), a row in a different project, and one orphan enterprise row.

Both joins return the same three rows, and the symmetric difference is empty:

```
===== C. Symmetric difference — any row returned by one and not the other =====
 side | id | name | description | verified
------+----+------+-------------+----------
(0 rows)
```

The orphan is present in the table and reachable with no scope filter, which is what makes the second argument load-bearing rather than theoretical:

```
    base_id    |     description      | effective_scope
---------------+----------------------+-----------------
 (no base row) | ORPHAN — no base row |
```

Its `effective_scope` is NULL, so the scope filter drops it. Re-checked with `exclude_hidden=true` and with the `verified` filter, since those conditions do read enterprise columns. Symmetric difference empty in both.

</details>

<details>
<summary>Plans, before and after</summary>

Local Postgres seeded with 605k definitions across 3000 projects and 302k enterprise rows, querying a project holding 5000 definitions, no `event_type` filter.

`FULL OUTER JOIN`:

```
Hash Full Join (actual rows=5000)
  Buffers: shared hit=4698 read=6413, temp read=4654 written=4654
  ->  Seq Scan on posthog_eventdefinition (actual rows=605000)
  ->  Hash (actual rows=302306)
        ->  Seq Scan on ee_enterpriseeventdefinition (actual rows=302306)
Execution Time: 435.820 ms
```

`LEFT JOIN`:

```
Hash Right Join (actual rows=5000)
  Buffers: shared hit=3839
  ->  Seq Scan on ee_enterpriseeventdefinition (actual rows=302306)
  ->  Hash (actual rows=5000)
        ->  Bitmap Heap Scan on posthog_eventdefinition (actual rows=5000)
              ->  Bitmap Index Scan on event_definition_proj_uniq (actual rows=5000)
                    Index Cond: (COALESCE(project_id, (team_id)::bigint) = 9999)
Execution Time: 47.756 ms
```

Adding `name NOT LIKE '$%'` to the full-join form produces the good plan, which is why the problem is parameter-dependent. Restoring the older non-COALESCE scope filter under the full join also produces the good plan, which pins the interaction on the join type rather than on either change alone.

</details>

Ran the SQL-builder tests and the list tests locally. Repo-wide `mypy` was clean on the pre-split branch and this diff does not change types.

Not run: no manual testing in a browser. The change is invisible in the UI.

> [!NOTE]
> Stacked on [#90873](https://github.com/PostHog/posthog/pull/90873), which carries the column-ordering half. That half was split out at review request because it is uncontroversial and this one needed the reasoning above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.

The original ask was to rewrite the scope filter onto the coalesce index. That turned out to be already done, so the investigation moved to what else could produce a sequential scan; reproducing the plan locally found the join.

Review then asked whether the enterprise table can hold definitions the base table does not have. The first version of this PR answered that from the foreign key alone, which is the weaker of the two available arguments — it holds only as long as the constraint does. The orphan test above was written to find the stronger one, and did. Both are now in the code comment.

Adding a `(project_id, name)` index was considered and dropped: the plan shows the existing coalesce index serving the query once the join stops blocking it.

No customer data, logs, or thread contents reached this diff. The seed and fixture data behind every result above is synthetic.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KUMHT64A/p1787845895091329?thread_ts=1787845895.091329&cid=C09KUMHT64A)*
