### PR TITLE
fix(ci): install protoc for the replay vision eval workflow

### DIFF
--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -111,6 +111,12 @@ jobs:
                   toolchain: 1.91.1
                   components: cargo
 
+            - name: Install protoc
+              # A one-shot suite builds the personhog binaries during preflight, and their proto
+              # crate compiles .proto files in a build script. The runner image has no protoc.
+              if: steps.gate.outputs.enabled == 'true'
+              uses: ./.github/actions/setup-protoc
+
             - name: Install sqlx-cli
               if: steps.gate.outputs.enabled == 'true'
               uses: ./.github/actions/setup-sqlx-cli


### PR DESCRIPTION
## Problem

The Replay Vision golden-dataset eval cannot finish a dispatch.
It dies in preflight, after the Docker stack has booted and a fresh dataset has already been collected against the project API key.

`eval_scanner_quality` is a one-shot suite, so the harness builds the personhog binaries before it runs any case.
`requirements.py:61` maps `ONE_SHOT` to `Infra.PERSONHOG`, and `lifecycle.py:138` calls `ensure_personhog_binaries()`.
That shells out to `cargo build -p personhog-replica -p personhog-router`.
Both crates depend on `personhog-proto`, whose build script compiles `.proto` files, so the build needs `protoc` on PATH.
The `ubuntu-latest` image does not ship it.

The gap is CI-only.
Local runs go through a flox shell, which supplies protoc (`.flox/env/manifest.toml:51`), and other workflows that build these crates install it, most through this same action.

Nobody has hit it because the workflow has never run past its secret gate.
`REPLAY_VISION_EVAL_POSTHOG_API_KEY` is unset.
Five runs exist, all predating the dispatch-only change: two reached the gate and skipped every later step, three never started the job.

## Changes

- A dispatch now reaches the scanner suite instead of failing in preflight, because the job installs protoc through the existing `setup-protoc` action.
- The step sits between the Rust toolchain and sqlx-cli, gated on the same secret check as its neighbours.

The whole diff is that one step.

## How did you test this code?

Not run: the eval itself.
It needs five secrets, one of which is unset, and a real dispatch spends LLM calls and downloads recordings.

The defect was found by static trace, with every link confirmed against master.

<details>
<summary>Chain from suite kind to the missing binary</summary>

| Link | Evidence |
| --- | --- |
| suite is one-shot | `eval_scanner_quality.py:49` |
| one-shot requires personhog | `requirements.py:61` |
| personhog builds during preflight | `lifecycle.py:137-138`, ahead of `_bootstrap` |
| the build shells out to cargo | `services.py`, raising `PreflightError` on failure |
| both crates need the proto crate | `personhog-replica/Cargo.toml:10`, `personhog-router/Cargo.toml:11` |
| the proto crate needs protoc | `personhog-proto/build.rs`, `tonic_build::configure()` |
| protoc is not vendored | no `protoc-bin-vendored` or `protobuf-src` in `rust/Cargo.lock` |
| the runner has no protoc | actions/runner-images Ubuntu 24.04 manifest lists none |

</details>

`bin/hogli lint:workflows` and `actionlint` pass on the edited file, and CI reports both with more authority.
Step order was checked on the parsed YAML: checkout, then protoc, then the eval step that triggers the build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
`products/posthog_ai/eval_harness/README.md:26` already directs local runs through a flox shell, which supplies protoc.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude authored this PR while auditing the workflow that merged in #83493.
The audit started from the observation that the workflow had never executed anything past its secret gate, so none of its downstream steps had ever been exercised.

Eight contracts were probed in parallel and every candidate finding was adversarially verified.
Six contracts held.
Two probes independently found this protoc gap.
Six other candidate findings were refuted, including three separate claims that the 60-minute timeout was too small: `ci-ai.yml` performs the same uncached bootstrap plus full LLM eval matrices inside 45 minutes.

Reusing the existing composite action beats an inline `apt-get install protobuf-compiler`, because the action pins the protoc version and caches the download.

Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
