### PR TITLE
fix(proxy): omit redirect metadata when disabled

### DIFF
--- a/posthog/temporal/proxy_service/cloudflare.py
+++ b/posthog/temporal/proxy_service/cloudflare.py
@@ -264,7 +264,7 @@ def create_custom_hostname(domain: str, root_redirect_url: str | None = None) ->
             },
         },
     }
-    if root_redirect_url is not None:
+    if root_redirect_url:
         payload["custom_metadata"] = {"root_redirect_url": root_redirect_url}
 
     response = requests.post(url, headers=_get_headers(), json=payload, timeout=CLOUDFLARE_API_TIMEOUT_S)

--- a/posthog/temporal/proxy_service/cloudflare.py
+++ b/posthog/temporal/proxy_service/cloudflare.py
@@ -263,8 +263,9 @@ def create_custom_hostname(domain: str, root_redirect_url: str | None = None) ->
                 "min_tls_version": CLOUDFLARE_MIN_TLS_VERSION,
             },
         },
-        "custom_metadata": {"root_redirect_url": root_redirect_url or ""},
     }
+    if root_redirect_url is not None:
+        payload["custom_metadata"] = {"root_redirect_url": root_redirect_url}
 
     response = requests.post(url, headers=_get_headers(), json=payload, timeout=CLOUDFLARE_API_TIMEOUT_S)
     data = _handle_response(response)

--- a/posthog/temporal/proxy_service/test/test_cloudflare.py
+++ b/posthog/temporal/proxy_service/test/test_cloudflare.py
@@ -147,6 +147,17 @@ class TestCreateCustomHostname(SimpleTestCase):
             timeout=8.0,
         )
 
+    @patch("posthog.temporal.proxy_service.cloudflare.requests.post")
+    def test_omits_redirect_metadata_when_root_redirect_is_disabled(self, post_request):
+        response = Mock()
+        response.json.return_value = {"success": True, "result": _hostname_payload()}
+        post_request.return_value = response
+
+        create_custom_hostname("p.example.com")
+
+        request_payload = post_request.call_args.kwargs["json"]
+        assert "custom_metadata" not in request_payload
+
     @patch("posthog.temporal.proxy_service.cloudflare.requests.patch")
     def test_preserves_existing_metadata(self, patch_request):
         hostname = _parse_hostname(_hostname_payload(custom_metadata={"existing": "value"}))


### PR DESCRIPTION
## Problem

Managed reverse proxies send an empty custom metadata object when root redirects are disabled. This adds unnecessary configuration to Cloudflare-managed hostnames.

## Changes

- Cloudflare custom-hostname requests omit custom metadata unless a root redirect URL is configured
- Existing root redirect configuration continues to send its metadata
- No user-visible UI changes require screenshots

## How did you test this code?

- Added a regression test for requests without a root redirect URL
- `uv run ruff check posthog/temporal/proxy_service/cloudflare.py posthog/temporal/proxy_service/test/test_cloudflare.py` passed
- `uv run ruff format --check posthog/temporal/proxy_service/cloudflare.py posthog/temporal/proxy_service/test/test_cloudflare.py` passed
- The focused pytest file could not run because the local PostgreSQL service is unavailable

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change with repository tools. Skills invoked: `/writing-dataclasses`, `/maintaining-python-tests`, `/writing-tests`, and `/writing-pr-descriptions`. The implementation keeps the existing function contract and limits the change to the Cloudflare request payload.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*