### PR TITLE
feat(aio): summarize traces with gpt-5-nano on the flex tier

### DIFF
--- a/posthog/temporal/ai_observability/trace_summarization/README.md
+++ b/posthog/temporal/ai_observability/trace_summarization/README.md
@@ -136,21 +136,21 @@ Teams are discovered dynamically via `team_discovery.py`. Guaranteed teams (in `
 
 Key constants in `constants.py`:
 
-| Constant                                    | Default        | Description                                     |
-| ------------------------------------------- | -------------- | ----------------------------------------------- |
-| `DEFAULT_MAX_ITEMS_PER_WINDOW`              | 15             | Max items per window                            |
-| `DEFAULT_BATCH_SIZE`                        | 5              | Concurrent item processing                      |
-| `DEFAULT_MAX_CONCURRENT_TEAMS`              | 20             | Max teams to process in parallel                |
-| `DEFAULT_MODE`                              | "detailed"     | Summary detail level                            |
-| `DEFAULT_MODEL`                             | "gpt-4.1-nano" | LLM model for summarization                     |
-| `DEFAULT_WINDOW_MINUTES`                    | 60             | Time window to query                            |
-| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES`        | 30             | Max per-team workflow duration                  |
-| `COORDINATOR_EXECUTION_TIMEOUT_MINUTES`     | 55             | Max coordinator workflow duration               |
-| `SAMPLE_TIMEOUT_SECONDS`                    | 900            | Sampling activity timeout (per attempt)         |
-| `FETCH_AND_FORMAT_START_TO_CLOSE_TIMEOUT`   | 120s           | Fetch + format activity timeout (per attempt)   |
-| `FETCH_AND_FORMAT_HEARTBEAT_TIMEOUT`        | 60s            | Heartbeat window for fetch activity             |
-| `SUMMARIZE_AND_SAVE_START_TO_CLOSE_TIMEOUT` | 900s           | Summarize + save activity timeout (per attempt) |
-| `SUMMARIZE_AND_SAVE_HEARTBEAT_TIMEOUT`      | 60s            | Heartbeat window for summarize activity         |
+| Constant                                    | Default      | Description                                     |
+| ------------------------------------------- | ------------ | ----------------------------------------------- |
+| `DEFAULT_MAX_ITEMS_PER_WINDOW`              | 15           | Max items per window                            |
+| `DEFAULT_BATCH_SIZE`                        | 5            | Concurrent item processing                      |
+| `DEFAULT_MAX_CONCURRENT_TEAMS`              | 20           | Max teams to process in parallel                |
+| `DEFAULT_MODE`                              | "detailed"   | Summary detail level                            |
+| `DEFAULT_MODEL`                             | "gpt-5-nano" | LLM model for summarization                     |
+| `DEFAULT_WINDOW_MINUTES`                    | 60           | Time window to query                            |
+| `WORKFLOW_EXECUTION_TIMEOUT_MINUTES`        | 30           | Max per-team workflow duration                  |
+| `COORDINATOR_EXECUTION_TIMEOUT_MINUTES`     | 55           | Max coordinator workflow duration               |
+| `SAMPLE_TIMEOUT_SECONDS`                    | 900          | Sampling activity timeout (per attempt)         |
+| `FETCH_AND_FORMAT_START_TO_CLOSE_TIMEOUT`   | 120s         | Fetch + format activity timeout (per attempt)   |
+| `FETCH_AND_FORMAT_HEARTBEAT_TIMEOUT`        | 60s          | Heartbeat window for fetch activity             |
+| `SUMMARIZE_AND_SAVE_START_TO_CLOSE_TIMEOUT` | 900s         | Summarize + save activity timeout (per attempt) |
+| `SUMMARIZE_AND_SAVE_HEARTBEAT_TIMEOUT`      | 60s          | Heartbeat window for summarize activity         |
 
 Retry policies: `SAMPLE_RETRY_POLICY` (5 attempts with backoff), `FETCH_AND_FORMAT_RETRY_POLICY` (2 attempts), `SUMMARIZE_AND_SAVE_RETRY_POLICY` (2 attempts with backoff, `TextReprExpiredError` non-retryable), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (1 attempt). All retry policies exclude `ValueError` and `TypeError` from retries.
 

--- a/posthog/temporal/ai_observability/trace_summarization/constants.py
+++ b/posthog/temporal/ai_observability/trace_summarization/constants.py
@@ -15,7 +15,7 @@ DEFAULT_TRACE_BATCH_SIZE = 6  # Traces processed in small parallel batches
 DEFAULT_MODE = SummarizationMode.DETAILED
 DEFAULT_WINDOW_MINUTES = 60  # Process traces from last N minutes (matches schedule frequency)
 DEFAULT_WINDOW_OFFSET_MINUTES = 30  # Offset window into the past so traces have time to fully complete
-DEFAULT_MODEL = OpenAIModel.GPT_4_1_NANO
+DEFAULT_MODEL = OpenAIModel.GPT_5_NANO
 
 # Max estimated raw trace size (in characters) before formatting.
 # Traces exceeding this are skipped — formatting huge traces is CPU-intensive

--- a/posthog/temporal/ai_observability/trace_summarization/summarize_and_save.py
+++ b/posthog/temporal/ai_observability/trace_summarization/summarize_and_save.py
@@ -209,12 +209,15 @@ async def summarize_and_save_activity(input: SummarizeAndSaveInput) -> Summariza
         model_enum = OpenAIModel(input.model) if input.model else None
 
         t0 = time.monotonic()
+        # The batch pipeline can wait for its summaries, so request the cheaper flex
+        # service tier. The provider falls back to the standard tier when flex is refused.
         summary_result = await database_sync_to_async(summarize, thread_sensitive=False)(
             text_repr=text_repr,
             team_id=input.team_id,
             mode=mode_enum,
             model=model_enum,
             user_id=f"temporal-workflow-team-{input.team_id}",
+            flex=True,
         )
         llm_duration_s = time.monotonic() - t0
         log.info(

--- a/products/ai_observability/backend/summarization/budget.py
+++ b/products/ai_observability/backend/summarization/budget.py
@@ -12,6 +12,7 @@ MODEL_CONTEXT_TOKENS: dict[str, int] = {
     OpenAIModel.GPT_4O_MINI: 128_000,
     OpenAIModel.GPT_4O: 128_000,
     OpenAIModel.GPT_5_MINI: 400_000,
+    OpenAIModel.GPT_5_NANO: 400_000,
 }
 
 # Held back from the window for the system prompt and the model's own response.

--- a/products/ai_observability/backend/summarization/constants.py
+++ b/products/ai_observability/backend/summarization/constants.py
@@ -8,3 +8,5 @@ DEFAULT_MODE = SummarizationMode.MINIMAL
 
 # Timeout configuration (seconds)
 SUMMARIZATION_TIMEOUT = 120
+# Flex requests queue for spare provider capacity, so they need a longer deadline than standard calls.
+SUMMARIZATION_FLEX_TIMEOUT = 600

--- a/products/ai_observability/backend/summarization/llm/call.py
+++ b/products/ai_observability/backend/summarization/llm/call.py
@@ -18,6 +18,7 @@ def summarize(
     mode: SummarizationMode = DEFAULT_MODE,
     model: OpenAIModel | None = None,
     user_id: str | None = None,
+    flex: bool = False,
 ) -> SummarizationResponse:
     """
     Generate AI-powered summary from text representation via LLM gateway.
@@ -28,9 +29,10 @@ def summarize(
         mode: Summary detail level
         model: OpenAI model to use (defaults to gpt-4.1-mini)
         user_id: Optional user distinct_id for analytics attribution
+        flex: Request the flex service tier, which is cheaper but slower (gpt-5 models only)
 
     Returns:
         Structured summarization response with flow diagram, bullets, and notes
     """
     openai_model = cast(OpenAIModel, model) if model else DEFAULT_MODEL_OPENAI
-    return summarize_with_openai(text_repr, team_id, mode, openai_model, user_id)
+    return summarize_with_openai(text_repr, team_id, mode, openai_model, user_id, flex=flex)

--- a/products/ai_observability/backend/summarization/llm/openai.py
+++ b/products/ai_observability/backend/summarization/llm/openai.py
@@ -1,20 +1,25 @@
 """OpenAI provider for LLM summarization, routed through the internal Go ai-gateway
 when configured, else the Python LLM gateway."""
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import structlog
-from openai.types.chat import ChatCompletionMessageParam
+from openai import APITimeoutError, RateLimitError
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 from rest_framework import exceptions
 
 from posthog.llm.gateway_client import build_openai_client, team_distinct_id
 
-from ..constants import SUMMARIZATION_TIMEOUT
+from ..constants import SUMMARIZATION_FLEX_TIMEOUT, SUMMARIZATION_TIMEOUT
 from ..models import OpenAIModel, SummarizationMode
 from ..utils import load_summarization_template
 from .schema import SummarizationResponse
 
 logger = structlog.get_logger(__name__)
+
+
+def _is_gpt5_model(model: OpenAIModel) -> bool:
+    return str(model).startswith("gpt-5")
 
 
 def summarize_with_openai(
@@ -23,6 +28,7 @@ def summarize_with_openai(
     mode: SummarizationMode,
     model: OpenAIModel,
     user_id: str | None = None,
+    flex: bool = False,
 ) -> SummarizationResponse:
     """Generate summary using OpenAI API via LLM gateway with structured outputs."""
     system_prompt = load_summarization_template(f"prompts/system_{mode}.djt", {})
@@ -41,12 +47,19 @@ def summarize_with_openai(
         {"role": "user", "content": user_prompt},
     ]
 
-    try:
-        response = client.chat.completions.create(
+    def _create(service_tier: Literal["flex"] | None, timeout: float) -> ChatCompletion:
+        extra: dict[str, Any] = {}
+        if _is_gpt5_model(model):
+            # gpt-5 models are reasoning models, and reasoning tokens bill as output
+            # tokens. Minimal effort keeps output volume at gpt-4.1 levels.
+            extra["reasoning_effort"] = "minimal"
+        if service_tier is not None:
+            extra["service_tier"] = service_tier
+        return client.chat.completions.create(
             model=str(model),
             messages=messages,
             user=resolved_distinct_id,
-            timeout=SUMMARIZATION_TIMEOUT,
+            timeout=timeout,
             response_format=cast(
                 Any,
                 {
@@ -58,7 +71,21 @@ def summarize_with_openai(
                     },
                 },
             ),
+            **extra,
         )
+
+    # Only gpt-5 family models accept service_tier="flex"; gpt-4.1 requests would be rejected.
+    use_flex = flex and _is_gpt5_model(model)
+    try:
+        if use_flex:
+            try:
+                response = _create("flex", SUMMARIZATION_FLEX_TIMEOUT)
+            except (RateLimitError, APITimeoutError):
+                # Flex runs on spare provider capacity, so OpenAI can refuse (429) or stall
+                # the request. Retry once at the standard tier so the window still gets its summary.
+                response = _create(None, SUMMARIZATION_TIMEOUT)
+        else:
+            response = _create(None, SUMMARIZATION_TIMEOUT)
 
         content = response.choices[0].message.content
         if not content:

--- a/products/ai_observability/backend/summarization/models.py
+++ b/products/ai_observability/backend/summarization/models.py
@@ -11,6 +11,7 @@ class OpenAIModel(StrEnum):
     GPT_4O_MINI = "gpt-4o-mini"
     GPT_4O = "gpt-4o"
     GPT_5_MINI = "gpt-5-mini"
+    GPT_5_NANO = "gpt-5-nano"
 
     @classmethod
     def parse(cls, value: str) -> "OpenAIModel":

--- a/products/ai_observability/backend/summarization/tests/test_call.py
+++ b/products/ai_observability/backend/summarization/tests/test_call.py
@@ -35,6 +35,7 @@ class TestSummarize:
                 DEFAULT_MODE,
                 DEFAULT_MODEL_OPENAI,
                 None,
+                flex=False,
             )
             assert result == mock_response
 

--- a/products/ai_observability/backend/summarization/tests/test_providers.py
+++ b/products/ai_observability/backend/summarization/tests/test_providers.py
@@ -3,11 +3,19 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
+import httpx
+from openai import RateLimitError
 from rest_framework import exceptions
 
+from products.ai_observability.backend.summarization.constants import SUMMARIZATION_FLEX_TIMEOUT, SUMMARIZATION_TIMEOUT
 from products.ai_observability.backend.summarization.llm.openai import summarize_with_openai
 from products.ai_observability.backend.summarization.llm.schema import SummarizationResponse
 from products.ai_observability.backend.summarization.models import OpenAIModel, SummarizationMode
+
+
+def _rate_limit_error() -> RateLimitError:
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    return RateLimitError("rate limited", response=httpx.Response(429, request=request), body=None)
 
 
 @pytest.fixture
@@ -162,3 +170,77 @@ class TestSummarizeWithOpenAI:
             call_kwargs = mock_client.chat.completions.create.call_args[1]
             assert call_kwargs["response_format"]["type"] == "json_schema"
             assert call_kwargs["response_format"]["json_schema"]["strict"] is True
+
+    @pytest.mark.parametrize(
+        "model,flex,expected_tier,expected_effort,expected_timeout",
+        [
+            (OpenAIModel.GPT_5_NANO, True, "flex", "minimal", SUMMARIZATION_FLEX_TIMEOUT),
+            (OpenAIModel.GPT_5_NANO, False, None, "minimal", SUMMARIZATION_TIMEOUT),
+            (OpenAIModel.GPT_4_1_MINI, True, None, None, SUMMARIZATION_TIMEOUT),
+        ],
+    )
+    def test_service_tier_and_reasoning_effort_selection(
+        self, valid_response_json, model, flex, expected_tier, expected_effort, expected_timeout
+    ):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.ai_observability.backend.summarization.llm.openai.build_openai_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.return_value = mock_response
+
+            summarize_with_openai(
+                text_repr="L1: Test",
+                team_id=1,
+                mode=SummarizationMode.MINIMAL,
+                model=model,
+                flex=flex,
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args[1]
+            assert call_kwargs.get("service_tier") == expected_tier
+            assert call_kwargs.get("reasoning_effort") == expected_effort
+            assert call_kwargs["timeout"] == expected_timeout
+
+    def test_flex_rate_limit_falls_back_to_standard_tier(self, valid_response_json):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = valid_response_json
+
+        with patch("products.ai_observability.backend.summarization.llm.openai.build_openai_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.side_effect = [_rate_limit_error(), mock_response]
+
+            result = summarize_with_openai(
+                text_repr="L1: Test",
+                team_id=1,
+                mode=SummarizationMode.MINIMAL,
+                model=OpenAIModel.GPT_5_NANO,
+                flex=True,
+            )
+
+            assert isinstance(result, SummarizationResponse)
+            assert mock_client.chat.completions.create.call_count == 2
+            retry_kwargs = mock_client.chat.completions.create.call_args_list[1][1]
+            assert "service_tier" not in retry_kwargs
+            assert retry_kwargs["timeout"] == SUMMARIZATION_TIMEOUT
+
+    def test_standard_tier_rate_limit_does_not_retry(self, valid_response_json):
+        with patch("products.ai_observability.backend.summarization.llm.openai.build_openai_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.chat.completions.create.side_effect = _rate_limit_error()
+
+            with pytest.raises(exceptions.APIException, match="Failed to generate summary"):
+                summarize_with_openai(
+                    text_repr="L1: Test",
+                    team_id=1,
+                    mode=SummarizationMode.MINIMAL,
+                    model=OpenAIModel.GPT_5_NANO,
+                    flex=False,
+                )
+
+            assert mock_client.chat.completions.create.call_count == 1


### PR DESCRIPTION
## Problem

- Every trace summary the clusters pipeline writes pays OpenAI's legacy gpt-4.1-nano rate, twice the current gpt-5-nano price per input token.
- Input tokens dominate this workload, and the hourly batch volume makes summarization the pipeline's largest LLM cost line.
- gpt-4.1 models also cannot use OpenAI's [flex service tier](https://developers.openai.com/api/docs/guides/flex-processing), which bills latency-tolerant traffic at Batch API rates (50 percent off).

## Changes

- The batch summarization pipeline now uses gpt-5-nano instead of gpt-4.1-nano. Summary wording can shift; the response schema and emitted events stay the same.
- Batch calls request the flex service tier, which bills at Batch API rates on the same synchronous API.
- Flex replaces the obvious alternative, the OpenAI Batch API: the discount is the same, but batch needs JSONL job infrastructure, gateway routes for `/v1/files` and `/v1/batches`, and a 24-hour completion window against an hourly product.
- On a flex 429 or timeout, the call retries once at the standard tier, so an hourly window never starves.
- gpt-5 calls set reasoning effort to minimal. Without it, thinking tokens bill as output and cancel the saving.
- The on-demand summarization endpoint is unchanged: gpt-4.1-mini default on the standard tier, so users never wait on flex capacity.
- The riskiest part is the tier selection and fallback in `summarization/llm/openai.py`. The rest is mechanical: the enum entry, a 400K-token input budget row, and the pipeline README.

> [!NOTE]
> The change fails safe. If the AI gateway strips `service_tier`, calls run at the standard tier with no error, only without the discount. Cluster boundaries can shift for a few days after deploy because clustering consumes summaries through their embeddings; clusters already recompute daily.

Nothing user-visible changes apart from summary wording.

## How did you test this code?

- A parameterized test asserts flex, minimal reasoning effort, and the longer timeout apply only to gpt-5 models that request flex. It guards against sending `service_tier` to gpt-4.1 models, which reject the field.
- A fallback test asserts a flex 429 retries once at the standard tier. Removing the fallback would fail hourly windows whenever flex capacity runs short.
- A companion test asserts a standard-tier 429 still fails without a retry, keeping the old error path.
- Not run: the database-backed temporal workflow suites, because this session has no local Postgres.
- Not verified: that the AI gateway forwards `service_tier` upstream, and that cost telemetry prices flex tokens at flex rates. Both need a check before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The trace summarization README's configuration table now shows the new default model.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: audited the pipeline's OpenAI call sites, current OpenAI pricing tiers, and gateway route coverage before writing code. The session's cost analysis used internal telemetry; its figures are deliberately left out of this public description.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The session first produced a written plan, then applied its first two steps here (model switch, flex tier). Gateway `service_tier` passthrough verification and a summary-quality shadow run remain before marking ready.
