### PR TITLE
fix(surveys): order the SDK survey payload by launch date

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3516,7 +3516,11 @@ def get_surveys_response(team: Team) -> dict[str, Any]:
         # external_survey case in their type enums at all.
         .exclude(type=Survey.SurveyType.EXTERNAL_SURVEY)
         .select_related("linked_flag", "targeting_flag", "internal_targeting_flag")
-        .prefetch_related("actions"),
+        .prefetch_related("actions")
+        # SDKs display one popover at a time and break appearance-delay ties by payload
+        # order, so this ordering decides which of two colliding surveys a user sees.
+        # Launch order (oldest first) keeps that winner deterministic across cache rebuilds.
+        .order_by("start_date", "created_at"),
         many=True,
     ).data
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3520,7 +3520,7 @@ def get_surveys_response(team: Team) -> dict[str, Any]:
         # SDKs display one popover at a time and break appearance-delay ties by payload
         # order, so this ordering decides which of two colliding surveys a user sees.
         # Launch order (oldest first) keeps that winner deterministic across cache rebuilds.
-        .order_by("start_date", "created_at"),
+        .order_by("start_date", "created_at", "id"),
         many=True,
     ).data
 

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -487,6 +487,28 @@ class TestSurvey(APIBaseTest):
 
         assert (str(survey.id) in payload_ids) is expected_in_payload
 
+    def test_sdk_payload_orders_surveys_by_launch_date(self) -> None:
+        # SDKs break display ties by payload order, so it must be deterministic: oldest launch first.
+        launch_dates = [
+            datetime(2026, 1, 3, tzinfo=UTC),
+            datetime(2026, 1, 1, tzinfo=UTC),
+            datetime(2026, 1, 2, tzinfo=UTC),
+        ]
+        surveys = [
+            Survey.objects.create(
+                team=self.team,
+                name=f"Ordered survey {i}",
+                type="popover",
+                start_date=start_date,
+                questions=[{"type": "open", "id": "q1", "question": "How are you?"}],
+            )
+            for i, start_date in enumerate(launch_dates)
+        ]
+
+        payload_ids = [str(item["id"]) for item in get_surveys_response(self.team)["surveys"]]
+
+        assert payload_ids == [str(surveys[1].id), str(surveys[2].id), str(surveys[0].id)]
+
     def test_sdk_payload_strips_non_runtime_question_fields(self) -> None:
         self.team.survey_config = {"appearance": {"backgroundColor": "black"}}
         self.team.save(update_fields=["survey_config"])

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -488,26 +488,37 @@ class TestSurvey(APIBaseTest):
         assert (str(survey.id) in payload_ids) is expected_in_payload
 
     def test_sdk_payload_orders_surveys_by_launch_date(self) -> None:
-        # SDKs break display ties by payload order, so it must be deterministic: oldest launch first.
-        launch_dates = [
-            datetime(2026, 1, 3, tzinfo=UTC),
-            datetime(2026, 1, 1, tzinfo=UTC),
-            datetime(2026, 1, 2, tzinfo=UTC),
-        ]
-        surveys = [
-            Survey.objects.create(
+        # SDKs break display ties by payload order, so it must be deterministic:
+        # oldest launch first, created_at as the tie-break.
+        def create_survey(name: str, start_date: datetime, created_at: datetime) -> Survey:
+            survey = Survey.objects.create(
                 team=self.team,
-                name=f"Ordered survey {i}",
+                name=name,
                 type="popover",
                 start_date=start_date,
                 questions=[{"type": "open", "id": "q1", "question": "How are you?"}],
             )
-            for i, start_date in enumerate(launch_dates)
-        ]
+            Survey.objects.filter(id=survey.id).update(created_at=created_at)
+            return survey
+
+        launched_last = create_survey(
+            "Launched last", datetime(2026, 1, 3, tzinfo=UTC), datetime(2026, 1, 1, tzinfo=UTC)
+        )
+        launched_first = create_survey(
+            "Launched first", datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)
+        )
+        tie_created_second = create_survey(
+            "Tie created second", datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 2, tzinfo=UTC)
+        )
+        tie_created_first = create_survey(
+            "Tie created first", datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 1, tzinfo=UTC)
+        )
 
         payload_ids = [str(item["id"]) for item in get_surveys_response(self.team)["surveys"]]
 
-        assert payload_ids == [str(surveys[1].id), str(surveys[2].id), str(surveys[0].id)]
+        assert payload_ids == [
+            str(survey.id) for survey in [launched_first, tie_created_first, tie_created_second, launched_last]
+        ]
 
     def test_sdk_payload_strips_non_runtime_question_fields(self) -> None:
         self.team.survey_config = {"appearance": {"backgroundColor": "black"}}

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -489,7 +489,7 @@ class TestSurvey(APIBaseTest):
 
     def test_sdk_payload_orders_surveys_by_launch_date(self) -> None:
         # SDKs break display ties by payload order, so it must be deterministic:
-        # oldest launch first, created_at as the tie-break.
+        # oldest launch first, then created_at, then id.
         def create_survey(name: str, start_date: datetime, created_at: datetime) -> Survey:
             survey = Survey.objects.create(
                 team=self.team,
@@ -513,11 +513,22 @@ class TestSurvey(APIBaseTest):
         tie_created_first = create_survey(
             "Tie created first", datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 1, tzinfo=UTC)
         )
+        full_tie_a = create_survey("Full tie a", datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC))
+        full_tie_b = create_survey("Full tie b", datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC))
+        id_tie_first, id_tie_second = sorted([full_tie_a, full_tie_b], key=lambda survey: str(survey.id))
 
         payload_ids = [str(item["id"]) for item in get_surveys_response(self.team)["surveys"]]
 
         assert payload_ids == [
-            str(survey.id) for survey in [launched_first, tie_created_first, tie_created_second, launched_last]
+            str(survey.id)
+            for survey in [
+                launched_first,
+                tie_created_first,
+                tie_created_second,
+                id_tie_first,
+                id_tie_second,
+                launched_last,
+            ]
         ]
 
     def test_sdk_payload_strips_non_runtime_question_fields(self) -> None:


### PR DESCRIPTION
## Problem

- A user who matches two running popover surveys sees whichever one the API happened to list first, not a defined choice.
- When those surveys set a seen-survey wait period, that arbitrary winner also blocks the other survey for the whole period, so exposure between overlapping surveys skews heavily toward one of them.
- SDKs display one popover at a time and break appearance-delay ties by payload order. `get_surveys_response` had no `order_by`, so unspecified Postgres row order froze into the cached payload.
- Origin: [Slack support thread](https://posthog.slack.com/archives/C09K1C75WQ4/p1787594176830539) about uneven exposure between two overlapping surveys.

## Changes

- Users who match several running surveys now see the earliest-launched one first: the SDK payload orders by `start_date`, `created_at`, `id`.
- The fix lands in `get_surveys_response`, which both payload paths (remote config and the surveys HyperCache) build from, so existing SDK versions pick it up on the next cache rebuild with no SDK release.

> [!WARNING]
> Two deploy effects to expect:
> - `RemoteConfig.sync()` compares configs with order-sensitive list equality, so the first nightly `sync_all_remote_configs` after deploy sees a changed config for every team with 2+ running surveys whose stored order differs. Those teams get a one-time save, S3 rewrite, and CDN purge.
> - Teams where collisions currently favor a later-launched survey flip to the earlier one. The current winner is unspecified and can already change on any cache rebuild, so no in-app notice is shipped.

## How did you test this code?

- New `test_sdk_payload_orders_surveys_by_launch_date` catches two regressions no existing test did: removing the `order_by` (payload reverts to unspecified order) and dropping the `created_at` tie-break.
- The `sdk_payload` test group and the remote config survey tests pass locally.
- Not run locally: the full `test_survey.py` suite; CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No doc under `docs/` describes multi-survey display order (searched `docs/` for popover, wait period, and multiple-survey wording); nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: debugged a customer support thread about uneven exposure between two overlapping surveys, traced the root cause to the unordered payload plus the seen-survey wait period, then shipped this fix. Committed test data is invented; no customer material from the session is in the diff or this description.
- Skills invoked: /improving-drf-endpoints, /writing-tests, /reviewing-before-pr, /code-review, /writing-pr-descriptions.
- Local review receipt: `hogli review` could not run in this sandbox (Greptile CLI install blocked), so the local pass was the harness /code-review fallback and the Greptile bot review still applies. Findings and dispositions: one-time remote config resync and CDN purge (documented above, not mitigated), missing `id` tie-break (fixed), untested `created_at` tie-break (fixed), index-based test assertion (fixed), SDK tie-break premise (verified against posthog-js `_sortSurveysByAppearanceDelay`). `codex review --base master` found no actionable defects.
