### PR TITLE
chore(replay): reuse the shared object storage client for chunks

### DIFF
--- a/posthog/temporal/session_replay/delete_recordings/object_storage.py
+++ b/posthog/temporal/session_replay/delete_recordings/object_storage.py
@@ -2,21 +2,12 @@
 
 Avoids exceeding Temporal's ~2MB payload limit by storing session IDs
 as chunked files in S3 instead of inline in the workflow input.
-
-Write path (sync, from Django admin): uses posthog.storage.object_storage.write()
-Read/delete path (async, from Temporal activities): uses aioboto3
 """
 
 import math
+import asyncio
 import logging
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from itertools import batched
-
-from django.conf import settings
-
-import aioboto3
-from botocore.client import Config
 
 from posthog.storage import object_storage
 
@@ -53,47 +44,18 @@ def store_session_id_chunks(
     return prefix, total_chunks
 
 
-@asynccontextmanager
-async def _s3_client() -> AsyncIterator:
-    session = aioboto3.Session()
-    async with session.client(  # type: ignore[call-overload]
-        "s3",
-        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
-        aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-        config=Config(
-            signature_version="s3v4",
-            connect_timeout=1,
-            retries={"max_attempts": 1},
-        ),
-        region_name=settings.OBJECT_STORAGE_REGION,
-    ) as client:
-        yield client
-
-
 async def load_session_id_chunk(prefix: str, chunk_index: int) -> list[str]:
     key = generate_chunk_key(prefix, chunk_index)
-    async with _s3_client() as client:
-        try:
-            response = await client.get_object(
-                Bucket=settings.OBJECT_STORAGE_BUCKET,
-                Key=key,
-            )
-        except client.exceptions.NoSuchKey:
-            raise ValueError(f"Chunk file not found: {key}")
-        raw = await response["Body"].read()
+    # The shared object storage client is synchronous, so run it off the event loop.
+    raw = await asyncio.to_thread(object_storage.read_bytes, key, missing_ok=True)
+    if raw is None:
+        raise ValueError(f"Chunk file not found: {key}")
 
     return [line for line in raw.decode("utf-8").split("\n") if line]
 
 
 async def delete_session_id_chunks(prefix: str, total_chunks: int) -> None:
-    async with _s3_client() as client:
-        for i in range(total_chunks):
-            key = generate_chunk_key(prefix, i)
-            try:
-                await client.delete_object(
-                    Bucket=settings.OBJECT_STORAGE_BUCKET,
-                    Key=key,
-                )
-            except Exception:
-                logger.warning("Failed to delete chunk %s, orphaned object may remain", key, exc_info=True)
+    keys = [generate_chunk_key(prefix, i) for i in range(total_chunks)]
+    failed_keys = await asyncio.to_thread(object_storage.delete_objects, keys)
+    if failed_keys:
+        logger.warning("Failed to delete chunks %s, orphaned objects may remain", failed_keys)

--- a/posthog/temporal/tests/session_replay/delete_recordings/test_chunk_storage.py
+++ b/posthog/temporal/tests/session_replay/delete_recordings/test_chunk_storage.py
@@ -1,6 +1,9 @@
-import pytest
-from unittest.mock import AsyncMock, patch
+import logging
 
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.storage.object_storage import ObjectStorageError
 from posthog.temporal.session_replay.delete_recordings.object_storage import (
     delete_session_id_chunks,
     generate_chunk_key,
@@ -8,6 +11,24 @@ from posthog.temporal.session_replay.delete_recordings.object_storage import (
     load_session_id_chunk,
     store_session_id_chunks,
 )
+
+STORAGE_MODULE = "posthog.temporal.session_replay.delete_recordings.object_storage.object_storage"
+
+
+def fake_storage(stored: dict[str, bytes], failed_keys: list[str] | None = None) -> MagicMock:
+    # Mirrors the shared client contract: a missing key is only tolerated when the
+    # caller opts in, otherwise the read raises.
+    def read_bytes(key: str, *, missing_ok: bool = False) -> bytes | None:
+        if key in stored:
+            return stored[key]
+        if not missing_ok:
+            raise ObjectStorageError("read failed")
+        return None
+
+    storage = MagicMock()
+    storage.read_bytes.side_effect = read_bytes
+    storage.delete_objects.return_value = failed_keys or []
+    return storage
 
 
 @pytest.mark.parametrize(
@@ -45,7 +66,7 @@ def test_generate_chunk_key(prefix, chunk_index, expected):
 def test_store_session_id_chunks(session_ids, chunk_size, expected_chunks, expected_last_chunk_size):
     written: dict[str, str] = {}
 
-    with patch("posthog.temporal.session_replay.delete_recordings.object_storage.object_storage") as mock_os:
+    with patch(STORAGE_MODULE) as mock_os:
         mock_os.write = lambda key, content: written.update({key: content})
 
         prefix, total_chunks = store_session_id_chunks("wf-test", session_ids, chunk_size)
@@ -67,61 +88,66 @@ def test_store_session_id_chunks(session_ids, chunk_size, expected_chunks, expec
     assert len(written[last_key].split("\n")) == expected_last_chunk_size
 
 
+@pytest.mark.parametrize(
+    "chunk_content, expected",
+    [
+        pytest.param(b"session-a\nsession-b\nsession-c", ["session-a", "session-b", "session-c"], id="three_ids"),
+        pytest.param(b"session-a\n\nsession-b\n", ["session-a", "session-b"], id="skips_empty_lines"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_load_session_id_chunk():
-    chunk_content = b"session-a\nsession-b\nsession-c"
+async def test_load_session_id_chunk(chunk_content, expected):
+    storage = fake_storage({"deletion-inputs/wf-1/chunk-0002.csv": chunk_content})
 
-    mock_body = AsyncMock()
-    mock_body.read = AsyncMock(return_value=chunk_content)
+    with patch(STORAGE_MODULE, storage):
+        result = await load_session_id_chunk("deletion-inputs/wf-1/", 2)
 
-    mock_client = AsyncMock()
-    mock_client.get_object = AsyncMock(return_value={"Body": mock_body})
-
-    with patch("posthog.temporal.session_replay.delete_recordings.object_storage._s3_client") as mock_ctx:
-        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
-
-        result = await load_session_id_chunk("deletion-inputs/wf-1/", 0)
-
-    assert result == ["session-a", "session-b", "session-c"]
-    mock_client.get_object.assert_called_once()
+    assert result == expected
 
 
 @pytest.mark.asyncio
-async def test_load_session_id_chunk_skips_empty_lines():
-    chunk_content = b"session-a\n\nsession-b\n"
+async def test_load_session_id_chunk_raises_when_chunk_is_missing():
+    storage = fake_storage({"deletion-inputs/wf-1/chunk-0000.csv": b"session-a"})
 
-    mock_body = AsyncMock()
-    mock_body.read = AsyncMock(return_value=chunk_content)
+    with patch(STORAGE_MODULE, storage):
+        with pytest.raises(ValueError, match="deletion-inputs/wf-1/chunk-0001.csv"):
+            await load_session_id_chunk("deletion-inputs/wf-1/", 1)
 
-    mock_client = AsyncMock()
-    mock_client.get_object = AsyncMock(return_value={"Body": mock_body})
 
-    with patch("posthog.temporal.session_replay.delete_recordings.object_storage._s3_client") as mock_ctx:
-        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+@pytest.mark.parametrize(
+    "total_chunks, expected_keys",
+    [
+        pytest.param(1, ["deletion-inputs/wf-1/chunk-0000.csv"], id="single_chunk"),
+        pytest.param(
+            3,
+            [
+                "deletion-inputs/wf-1/chunk-0000.csv",
+                "deletion-inputs/wf-1/chunk-0001.csv",
+                "deletion-inputs/wf-1/chunk-0002.csv",
+            ],
+            id="multiple_chunks",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_delete_session_id_chunks(total_chunks, expected_keys):
+    storage = fake_storage({})
 
-        result = await load_session_id_chunk("deletion-inputs/wf-1/", 0)
+    with patch(STORAGE_MODULE, storage):
+        await delete_session_id_chunks("deletion-inputs/wf-1/", total_chunks)
 
-    assert result == ["session-a", "session-b"]
+    storage.delete_objects.assert_called_once_with(expected_keys)
 
 
 @pytest.mark.asyncio
-async def test_delete_session_id_chunks():
-    mock_client = AsyncMock()
-    mock_client.delete_object = AsyncMock()
+async def test_delete_session_id_chunks_logs_orphans(caplog):
+    orphan = "deletion-inputs/wf-1/chunk-0001.csv"
+    storage = fake_storage({}, failed_keys=[orphan])
 
     with (
-        patch("posthog.temporal.session_replay.delete_recordings.object_storage._s3_client") as mock_ctx,
-        patch("posthog.temporal.session_replay.delete_recordings.object_storage.settings") as mock_settings,
+        patch(STORAGE_MODULE, storage),
+        caplog.at_level(logging.WARNING, logger="posthog.temporal.session_replay.delete_recordings.object_storage"),
     ):
-        mock_settings.OBJECT_STORAGE_BUCKET = "test-bucket"
-        mock_ctx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+        await delete_session_id_chunks("deletion-inputs/wf-1/", 2)
 
-        await delete_session_id_chunks("deletion-inputs/wf-1/", 3)
-
-    assert mock_client.delete_object.call_count == 3
-    mock_client.delete_object.assert_any_call(Bucket="test-bucket", Key="deletion-inputs/wf-1/chunk-0000.csv")
-    mock_client.delete_object.assert_any_call(Bucket="test-bucket", Key="deletion-inputs/wf-1/chunk-0001.csv")
-    mock_client.delete_object.assert_any_call(Bucket="test-bucket", Key="deletion-inputs/wf-1/chunk-0002.csv")
+    assert orphan in caplog.text


### PR DESCRIPTION
## Problem

Session recording deletion runs can stall on a single chunk read for as long as the botocore default read timeout allows, when the object store accepts the connection and then stops sending bytes.
The chunk storage helper builds its own `aioboto3` client with no read timeout.

That helper also duplicates three things `posthog/storage/object_storage.py` already provides: client construction from the same four `OBJECT_STORAGE_*` settings, reading an object, and deleting a set of keys.

## Changes

- Chunk reads now fail after the shared client's 5 second read timeout instead of hanging on a silent object store.
- Cleanup now deletes every chunk in one batched call (up to 1000 keys per call) instead of one call per chunk.
- Delete failures now log through the shared client as `logger.exception` plus `capture_exception`, not a local `logger.warning`. Keys the store reports as failed still log a warning that names them.
- `asyncio.to_thread` runs the synchronous shared client. `asyncio.to_thread` is not cancellable, so a cancelled activity returns while the S3 call finishes in a worker thread.
- `load_session_id_chunk` calls `object_storage.read_bytes(key, missing_ok=True)` and `delete_session_id_chunks` calls `object_storage.delete_objects(keys)`. The local `_s3_client` context manager is gone.
- Mechanical: the tests patch the shared module instead of the removed `_s3_client`.

Nothing user-visible changes. The deletion workflow keeps the same activity signatures and the same failure handling in `activities.py`.

## How did you test this code?

- `test_delete_session_id_chunks` asserts the exact chunk key list reaches `delete_objects` in a single call, so a batching change that drops, duplicates, or reorders keys fails.
- `test_load_session_id_chunk_raises_when_chunk_is_missing` uses a fake that raises unless `missing_ok` is passed. Dropping `missing_ok=True` makes the "chunk file not found" branch unreachable, and this test fails when that happens.
- `test_delete_session_id_chunks_logs_orphans` fails if the failed-key warning goes away, which would let orphaned chunks pass silently.
- Both new assertions were verified by mutation: removing `missing_ok=True` and removing the warning each turned the matching test red.
- Ran `ruff check` and `ruff format` on both touched files.
- Not run: any test against a real object store. The suite stubs the shared storage module.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Desktop (Claude Code). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The shared client is synchronous, so the alternative was to keep an async client and copy the read timeout into it. Reusing the shared helpers removes the duplicated config instead of restating it, at the cost of the `asyncio.to_thread` cancellation semantics noted in Changes.

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
