### PR TITLE
feat(aio): add cache optimization scout template to self-driving tab

### DIFF
--- a/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
+++ b/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
@@ -1,0 +1,159 @@
+---
+name: signals-scout-ai-observability-cache-optimization
+description: >
+  Finds AI workloads that resend a large stable prompt prefix without caching it, verifies the gap
+  at the call site in code, and reports only fixes with a positive net saving.
+scout-tags:
+  - ai-observability
+---
+
+# AI cache optimization
+
+Watch LLM generation events for workloads that repeat a large prompt but do not cache it. Report the workloads where a cache fix cuts input cost, and only when you have located the fix in code.
+
+Cached input tokens usually cost a tenth to half the uncached rate, so caching is one of the cheapest savings available. The gaps are also easy to reintroduce without noticing: a refactor drops a cache marker, or a new feature injects dynamic content ahead of the stable prompt. Watch for both the missing setup and the silent regression.
+
+## Use the packaged analysis skills
+
+Load these preinstalled skills through the runtime's packaged-skill mechanism when relevant:
+
+- `exploring-llm-costs`
+- `exploring-llm-traces`
+- `querying-posthog-data`
+
+These are packaged runtime skills, not project skill-store entries. Do not use `skill-list` or `skill-get` to load them.
+
+## Avoid duplicate work
+
+Read this Scout's last 14 days of run summaries with `scout-runs-list`, filtered by its exact `skill_name` and current `skill_version`. Retrieve relevant details with `scout-runs-retrieve`.
+
+Search the scratchpad and recent Inbox reports for the workflow, model, and call site. If a live report already covers the same workflow, add only materially new evidence with `scout-edit-report`. Skip unchanged issues. Never create a second report for an unchanged issue.
+
+## Data source
+
+Read `$ai_generation` events from the last 7 days, windowed on the ingestion timestamp. Prompts change often, so older windows mislead. Each row carries `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_cost_usd`, `output_cost_usd`, `model`, `provider`, and `input`.
+
+Exclude corrupt rows before you aggregate. Token counts far beyond the model's context window, and per-call costs far beyond what the token counts can produce, inflate every total.
+
+## Split into workflows
+
+Group so each row is one repeated workflow, not one mixed bucket. Split on the feature or product tag, the `model`, the `provider`, and the prompt, trace, or span name. In a multi-tenant project, split on the tenant id too.
+
+A workflow is one product surface plus one model that sends a similar prompt shape many times.
+
+## Token semantics
+
+The model family sets how the provider counts input tokens. Handle each family on its own.
+
+- Claude models: `input_tokens` excludes cache. Total input equals `input_tokens` plus `cache_read` plus `cache_write`. Uncached input equals `input_tokens`.
+- All other models: `input_tokens` includes cache. Uncached input equals `input_tokens` minus `cache_read`.
+
+Read the family from the `model` string, not the `provider` field. The `provider` field is not reliable.
+
+For cost, add `input_cost_usd` and `output_cost_usd`. Do not trust `total_cost_usd`. It undercounts Claude rows.
+
+## Detect an underperforming cache
+
+For each workflow, compute the cache-hit ratio: `cache_read` divided by the sum of uncached input, `cache_read`, and `cache_write`. Then compute the uncached input cost: uncached input tokens times the workflow input rate. Read the input rate from rows where `cache_read` and `cache_write` are both zero.
+
+Flag a workflow when its hit ratio sits below its peers and its uncached input cost is high. Compare each workflow against four baselines.
+
+1. Its own past weeks.
+2. Other workflows on the same model.
+3. The same workflow on its other models.
+4. The best-caching workflow in the same project.
+
+Baseline 3 catches the classic false positive. A span or prompt name usually covers several models. When the same name caches well on its main model and badly on a smaller slice, the workflow is not uncached: the gap lives in one slice, and its fix lives at a different call site from the one that already caches. Say which model slice you mean.
+
+## Confirm the prefix repeats
+
+A low hit ratio alone proves nothing. Some prompts differ on every call. Before going further, sample the `input` field and measure two separate things per workflow.
+
+- The repeat share: how many calls start with the same content at all.
+- The common prefix length: how far into the prompt those calls stay identical, in tokens.
+
+Measure the prefix. Do not infer it from a fixed-size hash: a hash of the first 1,500 characters proves that about 375 tokens match and says nothing about the rest.
+
+Then check the measured prefix against the provider's minimum cacheable prefix. Below the minimum the provider ignores the breakpoint silently: `cache_creation_input_tokens` stays 0 and no error is raised, so no fix is possible there. Anthropic needs 1024 tokens for Sonnet and Opus and 2048 for Haiku. OpenAI needs 1024. For other families, look up the documented minimum rather than assuming there is none.
+
+If the captured `input` is redacted or truncated, you cannot measure the prefix. Hold the candidate rather than reporting an unverifiable one.
+
+## Check the reuse shape
+
+A stable prefix only pays off when a later call reads it back, inside the provider's cache time-to-live. Count the calls per trace or conversation, check whether the prompt grows across them, and check the spacing between calls against the TTL.
+
+- Many calls per trace with a growing prompt: an append-only loop where each turn resends the previous turns. Reuse is real and the saving is large.
+- One call per trace: nothing to reuse inside the trace. Only the prefix shared across traces is cacheable, which is usually just the system prompt. Check it against the minimum above.
+- Calls spaced past the TTL: every call writes and nothing reads. The fix is the reuse rate or the window, not a breakpoint.
+
+Report the shape you found. A workflow that is one-shot by construction cannot be fixed by a breakpoint, however much it spends.
+
+## What breaks a cache
+
+The provider keys the cache on the model, the tool definitions, the system content, and the exact token prefix, in request order. A single early volatile token invalidates everything after it, and a mismatch in tools or model means two call sites can never share a cache however similar their prompts look.
+
+A cache holds stable content: the system prompt, tool schemas, few-shot examples, fixed documents, and the conversation history up to the last turn. It cannot hold volatile content: the newest user message, per-call retrieved documents, timestamps, request ids, and user ids.
+
+So the fix is usually ordering. Put stable content first, volatile content last, and take timestamps and ids out of the prefix. Anthropic caches only where the code sets a `cache_control` breakpoint: put it at the end of the stable prefix, and cache the growing history at the last stable turn, not only the system prompt. OpenAI, Google, and DeepSeek cache the prefix automatically above a minimum, so ordering alone fixes them.
+
+## Confirm the fix in code
+
+The data shows a workflow does not cache. It cannot show whether that is an oversight, a deliberate choice, or unfixable. Read the call site before reporting. This gate removes most false positives: a candidate that clears the data checks is not a finding until you have read the code behind it.
+
+You can do this. Clone the repository the project is linked to, and use `gh` read access for anything outside the clone. Do the data work first and clone only once a candidate has cleared the checks above.
+
+Find the call site. Grep for the span or prompt name, the feature tag, and the model id. The span name is usually the class, function, or chain that builds the request, so it is the strongest search term. When it resolves to a class, read the class and its base classes: the volatile injection often lives in a wrapper or mixin, not in the file that names the span.
+
+Then answer four questions.
+
+1. Does this call site already cache? If the same class or helper sets a breakpoint for another model or caller, the gap is in one slice. Find that slice's own call site. Do not report against the shared prompt builder that already works.
+2. Is the absence deliberate? Code that strips or suppresses cache markers is a design decision until proven otherwise. Read the blame and the pull request that introduced it, and check its review discussion. State in the report either the reason you found or that you looked and found none. A report that reads as "nobody thought of caching here" when someone did gets dismissed.
+3. Does anything volatile sit in the prefix? A current timestamp, a request id, or an injected per-call context block ahead of the stable content defeats any breakpoint. If one is there, moving or pinning it is the fix, and it comes before the breakpoint.
+4. Would the fix reduce the bill? Re-check the reuse shape against what the code does. Code that summarizes, compacts, reranks, or classifies in a single pass has no second call to read the cache back.
+
+Name the exact file and function you would change, and derive the suggested reviewer from that file, using the repository's ownership files (`CODEOWNERS` or `owners.yaml`) when present. You found the gap in observability data, but the fix belongs to whoever owns the calling code: route the report to them. If you cannot find the call site, say so and lower your confidence. Do not present a guess at the call site as a located fix, and do not fall back to the product's main prompt builder as the target: that is usually the path that already caches correctly.
+
+If the project has no linked repository, report the finding as unverified, say which causes you could not rule out, and keep the estimate conservative.
+
+## Patterns to report
+
+Zero cache reads looks the same in the data whatever the cause. Name the cause in the report, because the fixes do not overlap.
+
+- No breakpoint: the code never marks a prefix, the input repeats, and the prefix clears the minimum. Set a breakpoint at the end of the stable prefix.
+- Volatile prefix: a per-call timestamp, id, or injected context block sits ahead of the stable content. Pin or move it first. A breakpoint alone changes nothing.
+- Under-caching: the hit ratio sits below peers and the input repeats. Extend the breakpoint to the full stable prefix.
+- Cache thrash: `cache_write` runs above `cache_read`. Fix the window or the reuse rate.
+- Repeated identical call: the same call recurs at a near-constant input size within one trace or conversation. That is usually a retry or compaction loop, not a caching gap. Lead with "this runs more often than it should" and mention caching only as a secondary mitigation.
+
+And the shapes that are not findings: no reuse available (one call per trace, or the shared prefix sits below the provider minimum), a deliberate removal whose stated reason still holds, a well-cached workflow at peer hit ratio, and low repetition with a repeat share below 0.25.
+
+## Estimate the net saving
+
+Build the estimate from the prefix you measured, not from a constant.
+
+Cacheable tokens equal the measured common prefix length times the number of calls that can read it back. A call reads back only when an earlier call in the same cache window already wrote the prefix, so the first call in each trace writes and does not read.
+
+The gross saving equals cacheable tokens times the input rate times the family discount: 0.9 for Claude, 0.5 for the auto-cache families. For providers that charge for writes, subtract the write cost: Anthropic bills cache writes at 1.25 times the input rate, so a breakpoint on a path that mostly writes and rarely reads raises the bill. Report the net figure. If the net saving is negative or trivial, do not file the finding.
+
+Never scale a saving by the total tokens of the calls that share a prefix. Only the shared part is cacheable. That mistake turns a short system prompt into a large fake number.
+
+## Disqualifiers
+
+Skip a workflow when any of these hold.
+
+- The repeat share sits below 0.25.
+- The uncached input cost sits below a floor worth a person's attention. Set the floor from the project's overall spend.
+- The measured common prefix sits below the provider's minimum cacheable prefix.
+- The workflow is one call per trace and the cross-trace prefix is below that minimum.
+- The model caches automatically and the prefix already matches.
+- The same workflow already caches well on another model and the path you would change is the one that already works.
+- The call site removes caching deliberately and the stated reason still holds.
+- The captured `input` is redacted or truncated, so the prefix cannot be measured.
+
+## When to stop
+
+Report only workflows with a repeated prefix above the provider minimum, a low hit ratio, reuse available in the call shape, a fix you located in code, and a positive net saving. Hold the rest.
+
+Title a new report `AI cache optimization: <workflow and cause>`. Include the comparison window, the measured prefix length, the reuse shape, the named cause, the file and function to change, and the net saving. Write memory for held candidates and close the run when nothing clears the bar.
+
+Finish with a short run summary covering what you checked, what you reported or updated, and what you ruled out.

--- a/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
+++ b/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
@@ -1,17 +1,20 @@
 ---
 name: signals-scout-ai-observability-cache-optimization
 description: >
-  Finds AI workloads that resend a large stable prompt prefix without caching it, verifies the gap
-  at the call site in code, and reports only fixes with a positive net saving.
+  Finds AI workloads that resend a large prompt prefix without caching it.
+  Verifies each gap at the call site in code and reports only fixes with a positive net saving.
 scout-tags:
   - ai-observability
 ---
 
 # AI cache optimization
 
-Watch LLM generation events for workloads that repeat a large prompt but do not cache it. Report the workloads where a cache fix cuts input cost, and only when you have located the fix in code.
+Watch LLM generation events for workloads that resend a large stable prompt without caching it.
+Report a workload only when you have located a code fix that cuts input cost.
 
-Cached input tokens usually cost a tenth to half the uncached rate, so caching is one of the cheapest savings available. The gaps are also easy to reintroduce without noticing: a refactor drops a cache marker, or a new feature injects dynamic content ahead of the stable prompt. Watch for both the missing setup and the silent regression.
+- Cached input tokens cost a tenth to half the uncached rate, so caching is one of the cheapest savings available.
+- Cache gaps also come back silently: a refactor drops a cache marker, or a new feature injects dynamic content ahead of the stable prompt.
+- Hunt both the missing setup and the silent regression.
 
 ## Use the packaged analysis skills
 
@@ -25,135 +28,146 @@ These are packaged runtime skills, not project skill-store entries. Do not use `
 
 ## Avoid duplicate work
 
-Read this Scout's last 14 days of run summaries with `scout-runs-list`, filtered by its exact `skill_name` and current `skill_version`. Retrieve relevant details with `scout-runs-retrieve`.
+- Read this scout's last 14 days of run summaries with `scout-runs-list`. Filter by its exact `skill_name` and current `skill_version`.
+- Retrieve details for relevant runs with `scout-runs-retrieve`.
+- Search the scratchpad and recent Inbox reports for the workflow, the model, and the call site.
+- If a live report covers the same workflow, add only materially new evidence with `scout-edit-report`.
+- Never create a second report for an unchanged issue.
 
-Search the scratchpad and recent Inbox reports for the workflow, model, and call site. If a live report already covers the same workflow, add only materially new evidence with `scout-edit-report`. Skip unchanged issues. Never create a second report for an unchanged issue.
+## Where to look
 
-## Data source
+- Read `$ai_generation` events from the last 7 days. Window on the ingestion timestamp: prompts change often, so older windows mislead.
+- Each row carries `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_cost_usd`, `output_cost_usd`, `model`, `provider`, and `input`.
+- Exclude corrupt rows before you aggregate: token counts far past the model's context window, and per-call costs far past what the tokens can produce.
+- Group rows into workflows. Split on the feature or product tag, the `model`, the `provider`, and the prompt, trace, or span name.
+- If the project is multi-tenant, split on the tenant id too.
+- A workflow is one product surface plus one model that sends a similar prompt shape many times.
 
-Read `$ai_generation` events from the last 7 days, windowed on the ingestion timestamp. Prompts change often, so older windows mislead. Each row carries `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_cost_usd`, `output_cost_usd`, `model`, `provider`, and `input`.
+## Token and cost semantics
 
-Exclude corrupt rows before you aggregate. Token counts far beyond the model's context window, and per-call costs far beyond what the token counts can produce, inflate every total.
-
-## Split into workflows
-
-Group so each row is one repeated workflow, not one mixed bucket. Split on the feature or product tag, the `model`, the `provider`, and the prompt, trace, or span name. In a multi-tenant project, split on the tenant id too.
-
-A workflow is one product surface plus one model that sends a similar prompt shape many times.
-
-## Token semantics
-
-The model family sets how the provider counts input tokens. Handle each family on its own.
-
-- Claude models: `input_tokens` excludes cache. Total input equals `input_tokens` plus `cache_read` plus `cache_write`. Uncached input equals `input_tokens`.
+- Claude models: `input_tokens` excludes cache. Uncached input equals `input_tokens`. Total input adds `cache_read` and `cache_write` on top.
 - All other models: `input_tokens` includes cache. Uncached input equals `input_tokens` minus `cache_read`.
+- Read the family from the `model` string. The `provider` field is not reliable.
+- For cost, add `input_cost_usd` and `output_cost_usd`. Do not trust `total_cost_usd`: it undercounts Claude rows.
 
-Read the family from the `model` string, not the `provider` field. The `provider` field is not reliable.
+## The cache mistakes to hunt
 
-For cost, add `input_cost_usd` and `output_cost_usd`. Do not trust `total_cost_usd`. It undercounts Claude rows.
+The provider keys a cache entry on the model, the tool definitions, the system content, and the exact token prefix, in request order.
+Every mistake below breaks one of those keys.
+Name the matching mistake in every report, because the fixes do not overlap.
+
+- **Volatile before stable.** A timestamp, request id, user block, injected memory, or retrieved document sits ahead of the stable prompt. One early changed token invalidates everything after it. Fix: move volatile content to the end, or pin it.
+- **No cache marker.** Anthropic caches only where the code sets a `cache_control` breakpoint. Without one, reads stay at zero however stable the prompt. Fix: set the breakpoint at the end of the stable prefix.
+- **Marker stripped or dropped.** A wrapper, mixin, or refactor removes an inherited breakpoint. Read the blame before you call it an accident. Fix: restore the marker, unless the recorded reason still holds.
+- **Breakpoint too early.** Only the system prompt carries the marker, and the growing conversation history re-bills at the full rate each turn. Fix: cache at the last stable turn, not only the system prompt.
+- **Paid writes that nothing reads.** Anthropic bills a cache write at 1.25 times the input rate. A breakpoint on a one-shot path raises the bill. Fix: remove the breakpoint, or raise the reuse.
+- **Split caches.** Two call sites send near-identical prompts with different tools, system content, model, or thinking config. They can never share an entry. Fix: align the whole prefix, or accept the split.
+- **Calls spaced past the TTL.** Every call writes, and the entry expires before the next call reads it. Fix: raise the reuse rate or extend the cache window.
+- **Unstable assembly.** The code serializes the same items in a different order per call. Same content, different prefix, zero hits. Fix: make the assembly deterministic.
+- **Repeated identical call.** The same call recurs at a near-constant input size inside one trace. That is usually a retry or compaction loop, not a cache gap. Lead with the loop and mention caching second.
+
+OpenAI, Google, and DeepSeek cache the prefix automatically above a minimum length, so ordering alone fixes them.
+Anthropic needs the explicit breakpoint on top of correct ordering.
 
 ## Detect an underperforming cache
 
-For each workflow, compute the cache-hit ratio: `cache_read` divided by the sum of uncached input, `cache_read`, and `cache_write`. Then compute the uncached input cost: uncached input tokens times the workflow input rate. Read the input rate from rows where `cache_read` and `cache_write` are both zero.
+- Per workflow, compute the cache-hit ratio: `cache_read` divided by the sum of uncached input, `cache_read`, and `cache_write`.
+- Compute the uncached input cost: uncached tokens times the input rate. Read the rate from rows with zero cache activity.
+- Flag a workflow when its hit ratio sits below its peers and its uncached cost is large.
 
-Flag a workflow when its hit ratio sits below its peers and its uncached input cost is high. Compare each workflow against four baselines.
+Compare each flagged workflow against four baselines:
 
 1. Its own past weeks.
 2. Other workflows on the same model.
 3. The same workflow on its other models.
-4. The best-caching workflow in the same project.
+4. The best-caching workflow in the project.
 
-Baseline 3 catches the classic false positive. A span or prompt name usually covers several models. When the same name caches well on its main model and badly on a smaller slice, the workflow is not uncached: the gap lives in one slice, and its fix lives at a different call site from the one that already caches. Say which model slice you mean.
+Baseline 3 catches the classic false positive.
+A span name that caches well on its main model and badly on one slice is not an uncached workflow.
+The gap lives in that slice, and its fix lives at a different call site.
+Name the model slice you mean.
 
-## Confirm the prefix repeats
+## Verify the data before you touch code
 
-A low hit ratio alone proves nothing. Some prompts differ on every call. Before going further, sample the `input` field and measure two separate things per workflow.
+Do:
 
-- The repeat share: how many calls start with the same content at all.
-- The common prefix length: how far into the prompt those calls stay identical, in tokens.
+- Sample the `input` field per workflow.
+- Measure the repeat share: how many calls start with the same content.
+- Measure the common prefix length in tokens: how far the calls stay identical.
+- Check the measured prefix against the provider minimum. Anthropic needs 1024 tokens on Sonnet and Opus and 2048 on Haiku. OpenAI needs 1024. Look up other families.
+- Classify the reuse shape. An append-only loop, with many growing calls per trace, pays the most. One call per trace leaves only the cross-trace system prompt. Calls spaced past the TTL pay for writes only.
 
-Measure the prefix. Do not infer it from a fixed-size hash: a hash of the first 1,500 characters proves that about 375 tokens match and says nothing about the rest.
+Do not:
 
-Then check the measured prefix against the provider's minimum cacheable prefix. Below the minimum the provider ignores the breakpoint silently: `cache_creation_input_tokens` stays 0 and no error is raised, so no fix is possible there. Anthropic needs 1024 tokens for Sonnet and Opus and 2048 for Haiku. OpenAI needs 1024. For other families, look up the documented minimum rather than assuming there is none.
-
-If the captured `input` is redacted or truncated, you cannot measure the prefix. Hold the candidate rather than reporting an unverifiable one.
-
-## Check the reuse shape
-
-A stable prefix only pays off when a later call reads it back, inside the provider's cache time-to-live. Count the calls per trace or conversation, check whether the prompt grows across them, and check the spacing between calls against the TTL.
-
-- Many calls per trace with a growing prompt: an append-only loop where each turn resends the previous turns. Reuse is real and the saving is large.
-- One call per trace: nothing to reuse inside the trace. Only the prefix shared across traces is cacheable, which is usually just the system prompt. Check it against the minimum above.
-- Calls spaced past the TTL: every call writes and nothing reads. The fix is the reuse rate or the window, not a breakpoint.
-
-Report the shape you found. A workflow that is one-shot by construction cannot be fixed by a breakpoint, however much it spends.
-
-## What breaks a cache
-
-The provider keys the cache on the model, the tool definitions, the system content, and the exact token prefix, in request order. A single early volatile token invalidates everything after it, and a mismatch in tools or model means two call sites can never share a cache however similar their prompts look.
-
-A cache holds stable content: the system prompt, tool schemas, few-shot examples, fixed documents, and the conversation history up to the last turn. It cannot hold volatile content: the newest user message, per-call retrieved documents, timestamps, request ids, and user ids.
-
-So the fix is usually ordering. Put stable content first, volatile content last, and take timestamps and ids out of the prefix. Anthropic caches only where the code sets a `cache_control` breakpoint: put it at the end of the stable prefix, and cache the growing history at the last stable turn, not only the system prompt. OpenAI, Google, and DeepSeek cache the prefix automatically above a minimum, so ordering alone fixes them.
+- Do not infer the prefix from a fixed-size hash. A hash of the first 1,500 characters proves about 375 tokens match and says nothing about the rest.
+- Do not expect an error below the provider minimum. The provider ignores the breakpoint silently: `cache_creation_input_tokens` stays 0.
+- Do not report a workflow whose captured `input` arrives redacted or truncated. You cannot measure the prefix. Hold it.
+- Do not expect a breakpoint to fix a one-shot workflow. There is no second call to read the cache back.
 
 ## Confirm the fix in code
 
-The data shows a workflow does not cache. It cannot show whether that is an oversight, a deliberate choice, or unfixable. Read the call site before reporting. This gate removes most false positives: a candidate that clears the data checks is not a finding until you have read the code behind it.
+The data shows that a workflow does not cache.
+It cannot show whether that is an oversight, a choice, or unfixable.
+This gate removes most false positives: a candidate is not a finding until you have read the code behind it.
 
-You can do this. Clone the repository the project is linked to, and use `gh` read access for anything outside the clone. Do the data work first and clone only once a candidate has cleared the checks above.
+Where to look:
 
-Find the call site. Grep for the span or prompt name, the feature tag, and the model id. The span name is usually the class, function, or chain that builds the request, so it is the strongest search term. When it resolves to a class, read the class and its base classes: the volatile injection often lives in a wrapper or mixin, not in the file that names the span.
+- Clone the linked repository once a candidate clears the data checks, not before. Use `gh` read access for anything outside the clone.
+- Grep for the span or prompt name, the feature tag, and the model id. The span name usually names the class or chain that builds the request.
+- When it resolves to a class, read the base classes too. The volatile injection often lives in a wrapper or mixin, not in the file that names the span.
 
-Then answer four questions.
+Answer four questions:
 
-1. Does this call site already cache? If the same class or helper sets a breakpoint for another model or caller, the gap is in one slice. Find that slice's own call site. Do not report against the shared prompt builder that already works.
-2. Is the absence deliberate? Code that strips or suppresses cache markers is a design decision until proven otherwise. Read the blame and the pull request that introduced it, and check its review discussion. State in the report either the reason you found or that you looked and found none. A report that reads as "nobody thought of caching here" when someone did gets dismissed.
-3. Does anything volatile sit in the prefix? A current timestamp, a request id, or an injected per-call context block ahead of the stable content defeats any breakpoint. If one is there, moving or pinning it is the fix, and it comes before the breakpoint.
-4. Would the fix reduce the bill? Re-check the reuse shape against what the code does. Code that summarizes, compacts, reranks, or classifies in a single pass has no second call to read the cache back.
+1. Does this call site already cache? A shared helper that caches for another model or caller means the gap lives in one slice. Find that slice's own call site.
+2. Is the absence deliberate? Code that strips cache markers records a decision. Read the blame and the pull request behind it. State the reason you found, or state that you looked and found none.
+3. Does anything volatile sit in the prefix? If yes, moving or pinning it is the fix, and it comes before any breakpoint.
+4. Would the fix cut the bill? Code that summarizes, compacts, reranks, or classifies in one pass has no second call to read the cache back.
 
-Name the exact file and function you would change, and derive the suggested reviewer from that file, using the repository's ownership files (`CODEOWNERS` or `owners.yaml`) when present. You found the gap in observability data, but the fix belongs to whoever owns the calling code: route the report to them. If you cannot find the call site, say so and lower your confidence. Do not present a guess at the call site as a located fix, and do not fall back to the product's main prompt builder as the target: that is usually the path that already caches correctly.
+Then:
 
-If the project has no linked repository, report the finding as unverified, say which causes you could not rule out, and keep the estimate conservative.
-
-## Patterns to report
-
-Zero cache reads looks the same in the data whatever the cause. Name the cause in the report, because the fixes do not overlap.
-
-- No breakpoint: the code never marks a prefix, the input repeats, and the prefix clears the minimum. Set a breakpoint at the end of the stable prefix.
-- Volatile prefix: a per-call timestamp, id, or injected context block sits ahead of the stable content. Pin or move it first. A breakpoint alone changes nothing.
-- Under-caching: the hit ratio sits below peers and the input repeats. Extend the breakpoint to the full stable prefix.
-- Cache thrash: `cache_write` runs above `cache_read`. Fix the window or the reuse rate.
-- Repeated identical call: the same call recurs at a near-constant input size within one trace or conversation. That is usually a retry or compaction loop, not a caching gap. Lead with "this runs more often than it should" and mention caching only as a secondary mitigation.
-
-And the shapes that are not findings: no reuse available (one call per trace, or the shared prefix sits below the provider minimum), a deliberate removal whose stated reason still holds, a well-cached workflow at peer hit ratio, and low repetition with a repeat share below 0.25.
+- Name the exact file and function you would change.
+- Derive the suggested reviewer from that file, with `CODEOWNERS` or `owners.yaml` when present. The fix belongs to whoever owns the calling code, not to whoever owns the observability data.
+- If you cannot find the call site, say so and lower your confidence. Do not present a guess as a located fix.
+- Do not fall back to the product's main prompt builder as the target. That path usually caches correctly already.
+- If the project has no linked repository, report the finding as unverified. Say which causes you could not rule out, and keep the estimate conservative.
 
 ## Estimate the net saving
 
-Build the estimate from the prefix you measured, not from a constant.
+- Cacheable tokens equal the measured prefix length times the calls that read it back. The first call in each cache window writes and does not read.
+- The gross saving equals cacheable tokens times the input rate times the discount: 0.9 for Claude, 0.5 for the auto-cache families.
+- Subtract the write cost for providers that charge for writes. A path that mostly writes and rarely reads gets more expensive, not cheaper.
+- Report the net figure.
+- Never scale a saving by the total tokens of the calls that share a prefix. Only the shared part is cacheable. That mistake turns a short system prompt into a large fake number.
 
-Cacheable tokens equal the measured common prefix length times the number of calls that can read it back. A call reads back only when an earlier call in the same cache window already wrote the prefix, so the first call in each trace writes and does not read.
+## Do not report
 
-The gross saving equals cacheable tokens times the input rate times the family discount: 0.9 for Claude, 0.5 for the auto-cache families. For providers that charge for writes, subtract the write cost: Anthropic bills cache writes at 1.25 times the input rate, so a breakpoint on a path that mostly writes and rarely reads raises the bill. Report the net figure. If the net saving is negative or trivial, do not file the finding.
-
-Never scale a saving by the total tokens of the calls that share a prefix. Only the shared part is cacheable. That mistake turns a short system prompt into a large fake number.
-
-## Disqualifiers
-
-Skip a workflow when any of these hold.
-
-- The repeat share sits below 0.25.
-- The uncached input cost sits below a floor worth a person's attention. Set the floor from the project's overall spend.
-- The measured common prefix sits below the provider's minimum cacheable prefix.
-- The workflow is one call per trace and the cross-trace prefix is below that minimum.
-- The model caches automatically and the prefix already matches.
-- The same workflow already caches well on another model and the path you would change is the one that already works.
-- The call site removes caching deliberately and the stated reason still holds.
-- The captured `input` is redacted or truncated, so the prefix cannot be measured.
+- A workflow where most sampled calls do not share a prefix. The input is unique by construction.
+- A workflow whose uncached cost sits below a floor worth a person's attention. Set the floor from the project's overall spend.
+- A measured prefix below the provider minimum.
+- A one-shot workflow whose cross-trace prefix sits below that minimum.
+- An auto-cache model whose prefix already matches.
+- A workflow that caches well on another model, when the path you would change is the one that already works.
+- A deliberate removal whose recorded reason still holds.
+- A negative or trivial net saving.
 
 ## When to stop
 
-Report only workflows with a repeated prefix above the provider minimum, a low hit ratio, reuse available in the call shape, a fix you located in code, and a positive net saving. Hold the rest.
+A finding needs all five. Hold anything that misses one.
 
-Title a new report `AI cache optimization: <workflow and cause>`. Include the comparison window, the measured prefix length, the reuse shape, the named cause, the file and function to change, and the net saving. Write memory for held candidates and close the run when nothing clears the bar.
+1. A repeated prefix above the provider minimum.
+2. A hit ratio below peers.
+3. Reuse available in the call shape.
+4. A fix located in code.
+5. A positive net saving.
 
-Finish with a short run summary covering what you checked, what you reported or updated, and what you ruled out.
+Title a new report `AI cache optimization: <workflow and cause>`. Include:
+
+- the comparison window
+- the measured prefix length
+- the reuse shape
+- the named mistake from the list above
+- the file and function to change
+- the net saving
+
+Write memory for held candidates.
+Close the run with a short summary: what you checked, what you reported or updated, and what you ruled out.

--- a/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
+++ b/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
@@ -40,6 +40,8 @@ These are packaged runtime skills, not project skill-store entries. Do not use `
 - Each row carries `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_cost_usd`, `output_cost_usd`, `model`, `provider`, and `input`.
 - Exclude corrupt rows before you aggregate: token counts far past the model's context window, and per-call costs far past what the tokens can produce.
 - Group rows into workflows. Split on the feature or product tag, the `model`, the `provider`, and the prompt, trace, or span name.
+- Discover the product tag from the team's event schema. Teams send whatever tag property they chose, so do not assume one name is present.
+- Verify the split before you use it. A span name can cover several unrelated callers, and a tag that reads empty on every row means the split did not resolve. Find another dimension that separates the callers, such as a trace id prefix. Never treat an unresolved bucket as one workflow.
 - If the project is multi-tenant, split on the tenant id too.
 - A workflow is one product surface plus one model that sends a similar prompt shape many times.
 
@@ -131,6 +133,15 @@ Then:
 - Do not fall back to the product's main prompt builder as the target. That path usually caches correctly already.
 - If the project has no linked repository, report the finding as unverified. Say which causes you could not rule out, and keep the estimate conservative.
 
+## Re-validate an existing report
+
+A run that re-checks a live report has a different job from a run that finds a new one.
+
+- Do the code check again. The data alone cannot tell you whether a fix shipped.
+- Read the call site as it stands today, not as the report describes it. The report's linked pull request is one attempt, and a later attempt often lands under a different number.
+- Search the repository for merged commits that touch the file the report names, since the report's filing date. An unlinked merged fix is the most common reason a finding looks unchanged.
+- When a fix shipped and the metric did not move, say so and give the reason. Treat the finding as closed unless you can name what the fix left undone.
+
 ## Estimate the net saving
 
 - Cacheable tokens equal the measured prefix length times the calls that read it back. The first call in each cache window writes and does not read.
@@ -168,6 +179,11 @@ Title a new report `AI cache optimization: <workflow and cause>`. Include:
 - the named mistake from the list above
 - the file and function to change
 - the net saving
+
+Re-measuring an unchanged number is not new evidence.
+
+- Add a note to a live report only when something changed: a fix shipped, the workload changed shape, or the cause differs from the named one.
+- Otherwise write the scratchpad entry and close the run silently. A repeated-numbers note reaches a Slack channel and costs a person's attention for nothing.
 
 Write memory for held candidates.
 Close the run with a short summary: what you checked, what you reported or updated, and what you ruled out.

--- a/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
+++ b/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
@@ -10,7 +10,7 @@ scout-tags:
 # AI cache optimization
 
 Watch LLM generation events for workloads that resend a large stable prompt without caching it.
-Report a workload only when you have located a code fix that cuts input cost.
+Report a workload only when you have located a code fix that cuts total cost.
 
 - Cached input tokens cost a tenth to half the uncached rate, so caching is one of the cheapest savings available.
 - Cache gaps also come back silently: a refactor drops a cache marker, or a new feature injects dynamic content ahead of the stable prompt.
@@ -25,14 +25,6 @@ Load these preinstalled skills through the runtime's packaged-skill mechanism wh
 - `querying-posthog-data`
 
 These are packaged runtime skills, not project skill-store entries. Do not use `skill-list` or `skill-get` to load them.
-
-## Avoid duplicate work
-
-- Read this scout's last 14 days of run summaries with `scout-runs-list`. Filter by its exact `skill_name` and current `skill_version`.
-- Retrieve details for relevant runs with `scout-runs-retrieve`.
-- Search the scratchpad and recent Inbox reports for the workflow, the model, and the call site.
-- If a live report covers the same workflow, add only materially new evidence with `scout-edit-report`.
-- Never create a second report for an unchanged issue.
 
 ## Where to look
 

--- a/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
+++ b/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
@@ -110,11 +110,11 @@ Do not:
 
 The data shows that a workflow does not cache.
 It cannot show whether that is an oversight, a choice, or unfixable.
-This gate removes most false positives: a candidate is not a finding until you have read the code behind it.
+This gate removes most false positives: a candidate with a linked repository is not a finding until you have read the code behind it.
 
 Where to look:
 
-- Clone the linked repository once a candidate clears the data checks, not before. Use `gh` read access for anything outside the clone.
+- Read the calling code in the linked repository once a candidate clears the data checks, not before.
 - Grep for the span or prompt name, the feature tag, and the model id. The span name usually names the class or chain that builds the request.
 - When it resolves to a class, read the base classes too. The volatile injection often lives in a wrapper or mixin, not in the file that names the span.
 
@@ -146,7 +146,7 @@ A run that re-checks a live report has a different job from a run that finds a n
 
 - Cacheable tokens equal the measured prefix length times the calls that read it back. The first call in each cache window writes and does not read.
 - The gross saving equals cacheable tokens times the input rate times the discount: 0.9 for Claude, 0.5 for the auto-cache families.
-- Subtract the write cost for providers that charge for writes. A path that mostly writes and rarely reads gets more expensive, not cheaper.
+- Subtract the write surcharge for providers that charge for writes. Count only the surcharge above the input rate, not the full write price: the write replaces input the call already pays for. Anthropic's surcharge is 0.25 times the input rate. A path that mostly writes and rarely reads still gets more expensive, not cheaper.
 - Report the net figure.
 - Never scale a saving by the total tokens of the calls that share a prefix. Only the shared part is cacheable. That mistake turns a short system prompt into a large fake number.
 

--- a/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
+++ b/products/ai_observability/backend/scouts/signals-scout-ai-observability-cache-optimization.md
@@ -29,7 +29,7 @@ These are packaged runtime skills, not project skill-store entries. Do not use `
 ## Where to look
 
 - Read `$ai_generation` events from the last 7 days. Window on the ingestion timestamp: prompts change often, so older windows mislead.
-- Each row carries `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_cost_usd`, `output_cost_usd`, `model`, `provider`, and `input`.
+- Each row carries `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_cost_usd`, `output_cost_usd`, `model`, `provider`, `input`, and the accounting flag `$ai_cache_reporting_exclusive`.
 - Exclude corrupt rows before you aggregate: token counts far past the model's context window, and per-call costs far past what the tokens can produce.
 - Group rows into workflows. Split on the feature or product tag, the `model`, the `provider`, and the prompt, trace, or span name.
 - Discover the product tag from the team's event schema. Teams send whatever tag property they chose, so do not assume one name is present.
@@ -39,10 +39,11 @@ These are packaged runtime skills, not project skill-store entries. Do not use `
 
 ## Token and cost semantics
 
-- Claude models: `input_tokens` excludes cache. Uncached input equals `input_tokens`. Total input adds `cache_read` and `cache_write` on top.
-- All other models: `input_tokens` includes cache. Uncached input equals `input_tokens` minus `cache_read`.
-- Read the family from the `model` string. The `provider` field is not reliable.
-- For cost, add `input_cost_usd` and `output_cost_usd`. Do not trust `total_cost_usd`: it undercounts Claude rows.
+- Providers report cache tokens two ways. Ingestion resolves the convention per event and writes it to the `$ai_cache_reporting_exclusive` boolean, so read the flag on each row.
+- Exclusive rows: `input_tokens` excludes cache. Uncached input equals `input_tokens`. Total input adds `cache_read` and `cache_write` on top.
+- Inclusive rows: `input_tokens` includes cache. Uncached input equals `input_tokens` minus `cache_read`. Total input equals `input_tokens`.
+- Do not infer the convention from the model or provider name. It varies by SDK and SDK version.
+- For cost, add `input_cost_usd` and `output_cost_usd`. Do not trust `total_cost_usd`: it undercounts rows that report exclusively.
 
 ## The cache mistakes to hunt
 
@@ -54,7 +55,7 @@ Name the matching mistake in every report, because the fixes do not overlap.
 - **No cache marker.** Anthropic caches only where the code sets a `cache_control` breakpoint. Without one, reads stay at zero however stable the prompt. Fix: set the breakpoint at the end of the stable prefix.
 - **Marker stripped or dropped.** A wrapper, mixin, or refactor removes an inherited breakpoint. Read the blame before you call it an accident. Fix: restore the marker, unless the recorded reason still holds.
 - **Breakpoint too early.** Only the system prompt carries the marker, and the growing conversation history re-bills at the full rate each turn. Fix: cache at the last stable turn, not only the system prompt.
-- **Paid writes that nothing reads.** Anthropic bills a cache write at 1.25 times the input rate. A breakpoint on a one-shot path raises the bill. Fix: remove the breakpoint, or raise the reuse.
+- **Paid writes that nothing reads.** Anthropic bills a cache write at 1.25 to 2 times the input rate, depending on the TTL. A breakpoint on a one-shot path raises the bill. Fix: remove the breakpoint, or raise the reuse.
 - **Split caches.** Two call sites send near-identical prompts with different tools, system content, model, or thinking config. They can never share an entry. Fix: align the whole prefix, or accept the split.
 - **Calls spaced past the TTL.** Every call writes, and the entry expires before the next call reads it. Fix: raise the reuse rate or extend the cache window.
 - **Unstable assembly.** The code serializes the same items in a different order per call. Same content, different prefix, zero hits. Fix: make the assembly deterministic.
@@ -65,7 +66,7 @@ Anthropic needs the explicit breakpoint on top of correct ordering.
 
 ## Detect an underperforming cache
 
-- Per workflow, compute the cache-hit ratio: `cache_read` divided by the sum of uncached input, `cache_read`, and `cache_write`.
+- Per workflow, compute the cache-hit ratio: `cache_read` divided by the total input that the accounting flag defines above.
 - Compute the uncached input cost: uncached tokens times the input rate. Read the rate from rows with zero cache activity.
 - Flag a workflow when its hit ratio sits below its peers and its uncached cost is large.
 
@@ -88,7 +89,7 @@ Do:
 - Sample the `input` field per workflow.
 - Measure the repeat share: how many calls start with the same content.
 - Measure the common prefix length in tokens: how far the calls stay identical.
-- Check the measured prefix against the provider minimum. Anthropic needs 1024 tokens on Sonnet and Opus and 2048 on Haiku. OpenAI needs 1024. Look up other families.
+- Check the measured prefix against the provider minimum for the exact model. The minimum varies per model and per release: recent Anthropic models range from 512 to 4,096 tokens, and OpenAI needs 1,024. Look up the current value in the provider's caching docs. When you cannot confirm it, gate on the largest minimum in the model's family.
 - Classify the reuse shape. An append-only loop, with many growing calls per trace, pays the most. One call per trace leaves only the cross-trace system prompt. Calls spaced past the TTL pay for writes only.
 
 Do not:
@@ -138,8 +139,8 @@ A run that re-checks a live report has a different job from a run that finds a n
 
 - Cacheable tokens equal the measured prefix length times the calls that read it back. The first call in each cache window writes and does not read.
 - The gross saving equals cacheable tokens times the input rate times the discount: 0.9 for Claude, 0.5 for the auto-cache families.
-- Subtract the write surcharge for providers that charge for writes. Count only the surcharge above the input rate, not the full write price: the write replaces input the call already pays for. Anthropic's surcharge is 0.25 times the input rate. A path that mostly writes and rarely reads still gets more expensive, not cheaper.
-- Report the net figure.
+- Subtract the write surcharge for providers that charge for writes. Count only the surcharge above the input rate, not the full write price: the write replaces input the call already pays for. The surcharge depends on the cache TTL: Anthropic bills five-minute writes at 1.25 times the input rate and one-hour writes at 2 times. Price the surcharge at the TTL the fix would use. A path that mostly writes and rarely reads still gets more expensive, not cheaper.
+- Report the net figure in dollars. State a percentage only against the workload's full cost, output and per-request fees included, or label it as a share of input token cost.
 - Never scale a saving by the total tokens of the calls that share a prefix. Only the shared part is cacheable. That mistake turns a short system prompt into a large fake number.
 
 ## Do not report

--- a/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.test.tsx
+++ b/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.test.tsx
@@ -262,7 +262,7 @@ describe('AIObservabilitySelfDriving', () => {
             </Provider>
         )
 
-        expect(screen.getAllByText('Use template')).toHaveLength(3)
+        expect(screen.getAllByText('Use template')).toHaveLength(4)
 
         // Counting the labels alone passes even when every button is disabled, which is what
         // happens if the scene stops granting scout-creation access. Prove one actually opens.

--- a/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.tsx
+++ b/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { combineUrl } from 'kea-router'
 import type { ReactNode } from 'react'
 
-import { IconCalendar, IconPlus, IconQuestion, IconUser, IconWarning } from '@posthog/icons'
+import { IconCalendar, IconDatabase, IconPlus, IconQuestion, IconUser, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -160,6 +160,7 @@ const TEMPLATE_ICONS: Record<AIObservabilityScoutTemplate['key'], JSX.Element> =
     'daily-digest': <IconCalendar />,
     'costly-users': <IconUser />,
     'error-patterns': <IconWarning />,
+    'cache-optimization': <IconDatabase />,
 }
 
 /**

--- a/products/ai_observability/frontend/selfDriving/aiObservabilityScoutTemplates.test.ts
+++ b/products/ai_observability/frontend/selfDriving/aiObservabilityScoutTemplates.test.ts
@@ -7,8 +7,8 @@ import {
 } from './aiObservabilityScoutTemplates'
 
 describe('AI observability scout templates', () => {
-    it('provides three uniquely named templates', () => {
-        expect(AI_OBSERVABILITY_SCOUT_TEMPLATES).toHaveLength(3)
+    it('provides four uniquely named templates', () => {
+        expect(AI_OBSERVABILITY_SCOUT_TEMPLATES).toHaveLength(4)
 
         const names = AI_OBSERVABILITY_SCOUT_TEMPLATES.map((template) => template.initialValues.name)
         expect(new Set(names).size).toBe(names.length)

--- a/products/ai_observability/frontend/selfDriving/aiObservabilityScoutTemplates.ts
+++ b/products/ai_observability/frontend/selfDriving/aiObservabilityScoutTemplates.ts
@@ -4,13 +4,14 @@ import type { SignalScoutConfigApi } from 'products/signals/frontend/generated/a
 import type { ScoutCreateInitialValues } from 'products/signals/frontend/inbox/logics/scoutCreateModalLogic'
 import { scoutTags } from 'products/signals/frontend/inbox/utils/scoutTags'
 
+import cacheOptimizationSkill from '../../backend/scouts/signals-scout-ai-observability-cache-optimization.md?raw'
 import costlyUsersSkill from '../../backend/scouts/signals-scout-ai-observability-costly-users.md?raw'
 import dailyDigestSkill from '../../backend/scouts/signals-scout-ai-observability-daily-digest.md?raw'
 import errorPatternsSkill from '../../backend/scouts/signals-scout-ai-observability-error-patterns.md?raw'
 
 export const AI_OBSERVABILITY_SCOUT_TAG = 'ai-observability'
 
-export type AIObservabilityScoutTemplateKey = 'daily-digest' | 'costly-users' | 'error-patterns'
+export type AIObservabilityScoutTemplateKey = 'daily-digest' | 'costly-users' | 'error-patterns' | 'cache-optimization'
 
 export interface AIObservabilityScoutTemplate {
     key: AIObservabilityScoutTemplateKey
@@ -93,6 +94,14 @@ export const AI_OBSERVABILITY_SCOUT_TEMPLATES: AIObservabilityScoutTemplate[] = 
         description: 'Read real traces to find recurring errors and silent AI failures worth fixing.',
         schedule: 'Daily at 9:00 AM',
         initialValues: readScoutSkill(errorPatternsSkill, 'signals-scout-ai-observability-error-patterns.md'),
+    },
+    {
+        key: 'cache-optimization',
+        title: 'Cache optimization',
+        description:
+            'Find workloads that resend large prompts without caching, locate the fix in code, and size the net saving.',
+        schedule: 'Daily at 9:00 AM',
+        initialValues: readScoutSkill(cacheOptimizationSkill, 'signals-scout-ai-observability-cache-optimization.md'),
     },
 ]
 


### PR DESCRIPTION
## Problem

The AI observability self-driving tab has no scout template for provider cache misses. Uncached workloads and quietly reintroduced cache regressions surface only when someone reads the cost data by hand.

A naive cache scout files false positives. Zero cache reads can mean a missing breakpoint, a one-shot workload, or a volatile prefix, and the fixes do not overlap. The prompt here distills a custom scout iterated against real data and review feedback ([origin thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787239328887319), [follow-up](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1787623443464769)).

## Changes

- The self-driving tab shows a fourth template card, "Cache optimization": a daily scout that finds workloads resending large prompts without caching them.
- The prompt gates every report on four checks, in order:
  - The measured common prefix clears the provider's minimum cacheable length.
  - The reuse shape supports a read: calls per trace, prompt growth, and spacing inside the cache TTL.
  - The call site is read in code, including blame history for deliberately stripped cache markers.
  - The saving is positive net of cache-write surcharges, computed from the measured prefix, not a constant.
- Reports route to the calling code's owner via the repo's ownership files, not to whoever owns the observability data.
- Mechanical: one `?raw` import and registry entry, one icon, two test counts bumped from 3 to 4.

No screenshot: the card is a fourth instance of the existing template card in the existing grid, behind the `AI_OBSERVABILITY_SELF_DRIVING` flag.

## How did you test this code?

- `hogli test` on the two affected suites passes; the parameterized template test validates the new markdown's frontmatter, body shape, and config.
- No new tests: the existing `it.each` runs per template entry, so the new entry is asserted automatically.
- Frontend typecheck adds no new errors.
- Not run: browser testing of the tab.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the self-driving tab is feature-flagged and has no docs page yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session. Research covered the source scout's skill body, config, steering notes, and scratchpad via the PostHog MCP, plus the originating Slack threads.
- Skills invoked: `posthog:authoring-scouts`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The prompt generalizes a project-2 custom scout (v4). Project-specific ownership tables, internal call-site names, and fixed corrupt-row thresholds were replaced with generic equivalents; the committed prompt carries no session-internal metrics.
