### PR TITLE
fix(experiments): scope event definition lookups by coalesce

### DIFF
--- a/products/event_definitions/backend/logic/placeholder.py
+++ b/products/event_definitions/backend/logic/placeholder.py
@@ -5,12 +5,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
-from django.db.models import Q
 
 from posthog.models import Team
 from posthog.settings import EE_AVAILABLE
 
-from products.event_definitions.backend.models import EventDefinition
+from products.event_definitions.backend.models import EventDefinition, effective_project_id_expr
 
 if TYPE_CHECKING:
     from ee.models.event_definition import EnterpriseEventDefinition
@@ -29,11 +28,10 @@ def create_placeholder_event_definitions(*, team_id: int, definitions: Sequence[
 
     project_id = Team.objects.values_list("project_id", flat=True).get(id=team_id)
     names = [definition.name for definition in definitions]
-    event_definitions_by_name = {
+    event_definitions_by_name: dict[str, EventDefinition] = {
         event_definition.name: event_definition
-        for event_definition in EventDefinition.objects.filter(
-            Q(project_id=project_id) | Q(project_id__isnull=True, team_id=project_id),
-            name__in=names,
+        for event_definition in EventDefinition.objects.alias(effective_project_id=effective_project_id_expr()).filter(
+            effective_project_id=project_id, name__in=names
         )
     }
 

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -56,6 +56,7 @@ from posthog.utils import str_to_bool
 
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
+from products.event_definitions.backend.models import EventDefinition, effective_project_id_expr
 from products.experiments.backend.flag_cleanup import build_cleanup_prompt, cleanup_plan
 from products.experiments.backend.hogql_queries import CONTROL_VARIANT_KEY, get_baseline_variant_key
 from products.experiments.backend.hogql_queries.base_query_utils import is_threshold_supported_math
@@ -1200,19 +1201,16 @@ class ExperimentService:
         if not event_names:
             return
 
-        from products.event_definitions.backend.models.event_definition import EventDefinition
-
         project_id = self.team.project_id
-        # Uses `team_id = project_id` (not team_id = self.team.id)
+        # `COALESCE(project_id, team_id)` falls back to `team_id` (not self.team.id)
         # on purpose: legacy EventDefinitions (project_id IS NULL) belong to the
         # *primary* team, and primary_team.id == project.id by convention. This
         # mirrors the picker SQL in posthog/api/event_definition.py so sibling
         # teams can validate against legacy primary-team events the picker shows.
         existing = set(
-            EventDefinition.objects.filter(
-                Q(project_id=project_id) | Q(project_id__isnull=True, team_id=project_id),
-                name__in=event_names,
-            ).values_list("name", flat=True)
+            EventDefinition.objects.alias(effective_project_id=effective_project_id_expr())
+            .filter(effective_project_id=project_id, name__in=event_names)
+            .values_list("name", flat=True)
         )
         unknown = event_names - existing
         if unknown:


### PR DESCRIPTION
## Problem

Two more callers scope their event definition lookup with a filter no index can serve. They are copies of the shape fixed for Replay Vision in [#90365](https://github.com/PostHog/posthog/pull/90365), found by grepping for it rather than by anything reporting them.

- Experiment metric validation checks every event name a metric references, on each create and update.
- The setup wizard looks up placeholder definitions when a session completes.
- Both filtered with `Q(project_id=X) | Q(project_id__isnull=True, team_id=X)`, which selects the same rows as `COALESCE(project_id, team_id) = X` but cannot use the composite scope index.
- Postgres bitmap-ORs two narrower scans instead. Neither branch applies both predicates, so each reads more than it needs and the recheck discards the surplus, which grows with the tenant rather than with the request.

Neither is as hot as the Replay Vision path, so this is preventive: the shape is what spreads, and leaving two copies behind invites a third.

## Changes

Nothing user-visible changes. Both call sites return the same definitions, by a plan that seeks the index.

- Both queries filter on `COALESCE(project_id, team_id)` through the existing `effective_project_id_expr()` helper.
- The plan changes from a bitmap OR to an index scan on `event_definition_proj_uniq`, with `name` as a second scan key.
- The wizard placeholder dict carries a type annotation, because `.alias()` narrows the queryset's model type and mypy then rejects the plain instance that `get_or_create` assigns into the same dict. Mechanical.
- The experiments import moves to module level, where the module already imports `Action` and `Cohort`. Mechanical.

## How did you test this code?

No behavior test was added. The two filter forms select the same rows, so no behavior test can tell them apart, and existing coverage already exercises both branches of the scope. `test_event_definition_task_reuses_definition_from_sibling_environment` covers the wizard path across environments, and the experiment metric validation tests cover unknown and sibling-project event names.

Ran `products/wizard/backend/tests/test_logic.py` and `products/experiments/backend/test/test_experiment_service.py`. Repo-wide `mypy` is clean, and `tach check` passes.

The plan comparison behind the index claim is recorded in [#90365](https://github.com/PostHog/posthog/pull/90365), measured on the same table with the same filter forms.

Not run: no manual testing in a browser. Neither change has a UI.

> [!NOTE]
> Stacked on [#90365](https://github.com/PostHog/posthog/pull/90365), which carries the Replay Vision call site and the shared helper's docstring. [#90444](https://github.com/PostHog/posthog/pull/90444) sits on top and adds the lint rule, which can only report zero findings once both this PR and #90365 land.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5). Skills invoked: `/writing-pr-descriptions`.

Split out of [#90365](https://github.com/PostHog/posthog/pull/90365) on request, so the Replay Vision change reaches its owners without two unrelated products attached.

No customer data, logs, or thread contents reached this diff.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KUMHT64A/p1787845895091329?thread_ts=1787845895.091329&cid=C09KUMHT64A)*
