### PR TITLE
chore(experiments): experiments scene product migration status tag

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionExperiments.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionExperiments.tsx
@@ -10,11 +10,12 @@ import {
     type ExperimentBasicApi,
     eventExperimentsLogic,
 } from 'scenes/data-management/events/eventExperimentsLogic'
-import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { EventDefinition, ExperimentStatus } from '~/types'
+
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 
 export function EventDefinitionExperiments({ definition }: { definition: EventDefinition }): JSX.Element {
     const event = definition.name

--- a/frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentTabContent/RelatedExperimentsTable.tsx
@@ -9,11 +9,11 @@ import stringWithWBR from 'lib/utils/stringWithWBR'
 import { getExperimentStatus } from 'scenes/experiments/experimentStatus'
 import { urls } from 'scenes/urls'
 
-import { StatusTag } from '~/scenes/experiments/ExperimentView/StatusTag'
 import { isLegacyExperiment } from '~/scenes/experiments/utils'
 import type { Experiment } from '~/types'
 import { ExperimentStatus } from '~/types'
 
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 import { getShippedVariantKey, isSingleVariantShipped } from 'products/experiments/frontend/scenes/experimentsLogic'
 
 type RelatedExperimentsTableProps = {

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -12,6 +12,8 @@ import { urls } from 'scenes/urls'
 
 import { ExperimentStatsMethod, ExperimentStatus } from '~/types'
 
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
+
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
@@ -19,7 +21,6 @@ import { ExperimentDuration } from './ExperimentDuration'
 import { ExperimentReloadActionContainer } from './ExperimentReloadActionContainer'
 import { flagCleanupTaskLogic } from './flagCleanupTaskLogic'
 import { RunningTime } from './RunningTime'
-import { StatusTag } from './StatusTag'
 
 function FlagCleanupField({ experimentId, taskId }: { experimentId: number; taskId: string }): JSX.Element | null {
     const { cleanupTask } = useValues(flagCleanupTaskLogic({ experimentId }))

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -6,6 +6,8 @@ import { LemonCard } from 'lib/lemon-ui/LemonCard'
 
 import { ExperimentStatus } from '~/types'
 
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
+
 import {
     getExperimentChangeDescription,
     getHoldoutChangeDescription,
@@ -13,7 +15,6 @@ import {
     nameOrLinkToExperiment,
     nameOrLinkToSharedMetric,
 } from './activity-descriptions'
-import { StatusTag } from './ExperimentView/StatusTag'
 
 //exporting so the linter doesn't complain about this not being used
 export const ExperimentDetails = ({

--- a/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/ExperimentsNotebookTable.tsx
+++ b/frontend/src/scenes/notebooks/AddExperimentsToNotebookModal/ExperimentsNotebookTable.tsx
@@ -8,8 +8,9 @@ import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/Le
 import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { getExperimentStatus } from 'scenes/experiments/experimentStatus'
 
-import { StatusTag } from '~/scenes/experiments/ExperimentView/StatusTag'
 import { Experiment } from '~/types'
+
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 
 import { addExperimentsToNotebookModalLogic } from './addExperimentsToNotebookModalLogic'
 

--- a/products/dashboards/frontend/widgets/experiments/ExperimentResultsWidget.tsx
+++ b/products/dashboards/frontend/widgets/experiments/ExperimentResultsWidget.tsx
@@ -9,11 +9,12 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
-import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import { urls } from 'scenes/urls'
 
 import type { ExperimentMetric, NewExperimentQueryResponse } from '~/queries/schema/schema-general'
 import type { ExperimentStatus } from '~/types'
+
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 
 import { WidgetCardBodyMessage, WidgetCardContent } from '../../components/WidgetCard'
 import type { DashboardWidgetComponentProps } from '../registry'

--- a/products/dashboards/frontend/widgets/experiments/ExperimentsListWidget.tsx
+++ b/products/dashboards/frontend/widgets/experiments/ExperimentsListWidget.tsx
@@ -9,10 +9,11 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
-import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import { urls } from 'scenes/urls'
 
 import { type ExperimentConclusion, type ExperimentStatus } from '~/types'
+
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 
 import {
     WIDGET_LIST_COUNT_EXPERIMENTS,

--- a/products/dashboards/frontend/widgets/previews/ExperimentsWidgetPreviews.tsx
+++ b/products/dashboards/frontend/widgets/previews/ExperimentsWidgetPreviews.tsx
@@ -1,10 +1,11 @@
 import { clsx } from 'clsx'
 
 import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
-import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 
 import type { ExperimentMetric, NewExperimentQueryResponse } from '~/queries/schema/schema-general'
 import { type ExperimentConclusion, type ExperimentStatus } from '~/types'
+
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 
 import {
     experimentResultsSamplePayload,

--- a/products/experiments/frontend/components/StatusTag.tsx
+++ b/products/experiments/frontend/components/StatusTag.tsx
@@ -5,7 +5,7 @@ import { ExperimentStatus } from '~/types'
 import {
     getExperimentStatusColor,
     getExperimentStatusLabel,
-} from '../../../../../products/experiments/frontend/scenes/experimentsLogic'
+} from 'products/experiments/frontend/scenes/experimentsLogic'
 
 export function StatusTag({ status }: { status: ExperimentStatus }): JSX.Element {
     return (

--- a/products/experiments/frontend/legacy/LegacyExperimentInfo.tsx
+++ b/products/experiments/frontend/legacy/LegacyExperimentInfo.tsx
@@ -12,12 +12,12 @@ import { Label } from 'lib/ui/Label/Label'
 import { cn } from 'lib/utils/css-classes'
 import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
 import { getExperimentStatus, isExperimentPaused } from 'scenes/experiments/experimentStatus'
-import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { ExperimentStatsMethod, ExperimentStatus } from '~/types'
 
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 import { LegacyExperimentDates, legacyExperimentLogic } from 'products/experiments/frontend/legacy'
 import { isSingleVariantShipped, getShippedVariantKey } from 'products/experiments/frontend/scenes/experimentsLogic'
 /**

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -36,7 +36,6 @@ import {
 } from 'scenes/experiments/experimentActions'
 import { getExperimentStatus } from 'scenes/experiments/experimentStatus'
 import { ExperimentVelocityStats } from 'scenes/experiments/ExperimentVelocityStats'
-import { StatusTag } from 'scenes/experiments/ExperimentView/StatusTag'
 import MaxTool from 'scenes/max/MaxTool'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -58,6 +57,7 @@ import {
     ExperimentsTabs,
 } from '~/types'
 
+import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
 /**
  * these scenes are handled as child components. This works fine, but breaks the expectation of scenes


### PR DESCRIPTION
## Problem

`StatusTag` still lives under `frontend/src/scenes/experiments`. It belongs in the experiments product folder.

## Changes

Mechanical move of `StatusTag` to `products/experiments/frontend/components`. All importers now use the `products/` path. No behavior change.

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments products/experiments/frontend
```

![cat-type-small](https://github.com/user-attachments/assets/b6a689db-7a43-4fca-8bd7-b31d6409d045)

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /stacking-prs (local)
- /writing-ui-components (local)
- /writing-pull-requests (local)

Relevant decisions:

- Each file moves in its own stacked PR, so review stays small and mechanical.
- Components go to `products/experiments/frontend/components`; helper modules go to the frontend root. No `../` imports.