### PR TITLE
feat(replay_vision): draft the model and a credit budget for goal-based scanners

### DIFF
--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -1278,14 +1278,15 @@ class DraftScannerRequestSerializer(serializers.Serializer):
         max_length=2000,
         help_text="What the user wants to accomplish, e.g. 'find out where users get stuck during onboarding'.",
     )
-    monthly_scan_budget = serializers.IntegerField(
+    monthly_credit_budget = serializers.IntegerField(
         required=False,
         min_value=1,
-        max_value=1_000_000,
+        max_value=100_000_000,
         help_text=(
-            "Goal-based flow only: how many replays a month the scanner may watch. The draft solves "
-            "`sampling_mode` and `sampling_rate` so the projection lands on this number. Omitted on the "
-            "legacy flow, and ignored while the goal-based flow's flag is off for the caller."
+            "Goal-based flow only: credits a month to spend (1 credit = $0.01). The draft picks the "
+            "`model`, then solves `sampling_mode` and `sampling_rate` so the projected spend lands on "
+            "this number, and sets `credit_limit` to it as a hard cap. Omitted on the legacy flow, and "
+            "ignored while the goal-based flow's flag is off for the caller."
         ),
     )
 
@@ -1324,18 +1325,33 @@ class DraftScannerResponseSerializer(serializers.Serializer):
     sampling_rate = serializers.FloatField(
         allow_null=True,
         help_text=(
-            "Goal-based flow only: the random sampling rate solved from `monthly_scan_budget`, 0..1. "
+            "Goal-based flow only: the random sampling rate solved from `monthly_credit_budget`, 0..1. "
             "1.0 when the budget covers every matching recording. Floored at the minimum rate, so a "
             "budget below that floor keeps the minimum. Null whenever `sampling_mode` is."
+        ),
+    )
+    model = serializers.ChoiceField(
+        choices=ScannerModel.choices,
+        allow_null=True,
+        help_text=(
+            "Goal-based flow only: the observation model the draft chose for the goal, by how much "
+            "judgment it needs. Null on the legacy flow, where the wizard keeps its default model."
+        ),
+    )
+    credit_limit = serializers.IntegerField(
+        allow_null=True,
+        help_text=(
+            "Goal-based flow only: the monthly credit cap, set to `monthly_credit_budget` so a "
+            "mis-estimate stops the scanner at the credits the user agreed to. Null on the legacy flow."
         ),
     )
     estimated_monthly_observations = serializers.IntegerField(
         allow_null=True,
         help_text=(
             "Goal-based flow only: recordings a month the drafted scanner is projected to watch under "
-            "the solved dials. At or under `monthly_scan_budget`, except when the budget is below what "
-            "the minimum sampling rate can reach, where this is the floor and exceeds the budget. Null "
-            "whenever `sampling_mode` is."
+            "the solved dials. Its credit cost lands at or under `monthly_credit_budget`, except when "
+            "the budget is below what the minimum sampling rate can reach, where this is the floor and "
+            "exceeds the budget. Null whenever `sampling_mode` is."
         ),
     )
 
@@ -2103,16 +2119,16 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         body.is_valid(raise_exception=True)
 
         goal = body.validated_data["goal"]
-        monthly_scan_budget = body.validated_data.get("monthly_scan_budget")
+        monthly_credit_budget = body.validated_data.get("monthly_credit_budget")
         # A budget only means the goal-based flow when the flag says so: on a client/rollout skew
         # the request degrades to a legacy draft instead of half-applying the new flow.
-        goal_flow = monthly_scan_budget is not None and _goal_flow_enabled(cast(User, request.user), self.team)
+        goal_flow = monthly_credit_budget is not None and _goal_flow_enabled(cast(User, request.user), self.team)
         # The goal is customer text, so only its length goes into telemetry.
         draft_properties: dict[str, Any] = {
             "goal_length": len(goal),
             "team_id": self.team_id,
             "goal_flow": goal_flow,
-            "monthly_scan_budget": monthly_scan_budget,
+            "monthly_credit_budget": monthly_credit_budget,
         }
         # Core memory's own API is INTERNAL (session-only), so scoped tokens must not
         # receive its content through the draft either.
@@ -2124,7 +2140,7 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                     team=self.team,
                     user=cast(User, request.user),
                     goal=goal,
-                    monthly_scan_budget=cast(int, monthly_scan_budget),
+                    monthly_credit_budget=cast(int, monthly_credit_budget),
                     user_access_control=self.user_access_control,
                     include_business_context=include_business_context,
                 )
@@ -2161,6 +2177,8 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                 "has_query": bool(drafted.query),
                 "sampling_mode": drafted.sampling_mode,
                 "sampling_rate": drafted.sampling_rate,
+                "model": drafted.model,
+                "credit_limit": drafted.credit_limit,
                 "estimated_monthly_observations": drafted.estimated_monthly_observations,
             },
             team=self.team,
@@ -2178,6 +2196,8 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                     "query": drafted.query,
                     "sampling_mode": drafted.sampling_mode,
                     "sampling_rate": drafted.sampling_rate,
+                    "model": drafted.model,
+                    "credit_limit": drafted.credit_limit,
                     "estimated_monthly_observations": drafted.estimated_monthly_observations,
                 }
             ).data

--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -30,7 +30,8 @@ from posthog.models.team import Team
 from posthog.models.user import User
 
 from products.access_control.backend.facade.user_access_control import UserAccessControl
-from products.replay_vision.backend.models.replay_scanner import ReplayScanner, SamplingMode, ScannerType
+from products.replay_vision.backend.billing import observation_credits_for_model
+from products.replay_vision.backend.models.replay_scanner import ReplayScanner, SamplingMode, ScannerModel, ScannerType
 from products.replay_vision.backend.queries.scanner_candidate_query import MIN_SAMPLING_RATE, SAMPLE_RATE_PRECISION
 from products.replay_vision.backend.queries.scanner_volume_estimate import (
     PREVIEW_ESTIMATE_BUDGET,
@@ -146,6 +147,10 @@ class ScannerDraft:
     sampling_mode: str | None = None
     sampling_rate: float | None = None
     estimated_monthly_observations: int | None = None
+    # The observation model the goal-based flow chose, and the monthly credit cap set to the stated
+    # budget so a mis-estimate cannot overspend it. None on the legacy path.
+    model: str | None = None
+    credit_limit: int | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -574,6 +579,14 @@ class _LlmDraftV2(BaseModel):
         default="comprehensive",
         description="Which sessions deserve the budget when it cannot cover everything; see the drafting rules.",
     )
+    model: Literal["gemini-3.5-flash-lite", "gemini-3-flash-preview", "gemini-3.7-flash"] = Field(
+        default="gemini-3-flash-preview",
+        description="The model that watches each recording. Pick by how much judgment the goal needs: "
+        "'gemini-3.5-flash-lite' (cheapest, 2 credits) for a simple yes/no check, 'gemini-3-flash-preview' "
+        "(balanced, 5 credits) for an everyday scanner, 'gemini-3.7-flash' (most capable, 15 credits) for "
+        "nuanced scoring, summarizing, or subtle judgment. A pricier model watches fewer recordings for the "
+        "same budget, so only step up when the goal truly needs the extra judgment.",
+    )
 
 
 _SYSTEM_PROMPT_V2 = """
@@ -630,9 +643,17 @@ Pick the single type that best fits the goal, then draft the scanner:
   - balanced: drops only the least eventful sessions. For general questions tilted toward engaged usage.
   - focused: keeps only clearly eventful sessions. Only when the goal explicitly hunts intense moments:
     rage, frustration, heavy usage, power users.
-- rationale: one or two sentences, addressed to the user, explaining why the chosen type and settings fit
-  their goal (e.g. why a classifier rather than a scorer, or which pages the filter covers and why). It is
-  shown next to the draft; plain language, and don't restate the config itself.
+- model: which model watches each recording, chosen by how much judgment the goal needs, NOT by budget
+  (the budget is spent by watching fewer recordings, never by dropping to a weaker model):
+  - gemini-3.5-flash-lite (cheapest): a simple, unambiguous yes/no monitor where the answer is obvious
+    from the recording ("did the user reach the confirmation page?").
+  - gemini-3-flash-preview (balanced): the default. Most everyday monitors and classifiers, where the
+    judgment is moderate.
+  - gemini-3.7-flash (most capable): scoring intensity, summarizing, or any goal needing subtle reading
+    of intent, emotion, or a hard multi-step judgment.
+- rationale: one or two sentences, addressed to the user, explaining why the chosen type, model, and
+  settings fit their goal (e.g. why a scorer on the capable model, or which pages the filter covers and
+  why). It is shown next to the draft; plain language, and don't restate the config itself.
 
 The briefing may include the company's name, its business context, and the team's existing scanners:
 - Use the business context to make the name, description, and prompt specific to THIS company's product,
@@ -756,10 +777,14 @@ def _solve_budget(
     team: Team,
     user: User,
     query: dict[str, Any] | None,
-    monthly_scan_budget: int,
+    monthly_credit_budget: int,
+    credits_per_observation: int,
     model_mode: str,
 ) -> _BudgetSolution:
-    """Set the two dials from the stated budget.
+    """Set the two dials from the stated credit budget.
+
+    The budget is credits, so the number of recordings it buys depends on the chosen model's price:
+    a pricier model buys fewer recordings. Convert to an observation budget first, then solve.
 
     Budget covers everything: watch everything. No quality filter, no sampling — a filter would only
     hide sessions the budget could have paid for.
@@ -770,6 +795,7 @@ def _solve_budget(
 
     Raises on estimate failure; the caller degrades to an uncosted draft.
     """
+    monthly_scan_budget = monthly_credit_budget // max(1, credits_per_observation)
     recordings_query = RecordingsQuery.model_validate(query or {"kind": "RecordingsQuery"})
     comprehensive = estimate_scanner_session_volume(
         team=team,
@@ -861,6 +887,7 @@ def _finalize_v2(
         rationale=parsed.rationale.strip()[:_MAX_RATIONALE_LENGTH],
         query=query,
         sampling_mode=parsed.sampling_mode,
+        model=parsed.model,
     )
 
 
@@ -869,12 +896,12 @@ def draft_scanner_from_goal_v2(
     team: Team,
     user: User,
     goal: str,
-    monthly_scan_budget: int,
+    monthly_credit_budget: int,
     user_access_control: UserAccessControl,
     include_business_context: bool = True,
 ) -> ScannerDraft:
     """The goal-based flow: ground the goal in the team's real pages, draft the whole scanner in one
-    model call, then solve the sampling dials from the stated monthly budget.
+    model call, then solve the sampling dials from the stated monthly credit budget.
 
     Raises DraftError on model failure. A costing failure does not fail the draft: the sampling
     fields come back None and the wizard keeps its defaults.
@@ -913,13 +940,17 @@ def draft_scanner_from_goal_v2(
         allowed_events=events,
         team_id=team.id,
     )
+    # The cap is the stated budget, so a mis-estimate stops the scanner at the credits the user
+    # agreed to rather than overspending. Kept even when costing fails, so the guardrail survives.
+    draft = replace(draft, credit_limit=monthly_credit_budget)
 
     try:
         solution = _solve_budget(
             team=team,
             user=user,
             query=draft.query,
-            monthly_scan_budget=monthly_scan_budget,
+            monthly_credit_budget=monthly_credit_budget,
+            credits_per_observation=observation_credits_for_model(draft.model or ScannerModel.GEMINI_3_FLASH_PREVIEW),
             model_mode=draft.sampling_mode or SamplingMode.COMPREHENSIVE,
         )
     except Exception:

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -448,6 +448,8 @@ class TestDraftScannerEndpoint(_VisionAPITestCase):
             # Goal-flow fields are null on the legacy path: the wizard keeps its own defaults.
             "sampling_mode": None,
             "sampling_rate": None,
+            "model": None,
+            "credit_limit": None,
             "estimated_monthly_observations": None,
         }
 
@@ -714,7 +716,7 @@ class TestFinalizeV2:
 
 
 class TestSolveBudget(_VisionAPITestCase):
-    def _solve(self, *, budget, model_mode="focused", monthly_by_mode=None):
+    def _solve(self, *, budget, model_mode="focused", monthly_by_mode=None, credits_per_observation=1):
         # Counting is ClickHouse's job with its own tests; these assert the dial arithmetic.
         monthly_by_mode = monthly_by_mode or {}
 
@@ -727,7 +729,10 @@ class TestSolveBudget(_VisionAPITestCase):
                 team=self.team,
                 user=self.user,
                 query=None,
-                monthly_scan_budget=budget,
+                # Default 1 credit per observation, so the credit budget equals the recording budget
+                # and these assertions stay about the dial arithmetic, not the price conversion.
+                monthly_credit_budget=budget,
+                credits_per_observation=credits_per_observation,
                 model_mode=model_mode,
             )
 
@@ -768,6 +773,17 @@ class TestSolveBudget(_VisionAPITestCase):
         assert solution.estimated_monthly_observations == round(10_000_000 * MIN_SAMPLING_RATE)
         assert solution.estimated_monthly_observations > 1
 
+    def test_a_pricier_model_buys_fewer_recordings_for_the_same_budget(self):
+        # 1000 credits at 5 credits/observation buys 200 recordings; the matched pool is larger, so
+        # the rate solves down to fit the 200 the budget can actually pay for.
+        solution = self._solve(
+            budget=1_000, credits_per_observation=5, model_mode="comprehensive", monthly_by_mode={"comprehensive": 800}
+        )
+
+        assert solution.sampling_mode == "comprehensive"
+        assert solution.sampling_rate < 1.0
+        assert solution.estimated_monthly_observations <= 200
+
 
 class TestDraftV2(_VisionAPITestCase):
     def _run(self, *, pages=(), generate=None, estimate_error=False):
@@ -789,7 +805,9 @@ class TestDraftV2(_VisionAPITestCase):
                 team=self.team,
                 user=self.user,
                 goal="find out where people give up in billing",
-                monthly_scan_budget=1_000,
+                # 10,000 credits at the default model's 5 credits/observation buys 2,000 recordings,
+                # above the 300 the estimate matches, so the floodgates case stays comprehensive.
+                monthly_credit_budget=10_000,
                 user_access_control=_access_control(allow=True),
             )
 
@@ -801,6 +819,9 @@ class TestDraftV2(_VisionAPITestCase):
         assert draft.sampling_mode is None
         assert draft.sampling_rate is None
         assert draft.estimated_monthly_observations is None
+        # The credit cap and model are the guardrail, so they survive a costing failure.
+        assert draft.credit_limit == 10_000
+        assert draft.model == "gemini-3-flash-preview"
 
     def test_a_pages_query_failure_still_drafts_from_events(self):
         with (
@@ -815,7 +836,7 @@ class TestDraftV2(_VisionAPITestCase):
                 team=self.team,
                 user=self.user,
                 goal="billing",
-                monthly_scan_budget=100,
+                monthly_credit_budget=100,
                 user_access_control=_access_control(allow=True),
             )
 
@@ -831,6 +852,12 @@ class TestDraftV2(_VisionAPITestCase):
         assert draft.sampling_mode == "comprehensive"
         assert draft.sampling_rate == 1.0
         assert draft.estimated_monthly_observations == 300
+
+    def test_the_model_and_credit_cap_reach_the_draft(self):
+        draft = self._run(pages=("/billing",), generate=_draft_v2(model="gemini-3.7-flash"))
+
+        assert draft.model == "gemini-3.7-flash"
+        assert draft.credit_limit == 10_000
 
 
 class TestDraftEndpointGoalFlow(_VisionAPITestCase):
@@ -854,6 +881,8 @@ class TestDraftEndpointGoalFlow(_VisionAPITestCase):
             sampling_mode="comprehensive",
             sampling_rate=0.25,
             estimated_monthly_observations=1_000,
+            model="gemini-3.7-flash",
+            credit_limit=5_000,
         )
 
     def test_budget_with_the_flag_on_takes_the_goal_flow(self):
@@ -863,15 +892,17 @@ class TestDraftEndpointGoalFlow(_VisionAPITestCase):
             patch(f"{_API_MODULE}.draft_scanner_from_goal") as legacy,
         ):
             resp = self.client.post(
-                self.draft_url, data={"goal": "billing give-ups", "monthly_scan_budget": 1000}, format="json"
+                self.draft_url, data={"goal": "billing give-ups", "monthly_credit_budget": 5000}, format="json"
             )
 
         assert resp.status_code == status.HTTP_200_OK
         assert not legacy.called
-        assert v2.call_args.kwargs["monthly_scan_budget"] == 1000
+        assert v2.call_args.kwargs["monthly_credit_budget"] == 5000
         body = resp.json()
         assert body["sampling_mode"] == "comprehensive"
         assert body["sampling_rate"] == 0.25
+        assert body["model"] == "gemini-3.7-flash"
+        assert body["credit_limit"] == 5000
         assert body["estimated_monthly_observations"] == 1000
 
     def test_budget_with_the_flag_off_degrades_to_the_legacy_draft(self):
@@ -883,7 +914,7 @@ class TestDraftEndpointGoalFlow(_VisionAPITestCase):
             patch(_GENERATE_PATH, return_value=_draft()),
         ):
             resp = self.client.post(
-                self.draft_url, data={"goal": "billing give-ups", "monthly_scan_budget": 1000}, format="json"
+                self.draft_url, data={"goal": "billing give-ups", "monthly_credit_budget": 1000}, format="json"
             )
 
         assert resp.status_code == status.HTTP_200_OK
@@ -891,6 +922,8 @@ class TestDraftEndpointGoalFlow(_VisionAPITestCase):
         body = resp.json()
         assert body["sampling_mode"] is None
         assert body["sampling_rate"] is None
+        assert body["model"] is None
+        assert body["credit_limit"] is None
         assert body["estimated_monthly_observations"] is None
 
     def test_no_budget_never_consults_the_flag(self):

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -2365,11 +2365,11 @@ export interface DraftScannerRequestApi {
      */
     goal: string
     /**
-     * Goal-based flow only: how many replays a month the scanner may watch. The draft solves `sampling_mode` and `sampling_rate` so the projection lands on this number. Omitted on the legacy flow, and ignored while the goal-based flow's flag is off for the caller.
+     * Goal-based flow only: credits a month to spend (1 credit = $0.01). The draft picks the `model`, then solves `sampling_mode` and `sampling_rate` so the projected spend lands on this number, and sets `credit_limit` to it as a hard cap. Omitted on the legacy flow, and ignored while the goal-based flow's flag is off for the caller.
      * @minimum 1
-     * @maximum 1000000
+     * @maximum 100000000
      */
-    monthly_scan_budget?: number
+    monthly_credit_budget?: number
 }
 
 /**
@@ -2400,12 +2400,23 @@ export interface DraftScannerResponseApi {
      * * `comprehensive` - Comprehensive */
     sampling_mode: SamplingModeEnumApi | null
     /**
-     * Goal-based flow only: the random sampling rate solved from `monthly_scan_budget`, 0..1. 1.0 when the budget covers every matching recording. Floored at the minimum rate, so a budget below that floor keeps the minimum. Null whenever `sampling_mode` is.
+     * Goal-based flow only: the random sampling rate solved from `monthly_credit_budget`, 0..1. 1.0 when the budget covers every matching recording. Floored at the minimum rate, so a budget below that floor keeps the minimum. Null whenever `sampling_mode` is.
      * @nullable
      */
     sampling_rate: number | null
+    /** Goal-based flow only: the observation model the draft chose for the goal, by how much judgment it needs. Null on the legacy flow, where the wizard keeps its default model.
+     *
+     * * `gemini-3.5-flash-lite` - Gemini 3.5 Flash Lite
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+     * * `gemini-3.7-flash` - Gemini 3.7 Flash */
+    model: ScannerModelEnumApi | null
     /**
-     * Goal-based flow only: recordings a month the drafted scanner is projected to watch under the solved dials. At or under `monthly_scan_budget`, except when the budget is below what the minimum sampling rate can reach, where this is the floor and exceeds the budget. Null whenever `sampling_mode` is.
+     * Goal-based flow only: the monthly credit cap, set to `monthly_credit_budget` so a mis-estimate stops the scanner at the credits the user agreed to. Null on the legacy flow.
+     * @nullable
+     */
+    credit_limit: number | null
+    /**
+     * Goal-based flow only: recordings a month the drafted scanner is projected to watch under the solved dials. Its credit cost lands at or under `monthly_credit_budget`, except when the budget is below what the minimum sampling rate can reach, where this is the floor and exceeds the budget. Null whenever `sampling_mode` is.
      * @nullable
      */
     estimated_monthly_observations: number | null

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -1454,7 +1454,7 @@ export const VisionScannersScoutsCreateBody = /* @__PURE__ */ zod
  */
 export const visionScannersDraftCreateBodyGoalMax = 2000
 
-export const visionScannersDraftCreateBodyMonthlyScanBudgetMax = 1000000
+export const visionScannersDraftCreateBodyMonthlyCreditBudgetMax = 100000000
 
 export const VisionScannersDraftCreateBody = /* @__PURE__ */ zod
     .object({
@@ -1462,13 +1462,13 @@ export const VisionScannersDraftCreateBody = /* @__PURE__ */ zod
             .string()
             .max(visionScannersDraftCreateBodyGoalMax)
             .describe("What the user wants to accomplish, e.g. 'find out where users get stuck during onboarding'."),
-        monthly_scan_budget: zod
+        monthly_credit_budget: zod
             .number()
             .min(1)
-            .max(visionScannersDraftCreateBodyMonthlyScanBudgetMax)
+            .max(visionScannersDraftCreateBodyMonthlyCreditBudgetMax)
             .optional()
             .describe(
-                "Goal-based flow only: how many replays a month the scanner may watch. The draft solves `sampling_mode` and `sampling_rate` so the projection lands on this number. Omitted on the legacy flow, and ignored while the goal-based flow's flag is off for the caller."
+                "Goal-based flow only: credits a month to spend (1 credit = $0.01). The draft picks the `model`, then solves `sampling_mode` and `sampling_rate` so the projected spend lands on this number, and sets `credit_limit` to it as a hard cap. Omitted on the legacy flow, and ignored while the goal-based flow's flag is off for the caller."
             ),
     })
     .describe("Body of POST \/vision\/scanners\/draft\/ — the user's goal, stated in their own words.")

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -28784,11 +28784,11 @@ export namespace Schemas {
          */
       goal: string;
       /**
-         * Goal-based flow only: how many replays a month the scanner may watch. The draft solves `sampling_mode` and `sampling_rate` so the projection lands on this number. Omitted on the legacy flow, and ignored while the goal-based flow's flag is off for the caller.
+         * Goal-based flow only: credits a month to spend (1 credit = $0.01). The draft picks the `model`, then solves `sampling_mode` and `sampling_rate` so the projected spend lands on this number, and sets `credit_limit` to it as a hard cap. Omitted on the legacy flow, and ignored while the goal-based flow's flag is off for the caller.
          * @minimum 1
-         * @maximum 1000000
+         * @maximum 100000000
          */
-      monthly_scan_budget?: number;
+      monthly_credit_budget?: number;
     }
 
     /**
@@ -28822,6 +28822,20 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `gemini-3.5-flash-lite` - Gemini 3.5 Flash Lite
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+     * * `gemini-3.7-flash` - Gemini 3.7 Flash
+     */
+    export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
+
+
+    export const ScannerModelEnum = {
+      Gemini35FlashLite: 'gemini-3.5-flash-lite',
+      Gemini3FlashPreview: 'gemini-3-flash-preview',
+      Gemini37Flash: 'gemini-3.7-flash',
+    } as const;
+
+    /**
      * An AI-drafted scanner configuration, ready to seed the creation wizard. Nothing is persisted.
      */
     export interface DraftScannerResponse {
@@ -28849,12 +28863,23 @@ export namespace Schemas {
        * * `comprehensive` - Comprehensive */
       sampling_mode: SamplingModeEnum | null;
       /**
-         * Goal-based flow only: the random sampling rate solved from `monthly_scan_budget`, 0..1. 1.0 when the budget covers every matching recording. Floored at the minimum rate, so a budget below that floor keeps the minimum. Null whenever `sampling_mode` is.
+         * Goal-based flow only: the random sampling rate solved from `monthly_credit_budget`, 0..1. 1.0 when the budget covers every matching recording. Floored at the minimum rate, so a budget below that floor keeps the minimum. Null whenever `sampling_mode` is.
          * @nullable
          */
       sampling_rate: number | null;
+      /** Goal-based flow only: the observation model the draft chose for the goal, by how much judgment it needs. Null on the legacy flow, where the wizard keeps its default model.
+       *
+       * * `gemini-3.5-flash-lite` - Gemini 3.5 Flash Lite
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.7-flash` - Gemini 3.7 Flash */
+      model: ScannerModelEnum | null;
       /**
-         * Goal-based flow only: recordings a month the drafted scanner is projected to watch under the solved dials. At or under `monthly_scan_budget`, except when the budget is below what the minimum sampling rate can reach, where this is the floor and exceeds the budget. Null whenever `sampling_mode` is.
+         * Goal-based flow only: the monthly credit cap, set to `monthly_credit_budget` so a mis-estimate stops the scanner at the credits the user agreed to. Null on the legacy flow.
+         * @nullable
+         */
+      credit_limit: number | null;
+      /**
+         * Goal-based flow only: recordings a month the drafted scanner is projected to watch under the solved dials. Its credit cost lands at or under `monthly_credit_budget`, except when the budget is below what the minimum sampling rate can reach, where this is the floor and exceeds the budget. Null whenever `sampling_mode` is.
          * @nullable
          */
       estimated_monthly_observations: number | null;
@@ -31832,20 +31857,6 @@ export namespace Schemas {
       /** Hash of the uploaded symbol set content. */
       content_hash: string;
     }
-
-    /**
-     * * `gemini-3.5-flash-lite` - Gemini 3.5 Flash Lite
-     * * `gemini-3-flash-preview` - Gemini 3 Flash
-     * * `gemini-3.7-flash` - Gemini 3.7 Flash
-     */
-    export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
-
-
-    export const ScannerModelEnum = {
-      Gemini35FlashLite: 'gemini-3.5-flash-lite',
-      Gemini3FlashPreview: 'gemini-3-flash-preview',
-      Gemini37Flash: 'gemini-3.7-flash',
-    } as const;
 
     /**
      * The experiment a scanner watches. Scans derive their person-scoped exposure filter from


### PR DESCRIPTION
## Problem

The goal-based scanner draft always used one fixed model and asked for a recording count. A recording count does not map to a fixed cost once the model can vary, and nothing capped what a mis-estimate could spend.

This is the backend layer of the goal-based creation flow, split out from [#88905](https://github.com/PostHog/posthog/pull/88905) so the cost and credit-cap logic reviews on its own. The frontend that consumes it stacks on top. Everything is behind the `vision-goal-based-creation-flow` flag, `test` variant only. Flag off changes nothing.

## Changes

- The draft picks the observation model by how much judgment the goal needs: cheapest for a simple yes/no monitor, most capable for nuanced scoring or summaries.
- The request takes a monthly credit budget instead of a recording count. `_solve_budget` converts credits to a recording budget at the chosen model's price, so a pricier model watches fewer recordings for the same spend.
- The draft sets the scanner's `credit_limit` to the stated budget, so a mis-estimate stops the scanner at the credits the user agreed to. This is a default the create endpoint re-validates; the runtime cap enforcement is unchanged.
- Mechanical: renamed the request field `monthly_scan_budget` to `monthly_credit_budget`, regenerated frontend and MCP types.

The runtime credit-cap enforcement (quota, budget check, observation gate) is not touched.

## How did you test this code?

- `test_scanner_draft.py`: the draft picks a model, converts the credit budget at that model's price, and sets the cap. Catches a pricier model no longer buying fewer recordings, and a lost cap. 78 tests pass locally.
- The generated type files match `hogli build:openapi` output exactly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split from #88905 with Claude Code to isolate the cost/credit logic for review. No customer conversation, ticket, or log shaped this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
